### PR TITLE
Add Gemma 4 and Phi-4-mini baseline decode timings

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -10,23 +10,27 @@ issue with your GPU arch, ROCm/CUDA versions, and the exact command line.
 ## HIP — `gfx1150` (AMD Radeon 890M iGPU)
 
 16 CUs, 2.9 GHz core, shared with system memory. Measurements from
-2026-04-20 on commit `d91a993` (2× grid oversubscription merged).
+2026-04-20 on commit `b075b00` (0.8B-native kernel deleted, 2× grid
+oversubscription merged).
+
+### Qwen3.5
 
 | Model              | Quant | ms/tok | tok/s |
 |--------------------|-------|-------:|------:|
-| qwen3.5-0.8b       | BF16  | 91     | 11.0  |
-| qwen3.5-0.8b       | INT4  | 78     | 12.8  |
-| qwen3.5-2b         | BF16  | 159    | 6.3   |
-| qwen3.5-2b         | INT4  | 118    | 8.5   |
-| qwen3.5-4b         | BF16  | 514    | 1.9   |
-| qwen3.5-4b         | INT4  | 286    | 3.5   |
-| qwen3.5-9b         | FP8   | 697    | 1.4   |
+| qwen3.5-0.8b       | BF16  |   91   | 11.0  |
+| qwen3.5-0.8b       | INT4  |   78   | 12.8  |
+| qwen3.5-2b         | BF16  |  159   |  6.3  |
+| qwen3.5-2b         | INT4  |  118   |  8.5  |
+| qwen3.5-4b         | BF16  |  514   |  1.9  |
+| qwen3.5-4b         | INT4  |  286   |  3.5  |
+| qwen3.5-9b         | FP8   |  697   |  1.4  |
 
 Notes:
 
-- `qwen3.5-0.8b` decode (both BF16 and INT4) routes through the 4B persistent
-  megakernel. The native 0.8B decode kernel has a documented page-fault on
-  this machine and is not on the shipping path.
+- `qwen3.5-0.8b` decode (both BF16 and INT4) runs through the 4B persistent
+  megakernel. The dedicated 0.8B-native kernel was deleted on 2026-04-20 —
+  it had no INT4/FP8 path and was ~2.8× slower than the 4B-routed path
+  even for BF16.
 - `qwen3.5-9b` INT4 bake runs out of VRAM during GPTQ calibration on 16 GiB
   cards. Consumers pull the released bake from GitHub releases (see
   [bake-distribution.md](bake-distribution.md)); the INT4 runtime itself is
@@ -34,8 +38,27 @@ Notes:
 - FP8-runtime and FP8-KV paths (`--fp8-runtime`, `--kv-fp8`) are only wired
   for the Qwen family on HIP. Gemma 4 and Phi-4-mini reject both flags.
 
-Gemma 4 and Phi-4-mini timings on gfx1150 are not in the current measurement
-set — add them here when next measured.
+### Gemma 4
+
+| Model        | Quant | ms/tok | tok/s |
+|--------------|-------|-------:|------:|
+| gemma4-e2b   | BF16  |  673   | 1.49  |
+| gemma4-e2b   | INT4¹ |  418   | 2.39  |
+| gemma4-e4b   | BF16  | 1256   | 0.80  |
+
+¹ Gemma 4 E2B INT4 runs but quality is degraded — the GPTQ bake is
+distributed from releases and produces coherent first tokens but
+devolves into repetition within a few generations. INT4 quality
+calibration for the E2B bake is parked pending a revisit. E4B INT4
+calibration OOMs on this machine and is also parked — BF16 is the
+shipping path for E4B on gfx1150.
+
+### Phi-4-mini
+
+| Model        | Quant | ms/tok | tok/s |
+|--------------|-------|-------:|------:|
+| phi4-mini    | BF16  |  597   | 1.68  |
+| phi4-mini    | INT4  |  359   | 2.78  |
 
 ## CUDA — `sm86` (NVIDIA RTX 3090-class)
 


### PR DESCRIPTION
## Summary

Measured HIP/gfx1150 decode throughput for the remaining shipping families so the performance table has coverage beyond Qwen3.5. Same harness as the existing Qwen rows: single-sequence, 16-token generation on \`\"The quick brown fox jumps over\"\`.

| Model      | Quant | ms/tok | tok/s | Notes |
|------------|-------|-------:|------:|-------|
| gemma4-e2b | BF16  |  673   | 1.49  | |
| gemma4-e2b | INT4  |  418   | 2.39  | ⚠️ quality-calibration parked — coherent first tokens then degenerates |
| gemma4-e4b | BF16  | 1256   | 0.80  | INT4 bake calibration OOMs; BF16 is the shipping path |
| phi4-mini  | BF16  |  597   | 1.68  | |
| phi4-mini  | INT4  |  359   | 2.78  | |

Also regrouped the existing Qwen table under a \"Qwen3.5\" subheading and updated the 0.8B routing note (PR #10 deleted the native kernel today, the old \"documented page-fault on this machine\" wording was stale).

No code changes.

## Test plan

- [x] \`cargo build --release\` clean
- [x] All variants verified to produce decode output end-to-end (Gemma 4 E2B INT4 is flagged in the table because its output degenerates, but the throughput number is valid)
- [ ] Preview the PR render