### PR TITLE
HIP stage-timings + 2x grid oversubscription for 1.17-1.60× Qwen decode speedup

### DIFF
--- a/crates/kernel-ffi/src/ffi.rs
+++ b/crates/kernel-ffi/src/ffi.rs
@@ -135,6 +135,11 @@ unsafe extern "C" {
         arch_name_len: usize,
         total_vram_out: *mut u64,
     ) -> c_int;
+
+    fn dotcache_hip_device_clock_khz(
+        device_ordinal: c_int,
+        clock_rate_khz_out: *mut u32,
+    ) -> c_int;
 }
 
 #[cfg(supersonic_backend_cuda)]
@@ -1010,4 +1015,18 @@ pub fn query_gpu_info(ordinal: usize) -> Result<(String, u64), GpuError> {
         .to_string_lossy()
         .into_owned();
     Ok((arch_name, total_vram))
+}
+
+/// Query the HIP device clock rate (kHz) for cycle→ms conversion in `--emit-stage-timings`.
+pub fn query_hip_device_clock_khz(ordinal: usize) -> Result<u32, GpuError> {
+    let mut clock_khz: u32 = 0;
+    let status = unsafe {
+        dotcache_hip_device_clock_khz(ordinal as c_int, &mut clock_khz)
+    };
+    if status != 0 {
+        return Err(ffi_error(format!(
+            "hip_device_clock_khz failed with status {status}"
+        )));
+    }
+    Ok(clock_khz)
 }

--- a/crates/kernel-ffi/src/ffi.rs
+++ b/crates/kernel-ffi/src/ffi.rs
@@ -135,7 +135,13 @@ unsafe extern "C" {
         arch_name_len: usize,
         total_vram_out: *mut u64,
     ) -> c_int;
+}
 
+// HIP-only: the clock-rate bridge lives in `full_attention_bridge.cpp` and has
+// no CUDA counterpart (CUDA timing paths get clockRate via
+// `cudaGetDeviceProperties` on the Rust side).
+#[cfg(supersonic_backend_hip)]
+unsafe extern "C" {
     fn dotcache_hip_device_clock_khz(
         device_ordinal: c_int,
         clock_rate_khz_out: *mut u32,
@@ -1018,7 +1024,17 @@ pub fn query_gpu_info(ordinal: usize) -> Result<(String, u64), GpuError> {
 }
 
 /// Query the HIP device clock rate (kHz) for cycle→ms conversion in `--emit-stage-timings`.
+///
+/// On non-HIP builds this returns `GpuError::InvalidArg`; the caller is
+/// responsible for only invoking it when the active backend is HIP.
 pub fn query_hip_device_clock_khz(ordinal: usize) -> Result<u32, GpuError> {
+    #[cfg(not(supersonic_backend_hip))]
+    {
+        let _ = ordinal;
+        return Err(GpuError::InvalidArg("HIP backend not compiled".into()));
+    }
+    #[cfg(supersonic_backend_hip)]
+    {
     let mut clock_khz: u32 = 0;
     let status = unsafe {
         dotcache_hip_device_clock_khz(ordinal as c_int, &mut clock_khz)
@@ -1029,4 +1045,5 @@ pub fn query_hip_device_clock_khz(ordinal: usize) -> Result<u32, GpuError> {
         )));
     }
     Ok(clock_khz)
+    }
 }

--- a/crates/kernel-ffi/src/lib.rs
+++ b/crates/kernel-ffi/src/lib.rs
@@ -7,7 +7,7 @@ pub mod phi4;
 
 pub use ffi::{
     cuda_argmax_bf16, cuda_lm_head_argmax_bf16, matmul_rhs_transposed_4b,
-    persistent_decode, persistent_decode_4b, persistent_decode_qwen08_sm86_specialized, query_gpu_info, rms_norm, rms_norm_4b,
+    persistent_decode, persistent_decode_4b, persistent_decode_qwen08_sm86_specialized, query_gpu_info, query_hip_device_clock_khz, rms_norm, rms_norm_4b,
     rms_norm_4b_multirow, standalone_matvec, standalone_matvec_4b,
 };
 pub use layer_desc::{DecodeLayerDesc, FP8ScaleDesc, INT4ScaleDesc, KVCacheFp8Desc, BatchSeqDesc, MAX_BATCH_SIZE};

--- a/crates/runner/src/decode_engine.rs
+++ b/crates/runner/src/decode_engine.rs
@@ -3528,9 +3528,15 @@ impl DecodeEngine {
         .map_err(|e| anyhow::anyhow!("persistent_decode_4b batch kernel: {e}"))?;
         timings.persistent_ms = start.elapsed().as_secs_f64() * 1000.0;
         if enable_timing_slots {
-            let clock_rate_khz = gpu_hal::query_device_info(gpu_hal::Backend::Cuda, self.ordinal)
-                .map_err(|e| anyhow::anyhow!("query CUDA device clock rate: {e}"))?
-                .clock_rate_khz;
+            let clock_rate_khz = match self.hidden_io.backend() {
+                gpu_hal::Backend::Cuda => {
+                    gpu_hal::query_device_info(gpu_hal::Backend::Cuda, self.ordinal)
+                        .map_err(|e| anyhow::anyhow!("query CUDA device clock rate: {e}"))?
+                        .clock_rate_khz
+                }
+                gpu_hal::Backend::Hip => kernel_ffi::query_hip_device_clock_khz(self.ordinal)
+                    .map_err(|e| anyhow::anyhow!("query HIP device clock rate: {e}"))?,
+            };
             let sync_bytes = self
                 .scratch
                 .sync_buf

--- a/kernels/full_attention_4b.hip
+++ b/kernels/full_attention_4b.hip
@@ -6,6 +6,23 @@
 #include <math.h>
 #include <stdint.h>
 
+// Per-section timing slot layout (mirrors the CUDA kernel's layout so the Rust
+// reader `decode_persistent_4b_timing_slots` is backend-agnostic). Each layer
+// owns QWEN35_4B_TIMING_COUNT u64 slots; per-batch-item sections (CORE/OUT)
+// reserve 8 slots each so batch_size up to 8 is covered.
+enum Qwen35Persistent4BTimingSlot {
+    QWEN35_4B_TIMING_FULL_ATTN = 0,
+    QWEN35_4B_TIMING_FULL_ATTN_PROJ = 1,
+    QWEN35_4B_TIMING_FULL_ATTN_CORE_BASE = 2,
+    QWEN35_4B_TIMING_FULL_ATTN_OUT_BASE = 10,
+    QWEN35_4B_TIMING_LINEAR_PROJ = 18,
+    QWEN35_4B_TIMING_LINEAR_CORE_BASE = 19,
+    QWEN35_4B_TIMING_LINEAR_OUT_BASE = 27,
+    QWEN35_4B_TIMING_MLP_GATE_UP = 35,
+    QWEN35_4B_TIMING_MLP_DOWN = 36,
+    QWEN35_4B_TIMING_COUNT = 37,
+};
+
 // Weight descriptor for the persistent decode megakernel.
 // One struct per decoder layer (24 total for Qwen3.5-0.8B).
 // Immutable weight pointers are const; mutable state pointers are non-const.
@@ -3894,6 +3911,16 @@ __global__ void quantize_kv_to_fp8_kernel(
     }
 }
 
+__device__ __forceinline__ void qwen35_4b_hip_record_timing(
+    unsigned long long* timing_slots,
+    int slot,
+    unsigned long long start_clock
+) {
+    if (timing_slots != nullptr && threadIdx.x == 0) {
+        atomicMax(&timing_slots[slot], clock64() - start_clock);
+    }
+}
+
 template <typename T>
 __global__ void dotcache_qwen35_persistent_decode_kernel(
     int num_layers,
@@ -3906,6 +3933,7 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
     unsigned int* __restrict__ counters,
     unsigned int* __restrict__ barrier_counter,
     unsigned int* __restrict__ barrier_flag,
+    unsigned long long* __restrict__ timing_slots,  // nullptr disables; else [num_layers * 37]
     const T* __restrict__ cos_table,   // [max_positions, rotary_dim/2] RoPE cos
     const T* __restrict__ sin_table,   // [max_positions, rotary_dim/2] RoPE sin
     int rotary_dim,                      // partial rotary dimension (64 for Qwen3.5)
@@ -3977,6 +4005,9 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
 
     for (int layer = 0; layer < num_layers; ++layer) {
         const Qwen35DecodeLayerDesc& L = layers[layer];
+        unsigned long long* layer_timing_slots = timing_slots != nullptr
+            ? timing_slots + static_cast<size_t>(layer) * QWEN35_4B_TIMING_COUNT
+            : nullptr;
 
         // Match the component path's BF16 hidden-state boundaries: each layer
         // starts from BF16-hidden activations rather than carrying full F32
@@ -4033,6 +4064,8 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
             // ---- FULL ATTENTION ----
             // Step A: Q/K/V projections via work-stealing
             // Q: [q_out_dim, hidden_dim], K: [k_out_dim, hidden_dim], V: same as K
+            const unsigned long long full_attn_clock = clock64();
+            const unsigned long long full_attn_proj_clock = clock64();
             if (blockIdx.x == 0 && tid == 0) { counters[0] = 0; __threadfence(); }
             grid_barrier(barrier_counter, barrier_flag, nb);
 
@@ -4150,6 +4183,10 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
                 }
             }
             __syncthreads();
+            qwen35_4b_hip_record_timing(
+                layer_timing_slots,
+                QWEN35_4B_TIMING_FULL_ATTN_PROJ,
+                full_attn_proj_clock);
             grid_barrier(barrier_counter, barrier_flag, nb);
 
             // Step B-G: QK-norm, RoPE, KV cache, attention, gating, o_proj
@@ -4165,6 +4202,7 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
                 const int attn_size = nh * hd;          // 2048
 
             for (int b = 0; b < B; b++) {
+                const unsigned long long full_attn_core_clock = clock64();
                 // Per-sequence state: read from batch_descs when batched, else from L/seqlen_offset
                 const int seq_off_b  = batch_descs ? batch_descs[layer].seqlen_offset[b] : seqlen_offset;
                 void* kv_k_b         = batch_descs ? batch_descs[layer].kv_cache_k[b]    : L.kv_cache_k;
@@ -4517,7 +4555,12 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
                 } // end if (blockIdx.x == 0)
                 // Grid barrier: block 0 wrote attn_flat, all blocks need it for o_proj
                 grid_barrier(barrier_counter, barrier_flag, nb);
+                qwen35_4b_hip_record_timing(
+                    layer_timing_slots,
+                    QWEN35_4B_TIMING_FULL_ATTN_CORE_BASE + b,
+                    full_attn_core_clock);
 
+                const unsigned long long full_attn_out_clock = clock64();
                 // Step G: o_proj [hidden_dim, attn_size] × attn_flat → hidden_f32 (fused residual)
                 // Per-sequence: cache batch b's attn output in LDS, work-steal hidden_dim rows
                 {
@@ -4616,13 +4659,20 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
                     }
                 }
                 __syncthreads();
+                qwen35_4b_hip_record_timing(
+                    layer_timing_slots,
+                    QWEN35_4B_TIMING_FULL_ATTN_OUT_BASE + b,
+                    full_attn_out_clock);
                 grid_barrier(barrier_counter, barrier_flag, nb);
             } // end for (b) batch loop
             } // end full attention scope
+            qwen35_4b_hip_record_timing(
+                layer_timing_slots, QWEN35_4B_TIMING_FULL_ATTN, full_attn_clock);
 
         } else {
             // ---- LINEAR ATTENTION ----
             // Step A: qkv/z/b/a projections via work-stealing
+            const unsigned long long linear_proj_clock = clock64();
             if (blockIdx.x == 0 && tid == 0) { counters[0] = 0; __threadfence(); }
             grid_barrier(barrier_counter, barrier_flag, nb);
 
@@ -4732,12 +4782,15 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
                 }
             }
             __syncthreads();
+            qwen35_4b_hip_record_timing(
+                layer_timing_slots, QWEN35_4B_TIMING_LINEAR_PROJ, linear_proj_clock);
             grid_barrier(barrier_counter, barrier_flag, nb);
 
             // Step B-E: conv1d, recurrent state, gated norm, out_proj
             // Block 0 handles sequential recurrent operations (per-sequence loop).
             // O_proj uses all blocks via work-stealing (per-sequence loop).
             for (int b = 0; b < B; b++) {
+            const unsigned long long linear_core_clock = clock64();
             // Per-sequence state
             void* conv_b = batch_descs ? batch_descs[layer].conv_state[b] : L.conv_state;
             void* rec_b  = batch_descs ? batch_descs[layer].recurrent_state[b] : L.recurrent_state;
@@ -4964,7 +5017,12 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
             } // end if (blockIdx.x == 0) for linear attention core
             // Grid barrier: block 0 wrote attn_scratch_b, all blocks need it for out_proj
             grid_barrier(barrier_counter, barrier_flag, nb);
+            qwen35_4b_hip_record_timing(
+                layer_timing_slots,
+                QWEN35_4B_TIMING_LINEAR_CORE_BASE + b,
+                linear_core_clock);
 
+            const unsigned long long linear_out_clock = clock64();
             // Step E: out_proj [hidden_dim, val_dim] × attn_scratch → hidden_f32 (fused residual)
             // Per-sequence: cache batch b's output in LDS, work-steal hidden_dim rows
             {
@@ -5036,6 +5094,10 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
                 }
             }
             __syncthreads();
+            qwen35_4b_hip_record_timing(
+                layer_timing_slots,
+                QWEN35_4B_TIMING_LINEAR_OUT_BASE + b,
+                linear_out_clock);
             grid_barrier(barrier_counter, barrier_flag, nb);
             } // end for (b) batch loop for linear attention
 
@@ -5094,6 +5156,7 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
 
         // === Fused MLP gate+up+SwiGLU (all blocks work-steal, BATCHED) ===
         // Use full-block reductions here for parity with the component path.
+        const unsigned long long mlp_gate_up_clock = clock64();
         if (blockIdx.x == 0 && tid == 0) { counters[0] = 0; __threadfence(); }
         grid_barrier(barrier_counter, barrier_flag, nb);
 
@@ -5247,10 +5310,13 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
                 }
             }
         }
+        qwen35_4b_hip_record_timing(
+            layer_timing_slots, QWEN35_4B_TIMING_MLP_GATE_UP, mlp_gate_up_clock);
         grid_barrier(barrier_counter, barrier_flag, nb);
 
         // === MLP down_proj (all blocks work-steal, per-sequence) ===
         // Process one batch item at a time: cache SwiGLU output in LDS, work-steal
+        const unsigned long long mlp_down_clock = clock64();
         for (int b = 0; b < B; b++) {
             for (int c = tid; c < L.intermediate_size; c += bs)
                 lds_input[c] = gate_up[b * intermediate_size * 2 + c];
@@ -5330,6 +5396,8 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
             __syncthreads();
             grid_barrier(barrier_counter, barrier_flag, nb);
         } // end for (b) down_proj batch loop
+        qwen35_4b_hip_record_timing(
+            layer_timing_slots, QWEN35_4B_TIMING_MLP_DOWN, mlp_down_clock);
 
         // Residual add for MLP is fused into down_proj above.
 

--- a/kernels/full_attention_bridge.cpp
+++ b/kernels/full_attention_bridge.cpp
@@ -4490,3 +4490,15 @@ extern "C" int dotcache_query_gpu_info(
     *total_vram_out = static_cast<uint64_t>(props.totalGlobalMem);
     return 0;
 }
+
+extern "C" int dotcache_hip_device_clock_khz(
+    int device_ordinal,
+    uint32_t* clock_rate_khz_out) {
+    hipDeviceProp_t props;
+    hipError_t err = hipGetDeviceProperties(&props, device_ordinal);
+    if (err != hipSuccess) {
+        return static_cast<int>(err);
+    }
+    *clock_rate_khz_out = static_cast<uint32_t>(props.clockRate);
+    return 0;
+}

--- a/kernels/full_attention_bridge_4b.cpp
+++ b/kernels/full_attention_bridge_4b.cpp
@@ -4585,7 +4585,23 @@ int persistent_decode_device(
     hipDeviceProp_t props;
     if (hipGetDeviceProperties(&props, device_ordinal) != hipSuccess) return 250;
 
-    const int num_blocks = props.multiProcessorCount > 0 ? props.multiProcessorCount : 16;
+    // rocprofv3 on gfx1150 revealed `multiProcessorCount` reports 8 (WGP
+    // count on RDNA3, not CU count) while the device has 16 CUs — the
+    // original 1x grid left half the GPU idle with only 1 block/CU, and
+    // register pressure (VGPR=128) prevents a second resident block.
+    // Oversubscribing 2x (= one block per CU) is a proven safe win:
+    // ~1.57x faster on qwen3.5-0.8b BF16, no hangs across tested models.
+    // Higher multipliers (3x+) hang silently on models with more
+    // transformer layers (e.g. qwen3.5-2b) — suspected grid_barrier
+    // scaling issue. Env var `SUPERSONIC_QWEN4B_BLOCKS` allows override
+    // for tuning, but do not push past 2x without testing every model.
+    int num_blocks = props.multiProcessorCount > 0 ? props.multiProcessorCount : 16;
+    if (const char* bs_env = std::getenv("SUPERSONIC_QWEN4B_BLOCKS")) {
+        int override_val = std::atoi(bs_env);
+        if (override_val > 0) num_blocks = override_val;
+    } else {
+        num_blocks *= 2;
+    }
     constexpr int block_size = 256;
     // LDS: reduction scratch [block_size] + input cache [max(batch_size * hidden_dim, intermediate_size)]
     //      + FP8 LUT [256] (only when fp8_scales != nullptr, but always allocated for simplicity)

--- a/kernels/full_attention_bridge_4b.cpp
+++ b/kernels/full_attention_bridge_4b.cpp
@@ -4595,12 +4595,6 @@ int persistent_decode_device(
     const size_t fp8_lut_size = 256;  // FP8 E4M3 → F32 lookup table
     const size_t shared_bytes = (block_size + input_cache + fp8_lut_size) * sizeof(float);
 
-    // HIP kernel does not yet support per-section timing slots (CUDA sm86
-    // bring-up added `timing_slots` to the bridge/CUDA kernel but the HIP
-    // `.hip` signature was not updated). Silently drop the arg on HIP to
-    // keep the bridge ABI stable without risking gfx1150 codegen churn from
-    // mutating the kernel signature.
-    (void)timing_slots;
     hipLaunchKernelGGL(
         HIP_KERNEL_NAME(dotcache_qwen35_persistent_decode_kernel<T>),
         dim3(static_cast<unsigned int>(num_blocks)),
@@ -4617,6 +4611,7 @@ int persistent_decode_device(
         counters,
         barrier_counter,
         barrier_flag,
+        timing_slots,
         static_cast<const T*>(cos_table),
         static_cast<const T*>(sin_table),
         rotary_dim,

--- a/kernels/full_attention_bridge_4b.cpp
+++ b/kernels/full_attention_bridge_4b.cpp
@@ -4589,18 +4589,33 @@ int persistent_decode_device(
     // count on RDNA3, not CU count) while the device has 16 CUs — the
     // original 1x grid left half the GPU idle with only 1 block/CU, and
     // register pressure (VGPR=128) prevents a second resident block.
-    // Oversubscribing 2x (= one block per CU) is a proven safe win:
-    // ~1.57x faster on qwen3.5-0.8b BF16, no hangs across tested models.
+    // Oversubscribing 2x on RDNA3 (= one block per CU) is a proven safe
+    // win: ~1.57x faster on qwen3.5-0.8b BF16, no hangs across tested
+    // Qwen variants.
+    //
+    // HIP docs note `multiProcessorCount` reports CUs on CDNA (MI-series)
+    // and WGPs on RDNA. On arches where it already reports CU count, 2x
+    // would over-subscribe and can deadlock via `grid_barrier` when only
+    // one block/CU is resident. Restrict the default multiplier to the
+    // arches we've actually validated (gfx11xx RDNA3/3.5 at time of
+    // writing); other arches get the conservative 1x default.
+    //
     // Higher multipliers (3x+) hang silently on models with more
-    // transformer layers (e.g. qwen3.5-2b) — suspected grid_barrier
-    // scaling issue. Env var `SUPERSONIC_QWEN4B_BLOCKS` allows override
-    // for tuning, but do not push past 2x without testing every model.
+    // transformer layers (qwen3.5-2b at 4x produces no output) —
+    // suspected grid_barrier scaling issue. Env var
+    // `SUPERSONIC_QWEN4B_BLOCKS` allows runtime override for tuning.
     int num_blocks = props.multiProcessorCount > 0 ? props.multiProcessorCount : 16;
     if (const char* bs_env = std::getenv("SUPERSONIC_QWEN4B_BLOCKS")) {
         int override_val = std::atoi(bs_env);
         if (override_val > 0) num_blocks = override_val;
     } else {
-        num_blocks *= 2;
+        const char* arch = props.gcnArchName;
+        const bool is_rdna3_wgp_arch =
+            arch[0] == 'g' && arch[1] == 'f' && arch[2] == 'x' &&
+            arch[3] == '1' && arch[4] == '1';
+        if (is_rdna3_wgp_arch) {
+            num_blocks *= 2;
+        }
     }
     constexpr int block_size = 256;
     // LDS: reduction scratch [block_size] + input cache [max(batch_size * hidden_dim, intermediate_size)]


### PR DESCRIPTION
## Summary

Two commits on top of main:

1. **\`38dbaec\` — HIP stage-timing instrumentation** for the 4B persistent kernel. Restores the \`timing_slots\` parameter and adds \`clock64()\`-based \`atomicMax\` counters covering FULL_ATTN / PROJ / CORE / OUT, LINEAR_PROJ / CORE / OUT, MLP_GATE_UP / DOWN — mirroring the CUDA kernel's timing layout so the existing Rust decoder (\`decode_persistent_4b_timing_slots\`) works on HIP unchanged. Also branches the clock-rate query on backend (new \`query_hip_device_clock_khz\` bridge helper) so \`--emit-stage-timings\` stops erroring out with \"CUDA backend not compiled\" on HIP builds.

   Caveat: \`clock64()\` on gfx1150 doesn't tick at the rate \`hipDeviceProp_t::clockRate\` reports, so absolute ms values are garbage on HIP. Cycle *ratios* are consistent, so per-section breakdown is still informative. Absolute-ms calibration left as follow-up.

2. **\`2841b52\` — 2× grid oversubscription.** rocprofv3 kernel-trace on gfx1150 revealed \`hipDeviceProp_t::multiProcessorCount\` reports the RDNA3 **WGP** count (8), not the CU count (16) — so the persistent decode was running 8 blocks on a 16-CU device, leaving half the GPU idle. VGPR=128 register pressure caps each CU at one resident block regardless, so doubling to 16 blocks gives exactly 1 block/CU and saturates the device. Higher multipliers (3×+) hang silently on models with more layers, so 2× is the committed default. Env var \`SUPERSONIC_QWEN4B_BLOCKS\` allows runtime override.

## Measured decode speedups on gfx1150 (Radeon 890M iGPU)

16-token \"The quick brown fox jumps over\" prompt:

| Variant            | Before | After | Speedup |
|--------------------|-------:|------:|---------|
| qwen3.5-0.8b BF16  |    146 |    91 |   1.60× |
| qwen3.5-0.8b INT4  |    115 |    78 |   1.47× |
| qwen3.5-2b  BF16   |    238 |   159 |   1.50× |
| qwen3.5-2b  INT4   |    173 |   118 |   1.47× |
| qwen3.5-4b  BF16   |    604 |   514 |   1.17× |
| qwen3.5-4b  INT4   |    410 |   286 |   1.43× |
| qwen3.5-9b  FP8    |    966 |   697 |   1.39× |

All token streams match the 1×-grid baseline exactly. 4B BF16 shows the smallest speedup because per-block work is already large (intermediate_size=9728) so occupancy matters less.

## What stays open

- Higher multipliers (3×+) hang kernels with many layers (e.g. qwen3.5-2b at 4× silently produces no output). Suspected \`grid_barrier\` scaling issue — fixing it would unblock another ~30% (qwen3.5-0.8b at 4× ran at 63 ms/tok in a quick trial before the sweep started crashing on larger models).
- HIP \`clock64()\` tick-rate calibration for \`--emit-stage-timings\` absolute ms accuracy.
- VGPR=128 register pressure in the persistent kernel caps occupancy at 1 block/CU; reducing it (e.g. moving \`float p[MAX_BATCH_SIZE]\` scratch to LDS) could allow 2 blocks/CU.

## Test plan

- [x] \`cargo build --release\` green on gfx1150 (HIP)
- [x] Token-stream match vs baseline on qwen3.5-0.8b/2b/4b BF16 + INT4 and qwen3.5-9b FP8
- [x] rocprofv3 kernel-trace confirms 16-block grid on gfx1150 post-fix
- [ ] CUDA-side unchanged (persistent_decode_4b_cuda.cu and friends untouched) — verify on sm86 box before landing
- [ ] Golden corpus regression check on at least one representative variant