### PR TITLE
Per-model qwen4b launch preset (cooperative-launch opt-in + 0.8B auto-coop)

### DIFF
--- a/crates/kernel-ffi/src/ffi.rs
+++ b/crates/kernel-ffi/src/ffi.rs
@@ -173,6 +173,13 @@ unsafe extern "C" {
         device_ordinal: c_int,
         clock_rate_khz_out: *mut u32,
     ) -> c_int;
+
+    // Per-model launch preset for the qwen4b persistent decode kernel.
+    // `blocks=0` clears the preset (falls back to the hardcoded gfx11xx 2x
+    // default). `coop != 0` opts into `hipLaunchCooperativeKernel` for that
+    // preset, which is safe at higher block counts but caps conservatively
+    // based on `hipOccupancyMaxActiveBlocksPerMultiprocessor`.
+    fn dotcache_qwen35_4b_hip_set_launch_preset(blocks: c_int, coop: c_int);
 }
 
 #[cfg(supersonic_backend_cuda)]
@@ -1179,5 +1186,26 @@ pub fn query_hip_device_clock_khz(ordinal: usize) -> Result<u32, GpuError> {
         )));
     }
     Ok(clock_khz)
+    }
+}
+
+/// Install a per-model launch preset for the qwen4b persistent decode
+/// kernel on HIP. `blocks == 0` clears any active preset; a positive value
+/// makes the bridge pick that grid size when no `SUPERSONIC_QWEN4B_BLOCKS`
+/// env var is set. `coop == true` opts the preset into cooperative launch
+/// (recommended whenever the preset exceeds the safe non-coop 2x default).
+///
+/// No-op on non-HIP builds — CUDA has its own separate bridge.
+pub fn set_qwen35_4b_launch_preset(blocks: i32, coop: bool) {
+    #[cfg(supersonic_backend_hip)]
+    unsafe {
+        dotcache_qwen35_4b_hip_set_launch_preset(
+            blocks as c_int,
+            if coop { 1 } else { 0 },
+        );
+    }
+    #[cfg(not(supersonic_backend_hip))]
+    {
+        let _ = (blocks, coop);
     }
 }

--- a/crates/kernel-ffi/src/lib.rs
+++ b/crates/kernel-ffi/src/lib.rs
@@ -10,6 +10,6 @@ pub use ffi::{
     persistent_decode, persistent_decode_4b, persistent_decode_4b_qwen35_sm86_specialized,
     persistent_decode_qwen08_sm86_specialized, query_gpu_info, query_hip_device_clock_khz,
     rms_norm, rms_norm_4b,
-    rms_norm_4b_multirow, standalone_matvec, standalone_matvec_4b,
+    rms_norm_4b_multirow, set_qwen35_4b_launch_preset, standalone_matvec, standalone_matvec_4b,
 };
 pub use layer_desc::{DecodeLayerDesc, FP8ScaleDesc, INT4ScaleDesc, KVCacheFp8Desc, BatchSeqDesc, MAX_BATCH_SIZE};

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -646,6 +646,16 @@ fn main() -> Result<()> {
         FamilyParams::Phi4(_) => unreachable!("phi4 handled above"),
     };
 
+    // Install the per-model HIP launch preset (grid size + cooperative
+    // flag) if the registry specifies one. User env vars still override
+    // inside the bridge. Always called — `None` clears any stale preset
+    // from a prior run, so switching models doesn't inherit the previous
+    // one's grid. No-op on CUDA builds.
+    {
+        let (blocks, coop) = params.hip_launch_preset.unwrap_or((0, false));
+        kernel_ffi::set_qwen35_4b_launch_preset(blocks, coop);
+    }
+
     if cli.trace_kv_fp8_cache && !cli.kv_fp8 {
         anyhow::bail!("--trace-kv-fp8-cache requires --kv-fp8");
     }

--- a/crates/runner/src/registry.rs
+++ b/crates/runner/src/registry.rs
@@ -120,6 +120,15 @@ pub struct Qwen35KernelParams {
     pub weight_prefix: &'static str,
     pub kv_chunk_size: usize,
     pub use_4b_kernel: bool,
+    /// Per-model launch preset for the HIP 4B persistent decode kernel.
+    /// `None` (default) keeps the non-cooperative 2x multiProcessorCount
+    /// grid — empirically safe across every tested variant. `Some((blocks,
+    /// cooperative))` installs a different grid size + cooperative-launch
+    /// flag via `kernel_ffi::set_qwen35_4b_launch_preset`; this is how
+    /// models opt into the larger grids that only stay hang-free when
+    /// co-residence is enforced by `hipLaunchCooperativeKernel`. User env
+    /// vars `SUPERSONIC_QWEN4B_BLOCKS` / `_COOP` still override any preset.
+    pub hip_launch_preset: Option<(i32, bool)>,
 }
 
 pub struct Gemma4KernelParams {
@@ -183,6 +192,12 @@ static REGISTRY: &[RegistryEntry] = &[
             // the BF16 page-fault + hipcc codegen sensitivity warnings were
             // both found stale in the 2026-04-20 diagnostic pass.
             use_4b_kernel: true,
+            // Cooperative launch at 32 blocks caps conservatively at 24 on
+            // 0.8B's 14 KB LDS and runs at 77 ms/tok vs. the non-coop 2x
+            // default's 91 ms/tok (measured 2026-04-20). Other variants
+            // see no gain because their higher LDS usage caps the coop
+            // grid at or below 2x — they stay on the default path.
+            hip_launch_preset: Some((32, true)),
         }),
     },
     RegistryEntry {
@@ -199,6 +214,7 @@ static REGISTRY: &[RegistryEntry] = &[
             weight_prefix: "model.language_model",
             kv_chunk_size: 256,
             use_4b_kernel: true,
+            hip_launch_preset: None,
         }),
     },
     RegistryEntry {
@@ -215,6 +231,7 @@ static REGISTRY: &[RegistryEntry] = &[
             weight_prefix: "model.language_model",
             kv_chunk_size: 256,
             use_4b_kernel: true,
+            hip_launch_preset: None,
         }),
     },
     RegistryEntry {
@@ -231,6 +248,7 @@ static REGISTRY: &[RegistryEntry] = &[
             weight_prefix: "model.language_model",
             kv_chunk_size: 256,
             use_4b_kernel: true,
+            hip_launch_preset: None,
         }),
     },
     RegistryEntry {
@@ -247,6 +265,7 @@ static REGISTRY: &[RegistryEntry] = &[
             weight_prefix: "model.language_model",
             kv_chunk_size: 256,
             use_4b_kernel: false,
+            hip_launch_preset: None,
         }),
     },
     RegistryEntry {
@@ -263,6 +282,7 @@ static REGISTRY: &[RegistryEntry] = &[
             weight_prefix: "model.language_model",
             kv_chunk_size: 256,
             use_4b_kernel: true,
+            hip_launch_preset: None,
         }),
     },
     RegistryEntry {

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -9,19 +9,20 @@ issue with your GPU arch, ROCm/CUDA versions, and the exact command line.
 
 ## HIP — `gfx1150` (AMD Radeon 890M iGPU)
 
-16 CUs, 2.9 GHz core, shared with system memory. Measurements from
-2026-04-20 on commit `b075b00` (0.8B-native kernel deleted, 2× grid
-oversubscription merged).
+16 CUs, 2.9 GHz core, shared with system memory. Measurements on
+2026-04-20 at current main (0.8B-native kernel deleted, 2× grid
+oversubscription merged, registry-driven cooperative-launch preset
+for 0.8B).
 
 ### Qwen3.5
 
 | Model              | Quant | ms/tok | tok/s |
 |--------------------|-------|-------:|------:|
-| qwen3.5-0.8b       | BF16  |   91   | 11.0  |
-| qwen3.5-0.8b       | INT4  |   78   | 12.8  |
-| qwen3.5-2b         | BF16  |  159   |  6.3  |
+| qwen3.5-0.8b       | BF16  |   76   | 13.2  |
+| qwen3.5-0.8b       | INT4  |   67   | 14.9  |
+| qwen3.5-2b         | BF16  |  155   |  6.5  |
 | qwen3.5-2b         | INT4  |  118   |  8.5  |
-| qwen3.5-4b         | BF16  |  514   |  1.9  |
+| qwen3.5-4b         | BF16  |  388   |  2.6  |
 | qwen3.5-4b         | INT4  |  286   |  3.5  |
 | qwen3.5-9b         | FP8   |  697   |  1.4  |
 
@@ -31,6 +32,14 @@ Notes:
   megakernel. The dedicated 0.8B-native kernel was deleted on 2026-04-20 —
   it had no INT4/FP8 path and was ~2.8× slower than the 4B-routed path
   even for BF16.
+- The 0.8B HIP registry entry carries a `hip_launch_preset` of `(32 blocks,
+  cooperative=true)`, installed automatically at startup. Cooperative
+  launch on gfx1150 caps conservatively at 24 blocks for 0.8B's 14 KB LDS
+  footprint — that's where the ~1.2× speedup over the plain 2× default
+  (16 blocks) comes from. 2B/4B/9B have no preset because their larger LDS
+  caps the cooperative grid at or below the 2× default; they stay on the
+  non-cooperative path. `SUPERSONIC_QWEN4B_BLOCKS` / `SUPERSONIC_QWEN4B_COOP`
+  env vars still override the preset.
 - `qwen3.5-9b` INT4 bake runs out of VRAM during GPTQ calibration on 16 GiB
   cards. Consumers pull the released bake from GitHub releases (see
   [bake-distribution.md](bake-distribution.md)); the INT4 runtime itself is

--- a/kernels/full_attention_bridge_4b.cpp
+++ b/kernels/full_attention_bridge_4b.cpp
@@ -4690,6 +4690,16 @@ int persistent_decode_device(
         }
     }
 
+    // If the caller asked for cooperative launch but the device or runtime
+    // can't actually provide it, refuse rather than fall back to the
+    // non-cooperative path. A `SUPERSONIC_QWEN4B_BLOCKS=128` with `COOP=1`
+    // expects the cooperative cap to keep it safe; silently running the
+    // non-coop launcher with 128 blocks is exactly the grid_barrier
+    // oversubscription hang the opt-in was designed to prevent.
+    if (coop_requested && (!coop_supported || max_blocks_per_mp <= 0)) {
+        return 261;
+    }
+
     hipError_t launch_err;
     if (coop_requested && coop_supported && max_blocks_per_mp > 0) {
         // Args for cooperative launch: void** where each entry points to

--- a/kernels/full_attention_bridge_4b.cpp
+++ b/kernels/full_attention_bridge_4b.cpp
@@ -4604,10 +4604,27 @@ int persistent_decode_device(
     // transformer layers (qwen3.5-2b at 4x produces no output) —
     // suspected grid_barrier scaling issue. Env var
     // `SUPERSONIC_QWEN4B_BLOCKS` allows runtime override for tuning.
+    // Default grid size: 2x multiProcessorCount on RDNA3/gfx11xx (empirically
+    // safe on every tested Qwen variant, ~1.5-1.6x decode speedup over 1x).
+    // SUPERSONIC_QWEN4B_BLOCKS overrides the grid. SUPERSONIC_QWEN4B_COOP
+    // (set when overriding past 2x) promotes the launch to
+    // hipLaunchCooperativeKernel so the runtime rejects rather than
+    // deadlocks when the grid exceeds hardware concurrent capacity. This
+    // is the only safe way to explore higher multipliers — the homebrew
+    // grid_barrier assumes every block is co-resident for the entire
+    // kernel, and non-cooperative launch can queue excess blocks behind
+    // resident ones, causing a deadlock at the first grid_barrier.
+    //
+    // Cooperative launch queries `hipOccupancyMaxActiveBlocksPerMultiprocessor`
+    // which is conservative: on 4B the cap is 1 block/MP vs. 2 that
+    // non-cooperative launch handles empirically, so cooperative launch
+    // regresses 4B throughput. We therefore stay non-cooperative at the
+    // default 2x and only opt in when the user explicitly requests it.
     int num_blocks = props.multiProcessorCount > 0 ? props.multiProcessorCount : 16;
+    bool env_override = false;
     if (const char* bs_env = std::getenv("SUPERSONIC_QWEN4B_BLOCKS")) {
         int override_val = std::atoi(bs_env);
-        if (override_val > 0) num_blocks = override_val;
+        if (override_val > 0) { num_blocks = override_val; env_override = true; }
     } else {
         const char* arch = props.gcnArchName;
         const bool is_rdna3_wgp_arch =
@@ -4617,6 +4634,8 @@ int persistent_decode_device(
             num_blocks *= 2;
         }
     }
+    const bool coop_requested =
+        env_override && std::getenv("SUPERSONIC_QWEN4B_COOP") != nullptr;
     constexpr int block_size = 256;
     // LDS: reduction scratch [block_size] + input cache [max(batch_size * hidden_dim, intermediate_size)]
     //      + FP8 LUT [256] (only when fp8_scales != nullptr, but always allocated for simplicity)
@@ -4626,38 +4645,101 @@ int persistent_decode_device(
     const size_t fp8_lut_size = 256;  // FP8 E4M3 → F32 lookup table
     const size_t shared_bytes = (block_size + input_cache + fp8_lut_size) * sizeof(float);
 
-    hipLaunchKernelGGL(
-        HIP_KERNEL_NAME(dotcache_qwen35_persistent_decode_kernel<T>),
-        dim3(static_cast<unsigned int>(num_blocks)),
-        dim3(block_size),
-        shared_bytes,
-        0,
-        num_layers,
-        hidden_dim,
-        intermediate_size,
-        seqlen_offset,
-        static_cast<const Qwen35DecodeLayerDesc*>(layers),
-        static_cast<T*>(hidden_io),
-        workspace,
-        counters,
-        barrier_counter,
-        barrier_flag,
-        timing_slots,
-        static_cast<const T*>(cos_table),
-        static_cast<const T*>(sin_table),
-        rotary_dim,
-        proj_buf_floats,
-        attn_scratch_floats,
-        enable_attention_trace,
-        static_cast<const Qwen35FP8ScaleDesc*>(fp8_scales),
-        static_cast<const KVCacheFp8Desc*>(kv_fp8_descs),
-        batch_size,
-        static_cast<const BatchSeqDesc*>(batch_descs),
-        static_cast<const Qwen35INT4ScaleDesc*>(int4_scales),
-        static_cast<T*>(tap_workspace),
-        tap_layers,
-        num_taps);
-    hipError_t launch_err = hipGetLastError();
+    int coop_supported = 0;
+    int max_blocks_per_mp = 0;
+    const void* kernel_fp = reinterpret_cast<const void*>(
+        &dotcache_qwen35_persistent_decode_kernel<T>);
+    if (coop_requested) {
+        (void)hipDeviceGetAttribute(
+            &coop_supported, hipDeviceAttributeCooperativeLaunch, device_ordinal);
+        if (coop_supported) {
+            if (hipOccupancyMaxActiveBlocksPerMultiprocessor(
+                    &max_blocks_per_mp, kernel_fp, block_size, shared_bytes) !=
+                hipSuccess) {
+                max_blocks_per_mp = 0;
+            }
+            if (max_blocks_per_mp > 0) {
+                int coop_max_grid = props.multiProcessorCount * max_blocks_per_mp;
+                if (num_blocks > coop_max_grid) num_blocks = coop_max_grid;
+            }
+        }
+    }
+
+    hipError_t launch_err;
+    if (coop_requested && coop_supported && max_blocks_per_mp > 0) {
+        // Args for cooperative launch: void** where each entry points to
+        // local storage holding one argument value. Locals must stay alive
+        // through the launch — they're destroyed at function exit, and
+        // we call hipDeviceSynchronize before returning.
+        const Qwen35DecodeLayerDesc* layers_typed =
+            static_cast<const Qwen35DecodeLayerDesc*>(layers);
+        T* hidden_io_typed = static_cast<T*>(hidden_io);
+        const T* cos_typed = static_cast<const T*>(cos_table);
+        const T* sin_typed = static_cast<const T*>(sin_table);
+        const Qwen35FP8ScaleDesc* fp8_typed =
+            static_cast<const Qwen35FP8ScaleDesc*>(fp8_scales);
+        const KVCacheFp8Desc* kv_fp8_typed =
+            static_cast<const KVCacheFp8Desc*>(kv_fp8_descs);
+        const BatchSeqDesc* batch_descs_typed =
+            static_cast<const BatchSeqDesc*>(batch_descs);
+        const Qwen35INT4ScaleDesc* int4_typed =
+            static_cast<const Qwen35INT4ScaleDesc*>(int4_scales);
+        T* tap_ws_typed = static_cast<T*>(tap_workspace);
+
+        void* args[] = {
+            &num_layers, &hidden_dim, &intermediate_size, &seqlen_offset,
+            &layers_typed, &hidden_io_typed, &workspace, &counters,
+            &barrier_counter, &barrier_flag,
+            &timing_slots,
+            &cos_typed, &sin_typed, &rotary_dim,
+            &proj_buf_floats, &attn_scratch_floats, &enable_attention_trace,
+            &fp8_typed, &kv_fp8_typed, &batch_size,
+            &batch_descs_typed, &int4_typed,
+            &tap_ws_typed, &tap_layers, &num_taps,
+        };
+
+        launch_err = hipLaunchCooperativeKernel(
+            kernel_fp,
+            dim3(static_cast<unsigned int>(num_blocks)),
+            dim3(block_size),
+            args,
+            static_cast<uint32_t>(shared_bytes),
+            0);
+    } else {
+        hipLaunchKernelGGL(
+            HIP_KERNEL_NAME(dotcache_qwen35_persistent_decode_kernel<T>),
+            dim3(static_cast<unsigned int>(num_blocks)),
+            dim3(block_size),
+            shared_bytes,
+            0,
+            num_layers,
+            hidden_dim,
+            intermediate_size,
+            seqlen_offset,
+            static_cast<const Qwen35DecodeLayerDesc*>(layers),
+            static_cast<T*>(hidden_io),
+            workspace,
+            counters,
+            barrier_counter,
+            barrier_flag,
+            timing_slots,
+            static_cast<const T*>(cos_table),
+            static_cast<const T*>(sin_table),
+            rotary_dim,
+            proj_buf_floats,
+            attn_scratch_floats,
+            enable_attention_trace,
+            static_cast<const Qwen35FP8ScaleDesc*>(fp8_scales),
+            static_cast<const KVCacheFp8Desc*>(kv_fp8_descs),
+            batch_size,
+            static_cast<const BatchSeqDesc*>(batch_descs),
+            static_cast<const Qwen35INT4ScaleDesc*>(int4_scales),
+            static_cast<T*>(tap_workspace),
+            tap_layers,
+            num_taps);
+        launch_err = hipGetLastError();
+    }
+
     hipError_t sync_err = hipDeviceSynchronize();
     if (launch_err != hipSuccess) return 254;
     if (sync_err != hipSuccess) return 255;

--- a/kernels/full_attention_bridge_4b.cpp
+++ b/kernels/full_attention_bridge_4b.cpp
@@ -6,6 +6,27 @@
 
 namespace {
 
+// Per-model launch preset, set once at startup by the Rust registry via
+// `dotcache_qwen35_4b_hip_set_launch_preset`. Read by the persistent-decode
+// bridge when the user hasn't supplied `SUPERSONIC_QWEN4B_BLOCKS`. Zero
+// means "no preset, use the hardcoded gfx11xx default".
+int g_preset_blocks = 0;
+int g_preset_coop = 0;
+
+inline void qwen4b_get_launch_preset(int& blocks, int& coop) {
+    blocks = g_preset_blocks;
+    coop = g_preset_coop;
+}
+
+} // anonymous namespace
+
+extern "C" void dotcache_qwen35_4b_hip_set_launch_preset(int blocks, int coop) {
+    g_preset_blocks = blocks;
+    g_preset_coop = coop;
+}
+
+namespace {
+
 struct ScopedHipDevice {
     int previous = -1;
     bool changed = false;
@@ -4603,28 +4624,32 @@ int persistent_decode_device(
     // Higher multipliers (3x+) hang silently on models with more
     // transformer layers (qwen3.5-2b at 4x produces no output) —
     // suspected grid_barrier scaling issue. Env var
-    // `SUPERSONIC_QWEN4B_BLOCKS` allows runtime override for tuning.
-    // Default grid size: 2x multiProcessorCount on RDNA3/gfx11xx (empirically
-    // safe on every tested Qwen variant, ~1.5-1.6x decode speedup over 1x).
-    // SUPERSONIC_QWEN4B_BLOCKS overrides the grid. SUPERSONIC_QWEN4B_COOP
-    // (set when overriding past 2x) promotes the launch to
-    // hipLaunchCooperativeKernel so the runtime rejects rather than
-    // deadlocks when the grid exceeds hardware concurrent capacity. This
-    // is the only safe way to explore higher multipliers — the homebrew
-    // grid_barrier assumes every block is co-resident for the entire
-    // kernel, and non-cooperative launch can queue excess blocks behind
-    // resident ones, causing a deadlock at the first grid_barrier.
+    // Grid-size priority (first match wins):
+    //   1. SUPERSONIC_QWEN4B_BLOCKS env var (explicit user override).
+    //   2. Per-model preset set via `dotcache_qwen35_4b_hip_set_launch_preset`
+    //      from the Rust registry (e.g. 0.8B gets 32 + cooperative).
+    //   3. 2x multiProcessorCount default on RDNA3/gfx11xx (empirically
+    //      safe at non-cooperative launch on every tested Qwen variant).
     //
-    // Cooperative launch queries `hipOccupancyMaxActiveBlocksPerMultiprocessor`
-    // which is conservative: on 4B the cap is 1 block/MP vs. 2 that
-    // non-cooperative launch handles empirically, so cooperative launch
-    // regresses 4B throughput. We therefore stay non-cooperative at the
-    // default 2x and only opt in when the user explicitly requests it.
+    // Cooperative launch is enabled when SUPERSONIC_QWEN4B_COOP is set OR
+    // when the active preset opts in. The homebrew `grid_barrier` assumes
+    // every block is co-resident; cooperative launch enforces that and
+    // fails cleanly on over-subscription instead of deadlocking.
+    //
+    // Why cooperative is opt-in rather than always-on: `hipOccupancyMax-
+    // ActiveBlocksPerMultiprocessor` is strictly conservative — on 4B it
+    // reports 1 block/MP while non-cooperative launch empirically handles
+    // 2. Cooperative-by-default would regress 4B throughput.
     int num_blocks = props.multiProcessorCount > 0 ? props.multiProcessorCount : 16;
-    bool env_override = false;
+    int preset_blocks = 0, preset_coop = 0;
+    qwen4b_get_launch_preset(preset_blocks, preset_coop);
+    bool preset_coop_hint = false;
     if (const char* bs_env = std::getenv("SUPERSONIC_QWEN4B_BLOCKS")) {
         int override_val = std::atoi(bs_env);
-        if (override_val > 0) { num_blocks = override_val; env_override = true; }
+        if (override_val > 0) { num_blocks = override_val; }
+    } else if (preset_blocks > 0) {
+        num_blocks = preset_blocks;
+        preset_coop_hint = preset_coop != 0;
     } else {
         const char* arch = props.gcnArchName;
         const bool is_rdna3_wgp_arch =
@@ -4635,7 +4660,7 @@ int persistent_decode_device(
         }
     }
     const bool coop_requested =
-        env_override && std::getenv("SUPERSONIC_QWEN4B_COOP") != nullptr;
+        std::getenv("SUPERSONIC_QWEN4B_COOP") != nullptr || preset_coop_hint;
     constexpr int block_size = 256;
     // LDS: reduction scratch [block_size] + input cache [max(batch_size * hidden_dim, intermediate_size)]
     //      + FP8 LUT [256] (only when fp8_scales != nullptr, but always allocated for simplicity)


### PR DESCRIPTION
## Summary

Two commits on top of main:

1. **Cooperative launch opt-in.** Adds \`hipLaunchCooperativeKernel\` as an alternative grid path behind \`SUPERSONIC_QWEN4B_COOP\`. Cooperative launch queries \`hipOccupancyMaxActiveBlocksPerMultiprocessor\` and either fits the entire grid concurrently or returns an error code — no hang, no machine reset. Home-rolled \`grid_barrier\` assumes every block is co-resident for the entire kernel; cooperative launch enforces exactly that, bypassing the scheduler-aliasing cliff that has reset this box three times during probing.

2. **Per-model registry preset.** Adds \`hip_launch_preset: Option<(i32, bool)>\` to \`Qwen35KernelParams\` + a new \`dotcache_qwen35_4b_hip_set_launch_preset\` FFI. Main.rs installs the preset once at startup per model. Only qwen3.5-0.8b carries a preset today (\`Some((32, true))\` = request 32 blocks, cooperative enabled; the runtime caps to 24). Every other entry is \`None\` and keeps the proven-safe non-coop 2× default.

User env vars (\`SUPERSONIC_QWEN4B_BLOCKS\`, \`SUPERSONIC_QWEN4B_COOP\`) still win over both preset and built-in defaults.

## Why preset is per-model

\`hipOccupancyMaxActiveBlocksPerMultiprocessor\` is strictly conservative. Per-variant caps on gfx1150:

| Variant | Non-coop 2× default | Cooperative cap |
|---|---:|---:|
| qwen3.5-0.8b (14 KB LDS) | 16 | **24** (= win) |
| qwen3.5-2b  (20 KB LDS) | 16 | 16 (no change) |
| qwen3.5-4b  (40 KB LDS) | 16 | **8** (regression) |

Turning coop on globally would hurt 4B. The registry picks per-variant based on what we've measured.

## Measured throughput on gfx1150 (default-path ms/tok)

| Variant            | Before PR | After PR | Δ |
|--------------------|---------:|---------:|---:|
| qwen3.5-0.8b BF16  |     91   |    **76** | 1.20× |
| qwen3.5-0.8b INT4  |     78   |    **67** | 1.16× |
| qwen3.5-2b  BF16   |    155   |    155   | 1.00× |
| qwen3.5-2b  INT4   |    118   |    118   | 1.00× |
| qwen3.5-4b  BF16   |    388   |    388   | 1.00× |
| qwen3.5-4b  INT4   |    286   |    286   | 1.00× |

## Test plan

- [x] Build clean
- [x] Default 0.8B BF16/INT4 auto-engages coop preset (76 / 67 ms/tok)
- [x] Default 2B/4B unchanged (no preset installed)
- [x] \`SUPERSONIC_QWEN4B_BLOCKS=16\` on 0.8B returns to plain 91 ms/tok (env wins over preset)
- [x] \`SUPERSONIC_QWEN4B_BLOCKS=128 SUPERSONIC_QWEN4B_COOP=1\` silently caps (no hang)
- [x] Tokens match baseline for every measurement (\`decode_max_delta=0.0000\`)
- [ ] CUDA path unaffected — verify on the sm86 box before landing