### PR TITLE
WMMA port of prefill BF16 matmul

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -73,12 +73,15 @@ shipping path for E4B on gfx1150.
 
 Qwen3.5 BF16, 8-token generation, prefill ms + decode ms/tok at varying
 prompt size. Decode grows slowly with KV size; prefill grows linearly
-with prompt tokens:
+with prompt tokens. Prefill numbers reflect the RDNA3 WMMA
+(`v_wmma_f32_16x16x16_bf16`) matmul shipped 2026-04-20; set
+`SUPERSONIC_QWEN4B_DISABLE_WMMA=1` to fall back to the scalar kernel.
 
-| Variant            | 66 tok prefill | 258 tok prefill | 1026 tok prefill | decode @66 | decode @258 | decode @1026 |
-|--------------------|---------------:|----------------:|-----------------:|-----------:|------------:|-------------:|
-| qwen3.5-0.8b BF16  |     555 ms     |     2230 ms     |     11299 ms     |  77 ms/tok |  84 ms/tok  | 122 ms/tok   |
-| qwen3.5-2b  BF16   |    1310 ms     |     5412 ms     |     23963 ms     | 167 ms/tok | 233 ms/tok  | 229 ms/tok   |
+| Variant            | 1020 tok prefill (WMMA) | 1020 tok prefill (scalar) | WMMA speedup |
+|--------------------|------------------------:|--------------------------:|:-------------|
+| qwen3.5-0.8b BF16  |        5879 ms          |        11244 ms           |   1.91×      |
+| qwen3.5-2b  BF16   |        9206 ms          |        24963 ms           |   2.71×      |
+| qwen3.5-4b  BF16   |       29891 ms          |        70075 ms           |   2.34×      |
 
 At 1026-token prompts **prefill is 11-13× the total decode time for an
 8-token reply**. Any further decode optimization (cooperative launch
@@ -126,11 +129,13 @@ Implications for future work:
   is sub-linear because fixed kernel-launch and barrier overhead
   dominates at small KV sizes. In absolute terms it stays small
   (≤5% of decode step time across tested contexts).
-- Prefill is the big lever. 80% of its time is
-  `matmul_rhs_transposed_tiled_kernel`, a naive scalar-FMA
-  shared-memory tiled matmul with no WMMA. RDNA3's
-  `v_wmma_f32_16x16x16_bf16` (wavefront matrix op) would potentially
-  give 2-4× on that kernel and ~60-70% on prefill overall.
+- Prefill's dominant matmul used to be a naive scalar-FMA tiled kernel
+  eating ~80% of prefill time. As of 2026-04-20 it runs on a WMMA
+  (`v_wmma_f32_16x16x16_bf16`) port that lands 1.9–2.7× on prefill
+  end-to-end for the three BF16 Qwen variants (see the table above).
+  Further wins on top are possible — shared-memory tiling across
+  multiple waves, larger output tiles per block, dual-issue packing —
+  but require a second pass.
 
 ## CUDA — `sm86` (NVIDIA RTX 3090-class)
 

--- a/kernels/full_attention_4b.hip
+++ b/kernels/full_attention_4b.hip
@@ -2567,6 +2567,126 @@ __global__ void dotcache_qwen35_matmul_rhs_transposed_tiled_kernel(
     }
 }
 
+// =============================================================================
+// RDNA3 WMMA BF16 prefill matmul (wave32, 16x16x16 f32-accumulate).
+//
+// Computes: out[batch, m, n] = lhs[batch, m, k] × rhs[batch, n, k]^T
+//
+// Grid  : (ceil(n/16), ceil(m/16), batch_elems)
+// Block : 32 threads (one wavefront)
+//
+// Each block computes one 16x16 output tile using the hardware matrix
+// intrinsic, accumulating along K in chunks of 16. BF16 only.
+// =============================================================================
+
+#if defined(__gfx1100__) || defined(__gfx1101__) || defined(__gfx1102__) || \
+    defined(__gfx1103__) || defined(__gfx1150__) || defined(__gfx1151__) || \
+    defined(__gfx1152__)
+#define SUPERSONIC_HAS_WMMA_BF16 1
+#endif
+
+typedef short  supersonic_short16 __attribute__((ext_vector_type(16)));
+typedef float  supersonic_float8  __attribute__((ext_vector_type(8)));
+
+__global__ void dotcache_qwen35_matmul_rhs_transposed_tiled_wmma_kernel(
+    size_t batch_elems,
+    int m,
+    int n,
+    int k,
+    const hip_bfloat16* __restrict__ lhs,   // [batch, m, k]
+    const hip_bfloat16* __restrict__ rhs,   // [batch, n, k] (virtually transposed)
+    hip_bfloat16* __restrict__ out          // [batch, m, n]
+) {
+#ifdef SUPERSONIC_HAS_WMMA_BF16
+    const int lane = threadIdx.x;              // 0..31
+    const int lane_row = lane & 15;            // which row this lane owns
+    const int lane_half = lane >> 4;           // 0 for lanes 0-15, 1 for lanes 16-31
+    const int batch = blockIdx.z;
+    const int tile_row = blockIdx.y * 16;
+    const int tile_col = blockIdx.x * 16;
+
+    const int lhs_row_idx = tile_row + lane_row;
+    const int rhs_row_idx = tile_col + lane_row;
+    const bool lhs_in_range = lhs_row_idx < m;
+    const bool rhs_in_range = rhs_row_idx < n;
+
+    const size_t lhs_row_base = static_cast<size_t>(batch) * m * k +
+                                static_cast<size_t>(lhs_row_idx) * k;
+    const size_t rhs_row_base = static_cast<size_t>(batch) * n * k +
+                                static_cast<size_t>(rhs_row_idx) * k;
+
+    const uint16_t* lhs_row_u16 = reinterpret_cast<const uint16_t*>(lhs) + lhs_row_base;
+    const uint16_t* rhs_row_u16 = reinterpret_cast<const uint16_t*>(rhs) + rhs_row_base;
+
+    supersonic_float8 acc = {0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f};
+
+    // WMMA is a whole-wave cross-lane instruction: every lane must participate
+    // with well-defined A/B inputs, or the result is garbage on in-range lanes
+    // too (their output depends on the full 16x16 input matrix assembled from
+    // every lane's register). Keep the WMMA call uniform and zero-pad the
+    // inputs for out-of-range lanes.
+    //
+    // Fast path: K rounded down to a multiple of 16. Qwen3.5 hidden and
+    // intermediate sizes are always multiples of 16 so this covers the whole
+    // loop in practice; the tail below is defensive.
+    const int k_main = k & ~15;
+    for (int kk = 0; kk < k_main; kk += 16) {
+        supersonic_short16 a;
+        supersonic_short16 b;
+        if (lhs_in_range) {
+            #pragma unroll
+            for (int i = 0; i < 16; ++i) {
+                a[i] = static_cast<short>(lhs_row_u16[kk + i]);
+            }
+        } else {
+            #pragma unroll
+            for (int i = 0; i < 16; ++i) a[i] = 0;
+        }
+        if (rhs_in_range) {
+            #pragma unroll
+            for (int i = 0; i < 16; ++i) {
+                b[i] = static_cast<short>(rhs_row_u16[kk + i]);
+            }
+        } else {
+            #pragma unroll
+            for (int i = 0; i < 16; ++i) b[i] = 0;
+        }
+        acc = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a, b, acc);
+    }
+    // Tail (k % 16 != 0): pad with zeros. Rarely hit for Qwen3.5.
+    if (k_main != k) {
+        supersonic_short16 a = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
+        supersonic_short16 b = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
+        #pragma unroll
+        for (int i = 0; i < 16; ++i) {
+            int kc = k_main + i;
+            if (kc < k) {
+                if (lhs_in_range) a[i] = static_cast<short>(lhs_row_u16[kc]);
+                if (rhs_in_range) b[i] = static_cast<short>(rhs_row_u16[kc]);
+            }
+        }
+        acc = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a, b, acc);
+    }
+
+    // Store: lane L writes C[2*i + lane_half, lane_row] = acc[i] for i in 0..8.
+    const int out_col = tile_col + lane_row;
+    if (out_col < n) {
+        const size_t out_batch_base = static_cast<size_t>(batch) * m * n;
+        #pragma unroll
+        for (int i = 0; i < 8; ++i) {
+            int out_row = tile_row + 2 * i + lane_half;
+            if (out_row < m) {
+                out[out_batch_base + static_cast<size_t>(out_row) * n + out_col] =
+                    hip_bfloat16(acc[i]);
+            }
+        }
+    }
+#else
+    (void)batch_elems; (void)m; (void)n; (void)k;
+    (void)lhs; (void)rhs; (void)out;
+#endif
+}
+
 template <typename T>
 __global__ void dotcache_qwen35_batched_matmul_view_kernel(
     int batch_rank,

--- a/kernels/full_attention_bridge_4b.cpp
+++ b/kernels/full_attention_bridge_4b.cpp
@@ -3609,6 +3609,73 @@ int matmul_rhs_transposed_tiled_device(
     return 0;
 }
 
+// Cached per-device arch flag: does this device support RDNA3 WMMA intrinsics?
+// gfx11xx (RDNA3 / RDNA3.5) supports v_wmma_f32_16x16x16_bf16; older arches
+// (gfx10, gfx9, CDNA gfx9xx) do not, and gfx12 uses a different opcode the
+// kernel isn't compiled for yet. Env var SUPERSONIC_QWEN4B_DISABLE_WMMA=1
+// forces the scalar path for debugging / perf comparison.
+static bool device_supports_wmma_bf16(int device_ordinal) {
+    static bool cached[16] = {false};
+    static bool cached_set[16] = {false};
+    static bool env_disabled = false;
+    static bool env_checked = false;
+    if (!env_checked) {
+        const char* env = std::getenv("SUPERSONIC_QWEN4B_DISABLE_WMMA");
+        env_disabled = (env != nullptr && env[0] != '\0' && env[0] != '0');
+        env_checked = true;
+    }
+    if (env_disabled) return false;
+    if (device_ordinal < 0 || device_ordinal >= 16) {
+        // Fallback: uncached lookup for unusual ordinals.
+        hipDeviceProp_t props;
+        if (hipGetDeviceProperties(&props, device_ordinal) != hipSuccess) return false;
+        const char* arch = props.gcnArchName;
+        return arch && arch[0] == 'g' && arch[1] == 'f' && arch[2] == 'x' &&
+               arch[3] == '1' && arch[4] == '1';
+    }
+    if (!cached_set[device_ordinal]) {
+        hipDeviceProp_t props;
+        if (hipGetDeviceProperties(&props, device_ordinal) != hipSuccess) {
+            cached[device_ordinal] = false;
+        } else {
+            const char* arch = props.gcnArchName;
+            cached[device_ordinal] = arch && arch[0] == 'g' && arch[1] == 'f' &&
+                                     arch[2] == 'x' && arch[3] == '1' && arch[4] == '1';
+        }
+        cached_set[device_ordinal] = true;
+    }
+    return cached[device_ordinal];
+}
+
+static int matmul_rhs_transposed_tiled_wmma_bf16_device(
+    int device_ordinal,
+    size_t batch_elems,
+    int m, int n, int k,
+    const void* lhs,
+    const void* rhs,
+    void* out
+) {
+    ScopedHipDevice scoped(device_ordinal);
+    constexpr int TILE_M = 16;
+    constexpr int TILE_N = 16;
+    const int grid_x = (n + TILE_N - 1) / TILE_N;
+    const int grid_y = (m + TILE_M - 1) / TILE_M;
+    const int grid_z = static_cast<int>(batch_elems);
+    const int threads = 32;  // one wavefront per tile
+    hipLaunchKernelGGL(
+        dotcache_qwen35_matmul_rhs_transposed_tiled_wmma_kernel,
+        dim3(grid_x, grid_y, grid_z), dim3(threads), 0, 0,
+        batch_elems, m, n, k,
+        static_cast<const hip_bfloat16*>(lhs),
+        static_cast<const hip_bfloat16*>(rhs),
+        static_cast<hip_bfloat16*>(out));
+    hipError_t launch_err = hipGetLastError();
+    hipError_t sync_err = hipDeviceSynchronize();
+    if (launch_err != hipSuccess) return 280;
+    if (sync_err != hipSuccess) return 281;
+    return 0;
+}
+
 extern "C" int dotcache_qwen35_4b_hip_matmul_rhs_transposed_tiled(
     int dtype,
     size_t device_ordinal,
@@ -3619,6 +3686,11 @@ extern "C" int dotcache_qwen35_4b_hip_matmul_rhs_transposed_tiled(
     void* out) {
     switch (dtype) {
     case 2:
+        if (device_supports_wmma_bf16(static_cast<int>(device_ordinal))) {
+            return matmul_rhs_transposed_tiled_wmma_bf16_device(
+                static_cast<int>(device_ordinal), batch_elems, m, n, k,
+                lhs, rhs, out);
+        }
         return matmul_rhs_transposed_tiled_device<hip_bfloat16>(
             static_cast<int>(device_ordinal), batch_elems, m, n, k,
             lhs, rhs, out);

--- a/kernels/full_attention_bridge_4b.cpp
+++ b/kernels/full_attention_bridge_4b.cpp
@@ -2,6 +2,7 @@
 
 #include <cstdlib>
 #include <hip/hip_runtime.h>
+#include <mutex>
 #include <stdint.h>
 
 namespace {
@@ -3614,36 +3615,38 @@ int matmul_rhs_transposed_tiled_device(
 // (gfx10, gfx9, CDNA gfx9xx) do not, and gfx12 uses a different opcode the
 // kernel isn't compiled for yet. Env var SUPERSONIC_QWEN4B_DISABLE_WMMA=1
 // forces the scalar path for debugging / perf comparison.
+//
+// `supersonic-serve` can call this concurrently from multiple request threads,
+// so initialization goes through `std::call_once` — plain non-atomic writes
+// would be a data race.
 static bool device_supports_wmma_bf16(int device_ordinal) {
-    static bool cached[16] = {false};
-    static bool cached_set[16] = {false};
+    static std::once_flag env_once;
     static bool env_disabled = false;
-    static bool env_checked = false;
-    if (!env_checked) {
+    std::call_once(env_once, [] {
         const char* env = std::getenv("SUPERSONIC_QWEN4B_DISABLE_WMMA");
         env_disabled = (env != nullptr && env[0] != '\0' && env[0] != '0');
-        env_checked = true;
-    }
+    });
     if (env_disabled) return false;
-    if (device_ordinal < 0 || device_ordinal >= 16) {
-        // Fallback: uncached lookup for unusual ordinals.
+
+    auto probe_arch = [](int ordinal) -> bool {
         hipDeviceProp_t props;
-        if (hipGetDeviceProperties(&props, device_ordinal) != hipSuccess) return false;
+        if (hipGetDeviceProperties(&props, ordinal) != hipSuccess) return false;
         const char* arch = props.gcnArchName;
         return arch && arch[0] == 'g' && arch[1] == 'f' && arch[2] == 'x' &&
                arch[3] == '1' && arch[4] == '1';
+    };
+
+    if (device_ordinal < 0 || device_ordinal >= 16) {
+        // Uncached lookup for unusual ordinals — happens at most once per call
+        // for a device outside the cached range.
+        return probe_arch(device_ordinal);
     }
-    if (!cached_set[device_ordinal]) {
-        hipDeviceProp_t props;
-        if (hipGetDeviceProperties(&props, device_ordinal) != hipSuccess) {
-            cached[device_ordinal] = false;
-        } else {
-            const char* arch = props.gcnArchName;
-            cached[device_ordinal] = arch && arch[0] == 'g' && arch[1] == 'f' &&
-                                     arch[2] == 'x' && arch[3] == '1' && arch[4] == '1';
-        }
-        cached_set[device_ordinal] = true;
-    }
+
+    static std::once_flag device_once[16];
+    static bool cached[16] = {false};
+    std::call_once(device_once[device_ordinal], [&] {
+        cached[device_ordinal] = probe_arch(device_ordinal);
+    });
     return cached[device_ordinal];
 }
 


### PR DESCRIPTION
## Summary

- New `dotcache_qwen35_matmul_rhs_transposed_tiled_wmma_kernel` in `full_attention_4b.hip` using the RDNA3 `v_wmma_f32_16x16x16_bf16` wavefront intrinsic. One wavefront (32 threads) computes one 16x16 output tile; K is accumulated in 16-wide chunks with an F32 accumulator.
- Runtime dispatch in `full_attention_bridge_4b.cpp`: BF16 on gfx11xx goes through WMMA (cached `gcnArchName` check), everything else keeps the existing scalar tiled kernel. `SUPERSONIC_QWEN4B_DISABLE_WMMA=1` forces the scalar path for A/B comparison.
- Scalar kernel stays intact — this is purely additive, no struct changes, no decode-path changes.

## Why

rocprofv3 on gfx1150 flagged the tiled matmul as ~80% of prefill time (8.4 s of 10.7 s total on qwen3.5-2b at 1026-tok context) — naive scalar FMAs in `v_fma_f32` with no matrix-unit participation.

## Results (gfx1150, Radeon 890M iGPU, 1020-token prompt, BF16)

| Model         | Scalar   | WMMA    | Speedup |
|---------------|---------:|--------:|:--------|
| qwen3.5-0.8b  | 11244 ms |  5879 ms | 1.91x   |
| qwen3.5-2b    | 24963 ms |  9206 ms | 2.71x   |
| qwen3.5-4b    | 70075 ms | 29891 ms | 2.34x   |

All three show `decode_max_delta=0.0000` and `gpu_oracle_max_delta=0.0000` against the scalar reference. `docs/performance.md` updated.

## Subtlety worth flagging for review

WMMA is a cross-lane instruction that assembles its operand matrix from every lane's registers. An `if (in_range) { WMMA(...) } else { ... }` structure produces garbage on the in-range lanes too. The kernel keeps the WMMA call uniform and only guards the *loads* — this is why the bounds-check isn't just pushed around the whole loop body.

## Test plan

- [x] `qwen3.5-0.8b --prompt "The quick brown fox jumps over" --max-new-tokens 8` — tokens match scalar exactly, decode_max_delta=0
- [x] `qwen3.5-2b` same prompt — tokens match scalar exactly, decode_max_delta=0
- [x] `qwen3.5-4b` same prompt — tokens match scalar exactly, decode_max_delta=0
- [x] 1020-token prompt prefill compared WMMA vs `SUPERSONIC_QWEN4B_DISABLE_WMMA=1` on all three sizes
- [ ] Sanity-run on a non-gfx11 HIP device if one is available (expected: runtime check picks the scalar fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)