### PR TITLE
Port Qwen INT4 prefill matmul to RDNA3 WMMA

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -98,6 +98,13 @@ with prompt tokens. Prefill numbers reflect the RDNA3 WMMA
 | qwen3.5-0.8b BF16  |        5879 ms          |        11244 ms           |   1.91×      |
 | qwen3.5-2b  BF16   |        9206 ms          |        24963 ms           |   2.71×      |
 | qwen3.5-4b  BF16   |       29891 ms          |        70075 ms           |   2.34×      |
+| qwen3.5-2b  INT4   |        6681 ms          |        24532 ms           |   3.67×      |
+| qwen3.5-4b  INT4   |       18669 ms          |        73065 ms           |   3.91×      |
+| qwen3.5-9b  INT4   |       33486 ms          |       126646 ms           |   3.78×      |
+
+INT4 gains more than BF16 because the scalar INT4 kernel also pays the
+dequant cost every iteration — moving the loop body to WMMA BF16 with the
+dequant bundled into the B-matrix load amortizes both savings together.
 
 At 1026-token prompts **prefill is 11-13× the total decode time for an
 8-token reply**. Any further decode optimization (cooperative launch

--- a/kernels/full_attention_4b.hip
+++ b/kernels/full_attention_4b.hip
@@ -2947,6 +2947,162 @@ __global__ void dotcache_qwen35_matmul_int4_dequant_kernel(
     }
 }
 
+// =============================================================================
+// RDNA3 WMMA INT4-dequant prefill matmul (wave32, 16x16x16 f32-accumulate).
+//
+// Same input layout as dotcache_qwen35_matmul_int4_dequant_kernel:
+//   lhs  [batch, m, k]          BF16
+//   rhs  [batch, n, k/2]        packed INT4 (low nibble = even k index)
+//   scl  [n/group, k/group]     BF16 scale
+//   zro  [n/group, k/group]     BF16 zero
+//   out  [batch, m, n]          BF16
+//
+// Each block runs one wavefront computing a single 16x16 output tile; each
+// lane holds one row of A (lhs) or B (dequantized rhs). K is accumulated in
+// 16-wide chunks. Since group_size is 128 in the Qwen GPTQ bake and k-chunks
+// are 16, every 16-K chunk lies entirely inside one group — the scale/zero
+// fetch happens once per chunk per lane.
+//
+// Same WMMA gotcha as the BF16 kernel: the intrinsic assembles its operand
+// matrix from every lane's registers, so the call must be uniform across
+// the wave. Only the loads are guarded; zero-padding lanes that are out of
+// range participate as no-ops.
+// =============================================================================
+
+__global__ void dotcache_qwen35_matmul_int4_dequant_wmma_kernel(
+    size_t batch_elems,
+    int m,
+    int n,
+    int k,
+    const hip_bfloat16* __restrict__ lhs,    // [batch, m, k]
+    const uint8_t* __restrict__ rhs_int4,    // [batch, n, k/2]
+    const hip_bfloat16* __restrict__ scale,  // [n/group, k/group]
+    const hip_bfloat16* __restrict__ zero,   // [n/group, k/group]
+    int group_size,
+    hip_bfloat16* __restrict__ out           // [batch, m, n]
+) {
+#ifdef SUPERSONIC_HAS_WMMA_BF16
+    const int lane = threadIdx.x;
+    const int lane_row = lane & 15;
+    const int lane_half = lane >> 4;
+    const int batch = blockIdx.z;
+    const int tile_row = blockIdx.y * 16;
+    const int tile_col = blockIdx.x * 16;
+
+    const int lhs_row_idx = tile_row + lane_row;
+    const int rhs_row_idx = tile_col + lane_row;
+    const bool lhs_in_range = lhs_row_idx < m;
+    const bool rhs_in_range = rhs_row_idx < n;
+
+    const int k_packed = k / 2;
+    const int scale_cols = (k + group_size - 1) / group_size;
+
+    const size_t lhs_row_base = static_cast<size_t>(batch) * m * k +
+                                static_cast<size_t>(lhs_row_idx) * k;
+    const size_t rhs_row_base = static_cast<size_t>(batch) * n * k_packed +
+                                static_cast<size_t>(rhs_row_idx) * k_packed;
+
+    const uint16_t* lhs_row_u16 = reinterpret_cast<const uint16_t*>(lhs) + lhs_row_base;
+    const uint8_t*  rhs_row_u8  = rhs_int4 + rhs_row_base;
+
+    supersonic_float8 acc = {0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f};
+
+    const int k_main = k & ~15;
+    for (int kk = 0; kk < k_main; kk += 16) {
+        // --- A (lhs, BF16) ---
+        supersonic_short16 a;
+        if (lhs_in_range) {
+            #pragma unroll
+            for (int i = 0; i < 16; ++i) a[i] = static_cast<short>(lhs_row_u16[kk + i]);
+        } else {
+            #pragma unroll
+            for (int i = 0; i < 16; ++i) a[i] = 0;
+        }
+
+        // --- B (rhs, INT4 → BF16) ---
+        supersonic_short16 b;
+        if (rhs_in_range) {
+            const int group_id = kk / group_size;
+            const int scale_idx = rhs_row_idx / group_size * scale_cols + group_id;
+            const float s = static_cast<float>(scale[scale_idx]);
+            const float z = static_cast<float>(zero[scale_idx]);
+            const float zs = z * s;
+            // 16 K values = 8 packed bytes. kk is a multiple of 16 so the byte
+            // offset is always aligned on a nibble boundary (low nibble = even k).
+            const int byte_base = kk >> 1;
+            #pragma unroll
+            for (int i = 0; i < 8; ++i) {
+                uint8_t packed = rhs_row_u8[byte_base + i];
+                int n0 = packed & 0xF;
+                int n1 = (packed >> 4) & 0xF;
+                float v0 = bf16_round_rne_f32_finite(static_cast<float>(n0) * s - zs);
+                float v1 = bf16_round_rne_f32_finite(static_cast<float>(n1) * s - zs);
+                uint32_t b0, b1;
+                __builtin_memcpy(&b0, &v0, 4);
+                __builtin_memcpy(&b1, &v1, 4);
+                b[2 * i]     = static_cast<short>(b0 >> 16);
+                b[2 * i + 1] = static_cast<short>(b1 >> 16);
+            }
+        } else {
+            #pragma unroll
+            for (int i = 0; i < 16; ++i) b[i] = 0;
+        }
+
+        acc = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a, b, acc);
+    }
+    // Tail (k % 16 != 0): Qwen hidden/intermediate sizes are all multiples of
+    // 128, so this branch is unreachable in practice — keep defensive.
+    if (k_main != k) {
+        supersonic_short16 a = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
+        supersonic_short16 b = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
+        if (lhs_in_range) {
+            #pragma unroll
+            for (int i = 0; i < 16; ++i) {
+                int kc = k_main + i;
+                if (kc < k) a[i] = static_cast<short>(lhs_row_u16[kc]);
+            }
+        }
+        if (rhs_in_range) {
+            const int group_id0 = k_main / group_size;
+            const int scale_idx = rhs_row_idx / group_size * scale_cols + group_id0;
+            const float s = static_cast<float>(scale[scale_idx]);
+            const float z = static_cast<float>(zero[scale_idx]);
+            const float zs = z * s;
+            #pragma unroll
+            for (int i = 0; i < 16; ++i) {
+                int kc = k_main + i;
+                if (kc < k) {
+                    uint8_t packed = rhs_row_u8[kc >> 1];
+                    int nib = (kc & 1) ? ((packed >> 4) & 0xF) : (packed & 0xF);
+                    float v = bf16_round_rne_f32_finite(static_cast<float>(nib) * s - zs);
+                    uint32_t bits;
+                    __builtin_memcpy(&bits, &v, 4);
+                    b[i] = static_cast<short>(bits >> 16);
+                }
+            }
+        }
+        acc = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a, b, acc);
+    }
+
+    // Store: lane L writes C[2*i + lane_half, lane_row] = acc[i] for i in 0..8.
+    const int out_col = tile_col + lane_row;
+    if (out_col < n) {
+        const size_t out_batch_base = static_cast<size_t>(batch) * m * n;
+        #pragma unroll
+        for (int i = 0; i < 8; ++i) {
+            int out_row = tile_row + 2 * i + lane_half;
+            if (out_row < m) {
+                out[out_batch_base + static_cast<size_t>(out_row) * n + out_col] =
+                    hip_bfloat16(acc[i]);
+            }
+        }
+    }
+#else
+    (void)batch_elems; (void)m; (void)n; (void)k;
+    (void)lhs; (void)rhs_int4; (void)scale; (void)zero; (void)group_size; (void)out;
+#endif
+}
+
 template <typename T>
 __global__ void dotcache_qwen35_delta_full_scan_pack_kernel(
     int batch_heads,

--- a/kernels/full_attention_bridge_4b.cpp
+++ b/kernels/full_attention_bridge_4b.cpp
@@ -3843,8 +3843,16 @@ extern "C" int dotcache_qwen35_4b_hip_matmul_int4_dequant(
     int group_size,
     void* out) {
     switch (dtype) {
-    case 2:
-        if (device_supports_wmma_bf16(static_cast<int>(device_ordinal))) {
+    case 2: {
+        // WMMA path dequantizes a full 16-wide K chunk with one scale/zero
+        // fetch, which is only correct when a 16-value chunk is guaranteed
+        // to stay inside one quantization group. That requires
+        // `group_size % 16 == 0` (holds for the shipped GPTQ bakes at
+        // group_size=128, but weights.rs reads the value from metadata so a
+        // custom bake could land something else). Fall back to the scalar
+        // kernel otherwise.
+        if (group_size % 16 == 0 &&
+            device_supports_wmma_bf16(static_cast<int>(device_ordinal))) {
             return matmul_int4_dequant_wmma_bf16_device(
                 static_cast<int>(device_ordinal), batch_elems, m, n, k,
                 lhs, rhs_int4, scale, zero, group_size, out);
@@ -3852,6 +3860,7 @@ extern "C" int dotcache_qwen35_4b_hip_matmul_int4_dequant(
         return matmul_int4_dequant_device<hip_bfloat16>(
             static_cast<int>(device_ordinal), batch_elems, m, n, k,
             lhs, rhs_int4, scale, zero, group_size, out);
+    }
     default:
         return 272;
     }

--- a/kernels/full_attention_bridge_4b.cpp
+++ b/kernels/full_attention_bridge_4b.cpp
@@ -3796,6 +3796,41 @@ int matmul_int4_dequant_device(
     return 0;
 }
 
+static int matmul_int4_dequant_wmma_bf16_device(
+    int device_ordinal,
+    size_t batch_elems,
+    int m, int n, int k,
+    const void* lhs,
+    const void* rhs_int4,
+    const void* scale,
+    const void* zero,
+    int group_size,
+    void* out
+) {
+    ScopedHipDevice scoped(device_ordinal);
+    constexpr int TILE_M = 16;
+    constexpr int TILE_N = 16;
+    const int grid_x = (n + TILE_N - 1) / TILE_N;
+    const int grid_y = (m + TILE_M - 1) / TILE_M;
+    const int grid_z = static_cast<int>(batch_elems);
+    const int threads = 32;  // one wavefront per tile
+    hipLaunchKernelGGL(
+        dotcache_qwen35_matmul_int4_dequant_wmma_kernel,
+        dim3(grid_x, grid_y, grid_z), dim3(threads), 0, 0,
+        batch_elems, m, n, k,
+        static_cast<const hip_bfloat16*>(lhs),
+        static_cast<const uint8_t*>(rhs_int4),
+        static_cast<const hip_bfloat16*>(scale),
+        static_cast<const hip_bfloat16*>(zero),
+        group_size,
+        static_cast<hip_bfloat16*>(out));
+    hipError_t launch_err = hipGetLastError();
+    hipError_t sync_err = hipDeviceSynchronize();
+    if (launch_err != hipSuccess) return 290;
+    if (sync_err != hipSuccess) return 291;
+    return 0;
+}
+
 extern "C" int dotcache_qwen35_4b_hip_matmul_int4_dequant(
     int dtype,
     size_t device_ordinal,
@@ -3809,6 +3844,11 @@ extern "C" int dotcache_qwen35_4b_hip_matmul_int4_dequant(
     void* out) {
     switch (dtype) {
     case 2:
+        if (device_supports_wmma_bf16(static_cast<int>(device_ordinal))) {
+            return matmul_int4_dequant_wmma_bf16_device(
+                static_cast<int>(device_ordinal), batch_elems, m, n, k,
+                lhs, rhs_int4, scale, zero, group_size, out);
+        }
         return matmul_int4_dequant_device<hip_bfloat16>(
             static_cast<int>(device_ordinal), batch_elems, m, n, k,
             lhs, rhs_int4, scale, zero, group_size, out);


### PR DESCRIPTION
## Summary

- New `dotcache_qwen35_matmul_int4_dequant_wmma_kernel` in `kernels/full_attention_4b.hip`. Each lane dequantizes 16 packed INT4 weights per K-chunk (group_size=128 ⇒ one scale/zero pair covers the whole 16-K chunk), rounds each through `bf16_round_rne_f32_finite` to match the decode megakernel's reference, then feeds the BF16 bits directly into `__builtin_amdgcn_wmma_f32_16x16x16_bf16_w32`.
- Bridge dispatch in `kernels/full_attention_bridge_4b.cpp` routes `dotcache_qwen35_4b_hip_matmul_int4_dequant`'s BF16-output case to the WMMA path on gfx11xx. Reuses the existing `device_supports_wmma_bf16` cache so the `SUPERSONIC_QWEN4B_DISABLE_WMMA=1` kill-switch covers both the BF16 and INT4 WMMA paths.
- Scalar `dotcache_qwen35_matmul_int4_dequant_kernel` stays intact as the non-gfx11 fallback.

## Why

The BF16 WMMA port (#16) left INT4 prefill still on the scalar kernel, which is a bigger problem than it sounds: the INT4 scalar kernel also pays dequant cost every inner-loop iteration. Bundling dequant into the B-matrix register load lets WMMA amortize both the tensor-unit win and the dequant-code-density win at once — this is why the speedup is larger than BF16 got.

## Results (gfx1150, Radeon 890M, 1020-token prompt, BF16 output)

| Variant           | Scalar    | WMMA     | Speedup |
|-------------------|----------:|---------:|:--------|
| qwen3.5-2b INT4   |  24532 ms |  6681 ms |  3.67×  |
| qwen3.5-4b INT4   |  73065 ms | 18669 ms |  3.91×  |
| qwen3.5-9b INT4   | 126646 ms | 33486 ms |  3.78×  |

Short-prompt tokens match `SUPERSONIC_QWEN4B_DISABLE_WMMA=1` exactly on 2b/4b/9b; `decode_max_delta=0` and `gpu_oracle_max_delta=0` on all three.

## Test plan

- [x] qwen3.5-2b `--int4 --prompt "The quick brown fox jumps over" --max-new-tokens 8` — tokens match scalar
- [x] qwen3.5-4b same — tokens match
- [x] qwen3.5-9b `--int4 --prompt "Hi" --max-new-tokens 4` — tokens match (short prompt because 9B decode is slow on this box)
- [x] 1020-token prefill perf on 2b/4b/9b vs scalar
- [ ] Sanity-run on a non-gfx11 HIP device if available (expected: scalar fallback)

## Follow-up worth flagging

Gemma 4 INT4 prefill still uses `g4_matvec_batched_int4_kernel` (work-stealing scalar). A port analogous to this one would be the natural next step if/when the E2B INT4 quality calibration revisit happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)