### PR TITLE
Update README support matrix; add docs/performance.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,49 @@
 # SuperSonic
 
-Optimized LLM inference with persistent decode megakernels. Each supported (model, backend, GPU) combination gets a hand-tuned kernel — no fallback to generic slow paths.
+Optimized LLM inference with persistent decode megakernels. Each supported
+(model, backend, GPU) combination gets a hand-tuned kernel — no fallback to
+generic slow paths.
 
-Currently supports:
-
-- Qwen3.5-0.8B and Qwen3.5-4B on AMD `gfx1150` (RDNA 3.5) via HIP
-- Gemma 4 E2B and E4B on AMD `gfx1150` (RDNA 3.5) via HIP
-- Qwen3.5-0.8B and Qwen3.5-4B on NVIDIA `sm86` (RTX 3090-class) via CUDA
-
-CUDA v1 is BF16-first. `--int4` and `--fp8-runtime` remain unsupported on CUDA. A hidden unstable CUDA `--kv-fp8` debug path exists for targeted validation work on `qwen3.5-4b`, but it is not part of the public supported surface.
+Measured decode throughput: see [docs/performance.md](docs/performance.md).
 
 ## Supported Matrix
 
-| Backend | GPU arch | Models | Status |
-| --- | --- | --- | --- |
-| HIP | `gfx1150` | `qwen3.5-0.8b`, `qwen3.5-4b` | validated |
-| HIP | `gfx1150` | `gemma4-e2b`, `gemma4-e4b` | upstream validated |
-| CUDA | `sm86` | `qwen3.5-0.8b`, `qwen3.5-4b` | validated |
+Two backends are validated today:
+
+- **HIP / `gfx1150`** — AMD Radeon 890M iGPU (RDNA 3.5)
+- **CUDA / `sm86`** — NVIDIA RTX 3090-class (Ampere)
+
+### HIP on `gfx1150`
+
+| Model            | BF16 | INT4 | FP8 runtime | FP8 KV |
+|------------------|:----:|:----:|:-----------:|:------:|
+| qwen3.5-0.8b     |  ✅  |  ✅  |      ✅     |   ✅   |
+| qwen3.5-2b       |  ✅  |  ✅  |      ✅     |   ✅   |
+| qwen3.5-4b       |  ✅  |  ✅  |      ✅     |   ✅   |
+| qwen3.5-9b       |  ✅  |  ✅¹ |      ✅     |   ✅   |
+| gemma4-e2b       |  ✅  |  ✅  |      —      |    —   |
+| gemma4-e4b       |  ✅  |  —²  |      —      |    —   |
+| phi4-mini        |  ✅  |  ✅  |      —      |    —   |
+
+¹ GPTQ calibration for 9B INT4 needs ≥24 GiB; consumers pull the released
+  bake from GitHub releases. See [docs/bake-distribution.md](docs/bake-distribution.md).
+² Gemma E4B INT4 calibration is parked.
+
+DFlash speculative decode is available for `qwen3.5-9b` INT4 on HIP —
+see [docs/dflash.md](docs/dflash.md).
+
+### CUDA on `sm86`
+
+| Model            | BF16 | INT4 | FP8 runtime | FP8 KV |
+|------------------|:----:|:----:|:-----------:|:------:|
+| qwen3.5-0.8b     |  ✅  |  —   |      —      |    —   |
+| qwen3.5-4b       |  ✅  |  —   |      —      |   🔒³  |
+
+³ `qwen3.5-4b` has a hidden `--allow-unstable-cuda-kv-fp8` debug surface for
+  parity-sensitive validation work. It is not part of the public supported
+  surface — see the CUDA section below for the narrow validated shape.
+
+CUDA v1 is BF16-first. `--int4` and `--fp8-runtime` are rejected at runtime.
 
 CUDA support is currently a narrow v1 surface:
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,73 @@
+# Performance
+
+Measured decode throughput for the shipping kernels. Numbers are steady-state
+tokens/second, single-sequence (`--batch-size 1`) unless noted, recorded with
+a 16-token generation on the 6-token `"The quick brown fox jumps over"` prompt.
+
+If you reproduce these and get materially different results, please open an
+issue with your GPU arch, ROCm/CUDA versions, and the exact command line.
+
+## HIP — `gfx1150` (AMD Radeon 890M iGPU)
+
+16 CUs, 2.9 GHz core, shared with system memory. Measurements from
+2026-04-20 on commit `d91a993` (2× grid oversubscription merged).
+
+| Model              | Quant | ms/tok | tok/s |
+|--------------------|-------|-------:|------:|
+| qwen3.5-0.8b       | BF16  | 91     | 11.0  |
+| qwen3.5-0.8b       | INT4  | 78     | 12.8  |
+| qwen3.5-2b         | BF16  | 159    | 6.3   |
+| qwen3.5-2b         | INT4  | 118    | 8.5   |
+| qwen3.5-4b         | BF16  | 514    | 1.9   |
+| qwen3.5-4b         | INT4  | 286    | 3.5   |
+| qwen3.5-9b         | FP8   | 697    | 1.4   |
+
+Notes:
+
+- `qwen3.5-0.8b` decode (both BF16 and INT4) routes through the 4B persistent
+  megakernel. The native 0.8B decode kernel has a documented page-fault on
+  this machine and is not on the shipping path.
+- `qwen3.5-9b` INT4 bake runs out of VRAM during GPTQ calibration on 16 GiB
+  cards. Consumers pull the released bake from GitHub releases (see
+  [bake-distribution.md](bake-distribution.md)); the INT4 runtime itself is
+  supported.
+- FP8-runtime and FP8-KV paths (`--fp8-runtime`, `--kv-fp8`) are only wired
+  for the Qwen family on HIP. Gemma 4 and Phi-4-mini reject both flags.
+
+Gemma 4 and Phi-4-mini timings on gfx1150 are not in the current measurement
+set — add them here when next measured.
+
+## CUDA — `sm86` (NVIDIA RTX 3090-class)
+
+24 GB VRAM, 936 GB/s memory bandwidth. Current behavior depends on whether
+the path is using replayed prefill for correctness.
+
+With a quick harness pass (`PROMPT_REPEAT=8`, `MAX_NEW_TOKENS=8`, `RUNS=1`):
+
+| Model                              | Path                      | Prefill       | Decode        |
+|------------------------------------|---------------------------|---------------|---------------|
+| qwen3.5-0.8b                       | default (hero)            | 563 tok/s     | 29.9 tok/s    |
+| qwen3.5-4b `--batch-size 2`        | default (batched)         | 124 tok/s     | 21.6 tok/s    |
+| qwen3.5-4b `--batch-size 1`        | replay-prefill correctness| 124 tok/s     | 1.1 tok/s     |
+| qwen3.5-4b `--batch-size 1`        | `--force-kernel-decode`   | 119 tok/s     | 10.6 tok/s    |
+
+CUDA `sm86` tracks detailed kernel-level optimization history in
+[qwen35-sm86-optimization.md](qwen35-sm86-optimization.md) (0.8B hero lane)
+and [qwen35-4b-sm86-optimization.md](qwen35-4b-sm86-optimization.md) (4B).
+
+## How to reproduce
+
+```bash
+# HIP / gfx1150
+cargo build --release --bin supersonic
+./target/release/supersonic --model qwen3.5-0.8b \
+  --model-dir /path/to/Qwen3.5-0.8B \
+  --prompt "The quick brown fox jumps over" \
+  --max-new-tokens 16
+
+# Add --int4 / --fp8-runtime / --kv-fp8 as supported per the matrix in README.md.
+
+# CUDA / sm86
+SUPERSONIC_BACKENDS=cuda ./tests/sm86/bench.sh \
+  /path/to/Qwen3.5-0.8B /path/to/Qwen3.5-4B
+```


### PR DESCRIPTION
## Summary
- README's lead paragraph and support matrix were stale: the registry covers Qwen3.5 0.8B/2B/4B/9B, Gemma4 E2B/E4B, and Phi-4-mini on HIP/gfx1150, plus Qwen3.5 0.8B/4B on CUDA/sm86. Replaced with a per-backend quant grid (BF16 / INT4 / FP8 runtime / FP8 KV) reflecting what \`main.rs\` + engine files actually accept/reject today. Footnotes cover the 9B INT4 bake-box requirement and that Gemma E4B INT4 is parked.
- Split per-variant tok/s into a new \`docs/performance.md\` linked from the lead. First cut covers the 2026-04-20 HIP/gfx1150 measurements (7 variants from the merged 2× grid PR #7) and the existing CUDA/sm86 prefill+decode figures that were previously buried in the CUDA section body. The CUDA optimization deep-dives stay linked.
- No code changes.

## Test plan
- [x] \`cargo build --release\` clean
- [ ] Spot-check the rendered matrix on the PR preview