### PR TITLE
Gemma 4 batched decode: one-launch BF16 + INT4 megakernels

### DIFF
--- a/crates/kernel-ffi/src/gemma4.rs
+++ b/crates/kernel-ffi/src/gemma4.rs
@@ -1685,6 +1685,46 @@ impl Default for Gemma4Int4ScaleDesc {
     }
 }
 
+/// Per-sequence state pointers for batched Gemma 4 decode.
+///
+/// One `Gemma4BatchSeqDesc` per layer (parallel array to
+/// [`Gemma4DecodeLayerDesc`]), holding per-sequence mutable state for up to
+/// [`crate::layer_desc::MAX_BATCH_SIZE`] sequences. Mirrors Qwen's
+/// [`crate::layer_desc::BatchSeqDesc`] but trimmed to Gemma 4's needs:
+/// no linear-attention (`conv_state` / `recurrent_state`), no FP8 KV
+/// (`kv_scale_*`), no BF16 shadow caches.
+///
+/// When `batch_size == 1` the kernel reads per-sequence state from the layer
+/// descriptor's own `kv_cache_k` / `kv_cache_v` and the scalar `position`
+/// argument — `batch_descs` is `nullptr`. When `batch_size > 1`, the kernel
+/// reads per-sequence pointers and offsets from this struct instead.
+///
+/// Shared-KV layers must alias the source layer's per-sequence cache pointers
+/// (i.e. `batch_descs[shared_layer].kv_cache_k[b] == batch_descs[source_layer].kv_cache_k[b]`)
+/// — replication across sequences is the engine's responsibility, not the
+/// kernel's.
+#[repr(C)]
+#[derive(Debug, Clone)]
+pub struct Gemma4BatchSeqDesc {
+    /// Per-sequence position in the sequence (RoPE table lookup + KV write slot).
+    pub seqlen_offset: [c_int; crate::layer_desc::MAX_BATCH_SIZE],
+    /// Per-sequence K cache pointer (`[num_kv_heads, kv_max_t, head_dim]` BF16).
+    pub kv_cache_k: [*mut c_void; crate::layer_desc::MAX_BATCH_SIZE],
+    /// Per-sequence V cache pointer (`[num_kv_heads, kv_max_t, head_dim]` BF16).
+    pub kv_cache_v: [*mut c_void; crate::layer_desc::MAX_BATCH_SIZE],
+    /// Per-sequence allocated `T` dimension of the KV cache.
+    pub kv_max_t: [c_int; crate::layer_desc::MAX_BATCH_SIZE],
+}
+
+unsafe impl Send for Gemma4BatchSeqDesc {}
+unsafe impl Sync for Gemma4BatchSeqDesc {}
+
+impl Default for Gemma4BatchSeqDesc {
+    fn default() -> Self {
+        unsafe { std::mem::zeroed() }
+    }
+}
+
 /// Required F32 workspace (elements) for the persistent decode megakernel.
 /// Sized to the max of (fused_attn_block, fused_mlp_ple) needs across all
 /// layers — phase A and phase B run sequentially within each layer and share

--- a/crates/kernel-ffi/src/gemma4.rs
+++ b/crates/kernel-ffi/src/gemma4.rs
@@ -407,6 +407,47 @@ unsafe extern "C" {
         barrier_counter: *mut c_uint,
         barrier_flag: *mut c_uint,
     ) -> c_int;
+
+    fn dotcache_gemma4_hip_persistent_decode_batch(
+        dtype: c_int,
+        device_ordinal: usize,
+        num_layers: usize,
+        hidden_size: usize,
+        ple_hidden: usize,
+        eps: f32,
+        scale: f32,
+        batch_size: usize,
+        ws_stride: usize,
+        layers: *const c_void,
+        batch_descs: *const c_void,
+        hidden_io: *mut c_void,
+        per_layer_inputs: *const c_void,
+        workspace: *mut c_void,
+        matvec_counter: *mut c_uint,
+        barrier_counter: *mut c_uint,
+        barrier_flag: *mut c_uint,
+    ) -> c_int;
+
+    fn dotcache_gemma4_hip_persistent_decode_batch_int4(
+        dtype: c_int,
+        device_ordinal: usize,
+        num_layers: usize,
+        hidden_size: usize,
+        ple_hidden: usize,
+        eps: f32,
+        scale: f32,
+        batch_size: usize,
+        ws_stride: usize,
+        layers: *const c_void,
+        int4_scales: *const c_void,
+        batch_descs: *const c_void,
+        hidden_io: *mut c_void,
+        per_layer_inputs: *const c_void,
+        workspace: *mut c_void,
+        matvec_counter: *mut c_uint,
+        barrier_counter: *mut c_uint,
+        barrier_flag: *mut c_uint,
+    ) -> c_int;
 }
 
 #[cfg(not(supersonic_backend_hip))]
@@ -448,6 +489,8 @@ gemma4_stub! {
     fn dotcache_gemma4_hip_embed_gather_scaled(dtype: c_int, device_ordinal: usize, seq_len: usize, hidden_size: usize, vocab_size: usize, scale: f32, token_ids: *const c_uint, table: *const c_void, out: *mut c_void) -> c_int;
     fn dotcache_gemma4_hip_persistent_decode_int4(dtype: c_int, device_ordinal: usize, num_layers: usize, hidden_size: usize, ple_hidden: usize, position: usize, eps: f32, scale: f32, layers: *const c_void, int4_scales: *const c_void, hidden_io: *mut c_void, per_layer_inputs: *const c_void, workspace: *mut c_void, matvec_counter: *mut c_uint, barrier_counter: *mut c_uint, barrier_flag: *mut c_uint) -> c_int;
     fn dotcache_gemma4_hip_persistent_decode(dtype: c_int, device_ordinal: usize, num_layers: usize, hidden_size: usize, ple_hidden: usize, position: usize, eps: f32, scale: f32, layers: *const c_void, hidden_io: *mut c_void, per_layer_inputs: *const c_void, workspace: *mut c_void, matvec_counter: *mut c_uint, barrier_counter: *mut c_uint, barrier_flag: *mut c_uint) -> c_int;
+    fn dotcache_gemma4_hip_persistent_decode_batch(dtype: c_int, device_ordinal: usize, num_layers: usize, hidden_size: usize, ple_hidden: usize, eps: f32, scale: f32, batch_size: usize, ws_stride: usize, layers: *const c_void, batch_descs: *const c_void, hidden_io: *mut c_void, per_layer_inputs: *const c_void, workspace: *mut c_void, matvec_counter: *mut c_uint, barrier_counter: *mut c_uint, barrier_flag: *mut c_uint) -> c_int;
+    fn dotcache_gemma4_hip_persistent_decode_batch_int4(dtype: c_int, device_ordinal: usize, num_layers: usize, hidden_size: usize, ple_hidden: usize, eps: f32, scale: f32, batch_size: usize, ws_stride: usize, layers: *const c_void, int4_scales: *const c_void, batch_descs: *const c_void, hidden_io: *mut c_void, per_layer_inputs: *const c_void, workspace: *mut c_void, matvec_counter: *mut c_uint, barrier_counter: *mut c_uint, barrier_flag: *mut c_uint) -> c_int;
 }
 
 /// Gemma-variant RMSNorm — plain `weight * (x / sqrt(mean(x^2) + eps))` with
@@ -1798,6 +1841,83 @@ pub fn persistent_decode(
     Ok(())
 }
 
+/// Batched variant of [`persistent_decode`] — runs `batch_size` parallel
+/// decode tokens through all layers in a single kernel launch. Weight reads
+/// in the six matmul phases (Q/K/V, o_proj, gate+up, down, per_layer_input_gate,
+/// per_layer_projection) are amortized across sequences.
+///
+/// Buffer shapes:
+/// - `layers`: `[num_layers]` of [`Gemma4DecodeLayerDesc`] (same as single-seq).
+/// - `batch_descs`: `[num_layers]` of [`Gemma4BatchSeqDesc`], one per layer.
+///   `batch_descs[l].kv_cache_k[b]`, `.kv_cache_v[b]`, `.seqlen_offset[b]`,
+///   `.kv_max_t[b]` encode sequence `b`'s state for layer `l`. Shared-KV layers
+///   must alias the source layer's per-sequence KV pointers in the same `b`.
+/// - `hidden_io`: `[batch_size, hidden_size]` BF16 contiguous (in/out per seq).
+/// - `per_layer_inputs`: `[batch_size, num_layers, ple_hidden]` BF16 contiguous.
+/// - `workspace`: `batch_size * persistent_decode_workspace_elems(...)` F32.
+///
+/// `ws_stride` must equal the value returned by
+/// [`persistent_decode_workspace_elems`] for this engine's configuration —
+/// it's the per-sequence slice size into `workspace`.
+///
+/// All sequences in the batch must share the same allocated `max_t`
+/// (`batch_descs[l].kv_max_t[b] == layers[l].kv_max_t` for every `b`); the
+/// kernel uses `layers[l].kv_max_t` as the uniform scores-stride across seqs.
+#[allow(clippy::too_many_arguments)]
+pub fn persistent_decode_batch(
+    ordinal: usize,
+    dtype: ScalarType,
+    layers: &GpuBuffer,
+    batch_descs: &GpuBuffer,
+    hidden_io: &mut GpuBuffer,
+    per_layer_inputs: &GpuBuffer,
+    workspace: &mut GpuBuffer,
+    matvec_counter: &mut GpuBuffer,
+    barrier_counter: &mut GpuBuffer,
+    barrier_flag: &mut GpuBuffer,
+    num_layers: usize,
+    hidden_size: usize,
+    ple_hidden: usize,
+    batch_size: usize,
+    ws_stride: usize,
+    eps: f32,
+    scale: f32,
+) -> Result<(), GpuError> {
+    if batch_size == 0 || batch_size > crate::layer_desc::MAX_BATCH_SIZE {
+        return Err(GpuError::Hip(format!(
+            "gemma4 persistent_decode_batch: batch_size {batch_size} out of range [1, {}]",
+            crate::layer_desc::MAX_BATCH_SIZE
+        )));
+    }
+    let status = unsafe {
+        dotcache_gemma4_hip_persistent_decode_batch(
+            dtype.kernel_dtype_code(),
+            ordinal,
+            num_layers,
+            hidden_size,
+            ple_hidden,
+            eps,
+            scale,
+            batch_size,
+            ws_stride,
+            layers.as_ptr(),
+            batch_descs.as_ptr(),
+            hidden_io.as_mut_ptr(),
+            per_layer_inputs.as_ptr(),
+            workspace.as_mut_ptr(),
+            matvec_counter.as_mut_ptr() as *mut c_uint,
+            barrier_counter.as_mut_ptr() as *mut c_uint,
+            barrier_flag.as_mut_ptr() as *mut c_uint,
+        )
+    };
+    if status != 0 {
+        return Err(GpuError::Hip(format!(
+            "gemma4 persistent_decode_batch failed with status {status}"
+        )));
+    }
+    Ok(())
+}
+
 /// INT4 version of [`persistent_decode`]. Runs a full Gemma 4 forward pass
 /// for one decode token in a single kernel launch with all Q/K/V/O/gate/up/
 /// down/per_layer_input_gate/per_layer_projection matmuls INT4-dequantized
@@ -1854,6 +1974,71 @@ pub fn persistent_decode_int4(
     if status != 0 {
         return Err(GpuError::Hip(format!(
             "gemma4 persistent_decode_int4 failed with status {status}"
+        )));
+    }
+    Ok(())
+}
+
+/// Batched INT4 variant of [`persistent_decode_int4`] — runs `batch_size`
+/// parallel decode tokens through all layers in a single kernel launch with
+/// every matmul INT4-dequantized inline. Same buffer conventions as
+/// [`persistent_decode_batch`] plus the `int4_scales` parallel array.
+///
+/// `ws_stride` must equal [`persistent_decode_workspace_elems`] for this
+/// engine's configuration. `workspace` must be sized `batch_size * ws_stride`
+/// F32 elements.
+#[allow(clippy::too_many_arguments)]
+pub fn persistent_decode_batch_int4(
+    ordinal: usize,
+    dtype: ScalarType,
+    layers: &GpuBuffer,
+    int4_scales: &GpuBuffer,
+    batch_descs: &GpuBuffer,
+    hidden_io: &mut GpuBuffer,
+    per_layer_inputs: &GpuBuffer,
+    workspace: &mut GpuBuffer,
+    matvec_counter: &mut GpuBuffer,
+    barrier_counter: &mut GpuBuffer,
+    barrier_flag: &mut GpuBuffer,
+    num_layers: usize,
+    hidden_size: usize,
+    ple_hidden: usize,
+    batch_size: usize,
+    ws_stride: usize,
+    eps: f32,
+    scale: f32,
+) -> Result<(), GpuError> {
+    if batch_size == 0 || batch_size > crate::layer_desc::MAX_BATCH_SIZE {
+        return Err(GpuError::Hip(format!(
+            "gemma4 persistent_decode_batch_int4: batch_size {batch_size} out of range [1, {}]",
+            crate::layer_desc::MAX_BATCH_SIZE
+        )));
+    }
+    let status = unsafe {
+        dotcache_gemma4_hip_persistent_decode_batch_int4(
+            dtype.kernel_dtype_code(),
+            ordinal,
+            num_layers,
+            hidden_size,
+            ple_hidden,
+            eps,
+            scale,
+            batch_size,
+            ws_stride,
+            layers.as_ptr(),
+            int4_scales.as_ptr(),
+            batch_descs.as_ptr(),
+            hidden_io.as_mut_ptr(),
+            per_layer_inputs.as_ptr(),
+            workspace.as_mut_ptr(),
+            matvec_counter.as_mut_ptr() as *mut c_uint,
+            barrier_counter.as_mut_ptr() as *mut c_uint,
+            barrier_flag.as_mut_ptr() as *mut c_uint,
+        )
+    };
+    if status != 0 {
+        return Err(GpuError::Hip(format!(
+            "gemma4 persistent_decode_batch_int4 failed with status {status}"
         )));
     }
     Ok(())

--- a/crates/runner/src/bin/gemma4_batched_divergent_test.rs
+++ b/crates/runner/src/bin/gemma4_batched_divergent_test.rs
@@ -1,0 +1,298 @@
+//! Divergent-position batched-decode correctness harness.
+//!
+//! Verifies the batched Gemma 4 megakernels (BF16 `g4::persistent_decode_batch`
+//! and INT4 `g4::persistent_decode_batch_int4`) correctly read per-sequence
+//! `seqlen_offset[b]` from `Gemma4BatchSeqDesc` by staggering sequences at
+//! different positions inside a single kernel launch.
+//!
+//! Strategy (works identically for BF16 and INT4): after prefill + replication,
+//! all B sequences share the same KV cache at position = `prompt_len`. We then
+//! advance seq 0 one step ahead using the single-seq `decode_step` API (which
+//! only writes to seq 0's cache — both engines' `decode_step` goes through the
+//! single-seq megakernel that reads KV pointers from seq 0's descriptor). After
+//! that, one `decode_step_batch` launch runs with positions
+//!   [len+1, len, len, ..., len]
+//! — seq 0 is one token ahead of the others. The batched kernel must read
+//! `seqlen_offset[0] = len+1` and `seqlen_offset[b>=1] = len` from batch_descs
+//! to produce the right outputs.
+//!
+//! Reference trajectory is a fresh single-seq engine running the same prompt
+//! for N decode steps. We compare greedy-sampled tokens against the reference.
+//! Divergent-position correctness holds iff:
+//!   - seq 0's t=1 batched output matches reference token at prompt_len+1
+//!   - seqs 1..B's t=0 batched outputs match reference token at prompt_len
+//!
+//! Running multiple batched steps amplifies any bug: by step K, seq 0 has
+//! position len+1+K while the others are at len+K.
+//!
+//! Usage:
+//!   cargo run --release --bin gemma4_batched_divergent_test -- \
+//!       --model-dir <ckpt> [--int4] [--batch-size 4] [--max-new-tokens 6]
+
+use std::path::PathBuf;
+use std::time::Instant;
+
+use anyhow::{anyhow, bail, Result};
+use clap::Parser;
+
+#[path = "../gemma4_engine.rs"]
+mod gemma4_engine;
+#[path = "../gemma4_int4_engine.rs"]
+mod gemma4_int4_engine;
+use gemma4_engine::Gemma4Engine;
+use gemma4_int4_engine::Gemma4Int4Engine;
+
+#[derive(Parser, Debug)]
+#[command(about = "Gemma 4 batched-decode divergent-position correctness test")]
+struct Cli {
+    /// Local Gemma 4 snapshot directory (config.json + safetensors + tokenizer.json).
+    #[arg(long)]
+    model_dir: PathBuf,
+    /// Weight prefix inside the checkpoint.
+    #[arg(long, default_value = "model.language_model")]
+    weight_prefix: String,
+    /// HIP device ordinal.
+    #[arg(long, default_value_t = 0)]
+    device: usize,
+    /// Run the INT4 GPTQ engine instead of BF16.
+    #[arg(long)]
+    int4: bool,
+    /// Batch size (>= 2).
+    #[arg(long, default_value_t = 4)]
+    batch_size: usize,
+    /// Number of decode steps to run after the stagger (exercises per-seq
+    /// position arithmetic over multiple steps).
+    #[arg(long, default_value_t = 6)]
+    max_new_tokens: usize,
+    /// Prompt text. Tokenized with the snapshot's tokenizer.json.
+    #[arg(long, default_value = "Hello, world")]
+    prompt: String,
+}
+
+enum Runtime {
+    Bf16(Gemma4Engine),
+    Int4(Gemma4Int4Engine),
+}
+
+impl Runtime {
+    fn prefill(&mut self, prompt: &[u32]) -> Result<Vec<f32>> {
+        match self {
+            Self::Bf16(e) => e.prefill(prompt),
+            Self::Int4(e) => e.prefill(prompt),
+        }
+    }
+    fn decode_step(&mut self, tok: u32, pos: usize) -> Result<Vec<f32>> {
+        match self {
+            Self::Bf16(e) => e.decode_step(tok, pos),
+            Self::Int4(e) => e.decode_step(tok, pos),
+        }
+    }
+    fn decode_step_batch(
+        &mut self,
+        toks: &[u32],
+        positions: &[usize],
+    ) -> Result<Vec<Vec<f32>>> {
+        match self {
+            Self::Bf16(e) => e.decode_step_batch(toks, positions),
+            Self::Int4(e) => e.decode_step_batch(toks, positions),
+        }
+    }
+    fn replicate_seq0_kv(&mut self) -> Result<()> {
+        match self {
+            Self::Bf16(e) => e.replicate_seq0_kv(),
+            Self::Int4(e) => e.replicate_seq0_kv(),
+        }
+    }
+    fn batch_size(&self) -> usize {
+        match self {
+            Self::Bf16(e) => e.batch_size(),
+            Self::Int4(e) => e.batch_size(),
+        }
+    }
+}
+
+fn greedy_sample(logits: &[f32]) -> u32 {
+    let mut best = 0usize;
+    let mut best_val = f32::NEG_INFINITY;
+    for (i, &x) in logits.iter().enumerate() {
+        if x > best_val {
+            best_val = x;
+            best = i;
+        }
+    }
+    best as u32
+}
+
+fn load_engine(
+    cli: &Cli,
+    weight_prefix: &'static str,
+    batch_size: usize,
+) -> Result<Runtime> {
+    // `context_tokens` must fit prompt + max_new_tokens + stagger step.
+    let context_tokens = 128usize;
+    if cli.int4 {
+        Ok(Runtime::Int4(Gemma4Int4Engine::load_with_batch(
+            &cli.model_dir,
+            weight_prefix,
+            context_tokens,
+            cli.device,
+            batch_size,
+        )?))
+    } else {
+        Ok(Runtime::Bf16(Gemma4Engine::load_with_batch(
+            &cli.model_dir,
+            weight_prefix,
+            context_tokens,
+            cli.device,
+            batch_size,
+        )?))
+    }
+}
+
+fn run_reference_trajectory(
+    cli: &Cli,
+    weight_prefix: &'static str,
+    prompt: &[u32],
+    steps: usize,
+) -> Result<Vec<u32>> {
+    // Fresh B=1 engine. Prefill + `steps` single-seq decode steps = reference.
+    let mut engine = load_engine(cli, weight_prefix, 1)?;
+    let mut out = Vec::with_capacity(steps);
+    let last = engine.prefill(prompt)?;
+    let mut tok = greedy_sample(&last);
+    out.push(tok);
+    for k in 1..steps {
+        let pos = prompt.len() + k - 1;
+        let logits = engine.decode_step(tok, pos)?;
+        tok = greedy_sample(&logits);
+        out.push(tok);
+    }
+    Ok(out)
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    if cli.batch_size < 2 {
+        bail!("--batch-size must be >= 2 (this test exercises divergent positions)");
+    }
+    let steps = cli.max_new_tokens;
+    if steps < 2 {
+        bail!("--max-new-tokens must be >= 2 (stagger needs one reference step)");
+    }
+
+    // Engines want a `&'static str` weight prefix; leak the CLI-owned String.
+    let weight_prefix: &'static str = Box::leak(cli.weight_prefix.clone().into_boxed_str());
+
+    // Tokenize the prompt exactly as the supersonic CLI does.
+    let tokenizer_path = cli.model_dir.join("tokenizer.json");
+    let tokenizer = tokenizers::Tokenizer::from_file(&tokenizer_path)
+        .map_err(|e| anyhow!("load tokenizer {}: {e}", tokenizer_path.display()))?;
+    let encoding = tokenizer
+        .encode(cli.prompt.as_str(), true)
+        .map_err(|e| anyhow!("tokenize: {e}"))?;
+    let prompt: Vec<u32> = encoding.get_ids().to_vec();
+    let prompt_len = prompt.len();
+    eprintln!(
+        "[test] prompt_len={} tokens={:?} int4={} B={}",
+        prompt_len, prompt, cli.int4, cli.batch_size
+    );
+
+    // --- Single-seq reference trajectory (N tokens from this prompt).
+    let t0 = Instant::now();
+    let reference = run_reference_trajectory(&cli, weight_prefix, &prompt, steps + 1)?;
+    eprintln!(
+        "[ref] {} single-seq steps in {:.0}ms → tokens {:?}",
+        reference.len(),
+        t0.elapsed().as_millis(),
+        reference
+    );
+
+    // --- Batched run with a stagger: seq 0 is ALWAYS one step ahead of seqs 1..B.
+    let mut engine = load_engine(&cli, weight_prefix, cli.batch_size)?;
+    assert_eq!(engine.batch_size(), cli.batch_size);
+    let _ = engine.prefill(&prompt)?;
+    engine.replicate_seq0_kv()?;
+
+    // Stagger: advance seq 0 by one single-seq decode step.
+    // seq 0 writes KV at position=prompt_len; all other seqs' caches stay put.
+    let logits0 = engine.decode_step(reference[0], prompt_len)?;
+    let seq0_first = greedy_sample(&logits0);
+    // seq 0's first batched-step input token is reference[1] (we just predicted
+    // that from the stagger). If the stagger matches ref, reference[1] ==
+    // seq0_first; assert that explicitly.
+    if seq0_first != reference[1] {
+        bail!(
+            "stagger failed: single-seq decode_step produced {} but ref[1]={}",
+            seq0_first, reference[1]
+        );
+    }
+
+    // Per-seq rolling state for the batched trajectory.
+    // seq 0 is "ahead by 1" throughout — at batched step k, seq 0's position is
+    // prompt_len + 1 + k while seqs 1..B are at prompt_len + k.
+    let b = cli.batch_size;
+    let mut cur_tokens: Vec<u32> = vec![reference[0]; b]; // seqs 1..B start at ref[0]
+    cur_tokens[0] = reference[1]; // seq 0 is at step 1
+
+    // Record each seq's greedy trajectory across `steps` batched iterations.
+    let mut seq_trajectories: Vec<Vec<u32>> = vec![Vec::with_capacity(steps); b];
+
+    for k in 0..steps {
+        let mut positions: Vec<usize> = vec![prompt_len + k; b];
+        positions[0] = prompt_len + 1 + k;
+        if *positions.iter().max().unwrap() + 1 >= 128 {
+            bail!("context overflow; bump context_tokens");
+        }
+        let outs = engine.decode_step_batch(&cur_tokens, &positions)?;
+        for seq in 0..b {
+            let tok = greedy_sample(&outs[seq]);
+            seq_trajectories[seq].push(tok);
+            cur_tokens[seq] = tok;
+        }
+    }
+
+    // --- Correctness checks.
+    // Reference trajectory indices:
+    //   seq 0 at batched step k expected: reference[2 + k]  (seq 0 is step-1 ahead)
+    //   seq b>=1 at batched step k expected: reference[1 + k]
+    let mut failures: Vec<String> = Vec::new();
+    for seq in 0..b {
+        let offset = if seq == 0 { 2 } else { 1 };
+        for k in 0..steps {
+            let expected_ix = offset + k;
+            if expected_ix >= reference.len() {
+                // Ran out of reference tokens; stop comparing this seq.
+                break;
+            }
+            let expected = reference[expected_ix];
+            let actual = seq_trajectories[seq][k];
+            if actual != expected {
+                failures.push(format!(
+                    "seq {seq} step {k}: pos={} expected {} got {}",
+                    if seq == 0 { prompt_len + 1 + k } else { prompt_len + k },
+                    expected, actual
+                ));
+            }
+        }
+    }
+
+    eprintln!("[batched] per-seq trajectories:");
+    for (seq, traj) in seq_trajectories.iter().enumerate() {
+        let pos_start = if seq == 0 { prompt_len + 1 } else { prompt_len };
+        eprintln!("  seq {seq} (pos start={pos_start}): {traj:?}");
+    }
+
+    if failures.is_empty() {
+        eprintln!(
+            "[PASS] B={} int4={}: all {} seqs matched single-seq reference across {} batched steps \
+             with divergent positions (seq 0 always 1 ahead of seqs 1..{}).",
+            cli.batch_size, cli.int4, cli.batch_size, steps, cli.batch_size - 1
+        );
+        Ok(())
+    } else {
+        for f in &failures {
+            eprintln!("  FAIL: {f}");
+        }
+        bail!("divergent-position test failed with {} mismatches", failures.len());
+    }
+}

--- a/crates/runner/src/gemma4_engine.rs
+++ b/crates/runner/src/gemma4_engine.rs
@@ -381,6 +381,12 @@ pub struct Gemma4Engine {
     weight_prefix: &'static str,
     max_t: usize,
     device: usize,
+    /// Number of parallel decode sequences this engine is sized for. Always
+    /// `>= 1`. When `batch_size > 1` the engine holds `batch_size` parallel
+    /// sets of K/V caches + descriptor arrays so each sequence can decode into
+    /// its own state. Phase 1 dispatches sequences serially through the
+    /// existing single-seq megakernel; Phase 2 will fold them into one launch.
+    batch_size: usize,
 
     layers: Vec<LayerWeights>,
     lm_head_w: GpuBuffer, // tied to embed_tokens on E2B/E4B
@@ -393,13 +399,20 @@ pub struct Gemma4Engine {
     full_cos: GpuBuffer,
     full_sin: GpuBuffer,
 
-    k_caches: Vec<GpuBuffer>,
-    v_caches: Vec<GpuBuffer>,
+    /// Per-sequence K/V caches: `k_caches[seq][layer]`. Outer length is
+    /// `batch_size`, inner length is `num_hidden_layers`. Each inner buffer
+    /// has shape `[num_kv_heads, max_t, head_dim]`.
+    k_caches: Vec<Vec<GpuBuffer>>,
+    v_caches: Vec<Vec<GpuBuffer>>,
 
-    // Megakernel-side state (built once, reused every decode step).
+    // Megakernel-side state. With per-sequence KV pointers baked into the
+    // descriptor array, we hold `batch_size` separate descriptor arrays —
+    // each sequence picks the matching `layers_gpu[seq]` for its single-seq
+    // kernel call. (Phase 2 will collapse these into one batched-kernel
+    // arg + a per-layer Gemma4BatchSeqDesc array.)
     #[allow(dead_code)]
-    descs: Vec<Gemma4DecodeLayerDesc>, // kept alive so the GPU-side `layers_gpu` pointers stay valid
-    layers_gpu: GpuBuffer,
+    descs: Vec<Vec<Gemma4DecodeLayerDesc>>, // kept alive so `layers_gpu[seq]` pointers stay valid
+    layers_gpu: Vec<GpuBuffer>,
     mega_workspace: GpuBuffer,
     mega_matvec_counter: GpuBuffer,
     mega_barrier_counter: GpuBuffer,
@@ -410,15 +423,42 @@ pub struct Gemma4Engine {
 }
 
 impl Gemma4Engine {
-    /// Load all weights for a Gemma 4 dense variant and initialize GPU state.
-    /// `max_t` is the maximum token position the engine will ever be asked to
-    /// handle (prompt length + max new tokens) — K/V caches are sized once.
+    /// Load all weights for a Gemma 4 dense variant and initialize GPU state
+    /// for a single decoding sequence (`batch_size = 1`). Convenience wrapper
+    /// for [`Self::load_with_batch`] that preserves the original signature.
     pub fn load(
         model_dir: &Path,
         weight_prefix: &'static str,
         max_t: usize,
         device: usize,
     ) -> Result<Self> {
+        Self::load_with_batch(model_dir, weight_prefix, max_t, device, 1)
+    }
+
+    /// Load all weights and initialize GPU state for `batch_size` parallel
+    /// sequences. `max_t` is the maximum token position any sequence will ever
+    /// be asked to handle (prompt length + max new tokens) — K/V caches are
+    /// sized once per sequence.
+    ///
+    /// Per-sequence allocations grow linearly with `batch_size`:
+    /// `batch_size * num_layers * (k_cache + v_cache + descriptor_array)`.
+    pub fn load_with_batch(
+        model_dir: &Path,
+        weight_prefix: &'static str,
+        max_t: usize,
+        device: usize,
+        batch_size: usize,
+    ) -> Result<Self> {
+        if batch_size == 0 {
+            bail!("Gemma4Engine: batch_size must be >= 1");
+        }
+        if batch_size > kernel_ffi::MAX_BATCH_SIZE {
+            bail!(
+                "Gemma4Engine: batch_size {} > MAX_BATCH_SIZE {}",
+                batch_size,
+                kernel_ffi::MAX_BATCH_SIZE
+            );
+        }
         gpu_hal::set_device(device).map_err(|e| anyhow!("set_device: {e}"))?;
         let config: Config = ::gemma4::config::load_config(model_dir)
             .map_err(|e| anyhow!("load_config: {e}"))?;
@@ -443,14 +483,22 @@ impl Gemma4Engine {
         let num_kv_heads = tcfg.num_key_value_heads;
         let num_q_heads = tcfg.num_attention_heads;
 
-        // One K/V buffer per layer — prefill fills them all; decode reads
-        // shared-layer descriptors via pointer-alias into the source's buffer.
-        let mut k_caches: Vec<GpuBuffer> = Vec::with_capacity(num_layers);
-        let mut v_caches: Vec<GpuBuffer> = Vec::with_capacity(num_layers);
-        for l in 0..num_layers {
-            let hd = layers[l].head_dim;
-            k_caches.push(GpuBuffer::zeros(device, dtype, &[num_kv_heads, max_t, hd])?);
-            v_caches.push(GpuBuffer::zeros(device, dtype, &[num_kv_heads, max_t, hd])?);
+        // Per-sequence K/V buffers — `[seq][layer]`. Each sequence has its own
+        // cache so decode steps are fully decoupled. Shared-KV layers within
+        // a sequence still alias the source layer's buffer (handled below in
+        // descriptor construction).
+        let mut k_caches: Vec<Vec<GpuBuffer>> = Vec::with_capacity(batch_size);
+        let mut v_caches: Vec<Vec<GpuBuffer>> = Vec::with_capacity(batch_size);
+        for _ in 0..batch_size {
+            let mut ks: Vec<GpuBuffer> = Vec::with_capacity(num_layers);
+            let mut vs: Vec<GpuBuffer> = Vec::with_capacity(num_layers);
+            for l in 0..num_layers {
+                let hd = layers[l].head_dim;
+                ks.push(GpuBuffer::zeros(device, dtype, &[num_kv_heads, max_t, hd])?);
+                vs.push(GpuBuffer::zeros(device, dtype, &[num_kv_heads, max_t, hd])?);
+            }
+            k_caches.push(ks);
+            v_caches.push(vs);
         }
 
         let sliding_head_dim = tcfg.head_dim_for(AttnKind::Sliding);
@@ -470,77 +518,86 @@ impl Gemma4Engine {
         let full_cos = upload_bf16(device, &[max_t, full_head_dim], &fcos_h)?;
         let full_sin = upload_bf16(device, &[max_t, full_head_dim], &fsin_h)?;
 
-        // --- Persistent-decode descriptor array. Shared layers alias their
-        //     source's K/V cache pointers so the megakernel sees a single
-        //     coherent memory region for the source → shared dependency.
-        let mut descs: Vec<Gemma4DecodeLayerDesc> = Vec::with_capacity(num_layers);
-        for l in 0..num_layers {
-            let w = &layers[l];
-            let kind_code: c_int = match w.kind {
-                AttnKind::Sliding => 0,
-                AttnKind::Full => 1,
-            };
-            let sliding_window = match w.kind {
-                AttnKind::Sliding => tcfg.sliding_window as c_int,
-                AttnKind::Full => 0,
-            };
-            let (cos_table_buf, sin_table_buf) = match w.kind {
-                AttnKind::Sliding => (&sliding_cos, &sliding_sin),
-                AttnKind::Full => (&full_cos, &full_sin),
-            };
-            let src_idx = if w.shared_kv { w.kv_source } else { l };
-            let k_buf = &k_caches[src_idx];
-            let v_buf = &v_caches[src_idx];
+        // --- Persistent-decode descriptor arrays — one per sequence. Each
+        //     sequence's descriptor array embeds *that sequence's* K/V cache
+        //     pointers so the single-seq megakernel can decode any sequence
+        //     by being handed the matching `layers_gpu[seq]`. Shared-KV layers
+        //     alias the source layer's buffer **within the same sequence**.
+        let mut descs: Vec<Vec<Gemma4DecodeLayerDesc>> = Vec::with_capacity(batch_size);
+        let mut layers_gpu: Vec<GpuBuffer> = Vec::with_capacity(batch_size);
+        for seq in 0..batch_size {
+            let mut seq_descs: Vec<Gemma4DecodeLayerDesc> = Vec::with_capacity(num_layers);
+            for l in 0..num_layers {
+                let w = &layers[l];
+                let kind_code: c_int = match w.kind {
+                    AttnKind::Sliding => 0,
+                    AttnKind::Full => 1,
+                };
+                let sliding_window = match w.kind {
+                    AttnKind::Sliding => tcfg.sliding_window as c_int,
+                    AttnKind::Full => 0,
+                };
+                let (cos_table_buf, sin_table_buf) = match w.kind {
+                    AttnKind::Sliding => (&sliding_cos, &sliding_sin),
+                    AttnKind::Full => (&full_cos, &full_sin),
+                };
+                let src_idx = if w.shared_kv { w.kv_source } else { l };
+                let k_buf = &k_caches[seq][src_idx];
+                let v_buf = &v_caches[seq][src_idx];
 
-            let k_proj_ptr = w.k_proj.as_ref().map(|b| b.as_ptr()).unwrap_or(std::ptr::null());
-            let v_proj_ptr = w.v_proj.as_ref().map(|b| b.as_ptr()).unwrap_or(std::ptr::null());
-            let k_norm_ptr = w.k_norm.as_ref().map(|b| b.as_ptr()).unwrap_or(std::ptr::null());
+                let k_proj_ptr = w.k_proj.as_ref().map(|b| b.as_ptr()).unwrap_or(std::ptr::null());
+                let v_proj_ptr = w.v_proj.as_ref().map(|b| b.as_ptr()).unwrap_or(std::ptr::null());
+                let k_norm_ptr = w.k_norm.as_ref().map(|b| b.as_ptr()).unwrap_or(std::ptr::null());
 
-            descs.push(Gemma4DecodeLayerDesc {
-                layer_type: kind_code,
-                shared_kv: if w.shared_kv { 1 } else { 0 },
-                num_q_heads: num_q_heads as c_int,
-                num_kv_heads: num_kv_heads as c_int,
-                head_dim: w.head_dim as c_int,
-                rotary_dim: w.head_dim as c_int,
-                sliding_window,
-                intermediate_size: w.intermediate_size as c_int,
-                kv_max_t: max_t as c_int,
-                layer_scalar: w.layer_scalar,
-                input_norm_w: w.input_norm.as_ptr(),
-                q_proj_w: w.q_proj.as_ptr(),
-                k_proj_w: k_proj_ptr,
-                v_proj_w: v_proj_ptr,
-                q_norm_w: w.q_norm.as_ptr(),
-                k_norm_w: k_norm_ptr,
-                o_proj_w: w.o_proj.as_ptr(),
-                post_attn_norm_w: w.post_attn_norm.as_ptr(),
-                pre_ff_norm_w: w.pre_ff_norm.as_ptr(),
-                gate_proj_w: w.gate_proj.as_ptr(),
-                up_proj_w: w.up_proj.as_ptr(),
-                down_proj_w: w.down_proj.as_ptr(),
-                post_ff_norm_w: w.post_ff_norm.as_ptr(),
-                per_layer_input_gate_w: w.per_layer_input_gate_w.as_ptr(),
-                per_layer_projection_w: w.per_layer_projection_w.as_ptr(),
-                post_per_layer_input_norm_w: w.post_per_layer_input_norm_w.as_ptr(),
-                cos_table: cos_table_buf.as_ptr(),
-                sin_table: sin_table_buf.as_ptr(),
-                kv_cache_k: k_buf.as_ptr() as *mut c_void,
-                kv_cache_v: v_buf.as_ptr() as *mut c_void,
-            });
+                seq_descs.push(Gemma4DecodeLayerDesc {
+                    layer_type: kind_code,
+                    shared_kv: if w.shared_kv { 1 } else { 0 },
+                    num_q_heads: num_q_heads as c_int,
+                    num_kv_heads: num_kv_heads as c_int,
+                    head_dim: w.head_dim as c_int,
+                    rotary_dim: w.head_dim as c_int,
+                    sliding_window,
+                    intermediate_size: w.intermediate_size as c_int,
+                    kv_max_t: max_t as c_int,
+                    layer_scalar: w.layer_scalar,
+                    input_norm_w: w.input_norm.as_ptr(),
+                    q_proj_w: w.q_proj.as_ptr(),
+                    k_proj_w: k_proj_ptr,
+                    v_proj_w: v_proj_ptr,
+                    q_norm_w: w.q_norm.as_ptr(),
+                    k_norm_w: k_norm_ptr,
+                    o_proj_w: w.o_proj.as_ptr(),
+                    post_attn_norm_w: w.post_attn_norm.as_ptr(),
+                    pre_ff_norm_w: w.pre_ff_norm.as_ptr(),
+                    gate_proj_w: w.gate_proj.as_ptr(),
+                    up_proj_w: w.up_proj.as_ptr(),
+                    down_proj_w: w.down_proj.as_ptr(),
+                    post_ff_norm_w: w.post_ff_norm.as_ptr(),
+                    per_layer_input_gate_w: w.per_layer_input_gate_w.as_ptr(),
+                    per_layer_projection_w: w.per_layer_projection_w.as_ptr(),
+                    post_per_layer_input_norm_w: w.post_per_layer_input_norm_w.as_ptr(),
+                    cos_table: cos_table_buf.as_ptr(),
+                    sin_table: sin_table_buf.as_ptr(),
+                    kv_cache_k: k_buf.as_ptr() as *mut c_void,
+                    kv_cache_v: v_buf.as_ptr() as *mut c_void,
+                });
+            }
+            let desc_bytes: &[u8] = unsafe {
+                std::slice::from_raw_parts(
+                    seq_descs.as_ptr() as *const u8,
+                    seq_descs.len() * std::mem::size_of::<Gemma4DecodeLayerDesc>(),
+                )
+            };
+            let buf = GpuBuffer::from_host_bytes(
+                device,
+                ScalarType::U8,
+                &[desc_bytes.len()],
+                desc_bytes,
+            )?;
+            descs.push(seq_descs);
+            layers_gpu.push(buf);
+            let _ = seq; // kept for clarity at the outer index
         }
-        let desc_bytes: &[u8] = unsafe {
-            std::slice::from_raw_parts(
-                descs.as_ptr() as *const u8,
-                descs.len() * std::mem::size_of::<Gemma4DecodeLayerDesc>(),
-            )
-        };
-        let layers_gpu = GpuBuffer::from_host_bytes(
-            device,
-            ScalarType::U8,
-            &[desc_bytes.len()],
-            desc_bytes,
-        )?;
 
         let ple_hidden = tcfg.hidden_size_per_layer_input;
         let max_intermediate = (0..num_layers)
@@ -563,6 +620,7 @@ impl Gemma4Engine {
             weight_prefix,
             max_t,
             device,
+            batch_size,
             layers,
             lm_head_w,
             final_norm_w,
@@ -584,6 +642,11 @@ impl Gemma4Engine {
         })
     }
 
+    /// Number of parallel sequences this engine was sized for.
+    pub fn batch_size(&self) -> usize {
+        self.batch_size
+    }
+
     pub fn text_config(&self) -> &TextConfig {
         &self.tcfg
     }
@@ -592,11 +655,28 @@ impl Gemma4Engine {
         self.max_t
     }
 
-    /// Run batched Rust prefill over the whole prompt and return the softcapped
-    /// logits at the last prompt position. Populates every K/V cache buffer;
-    /// shared-KV layers get their slots replicated from the source layer's
-    /// cache via D2D copies.
+    /// Run prefill into sequence 0's K/V caches (convenience wrapper for
+    /// `prefill_seq(0, ...)` matching the original single-sequence API).
     pub fn prefill(&mut self, prompt_token_ids: &[u32]) -> Result<Vec<f32>> {
+        self.prefill_seq(0, prompt_token_ids)
+    }
+
+    /// Run batched Rust prefill over the whole prompt for sequence `seq_idx`
+    /// and return the softcapped logits at the last prompt position.
+    /// Populates every K/V cache buffer for that sequence; shared-KV layers
+    /// get their slots replicated from the source layer's cache via D2D
+    /// copies.
+    ///
+    /// To prefill `B` sequences with the same prompt, prefer `prefill` +
+    /// [`Self::replicate_seq0_kv`] — that runs the GPU work once and clones
+    /// the resulting cache contents instead of re-running prefill `B` times.
+    pub fn prefill_seq(&mut self, seq_idx: usize, prompt_token_ids: &[u32]) -> Result<Vec<f32>> {
+        if seq_idx >= self.batch_size {
+            bail!(
+                "prefill_seq: seq_idx {seq_idx} >= batch_size {}",
+                self.batch_size
+            );
+        }
         let seq_len = prompt_token_ids.len();
         if seq_len == 0 {
             bail!("prefill: empty prompt");
@@ -706,7 +786,8 @@ impl Gemma4Engine {
 
                 g4::kv_append_prefill(
                     device, dtype, &k_normed, &v_normed,
-                    &mut self.k_caches[layer_idx], &mut self.v_caches[layer_idx],
+                    &mut self.k_caches[seq_idx][layer_idx],
+                    &mut self.v_caches[seq_idx][layer_idx],
                     seq_len, num_kv_heads, head_dim, 0, max_t,
                 )?;
 
@@ -714,12 +795,12 @@ impl Gemma4Engine {
                 for shared_layer in (layer_idx + 1)..num_layers {
                     let s = &self.layers[shared_layer];
                     if s.shared_kv && s.kv_source == layer_idx {
-                        let (lo, hi) = self.k_caches.split_at_mut(shared_layer);
+                        let (lo, hi) = self.k_caches[seq_idx].split_at_mut(shared_layer);
                         copy_kv_slots_range(device,
                             &lo[layer_idx], &mut hi[0],
                             num_kv_heads, max_t, head_dim, 0, seq_len,
                         )?;
-                        let (lo, hi) = self.v_caches.split_at_mut(shared_layer);
+                        let (lo, hi) = self.v_caches[seq_idx].split_at_mut(shared_layer);
                         copy_kv_slots_range(device,
                             &lo[layer_idx], &mut hi[0],
                             num_kv_heads, max_t, head_dim, 0, seq_len,
@@ -734,7 +815,7 @@ impl Gemma4Engine {
                 GpuBuffer::zeros(device, ScalarType::F32, &[seq_len, num_q_heads, max_t])?;
             g4::attn_prefill(
                 device, dtype, &q_normed,
-                &self.k_caches[layer_idx], &self.v_caches[layer_idx],
+                &self.k_caches[seq_idx][layer_idx], &self.v_caches[seq_idx][layer_idx],
                 &mut scores, &mut attn_out,
                 seq_len, num_q_heads, num_kv_heads, head_dim, 0, max_t,
                 sliding_window, 1.0,
@@ -855,12 +936,30 @@ impl Gemma4Engine {
         Ok(logits_host)
     }
 
-    /// Single decode step via the persistent megakernel. Writes new K/V slot
-    /// at `pos` in every non-shared layer's cache (shared layers read the
-    /// source's cache via descriptor aliasing). Returns softcapped logits.
+    /// Single decode step on sequence 0 (convenience wrapper for
+    /// `decode_step_seq(0, ...)` matching the original single-sequence API).
     pub fn decode_step(&mut self, input_token_id: u32, pos: usize) -> Result<Vec<f32>> {
+        self.decode_step_seq(0, input_token_id, pos)
+    }
+
+    /// Run one decode step on sequence `seq_idx` via the persistent
+    /// megakernel. Writes a new K/V slot at `pos` in every non-shared layer
+    /// of that sequence's caches; shared layers read the source's cache via
+    /// descriptor aliasing. Returns softcapped logits.
+    pub fn decode_step_seq(
+        &mut self,
+        seq_idx: usize,
+        input_token_id: u32,
+        pos: usize,
+    ) -> Result<Vec<f32>> {
+        if seq_idx >= self.batch_size {
+            bail!(
+                "decode_step_seq: seq_idx {seq_idx} >= batch_size {}",
+                self.batch_size
+            );
+        }
         if pos >= self.max_t {
-            bail!("decode_step: pos {pos} >= max_t {}", self.max_t);
+            bail!("decode_step_seq: pos {pos} >= max_t {}", self.max_t);
         }
         let device = self.device;
         let dtype = ScalarType::BF16;
@@ -892,7 +991,7 @@ impl Gemma4Engine {
 
         g4::persistent_decode(
             device, dtype,
-            &self.layers_gpu,
+            &self.layers_gpu[seq_idx],
             &mut h_running,
             &pli_gpu,
             &mut self.mega_workspace,
@@ -918,6 +1017,69 @@ impl Gemma4Engine {
             *v = cap * (*v / cap).tanh();
         }
         Ok(logits_host)
+    }
+
+    /// Run one decode step on every sequence in the batch and return one set
+    /// of softcapped logits per sequence (`Vec<Vec<f32>>` length = batch_size).
+    ///
+    /// **Phase 1 implementation**: serially calls [`Self::decode_step_seq`]
+    /// for each sequence. Same throughput as B sequential single-sequence
+    /// runs — the API is in place but the perf win waits on the kernel-side
+    /// batched megakernel (Phase 2).
+    pub fn decode_step_batch(
+        &mut self,
+        input_tokens: &[u32],
+        positions: &[usize],
+    ) -> Result<Vec<Vec<f32>>> {
+        if input_tokens.len() != self.batch_size {
+            bail!(
+                "decode_step_batch: got {} tokens, batch_size is {}",
+                input_tokens.len(),
+                self.batch_size
+            );
+        }
+        if positions.len() != self.batch_size {
+            bail!(
+                "decode_step_batch: got {} positions, batch_size is {}",
+                positions.len(),
+                self.batch_size
+            );
+        }
+        let mut out = Vec::with_capacity(self.batch_size);
+        for b in 0..self.batch_size {
+            out.push(self.decode_step_seq(b, input_tokens[b], positions[b])?);
+        }
+        Ok(out)
+    }
+
+    /// D2D-copy sequence 0's K/V cache contents into every other sequence's
+    /// caches. Use this immediately after [`Self::prefill`] when all `B`
+    /// sequences share the same prompt — much cheaper than running prefill
+    /// `B` times. The destination cache shapes match seq 0's (the engine
+    /// allocates them identically), so this is a straight per-layer
+    /// `[num_kv_heads, max_t, head_dim]` byte copy per sequence pair.
+    pub fn replicate_seq0_kv(&mut self) -> Result<()> {
+        if self.batch_size <= 1 {
+            return Ok(());
+        }
+        let num_layers = self.tcfg.num_hidden_layers;
+        let device = self.device;
+        // Snapshot seq 0 byte sizes per layer (they're invariant across seqs).
+        for l in 0..num_layers {
+            let bytes = self.k_caches[0][l].len_bytes();
+            let v_bytes = self.v_caches[0][l].len_bytes();
+            for b in 1..self.batch_size {
+                let src_k = self.k_caches[0][l].as_ptr();
+                let src_v = self.v_caches[0][l].as_ptr();
+                let dst_k = self.k_caches[b][l].as_mut_ptr();
+                let dst_v = self.v_caches[b][l].as_mut_ptr();
+                gpu_hal::copy_d2d(device, dst_k, src_k, bytes)
+                    .map_err(|e| anyhow!("replicate_seq0_kv k layer {l} → seq {b}: {e}"))?;
+                gpu_hal::copy_d2d(device, dst_v, src_v, v_bytes)
+                    .map_err(|e| anyhow!("replicate_seq0_kv v layer {l} → seq {b}: {e}"))?;
+            }
+        }
+        Ok(())
     }
 
     /// Greedy sample — argmax.

--- a/crates/runner/src/gemma4_engine.rs
+++ b/crates/runner/src/gemma4_engine.rs
@@ -22,7 +22,7 @@ use ::gemma4::weight_spec as g4_spec;
 use gpu_hal::{GpuBuffer, ScalarType};
 use half::bf16;
 use kernel_ffi::gemma4 as g4;
-use kernel_ffi::gemma4::Gemma4DecodeLayerDesc;
+use kernel_ffi::gemma4::{Gemma4BatchSeqDesc, Gemma4DecodeLayerDesc};
 use memmap2::Mmap;
 use safetensors::SafeTensors;
 
@@ -405,14 +405,25 @@ pub struct Gemma4Engine {
     k_caches: Vec<Vec<GpuBuffer>>,
     v_caches: Vec<Vec<GpuBuffer>>,
 
-    // Megakernel-side state. With per-sequence KV pointers baked into the
-    // descriptor array, we hold `batch_size` separate descriptor arrays —
-    // each sequence picks the matching `layers_gpu[seq]` for its single-seq
-    // kernel call. (Phase 2 will collapse these into one batched-kernel
-    // arg + a per-layer Gemma4BatchSeqDesc array.)
+    // Megakernel-side state. Per-sequence layer-descriptor arrays hold each
+    // sequence's KV cache pointers — used by [`decode_step_seq`] to call the
+    // single-seq megakernel. The batched megakernel (Phase 2) reuses
+    // `layers_gpu[0]` for shape/weight pointers (KV fields ignored) and reads
+    // per-sequence K/V + position from `batch_descs_gpu`.
     #[allow(dead_code)]
     descs: Vec<Vec<Gemma4DecodeLayerDesc>>, // kept alive so `layers_gpu[seq]` pointers stay valid
     layers_gpu: Vec<GpuBuffer>,
+
+    /// `[num_layers]` parallel-array of [`Gemma4BatchSeqDesc`] on GPU, holding
+    /// per-sequence KV pointers + positions for the batched megakernel. Only
+    /// populated when `batch_size > 1`. Shared-KV layers alias the source
+    /// layer's per-sequence KV pointers (no extra replication).
+    batch_descs_host: Vec<Gemma4BatchSeqDesc>,
+    batch_descs_gpu: Option<GpuBuffer>,
+    /// Per-sequence slice stride into `mega_workspace` for the batched kernel
+    /// (= `persistent_decode_workspace_elems(...)`).
+    mega_ws_stride: usize,
+
     mega_workspace: GpuBuffer,
     mega_matvec_counter: GpuBuffer,
     mega_barrier_counter: GpuBuffer,
@@ -608,7 +619,47 @@ impl Gemma4Engine {
             tcfg.hidden_size, num_q_heads, num_kv_heads, full_head_dim, max_t,
             max_intermediate, ple_hidden,
         );
-        let mega_workspace = GpuBuffer::zeros(device, ScalarType::F32, &[workspace_elems])?;
+        // Batched kernel needs `B * workspace_elems`; single-seq kernel ignores
+        // the surplus. Always size for `batch_size` so both paths work.
+        let mega_workspace =
+            GpuBuffer::zeros(device, ScalarType::F32, &[batch_size * workspace_elems])?;
+        let mega_ws_stride = workspace_elems;
+
+        // Per-layer batched-seq descriptor array. `seqlen_offset` is updated
+        // per decode step; KV pointers and kv_max_t are fixed at engine-build
+        // time. Shared-KV layers inherit the source layer's per-sequence
+        // pointers so the kernel never needs to look up the mapping.
+        let mut batch_descs_host: Vec<Gemma4BatchSeqDesc> =
+            vec![Gemma4BatchSeqDesc::default(); num_layers];
+        for l in 0..num_layers {
+            let src_idx = {
+                let w = &layers[l];
+                if w.shared_kv { w.kv_source } else { l }
+            };
+            let d = &mut batch_descs_host[l];
+            for b in 0..batch_size {
+                d.seqlen_offset[b] = 0;
+                d.kv_cache_k[b] = k_caches[b][src_idx].as_ptr() as *mut c_void;
+                d.kv_cache_v[b] = v_caches[b][src_idx].as_ptr() as *mut c_void;
+                d.kv_max_t[b] = max_t as c_int;
+            }
+        }
+        let batch_descs_gpu = if batch_size > 1 {
+            let desc_bytes: &[u8] = unsafe {
+                std::slice::from_raw_parts(
+                    batch_descs_host.as_ptr() as *const u8,
+                    batch_descs_host.len() * std::mem::size_of::<Gemma4BatchSeqDesc>(),
+                )
+            };
+            Some(GpuBuffer::from_host_bytes(
+                device,
+                ScalarType::U8,
+                &[desc_bytes.len()],
+                desc_bytes,
+            )?)
+        } else {
+            None
+        };
         let mega_matvec_counter = GpuBuffer::zeros(device, ScalarType::U32, &[1])?;
         let mega_barrier_counter = GpuBuffer::zeros(device, ScalarType::U32, &[1])?;
         let mega_barrier_flag = GpuBuffer::zeros(device, ScalarType::U32, &[1])?;
@@ -634,6 +685,9 @@ impl Gemma4Engine {
             v_caches,
             descs,
             layers_gpu,
+            batch_descs_host,
+            batch_descs_gpu,
+            mega_ws_stride,
             mega_workspace,
             mega_matvec_counter,
             mega_barrier_counter,
@@ -1022,10 +1076,10 @@ impl Gemma4Engine {
     /// Run one decode step on every sequence in the batch and return one set
     /// of softcapped logits per sequence (`Vec<Vec<f32>>` length = batch_size).
     ///
-    /// **Phase 1 implementation**: serially calls [`Self::decode_step_seq`]
-    /// for each sequence. Same throughput as B sequential single-sequence
-    /// runs — the API is in place but the perf win waits on the kernel-side
-    /// batched megakernel (Phase 2).
+    /// When `batch_size == 1`, delegates to [`Self::decode_step_seq`] (which
+    /// uses the single-seq megakernel). When `batch_size > 1`, folds the work
+    /// into a single launch of the batched megakernel so weight reads amortize
+    /// across sequences.
     pub fn decode_step_batch(
         &mut self,
         input_tokens: &[u32],
@@ -1045,11 +1099,129 @@ impl Gemma4Engine {
                 self.batch_size
             );
         }
-        let mut out = Vec::with_capacity(self.batch_size);
-        for b in 0..self.batch_size {
-            out.push(self.decode_step_seq(b, input_tokens[b], positions[b])?);
+        for (b, &pos) in positions.iter().enumerate() {
+            if pos >= self.max_t {
+                bail!("decode_step_batch: seq {b} pos {pos} >= max_t {}", self.max_t);
+            }
         }
-        Ok(out)
+
+        if self.batch_size == 1 {
+            return Ok(vec![self.decode_step_seq(0, input_tokens[0], positions[0])?]);
+        }
+
+        let device = self.device;
+        let dtype = ScalarType::BF16;
+        let hidden_size = self.tcfg.hidden_size;
+        let eps = self.tcfg.rms_norm_eps as f32;
+        let ple_hidden = self.tcfg.hidden_size_per_layer_input;
+        let num_layers = self.tcfg.num_hidden_layers;
+        let vocab_size = self.tcfg.vocab_size;
+        let b = self.batch_size;
+
+        // Stack per-seq embedded hidden inputs → [B, hidden_size] BF16.
+        let mut hidden_host_f32: Vec<f32> = Vec::with_capacity(b * hidden_size);
+        for &tok in input_tokens {
+            let row = load_scaled_embed_row(
+                &self.loader,
+                &format!("{}.embed_tokens.weight", self.weight_prefix),
+                tok,
+                hidden_size,
+            )?;
+            hidden_host_f32.extend_from_slice(&row);
+        }
+        let mut hidden_io = upload_bf16(device, &[b, hidden_size], &hidden_host_f32)?;
+
+        // Stack per-seq PLIs → [B, num_layers, ple_hidden] BF16.
+        let expected_pli_bytes = num_layers * ple_hidden * 2;
+        let mut pli_bytes: Vec<u8> = Vec::with_capacity(b * expected_pli_bytes);
+        for &tok in input_tokens {
+            let per_seq = self.compute_per_layer_inputs_single(tok)?;
+            if per_seq.len() != expected_pli_bytes {
+                bail!(
+                    "compute_per_layer_inputs_single returned {} bytes, expected {}",
+                    per_seq.len(), expected_pli_bytes
+                );
+            }
+            pli_bytes.extend_from_slice(&per_seq);
+        }
+        let pli_gpu = GpuBuffer::from_host_bytes(
+            device, dtype, &[b, num_layers, ple_hidden], &pli_bytes,
+        )?;
+
+        // Update per-step `seqlen_offset[b]` in each layer's batch desc, then
+        // re-upload the whole [num_layers] array. KV pointers and kv_max_t are
+        // invariant across decode steps.
+        for l in 0..num_layers {
+            for (i, &pos) in positions.iter().enumerate() {
+                self.batch_descs_host[l].seqlen_offset[i] = pos as c_int;
+            }
+        }
+        let batch_descs_gpu = self
+            .batch_descs_gpu
+            .as_mut()
+            .ok_or_else(|| anyhow!("decode_step_batch: batch_descs_gpu missing"))?;
+        let desc_bytes: &[u8] = unsafe {
+            std::slice::from_raw_parts(
+                self.batch_descs_host.as_ptr() as *const u8,
+                self.batch_descs_host.len() * std::mem::size_of::<Gemma4BatchSeqDesc>(),
+            )
+        };
+        gpu_hal::copy_h2d(
+            device,
+            batch_descs_gpu.as_mut_ptr(),
+            desc_bytes.as_ptr() as *const c_void,
+            desc_bytes.len(),
+        )
+        .map_err(|e| anyhow!("upload batch_descs: {e}"))?;
+
+        // Batched megakernel launch — reuses seq 0's layers_gpu for shape +
+        // weight pointers (KV fields ignored; kernel reads them from
+        // batch_descs).
+        g4::persistent_decode_batch(
+            device, dtype,
+            &self.layers_gpu[0],
+            batch_descs_gpu,
+            &mut hidden_io,
+            &pli_gpu,
+            &mut self.mega_workspace,
+            &mut self.mega_matvec_counter,
+            &mut self.mega_barrier_counter,
+            &mut self.mega_barrier_flag,
+            num_layers, hidden_size, ple_hidden,
+            b, self.mega_ws_stride,
+            eps, 1.0f32,
+        )?;
+
+        // Final norm + lm_head + softcap, per seq. These are 2048→262144 matvecs;
+        // running them serially is fine — they dominate neither bandwidth nor
+        // latency at B=4 (~3 ms at hidden=2048, vocab=262k on gfx1150).
+        let cap = self.tcfg.final_logit_softcapping.unwrap_or(30.0) as f32;
+        let mut outs: Vec<Vec<f32>> = Vec::with_capacity(b);
+        for seq in 0..b {
+            let row_off_bytes = seq * hidden_size * 2;
+            let mut seq_hidden = GpuBuffer::zeros(device, dtype, &[hidden_size])?;
+            unsafe {
+                let src_ptr = hidden_io.offset_ptr(row_off_bytes);
+                gpu_hal::copy_d2d(device, seq_hidden.as_mut_ptr(), src_ptr, hidden_size * 2)
+                    .map_err(|e| anyhow!("copy seq {seq} hidden: {e}"))?;
+            }
+            let mut post_norm = GpuBuffer::zeros(device, dtype, &[hidden_size])?;
+            g4::rms_norm(
+                device, dtype, &mut post_norm, &seq_hidden, Some(&self.final_norm_w),
+                eps, hidden_size,
+            )?;
+            let mut logits_gpu = GpuBuffer::zeros(device, dtype, &[vocab_size])?;
+            g4::matvec(
+                device, dtype, &mut logits_gpu, &post_norm, &self.lm_head_w,
+                hidden_size, vocab_size, &mut self.counter,
+            )?;
+            let mut logits_host = download_bf16(&logits_gpu)?;
+            for v in logits_host.iter_mut() {
+                *v = cap * (*v / cap).tanh();
+            }
+            outs.push(logits_host);
+        }
+        Ok(outs)
     }
 
     /// D2D-copy sequence 0's K/V cache contents into every other sequence's

--- a/crates/runner/src/gemma4_int4_engine.rs
+++ b/crates/runner/src/gemma4_int4_engine.rs
@@ -24,7 +24,7 @@ use ::gemma4::weight_spec as g4_spec;
 use gpu_hal::{GpuBuffer, ScalarType};
 use half::bf16;
 use kernel_ffi::gemma4 as g4;
-use kernel_ffi::gemma4::{Gemma4DecodeLayerDesc, Gemma4Int4ScaleDesc};
+use kernel_ffi::gemma4::{Gemma4BatchSeqDesc, Gemma4DecodeLayerDesc, Gemma4Int4ScaleDesc};
 use model_store::BakedStore;
 
 const INT4_GROUP_SIZE: usize = 128;
@@ -334,8 +334,25 @@ pub struct Gemma4Int4Engine {
     full_cos: GpuBuffer,
     full_sin: GpuBuffer,
 
+    // Sequence-0 KV caches — also the single-seq path's only KV state.
     k_caches: Vec<GpuBuffer>,
     v_caches: Vec<GpuBuffer>,
+
+    // Sequences 1..batch_size: `extra_k_caches[seq-1][layer]`. Empty when
+    // `batch_size == 1`. Populated by [`replicate_seq0_kv`] after a prefill
+    // call and read by [`decode_step_batch`] through `batch_descs_gpu`.
+    extra_k_caches: Vec<Vec<GpuBuffer>>,
+    extra_v_caches: Vec<Vec<GpuBuffer>>,
+
+    batch_size: usize,
+    /// `[num_layers]` per-sequence descriptor array on GPU (populated when
+    /// `batch_size > 1`). Read by the batched INT4 megakernel for KV pointers
+    /// and `seqlen_offset[b]` per decode step.
+    batch_descs_host: Vec<Gemma4BatchSeqDesc>,
+    batch_descs_gpu: Option<GpuBuffer>,
+    /// Per-sequence slice stride into `fused_workspace` for the batched
+    /// megakernel (= [`g4::persistent_decode_workspace_elems`]).
+    fused_ws_stride: usize,
 
     counter: GpuBuffer,
 
@@ -361,12 +378,38 @@ pub struct Gemma4Int4Engine {
 }
 
 impl Gemma4Int4Engine {
+    /// Convenience wrapper for single-sequence loads (preserves original
+    /// signature). Delegates to [`Self::load_with_batch`] with `batch_size=1`.
     pub fn load(
         model_dir: &Path,
         weight_prefix: &str,
         max_t: usize,
         device: usize,
     ) -> Result<Self> {
+        Self::load_with_batch(model_dir, weight_prefix, max_t, device, 1)
+    }
+
+    /// Load an INT4 GPTQ bake and initialize GPU state for `batch_size`
+    /// parallel sequences. `batch_size == 1` matches the legacy single-seq
+    /// behaviour; `batch_size > 1` allocates B-1 additional per-layer K/V
+    /// cache sets and builds the batched-megakernel descriptor array.
+    pub fn load_with_batch(
+        model_dir: &Path,
+        weight_prefix: &str,
+        max_t: usize,
+        device: usize,
+        batch_size: usize,
+    ) -> Result<Self> {
+        if batch_size == 0 {
+            bail!("Gemma4Int4Engine: batch_size must be >= 1");
+        }
+        if batch_size > kernel_ffi::MAX_BATCH_SIZE {
+            bail!(
+                "Gemma4Int4Engine: batch_size {} > MAX_BATCH_SIZE {}",
+                batch_size,
+                kernel_ffi::MAX_BATCH_SIZE
+            );
+        }
         gpu_hal::set_device(device).map_err(|e| anyhow!("set_device: {e}"))?;
         let config: Config = ::gemma4::config::load_config(model_dir)
             .map_err(|e| anyhow!("load_config: {e}"))?;
@@ -454,8 +497,14 @@ impl Gemma4Int4Engine {
             tcfg.hidden_size, num_q_heads, num_kv_heads, head_dim_max, max_t,
             intermediate_max, ple_hidden,
         );
-        let fused_workspace =
-            GpuBuffer::zeros(device, ScalarType::F32, &[fused_workspace_elems])?;
+        let fused_ws_stride = fused_workspace_elems;
+        // Workspace is sized `batch_size * ws_stride`; the single-seq path
+        // only uses the first slice, the batched path uses all B slices.
+        let fused_workspace = GpuBuffer::zeros(
+            device,
+            ScalarType::F32,
+            &[batch_size * fused_workspace_elems],
+        )?;
         let fused_matvec_counter = GpuBuffer::zeros(device, ScalarType::U32, &[1])?;
         let fused_barrier_counter = GpuBuffer::zeros(device, ScalarType::U32, &[1])?;
         let fused_barrier_flag = GpuBuffer::zeros(device, ScalarType::U32, &[1])?;
@@ -568,6 +617,55 @@ impl Gemma4Int4Engine {
             device, ScalarType::U8, &[int4_scales_bytes.len()], int4_scales_bytes,
         )?;
 
+        // --- Per-sequence KV caches and batched-seq descriptor array.
+        // Extras exist only for seq 1..batch_size. Shared-KV layers inherit
+        // the source layer's per-sequence pointer (same rule as seq 0's
+        // aliasing in `layer_descs` above).
+        let mut extra_k_caches: Vec<Vec<GpuBuffer>> = Vec::with_capacity(batch_size - 1);
+        let mut extra_v_caches: Vec<Vec<GpuBuffer>> = Vec::with_capacity(batch_size - 1);
+        for _ in 1..batch_size {
+            let mut ks: Vec<GpuBuffer> = Vec::with_capacity(num_layers);
+            let mut vs: Vec<GpuBuffer> = Vec::with_capacity(num_layers);
+            for l in 0..num_layers {
+                let hd = layers[l].head_dim;
+                ks.push(GpuBuffer::zeros(device, dtype, &[num_kv_heads, max_t, hd])?);
+                vs.push(GpuBuffer::zeros(device, dtype, &[num_kv_heads, max_t, hd])?);
+            }
+            extra_k_caches.push(ks);
+            extra_v_caches.push(vs);
+        }
+
+        let mut batch_descs_host: Vec<Gemma4BatchSeqDesc> =
+            vec![Gemma4BatchSeqDesc::default(); num_layers];
+        for l in 0..num_layers {
+            let src_idx = if layers[l].shared_kv { layers[l].kv_source } else { l };
+            let d = &mut batch_descs_host[l];
+            // Seq 0: use the main k_caches/v_caches. Seqs 1..B: use extras.
+            d.seqlen_offset[0] = 0;
+            d.kv_cache_k[0] = k_caches[src_idx].as_ptr() as *mut c_void;
+            d.kv_cache_v[0] = v_caches[src_idx].as_ptr() as *mut c_void;
+            d.kv_max_t[0] = max_t as c_int;
+            for b in 1..batch_size {
+                d.seqlen_offset[b] = 0;
+                d.kv_cache_k[b] = extra_k_caches[b - 1][src_idx].as_ptr() as *mut c_void;
+                d.kv_cache_v[b] = extra_v_caches[b - 1][src_idx].as_ptr() as *mut c_void;
+                d.kv_max_t[b] = max_t as c_int;
+            }
+        }
+        let batch_descs_gpu = if batch_size > 1 {
+            let desc_bytes: &[u8] = unsafe {
+                std::slice::from_raw_parts(
+                    batch_descs_host.as_ptr() as *const u8,
+                    batch_descs_host.len() * std::mem::size_of::<Gemma4BatchSeqDesc>(),
+                )
+            };
+            Some(GpuBuffer::from_host_bytes(
+                device, ScalarType::U8, &[desc_bytes.len()], desc_bytes,
+            )?)
+        } else {
+            None
+        };
+
         Ok(Self {
             tcfg,
             store,
@@ -585,6 +683,12 @@ impl Gemma4Int4Engine {
             full_sin,
             k_caches,
             v_caches,
+            extra_k_caches,
+            extra_v_caches,
+            batch_size,
+            batch_descs_host,
+            batch_descs_gpu,
+            fused_ws_stride,
             counter,
             fused_workspace,
             fused_matvec_counter,
@@ -595,6 +699,35 @@ impl Gemma4Int4Engine {
             int4_scale_descs,
             int4_scales_gpu,
         })
+    }
+
+    pub fn batch_size(&self) -> usize {
+        self.batch_size
+    }
+
+    /// D2D-copy sequence 0's K/V cache contents into every other sequence's
+    /// caches. Use after `prefill` when all `B` sequences share the prompt.
+    pub fn replicate_seq0_kv(&mut self) -> Result<()> {
+        if self.batch_size <= 1 {
+            return Ok(());
+        }
+        let num_layers = self.tcfg.num_hidden_layers;
+        let device = self.device;
+        for l in 0..num_layers {
+            let bytes = self.k_caches[l].len_bytes();
+            let v_bytes = self.v_caches[l].len_bytes();
+            let src_k = self.k_caches[l].as_ptr();
+            let src_v = self.v_caches[l].as_ptr();
+            for b in 1..self.batch_size {
+                let dst_k = self.extra_k_caches[b - 1][l].as_mut_ptr();
+                let dst_v = self.extra_v_caches[b - 1][l].as_mut_ptr();
+                gpu_hal::copy_d2d(device, dst_k, src_k, bytes)
+                    .map_err(|e| anyhow!("int4 replicate_seq0_kv k layer {l} → seq {b}: {e}"))?;
+                gpu_hal::copy_d2d(device, dst_v, src_v, v_bytes)
+                    .map_err(|e| anyhow!("int4 replicate_seq0_kv v layer {l} → seq {b}: {e}"))?;
+            }
+        }
+        Ok(())
     }
 
     pub fn text_config(&self) -> &TextConfig {
@@ -1107,6 +1240,145 @@ impl Gemma4Int4Engine {
             *v = cap * (*v / cap).tanh();
         }
         Ok(logits_host)
+    }
+
+    /// Run one INT4 decode step on every sequence in the batch via the
+    /// batched persistent megakernel. Returns softcapped logits per seq.
+    ///
+    /// When `batch_size == 1`, delegates to [`Self::decode_step`]. When
+    /// `batch_size > 1`, one launch of `g4::persistent_decode_batch_int4`
+    /// folds the B forward passes — weight reads *and* INT4 dequant are
+    /// amortized across sequences.
+    pub fn decode_step_batch(
+        &mut self,
+        input_tokens: &[u32],
+        positions: &[usize],
+    ) -> Result<Vec<Vec<f32>>> {
+        if input_tokens.len() != self.batch_size {
+            bail!(
+                "decode_step_batch: got {} tokens, batch_size is {}",
+                input_tokens.len(), self.batch_size
+            );
+        }
+        if positions.len() != self.batch_size {
+            bail!(
+                "decode_step_batch: got {} positions, batch_size is {}",
+                positions.len(), self.batch_size
+            );
+        }
+        for (b, &pos) in positions.iter().enumerate() {
+            if pos >= self.max_t {
+                bail!("decode_step_batch: seq {b} pos {pos} >= max_t {}", self.max_t);
+            }
+        }
+
+        if self.batch_size == 1 {
+            return Ok(vec![self.decode_step(input_tokens[0], positions[0])?]);
+        }
+
+        let device = self.device;
+        let dtype = ScalarType::BF16;
+        let hidden_size = self.tcfg.hidden_size;
+        let eps = self.tcfg.rms_norm_eps as f32;
+        let ple_hidden = self.tcfg.hidden_size_per_layer_input;
+        let num_layers = self.tcfg.num_hidden_layers;
+        let vocab_size = self.tcfg.vocab_size;
+        let b = self.batch_size;
+
+        // Stack per-seq embedded hidden inputs → [B, hidden_size] BF16.
+        let mut hidden_host_f32: Vec<f32> = Vec::with_capacity(b * hidden_size);
+        for &tok in input_tokens {
+            let row = self.load_scaled_embed_row(tok)?;
+            hidden_host_f32.extend_from_slice(&row);
+        }
+        let mut hidden_io = upload_bf16(device, &[b, hidden_size], &hidden_host_f32)?;
+
+        // Stack per-seq PLIs → [B, num_layers, ple_hidden] BF16.
+        let expected_pli_bytes = num_layers * ple_hidden * 2;
+        let mut pli_bytes: Vec<u8> = Vec::with_capacity(b * expected_pli_bytes);
+        for &tok in input_tokens {
+            let per_seq = self.compute_per_layer_inputs_single(tok)?;
+            if per_seq.len() != expected_pli_bytes {
+                bail!(
+                    "compute_per_layer_inputs_single returned {} bytes, expected {}",
+                    per_seq.len(), expected_pli_bytes
+                );
+            }
+            pli_bytes.extend_from_slice(&per_seq);
+        }
+        let pli_gpu = GpuBuffer::from_host_bytes(
+            device, dtype, &[b, num_layers, ple_hidden], &pli_bytes,
+        )?;
+
+        // Update per-step `seqlen_offset[b]` in each layer's batch desc, then
+        // re-upload the whole [num_layers] array.
+        for l in 0..num_layers {
+            for (i, &pos) in positions.iter().enumerate() {
+                self.batch_descs_host[l].seqlen_offset[i] = pos as c_int;
+            }
+        }
+        let batch_descs_gpu = self
+            .batch_descs_gpu
+            .as_mut()
+            .ok_or_else(|| anyhow!("int4 decode_step_batch: batch_descs_gpu missing"))?;
+        let desc_bytes: &[u8] = unsafe {
+            std::slice::from_raw_parts(
+                self.batch_descs_host.as_ptr() as *const u8,
+                self.batch_descs_host.len() * std::mem::size_of::<Gemma4BatchSeqDesc>(),
+            )
+        };
+        gpu_hal::copy_h2d(
+            device,
+            batch_descs_gpu.as_mut_ptr(),
+            desc_bytes.as_ptr() as *const c_void,
+            desc_bytes.len(),
+        )
+        .map_err(|e| anyhow!("int4 upload batch_descs: {e}"))?;
+
+        g4::persistent_decode_batch_int4(
+            device, dtype,
+            &self.layers_gpu,
+            &self.int4_scales_gpu,
+            batch_descs_gpu,
+            &mut hidden_io,
+            &pli_gpu,
+            &mut self.fused_workspace,
+            &mut self.fused_matvec_counter,
+            &mut self.fused_barrier_counter,
+            &mut self.fused_barrier_flag,
+            num_layers, hidden_size, ple_hidden,
+            b, self.fused_ws_stride,
+            eps, 1.0f32,
+        )?;
+
+        // Per-seq final norm + lm_head + softcap.
+        let cap = self.tcfg.final_logit_softcapping.unwrap_or(30.0) as f32;
+        let mut outs: Vec<Vec<f32>> = Vec::with_capacity(b);
+        for seq in 0..b {
+            let row_off_bytes = seq * hidden_size * 2;
+            let mut seq_hidden = GpuBuffer::zeros(device, dtype, &[hidden_size])?;
+            unsafe {
+                let src_ptr = hidden_io.offset_ptr(row_off_bytes);
+                gpu_hal::copy_d2d(device, seq_hidden.as_mut_ptr(), src_ptr, hidden_size * 2)
+                    .map_err(|e| anyhow!("int4 copy seq {seq} hidden: {e}"))?;
+            }
+            let mut post_norm = GpuBuffer::zeros(device, dtype, &[hidden_size])?;
+            g4::rms_norm(
+                device, dtype, &mut post_norm, &seq_hidden, Some(&self.final_norm_w),
+                eps, hidden_size,
+            )?;
+            let mut logits_gpu = GpuBuffer::zeros(device, dtype, &[vocab_size])?;
+            g4::matvec(
+                device, dtype, &mut logits_gpu, &post_norm, &self.lm_head_w,
+                hidden_size, vocab_size, &mut self.counter,
+            )?;
+            let mut logits_host = download_bf16(&logits_gpu)?;
+            for v in logits_host.iter_mut() {
+                *v = cap * (*v / cap).tanh();
+            }
+            outs.push(logits_host);
+        }
+        Ok(outs)
     }
 
     /// Per-layer fused INT4 decode step (Step 29/30 path) — retained for

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -40,9 +40,10 @@ impl Gemma4Runtime {
         }
     }
 
-    /// Run one decode step on every sequence. Only the BF16 megakernel
-    /// engine supports `batch_size > 1` in Phase 1; INT4 still runs the
-    /// primitive-chain decode and is single-sequence only.
+    /// Run one decode step on every sequence in the batch. Both BF16 and
+    /// INT4 engines honour `--batch-size > 1` via their batched persistent
+    /// megakernels (BF16: `g4::persistent_decode_batch`, INT4:
+    /// `g4::persistent_decode_batch_int4`).
     fn decode_step_batch(
         &mut self,
         input_tokens: &[u32],
@@ -50,25 +51,23 @@ impl Gemma4Runtime {
     ) -> anyhow::Result<Vec<Vec<f32>>> {
         match self {
             Self::Bf16(e) => e.decode_step_batch(input_tokens, positions),
-            Self::Int4(_) => {
-                anyhow::bail!("Gemma 4 INT4 engine does not yet support --batch-size > 1")
-            }
+            Self::Int4(e) => e.decode_step_batch(input_tokens, positions),
         }
     }
 
     /// Replicate seq 0's K/V cache contents into every other sequence's
-    /// caches. Only meaningful for the BF16 engine; no-op on INT4.
+    /// caches. Applies to both BF16 and INT4 engines.
     fn replicate_seq0_kv(&mut self) -> anyhow::Result<()> {
         match self {
             Self::Bf16(e) => e.replicate_seq0_kv(),
-            Self::Int4(_) => Ok(()),
+            Self::Int4(e) => e.replicate_seq0_kv(),
         }
     }
 
     fn batch_size(&self) -> usize {
         match self {
             Self::Bf16(e) => e.batch_size(),
-            Self::Int4(_) => 1,
+            Self::Int4(e) => e.batch_size(),
         }
     }
 
@@ -231,8 +230,8 @@ struct Cli {
     trace_prefill_layers: bool,
 
     /// Batch size for decode (number of sequences decoded in parallel).
-    /// Default 1. B=2 is supported on the 4B kernel and can improve aggregate throughput.
-    /// Requires 4B kernel (2B/4B/9B models).
+    /// Default 1. Supported on Qwen3.5 (requires 4B kernel: 2B/4B/9B models)
+    /// and Gemma 4 BF16 + INT4 via per-family batched megakernels.
     #[arg(long, default_value = "1")]
     batch_size: usize,
 
@@ -1524,11 +1523,6 @@ fn run_gemma4(
             kernel_ffi::MAX_BATCH_SIZE
         );
     }
-    if cli.batch_size > 1 && cli.int4 {
-        anyhow::bail!(
-            "Gemma 4 INT4 engine does not yet support --batch-size > 1 (Phase 1 batches BF16 only)"
-        );
-    }
     if cli.oracle_prefill || cli.gpu_validate {
         anyhow::bail!("Gemma 4 does not yet support --oracle-prefill / --gpu-validate");
     }
@@ -1656,11 +1650,12 @@ fn run_gemma4(
             }
         }
         eprintln!("[gemma4] loading INT4 GPTQ bake (primitive-chain decode)");
-        Gemma4Runtime::Int4(gemma4_int4_engine::Gemma4Int4Engine::load(
+        Gemma4Runtime::Int4(gemma4_int4_engine::Gemma4Int4Engine::load_with_batch(
             &cli.model_dir,
             params.weight_prefix,
             context_tokens,
             ordinal,
+            cli.batch_size,
         )?)
     } else {
         Gemma4Runtime::Bf16(gemma4_engine::Gemma4Engine::load_with_batch(

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -40,6 +40,38 @@ impl Gemma4Runtime {
         }
     }
 
+    /// Run one decode step on every sequence. Only the BF16 megakernel
+    /// engine supports `batch_size > 1` in Phase 1; INT4 still runs the
+    /// primitive-chain decode and is single-sequence only.
+    fn decode_step_batch(
+        &mut self,
+        input_tokens: &[u32],
+        positions: &[usize],
+    ) -> anyhow::Result<Vec<Vec<f32>>> {
+        match self {
+            Self::Bf16(e) => e.decode_step_batch(input_tokens, positions),
+            Self::Int4(_) => {
+                anyhow::bail!("Gemma 4 INT4 engine does not yet support --batch-size > 1")
+            }
+        }
+    }
+
+    /// Replicate seq 0's K/V cache contents into every other sequence's
+    /// caches. Only meaningful for the BF16 engine; no-op on INT4.
+    fn replicate_seq0_kv(&mut self) -> anyhow::Result<()> {
+        match self {
+            Self::Bf16(e) => e.replicate_seq0_kv(),
+            Self::Int4(_) => Ok(()),
+        }
+    }
+
+    fn batch_size(&self) -> usize {
+        match self {
+            Self::Bf16(e) => e.batch_size(),
+            Self::Int4(_) => 1,
+        }
+    }
+
     fn greedy_sample(logits: &[f32]) -> u32 {
         gemma4_engine::Gemma4Engine::greedy_sample(logits)
     }
@@ -1486,8 +1518,16 @@ fn run_gemma4(
     if cli.fp8_runtime || cli.kv_fp8 {
         anyhow::bail!("Gemma 4 does not yet support --fp8-runtime / --kv-fp8");
     }
-    if cli.batch_size != 1 {
-        anyhow::bail!("Gemma 4 does not yet support --batch-size > 1");
+    if cli.batch_size < 1 || cli.batch_size > kernel_ffi::MAX_BATCH_SIZE {
+        anyhow::bail!(
+            "--batch-size must be 1..{}",
+            kernel_ffi::MAX_BATCH_SIZE
+        );
+    }
+    if cli.batch_size > 1 && cli.int4 {
+        anyhow::bail!(
+            "Gemma 4 INT4 engine does not yet support --batch-size > 1 (Phase 1 batches BF16 only)"
+        );
     }
     if cli.oracle_prefill || cli.gpu_validate {
         anyhow::bail!("Gemma 4 does not yet support --oracle-prefill / --gpu-validate");
@@ -1623,11 +1663,12 @@ fn run_gemma4(
             ordinal,
         )?)
     } else {
-        Gemma4Runtime::Bf16(gemma4_engine::Gemma4Engine::load(
+        Gemma4Runtime::Bf16(gemma4_engine::Gemma4Engine::load_with_batch(
             &cli.model_dir,
             params.weight_prefix,
             context_tokens,
             ordinal,
+            cli.batch_size,
         )?)
     };
     eprintln!("[weights] loaded in {:.0}ms", t0.elapsed().as_millis());
@@ -1659,42 +1700,71 @@ fn run_gemma4(
 
     let prefill_start = Instant::now();
     let prefill_logits = engine.prefill(&prompt_ids)?;
-    let mut next_token = Gemma4Runtime::greedy_sample(&prefill_logits);
+    let prefill_token = Gemma4Runtime::greedy_sample(&prefill_logits);
     eprintln!(
         "[prefill] native GPU prefill done in {:.0}ms",
         prefill_start.elapsed().as_millis()
     );
 
+    let batch_size = engine.batch_size();
+    if batch_size > 1 {
+        eprintln!(
+            "[batch] replicating prefill K/V across {} sequences",
+            batch_size
+        );
+        engine.replicate_seq0_kv()?;
+    }
+
     if let Some(ref oracle) = oracle_output {
         let prefill_delta = validate::max_abs_delta(&prefill_logits, &oracle.prefill_logits);
         eprintln!("[validate] prefill logit delta={prefill_delta:.4}");
         if let Some(&oracle_first) = oracle.generated_token_ids.first() {
-            if oracle_first != next_token {
+            if oracle_first != prefill_token {
                 eprintln!(
-                    "[validate] WARNING: prefill token mismatch! native={next_token} oracle={oracle_first}"
+                    "[validate] WARNING: prefill token mismatch! native={prefill_token} oracle={oracle_first}"
                 );
             }
+        }
+        if batch_size > 1 {
+            eprintln!("[validate] WARNING: --validate compares oracle vs sequence 0 only when --batch-size > 1");
         }
     }
 
     let seqlen_start = prompt_ids.len();
-    let mut generated_ids: Vec<u32> = Vec::new();
     let eos_ids = t.eos_token_ids();
     let mut max_delta = 0.0f32;
     let mut token_mismatches = 0usize;
 
+    // Per-sequence decode state. All sequences start from the same prefill
+    // token; greedy sampling will keep them identical unless something
+    // diverges (useful sanity check until Phase 2 adds true per-sequence
+    // prompts).
+    let mut next_tokens: Vec<u32> = vec![prefill_token; batch_size];
+    let mut generated_per_seq: Vec<Vec<u32>> = vec![Vec::new(); batch_size];
+    let mut seq_done: Vec<bool> = vec![false; batch_size];
+    let mut steps_done: usize = 0;
+
     let decode_start = Instant::now();
     for step in 0..cli.max_new_tokens {
-        if eos_ids.contains(&next_token) {
+        // Mark any newly-EOSed sequences but keep stepping until ALL sequences
+        // have stopped — the megakernel still has to handle the active ones.
+        for b in 0..batch_size {
+            if !seq_done[b] && eos_ids.contains(&next_tokens[b]) {
+                seq_done[b] = true;
+            }
+        }
+        if seq_done.iter().all(|d| *d) {
             break;
         }
         let pos = seqlen_start + step;
-        let logits = engine.decode_step(next_token, pos)?;
+        let positions: Vec<usize> = vec![pos; batch_size];
+        let logits_per_seq = engine.decode_step_batch(&next_tokens, &positions)?;
 
         if let Some(ref oracle) = oracle_output {
             if step < oracle.decode_logits.len() {
                 let oracle_logits = &oracle.decode_logits[step];
-                let delta = validate::max_abs_delta(&logits, oracle_logits);
+                // Always compare against sequence 0 (canonical run).
+                let delta = validate::max_abs_delta(&logits_per_seq[0], oracle_logits);
                 if delta > max_delta {
                     max_delta = delta;
                 }
@@ -1703,7 +1773,7 @@ fn run_gemma4(
                 } else {
                     None
                 };
-                let rust_next = Gemma4Runtime::greedy_sample(&logits);
+                let rust_next = Gemma4Runtime::greedy_sample(&logits_per_seq[0]);
                 let mismatch_tag = match oracle_next {
                     Some(ot) if ot != rust_next => {
                         token_mismatches += 1;
@@ -1712,43 +1782,69 @@ fn run_gemma4(
                     _ => String::new(),
                 };
                 eprintln!(
-                    "[validate] step={step} pos={pos} delta={delta:.4} input_tok={next_token} rust_next={rust_next}{mismatch_tag}"
+                    "[validate] step={step} pos={pos} delta={delta:.4} input_tok={} rust_next={rust_next}{mismatch_tag}",
+                    next_tokens[0]
                 );
             }
         }
 
-        let sampled = Gemma4Runtime::greedy_sample(&logits);
-        generated_ids.push(next_token);
-        next_token = sampled;
+        // Sample per sequence and roll forward — but only record sampled
+        // tokens for sequences that haven't already hit EOS.
+        for b in 0..batch_size {
+            if seq_done[b] {
+                continue;
+            }
+            let sampled = Gemma4Runtime::greedy_sample(&logits_per_seq[b]);
+            generated_per_seq[b].push(next_tokens[b]);
+            next_tokens[b] = sampled;
+        }
+        steps_done = step + 1;
     }
     let decode_ms = decode_start.elapsed().as_secs_f64() * 1000.0;
 
-    let all_ids: Vec<u32> = prompt_ids
-        .iter()
-        .copied()
-        .chain(generated_ids.iter().copied())
-        .collect();
-    let text = tokenizer
-        .decode(&all_ids, true)
-        .map_err(|e| anyhow::anyhow!("detokenize: {e}"))?;
-
-    println!("{text}");
-    println!(
-        "[tokens] {}",
-        generated_ids
+    // Print every sequence. For batch_size == 1 the output matches the
+    // pre-batched format (no `[seq=N]` prefix).
+    for b in 0..batch_size {
+        let all_ids: Vec<u32> = prompt_ids
             .iter()
-            .map(|id| id.to_string())
-            .collect::<Vec<_>>()
-            .join(" ")
-    );
+            .copied()
+            .chain(generated_per_seq[b].iter().copied())
+            .collect();
+        let text = tokenizer
+            .decode(&all_ids, true)
+            .map_err(|e| anyhow::anyhow!("detokenize: {e}"))?;
+        if batch_size == 1 {
+            println!("{text}");
+            println!(
+                "[tokens] {}",
+                generated_per_seq[b]
+                    .iter()
+                    .map(|id| id.to_string())
+                    .collect::<Vec<_>>()
+                    .join(" ")
+            );
+        } else {
+            println!("[seq={b}] {text}");
+            println!(
+                "[seq={b}][tokens] {}",
+                generated_per_seq[b]
+                    .iter()
+                    .map(|id| id.to_string())
+                    .collect::<Vec<_>>()
+                    .join(" ")
+            );
+        }
+    }
+
+    let total_generated: usize = generated_per_seq.iter().map(|v| v.len()).sum();
     eprintln!(
-        "[result] prompt_tokens={} generated_tokens={} decode_ms={decode_ms:.0} ms_per_tok={:.0}{}",
+        "[result] prompt_tokens={} generated_tokens={} steps={steps_done} batch_size={batch_size} decode_ms={decode_ms:.0} ms_per_step={:.0}{}",
         prompt_ids.len(),
-        generated_ids.len(),
-        if generated_ids.is_empty() {
+        total_generated,
+        if steps_done == 0 {
             0.0
         } else {
-            decode_ms / generated_ids.len() as f64
+            decode_ms / steps_done as f64
         },
         if oracle_output.is_some() {
             format!(" decode_max_delta={max_delta:.4} token_mismatches={token_mismatches}")

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -1598,21 +1598,33 @@ fn run_gemma4(
             kv_per_token += (t.num_key_value_heads * hd * 2) as u64;
         }
     }
-    let kv_bytes = kv_per_token * context_tokens as u64 * BF16_BYTES;
+    // Both BF16 and INT4 engines allocate `batch_size` parallel KV cache sets
+    // (one per decode sequence); scale accordingly so `--batch-size > 1` can't
+    // pass the preflight check and then OOM during engine load.
+    let batch_size_u64 = cli.batch_size as u64;
+    let kv_bytes_per_seq = kv_per_token * context_tokens as u64 * BF16_BYTES;
+    let kv_bytes = kv_bytes_per_seq * batch_size_u64;
     let estimated_vram =
         ((entry.vram.fixed_bytes + kv_bytes) as f64 * entry.vram.overhead_factor) as u64;
     let gib = |b: u64| b as f64 / (1024.0 * 1024.0 * 1024.0);
     eprintln!(
-        "[vram] estimated={:.2}GiB (weights+scratch={:.2}GiB + kv_cache={:.2}GiB for {}tok) available={:.1}GiB",
+        "[vram] estimated={:.2}GiB (weights+scratch={:.2}GiB + kv_cache={:.2}GiB for {}tok x B={}) available={:.1}GiB",
         gib(estimated_vram),
         gib(entry.vram.fixed_bytes),
         gib(kv_bytes),
         context_tokens,
+        cli.batch_size,
         gib(total_vram),
     );
     if estimated_vram > total_vram {
+        let reduce_hint = if cli.batch_size > 1 {
+            "Reduce --context-size, --max-new-tokens, or --batch-size."
+        } else {
+            "Reduce --context-size or --max-new-tokens."
+        };
         anyhow::bail!(
-            "Insufficient VRAM for {context_tokens}-token context: need ~{:.2}GiB, GPU has {:.1}GiB. Reduce --context-size or --max-new-tokens.",
+            "Insufficient VRAM for {context_tokens}-token context at batch_size={}: need ~{:.2}GiB, GPU has {:.1}GiB. {reduce_hint}",
+            cli.batch_size,
             gib(estimated_vram),
             gib(total_vram),
         );

--- a/kernels/gemma4.hip
+++ b/kernels/gemma4.hip
@@ -2466,6 +2466,22 @@ struct Gemma4Int4ScaleDesc {
     int         group_size;
 };
 
+// Mirror of `Gemma4BatchSeqDesc` in `crates/kernel-ffi/src/gemma4.rs`. One
+// per layer (parallel to `Gemma4DecodeLayerDesc`), holding per-sequence
+// state arrays for the batched persistent decode kernel. Field order and
+// array length must match the Rust `#[repr(C)]` declaration exactly.
+//
+// `G4_MAX_BATCH_SIZE` mirrors `kernel_ffi::layer_desc::MAX_BATCH_SIZE` (8).
+// Only the first `batch_size` entries are populated; remaining slots are
+// ignored by the kernel.
+#define G4_MAX_BATCH_SIZE 8
+struct Gemma4BatchSeqDesc {
+    int   seqlen_offset[G4_MAX_BATCH_SIZE];
+    void* kv_cache_k[G4_MAX_BATCH_SIZE];
+    void* kv_cache_v[G4_MAX_BATCH_SIZE];
+    int   kv_max_t[G4_MAX_BATCH_SIZE];
+};
+
 template <typename T>
 __global__ void g4_persistent_decode_kernel(
     int num_layers,
@@ -2970,6 +2986,709 @@ __global__ void g4_persistent_decode_kernel(
         for (int c = tid + blockIdx.x * bs; c < hidden_size; c += bs * nb) {
             const float v = (b_h_pre_ple[c] + b_normed_ple[c]) * layer_scalar;
             hidden_io[c] = g4_from_float<T>(v);
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+    }
+}
+
+// =============================================================================
+// Persistent decode megakernel — batched variant (Phase 2).
+//
+// Structural clone of `g4_persistent_decode_kernel` that runs `batch_size`
+// decode tokens through all layers in a single kernel launch. Weight reads in
+// the six matvec phases (A2 QKV, A7 o_proj, B2 gate+up, B4 down,
+// B7 per_layer_input_gate, B9 per_layer_projection) are amortized across
+// sequences via per-sequence scalar accumulators — each weight row is loaded
+// once and dot-producted against `batch_size` activation vectors.
+//
+// Non-matmul phases (norms, RoPE, attention scores/softmax/value aggregation,
+// KV append, gelu*up, gelu*ple, residuals, layer_scalar multiply) iterate
+// over sequences serially — they're not bandwidth-bound on weights and this
+// keeps the control flow close to the validated single-seq body.
+//
+// Per-sequence state (`seqlen_offset`, `kv_cache_k/v`, `kv_max_t`) lives in
+// the `batch_descs[num_layers]` array, indexed by `[layer]`. Shared-KV layers
+// must have their per-sequence `kv_cache_k/v` pointers aliased to the source
+// layer's per-sequence pointers — the kernel does not replicate.
+//
+// Workspace layout: each sequence gets its own `ws_stride`-element slice of
+// `workspace`. Within a slice the layout matches the single-seq kernel exactly
+// (Phase A and Phase B share the slice from offset 0). The caller sizes
+// `workspace` as `batch_size * persistent_decode_workspace_elems(...)` floats.
+//
+// `hidden_io` is `[batch_size, hidden_size]` contiguous; `per_layer_inputs` is
+// `[batch_size, num_layers, ple_hidden]` contiguous.
+// =============================================================================
+template <typename T>
+__global__ void g4_persistent_decode_batch_kernel(
+    int num_layers,
+    int hidden_size,
+    int ple_hidden,
+    float eps,
+    float scale,
+    int batch_size,
+    int ws_stride,
+    const Gemma4DecodeLayerDesc* __restrict__ layers,
+    const Gemma4BatchSeqDesc* __restrict__ batch_descs,  // [num_layers]
+    T* __restrict__ hidden_io,                           // [B, hidden_size] BF16
+    const T* __restrict__ per_layer_inputs,              // [B, num_layers, ple_hidden] BF16
+    float* __restrict__ workspace,                       // [B * ws_stride]
+    unsigned int* __restrict__ matvec_counter,
+    unsigned int* __restrict__ barrier_counter,
+    unsigned int* __restrict__ barrier_flag
+) __attribute__((launch_bounds(256, 1))) {
+    const int tid = threadIdx.x;
+    const int bs = blockDim.x;
+    const int nb = gridDim.x;
+    const int B = batch_size;
+
+    extern __shared__ float lds[];
+
+    for (int layer = 0; layer < num_layers; ++layer) {
+        const Gemma4DecodeLayerDesc L = layers[layer];
+        const Gemma4BatchSeqDesc   S = batch_descs[layer];
+        const int num_q_heads = L.num_q_heads;
+        const int num_kv_heads = L.num_kv_heads;
+        const int head_dim = L.head_dim;
+        const int rotary_dim = L.rotary_dim;
+        const int sliding_window = L.sliding_window;
+        const int shared_kv = L.shared_kv;
+        const int q_dim = num_q_heads * head_dim;
+        const int kv_dim = num_kv_heads * head_dim;
+
+        const T* input_norm_w = static_cast<const T*>(L.input_norm_w);
+        const T* q_proj_w = static_cast<const T*>(L.q_proj_w);
+        const T* k_proj_w = static_cast<const T*>(L.k_proj_w);
+        const T* v_proj_w = static_cast<const T*>(L.v_proj_w);
+        const T* q_norm_w = static_cast<const T*>(L.q_norm_w);
+        const T* k_norm_w = static_cast<const T*>(L.k_norm_w);
+        const T* o_proj_w = static_cast<const T*>(L.o_proj_w);
+        const T* post_attn_norm_w = static_cast<const T*>(L.post_attn_norm_w);
+        const T* cos_table = static_cast<const T*>(L.cos_table);
+        const T* sin_table = static_cast<const T*>(L.sin_table);
+
+        // =========================================================
+        // Phase A — attention block (per-seq loops).
+        // =========================================================
+
+        // A0: load hidden_io BF16 → hidden_f32 for each sequence.
+        for (int b = 0; b < B; ++b) {
+            float* hidden_f32 = workspace + b * ws_stride;
+            T* hb = hidden_io + static_cast<size_t>(b) * hidden_size;
+            for (int c = tid + blockIdx.x * bs; c < hidden_size; c += bs * nb) {
+                hidden_f32[c] = g4_to_float(hb[c]);
+            }
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        // A1: input_norm on block 0 (loop B).
+        if (blockIdx.x == 0) {
+            for (int b = 0; b < B; ++b) {
+                float* hidden_f32 = workspace + b * ws_stride;
+                float* normed_f32 = hidden_f32 + hidden_size;
+                g4_block_rms_norm_f32<T>(normed_f32, hidden_f32, input_norm_w,
+                                          hidden_size, eps, lds);
+            }
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        // A2: work-stealing QKV matmul — amortize weight load across B seqs.
+        if (blockIdx.x == 0 && tid == 0) {
+            __atomic_store_n(matvec_counter, 0u, __ATOMIC_RELAXED);
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        {
+            const int total_qkv = shared_kv ? q_dim : (q_dim + 2 * kv_dim);
+            while (true) {
+                __shared__ unsigned int claimed;
+                if (tid == 0) claimed = atomicAdd(matvec_counter, 1u);
+                __syncthreads();
+                const unsigned int row = claimed;
+                if (row >= static_cast<unsigned int>(total_qkv)) break;
+
+                const T* w;
+                int weight_row;
+                if (row < static_cast<unsigned int>(q_dim)) {
+                    w = q_proj_w;
+                    weight_row = static_cast<int>(row);
+                } else if (row < static_cast<unsigned int>(q_dim + kv_dim)) {
+                    w = k_proj_w;
+                    weight_row = static_cast<int>(row - q_dim);
+                } else {
+                    w = v_proj_w;
+                    weight_row = static_cast<int>(row - q_dim - kv_dim);
+                }
+                const T* w_row =
+                    w + static_cast<size_t>(weight_row) * hidden_size;
+
+                float pacc[G4_MAX_BATCH_SIZE];
+                #pragma unroll
+                for (int b = 0; b < G4_MAX_BATCH_SIZE; ++b) pacc[b] = 0.0f;
+
+                for (int c = tid; c < hidden_size; c += bs) {
+                    const float wv = g4_to_float(w_row[c]);
+                    for (int b = 0; b < B; ++b) {
+                        const float* normed_f32 = workspace + b * ws_stride + hidden_size;
+                        pacc[b] += wv * normed_f32[c];
+                    }
+                }
+
+                for (int b = 0; b < B; ++b) {
+                    lds[tid] = pacc[b];
+                    __syncthreads();
+                    for (int s = bs / 2; s > 0; s >>= 1) {
+                        if (tid < s) lds[tid] += lds[tid + s];
+                        __syncthreads();
+                    }
+                    if (tid == 0) {
+                        float* proj_f32 = workspace + b * ws_stride + 2 * hidden_size;
+                        proj_f32[row] = lds[0];
+                    }
+                    __syncthreads();
+                }
+            }
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        // A3: q/k/v norms + RoPE + KV append (block 0, per-seq loop).
+        if (blockIdx.x == 0) {
+            for (int b = 0; b < B; ++b) {
+                float* proj_f32 = workspace + b * ws_stride + 2 * hidden_size;
+                float* q_f32 = proj_f32;
+                float* k_f32 = proj_f32 + q_dim;
+                float* v_f32 = proj_f32 + q_dim + kv_dim;
+                const int position_b = S.seqlen_offset[b];
+                const int max_T_b = S.kv_max_t[b];
+                T* k_cache_b = static_cast<T*>(S.kv_cache_k[b]);
+                T* v_cache_b = static_cast<T*>(S.kv_cache_v[b]);
+                if (!shared_kv) {
+                    g4_block_rms_norm_per_head_f32<T>(q_f32, q_norm_w,
+                        num_q_heads, head_dim, eps, lds);
+                    g4_block_rms_norm_per_head_f32<T>(k_f32, k_norm_w,
+                        num_kv_heads, head_dim, eps, lds);
+                    g4_block_rms_norm_per_head_f32<T>(v_f32, (const T*)nullptr,
+                        num_kv_heads, head_dim, eps, lds);
+                    g4_block_rope_f32<T>(q_f32, cos_table, sin_table,
+                        num_q_heads, head_dim, rotary_dim, position_b);
+                    g4_block_rope_f32<T>(k_f32, cos_table, sin_table,
+                        num_kv_heads, head_dim, rotary_dim, position_b);
+                    g4_block_kv_append_f32_to_bf16<T>(k_f32, v_f32, k_cache_b, v_cache_b,
+                        num_kv_heads, head_dim, position_b, max_T_b);
+                } else {
+                    g4_block_rms_norm_per_head_f32<T>(q_f32, q_norm_w,
+                        num_q_heads, head_dim, eps, lds);
+                    g4_block_rope_f32<T>(q_f32, cos_table, sin_table,
+                        num_q_heads, head_dim, rotary_dim, position_b);
+                }
+            }
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        // A4: attention scores (per-seq loop).
+        const int num_q_per_kv = num_q_heads / num_kv_heads;
+        for (int b = 0; b < B; ++b) {
+            const int position_b = S.seqlen_offset[b];
+            const int max_T_b = S.kv_max_t[b];
+            const T* k_cache_b = static_cast<const T*>(S.kv_cache_k[b]);
+            const float* proj_f32 = workspace + b * ws_stride + 2 * hidden_size;
+            const float* q_f32 = proj_f32;
+            float* scores_f32 = workspace + b * ws_stride + 2 * hidden_size
+                                + q_dim + 2 * kv_dim;
+            const int kv_len = position_b + 1;
+            const int last = kv_len - 1;
+            const int min_t = (sliding_window > 0) ? max(0, last - sliding_window + 1) : 0;
+            const int total_items = num_q_heads * kv_len;
+            for (int item = blockIdx.x * bs + tid;
+                 item < total_items; item += nb * bs) {
+                const int t = item % kv_len;
+                const int q_h = item / kv_len;
+                float val;
+                if (t < min_t) {
+                    val = -INFINITY;
+                } else {
+                    const int kv_h = q_h / num_q_per_kv;
+                    const float* qr = q_f32 +
+                        static_cast<size_t>(q_h) * head_dim;
+                    const T* kr = k_cache_b +
+                        (static_cast<size_t>(kv_h) * max_T_b + t) * head_dim;
+                    float acc = 0.0f;
+                    for (int d = 0; d < head_dim; ++d) {
+                        acc += qr[d] * g4_to_float(kr[d]);
+                    }
+                    val = acc * scale;
+                }
+                scores_f32[static_cast<size_t>(q_h) * max_T_b + t] = val;
+            }
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        // A5: softmax per q head (per-seq loop).
+        for (int b = 0; b < B; ++b) {
+            const int position_b = S.seqlen_offset[b];
+            const int max_T_b = S.kv_max_t[b];
+            float* scores_f32 = workspace + b * ws_stride + 2 * hidden_size
+                                + q_dim + 2 * kv_dim;
+            const int kv_len = position_b + 1;
+            for (int q_h = blockIdx.x; q_h < num_q_heads; q_h += nb) {
+                float* row = scores_f32 + static_cast<size_t>(q_h) * max_T_b;
+                float pm = -INFINITY;
+                for (int t = tid; t < kv_len; t += bs) pm = fmaxf(pm, row[t]);
+                lds[tid] = pm;
+                __syncthreads();
+                for (int s = bs / 2; s > 0; s >>= 1) {
+                    if (tid < s) lds[tid] = fmaxf(lds[tid], lds[tid + s]);
+                    __syncthreads();
+                }
+                const float mx = lds[0];
+                __syncthreads();
+                float ps = 0.0f;
+                for (int t = tid; t < kv_len; t += bs) {
+                    const float e = expf(row[t] - mx);
+                    row[t] = e;
+                    ps += e;
+                }
+                lds[tid] = ps;
+                __syncthreads();
+                for (int s = bs / 2; s > 0; s >>= 1) {
+                    if (tid < s) lds[tid] += lds[tid + s];
+                    __syncthreads();
+                }
+                const float inv_sum = 1.0f / lds[0];
+                __syncthreads();
+                for (int t = tid; t < kv_len; t += bs) row[t] *= inv_sum;
+                __syncthreads();
+            }
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        // A6: value aggregation (per-seq loop).
+        for (int b = 0; b < B; ++b) {
+            const int position_b = S.seqlen_offset[b];
+            const int max_T_b = S.kv_max_t[b];
+            const T* v_cache_b = static_cast<const T*>(S.kv_cache_v[b]);
+            const float* scores_f32 = workspace + b * ws_stride + 2 * hidden_size
+                                      + q_dim + 2 * kv_dim;
+            float* attn_out_f32 = workspace + b * ws_stride + 2 * hidden_size
+                                  + q_dim + 2 * kv_dim + num_q_heads * max_T_b;
+            const int kv_len = position_b + 1;
+            const int total_items = num_q_heads * head_dim;
+            for (int item = blockIdx.x * bs + tid;
+                 item < total_items; item += nb * bs) {
+                const int d = item % head_dim;
+                const int q_h = item / head_dim;
+                const int kv_h = q_h / num_q_per_kv;
+                const float* pr = scores_f32 +
+                    static_cast<size_t>(q_h) * max_T_b;
+                float acc = 0.0f;
+                for (int t = 0; t < kv_len; ++t) {
+                    const T* vr = v_cache_b +
+                        (static_cast<size_t>(kv_h) * max_T_b + t) * head_dim;
+                    acc += pr[t] * g4_to_float(vr[d]);
+                }
+                attn_out_f32[static_cast<size_t>(q_h) * head_dim + d] = acc;
+            }
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        // A7: work-stealing o_proj — amortize weight load across B seqs.
+        // `scores_f32` has stride `num_q_heads * max_T_b` per seq. All seqs in
+        // this engine share the same allocated `max_t` (L.kv_max_t), so use it
+        // as the uniform stride when computing offsets past scores_f32.
+        const int attn_out_base_off = 2 * hidden_size + q_dim + 2 * kv_dim
+                                    + num_q_heads * L.kv_max_t;
+        if (blockIdx.x == 0 && tid == 0) {
+            __atomic_store_n(matvec_counter, 0u, __ATOMIC_RELAXED);
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        while (true) {
+            __shared__ unsigned int claimed;
+            if (tid == 0) claimed = atomicAdd(matvec_counter, 1u);
+            __syncthreads();
+            const unsigned int row = claimed;
+            if (row >= static_cast<unsigned int>(hidden_size)) break;
+            const T* wr = o_proj_w + static_cast<size_t>(row) * q_dim;
+
+            float pacc[G4_MAX_BATCH_SIZE];
+            #pragma unroll
+            for (int b = 0; b < G4_MAX_BATCH_SIZE; ++b) pacc[b] = 0.0f;
+
+            for (int c = tid; c < q_dim; c += bs) {
+                const float wv = g4_to_float(wr[c]);
+                for (int b = 0; b < B; ++b) {
+                    const float* attn_out_f32 = workspace + b * ws_stride
+                                                + attn_out_base_off;
+                    pacc[b] += wv * attn_out_f32[c];
+                }
+            }
+
+            for (int b = 0; b < B; ++b) {
+                lds[tid] = pacc[b];
+                __syncthreads();
+                for (int s = bs / 2; s > 0; s >>= 1) {
+                    if (tid < s) lds[tid] += lds[tid + s];
+                    __syncthreads();
+                }
+                if (tid == 0) {
+                    float* oproj_f32 = workspace + b * ws_stride
+                                       + attn_out_base_off + q_dim;
+                    oproj_f32[row] = lds[0];
+                }
+                __syncthreads();
+            }
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        // A8: post_attn_norm on block 0 (loop B).
+        if (blockIdx.x == 0) {
+            for (int b = 0; b < B; ++b) {
+                float* oproj_f32 = workspace + b * ws_stride
+                                   + attn_out_base_off + q_dim;
+                float* oproj_normed = oproj_f32 + hidden_size;
+                g4_block_rms_norm_f32<T>(oproj_normed, oproj_f32, post_attn_norm_w,
+                                          hidden_size, eps, lds);
+            }
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        // A9: residual add + BF16 store → hidden_io = h_mid, per-seq.
+        for (int b = 0; b < B; ++b) {
+            const float* hidden_f32 = workspace + b * ws_stride;
+            const float* oproj_normed = workspace + b * ws_stride
+                                        + attn_out_base_off + q_dim + hidden_size;
+            T* hb = hidden_io + static_cast<size_t>(b) * hidden_size;
+            for (int c = tid + blockIdx.x * bs; c < hidden_size; c += bs * nb) {
+                hb[c] = g4_from_float<T>(hidden_f32[c] + oproj_normed[c]);
+            }
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        // =========================================================
+        // Phase B — MLP + PLE (per-seq loops).
+        // =========================================================
+        const int intermediate_size = L.intermediate_size;
+        const float layer_scalar = L.layer_scalar;
+        const T* pre_ff_norm_w = static_cast<const T*>(L.pre_ff_norm_w);
+        const T* gate_proj_w = static_cast<const T*>(L.gate_proj_w);
+        const T* up_proj_w = static_cast<const T*>(L.up_proj_w);
+        const T* down_proj_w = static_cast<const T*>(L.down_proj_w);
+        const T* post_ff_norm_w = static_cast<const T*>(L.post_ff_norm_w);
+        const T* pli_gate_w =
+            static_cast<const T*>(L.per_layer_input_gate_w);
+        const T* pli_proj_w =
+            static_cast<const T*>(L.per_layer_projection_w);
+        const T* pli_post_norm_w =
+            static_cast<const T*>(L.post_per_layer_input_norm_w);
+
+        // Per-seq Phase-B workspace layout (slice base = workspace + b*ws_stride):
+        //   [0]                               b_hidden_f32  [hidden]
+        //   [hidden]                          b_normed_ff   [hidden]
+        //   [2*hidden]                        b_gate_up     [2*intermediate]
+        //   [2*hidden + 2*inter]              b_gated_proj  [intermediate]
+        //   [2*hidden + 3*inter]              b_down_out    [hidden]
+        //   [3*hidden + 3*inter]              b_normed_down [hidden]
+        //   [4*hidden + 3*inter]              b_h_pre_ple   [hidden]
+        //   [5*hidden + 3*inter]              b_gated_ple   [ple_hidden]
+        //   [5*hidden + 3*inter + ple_h]      b_gated_act   [ple_hidden]
+        //   [5*hidden + 3*inter + 2*ple_h]    b_projected   [hidden]
+        //   [6*hidden + 3*inter + 2*ple_h]    b_normed_ple  [hidden]
+
+        // B0: load h_mid BF16 → b_hidden_f32 (per-seq).
+        for (int b = 0; b < B; ++b) {
+            float* b_hidden_f32 = workspace + b * ws_stride;
+            T* hb = hidden_io + static_cast<size_t>(b) * hidden_size;
+            for (int c = tid + blockIdx.x * bs; c < hidden_size; c += bs * nb) {
+                b_hidden_f32[c] = g4_to_float(hb[c]);
+            }
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        // B1: pre_ff_norm on block 0 (loop B).
+        if (blockIdx.x == 0) {
+            for (int b = 0; b < B; ++b) {
+                float* b_hidden_f32 = workspace + b * ws_stride;
+                float* b_normed_ff = b_hidden_f32 + hidden_size;
+                g4_block_rms_norm_f32<T>(b_normed_ff, b_hidden_f32, pre_ff_norm_w,
+                                          hidden_size, eps, lds);
+            }
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        // B2: work-stealing gate+up matmul — amortized.
+        if (blockIdx.x == 0 && tid == 0) {
+            __atomic_store_n(matvec_counter, 0u, __ATOMIC_RELAXED);
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        {
+            const int total_mlp1 = 2 * intermediate_size;
+            while (true) {
+                __shared__ unsigned int claimed;
+                if (tid == 0) claimed = atomicAdd(matvec_counter, 1u);
+                __syncthreads();
+                const unsigned int row = claimed;
+                if (row >= static_cast<unsigned int>(total_mlp1)) break;
+
+                const T* w = (row < static_cast<unsigned int>(intermediate_size))
+                    ? gate_proj_w : up_proj_w;
+                const int weight_row =
+                    (row < static_cast<unsigned int>(intermediate_size))
+                        ? static_cast<int>(row)
+                        : static_cast<int>(row - intermediate_size);
+                const T* wr = w + static_cast<size_t>(weight_row) * hidden_size;
+
+                float pacc[G4_MAX_BATCH_SIZE];
+                #pragma unroll
+                for (int b = 0; b < G4_MAX_BATCH_SIZE; ++b) pacc[b] = 0.0f;
+
+                for (int c = tid; c < hidden_size; c += bs) {
+                    const float wv = g4_to_float(wr[c]);
+                    for (int b = 0; b < B; ++b) {
+                        const float* b_normed_ff = workspace + b * ws_stride + hidden_size;
+                        pacc[b] += wv * b_normed_ff[c];
+                    }
+                }
+
+                for (int b = 0; b < B; ++b) {
+                    lds[tid] = pacc[b];
+                    __syncthreads();
+                    for (int s = bs / 2; s > 0; s >>= 1) {
+                        if (tid < s) lds[tid] += lds[tid + s];
+                        __syncthreads();
+                    }
+                    if (tid == 0) {
+                        float* b_gate_up = workspace + b * ws_stride + 2 * hidden_size;
+                        b_gate_up[row] = lds[0];
+                    }
+                    __syncthreads();
+                }
+            }
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        // B3: gated_proj[i] = gelu(gate[i]) * up[i], per-seq.
+        for (int b = 0; b < B; ++b) {
+            const float* b_gate_up = workspace + b * ws_stride + 2 * hidden_size;
+            const float* gate_slot = b_gate_up;
+            const float* up_slot = b_gate_up + intermediate_size;
+            float* b_gated_proj = workspace + b * ws_stride + 2 * hidden_size
+                                  + 2 * intermediate_size;
+            for (int i = tid + blockIdx.x * bs;
+                 i < intermediate_size; i += bs * nb) {
+                b_gated_proj[i] = g4_gelu_tanh_scalar(gate_slot[i]) * up_slot[i];
+            }
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        // B4: work-stealing down_proj — amortized.
+        if (blockIdx.x == 0 && tid == 0) {
+            __atomic_store_n(matvec_counter, 0u, __ATOMIC_RELAXED);
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        while (true) {
+            __shared__ unsigned int claimed;
+            if (tid == 0) claimed = atomicAdd(matvec_counter, 1u);
+            __syncthreads();
+            const unsigned int row = claimed;
+            if (row >= static_cast<unsigned int>(hidden_size)) break;
+
+            const T* wr = down_proj_w +
+                static_cast<size_t>(row) * intermediate_size;
+
+            float pacc[G4_MAX_BATCH_SIZE];
+            #pragma unroll
+            for (int b = 0; b < G4_MAX_BATCH_SIZE; ++b) pacc[b] = 0.0f;
+
+            for (int c = tid; c < intermediate_size; c += bs) {
+                const float wv = g4_to_float(wr[c]);
+                for (int b = 0; b < B; ++b) {
+                    const float* b_gated_proj = workspace + b * ws_stride
+                                                + 2 * hidden_size + 2 * intermediate_size;
+                    pacc[b] += wv * b_gated_proj[c];
+                }
+            }
+
+            for (int b = 0; b < B; ++b) {
+                lds[tid] = pacc[b];
+                __syncthreads();
+                for (int s = bs / 2; s > 0; s >>= 1) {
+                    if (tid < s) lds[tid] += lds[tid + s];
+                    __syncthreads();
+                }
+                if (tid == 0) {
+                    float* b_down_out = workspace + b * ws_stride
+                                        + 2 * hidden_size + 3 * intermediate_size;
+                    b_down_out[row] = lds[0];
+                }
+                __syncthreads();
+            }
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        // B5: post_ff_norm on block 0 (loop B).
+        if (blockIdx.x == 0) {
+            for (int b = 0; b < B; ++b) {
+                float* b_down_out = workspace + b * ws_stride
+                                    + 2 * hidden_size + 3 * intermediate_size;
+                float* b_normed_down = b_down_out + hidden_size;
+                g4_block_rms_norm_f32<T>(b_normed_down, b_down_out, post_ff_norm_w,
+                                          hidden_size, eps, lds);
+            }
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        // B6: h_pre_ple = b_hidden_f32 + b_normed_down, per-seq.
+        for (int b = 0; b < B; ++b) {
+            const float* b_hidden_f32 = workspace + b * ws_stride;
+            const float* b_normed_down = workspace + b * ws_stride
+                                         + 3 * hidden_size + 3 * intermediate_size;
+            float* b_h_pre_ple = workspace + b * ws_stride
+                                 + 4 * hidden_size + 3 * intermediate_size;
+            for (int c = tid + blockIdx.x * bs; c < hidden_size; c += bs * nb) {
+                b_h_pre_ple[c] = b_hidden_f32[c] + b_normed_down[c];
+            }
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        // B7: work-stealing per_layer_input_gate matvec — amortized.
+        if (blockIdx.x == 0 && tid == 0) {
+            __atomic_store_n(matvec_counter, 0u, __ATOMIC_RELAXED);
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        while (true) {
+            __shared__ unsigned int claimed;
+            if (tid == 0) claimed = atomicAdd(matvec_counter, 1u);
+            __syncthreads();
+            const unsigned int row = claimed;
+            if (row >= static_cast<unsigned int>(ple_hidden)) break;
+
+            const T* wr = pli_gate_w +
+                static_cast<size_t>(row) * hidden_size;
+
+            float pacc[G4_MAX_BATCH_SIZE];
+            #pragma unroll
+            for (int b = 0; b < G4_MAX_BATCH_SIZE; ++b) pacc[b] = 0.0f;
+
+            for (int c = tid; c < hidden_size; c += bs) {
+                const float wv = g4_to_float(wr[c]);
+                for (int b = 0; b < B; ++b) {
+                    const float* b_h_pre_ple = workspace + b * ws_stride
+                                               + 4 * hidden_size + 3 * intermediate_size;
+                    pacc[b] += wv * b_h_pre_ple[c];
+                }
+            }
+
+            for (int b = 0; b < B; ++b) {
+                lds[tid] = pacc[b];
+                __syncthreads();
+                for (int s = bs / 2; s > 0; s >>= 1) {
+                    if (tid < s) lds[tid] += lds[tid + s];
+                    __syncthreads();
+                }
+                if (tid == 0) {
+                    float* b_gated_ple = workspace + b * ws_stride
+                                         + 5 * hidden_size + 3 * intermediate_size;
+                    b_gated_ple[row] = lds[0];
+                }
+                __syncthreads();
+            }
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        // B8: gated_act = gelu(gated_ple) * per_layer_input, per-seq.
+        for (int b = 0; b < B; ++b) {
+            const float* b_gated_ple = workspace + b * ws_stride
+                                       + 5 * hidden_size + 3 * intermediate_size;
+            float* b_gated_act = workspace + b * ws_stride
+                                 + 5 * hidden_size + 3 * intermediate_size + ple_hidden;
+            const T* per_layer_input = per_layer_inputs
+                + (static_cast<size_t>(b) * num_layers + layer) * ple_hidden;
+            for (int i = tid + blockIdx.x * bs; i < ple_hidden; i += bs * nb) {
+                const float g = g4_gelu_tanh_scalar(b_gated_ple[i]);
+                b_gated_act[i] = g * g4_to_float(per_layer_input[i]);
+            }
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        // B9: work-stealing per_layer_projection matvec — amortized.
+        if (blockIdx.x == 0 && tid == 0) {
+            __atomic_store_n(matvec_counter, 0u, __ATOMIC_RELAXED);
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        while (true) {
+            __shared__ unsigned int claimed;
+            if (tid == 0) claimed = atomicAdd(matvec_counter, 1u);
+            __syncthreads();
+            const unsigned int row = claimed;
+            if (row >= static_cast<unsigned int>(hidden_size)) break;
+
+            const T* wr = pli_proj_w +
+                static_cast<size_t>(row) * ple_hidden;
+
+            float pacc[G4_MAX_BATCH_SIZE];
+            #pragma unroll
+            for (int b = 0; b < G4_MAX_BATCH_SIZE; ++b) pacc[b] = 0.0f;
+
+            for (int c = tid; c < ple_hidden; c += bs) {
+                const float wv = g4_to_float(wr[c]);
+                for (int b = 0; b < B; ++b) {
+                    const float* b_gated_act = workspace + b * ws_stride
+                                               + 5 * hidden_size + 3 * intermediate_size
+                                               + ple_hidden;
+                    pacc[b] += wv * b_gated_act[c];
+                }
+            }
+
+            for (int b = 0; b < B; ++b) {
+                lds[tid] = pacc[b];
+                __syncthreads();
+                for (int s = bs / 2; s > 0; s >>= 1) {
+                    if (tid < s) lds[tid] += lds[tid + s];
+                    __syncthreads();
+                }
+                if (tid == 0) {
+                    float* b_projected = workspace + b * ws_stride
+                                         + 5 * hidden_size + 3 * intermediate_size
+                                         + 2 * ple_hidden;
+                    b_projected[row] = lds[0];
+                }
+                __syncthreads();
+            }
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        // B10: post_per_layer_input_norm on block 0 (loop B).
+        if (blockIdx.x == 0) {
+            for (int b = 0; b < B; ++b) {
+                float* b_projected = workspace + b * ws_stride
+                                     + 5 * hidden_size + 3 * intermediate_size
+                                     + 2 * ple_hidden;
+                float* b_normed_ple = workspace + b * ws_stride
+                                      + 6 * hidden_size + 3 * intermediate_size
+                                      + 2 * ple_hidden;
+                g4_block_rms_norm_f32<T>(b_normed_ple, b_projected,
+                                          pli_post_norm_w,
+                                          hidden_size, eps, lds);
+            }
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        // B11: hidden_io = bf16((h_pre_ple + normed_ple) * layer_scalar), per-seq.
+        for (int b = 0; b < B; ++b) {
+            const float* b_h_pre_ple = workspace + b * ws_stride
+                                       + 4 * hidden_size + 3 * intermediate_size;
+            const float* b_normed_ple = workspace + b * ws_stride
+                                        + 6 * hidden_size + 3 * intermediate_size
+                                        + 2 * ple_hidden;
+            T* hb = hidden_io + static_cast<size_t>(b) * hidden_size;
+            for (int c = tid + blockIdx.x * bs; c < hidden_size; c += bs * nb) {
+                const float v = (b_h_pre_ple[c] + b_normed_ple[c]) * layer_scalar;
+                hb[c] = g4_from_float<T>(v);
+            }
         }
         g4_grid_barrier(barrier_counter, barrier_flag, nb);
     }
@@ -3598,6 +4317,776 @@ __global__ void g4_persistent_decode_int4_kernel(
         for (int c = tid + blockIdx.x * bs; c < hidden_size; c += bs * nb) {
             const float v = (b_h_pre_ple[c] + b_normed_ple[c]) * layer_scalar;
             hidden_io[c] = g4_from_float<T>(v);
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+    }
+}
+
+// =============================================================================
+// Persistent decode megakernel — batched INT4 variant.
+//
+// Structural clone of `g4_persistent_decode_batch_kernel`. Six matmul phases
+// (A2 QKV, A7 o_proj, B2 gate+up, B4 down, B7 per_layer_input_gate,
+// B9 per_layer_projection) retarget their inner reduction loops to the 8-wide
+// INT4 dequant path via `g4_int4_dequant_8`. Each work-stealing iteration
+// holds `float pacc[G4_MAX_BATCH_SIZE]` — the dequant'd row is shared across
+// all `B` sequences, so weight *and* dequant work are amortized. Non-matmul
+// phases (norms, RoPE, attn scores/softmax/value, KV append, gelu gating,
+// residuals, layer_scalar multiply) iterate sequences serially and are
+// byte-for-byte copies of the BF16 batched kernel.
+//
+// Per-sequence state lives in `batch_descs[num_layers]` (same struct as the
+// BF16 batched kernel). Workspace sliced per-seq with stride `ws_stride`.
+// `hidden_io` is `[B, hidden_size]` contiguous; `per_layer_inputs` is
+// `[B, num_layers, ple_hidden]` contiguous.
+// =============================================================================
+template <typename T>
+__global__ void g4_persistent_decode_batch_int4_kernel(
+    int num_layers,
+    int hidden_size,
+    int ple_hidden,
+    float eps,
+    float scale,
+    int batch_size,
+    int ws_stride,
+    const Gemma4DecodeLayerDesc* __restrict__ layers,
+    const Gemma4Int4ScaleDesc*   __restrict__ int4_scales,
+    const Gemma4BatchSeqDesc*    __restrict__ batch_descs,  // [num_layers]
+    T* __restrict__ hidden_io,                              // [B, hidden_size] BF16
+    const T* __restrict__ per_layer_inputs,                  // [B, num_layers, ple_hidden] BF16
+    float* __restrict__ workspace,                           // [B * ws_stride]
+    unsigned int* __restrict__ matvec_counter,
+    unsigned int* __restrict__ barrier_counter,
+    unsigned int* __restrict__ barrier_flag
+) __attribute__((launch_bounds(256, 1))) {
+    const int tid = threadIdx.x;
+    const int bs = blockDim.x;
+    const int nb = gridDim.x;
+    const int B = batch_size;
+
+    extern __shared__ float lds[];
+
+    for (int layer = 0; layer < num_layers; ++layer) {
+        const Gemma4DecodeLayerDesc L = layers[layer];
+        const Gemma4Int4ScaleDesc   SI = int4_scales[layer];
+        const Gemma4BatchSeqDesc    S = batch_descs[layer];
+        const int num_q_heads = L.num_q_heads;
+        const int num_kv_heads = L.num_kv_heads;
+        const int head_dim = L.head_dim;
+        const int rotary_dim = L.rotary_dim;
+        const int sliding_window = L.sliding_window;
+        const int shared_kv = L.shared_kv;
+        const int q_dim = num_q_heads * head_dim;
+        const int kv_dim = num_kv_heads * head_dim;
+        const int gsz = SI.group_size;
+
+        const T* input_norm_w = static_cast<const T*>(L.input_norm_w);
+        const T* q_norm_w = static_cast<const T*>(L.q_norm_w);
+        const T* k_norm_w = static_cast<const T*>(L.k_norm_w);
+        const T* post_attn_norm_w = static_cast<const T*>(L.post_attn_norm_w);
+        const T* cos_table = static_cast<const T*>(L.cos_table);
+        const T* sin_table = static_cast<const T*>(L.sin_table);
+
+        const uint8_t*      q_proj_packed = static_cast<const uint8_t*>(L.q_proj_w);
+        const uint8_t*      k_proj_packed = static_cast<const uint8_t*>(L.k_proj_w);
+        const uint8_t*      v_proj_packed = static_cast<const uint8_t*>(L.v_proj_w);
+        const uint8_t*      o_proj_packed = static_cast<const uint8_t*>(L.o_proj_w);
+        const hip_bfloat16* q_proj_scale  = static_cast<const hip_bfloat16*>(SI.q_proj_scale);
+        const hip_bfloat16* q_proj_zero   = static_cast<const hip_bfloat16*>(SI.q_proj_zero);
+        const hip_bfloat16* k_proj_scale  = static_cast<const hip_bfloat16*>(SI.k_proj_scale);
+        const hip_bfloat16* k_proj_zero   = static_cast<const hip_bfloat16*>(SI.k_proj_zero);
+        const hip_bfloat16* v_proj_scale  = static_cast<const hip_bfloat16*>(SI.v_proj_scale);
+        const hip_bfloat16* v_proj_zero   = static_cast<const hip_bfloat16*>(SI.v_proj_zero);
+        const hip_bfloat16* o_proj_scale  = static_cast<const hip_bfloat16*>(SI.o_proj_scale);
+        const hip_bfloat16* o_proj_zero   = static_cast<const hip_bfloat16*>(SI.o_proj_zero);
+
+        // A0: load hidden_io BF16 -> hidden_f32 per seq.
+        for (int b = 0; b < B; ++b) {
+            float* hidden_f32 = workspace + b * ws_stride;
+            T* hb = hidden_io + static_cast<size_t>(b) * hidden_size;
+            for (int c = tid + blockIdx.x * bs; c < hidden_size; c += bs * nb) {
+                hidden_f32[c] = g4_to_float(hb[c]);
+            }
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        // A1: input_norm on block 0 (loop B).
+        if (blockIdx.x == 0) {
+            for (int b = 0; b < B; ++b) {
+                float* hidden_f32 = workspace + b * ws_stride;
+                float* normed_f32 = hidden_f32 + hidden_size;
+                g4_block_rms_norm_f32<T>(normed_f32, hidden_f32, input_norm_w,
+                                          hidden_size, eps, lds);
+            }
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        // A2: work-stealing INT4 Q/K/V matmul - amortize weight+dequant across B seqs.
+        if (blockIdx.x == 0 && tid == 0) {
+            __atomic_store_n(matvec_counter, 0u, __ATOMIC_RELAXED);
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        const int scale_cols_in = (hidden_size + gsz - 1) / gsz;
+        const int byte_cols_in  = hidden_size / 2;
+
+        {
+            const int total_qkv = shared_kv ? q_dim : (q_dim + 2 * kv_dim);
+            while (true) {
+                __shared__ unsigned int claimed;
+                if (tid == 0) claimed = atomicAdd(matvec_counter, 1u);
+                __syncthreads();
+                const unsigned int row = claimed;
+                if (row >= static_cast<unsigned int>(total_qkv)) break;
+
+                const uint8_t*      w_packed_base;
+                const hip_bfloat16* w_scale_base;
+                const hip_bfloat16* w_zero_base;
+                int weight_row;
+                if (row < static_cast<unsigned int>(q_dim)) {
+                    w_packed_base = q_proj_packed;
+                    w_scale_base  = q_proj_scale;
+                    w_zero_base   = q_proj_zero;
+                    weight_row    = static_cast<int>(row);
+                } else if (row < static_cast<unsigned int>(q_dim + kv_dim)) {
+                    w_packed_base = k_proj_packed;
+                    w_scale_base  = k_proj_scale;
+                    w_zero_base   = k_proj_zero;
+                    weight_row    = static_cast<int>(row - q_dim);
+                } else {
+                    w_packed_base = v_proj_packed;
+                    w_scale_base  = v_proj_scale;
+                    w_zero_base   = v_proj_zero;
+                    weight_row    = static_cast<int>(row - q_dim - kv_dim);
+                }
+                const int scale_row = weight_row / gsz;
+                const uint8_t* w_row_bytes =
+                    w_packed_base + static_cast<size_t>(weight_row) * byte_cols_in;
+
+                float pacc[G4_MAX_BATCH_SIZE];
+                #pragma unroll
+                for (int b = 0; b < G4_MAX_BATCH_SIZE; ++b) pacc[b] = 0.0f;
+
+                for (int c0 = tid * 8; c0 < hidden_size; c0 += bs * 8) {
+                    uint32_t packed;
+                    __builtin_memcpy(&packed, w_row_bytes + (c0 / 2), 4);
+                    float w[8];
+                    g4_int4_dequant_8(packed, w_scale_base, w_zero_base,
+                                      scale_row, c0, scale_cols_in, gsz, w);
+                    for (int b = 0; b < B; ++b) {
+                        const float* normed_f32 = workspace + b * ws_stride + hidden_size;
+                        #pragma unroll
+                        for (int k = 0; k < 8; ++k) {
+                            pacc[b] += w[k] * normed_f32[c0 + k];
+                        }
+                    }
+                }
+                for (int b = 0; b < B; ++b) {
+                    lds[tid] = pacc[b];
+                    __syncthreads();
+                    for (int s = bs / 2; s > 0; s >>= 1) {
+                        if (tid < s) lds[tid] += lds[tid + s];
+                        __syncthreads();
+                    }
+                    if (tid == 0) {
+                        float* proj_f32 = workspace + b * ws_stride + 2 * hidden_size;
+                        proj_f32[row] = lds[0];
+                    }
+                    __syncthreads();
+                }
+            }
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        // A3: q/k/v norms + RoPE + KV append (block 0, per-seq loop).
+        if (blockIdx.x == 0) {
+            for (int b = 0; b < B; ++b) {
+                float* proj_f32 = workspace + b * ws_stride + 2 * hidden_size;
+                float* q_f32 = proj_f32;
+                float* k_f32 = proj_f32 + q_dim;
+                float* v_f32 = proj_f32 + q_dim + kv_dim;
+                const int position_b = S.seqlen_offset[b];
+                const int max_T_b = S.kv_max_t[b];
+                T* k_cache_b = static_cast<T*>(S.kv_cache_k[b]);
+                T* v_cache_b = static_cast<T*>(S.kv_cache_v[b]);
+                if (!shared_kv) {
+                    g4_block_rms_norm_per_head_f32<T>(q_f32, q_norm_w,
+                        num_q_heads, head_dim, eps, lds);
+                    g4_block_rms_norm_per_head_f32<T>(k_f32, k_norm_w,
+                        num_kv_heads, head_dim, eps, lds);
+                    g4_block_rms_norm_per_head_f32<T>(v_f32, (const T*)nullptr,
+                        num_kv_heads, head_dim, eps, lds);
+                    g4_block_rope_f32<T>(q_f32, cos_table, sin_table,
+                        num_q_heads, head_dim, rotary_dim, position_b);
+                    g4_block_rope_f32<T>(k_f32, cos_table, sin_table,
+                        num_kv_heads, head_dim, rotary_dim, position_b);
+                    g4_block_kv_append_f32_to_bf16<T>(k_f32, v_f32, k_cache_b, v_cache_b,
+                        num_kv_heads, head_dim, position_b, max_T_b);
+                } else {
+                    g4_block_rms_norm_per_head_f32<T>(q_f32, q_norm_w,
+                        num_q_heads, head_dim, eps, lds);
+                    g4_block_rope_f32<T>(q_f32, cos_table, sin_table,
+                        num_q_heads, head_dim, rotary_dim, position_b);
+                }
+            }
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        // A4: attention scores (per-seq loop).
+        const int num_q_per_kv = num_q_heads / num_kv_heads;
+        for (int b = 0; b < B; ++b) {
+            const int position_b = S.seqlen_offset[b];
+            const int max_T_b = S.kv_max_t[b];
+            const T* k_cache_b = static_cast<const T*>(S.kv_cache_k[b]);
+            const float* proj_f32 = workspace + b * ws_stride + 2 * hidden_size;
+            const float* q_f32 = proj_f32;
+            float* scores_f32 = workspace + b * ws_stride + 2 * hidden_size
+                                + q_dim + 2 * kv_dim;
+            const int kv_len = position_b + 1;
+            const int last = kv_len - 1;
+            const int min_t = (sliding_window > 0) ? max(0, last - sliding_window + 1) : 0;
+            const int total_items = num_q_heads * kv_len;
+            for (int item = blockIdx.x * bs + tid;
+                 item < total_items; item += nb * bs) {
+                const int t = item % kv_len;
+                const int q_h = item / kv_len;
+                float val;
+                if (t < min_t) {
+                    val = -INFINITY;
+                } else {
+                    const int kv_h = q_h / num_q_per_kv;
+                    const float* qr = q_f32 +
+                        static_cast<size_t>(q_h) * head_dim;
+                    const T* kr = k_cache_b +
+                        (static_cast<size_t>(kv_h) * max_T_b + t) * head_dim;
+                    float acc = 0.0f;
+                    for (int d = 0; d < head_dim; ++d) {
+                        acc += qr[d] * g4_to_float(kr[d]);
+                    }
+                    val = acc * scale;
+                }
+                scores_f32[static_cast<size_t>(q_h) * max_T_b + t] = val;
+            }
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        // A5: softmax per q head (per-seq loop).
+        for (int b = 0; b < B; ++b) {
+            const int position_b = S.seqlen_offset[b];
+            const int max_T_b = S.kv_max_t[b];
+            float* scores_f32 = workspace + b * ws_stride + 2 * hidden_size
+                                + q_dim + 2 * kv_dim;
+            const int kv_len = position_b + 1;
+            for (int q_h = blockIdx.x; q_h < num_q_heads; q_h += nb) {
+                float* row = scores_f32 + static_cast<size_t>(q_h) * max_T_b;
+                float pm = -INFINITY;
+                for (int t = tid; t < kv_len; t += bs) pm = fmaxf(pm, row[t]);
+                lds[tid] = pm;
+                __syncthreads();
+                for (int s = bs / 2; s > 0; s >>= 1) {
+                    if (tid < s) lds[tid] = fmaxf(lds[tid], lds[tid + s]);
+                    __syncthreads();
+                }
+                const float mx = lds[0];
+                __syncthreads();
+                float ps = 0.0f;
+                for (int t = tid; t < kv_len; t += bs) {
+                    const float e = expf(row[t] - mx);
+                    row[t] = e;
+                    ps += e;
+                }
+                lds[tid] = ps;
+                __syncthreads();
+                for (int s = bs / 2; s > 0; s >>= 1) {
+                    if (tid < s) lds[tid] += lds[tid + s];
+                    __syncthreads();
+                }
+                const float inv_sum = 1.0f / lds[0];
+                __syncthreads();
+                for (int t = tid; t < kv_len; t += bs) row[t] *= inv_sum;
+                __syncthreads();
+            }
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        // A6: value aggregation (per-seq loop).
+        for (int b = 0; b < B; ++b) {
+            const int position_b = S.seqlen_offset[b];
+            const int max_T_b = S.kv_max_t[b];
+            const T* v_cache_b = static_cast<const T*>(S.kv_cache_v[b]);
+            const float* scores_f32 = workspace + b * ws_stride + 2 * hidden_size
+                                      + q_dim + 2 * kv_dim;
+            float* attn_out_f32 = workspace + b * ws_stride + 2 * hidden_size
+                                  + q_dim + 2 * kv_dim + num_q_heads * max_T_b;
+            const int kv_len = position_b + 1;
+            const int total_items = num_q_heads * head_dim;
+            for (int item = blockIdx.x * bs + tid;
+                 item < total_items; item += nb * bs) {
+                const int d = item % head_dim;
+                const int q_h = item / head_dim;
+                const int kv_h = q_h / num_q_per_kv;
+                const float* pr = scores_f32 +
+                    static_cast<size_t>(q_h) * max_T_b;
+                float acc = 0.0f;
+                for (int t = 0; t < kv_len; ++t) {
+                    const T* vr = v_cache_b +
+                        (static_cast<size_t>(kv_h) * max_T_b + t) * head_dim;
+                    acc += pr[t] * g4_to_float(vr[d]);
+                }
+                attn_out_f32[static_cast<size_t>(q_h) * head_dim + d] = acc;
+            }
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        // A7: work-stealing INT4 o_proj - amortized.
+        const int attn_out_base_off = 2 * hidden_size + q_dim + 2 * kv_dim
+                                    + num_q_heads * L.kv_max_t;
+        if (blockIdx.x == 0 && tid == 0) {
+            __atomic_store_n(matvec_counter, 0u, __ATOMIC_RELAXED);
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        const int scale_cols_o = (q_dim + gsz - 1) / gsz;
+        const int byte_cols_o  = q_dim / 2;
+
+        while (true) {
+            __shared__ unsigned int claimed;
+            if (tid == 0) claimed = atomicAdd(matvec_counter, 1u);
+            __syncthreads();
+            const unsigned int row = claimed;
+            if (row >= static_cast<unsigned int>(hidden_size)) break;
+
+            const int scale_row = static_cast<int>(row) / gsz;
+            const uint8_t* w_row_bytes =
+                o_proj_packed + static_cast<size_t>(row) * byte_cols_o;
+
+            float pacc[G4_MAX_BATCH_SIZE];
+            #pragma unroll
+            for (int b = 0; b < G4_MAX_BATCH_SIZE; ++b) pacc[b] = 0.0f;
+
+            for (int c0 = tid * 8; c0 < q_dim; c0 += bs * 8) {
+                uint32_t packed;
+                __builtin_memcpy(&packed, w_row_bytes + (c0 / 2), 4);
+                float w[8];
+                g4_int4_dequant_8(packed, o_proj_scale, o_proj_zero,
+                                  scale_row, c0, scale_cols_o, gsz, w);
+                for (int b = 0; b < B; ++b) {
+                    const float* attn_out_f32 = workspace + b * ws_stride
+                                                + attn_out_base_off;
+                    #pragma unroll
+                    for (int k = 0; k < 8; ++k) {
+                        pacc[b] += w[k] * attn_out_f32[c0 + k];
+                    }
+                }
+            }
+
+            for (int b = 0; b < B; ++b) {
+                lds[tid] = pacc[b];
+                __syncthreads();
+                for (int s = bs / 2; s > 0; s >>= 1) {
+                    if (tid < s) lds[tid] += lds[tid + s];
+                    __syncthreads();
+                }
+                if (tid == 0) {
+                    float* oproj_f32 = workspace + b * ws_stride
+                                       + attn_out_base_off + q_dim;
+                    oproj_f32[row] = lds[0];
+                }
+                __syncthreads();
+            }
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        // A8: post_attn_norm on block 0 (loop B).
+        if (blockIdx.x == 0) {
+            for (int b = 0; b < B; ++b) {
+                float* oproj_f32 = workspace + b * ws_stride
+                                   + attn_out_base_off + q_dim;
+                float* oproj_normed = oproj_f32 + hidden_size;
+                g4_block_rms_norm_f32<T>(oproj_normed, oproj_f32, post_attn_norm_w,
+                                          hidden_size, eps, lds);
+            }
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        // A9: residual add + BF16 store -> hidden_io = h_mid.
+        for (int b = 0; b < B; ++b) {
+            const float* hidden_f32 = workspace + b * ws_stride;
+            const float* oproj_normed = workspace + b * ws_stride
+                                        + attn_out_base_off + q_dim + hidden_size;
+            T* hb = hidden_io + static_cast<size_t>(b) * hidden_size;
+            for (int c = tid + blockIdx.x * bs; c < hidden_size; c += bs * nb) {
+                hb[c] = g4_from_float<T>(hidden_f32[c] + oproj_normed[c]);
+            }
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        // ==== Phase B - MLP + PLE ====
+        const int intermediate_size = L.intermediate_size;
+        const float layer_scalar = L.layer_scalar;
+        const T* pre_ff_norm_w = static_cast<const T*>(L.pre_ff_norm_w);
+        const T* post_ff_norm_w = static_cast<const T*>(L.post_ff_norm_w);
+        const T* pli_post_norm_w =
+            static_cast<const T*>(L.post_per_layer_input_norm_w);
+
+        const uint8_t*      gate_proj_packed = static_cast<const uint8_t*>(L.gate_proj_w);
+        const uint8_t*      up_proj_packed   = static_cast<const uint8_t*>(L.up_proj_w);
+        const uint8_t*      down_proj_packed = static_cast<const uint8_t*>(L.down_proj_w);
+        const uint8_t*      pli_gate_packed  = static_cast<const uint8_t*>(L.per_layer_input_gate_w);
+        const uint8_t*      pli_proj_packed  = static_cast<const uint8_t*>(L.per_layer_projection_w);
+        const hip_bfloat16* gate_proj_scale  = static_cast<const hip_bfloat16*>(SI.gate_proj_scale);
+        const hip_bfloat16* gate_proj_zero   = static_cast<const hip_bfloat16*>(SI.gate_proj_zero);
+        const hip_bfloat16* up_proj_scale    = static_cast<const hip_bfloat16*>(SI.up_proj_scale);
+        const hip_bfloat16* up_proj_zero     = static_cast<const hip_bfloat16*>(SI.up_proj_zero);
+        const hip_bfloat16* down_proj_scale  = static_cast<const hip_bfloat16*>(SI.down_proj_scale);
+        const hip_bfloat16* down_proj_zero   = static_cast<const hip_bfloat16*>(SI.down_proj_zero);
+        const hip_bfloat16* pli_gate_scale   = static_cast<const hip_bfloat16*>(SI.per_layer_input_gate_scale);
+        const hip_bfloat16* pli_gate_zero    = static_cast<const hip_bfloat16*>(SI.per_layer_input_gate_zero);
+        const hip_bfloat16* pli_proj_scale   = static_cast<const hip_bfloat16*>(SI.per_layer_projection_scale);
+        const hip_bfloat16* pli_proj_zero    = static_cast<const hip_bfloat16*>(SI.per_layer_projection_zero);
+
+        // B0: load h_mid BF16 -> b_hidden_f32 per seq.
+        for (int b = 0; b < B; ++b) {
+            float* b_hidden_f32 = workspace + b * ws_stride;
+            T* hb = hidden_io + static_cast<size_t>(b) * hidden_size;
+            for (int c = tid + blockIdx.x * bs; c < hidden_size; c += bs * nb) {
+                b_hidden_f32[c] = g4_to_float(hb[c]);
+            }
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        // B1: pre_ff_norm on block 0 (loop B).
+        if (blockIdx.x == 0) {
+            for (int b = 0; b < B; ++b) {
+                float* b_hidden_f32 = workspace + b * ws_stride;
+                float* b_normed_ff = b_hidden_f32 + hidden_size;
+                g4_block_rms_norm_f32<T>(b_normed_ff, b_hidden_f32, pre_ff_norm_w,
+                                          hidden_size, eps, lds);
+            }
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        // B2: work-stealing INT4 gate+up - amortized.
+        if (blockIdx.x == 0 && tid == 0) {
+            __atomic_store_n(matvec_counter, 0u, __ATOMIC_RELAXED);
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        {
+            const int total_mlp1 = 2 * intermediate_size;
+            while (true) {
+                __shared__ unsigned int claimed;
+                if (tid == 0) claimed = atomicAdd(matvec_counter, 1u);
+                __syncthreads();
+                const unsigned int row = claimed;
+                if (row >= static_cast<unsigned int>(total_mlp1)) break;
+
+                const uint8_t*      w_packed_base;
+                const hip_bfloat16* w_scale_base;
+                const hip_bfloat16* w_zero_base;
+                int weight_row;
+                if (row < static_cast<unsigned int>(intermediate_size)) {
+                    w_packed_base = gate_proj_packed;
+                    w_scale_base  = gate_proj_scale;
+                    w_zero_base   = gate_proj_zero;
+                    weight_row    = static_cast<int>(row);
+                } else {
+                    w_packed_base = up_proj_packed;
+                    w_scale_base  = up_proj_scale;
+                    w_zero_base   = up_proj_zero;
+                    weight_row    = static_cast<int>(row - intermediate_size);
+                }
+                const int scale_row = weight_row / gsz;
+                const uint8_t* w_row_bytes =
+                    w_packed_base + static_cast<size_t>(weight_row) * byte_cols_in;
+
+                float pacc[G4_MAX_BATCH_SIZE];
+                #pragma unroll
+                for (int b = 0; b < G4_MAX_BATCH_SIZE; ++b) pacc[b] = 0.0f;
+
+                for (int c0 = tid * 8; c0 < hidden_size; c0 += bs * 8) {
+                    uint32_t packed;
+                    __builtin_memcpy(&packed, w_row_bytes + (c0 / 2), 4);
+                    float w[8];
+                    g4_int4_dequant_8(packed, w_scale_base, w_zero_base,
+                                      scale_row, c0, scale_cols_in, gsz, w);
+                    for (int b = 0; b < B; ++b) {
+                        const float* b_normed_ff = workspace + b * ws_stride + hidden_size;
+                        #pragma unroll
+                        for (int k = 0; k < 8; ++k) {
+                            pacc[b] += w[k] * b_normed_ff[c0 + k];
+                        }
+                    }
+                }
+                for (int b = 0; b < B; ++b) {
+                    lds[tid] = pacc[b];
+                    __syncthreads();
+                    for (int s = bs / 2; s > 0; s >>= 1) {
+                        if (tid < s) lds[tid] += lds[tid + s];
+                        __syncthreads();
+                    }
+                    if (tid == 0) {
+                        float* b_gate_up = workspace + b * ws_stride + 2 * hidden_size;
+                        b_gate_up[row] = lds[0];
+                    }
+                    __syncthreads();
+                }
+            }
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        // B3: gated_proj[i] = gelu(gate[i]) * up[i], per seq.
+        for (int b = 0; b < B; ++b) {
+            const float* b_gate_up = workspace + b * ws_stride + 2 * hidden_size;
+            const float* gate_slot = b_gate_up;
+            const float* up_slot = b_gate_up + intermediate_size;
+            float* b_gated_proj = workspace + b * ws_stride + 2 * hidden_size
+                                  + 2 * intermediate_size;
+            for (int i = tid + blockIdx.x * bs;
+                 i < intermediate_size; i += bs * nb) {
+                b_gated_proj[i] = g4_gelu_tanh_scalar(gate_slot[i]) * up_slot[i];
+            }
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        // B4: work-stealing INT4 down_proj - amortized.
+        if (blockIdx.x == 0 && tid == 0) {
+            __atomic_store_n(matvec_counter, 0u, __ATOMIC_RELAXED);
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        const int scale_cols_i = (intermediate_size + gsz - 1) / gsz;
+        const int byte_cols_i  = intermediate_size / 2;
+
+        while (true) {
+            __shared__ unsigned int claimed;
+            if (tid == 0) claimed = atomicAdd(matvec_counter, 1u);
+            __syncthreads();
+            const unsigned int row = claimed;
+            if (row >= static_cast<unsigned int>(hidden_size)) break;
+
+            const int scale_row = static_cast<int>(row) / gsz;
+            const uint8_t* w_row_bytes =
+                down_proj_packed + static_cast<size_t>(row) * byte_cols_i;
+
+            float pacc[G4_MAX_BATCH_SIZE];
+            #pragma unroll
+            for (int b = 0; b < G4_MAX_BATCH_SIZE; ++b) pacc[b] = 0.0f;
+
+            for (int c0 = tid * 8; c0 < intermediate_size; c0 += bs * 8) {
+                uint32_t packed;
+                __builtin_memcpy(&packed, w_row_bytes + (c0 / 2), 4);
+                float w[8];
+                g4_int4_dequant_8(packed, down_proj_scale, down_proj_zero,
+                                  scale_row, c0, scale_cols_i, gsz, w);
+                for (int b = 0; b < B; ++b) {
+                    const float* b_gated_proj = workspace + b * ws_stride
+                                                + 2 * hidden_size + 2 * intermediate_size;
+                    #pragma unroll
+                    for (int k = 0; k < 8; ++k) {
+                        pacc[b] += w[k] * b_gated_proj[c0 + k];
+                    }
+                }
+            }
+
+            for (int b = 0; b < B; ++b) {
+                lds[tid] = pacc[b];
+                __syncthreads();
+                for (int s = bs / 2; s > 0; s >>= 1) {
+                    if (tid < s) lds[tid] += lds[tid + s];
+                    __syncthreads();
+                }
+                if (tid == 0) {
+                    float* b_down_out = workspace + b * ws_stride
+                                        + 2 * hidden_size + 3 * intermediate_size;
+                    b_down_out[row] = lds[0];
+                }
+                __syncthreads();
+            }
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        // B5: post_ff_norm on block 0 (loop B).
+        if (blockIdx.x == 0) {
+            for (int b = 0; b < B; ++b) {
+                float* b_down_out = workspace + b * ws_stride
+                                    + 2 * hidden_size + 3 * intermediate_size;
+                float* b_normed_down = b_down_out + hidden_size;
+                g4_block_rms_norm_f32<T>(b_normed_down, b_down_out, post_ff_norm_w,
+                                          hidden_size, eps, lds);
+            }
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        // B6: h_pre_ple = b_hidden_f32 + b_normed_down, per seq.
+        for (int b = 0; b < B; ++b) {
+            const float* b_hidden_f32 = workspace + b * ws_stride;
+            const float* b_normed_down = workspace + b * ws_stride
+                                         + 3 * hidden_size + 3 * intermediate_size;
+            float* b_h_pre_ple = workspace + b * ws_stride
+                                 + 4 * hidden_size + 3 * intermediate_size;
+            for (int c = tid + blockIdx.x * bs; c < hidden_size; c += bs * nb) {
+                b_h_pre_ple[c] = b_hidden_f32[c] + b_normed_down[c];
+            }
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        // B7: work-stealing INT4 per_layer_input_gate - amortized.
+        if (blockIdx.x == 0 && tid == 0) {
+            __atomic_store_n(matvec_counter, 0u, __ATOMIC_RELAXED);
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        while (true) {
+            __shared__ unsigned int claimed;
+            if (tid == 0) claimed = atomicAdd(matvec_counter, 1u);
+            __syncthreads();
+            const unsigned int row = claimed;
+            if (row >= static_cast<unsigned int>(ple_hidden)) break;
+
+            const int scale_row = static_cast<int>(row) / gsz;
+            const uint8_t* w_row_bytes =
+                pli_gate_packed + static_cast<size_t>(row) * byte_cols_in;
+
+            float pacc[G4_MAX_BATCH_SIZE];
+            #pragma unroll
+            for (int b = 0; b < G4_MAX_BATCH_SIZE; ++b) pacc[b] = 0.0f;
+
+            for (int c0 = tid * 8; c0 < hidden_size; c0 += bs * 8) {
+                uint32_t packed;
+                __builtin_memcpy(&packed, w_row_bytes + (c0 / 2), 4);
+                float w[8];
+                g4_int4_dequant_8(packed, pli_gate_scale, pli_gate_zero,
+                                  scale_row, c0, scale_cols_in, gsz, w);
+                for (int b = 0; b < B; ++b) {
+                    const float* b_h_pre_ple = workspace + b * ws_stride
+                                               + 4 * hidden_size + 3 * intermediate_size;
+                    #pragma unroll
+                    for (int k = 0; k < 8; ++k) {
+                        pacc[b] += w[k] * b_h_pre_ple[c0 + k];
+                    }
+                }
+            }
+
+            for (int b = 0; b < B; ++b) {
+                lds[tid] = pacc[b];
+                __syncthreads();
+                for (int s = bs / 2; s > 0; s >>= 1) {
+                    if (tid < s) lds[tid] += lds[tid + s];
+                    __syncthreads();
+                }
+                if (tid == 0) {
+                    float* b_gated_ple = workspace + b * ws_stride
+                                         + 5 * hidden_size + 3 * intermediate_size;
+                    b_gated_ple[row] = lds[0];
+                }
+                __syncthreads();
+            }
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        // B8: gated_act = gelu(gated_ple) * per_layer_input, per seq.
+        for (int b = 0; b < B; ++b) {
+            const float* b_gated_ple = workspace + b * ws_stride
+                                       + 5 * hidden_size + 3 * intermediate_size;
+            float* b_gated_act = workspace + b * ws_stride
+                                 + 5 * hidden_size + 3 * intermediate_size + ple_hidden;
+            const T* per_layer_input = per_layer_inputs
+                + (static_cast<size_t>(b) * num_layers + layer) * ple_hidden;
+            for (int i = tid + blockIdx.x * bs; i < ple_hidden; i += bs * nb) {
+                const float g = g4_gelu_tanh_scalar(b_gated_ple[i]);
+                b_gated_act[i] = g * g4_to_float(per_layer_input[i]);
+            }
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        // B9: work-stealing INT4 per_layer_projection - amortized.
+        if (blockIdx.x == 0 && tid == 0) {
+            __atomic_store_n(matvec_counter, 0u, __ATOMIC_RELAXED);
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        const int scale_cols_ple = (ple_hidden + gsz - 1) / gsz;
+        const int byte_cols_ple  = ple_hidden / 2;
+
+        while (true) {
+            __shared__ unsigned int claimed;
+            if (tid == 0) claimed = atomicAdd(matvec_counter, 1u);
+            __syncthreads();
+            const unsigned int row = claimed;
+            if (row >= static_cast<unsigned int>(hidden_size)) break;
+
+            const int scale_row = static_cast<int>(row) / gsz;
+            const uint8_t* w_row_bytes =
+                pli_proj_packed + static_cast<size_t>(row) * byte_cols_ple;
+
+            float pacc[G4_MAX_BATCH_SIZE];
+            #pragma unroll
+            for (int b = 0; b < G4_MAX_BATCH_SIZE; ++b) pacc[b] = 0.0f;
+
+            for (int c0 = tid * 8; c0 < ple_hidden; c0 += bs * 8) {
+                uint32_t packed;
+                __builtin_memcpy(&packed, w_row_bytes + (c0 / 2), 4);
+                float w[8];
+                g4_int4_dequant_8(packed, pli_proj_scale, pli_proj_zero,
+                                  scale_row, c0, scale_cols_ple, gsz, w);
+                for (int b = 0; b < B; ++b) {
+                    const float* b_gated_act = workspace + b * ws_stride
+                                               + 5 * hidden_size + 3 * intermediate_size
+                                               + ple_hidden;
+                    #pragma unroll
+                    for (int k = 0; k < 8; ++k) {
+                        pacc[b] += w[k] * b_gated_act[c0 + k];
+                    }
+                }
+            }
+
+            for (int b = 0; b < B; ++b) {
+                lds[tid] = pacc[b];
+                __syncthreads();
+                for (int s = bs / 2; s > 0; s >>= 1) {
+                    if (tid < s) lds[tid] += lds[tid + s];
+                    __syncthreads();
+                }
+                if (tid == 0) {
+                    float* b_projected = workspace + b * ws_stride
+                                         + 5 * hidden_size + 3 * intermediate_size
+                                         + 2 * ple_hidden;
+                    b_projected[row] = lds[0];
+                }
+                __syncthreads();
+            }
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        // B10: post_per_layer_input_norm on block 0 (loop B).
+        if (blockIdx.x == 0) {
+            for (int b = 0; b < B; ++b) {
+                float* b_projected = workspace + b * ws_stride
+                                     + 5 * hidden_size + 3 * intermediate_size
+                                     + 2 * ple_hidden;
+                float* b_normed_ple = workspace + b * ws_stride
+                                      + 6 * hidden_size + 3 * intermediate_size
+                                      + 2 * ple_hidden;
+                g4_block_rms_norm_f32<T>(b_normed_ple, b_projected,
+                                          pli_post_norm_w,
+                                          hidden_size, eps, lds);
+            }
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        // B11: hidden_io = bf16((h_pre_ple + normed_ple) * layer_scalar), per seq.
+        for (int b = 0; b < B; ++b) {
+            const float* b_h_pre_ple = workspace + b * ws_stride
+                                       + 4 * hidden_size + 3 * intermediate_size;
+            const float* b_normed_ple = workspace + b * ws_stride
+                                        + 6 * hidden_size + 3 * intermediate_size
+                                        + 2 * ple_hidden;
+            T* hb = hidden_io + static_cast<size_t>(b) * hidden_size;
+            for (int c = tid + blockIdx.x * bs; c < hidden_size; c += bs * nb) {
+                const float v = (b_h_pre_ple[c] + b_normed_ple[c]) * layer_scalar;
+                hb[c] = g4_from_float<T>(v);
+            }
         }
         g4_grid_barrier(barrier_counter, barrier_flag, nb);
     }

--- a/kernels/gemma4_bridge.cpp
+++ b/kernels/gemma4_bridge.cpp
@@ -757,6 +757,90 @@ int persistent_decode_device(int device_ordinal,
 }
 
 template <typename T>
+int persistent_decode_batch_device(int device_ordinal,
+                                   int num_layers, int hidden_size, int ple_hidden,
+                                   float eps, float scale,
+                                   int batch_size, int ws_stride,
+                                   const void* layers,
+                                   const void* batch_descs,
+                                   void* hidden_io,
+                                   const void* per_layer_inputs,
+                                   void* workspace,
+                                   unsigned int* matvec_counter,
+                                   unsigned int* barrier_counter,
+                                   unsigned int* barrier_flag) {
+    ScopedHipDevice scoped(device_ordinal);
+
+    hipDeviceProp_t props;
+    if (hipGetDeviceProperties(&props, device_ordinal) != hipSuccess) return 721;
+    const int num_blocks =
+        props.multiProcessorCount > 0 ? props.multiProcessorCount : 1;
+    constexpr int BLOCK = 256;
+    const size_t lds_bytes = BLOCK * sizeof(float);
+
+    if (hipMemset(barrier_counter, 0, sizeof(unsigned int)) != hipSuccess) return 722;
+    if (hipMemset(barrier_flag, 0, sizeof(unsigned int)) != hipSuccess) return 723;
+
+    hipLaunchKernelGGL(
+        HIP_KERNEL_NAME(g4_persistent_decode_batch_kernel<T>),
+        dim3(num_blocks), dim3(BLOCK), lds_bytes, 0,
+        num_layers, hidden_size, ple_hidden, eps, scale,
+        batch_size, ws_stride,
+        static_cast<const Gemma4DecodeLayerDesc*>(layers),
+        static_cast<const Gemma4BatchSeqDesc*>(batch_descs),
+        static_cast<T*>(hidden_io),
+        static_cast<const T*>(per_layer_inputs),
+        static_cast<float*>(workspace),
+        matvec_counter, barrier_counter, barrier_flag);
+    if (hipGetLastError() != hipSuccess) return 724;
+    if (hipDeviceSynchronize() != hipSuccess) return 725;
+    return 0;
+}
+
+template <typename T>
+int persistent_decode_batch_int4_device(int device_ordinal,
+                                        int num_layers, int hidden_size, int ple_hidden,
+                                        float eps, float scale,
+                                        int batch_size, int ws_stride,
+                                        const void* layers,
+                                        const void* int4_scales,
+                                        const void* batch_descs,
+                                        void* hidden_io,
+                                        const void* per_layer_inputs,
+                                        void* workspace,
+                                        unsigned int* matvec_counter,
+                                        unsigned int* barrier_counter,
+                                        unsigned int* barrier_flag) {
+    ScopedHipDevice scoped(device_ordinal);
+
+    hipDeviceProp_t props;
+    if (hipGetDeviceProperties(&props, device_ordinal) != hipSuccess) return 731;
+    const int num_blocks =
+        props.multiProcessorCount > 0 ? props.multiProcessorCount : 1;
+    constexpr int BLOCK = 256;
+    const size_t lds_bytes = BLOCK * sizeof(float);
+
+    if (hipMemset(barrier_counter, 0, sizeof(unsigned int)) != hipSuccess) return 732;
+    if (hipMemset(barrier_flag, 0, sizeof(unsigned int)) != hipSuccess) return 733;
+
+    hipLaunchKernelGGL(
+        HIP_KERNEL_NAME(g4_persistent_decode_batch_int4_kernel<T>),
+        dim3(num_blocks), dim3(BLOCK), lds_bytes, 0,
+        num_layers, hidden_size, ple_hidden, eps, scale,
+        batch_size, ws_stride,
+        static_cast<const Gemma4DecodeLayerDesc*>(layers),
+        static_cast<const Gemma4Int4ScaleDesc*>(int4_scales),
+        static_cast<const Gemma4BatchSeqDesc*>(batch_descs),
+        static_cast<T*>(hidden_io),
+        static_cast<const T*>(per_layer_inputs),
+        static_cast<float*>(workspace),
+        matvec_counter, barrier_counter, barrier_flag);
+    if (hipGetLastError() != hipSuccess) return 734;
+    if (hipDeviceSynchronize() != hipSuccess) return 735;
+    return 0;
+}
+
+template <typename T>
 int persistent_decode_int4_device(int device_ordinal,
                                   int num_layers, int hidden_size, int ple_hidden,
                                   int position, float eps, float scale,
@@ -1349,6 +1433,65 @@ extern "C" int dotcache_gemma4_hip_persistent_decode(
     default: return 700;
     }
     #undef G4_PERSIST_ARGS
+}
+
+extern "C" int dotcache_gemma4_hip_persistent_decode_batch(
+    int dtype, size_t device_ordinal,
+    size_t num_layers, size_t hidden_size, size_t ple_hidden,
+    float eps, float scale,
+    size_t batch_size, size_t ws_stride,
+    const void* layers,
+    const void* batch_descs,
+    void* hidden_io, const void* per_layer_inputs,
+    void* workspace,
+    unsigned int* matvec_counter,
+    unsigned int* barrier_counter,
+    unsigned int* barrier_flag
+) {
+    #define G4_PERSIST_BATCH_ARGS                                                \
+        static_cast<int>(device_ordinal),                                        \
+        static_cast<int>(num_layers), static_cast<int>(hidden_size),             \
+        static_cast<int>(ple_hidden), eps, scale,                                \
+        static_cast<int>(batch_size), static_cast<int>(ws_stride),               \
+        layers, batch_descs, hidden_io, per_layer_inputs, workspace,             \
+        matvec_counter, barrier_counter, barrier_flag
+    switch (dtype) {
+    case 0: return persistent_decode_batch_device<__half>(G4_PERSIST_BATCH_ARGS);
+    case 1: return persistent_decode_batch_device<float>(G4_PERSIST_BATCH_ARGS);
+    case 2: return persistent_decode_batch_device<hip_bfloat16>(G4_PERSIST_BATCH_ARGS);
+    default: return 720;
+    }
+    #undef G4_PERSIST_BATCH_ARGS
+}
+
+extern "C" int dotcache_gemma4_hip_persistent_decode_batch_int4(
+    int dtype, size_t device_ordinal,
+    size_t num_layers, size_t hidden_size, size_t ple_hidden,
+    float eps, float scale,
+    size_t batch_size, size_t ws_stride,
+    const void* layers,
+    const void* int4_scales,
+    const void* batch_descs,
+    void* hidden_io, const void* per_layer_inputs,
+    void* workspace,
+    unsigned int* matvec_counter,
+    unsigned int* barrier_counter,
+    unsigned int* barrier_flag
+) {
+    #define G4_PERSIST_BATCH_INT4_ARGS                                           \
+        static_cast<int>(device_ordinal),                                        \
+        static_cast<int>(num_layers), static_cast<int>(hidden_size),             \
+        static_cast<int>(ple_hidden), eps, scale,                                \
+        static_cast<int>(batch_size), static_cast<int>(ws_stride),               \
+        layers, int4_scales, batch_descs, hidden_io, per_layer_inputs,           \
+        workspace, matvec_counter, barrier_counter, barrier_flag
+    switch (dtype) {
+    case 0: return persistent_decode_batch_int4_device<__half>(G4_PERSIST_BATCH_INT4_ARGS);
+    case 1: return persistent_decode_batch_int4_device<float>(G4_PERSIST_BATCH_INT4_ARGS);
+    case 2: return persistent_decode_batch_int4_device<hip_bfloat16>(G4_PERSIST_BATCH_INT4_ARGS);
+    default: return 730;
+    }
+    #undef G4_PERSIST_BATCH_INT4_ARGS
 }
 
 extern "C" int dotcache_gemma4_hip_persistent_decode_int4(


### PR DESCRIPTION
## Summary
- Phase 1 (commit 38ae3ab): refactors `Gemma4Engine` for per-seq state and adds the serial-dispatch `decode_step_batch` scaffolding + `Gemma4BatchSeqDesc` struct.
- Phase 2 (commit 3bd4a32): folds the B single-seq launches into one batched megakernel pass per family, for both BF16 and INT4. Weight reads (and INT4 dequant) amortize across sequences via `float pacc[G4_MAX_BATCH_SIZE]` per work-stealing iteration in the six matmul phases; non-matmul phases (norms, RoPE, attention, residuals) loop sequences serially inside the kernel.
- New kernel templates live alongside the single-seq ones — the existing, validated kernels are untouched per the `feedback_hipcc_codegen` advisory.
- `Gemma4Int4Engine` picks up `load_with_batch`, `extra_k_caches/extra_v_caches` for seqs 1..B, a `batch_descs_gpu` populated at load (seqlen_offsets refreshed per step), `replicate_seq0_kv`, and `decode_step_batch`. The runner's old `--int4 --batch-size >1` guard is gone.

## Correctness
- Same-prompt: BF16 and INT4 at B=1/2/3/4 produce byte-identical greedy token streams (gemma4-e2b, gfx1150).
- Divergent-position: new `gemma4_batched_divergent_test` binary staggers seq 0 one step ahead of seqs 1..B-1 and compares each seq's trajectory against a fresh single-seq reference. Exercises the per-seq `seqlen_offset[b]` -> KV-lookup path that same-position smoke tests can't cover. Passes on BF16 and INT4 at B=2 and B=4.

## Perf (gfx1150, gemma4-e2b, ms/seq, lower is better)
| | B=1 | B=2 | B=4 |
|---|---|---|---|
| BF16 | 604 | 466 (1.30×) | 348 (1.74×) |
| INT4 | 303 | 291 (1.04×) | 251 (1.21×) |

INT4's per-B gain is smaller than BF16's because INT4 weight bandwidth is already compressed 4×; dequant arithmetic dominates per-row work and benefits less from cross-sequence amortization.

## Test plan
- [x] `cargo build --release` — clean
- [x] `cargo run --release --bin supersonic -- --model gemma4-e2b --batch-size {1,2,3,4}` BF16 — identical tokens
- [x] `cargo run --release --bin supersonic -- --model gemma4-e2b --int4 --batch-size {1,2,4}` INT4 — identical tokens
- [x] `cargo run --release --bin gemma4_batched_divergent_test -- --model-dir ... --batch-size 4` BF16 — PASS
- [x] `cargo run --release --bin gemma4_batched_divergent_test -- --model-dir ... --batch-size 4 --int4` INT4 — PASS
- [x] Same divergent-position test at B=2 for both — PASS

## Known limitations
- All sequences in a batch must share the same allocated `max_t` (kernel uses `layers[l].kv_max_t` as uniform scores-stride across seqs).
- Final-norm + lm_head + softcap runs per-seq serially after the batched megakernel; at vocab=262k this is cheap relative to the main decode loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)