### PR TITLE
Make wave_reduce_sum_f32 honor runtime warpSize (Qwen + Phi-4)

### DIFF
--- a/kernels/full_attention_4b.hip
+++ b/kernels/full_attention_4b.hip
@@ -4047,11 +4047,12 @@ __global__ void dotcache_qwen35_norm_multi_proj_kernel(
 
 // Wave-level sum reduction using DPP/shuffle (Wave32 on RDNA3.5)
 __device__ inline float wave_reduce_sum_f32(float val) {
-    val += __shfl_xor(val, 16);
-    val += __shfl_xor(val, 8);
-    val += __shfl_xor(val, 4);
-    val += __shfl_xor(val, 2);
-    val += __shfl_xor(val, 1);
+    // Use runtime warpSize so this agrees with matvec loops that partition
+    // columns by `warpSize * N`. On gfx1150 (wave32) the loop unrolls to
+    // the same 5 __shfl_xor ops; on CDNA (wave64) it covers all 64 lanes.
+    for (int offset = warpSize / 2; offset > 0; offset >>= 1) {
+        val += __shfl_xor(val, offset);
+    }
     return val;
 }
 

--- a/kernels/full_attention_4b_cuda.cuh
+++ b/kernels/full_attention_4b_cuda.cuh
@@ -3785,13 +3785,14 @@ __global__ void dotcache_qwen35_norm_multi_proj_kernel(
 // eliminating syncthreads from the hot matvec loop.
 // =============================================================================
 
-// Wave-level sum reduction using DPP/shuffle (Wave32 on RDNA3.5)
+// Wave-level sum reduction using shuffle. Uses runtime warpSize so this
+// agrees with matvec loops that partition columns by `warpSize * N`.
+// On NVIDIA (warp=32) the loop unrolls to the same 5 ops; kept size-
+// agnostic for parity with the HIP twin (wave32 on RDNA, wave64 on CDNA).
 __device__ inline float wave_reduce_sum_f32(float val) {
-    val += __shfl_xor(val, 16);
-    val += __shfl_xor(val, 8);
-    val += __shfl_xor(val, 4);
-    val += __shfl_xor(val, 2);
-    val += __shfl_xor(val, 1);
+    for (int offset = warpSize / 2; offset > 0; offset >>= 1) {
+        val += __shfl_xor(val, offset);
+    }
     return val;
 }
 

--- a/kernels/phi4.hip
+++ b/kernels/phi4.hip
@@ -3711,13 +3711,14 @@ __global__ void phi4_norm_multi_proj_kernel(
 // eliminating syncthreads from the hot matvec loop.
 // =============================================================================
 
-// Wave-level sum reduction using DPP/shuffle (Wave32 on RDNA3.5)
+// Wave-level sum reduction using shuffle. Uses runtime warpSize so this
+// agrees with matvec loops that partition columns by `warpSize * N`.
+// On gfx1150 (wave32) the loop unrolls to the same 5 __shfl_xor ops;
+// on CDNA (wave64) it covers all 64 lanes.
 __device__ inline float wave_reduce_sum_f32(float val) {
-    val += __shfl_xor(val, 16);
-    val += __shfl_xor(val, 8);
-    val += __shfl_xor(val, 4);
-    val += __shfl_xor(val, 2);
-    val += __shfl_xor(val, 1);
+    for (int offset = warpSize / 2; offset > 0; offset >>= 1) {
+        val += __shfl_xor(val, offset);
+    }
     return val;
 }
 


### PR DESCRIPTION
## Summary

Apply the same fix as PR #24 (Gemma 4) to the Qwen and Phi-4 `wave_reduce_sum_f32` helpers. The original 5-step hardcoded `__shfl_xor` tree assumes wave32; the surrounding matvec loops partition columns by runtime `warpSize * N`. On wave64 (CDNA) the top 32 lanes of each wave would carry partial sums that the reduction dropped, producing incorrect outputs.

Same pattern, three files:
- `kernels/full_attention_4b.hip` (Qwen HIP)
- `kernels/full_attention_4b_cuda.cuh` (Qwen CUDA twin)
- `kernels/phi4.hip` (Phi-4 HIP)

## Correctness

On gfx1150 (wave32 compile-time constant) the loop unrolls to the same 5 `__shfl_xor` ops — no SASS/ISA change, tokens bit-exact:

- Qwen 0.8B BF16: `279 5983 40289 13 198 760 3841 13477 37550 33075 888 279 5983 40289 13 198` ✓
- Qwen 0.8B INT4: `279 46026 76981 303 279 14367 13 198 760 3049 579 803 369 279 803 314` ✓
- Qwen 2B BF16, INT4, 4B BF16: all bit-exact vs baseline

Phi-4 not exercised locally (model not cached), but the change mirrors the Qwen fix.

## Test plan

- [x] Build clean
- [x] Token-exact on Qwen 0.8B / 2B / 4B × BF16 / INT4 at 16-tok
- [x] No perf regression (within iGPU noise; loop unrolls to identical code on wave32)
- [ ] Phi-4 not tested this session; same code change, same test surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)