### PR TITLE
Oversubscribe full_attention_prefill grid 2x on gfx11xx

### DIFF
--- a/kernels/full_attention_bridge.cpp
+++ b/kernels/full_attention_bridge.cpp
@@ -77,7 +77,20 @@ int full_attention_prefill_device(
     if (hipMalloc(&d_row_counter, sizeof(unsigned int)) != hipSuccess) return 2;
     if (hipMemset(d_row_counter, 0, sizeof(unsigned int)) != hipSuccess) return 10;
 
-    const int grid = props.multiProcessorCount > 0 ? props.multiProcessorCount : 1;
+    // On RDNA3/gfx11xx `multiProcessorCount` reports WGPs (half the CU
+    // count), leaving half the device idle when we grid the prefill
+    // attention against it directly. Oversubscribe 2x on those arches,
+    // matching the decode default. The atomic row-counter inside the
+    // kernel already balances work across blocks, so extra blocks are
+    // harmless on arches where `multiProcessorCount` already reports CUs.
+    int grid = props.multiProcessorCount > 0 ? props.multiProcessorCount : 1;
+    {
+        const char* arch = props.gcnArchName;
+        const bool is_rdna3_wgp_arch =
+            arch[0] == 'g' && arch[1] == 'f' && arch[2] == 'x' &&
+            arch[3] == '1' && arch[4] == '1';
+        if (is_rdna3_wgp_arch) grid *= 2;
+    }
     const int block = props.warpSize > 0 ? props.warpSize : 32;
     if (head_dim > block * 8) return 14;
     hipLaunchKernelGGL(

--- a/kernels/full_attention_bridge_4b.cpp
+++ b/kernels/full_attention_bridge_4b.cpp
@@ -98,7 +98,17 @@ int full_attention_prefill_device(
     if (hipMalloc(&d_row_counter, sizeof(unsigned int)) != hipSuccess) return 2;
     if (hipMemset(d_row_counter, 0, sizeof(unsigned int)) != hipSuccess) return 10;
 
-    const int grid = props.multiProcessorCount > 0 ? props.multiProcessorCount : 1;
+    // RDNA3 `multiProcessorCount` reports WGPs, not CUs. Oversubscribe 2x
+    // on gfx11xx so the prefill attention kernel fills every CU; the
+    // kernel's atomic row-counter already handles extra blocks gracefully.
+    int grid = props.multiProcessorCount > 0 ? props.multiProcessorCount : 1;
+    {
+        const char* arch = props.gcnArchName;
+        const bool is_rdna3_wgp_arch =
+            arch[0] == 'g' && arch[1] == 'f' && arch[2] == 'x' &&
+            arch[3] == '1' && arch[4] == '1';
+        if (is_rdna3_wgp_arch) grid *= 2;
+    }
     const int block = props.warpSize > 0 ? props.warpSize : 32;
     if (head_dim > block * 8) return 14;
     hipLaunchKernelGGL(


### PR DESCRIPTION
## Summary

Same WGP-vs-CU miscount that the decode path fixed in PR #7. rocprofv3 on qwen3.5-2b prefill (480-token prompt) shows \`full_attention_prefill_kernel\` at 13% of prefill time (1401 ms of 10690 ms). It sizes its grid from \`multiProcessorCount\`, which reports WGPs (8 on gfx1150), leaving half the CUs idle. The kernel's atomic row-counter already balances work across any number of blocks, so doubling the grid on gfx11xx fills the device cleanly.

## Measured prefill (gfx1150, long prompt)

| Variant            | Prompt | Before | After | Speedup |
|--------------------|:------:|------:|------:|--------:|
| qwen3.5-0.8b       | 480tok |  5135 |  4349 | **1.18×** |
| qwen3.5-2b         | 480tok | 10690 | 10031 |  1.07×  |
| qwen3.5-4b         | 480tok | 29216 | 28800 |  1.01×  |

4B prefill is dominated (~80% GPU time) by the already-massively-oversubscribed tiled matmul, so the attention-prefill slice is a smaller proportion. 0.8B sees the biggest relative win.

## Not changed

Surveyed but left alone:

- \`delta_recurrent_prefill_kernel\` — fixed thread indexing (\`tid = blockIdx×blockDim+threadIdx\`), not work-stealing. Doubling the grid would double the work.
- \`linear_prefill_conv_pack_kernel\` — same fixed-thread indexing.
- \`matmul_rhs_transposed_tiled_kernel\` — grid is \`m×n×batch/256\` = hundreds of blocks already.

## Test plan

- [x] Build clean
- [x] decode_max_delta=0.0000 on qwen3.5-0.8b 480-token prompt (tokens match 1× baseline)
- [x] Prefill speedup measured above
- [ ] CUDA path unaffected (only HIP bridges touched; gate is \`gfx11\` prefix on \`gcnArchName\`)