### PR TITLE
Default Qwen single-seq decode to persistent megakernel (2-5× speedup)

### DIFF
--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -243,6 +243,9 @@ pub(crate) struct Cli {
 
     /// Debug-only: force single-sequence 4B decode to use the actual kernel path
     /// instead of the replayed prefill correctness path.
+    /// (Historical — `replayed prefill` is no longer the default; the kernel
+    /// path is used by default. This flag is kept as a no-op for callers
+    /// that still pass it explicitly.)
     #[arg(long, hide = true)]
     force_kernel_decode: bool,
 
@@ -250,6 +253,14 @@ pub(crate) struct Cli {
     /// instead of replayed prefill or the persistent kernel.
     #[arg(long, hide = true)]
     force_component_decode: bool,
+
+    /// Debug-only: restore the legacy "replay prefill each decode step" path
+    /// that was the default before 2026-04-20. Scales O(N) per token with
+    /// context length and was ~7x slower than the persistent megakernel path,
+    /// so retained only for parity validation. Mutually exclusive with
+    /// --force-kernel-decode / --force-component-decode.
+    #[arg(long, hide = true)]
+    force_replay_decode: bool,
 
     /// Debug-only: allow unstable CUDA KV-FP8 experiments on the 4B kernel path.
     /// This is intentionally hidden until the path is validated.
@@ -1162,8 +1173,16 @@ fn main() -> Result<()> {
         }
         false
     };
+    // Replay-prefill path used to be the default for 4B single-seq decode
+    // (safety net for numerical-parity work during the CUDA sm86 bring-up)
+    // but it scales O(N) per step with context length and was ~7x slower
+    // than the persistent megakernel at 64-token generations. Default is now
+    // the megakernel; --force-replay-decode re-enables the replay path for
+    // the rare case where someone genuinely wants to reproduce the older
+    // numeric semantics.
     let replay_decode_enabled = cli.batch_size == 1
         && params.use_4b_kernel
+        && cli.force_replay_decode
         && !cli.force_kernel_decode
         && !cli.force_component_decode
         && !cli.kv_fp8;
@@ -1173,8 +1192,15 @@ fn main() -> Result<()> {
         && !cli.force_kernel_decode;
     let component_single_decode_enabled =
         cli.batch_size == 1 && params.use_4b_kernel && cli.force_component_decode;
-    let kernel_single_decode_enabled =
-        cli.batch_size == 1 && params.use_4b_kernel && (cli.force_kernel_decode || cli.kv_fp8);
+    // Use the batched persistent megakernel path (decode_step_batch with b=1)
+    // for 4B single-seq decode by default — measured ~300 ms/tok on gfx1150
+    // vs ~500 ms/tok for decode_step() and ~2500 ms/tok for the legacy
+    // replay path. Opt-out via --force-replay-decode (legacy parity) or
+    // --force-component-decode (primitive-chain correctness).
+    let kernel_single_decode_enabled = cli.batch_size == 1
+        && params.use_4b_kernel
+        && !cli.force_replay_decode
+        && !cli.force_component_decode;
     let cuda_08b_hero_disabled = env::var_os("SUPERSONIC_DISABLE_CUDA_08B_HERO").is_some();
     let cuda_08b_hero_enabled = backend == Backend::Cuda
         && gpu_arch == GpuArch::Sm86

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -656,6 +656,24 @@ fn main() -> Result<()> {
         );
         params.use_4b_kernel = true;
     }
+    // qwen3.5-0.8b BF16 decode through the native full_attention.hip kernel
+    // reproducibly page-faults immediately after prefill on gfx1150 (null-
+    // pointer dereference inside the kernel; pre-existing bug, feedback memory
+    // `qwen08_bf16_fault`). The 4B megakernel has identical semantics for
+    // 0.8B shapes and is proven to work via the INT4 routing above, so route
+    // BF16 0.8B through it too. Removing this forcing once the native 0.8B
+    // kernel fault is diagnosed is safe.
+    if matches!(model_variant, registry::ModelVariant::Qwen3_5_0_8B)
+        && !params.use_4b_kernel
+        && backend == Backend::Hip
+    {
+        eprintln!(
+            "[perf] {} routing through 4B kernel (full_attention_4b.hip) \
+             to avoid pre-existing native 0.8B decode kernel page-fault",
+            model_variant
+        );
+        params.use_4b_kernel = true;
+    }
     let params = &params;
 
     if cli.trace_kv_fp8_cache && !cli.kv_fp8 {

--- a/kernels/full_attention_bridge_4b.cpp
+++ b/kernels/full_attention_bridge_4b.cpp
@@ -4595,6 +4595,12 @@ int persistent_decode_device(
     const size_t fp8_lut_size = 256;  // FP8 E4M3 → F32 lookup table
     const size_t shared_bytes = (block_size + input_cache + fp8_lut_size) * sizeof(float);
 
+    // HIP kernel does not yet support per-section timing slots (CUDA sm86
+    // bring-up added `timing_slots` to the bridge/CUDA kernel but the HIP
+    // `.hip` signature was not updated). Silently drop the arg on HIP to
+    // keep the bridge ABI stable without risking gfx1150 codegen churn from
+    // mutating the kernel signature.
+    (void)timing_slots;
     hipLaunchKernelGGL(
         HIP_KERNEL_NAME(dotcache_qwen35_persistent_decode_kernel<T>),
         dim3(static_cast<unsigned int>(num_blocks)),
@@ -4611,7 +4617,6 @@ int persistent_decode_device(
         counters,
         barrier_counter,
         barrier_flag,
-        timing_slots,
         static_cast<const T*>(cos_table),
         static_cast<const T*>(sin_table),
         rotary_dim,


### PR DESCRIPTION
## Summary
- Flip default 4B single-sequence decode from replay-prefill-per-step to persistent megakernel; add hidden \`--force-replay-decode\` escape hatch. Restores decode throughput after the CUDA sm86 bring-up (commit \`65085d8\`) made replay the silent default.
- Route \`qwen3.5-0.8b\` BF16 through the 4B megakernel path to dodge the pre-existing 0.8B native decode page-fault.
- HIP-only bridge fix: drop \`timing_slots\` from the HIP \`dotcache_qwen35_persistent_decode_kernel\` launch; the arg was added to the CUDA kernel + shared bridge in \`16012c8\` but never to the HIP kernel, so the HIP build was broken on origin/main. CUDA bridge/kernel unchanged.

## Measured decode throughput on gfx1150 (Radeon 890M iGPU)
| Variant           | Before          | After          | Speedup |
|-------------------|-----------------|----------------|---------|
| qwen3.5-0.8b BF16 | FAULT           | 136 ms/tok     | ∞       |
| qwen3.5-0.8b INT4 | 175 ms/tok      | 112-123 ms/tok | 1.4-1.6× |
| qwen3.5-2b BF16   | 371 ms/tok      | 254-268 ms/tok | 1.4×    |
| qwen3.5-2b INT4   | 408 ms/tok      | 173-188 ms/tok | 2.2-2.4× |
| qwen3.5-4b BF16   | 1056 @12tok, **2506 @64tok** | 512-600 ms/tok | 1.8× / **4-5× @64tok** |
| qwen3.5-4b INT4   | 1130 ms/tok     | 410-419 ms/tok | 2.7-2.8× |
| qwen3.5-4b FP8    | 1190 ms/tok    | 697-704 ms/tok  | 1.7×    |
| qwen3.5-9b FP8    | 2109 ms/tok    | 966-1089 ms/tok | 2.0-2.2× |

Biggest win is 4B BF16 at long context — replay was O(N) per decode step; the megakernel is O(1). After rebase, re-verified 4B BF16 on the quick-brown-fox prompt at 604 ms/tok.

## Test plan
- [x] \`cargo build --release\` green on gfx1150 (HIP)
- [x] Smoke test: qwen3.5-4b BF16, 16-token decode, coherent output, 604 ms/tok
- [ ] Re-run golden corpus on 0.8b/2b/4b/9b before landing (or rely on prior verification on branch HEAD \`a081b06\`)