### PR TITLE
[codex] Expand CUDA sm86 Qwen support and refresh perf snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,16 @@ see [docs/dflash.md](docs/dflash.md).
 | Model            | BF16 | INT4 | FP8 runtime | FP8 KV |
 |------------------|:----:|:----:|:-----------:|:------:|
 | qwen3.5-0.8b     |  ✅  |  —   |      —      |    —   |
+| qwen3.5-2b       |  ✅  |  —   |      —      |    —   |
 | qwen3.5-4b       |  ✅  |  —   |      —      |   ✅³  |
+| qwen3.5-9b       |  ✅  |  —   |      —      |    —   |
 
 ³ CUDA `--kv-fp8` is currently validated only for `qwen3.5-4b` on `sm86`.
-  Single-sequence decode keeps the replayed-prefill correctness path by
-  default; batched `--batch-size 2` uses the persistent kernel path.
+  Single-sequence BF16 decode now defaults to the persistent kernel path.
+  `--kv-fp8` single-sequence decode still uses replayed prefill for
+  correctness; batched `--batch-size 2` uses the persistent kernel path.
+  `qwen3.5-2b` and `qwen3.5-9b` are checked BF16 CUDA lanes on `sm86`, but do
+  not currently have CUDA KV-FP8, INT4, or FP8-runtime support.
 
 CUDA v1 is BF16-first. `--int4` and `--fp8-runtime` are rejected at runtime.
 
@@ -63,7 +68,7 @@ CUDA KV-FP8 is currently a narrow supported surface:
 - validated only on `qwen3.5-4b` / `sm86`
 - checked against the CPU oracle on the CUDA test machine
 - batched `--batch-size 2` uses the real persistent kernel path
-- single-sequence decode uses replayed prefill by default for correctness
+- single-sequence decode uses replayed prefill only for `--kv-fp8`
 - the BF16 KV sidecar is a bring-up aid for parity-sensitive reads/debugging, not part of normal BF16 CUDA runs
 - CUDA caps that sidecar to the most recent 128 KV positions by default for `--kv-fp8`, because full-prefix sidecar reads destabilized long-context parity on `sm86`; opt back into the full-prefix debug sidecar with `SUPERSONIC_DEBUG_ENABLE_CUDA_KV_FP8_BF16_SIDECAR=1`
 - normal CUDA BF16 runs do not allocate or use the sidecar
@@ -77,8 +82,10 @@ CUDA batched decode is currently validated only for:
 
 `--gpu-validate` is now part of the checked `sm86` debug surface for `qwen3.5-0.8b` and `qwen3.5-4b`.
 It is intentionally slower than normal decode: each step replays the full token history through the validated GPU prefill path and compares the resulting last-token logits against native decode.
-For `qwen3.5-4b` single-sequence CUDA decode on `sm86`, the current correctness-first path also uses replayed GPU prefill per decode step.
-That keeps longer prompt behavior closer to the oracle, but it is materially slower than the batched CUDA decode path.
+For `qwen3.5-4b` on `sm86`, normal BF16 single-sequence decode now uses the
+kernel path by default; replayed-prefill decode is legacy debugging behavior
+behind `--force-replay-decode`. CUDA `--kv-fp8` single-sequence decode still
+uses replayed GPU prefill for correctness.
 
 ## Quick Start
 
@@ -248,14 +255,15 @@ SUPERSONIC_BACKENDS=cuda ./tests/sm86/profile_qwen08_decode.sh \
 Set `PROFILE_MODE=fast` to disable the hero path while keeping CUDA fast-greedy,
 or `PROFILE_MODE=legacy` to force the old host-logits decode path.
 
-Current behavior on this `sm86` box depends on whether the path is using
-replayed prefill for correctness.
+Current behavior on this `sm86` box now defaults to the native kernel path for
+single-sequence `qwen3.5-4b`; the older replayed-prefill decode path is opt-in
+via `--force-replay-decode`.
 
 With a quick harness pass (`PROMPT_REPEAT=8`, `MAX_NEW_TOKENS=8`, `RUNS=1`):
 
-- `qwen3.5-0.8b`: prefill `199 ms` for 112 prompt tokens (`563 tok/s`), decode `268 ms` for 8 generated tokens (`29.9 tok/s`)
-- `qwen3.5-4b` single-sequence replay path: prefill `901 ms` for 112 prompt tokens (`124 tok/s`), decode `7486 ms` for 8 generated tokens (`1.1 tok/s`)
-- `qwen3.5-4b --batch-size 2`: prefill `906 ms` for 112 prompt tokens (`124 tok/s`), decode `741 ms` for 16 aggregate generated tokens (`21.6 tok/s`)
+- `qwen3.5-0.8b`: prefill `206 ms` for 112 prompt tokens (`544 tok/s`), decode `75 ms` for 8 generated tokens (`106.7 tok/s`)
+- `qwen3.5-4b --batch-size 1`: prefill `898 ms` for 112 prompt tokens (`124.7 tok/s`), decode `308 ms` for 8 generated tokens (`26.0 tok/s`)
+- `qwen3.5-4b --batch-size 2`: prefill `911 ms` for 112 prompt tokens (`122.9 tok/s`), decode `1042 ms` for 16 aggregate generated tokens (`15.4 tok/s`)
 
 There is also an explicit native single-sequence `4B` CUDA hero lane behind
 `--force-kernel-decode`. The exact lane is:
@@ -266,16 +274,16 @@ There is also an explicit native single-sequence `4B` CUDA hero lane behind
 - baked load
 - `--force-kernel-decode`
 - `--batch-size 1`
-- warmed `pp533 / tg128`
+- warmed `pp533 / tg16`
 
-Current best verified result on this box for that lane is commit `e5f244d`:
+Current best verified result on this box for that lane is commit `5a34190`:
 
-- prefill `4499 ms` (`118.5 tok/s`)
-- decode `8443 ms` (`15.2 tok/s`)
-- persistent decode stage `7714 ms`
+- prefill `5252 ms` (`101.5 tok/s`)
+- decode `727 ms` (`22.0 tok/s`)
+- persistent decode stage `655 ms`
 
 That single-stream lane is for Lucebox-style native-kernel optimization work.
-The validated production-throughput lane remains `qwen3.5-4b --batch-size 2`.
+`qwen3.5-4b --batch-size 2` remains the validated batched throughput lane.
 Detailed CUDA `sm86` history for both the `0.8B` and `4B` hero lanes lives in
 [docs/qwen35-sm86-optimization.md](/workspace/SuperSonic/docs/qwen35-sm86-optimization.md).
 

--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ see [docs/dflash.md](docs/dflash.md).
 | Model            | BF16 | INT4 | FP8 runtime | FP8 KV |
 |------------------|:----:|:----:|:-----------:|:------:|
 | qwen3.5-0.8b     |  ✅  |  —   |      —      |    —   |
-| qwen3.5-4b       |  ✅  |  —   |      —      |   🔒³  |
+| qwen3.5-4b       |  ✅  |  —   |      —      |   ✅³  |
 
-³ `qwen3.5-4b` has a hidden `--allow-unstable-cuda-kv-fp8` debug surface for
-  parity-sensitive validation work. It is not part of the public supported
-  surface — see the CUDA section below for the narrow validated shape.
+³ CUDA `--kv-fp8` is currently validated only for `qwen3.5-4b` on `sm86`.
+  Single-sequence decode keeps the replayed-prefill correctness path by
+  default; batched `--batch-size 2` uses the persistent kernel path.
 
 CUDA v1 is BF16-first. `--int4` and `--fp8-runtime` are rejected at runtime.
 
@@ -51,20 +51,21 @@ CUDA support is currently a narrow v1 surface:
 - BF16 decode path only
 - validated on NVIDIA `sm86` hardware (RTX 3090-class)
 - validated for both baked weights and direct `--no-bake` safetensors loads
-- hidden unstable CUDA `--kv-fp8` debug coverage currently exists only for `qwen3.5-4b` on `sm86`
+- CUDA `--kv-fp8` support is currently limited to `qwen3.5-4b` on `sm86`
 
 CUDA v1 does not currently support:
 
 - `--int4`
 - `--fp8-runtime`
 
-CUDA KV-FP8 is currently a debug-only surface:
+CUDA KV-FP8 is currently a narrow supported surface:
 
-- hidden behind `--allow-unstable-cuda-kv-fp8`
 - validated only on `qwen3.5-4b` / `sm86`
-- exercised on the real persistent kernel path with `--force-kernel-decode`
-- checked against the CPU oracle, not presented as a general CUDA v1 feature
+- checked against the CPU oracle on the CUDA test machine
+- batched `--batch-size 2` uses the real persistent kernel path
+- single-sequence decode uses replayed prefill by default for correctness
 - the BF16 KV sidecar is a bring-up aid for parity-sensitive reads/debugging, not part of normal BF16 CUDA runs
+- CUDA caps that sidecar to the most recent 128 KV positions by default for `--kv-fp8`, because full-prefix sidecar reads destabilized long-context parity on `sm86`; opt back into the full-prefix debug sidecar with `SUPERSONIC_DEBUG_ENABLE_CUDA_KV_FP8_BF16_SIDECAR=1`
 - normal CUDA BF16 runs do not allocate or use the sidecar
 - the sidecar can be disabled for A/B work with `SUPERSONIC_DEBUG_DISABLE_KV_FP8_BF16_SIDECAR=1`
 
@@ -174,6 +175,7 @@ Each `sm86` script currently validates:
 - oracle logit deltas
 - replay-based `--gpu-validate` deltas and token agreement
 - golden corpus coverage
+- CUDA `4B --kv-fp8` on the validated `sm86` lane
 
 `tests/sm86/run_batch.sh` adds `qwen3.5-4b --batch-size 2` coverage on the same `sm86` target.
 `tests/sm86/run_fast_greedy.sh` checks that the CUDA fast-greedy 0.8B path
@@ -185,18 +187,18 @@ for longer `4B` prompts today.
 `tests/sm86/run_long.sh` and `tests/sm86/run_4b_long.sh` add explicit long-context coverage
 against the CPU oracle using focused long-only golden corpora.
 
-The hidden CUDA KV-FP8 debug surface is validated separately with commands like:
+The CUDA KV-FP8 lane is validated separately with commands like:
 
 ```bash
 target/release/supersonic --backend cuda --oracle-device cpu \
   --model qwen3.5-4b --model-dir /path/to/Qwen3.5-4B \
   --prompt '中国的首都是' --max-new-tokens 8 \
-  --batch-size 2 --kv-fp8 --allow-unstable-cuda-kv-fp8 --force-kernel-decode --validate
+  --batch-size 2 --kv-fp8 --validate
 
 CORPUS_TIMEOUT=1200 tests/corpus/run_golden.sh \
   qwen3.5-4b /path/to/Qwen3.5-4B tests/corpus/golden_4b_batch2.json \
   target/release/supersonic --backend cuda --oracle-device cpu \
-  --batch-size 2 --kv-fp8 --allow-unstable-cuda-kv-fp8 --force-kernel-decode
+  --batch-size 2 --kv-fp8
 ```
 
 ### Benchmark baseline

--- a/crates/kernel-ffi/src/layer_desc.rs
+++ b/crates/kernel-ffi/src/layer_desc.rs
@@ -63,6 +63,11 @@ pub struct DecodeLayerDesc {
     pub kv_shadow_k: *mut c_void,
     pub kv_shadow_v: *mut c_void,
     pub kv_shadow_start: c_int,
+    // Optional linear Step-B debug export. When non-null on a linear layer,
+    // the kernel writes one selected channel's post-update conv-state taps,
+    // followed by qkv and conv_out scalars, into this F32 buffer.
+    pub debug_linear_trace_out: *mut c_void,
+    pub debug_linear_trace_channel: c_int,
 }
 
 unsafe impl Send for DecodeLayerDesc {}

--- a/crates/qwen35/src/loader.rs
+++ b/crates/qwen35/src/loader.rs
@@ -151,6 +151,43 @@ impl WeightLoader {
         Ok(buf)
     }
 
+    /// Load one BF16 row from a 2D tensor and expand it to F32 on CPU.
+    pub fn load_bf16_row_f32(&self, name: &str, row: usize) -> Result<Vec<f32>, LoadError> {
+        let &shard_idx = self
+            .index
+            .get(name)
+            .ok_or_else(|| LoadError::NotFound(name.to_string()))?;
+        let tensors = SafeTensors::deserialize(&self.shards[shard_idx])?;
+        let view = tensors.tensor(name)?;
+        if view.dtype() != safetensors::Dtype::BF16 {
+            return Err(LoadError::UnsupportedDtype(format!(
+                "{name}: expected BF16, got {:?}",
+                view.dtype()
+            )));
+        }
+        let shape = view.shape();
+        if shape.len() != 2 {
+            return Err(LoadError::UnsupportedDtype(format!(
+                "{name}: expected rank-2 tensor, got shape {shape:?}"
+            )));
+        }
+        let rows = shape[0];
+        let cols = shape[1];
+        if row >= rows {
+            return Err(LoadError::NotFound(format!(
+                "{name}: row {row} out of range for {rows} rows"
+            )));
+        }
+        let row_bytes = cols * 2;
+        let start = row * row_bytes;
+        let end = start + row_bytes;
+        let data = &view.data()[start..end];
+        Ok(data
+            .chunks_exact(2)
+            .map(|b| half::bf16::from_le_bytes([b[0], b[1]]).to_f32())
+            .collect())
+    }
+
     /// List all tensor names.
     pub fn tensor_names(&self) -> impl Iterator<Item = &str> {
         self.index.keys().map(String::as_str)

--- a/crates/qwen35/src/state.rs
+++ b/crates/qwen35/src/state.rs
@@ -165,6 +165,11 @@ impl LayerState {
     /// Record actual filled KV length (no reallocation).
     pub fn set_kv_filled(&mut self, filled: usize) {
         self.kv_filled = filled;
+        if self.kv_shadow_k.is_some() && self.kv_shadow_v.is_some() {
+            self.kv_shadow_start = kv_fp8_bf16_sidecar_window_tokens()
+                .map(|window| filled.saturating_sub(window))
+                .unwrap_or(0);
+        }
     }
 
     /// Get KV cache capacity (allocated seq dim).

--- a/crates/qwen35/src/state.rs
+++ b/crates/qwen35/src/state.rs
@@ -7,6 +7,12 @@ pub fn kv_fp8_bf16_sidecar_enabled() -> bool {
     std::env::var_os("SUPERSONIC_DEBUG_DISABLE_KV_FP8_BF16_SIDECAR").is_none()
 }
 
+pub fn kv_fp8_bf16_sidecar_window_tokens() -> Option<usize> {
+    std::env::var("SUPERSONIC_DEBUG_KV_FP8_BF16_SIDECAR_WINDOW")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+}
+
 /// Mutable per-layer state (KV cache, conv state, recurrent state).
 pub struct LayerState {
     pub kind: LayerKind,

--- a/crates/runner/src/decode_engine.rs
+++ b/crates/runner/src/decode_engine.rs
@@ -3584,8 +3584,17 @@ impl DecodeEngine {
 
         // 5. Launch batched persistent decode kernel
         let start = Instant::now();
+        // The CUDA single-stream hero specialization is only validated for the
+        // exact Qwen3.5-4B geometry. 2B/9B share the generic persistent path,
+        // but routing them through the specialized launch changes numerics.
+        let is_qwen35_4b_shape = config.hidden_size == 2560 &&
+            config.intermediate_size == 9216 &&
+            config.num_hidden_layers == 32 &&
+            config.num_attention_heads == 16 &&
+            config.num_key_value_heads == 4;
         let use_qwen35_4b_cuda_hero =
             self.hidden_io.backend() == gpu_hal::Backend::Cuda &&
+            is_qwen35_4b_shape &&
             b == 1 &&
             self.fp8_scale_device.is_none() &&
             self.int4_scale_device.is_none() &&

--- a/crates/runner/src/decode_engine.rs
+++ b/crates/runner/src/decode_engine.rs
@@ -101,6 +101,14 @@ fn f32_to_bf16_bytes_host(values: impl IntoIterator<Item = f32>) -> Vec<u8> {
         .collect()
 }
 
+fn is_qwen35_4b_shape(config: &TextConfig) -> bool {
+    config.hidden_size == 2560
+        && config.intermediate_size == 9216
+        && config.num_hidden_layers == 32
+        && config.num_attention_heads == 16
+        && config.num_key_value_heads == 4
+}
+
 pub struct DecodeEngine {
     weights: Qwen35Weights,
     state: ModelState,
@@ -3587,14 +3595,9 @@ impl DecodeEngine {
         // The CUDA single-stream hero specialization is only validated for the
         // exact Qwen3.5-4B geometry. 2B/9B share the generic persistent path,
         // but routing them through the specialized launch changes numerics.
-        let is_qwen35_4b_shape = config.hidden_size == 2560 &&
-            config.intermediate_size == 9216 &&
-            config.num_hidden_layers == 32 &&
-            config.num_attention_heads == 16 &&
-            config.num_key_value_heads == 4;
         let use_qwen35_4b_cuda_hero =
             self.hidden_io.backend() == gpu_hal::Backend::Cuda &&
-            is_qwen35_4b_shape &&
+            is_qwen35_4b_shape(config) &&
             b == 1 &&
             self.fp8_scale_device.is_none() &&
             self.int4_scale_device.is_none() &&

--- a/crates/runner/src/decode_engine.rs
+++ b/crates/runner/src/decode_engine.rs
@@ -3837,33 +3837,70 @@ impl DecodeEngine {
             .reset_sync()
             .map_err(|e| anyhow::anyhow!("trace reset batched decode sync: {e}"))?;
 
-        kernel_ffi::persistent_decode_4b(
-            self.ordinal,
-            ScalarType::BF16,
-            num_layers,
-            config.hidden_size,
-            config.intermediate_size,
-            seqlen_offset,
-            &self.scratch.desc_device,
-            &mut self.hidden_io,
-            &mut self.scratch.workspace,
-            &mut self.scratch.sync_buf,
-            &self.rotary.cos,
-            &self.rotary.sin,
-            self.rotary.rotary_dim,
-            self.proj_buf_floats,
-            self.attn_scratch_floats,
-            self.fp8_scale_device.as_ref(),
-            self.scratch.kv_fp8_desc_device.as_ref(),
-            b,
-            self.scratch.batch_seq_desc_device.as_ref(),
-            self.int4_scale_device.as_ref(),
-            false,
-            true,
-            None, // tap_workspace: DFlash-only, off in trace path
-            None, // tap_layers: DFlash-only, off in trace path
-        )
-        .map_err(|e| anyhow::anyhow!("trace persistent_decode_4b batch kernel: {e}"))?;
+        let use_qwen35_4b_cuda_hero =
+            self.hidden_io.backend() == gpu_hal::Backend::Cuda &&
+            is_qwen35_4b_shape(config) &&
+            b == 1 &&
+            self.fp8_scale_device.is_none() &&
+            self.int4_scale_device.is_none() &&
+            !self.kv_fp8;
+        let persist_result = if use_qwen35_4b_cuda_hero {
+            kernel_ffi::persistent_decode_4b_qwen35_sm86_specialized(
+                self.ordinal,
+                ScalarType::BF16,
+                num_layers,
+                config.hidden_size,
+                config.intermediate_size,
+                seqlen_offset,
+                &self.scratch.desc_device,
+                &mut self.hidden_io,
+                &mut self.scratch.workspace,
+                &mut self.scratch.sync_buf,
+                &self.rotary.cos,
+                &self.rotary.sin,
+                self.rotary.rotary_dim,
+                self.proj_buf_floats,
+                self.attn_scratch_floats,
+                self.fp8_scale_device.as_ref(),
+                self.scratch.kv_fp8_desc_device.as_ref(),
+                b,
+                self.scratch.batch_seq_desc_device.as_ref(),
+                self.int4_scale_device.as_ref(),
+                false,
+                true,
+                None, // tap_workspace: DFlash-only, off in trace path
+                None, // tap_layers: DFlash-only, off in trace path
+            )
+        } else {
+            kernel_ffi::persistent_decode_4b(
+                self.ordinal,
+                ScalarType::BF16,
+                num_layers,
+                config.hidden_size,
+                config.intermediate_size,
+                seqlen_offset,
+                &self.scratch.desc_device,
+                &mut self.hidden_io,
+                &mut self.scratch.workspace,
+                &mut self.scratch.sync_buf,
+                &self.rotary.cos,
+                &self.rotary.sin,
+                self.rotary.rotary_dim,
+                self.proj_buf_floats,
+                self.attn_scratch_floats,
+                self.fp8_scale_device.as_ref(),
+                self.scratch.kv_fp8_desc_device.as_ref(),
+                b,
+                self.scratch.batch_seq_desc_device.as_ref(),
+                self.int4_scale_device.as_ref(),
+                false,
+                true,
+                None, // tap_workspace: DFlash-only, off in trace path
+                None, // tap_layers: DFlash-only, off in trace path
+            )
+        };
+        persist_result
+            .map_err(|e| anyhow::anyhow!("trace persistent_decode_4b batch kernel: {e}"))?;
 
         let hidden = self
             .hidden_io

--- a/crates/runner/src/decode_engine.rs
+++ b/crates/runner/src/decode_engine.rs
@@ -2890,6 +2890,29 @@ impl DecodeEngine {
         Ok(result.logits)
     }
 
+    pub fn prefill_native_with_final_norm(
+        &mut self,
+        prompt_ids: &[u32],
+    ) -> Result<prefill_engine::PrefillResult> {
+        let result = prefill_engine::prefill(
+            &self.weights,
+            &mut self.state,
+            &self.rotary,
+            prompt_ids,
+            self.ordinal,
+            self.kv_chunk_size,
+            self.prefill_chunk_size,
+            self.kv_fp8,
+            self.use_4b_kernel,
+            false,
+            None,
+        )?;
+        self.scratch
+            .reset_sync()
+            .map_err(|e| anyhow::anyhow!("reset sync after prefill: {e}"))?;
+        Ok(result)
+    }
+
     /// Rebuild sequence-0 state from scratch by replaying native GPU prefill
     /// over the provided token history. Optionally replicates that state across
     /// extra batch slots for lockstep batch decoding.
@@ -3780,12 +3803,26 @@ impl DecodeEngine {
 
     /// Greedy argmax over logits.
     pub fn greedy_sample(logits: &[f32]) -> u32 {
-        logits
-            .iter()
-            .enumerate()
-            .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
-            .map(|(idx, _)| idx as u32)
-            .unwrap_or(0)
+        let mut best_idx = 0usize;
+        let mut best_val = f32::NEG_INFINITY;
+        for (idx, &val) in logits.iter().enumerate() {
+            if val > best_val {
+                best_idx = idx;
+                best_val = val;
+            }
+        }
+        best_idx as u32
+    }
+
+    pub fn last_normed_host_f32(&self) -> Result<Vec<f32>> {
+        let bytes = self
+            .normed_buf
+            .to_host_bytes()
+            .map_err(|e| anyhow::anyhow!("normed D2H: {e}"))?;
+        Ok(bytes
+            .chunks_exact(2)
+            .map(|b| half::bf16::from_le_bytes([b[0], b[1]]).to_f32())
+            .collect())
     }
 
     /// Copy prefill state from sequence 0 to all extra batch sequences.

--- a/crates/runner/src/decode_engine.rs
+++ b/crates/runner/src/decode_engine.rs
@@ -1025,19 +1025,6 @@ impl DecodeEngine {
         )
         .map_err(|e| anyhow::anyhow!("layer {idx} trace full layer k rope: {e}"))?;
 
-        kernel_ffi::prefill_ffi::transpose_shd_hsd(
-            self.ordinal, ScalarType::BF16, 1, num_q_heads, head_dim, &query_buf, &mut attn_q,
-        )
-        .map_err(|e| anyhow::anyhow!("layer {idx} trace full layer q transpose: {e}"))?;
-        kernel_ffi::prefill_ffi::transpose_shd_hsd(
-            self.ordinal, ScalarType::BF16, 1, num_kv_heads, head_dim, &k_buf, &mut step_k,
-        )
-        .map_err(|e| anyhow::anyhow!("layer {idx} trace full layer k transpose: {e}"))?;
-        kernel_ffi::prefill_ffi::transpose_shd_hsd(
-            self.ordinal, ScalarType::BF16, 1, num_kv_heads, head_dim, &v_buf, &mut step_v,
-        )
-        .map_err(|e| anyhow::anyhow!("layer {idx} trace full layer v transpose: {e}"))?;
-
         let (prefix_k_host, prefix_v_host, prefix_len) =
             self.assemble_full_attention_prefix_cache_bf16_host_for_state(state, idx)?;
         anyhow::ensure!(
@@ -1046,49 +1033,54 @@ impl DecodeEngine {
             prefix_len,
             seqlen_offset
         );
+        let q_rope_bytes = query_buf
+            .to_host_bytes()
+            .map_err(|e| anyhow::anyhow!("layer {idx} trace full layer q rope D2H: {e}"))?;
+        let k_step_bytes = k_buf
+            .to_host_bytes()
+            .map_err(|e| anyhow::anyhow!("layer {idx} trace full layer k rope D2H: {e}"))?;
+        let v_step_bytes = v_buf
+            .to_host_bytes()
+            .map_err(|e| anyhow::anyhow!("layer {idx} trace full layer v step D2H: {e}"))?;
+        let mut full_k_bytes = vec![0u8; num_kv_heads * kv_len * head_dim * elem_bytes];
+        let mut full_v_bytes = vec![0u8; num_kv_heads * kv_len * head_dim * elem_bytes];
+        let prefix_row_bytes = prefix_len * head_dim * elem_bytes;
+        let kv_row_bytes = kv_len * head_dim * elem_bytes;
+        let step_row_bytes = head_dim * elem_bytes;
+        for h in 0..num_kv_heads {
+            let prefix_src = h * prefix_row_bytes;
+            let full_dst = h * kv_row_bytes;
+            let step_src = h * step_row_bytes;
+            full_k_bytes[full_dst..full_dst + prefix_row_bytes]
+                .copy_from_slice(&prefix_k_host[prefix_src..prefix_src + prefix_row_bytes]);
+            full_v_bytes[full_dst..full_dst + prefix_row_bytes]
+                .copy_from_slice(&prefix_v_host[prefix_src..prefix_src + prefix_row_bytes]);
+            full_k_bytes[full_dst + prefix_row_bytes..full_dst + kv_row_bytes]
+                .copy_from_slice(&k_step_bytes[step_src..step_src + step_row_bytes]);
+            full_v_bytes[full_dst + prefix_row_bytes..full_dst + kv_row_bytes]
+                .copy_from_slice(&v_step_bytes[step_src..step_src + step_row_bytes]);
+        }
+        let attn_q = GpuBuffer::from_host_bytes(
+            self.ordinal,
+            ScalarType::BF16,
+            &[num_q_heads, 1, head_dim],
+            &q_rope_bytes,
+        )
+        .map_err(|e| anyhow::anyhow!("layer {idx} trace full layer attn_q H2D: {e}"))?;
         let kv_k_contig = GpuBuffer::from_host_bytes(
             self.ordinal,
             ScalarType::BF16,
             &[num_kv_heads, kv_len, head_dim],
-            &{
-                let mut bytes = vec![0u8; num_kv_heads * kv_len * head_dim * elem_bytes];
-                let copy = prefix_k_host.len();
-                bytes[..copy].copy_from_slice(&prefix_k_host);
-                bytes
-            },
+            &full_k_bytes,
         )
         .map_err(|e| anyhow::anyhow!("layer {idx} trace full layer kv_k_contig H2D: {e}"))?;
         let kv_v_contig = GpuBuffer::from_host_bytes(
             self.ordinal,
             ScalarType::BF16,
             &[num_kv_heads, kv_len, head_dim],
-            &{
-                let mut bytes = vec![0u8; num_kv_heads * kv_len * head_dim * elem_bytes];
-                let copy = prefix_v_host.len();
-                bytes[..copy].copy_from_slice(&prefix_v_host);
-                bytes
-            },
+            &full_v_bytes,
         )
         .map_err(|e| anyhow::anyhow!("layer {idx} trace full layer kv_v_contig H2D: {e}"))?;
-        let contig_stride = kv_len * head_dim * elem_bytes;
-        let step_stride = head_dim * elem_bytes;
-        let dst_offset = seqlen_offset * head_dim * elem_bytes;
-        for h in 0..num_kv_heads {
-            gpu_hal::copy_d2d(
-                self.ordinal,
-                kv_k_contig.offset_ptr(h * contig_stride + dst_offset) as *mut c_void,
-                step_k.offset_ptr(h * step_stride),
-                step_stride,
-            )
-            .map_err(|e| anyhow::anyhow!("layer {idx} trace full layer kv K append h={h}: {e}"))?;
-            gpu_hal::copy_d2d(
-                self.ordinal,
-                kv_v_contig.offset_ptr(h * contig_stride + dst_offset) as *mut c_void,
-                step_v.offset_ptr(h * step_stride),
-                step_stride,
-            )
-            .map_err(|e| anyhow::anyhow!("layer {idx} trace full layer kv V append h={h}: {e}"))?;
-        }
 
         kernel_ffi::prefill_ffi::full_attention_prefill(
             self.ordinal, ScalarType::BF16, 1, num_q_heads, num_kv_heads,
@@ -1100,10 +1092,15 @@ impl DecodeEngine {
             self.ordinal, ScalarType::F32, ScalarType::BF16, num_q_heads * head_dim, &attn_out_f32, &mut attn_out_bf16,
         )
         .map_err(|e| anyhow::anyhow!("layer {idx} trace full layer attn cast: {e}"))?;
-        kernel_ffi::prefill_ffi::transpose_shd_hsd(
-            self.ordinal, ScalarType::BF16, num_q_heads, 1, head_dim, &attn_out_bf16, &mut attn_flat,
+        attn_flat = GpuBuffer::from_host_bytes(
+            self.ordinal,
+            ScalarType::BF16,
+            &[1, q_dim],
+            &attn_out_bf16
+                .to_host_bytes()
+                .map_err(|e| anyhow::anyhow!("layer {idx} trace full layer attn bf16 D2H: {e}"))?,
         )
-        .map_err(|e| anyhow::anyhow!("layer {idx} trace full layer attn transpose: {e}"))?;
+        .map_err(|e| anyhow::anyhow!("layer {idx} trace full layer attn_flat H2D: {e}"))?;
         kernel_ffi::prefill_ffi::sigmoid_mul(
             self.ordinal, ScalarType::BF16, q_dim, &attn_flat, &gate_buf, &mut gated,
         )
@@ -1225,6 +1222,15 @@ impl DecodeEngine {
         &mut self,
         idx: usize,
     ) -> Result<ComponentLayerTrace> {
+        self.component_trace_full_layer_from_current_hidden_with_seqlen(idx, 0)
+    }
+
+    pub fn component_trace_full_layer_from_current_hidden_with_seqlen(
+        &mut self,
+        idx: usize,
+        seqlen_offset: usize,
+    ) -> Result<ComponentLayerTrace> {
+        let row_bytes = self.weights.config.hidden_size * ScalarType::BF16.size_in_bytes();
         kernel_ffi::prefill_ffi::rms_norm_rows(
             self.ordinal,
             ScalarType::BF16,
@@ -1238,11 +1244,26 @@ impl DecodeEngine {
         .map_err(|e| anyhow::anyhow!("layer {idx} component full-layer input rms_norm: {e}"))?;
 
         if self.weights.config.is_full_attention(idx) {
-            self.component_decode_full_attention_layer(idx, 0)?;
+            let hidden_in = self
+                .hidden_io
+                .to_host_bytes()
+                .map_err(|e| anyhow::anyhow!("layer {idx} component full-layer hidden D2H: {e}"))?;
+            let attn_trace = self.trace_full_attention_layer_output_from_hidden_current_state(
+                idx,
+                0,
+                &hidden_in[..row_bytes],
+                seqlen_offset,
+            )?;
+            self.hidden_io = GpuBuffer::from_host_bytes(
+                self.ordinal,
+                ScalarType::BF16,
+                &[1, self.weights.config.hidden_size],
+                &attn_trace.attn_hidden,
+            )
+            .map_err(|e| anyhow::anyhow!("layer {idx} component full-layer attn hidden H2D: {e}"))?;
         } else {
             self.component_decode_linear_attention_layer(idx, false)?;
         }
-        let row_bytes = self.weights.config.hidden_size * ScalarType::BF16.size_in_bytes();
         let attn_hidden = self
             .hidden_io
             .to_host_bytes()

--- a/crates/runner/src/decode_engine.rs
+++ b/crates/runner/src/decode_engine.rs
@@ -120,21 +120,19 @@ fn qwen35_4b_cuda_hero_enabled() -> bool {
     }
 }
 
-// Temporary correctness split for the CUDA Qwen3.5-4B persistent decode path.
-// Diagnostic traces show the layer-4 linear state is only later clobbered when
-// the same launch executes layer 4 and then continues onward. Relaunching from
-// layer 5 onward preserves correctness, so split the long-lived launch there
-// until the underlying in-kernel lifetime bug is fixed.
+// Keep the early split for the CUDA Qwen3.5-4B path. It remains part of the
+// validated long-context lane even after removing the default component
+// fallback.
 const QWEN35_4B_CUDA_SPLIT_LAYER: usize = 5;
 const QWEN35_4B_CUDA_COMPONENT_FALLBACK_TOKENS: usize = 512;
 
 fn qwen35_4b_cuda_long_context_component_fallback_enabled() -> bool {
-    match env::var("SUPERSONIC_DISABLE_QWEN35_4B_CUDA_LONG_FALLBACK") {
+    match env::var("SUPERSONIC_ENABLE_QWEN35_4B_CUDA_LONG_FALLBACK") {
         Ok(value) => {
             let value = value.trim();
-            value.is_empty() || value == "0"
+            value.is_empty() || value == "1"
         }
-        Err(_) => true,
+        Err(_) => false,
     }
 }
 

--- a/crates/runner/src/decode_engine.rs
+++ b/crates/runner/src/decode_engine.rs
@@ -3945,6 +3945,192 @@ impl DecodeEngine {
         Ok(hidden[start..end].to_vec())
     }
 
+    /// Debug-only: run the real 4B persistent decode kernel for the first
+    /// `num_layers` layers and export one selected linear layer/channel's
+    /// post-Step-B conv-state taps as F32 bytes.
+    ///
+    /// Output layout is `[state_len taps..., qkv_bf16, conv_out_bf16]`, all
+    /// widened to F32 by the kernel.
+    pub fn trace_persistent_linear_step_b_after_layers(
+        &mut self,
+        token_ids: &[u32],
+        seqlen_offset: usize,
+        num_layers: usize,
+        trace_layer: usize,
+        trace_channel: usize,
+    ) -> Result<Vec<u8>> {
+        assert_eq!(token_ids.len(), self.batch_size);
+        assert!(self.use_4b_kernel, "persistent trace requires 4b kernel");
+        let config = &self.weights.config;
+        let b = self.batch_size;
+        anyhow::ensure!(
+            num_layers <= config.num_hidden_layers,
+            "trace layer count {} exceeds model layers {}",
+            num_layers,
+            config.num_hidden_layers
+        );
+        anyhow::ensure!(
+            trace_layer < num_layers,
+            "trace layer {} out of range for num_layers {}",
+            trace_layer,
+            num_layers
+        );
+        anyhow::ensure!(
+            !config.is_full_attention(trace_layer),
+            "trace layer {} is not linear-attention",
+            trace_layer
+        );
+
+        let qkv_dim = config.linear_num_key_heads * config.linear_key_head_dim * 2
+            + config.linear_num_value_heads * config.linear_value_head_dim;
+        anyhow::ensure!(
+            trace_channel < qkv_dim,
+            "trace channel {} out of range for qkv_dim {}",
+            trace_channel,
+            qkv_dim
+        );
+
+        let row_bytes = config.hidden_size * ScalarType::BF16.size_in_bytes();
+        for (bi, &tid_val) in token_ids.iter().enumerate() {
+            let src_offset = tid_val as usize * row_bytes;
+            let dst_offset = bi * row_bytes;
+            gpu_hal::copy_d2d(
+                self.ordinal,
+                unsafe { (self.hidden_io.as_ptr() as *mut u8).add(dst_offset) as *mut c_void },
+                self.weights.embed_tokens.offset_ptr(src_offset),
+                row_bytes,
+            )
+            .map_err(|e| anyhow::anyhow!("linear step-b trace embedding lookup batch {bi}: {e}"))?;
+        }
+
+        let seqlen_offsets: Vec<usize> = vec![seqlen_offset; b];
+        for bi in 0..b {
+            let st = if bi == 0 {
+                &mut self.state
+            } else {
+                &mut self.extra_states[bi - 1]
+            };
+            for (i, ls) in st.layers.iter_mut().enumerate() {
+                if config.is_full_attention(i) {
+                    ls.ensure_kv_capacity(
+                        seqlen_offset,
+                        self.ordinal,
+                        config,
+                        self.kv_chunk_size,
+                        self.kv_fp8,
+                    )
+                    .map_err(|e| anyhow::anyhow!("linear step-b trace ensure KV capacity batch {bi} layer {i}: {e}"))?;
+                }
+            }
+        }
+
+        let state_len = config.linear_conv_kernel_dim - 1;
+        let mut debug_buf = GpuBuffer::zeros(self.ordinal, ScalarType::F32, &[state_len + 2])
+            .map_err(|e| anyhow::anyhow!("alloc linear step-b debug buffer: {e}"))?;
+
+        let mut descs = build_layer_descs(&self.weights, &self.state, seqlen_offset);
+        descs[trace_layer].debug_linear_trace_out = debug_buf.as_mut_ptr();
+        descs[trace_layer].debug_linear_trace_channel = trace_channel as i32;
+        self.scratch
+            .upload_descs(&descs)
+            .map_err(|e| anyhow::anyhow!("linear step-b trace upload descs: {e}"))?;
+
+        let state_refs: Vec<&ModelState> = std::iter::once(&self.state)
+            .chain(self.extra_states.iter())
+            .collect();
+        if let Some(batch_descs) = build_batch_seq_descs(&state_refs, &seqlen_offsets, self.kv_fp8) {
+            self.scratch
+                .upload_batch_seq_descs(&batch_descs)
+                .map_err(|e| anyhow::anyhow!("linear step-b trace upload batch seq descs: {e}"))?;
+        }
+
+        if let Some(kv_fp8_descs) = build_kv_fp8_descs(&self.state, self.kv_fp8) {
+            self.scratch
+                .upload_kv_fp8_descs(&kv_fp8_descs)
+                .map_err(|e| anyhow::anyhow!("linear step-b trace upload kv fp8 descs: {e}"))?;
+        }
+
+        gpu_hal::memset_zeros(
+            self.ordinal,
+            self.scratch.workspace.as_mut_ptr(),
+            self.scratch.workspace.len_bytes(),
+        )
+        .map_err(|e| anyhow::anyhow!("linear step-b trace clear workspace: {e}"))?;
+        self.scratch
+            .reset_sync()
+            .map_err(|e| anyhow::anyhow!("linear step-b trace reset sync: {e}"))?;
+
+        let use_qwen35_4b_cuda_hero =
+            self.hidden_io.backend() == gpu_hal::Backend::Cuda &&
+            is_qwen35_4b_shape(config) &&
+            qwen35_4b_cuda_hero_enabled() &&
+            b == 1 &&
+            self.fp8_scale_device.is_none() &&
+            self.int4_scale_device.is_none() &&
+            !self.kv_fp8;
+        let persist_result = if use_qwen35_4b_cuda_hero {
+            kernel_ffi::persistent_decode_4b_qwen35_sm86_specialized(
+                self.ordinal,
+                ScalarType::BF16,
+                num_layers,
+                config.hidden_size,
+                config.intermediate_size,
+                seqlen_offset,
+                &self.scratch.desc_device,
+                &mut self.hidden_io,
+                &mut self.scratch.workspace,
+                &mut self.scratch.sync_buf,
+                &self.rotary.cos,
+                &self.rotary.sin,
+                self.rotary.rotary_dim,
+                self.proj_buf_floats,
+                self.attn_scratch_floats,
+                self.fp8_scale_device.as_ref(),
+                self.scratch.kv_fp8_desc_device.as_ref(),
+                b,
+                self.scratch.batch_seq_desc_device.as_ref(),
+                self.int4_scale_device.as_ref(),
+                false,
+                false,
+                None,
+                None,
+            )
+        } else {
+            kernel_ffi::persistent_decode_4b(
+                self.ordinal,
+                ScalarType::BF16,
+                num_layers,
+                config.hidden_size,
+                config.intermediate_size,
+                seqlen_offset,
+                &self.scratch.desc_device,
+                &mut self.hidden_io,
+                &mut self.scratch.workspace,
+                &mut self.scratch.sync_buf,
+                &self.rotary.cos,
+                &self.rotary.sin,
+                self.rotary.rotary_dim,
+                self.proj_buf_floats,
+                self.attn_scratch_floats,
+                self.fp8_scale_device.as_ref(),
+                self.scratch.kv_fp8_desc_device.as_ref(),
+                b,
+                self.scratch.batch_seq_desc_device.as_ref(),
+                self.int4_scale_device.as_ref(),
+                false,
+                false,
+                None,
+                None,
+            )
+        };
+        persist_result
+            .map_err(|e| anyhow::anyhow!("linear step-b trace persistent_decode_4b kernel: {e}"))?;
+
+        debug_buf
+            .to_host_bytes()
+            .map_err(|e| anyhow::anyhow!("linear step-b trace D2H: {e}"))
+    }
+
     pub fn trace_persistent_linear_proj_buf_after_layers(
         &self,
         batch_index: usize,

--- a/crates/runner/src/decode_engine.rs
+++ b/crates/runner/src/decode_engine.rs
@@ -128,6 +128,78 @@ fn qwen35_4b_cuda_hero_enabled() -> bool {
 const QWEN35_4B_CUDA_SPLIT_LAYER: usize = 5;
 const QWEN35_4B_CUDA_COMPONENT_FALLBACK_TOKENS: usize = 512;
 
+fn qwen35_4b_cuda_long_context_component_fallback_enabled() -> bool {
+    match env::var("SUPERSONIC_DISABLE_QWEN35_4B_CUDA_LONG_FALLBACK") {
+        Ok(value) => {
+            let value = value.trim();
+            value.is_empty() || value == "0"
+        }
+        Err(_) => true,
+    }
+}
+
+fn qwen35_4b_cuda_split_windows(total_layers: usize) -> Vec<(usize, usize)> {
+    fn default_windows(total_layers: usize) -> Vec<(usize, usize)> {
+        if total_layers <= QWEN35_4B_CUDA_SPLIT_LAYER {
+            return vec![(0, total_layers)];
+        }
+        vec![
+            (0, QWEN35_4B_CUDA_SPLIT_LAYER),
+            (
+                QWEN35_4B_CUDA_SPLIT_LAYER,
+                total_layers - QWEN35_4B_CUDA_SPLIT_LAYER,
+            ),
+        ]
+    }
+
+    let raw = match env::var("SUPERSONIC_QWEN35_4B_CUDA_SPLIT_POINTS") {
+        Ok(value) => value,
+        Err(_) => return default_windows(total_layers),
+    };
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return default_windows(total_layers);
+    }
+
+    let mut split_points = Vec::new();
+    for part in raw.split(',') {
+        let part = part.trim();
+        if part.is_empty() {
+            continue;
+        }
+        let Ok(point) = part.parse::<usize>() else {
+            return default_windows(total_layers);
+        };
+        if point == 0 || point >= total_layers {
+            return default_windows(total_layers);
+        }
+        split_points.push(point);
+    }
+    if split_points.is_empty() {
+        return default_windows(total_layers);
+    }
+
+    split_points.sort_unstable();
+    split_points.dedup();
+
+    let mut windows = Vec::with_capacity(split_points.len() + 1);
+    let mut start = 0usize;
+    for point in split_points {
+        if point > start {
+            windows.push((start, point - start));
+            start = point;
+        }
+    }
+    if start < total_layers {
+        windows.push((start, total_layers - start));
+    }
+    if windows.is_empty() {
+        default_windows(total_layers)
+    } else {
+        windows
+    }
+}
+
 pub struct DecodeEngine {
     weights: Qwen35Weights,
     state: ModelState,
@@ -3573,6 +3645,7 @@ impl DecodeEngine {
             self.fp8_scale_device.is_none() &&
             self.int4_scale_device.is_none() &&
             !self.kv_fp8 &&
+            qwen35_4b_cuda_long_context_component_fallback_enabled() &&
             seqlen_offset >= QWEN35_4B_CUDA_COMPONENT_FALLBACK_TOKENS;
         if use_qwen35_4b_cuda_long_context_component_fallback {
             let logits = self.component_decode_step_4b(token_ids[0], seqlen_offset)?;
@@ -3681,13 +3754,7 @@ impl DecodeEngine {
             !self.kv_fp8 &&
             config.num_hidden_layers > QWEN35_4B_CUDA_SPLIT_LAYER;
         if use_qwen35_4b_cuda_split {
-            let windows = [
-                (0usize, QWEN35_4B_CUDA_SPLIT_LAYER),
-                (
-                    QWEN35_4B_CUDA_SPLIT_LAYER,
-                    config.num_hidden_layers - QWEN35_4B_CUDA_SPLIT_LAYER,
-                ),
-            ];
+            let windows = qwen35_4b_cuda_split_windows(config.num_hidden_layers);
             for (window_start, window_layers) in windows {
                 self.scratch
                     .upload_descs(&descs[window_start..window_start + window_layers])
@@ -4648,13 +4715,23 @@ impl DecodeEngine {
             .workspace
             .to_host_bytes()
             .map_err(|e| anyhow::anyhow!("persistent workspace D2H: {e}"))?;
+        let score_cols = self
+            .attn_scratch_floats
+            .saturating_sub(q_dim * 3)
+            / self.weights.config.num_attention_heads;
+        anyhow::ensure!(
+            kv_len <= score_cols,
+            "persistent full-attn scores kv_len {} exceeds scratch score columns {}",
+            kv_len,
+            score_cols,
+        );
         let start =
             (attn_scratch_base + batch_index * self.attn_scratch_floats + q_dim * 3) * 4;
-        let end = start + self.weights.config.num_attention_heads * self.kv_chunk_size * 4;
+        let end = start + self.weights.config.num_attention_heads * score_cols * 4;
         anyhow::ensure!(end <= bytes.len(), "persistent full-attn scores slice out of bounds");
         let full = &bytes[start..end];
         let mut out = Vec::with_capacity(self.weights.config.num_attention_heads * kv_len * 4);
-        let stride = self.kv_chunk_size * 4;
+        let stride = score_cols * 4;
         for h in 0..self.weights.config.num_attention_heads {
             let row = h * stride;
             out.extend_from_slice(&full[row..row + kv_len * 4]);

--- a/crates/runner/src/decode_engine.rs
+++ b/crates/runner/src/decode_engine.rs
@@ -13,7 +13,7 @@ use qwen35::rotary::RotaryTables;
 use qwen35::scratch::{
     PersistentDecodeScratch, PERSISTENT_4B_TIMING_SLOTS_PER_LAYER, PERSISTENT_SYNC_COUNTER_BYTES,
 };
-use qwen35::state::{kv_fp8_bf16_sidecar_enabled, ModelState};
+use qwen35::state::{kv_fp8_bf16_sidecar_enabled, kv_fp8_bf16_sidecar_window_tokens, ModelState};
 use qwen35::weights::Qwen35Weights;
 
 use crate::oracle::OracleOutput;
@@ -911,7 +911,9 @@ impl DecodeEngine {
                 )
                 .map_err(|e| anyhow::anyhow!("layer {layer_idx} shadow V copy h={h}: {e}"))?;
             }
-            ls.kv_shadow_start = 0;
+            ls.kv_shadow_start = kv_fp8_bf16_sidecar_window_tokens()
+                .map(|window| prefix_len.saturating_sub(window))
+                .unwrap_or(0);
         }
 
         Ok(())

--- a/crates/runner/src/decode_engine.rs
+++ b/crates/runner/src/decode_engine.rs
@@ -560,6 +560,10 @@ mod tests {
 }
 
 impl DecodeEngine {
+    pub fn scratch_debug_ptr(&self) -> usize {
+        self.scratch.workspace.as_ptr() as usize
+    }
+
     // Rebuild the BF16 sidecar from the current prefix cache when a KV-FP8 state
     // grows after prefill or is cloned for batched decode.
     fn load_kv_shadow_for_state_static(
@@ -748,7 +752,7 @@ impl DecodeEngine {
         hidden_bytes: &[u8],
         seqlen_offset: usize,
     ) -> Result<FullAttentionStageTrace> {
-        let config = &self.weights.config;
+        let config = self.weights.config.clone();
         let fw = self.weights.layers[idx]
             .full
             .as_ref()
@@ -900,7 +904,7 @@ impl DecodeEngine {
         hidden_bytes: &[u8],
         seqlen_offset: usize,
     ) -> Result<FullAttentionLayerOutputTrace> {
-        let config = &self.weights.config;
+        let config = self.weights.config.clone();
         let fw = self.weights.layers[idx]
             .full
             .as_ref()
@@ -1322,7 +1326,7 @@ impl DecodeEngine {
         batch_index: usize,
         seq_pos: usize,
     ) -> Result<(Vec<u8>, Vec<u8>)> {
-        let config = &self.weights.config;
+        let config = self.weights.config.clone();
         let ls = self.state_for_batch(batch_index)
             .layers
             .get(layer_idx)
@@ -3940,6 +3944,110 @@ impl DecodeEngine {
             .hidden_io
             .to_host_bytes()
             .map_err(|e| anyhow::anyhow!("trace hidden D2H: {e}"))?;
+        let start = batch_index * row_bytes;
+        let end = start + row_bytes;
+        Ok(hidden[start..end].to_vec())
+    }
+
+    /// Debug-only: run a BF16 4B persistent-kernel window over a sliced layer
+    /// descriptor range starting from a caller-supplied hidden row.
+    pub fn debug_decode_window_from_hidden_bf16(
+        &mut self,
+        hidden_bytes: &[u8],
+        seqlen_offset: usize,
+        start_layer: usize,
+        num_layers: usize,
+        batch_index: usize,
+    ) -> Result<Vec<u8>> {
+        anyhow::ensure!(self.batch_size == 1, "debug window requires batch_size=1");
+        anyhow::ensure!(self.use_4b_kernel, "debug window requires 4b kernel");
+        anyhow::ensure!(self.fp8_scale_device.is_none(), "debug window is BF16-only");
+        anyhow::ensure!(self.int4_scale_device.is_none(), "debug window is BF16-only");
+        anyhow::ensure!(!self.kv_fp8, "debug window does not support kv_fp8");
+
+        let config = self.weights.config.clone();
+        anyhow::ensure!(
+            start_layer < config.num_hidden_layers,
+            "debug window start_layer {} exceeds model layers {}",
+            start_layer,
+            config.num_hidden_layers
+        );
+        anyhow::ensure!(
+            start_layer + num_layers <= config.num_hidden_layers,
+            "debug window [{}, {}) exceeds model layers {}",
+            start_layer,
+            start_layer + num_layers,
+            config.num_hidden_layers
+        );
+        anyhow::ensure!(
+            hidden_bytes.len() == config.hidden_size * ScalarType::BF16.size_in_bytes(),
+            "debug window hidden len {} != hidden row bytes {}",
+            hidden_bytes.len(),
+            config.hidden_size * ScalarType::BF16.size_in_bytes()
+        );
+        anyhow::ensure!(
+            batch_index < self.batch_size,
+            "debug window batch index {} out of range for batch {}",
+            batch_index,
+            self.batch_size
+        );
+
+        self.set_hidden_from_bytes(hidden_bytes)?;
+
+        let descs = build_layer_descs(&self.weights, &self.state, seqlen_offset);
+        let window_descs = descs
+            .get(start_layer..start_layer + num_layers)
+            .ok_or_else(|| anyhow::anyhow!(
+                "debug window desc slice [{start_layer}, {}) missing",
+                start_layer + num_layers
+            ))?;
+        self.scratch
+            .upload_descs(window_descs)
+            .map_err(|e| anyhow::anyhow!("debug window upload descs: {e}"))?;
+
+        gpu_hal::memset_zeros(
+            self.ordinal,
+            self.scratch.workspace.as_mut_ptr(),
+            self.scratch.workspace.len_bytes(),
+        )
+        .map_err(|e| anyhow::anyhow!("debug window clear workspace: {e}"))?;
+        self.scratch
+            .reset_sync()
+            .map_err(|e| anyhow::anyhow!("debug window reset sync: {e}"))?;
+
+        kernel_ffi::persistent_decode_4b(
+            self.ordinal,
+            ScalarType::BF16,
+            num_layers,
+            config.hidden_size,
+            config.intermediate_size,
+            seqlen_offset,
+            &self.scratch.desc_device,
+            &mut self.hidden_io,
+            &mut self.scratch.workspace,
+            &mut self.scratch.sync_buf,
+            &self.rotary.cos,
+            &self.rotary.sin,
+            self.rotary.rotary_dim,
+            self.proj_buf_floats,
+            self.attn_scratch_floats,
+            None,
+            None,
+            self.batch_size,
+            None,
+            None,
+            false,
+            false,
+            None,
+            None,
+        )
+        .map_err(|e| anyhow::anyhow!("debug window persistent_decode_4b: {e}"))?;
+
+        let hidden = self
+            .hidden_io
+            .to_host_bytes()
+            .map_err(|e| anyhow::anyhow!("debug window hidden D2H: {e}"))?;
+        let row_bytes = config.hidden_size * ScalarType::BF16.size_in_bytes();
         let start = batch_index * row_bytes;
         let end = start + row_bytes;
         Ok(hidden[start..end].to_vec())

--- a/crates/runner/src/decode_engine.rs
+++ b/crates/runner/src/decode_engine.rs
@@ -467,6 +467,10 @@ pub struct FullAttentionLayerOutputTrace {
 struct Persistent4BLayerTiming {
     full_attn_ms: f64,
     full_attn_core_ms: f64,
+    full_attn_hero_prep_ms: f64,
+    full_attn_hero_loop_ms: f64,
+    full_attn_hero_merge_ms: f64,
+    full_attn_hero_gate_ms: f64,
     linear_proj_ms: f64,
     linear_core_ms: f64,
     linear_core_recurrent_ms: f64,
@@ -479,6 +483,10 @@ impl Persistent4BLayerTiming {
     fn add_assign(&mut self, rhs: &Self) {
         self.full_attn_ms += rhs.full_attn_ms;
         self.full_attn_core_ms += rhs.full_attn_core_ms;
+        self.full_attn_hero_prep_ms += rhs.full_attn_hero_prep_ms;
+        self.full_attn_hero_loop_ms += rhs.full_attn_hero_loop_ms;
+        self.full_attn_hero_merge_ms += rhs.full_attn_hero_merge_ms;
+        self.full_attn_hero_gate_ms += rhs.full_attn_hero_gate_ms;
         self.linear_proj_ms += rhs.linear_proj_ms;
         self.linear_core_ms += rhs.linear_core_ms;
         self.linear_core_recurrent_ms += rhs.linear_core_recurrent_ms;
@@ -530,11 +538,15 @@ fn maybe_dump_qwen35_4b_layer_timings(
     for layer in order.into_iter().take(emit) {
         let timing = &layer_timings[layer];
         eprintln!(
-            "[layer-timings] layer={} total_ms={:.3} full_attn_ms={:.3} full_attn_core_ms={:.3} linear_proj_ms={:.3} linear_core_ms={:.3} linear_core_recurrent_ms={:.3} linear_out_ms={:.3} mlp_ms={:.3} mlp_gate_up_ms={:.3} mlp_down_ms={:.3}",
+            "[layer-timings] layer={} total_ms={:.3} full_attn_ms={:.3} full_attn_core_ms={:.3} full_attn_hero_prep_ms={:.3} full_attn_hero_loop_ms={:.3} full_attn_hero_merge_ms={:.3} full_attn_hero_gate_ms={:.3} linear_proj_ms={:.3} linear_core_ms={:.3} linear_core_recurrent_ms={:.3} linear_out_ms={:.3} mlp_ms={:.3} mlp_gate_up_ms={:.3} mlp_down_ms={:.3}",
             layer,
             timing.total_ms(),
             timing.full_attn_ms,
             timing.full_attn_core_ms,
+            timing.full_attn_hero_prep_ms,
+            timing.full_attn_hero_loop_ms,
+            timing.full_attn_hero_merge_ms,
+            timing.full_attn_hero_gate_ms,
             timing.linear_proj_ms,
             timing.linear_core_ms,
             timing.linear_core_recurrent_ms,
@@ -549,6 +561,10 @@ fn maybe_dump_qwen35_4b_layer_timings(
 const PERSISTENT_4B_TIMING_FULL_ATTN: usize = 0;
 const PERSISTENT_4B_TIMING_FULL_ATTN_PROJ: usize = 1;
 const PERSISTENT_4B_TIMING_FULL_ATTN_CORE_BASE: usize = 2;
+const PERSISTENT_4B_TIMING_FULL_ATTN_HERO_PREP: usize = 3;
+const PERSISTENT_4B_TIMING_FULL_ATTN_HERO_LOOP: usize = 5;
+const PERSISTENT_4B_TIMING_FULL_ATTN_HERO_MERGE: usize = 6;
+const PERSISTENT_4B_TIMING_FULL_ATTN_HERO_GATE: usize = 7;
 const PERSISTENT_4B_TIMING_FULL_ATTN_OUT_BASE: usize = 10;
 const PERSISTENT_4B_TIMING_LINEAR_PROJ: usize = 18;
 const PERSISTENT_4B_TIMING_LINEAR_CORE_BASE: usize = 19;
@@ -610,6 +626,14 @@ fn decode_persistent_4b_timing_slots(
         let layer_full_attn_cycles = load_slot(layer_base + PERSISTENT_4B_TIMING_FULL_ATTN);
         let layer_full_attn_proj_cycles =
             load_slot(layer_base + PERSISTENT_4B_TIMING_FULL_ATTN_PROJ);
+        let layer_full_attn_hero_prep_cycles =
+            load_slot(layer_base + PERSISTENT_4B_TIMING_FULL_ATTN_HERO_PREP);
+        let layer_full_attn_hero_loop_cycles =
+            load_slot(layer_base + PERSISTENT_4B_TIMING_FULL_ATTN_HERO_LOOP);
+        let layer_full_attn_hero_merge_cycles =
+            load_slot(layer_base + PERSISTENT_4B_TIMING_FULL_ATTN_HERO_MERGE);
+        let layer_full_attn_hero_gate_cycles =
+            load_slot(layer_base + PERSISTENT_4B_TIMING_FULL_ATTN_HERO_GATE);
         let layer_linear_proj_cycles = load_slot(layer_base + PERSISTENT_4B_TIMING_LINEAR_PROJ);
         let layer_mlp_gate_up_cycles = load_slot(layer_base + PERSISTENT_4B_TIMING_MLP_GATE_UP);
         let layer_mlp_down_cycles = load_slot(layer_base + PERSISTENT_4B_TIMING_MLP_DOWN);
@@ -654,6 +678,22 @@ fn decode_persistent_4b_timing_slots(
                 ),
                 full_attn_core_ms: persistent_4b_clock_cycles_to_ms(
                     layer_full_attn_core_cycles,
+                    clock_rate_khz,
+                ),
+                full_attn_hero_prep_ms: persistent_4b_clock_cycles_to_ms(
+                    layer_full_attn_hero_prep_cycles,
+                    clock_rate_khz,
+                ),
+                full_attn_hero_loop_ms: persistent_4b_clock_cycles_to_ms(
+                    layer_full_attn_hero_loop_cycles,
+                    clock_rate_khz,
+                ),
+                full_attn_hero_merge_ms: persistent_4b_clock_cycles_to_ms(
+                    layer_full_attn_hero_merge_cycles,
+                    clock_rate_khz,
+                ),
+                full_attn_hero_gate_ms: persistent_4b_clock_cycles_to_ms(
+                    layer_full_attn_hero_gate_cycles,
                     clock_rate_khz,
                 ),
                 linear_proj_ms: persistent_4b_clock_cycles_to_ms(

--- a/crates/runner/src/decode_engine.rs
+++ b/crates/runner/src/decode_engine.rs
@@ -1,5 +1,6 @@
 use std::env;
 use std::ffi::c_void;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Instant;
 
 use anyhow::{Context, Result};
@@ -133,6 +134,20 @@ fn qwen35_4b_cuda_long_context_component_fallback_enabled() -> bool {
             value.is_empty() || value == "1"
         }
         Err(_) => false,
+    }
+}
+
+fn qwen35_4b_cuda_dump_layer_timings_topn() -> Option<usize> {
+    match env::var("SUPERSONIC_QWEN35_4B_CUDA_DUMP_LAYER_TIMINGS") {
+        Ok(value) => {
+            let value = value.trim();
+            if value.is_empty() {
+                Some(8)
+            } else {
+                value.parse::<usize>().ok().filter(|&topn| topn > 0)
+            }
+        }
+        Err(_) => None,
     }
 }
 
@@ -448,6 +463,89 @@ pub struct FullAttentionLayerOutputTrace {
     pub attn_hidden: Vec<u8>,
 }
 
+#[derive(Clone, Debug, Default)]
+struct Persistent4BLayerTiming {
+    full_attn_ms: f64,
+    full_attn_core_ms: f64,
+    linear_proj_ms: f64,
+    linear_core_ms: f64,
+    linear_core_recurrent_ms: f64,
+    linear_out_ms: f64,
+    mlp_gate_up_ms: f64,
+    mlp_down_ms: f64,
+}
+
+impl Persistent4BLayerTiming {
+    fn add_assign(&mut self, rhs: &Self) {
+        self.full_attn_ms += rhs.full_attn_ms;
+        self.full_attn_core_ms += rhs.full_attn_core_ms;
+        self.linear_proj_ms += rhs.linear_proj_ms;
+        self.linear_core_ms += rhs.linear_core_ms;
+        self.linear_core_recurrent_ms += rhs.linear_core_recurrent_ms;
+        self.linear_out_ms += rhs.linear_out_ms;
+        self.mlp_gate_up_ms += rhs.mlp_gate_up_ms;
+        self.mlp_down_ms += rhs.mlp_down_ms;
+    }
+
+    fn total_ms(&self) -> f64 {
+        self.full_attn_ms
+            + self.linear_proj_ms
+            + self.linear_core_ms
+            + self.linear_out_ms
+            + self.mlp_gate_up_ms
+            + self.mlp_down_ms
+    }
+
+    fn mlp_total_ms(&self) -> f64 {
+        self.mlp_gate_up_ms + self.mlp_down_ms
+    }
+}
+
+static QWEN35_4B_CUDA_LAYER_TIMINGS_DUMPED: AtomicBool = AtomicBool::new(false);
+
+fn maybe_dump_qwen35_4b_layer_timings(
+    layer_timings: &[Persistent4BLayerTiming],
+    topn: usize,
+    seqlen_offset: usize,
+    batch_size: usize,
+) {
+    if layer_timings.is_empty() {
+        return;
+    }
+    let mut order: Vec<usize> = (0..layer_timings.len()).collect();
+    order.sort_by(|&lhs, &rhs| {
+        layer_timings[rhs]
+            .total_ms()
+            .partial_cmp(&layer_timings[lhs].total_ms())
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    let emit = topn.min(order.len());
+    eprintln!(
+        "[layer-timings] seqlen_offset={} batch_size={} top_layers={} total_layers={}",
+        seqlen_offset,
+        batch_size,
+        emit,
+        layer_timings.len(),
+    );
+    for layer in order.into_iter().take(emit) {
+        let timing = &layer_timings[layer];
+        eprintln!(
+            "[layer-timings] layer={} total_ms={:.3} full_attn_ms={:.3} full_attn_core_ms={:.3} linear_proj_ms={:.3} linear_core_ms={:.3} linear_core_recurrent_ms={:.3} linear_out_ms={:.3} mlp_ms={:.3} mlp_gate_up_ms={:.3} mlp_down_ms={:.3}",
+            layer,
+            timing.total_ms(),
+            timing.full_attn_ms,
+            timing.full_attn_core_ms,
+            timing.linear_proj_ms,
+            timing.linear_core_ms,
+            timing.linear_core_recurrent_ms,
+            timing.linear_out_ms,
+            timing.mlp_total_ms(),
+            timing.mlp_gate_up_ms,
+            timing.mlp_down_ms,
+        );
+    }
+}
+
 const PERSISTENT_4B_TIMING_FULL_ATTN: usize = 0;
 const PERSISTENT_4B_TIMING_FULL_ATTN_PROJ: usize = 1;
 const PERSISTENT_4B_TIMING_FULL_ATTN_CORE_BASE: usize = 2;
@@ -474,6 +572,8 @@ fn decode_persistent_4b_timing_slots(
     num_layers: usize,
     batch_size: usize,
     clock_rate_khz: u32,
+    mut layer_timings: Option<&mut [Persistent4BLayerTiming]>,
+    layer_offset: usize,
 ) -> DecodeStageTimings {
     let timing_bytes =
         num_layers * PERSISTENT_4B_TIMING_SLOTS_PER_LAYER * std::mem::size_of::<u64>();
@@ -507,28 +607,81 @@ fn decode_persistent_4b_timing_slots(
     let split_batches = batch_size.min(2);
     for layer in 0..num_layers {
         let layer_base = layer * PERSISTENT_4B_TIMING_SLOTS_PER_LAYER;
-        full_attn_cycles += load_slot(layer_base + PERSISTENT_4B_TIMING_FULL_ATTN);
-        full_attn_proj_cycles += load_slot(layer_base + PERSISTENT_4B_TIMING_FULL_ATTN_PROJ);
-        linear_proj_cycles += load_slot(layer_base + PERSISTENT_4B_TIMING_LINEAR_PROJ);
-        mlp_gate_up_cycles += load_slot(layer_base + PERSISTENT_4B_TIMING_MLP_GATE_UP);
-        mlp_down_cycles += load_slot(layer_base + PERSISTENT_4B_TIMING_MLP_DOWN);
+        let layer_full_attn_cycles = load_slot(layer_base + PERSISTENT_4B_TIMING_FULL_ATTN);
+        let layer_full_attn_proj_cycles =
+            load_slot(layer_base + PERSISTENT_4B_TIMING_FULL_ATTN_PROJ);
+        let layer_linear_proj_cycles = load_slot(layer_base + PERSISTENT_4B_TIMING_LINEAR_PROJ);
+        let layer_mlp_gate_up_cycles = load_slot(layer_base + PERSISTENT_4B_TIMING_MLP_GATE_UP);
+        let layer_mlp_down_cycles = load_slot(layer_base + PERSISTENT_4B_TIMING_MLP_DOWN);
+        full_attn_cycles += layer_full_attn_cycles;
+        full_attn_proj_cycles += layer_full_attn_proj_cycles;
+        linear_proj_cycles += layer_linear_proj_cycles;
+        mlp_gate_up_cycles += layer_mlp_gate_up_cycles;
+        mlp_down_cycles += layer_mlp_down_cycles;
+        let mut layer_full_attn_core_cycles = 0u64;
+        let mut layer_linear_core_cycles = 0u64;
+        let mut layer_linear_out_cycles = 0u64;
+        let mut layer_linear_core_recurrent_cycles = 0u64;
         for b in 0..section_batches {
-            full_attn_core_cycles +=
+            let full_attn_core =
                 load_slot(layer_base + PERSISTENT_4B_TIMING_FULL_ATTN_CORE_BASE + b);
+            let linear_core = load_slot(layer_base + PERSISTENT_4B_TIMING_LINEAR_CORE_BASE + b);
+            let linear_out = load_slot(layer_base + PERSISTENT_4B_TIMING_LINEAR_OUT_BASE + b);
+            layer_full_attn_core_cycles += full_attn_core;
+            layer_linear_core_cycles += linear_core;
+            layer_linear_out_cycles += linear_out;
+            full_attn_core_cycles += full_attn_core;
             full_attn_out_cycles +=
                 load_slot(layer_base + PERSISTENT_4B_TIMING_FULL_ATTN_OUT_BASE + b);
-            linear_core_cycles +=
-                load_slot(layer_base + PERSISTENT_4B_TIMING_LINEAR_CORE_BASE + b);
-            linear_out_cycles +=
-                load_slot(layer_base + PERSISTENT_4B_TIMING_LINEAR_OUT_BASE + b);
+            linear_core_cycles += linear_core;
+            linear_out_cycles += linear_out;
         }
         for b in 0..split_batches {
             linear_core_conv_cycles +=
                 load_slot(layer_base + PERSISTENT_4B_TIMING_LINEAR_CORE_CONV_BASE + b);
-            linear_core_recurrent_cycles +=
+            let linear_core_recurrent =
                 load_slot(layer_base + PERSISTENT_4B_TIMING_LINEAR_CORE_RECURRENT_BASE + b);
+            layer_linear_core_recurrent_cycles += linear_core_recurrent;
+            linear_core_recurrent_cycles += linear_core_recurrent;
             linear_core_post_cycles +=
                 load_slot(layer_base + PERSISTENT_4B_TIMING_LINEAR_CORE_POST_BASE + b);
+        }
+        if let Some(layer_timings) = layer_timings.as_mut() {
+            let layer_timing = Persistent4BLayerTiming {
+                full_attn_ms: persistent_4b_clock_cycles_to_ms(
+                    layer_full_attn_cycles,
+                    clock_rate_khz,
+                ),
+                full_attn_core_ms: persistent_4b_clock_cycles_to_ms(
+                    layer_full_attn_core_cycles,
+                    clock_rate_khz,
+                ),
+                linear_proj_ms: persistent_4b_clock_cycles_to_ms(
+                    layer_linear_proj_cycles,
+                    clock_rate_khz,
+                ),
+                linear_core_ms: persistent_4b_clock_cycles_to_ms(
+                    layer_linear_core_cycles,
+                    clock_rate_khz,
+                ),
+                linear_core_recurrent_ms: persistent_4b_clock_cycles_to_ms(
+                    layer_linear_core_recurrent_cycles,
+                    clock_rate_khz,
+                ),
+                linear_out_ms: persistent_4b_clock_cycles_to_ms(
+                    layer_linear_out_cycles,
+                    clock_rate_khz,
+                ),
+                mlp_gate_up_ms: persistent_4b_clock_cycles_to_ms(
+                    layer_mlp_gate_up_cycles,
+                    clock_rate_khz,
+                ),
+                mlp_down_ms: persistent_4b_clock_cycles_to_ms(
+                    layer_mlp_down_cycles,
+                    clock_rate_khz,
+                ),
+            };
+            layer_timings[layer_offset + layer].add_assign(&layer_timing);
         }
     }
 
@@ -3650,6 +3803,21 @@ impl DecodeEngine {
             return Ok((vec![logits], DecodeStageTimings::default()));
         }
         let mut timings = DecodeStageTimings::default();
+        let dump_layer_timings_topn = if enable_timing_slots
+            && self.hidden_io.backend() == gpu_hal::Backend::Cuda
+            && is_qwen35_4b_shape(config)
+        {
+            qwen35_4b_cuda_dump_layer_timings_topn().and_then(|topn| {
+                QWEN35_4B_CUDA_LAYER_TIMINGS_DUMPED
+                    .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+                    .ok()
+                    .map(|_| topn)
+            })
+        } else {
+            None
+        };
+        let mut persistent_layer_timings = dump_layer_timings_topn
+            .map(|_| vec![Persistent4BLayerTiming::default(); config.num_hidden_layers]);
 
         // 1. Embedding lookup: place each sequence's embedding at offset b * hidden_size
         let row_bytes = config.hidden_size * ScalarType::BF16.size_in_bytes();
@@ -3852,6 +4020,8 @@ impl DecodeEngine {
                         window_layers,
                         1,
                         clock_rate_khz,
+                        persistent_layer_timings.as_deref_mut(),
+                        window_start,
                     ));
                 }
             }
@@ -3927,8 +4097,15 @@ impl DecodeEngine {
                     config.num_hidden_layers,
                     b,
                     clock_rate_khz,
+                    persistent_layer_timings.as_deref_mut(),
+                    0,
                 ));
             }
+        }
+        if let (Some(topn), Some(layer_timings)) =
+            (dump_layer_timings_topn, persistent_layer_timings.as_deref())
+        {
+            maybe_dump_qwen35_4b_layer_timings(layer_timings, topn, seqlen_offset, b);
         }
         timings.persistent_ms = start.elapsed().as_secs_f64() * 1000.0;
 

--- a/crates/runner/src/decode_engine.rs
+++ b/crates/runner/src/decode_engine.rs
@@ -120,6 +120,14 @@ fn qwen35_4b_cuda_hero_enabled() -> bool {
     }
 }
 
+// Temporary correctness split for the CUDA Qwen3.5-4B persistent decode path.
+// Diagnostic traces show the layer-4 linear state is only later clobbered when
+// the same launch executes layer 4 and then continues onward. Relaunching from
+// layer 5 onward preserves correctness, so split the long-lived launch there
+// until the underlying in-kernel lifetime bug is fixed.
+const QWEN35_4B_CUDA_SPLIT_LAYER: usize = 5;
+const QWEN35_4B_CUDA_COMPONENT_FALLBACK_TOKENS: usize = 512;
+
 pub struct DecodeEngine {
     weights: Qwen35Weights,
     state: ModelState,
@@ -3558,6 +3566,18 @@ impl DecodeEngine {
         assert!(self.use_4b_kernel, "batched decode requires 4b kernel");
         let config = &self.weights.config;
         let b = self.batch_size;
+        let use_qwen35_4b_cuda_long_context_component_fallback =
+            self.hidden_io.backend() == gpu_hal::Backend::Cuda &&
+            is_qwen35_4b_shape(config) &&
+            b == 1 &&
+            self.fp8_scale_device.is_none() &&
+            self.int4_scale_device.is_none() &&
+            !self.kv_fp8 &&
+            seqlen_offset >= QWEN35_4B_CUDA_COMPONENT_FALLBACK_TOKENS;
+        if use_qwen35_4b_cuda_long_context_component_fallback {
+            let logits = self.component_decode_step_4b(token_ids[0], seqlen_offset)?;
+            return Ok((vec![logits], DecodeStageTimings::default()));
+        }
         let mut timings = DecodeStageTimings::default();
 
         // 1. Embedding lookup: place each sequence's embedding at offset b * hidden_size
@@ -3628,6 +3648,19 @@ impl DecodeEngine {
 
         // 5. Launch batched persistent decode kernel
         let start = Instant::now();
+        let clock_rate_khz = if enable_timing_slots {
+            Some(match self.hidden_io.backend() {
+                gpu_hal::Backend::Cuda => {
+                    gpu_hal::query_device_info(gpu_hal::Backend::Cuda, self.ordinal)
+                        .map_err(|e| anyhow::anyhow!("query CUDA device clock rate: {e}"))?
+                        .clock_rate_khz
+                }
+                gpu_hal::Backend::Hip => kernel_ffi::query_hip_device_clock_khz(self.ordinal)
+                    .map_err(|e| anyhow::anyhow!("query HIP device clock rate: {e}"))?,
+            })
+        } else {
+            None
+        };
         // The CUDA single-stream hero specialization is only validated for the
         // exact Qwen3.5-4B geometry. 2B/9B share the generic persistent path,
         // but routing them through the specialized launch changes numerics.
@@ -3639,86 +3672,200 @@ impl DecodeEngine {
             self.fp8_scale_device.is_none() &&
             self.int4_scale_device.is_none() &&
             !self.kv_fp8;
-        let persist_result = if use_qwen35_4b_cuda_hero {
-            kernel_ffi::persistent_decode_4b_qwen35_sm86_specialized(
-                self.ordinal,
-                ScalarType::BF16,
-                config.num_hidden_layers,
-                config.hidden_size,
-                config.intermediate_size,
-                seqlen_offset,
-                &self.scratch.desc_device,
-                &mut self.hidden_io,
-                &mut self.scratch.workspace,
-                &mut self.scratch.sync_buf,
-                &self.rotary.cos,
-                &self.rotary.sin,
-                self.rotary.rotary_dim,
-                self.proj_buf_floats,
-                self.attn_scratch_floats,
-                self.fp8_scale_device.as_ref(),
-                self.scratch.kv_fp8_desc_device.as_ref(),
-                b,
-                self.scratch.batch_seq_desc_device.as_ref(),
-                self.int4_scale_device.as_ref(),
-                enable_timing_slots,
-                false,
-                None, // tap_workspace: DFlash-only, off in batched decode
-                None, // tap_layers: DFlash-only, off in batched decode
-            )
-        } else {
-            kernel_ffi::persistent_decode_4b(
-                self.ordinal,
-                ScalarType::BF16,
-                config.num_hidden_layers,
-                config.hidden_size,
-                config.intermediate_size,
-                seqlen_offset,
-                &self.scratch.desc_device,
-                &mut self.hidden_io,
-                &mut self.scratch.workspace,
-                &mut self.scratch.sync_buf,
-                &self.rotary.cos,
-                &self.rotary.sin,
-                self.rotary.rotary_dim,
-                self.proj_buf_floats,
-                self.attn_scratch_floats,
-                self.fp8_scale_device.as_ref(),
-                self.scratch.kv_fp8_desc_device.as_ref(),
-                b,
-                self.scratch.batch_seq_desc_device.as_ref(),
-                self.int4_scale_device.as_ref(),
-                enable_timing_slots,
-                false,
-                None, // tap_workspace: DFlash-only, off in batched decode
-                None, // tap_layers: DFlash-only, off in batched decode
-            )
-        };
-        persist_result
-            .map_err(|e| anyhow::anyhow!("persistent_decode_4b batch kernel: {e}"))?;
-        timings.persistent_ms = start.elapsed().as_secs_f64() * 1000.0;
-        if enable_timing_slots {
-            let clock_rate_khz = match self.hidden_io.backend() {
-                gpu_hal::Backend::Cuda => {
-                    gpu_hal::query_device_info(gpu_hal::Backend::Cuda, self.ordinal)
-                        .map_err(|e| anyhow::anyhow!("query CUDA device clock rate: {e}"))?
-                        .clock_rate_khz
+        let use_qwen35_4b_cuda_split =
+            self.hidden_io.backend() == gpu_hal::Backend::Cuda &&
+            is_qwen35_4b_shape(config) &&
+            b == 1 &&
+            self.fp8_scale_device.is_none() &&
+            self.int4_scale_device.is_none() &&
+            !self.kv_fp8 &&
+            config.num_hidden_layers > QWEN35_4B_CUDA_SPLIT_LAYER;
+        if use_qwen35_4b_cuda_split {
+            let windows = [
+                (0usize, QWEN35_4B_CUDA_SPLIT_LAYER),
+                (
+                    QWEN35_4B_CUDA_SPLIT_LAYER,
+                    config.num_hidden_layers - QWEN35_4B_CUDA_SPLIT_LAYER,
+                ),
+            ];
+            for (window_start, window_layers) in windows {
+                self.scratch
+                    .upload_descs(&descs[window_start..window_start + window_layers])
+                    .map_err(|e| anyhow::anyhow!(
+                        "upload descs for split window [{window_start}, {}): {e}",
+                        window_start + window_layers
+                    ))?;
+                gpu_hal::memset_zeros(
+                    self.ordinal,
+                    self.scratch.workspace.as_mut_ptr(),
+                    self.scratch.workspace.len_bytes(),
+                )
+                .map_err(|e| anyhow::anyhow!(
+                    "clear split decode workspace [{window_start}, {}): {e}",
+                    window_start + window_layers
+                ))?;
+                self.scratch
+                    .reset_sync()
+                    .map_err(|e| anyhow::anyhow!(
+                        "reset split decode sync [{window_start}, {}): {e}",
+                        window_start + window_layers
+                    ))?;
+
+                let window_result = if use_qwen35_4b_cuda_hero {
+                    kernel_ffi::persistent_decode_4b_qwen35_sm86_specialized(
+                        self.ordinal,
+                        ScalarType::BF16,
+                        window_layers,
+                        config.hidden_size,
+                        config.intermediate_size,
+                        seqlen_offset,
+                        &self.scratch.desc_device,
+                        &mut self.hidden_io,
+                        &mut self.scratch.workspace,
+                        &mut self.scratch.sync_buf,
+                        &self.rotary.cos,
+                        &self.rotary.sin,
+                        self.rotary.rotary_dim,
+                        self.proj_buf_floats,
+                        self.attn_scratch_floats,
+                        self.fp8_scale_device.as_ref(),
+                        None,
+                        1,
+                        None,
+                        self.int4_scale_device.as_ref(),
+                        enable_timing_slots,
+                        false,
+                        None,
+                        None,
+                    )
+                } else {
+                    kernel_ffi::persistent_decode_4b(
+                        self.ordinal,
+                        ScalarType::BF16,
+                        window_layers,
+                        config.hidden_size,
+                        config.intermediate_size,
+                        seqlen_offset,
+                        &self.scratch.desc_device,
+                        &mut self.hidden_io,
+                        &mut self.scratch.workspace,
+                        &mut self.scratch.sync_buf,
+                        &self.rotary.cos,
+                        &self.rotary.sin,
+                        self.rotary.rotary_dim,
+                        self.proj_buf_floats,
+                        self.attn_scratch_floats,
+                        self.fp8_scale_device.as_ref(),
+                        None,
+                        1,
+                        None,
+                        self.int4_scale_device.as_ref(),
+                        enable_timing_slots,
+                        false,
+                        None,
+                        None,
+                    )
+                };
+                window_result.map_err(|e| {
+                    anyhow::anyhow!(
+                        "persistent_decode_4b split window [{window_start}, {}): {e}",
+                        window_start + window_layers
+                    )
+                })?;
+
+                if let Some(clock_rate_khz) = clock_rate_khz {
+                    let sync_bytes = self
+                        .scratch
+                        .sync_buf
+                        .to_host_bytes()
+                        .map_err(|e| anyhow::anyhow!(
+                            "split timing slots D2H [{window_start}, {}): {e}",
+                            window_start + window_layers
+                        ))?;
+                    timings.add_assign(decode_persistent_4b_timing_slots(
+                        &sync_bytes,
+                        window_layers,
+                        1,
+                        clock_rate_khz,
+                    ));
                 }
-                gpu_hal::Backend::Hip => kernel_ffi::query_hip_device_clock_khz(self.ordinal)
-                    .map_err(|e| anyhow::anyhow!("query HIP device clock rate: {e}"))?,
+            }
+            self.scratch
+                .upload_descs(&descs)
+                .map_err(|e| anyhow::anyhow!("restore full descs after split decode: {e}"))?;
+        } else {
+            let persist_result = if use_qwen35_4b_cuda_hero {
+                kernel_ffi::persistent_decode_4b_qwen35_sm86_specialized(
+                    self.ordinal,
+                    ScalarType::BF16,
+                    config.num_hidden_layers,
+                    config.hidden_size,
+                    config.intermediate_size,
+                    seqlen_offset,
+                    &self.scratch.desc_device,
+                    &mut self.hidden_io,
+                    &mut self.scratch.workspace,
+                    &mut self.scratch.sync_buf,
+                    &self.rotary.cos,
+                    &self.rotary.sin,
+                    self.rotary.rotary_dim,
+                    self.proj_buf_floats,
+                    self.attn_scratch_floats,
+                    self.fp8_scale_device.as_ref(),
+                    self.scratch.kv_fp8_desc_device.as_ref(),
+                    b,
+                    self.scratch.batch_seq_desc_device.as_ref(),
+                    self.int4_scale_device.as_ref(),
+                    enable_timing_slots,
+                    false,
+                    None, // tap_workspace: DFlash-only, off in batched decode
+                    None, // tap_layers: DFlash-only, off in batched decode
+                )
+            } else {
+                kernel_ffi::persistent_decode_4b(
+                    self.ordinal,
+                    ScalarType::BF16,
+                    config.num_hidden_layers,
+                    config.hidden_size,
+                    config.intermediate_size,
+                    seqlen_offset,
+                    &self.scratch.desc_device,
+                    &mut self.hidden_io,
+                    &mut self.scratch.workspace,
+                    &mut self.scratch.sync_buf,
+                    &self.rotary.cos,
+                    &self.rotary.sin,
+                    self.rotary.rotary_dim,
+                    self.proj_buf_floats,
+                    self.attn_scratch_floats,
+                    self.fp8_scale_device.as_ref(),
+                    self.scratch.kv_fp8_desc_device.as_ref(),
+                    b,
+                    self.scratch.batch_seq_desc_device.as_ref(),
+                    self.int4_scale_device.as_ref(),
+                    enable_timing_slots,
+                    false,
+                    None, // tap_workspace: DFlash-only, off in batched decode
+                    None, // tap_layers: DFlash-only, off in batched decode
+                )
             };
-            let sync_bytes = self
-                .scratch
-                .sync_buf
-                .to_host_bytes()
-                .map_err(|e| anyhow::anyhow!("persistent timing slots D2H: {e}"))?;
-            timings.add_assign(decode_persistent_4b_timing_slots(
-                &sync_bytes,
-                config.num_hidden_layers,
-                b,
-                clock_rate_khz,
-            ));
+            persist_result
+                .map_err(|e| anyhow::anyhow!("persistent_decode_4b batch kernel: {e}"))?;
+            if let Some(clock_rate_khz) = clock_rate_khz {
+                let sync_bytes = self
+                    .scratch
+                    .sync_buf
+                    .to_host_bytes()
+                    .map_err(|e| anyhow::anyhow!("persistent timing slots D2H: {e}"))?;
+                timings.add_assign(decode_persistent_4b_timing_slots(
+                    &sync_bytes,
+                    config.num_hidden_layers,
+                    b,
+                    clock_rate_khz,
+                ));
+            }
         }
+        timings.persistent_ms = start.elapsed().as_secs_f64() * 1000.0;
 
         // 6. Update KV filled counts for all batch items
         let filled = seqlen_offset + 1;

--- a/crates/runner/src/decode_engine.rs
+++ b/crates/runner/src/decode_engine.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::ffi::c_void;
 use std::time::Instant;
 
@@ -107,6 +108,16 @@ fn is_qwen35_4b_shape(config: &TextConfig) -> bool {
         && config.num_hidden_layers == 32
         && config.num_attention_heads == 16
         && config.num_key_value_heads == 4
+}
+
+fn qwen35_4b_cuda_hero_enabled() -> bool {
+    match env::var("SUPERSONIC_DISABLE_QWEN35_4B_CUDA_HERO") {
+        Ok(value) => {
+            let value = value.trim();
+            value.is_empty() || value == "0"
+        }
+        Err(_) => true,
+    }
 }
 
 pub struct DecodeEngine {
@@ -3619,6 +3630,7 @@ impl DecodeEngine {
         let use_qwen35_4b_cuda_hero =
             self.hidden_io.backend() == gpu_hal::Backend::Cuda &&
             is_qwen35_4b_shape(config) &&
+            qwen35_4b_cuda_hero_enabled() &&
             b == 1 &&
             self.fp8_scale_device.is_none() &&
             self.int4_scale_device.is_none() &&
@@ -3861,6 +3873,7 @@ impl DecodeEngine {
         let use_qwen35_4b_cuda_hero =
             self.hidden_io.backend() == gpu_hal::Backend::Cuda &&
             is_qwen35_4b_shape(config) &&
+            qwen35_4b_cuda_hero_enabled() &&
             b == 1 &&
             self.fp8_scale_device.is_none() &&
             self.int4_scale_device.is_none() &&

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -975,6 +975,7 @@ fn main() -> Result<()> {
             &oracle_script, &model_id, &prompt_ids, cli.max_new_tokens,
             &cli.oracle_dtype, &oracle_device, true,
             fp8_oracle_dir.as_deref(),
+            None,
         )?;
         engine.load_prefill_state(&output)?;
         let first = output.generated_token_ids[0];
@@ -1033,6 +1034,8 @@ fn main() -> Result<()> {
             &oracle_device,
             emit_state,
             fp8_oracle_dir.as_deref(),
+            cli.trace_oracle_prefill_layer
+                .filter(|layer| text_config.is_full_attention(*layer)),
         )?;
 
         // Compare prefill logits
@@ -3330,7 +3333,34 @@ fn trace_oracle_prefill_layer(
         oracle_device,
         true,
         fp8_oracle_dir,
+        None,
     )?;
+    let mut native_prefix_k_delta = None;
+    let mut native_prefix_v_delta = None;
+    if engine.weights().config.is_full_attention(trace_layer) {
+        engine.reset()?;
+        let _ = engine.prefill_native(prefix_ids)?;
+        let (native_prefix_k, native_prefix_v, native_prefix_len) =
+            engine.full_attention_prefix_cache_bf16_host(trace_layer, 0)?;
+        engine.reset()?;
+        engine.load_prefill_state(&prefix_oracle)?;
+        let (oracle_prefix_k, oracle_prefix_v, oracle_prefix_len) =
+            engine.full_attention_prefix_cache_bf16_host(trace_layer, 0)?;
+        anyhow::ensure!(
+            native_prefix_len == oracle_prefix_len,
+            "trace layer {trace_layer} native prefix len {} != oracle prefix len {}",
+            native_prefix_len,
+            oracle_prefix_len,
+        );
+        native_prefix_k_delta = Some(validate::max_abs_delta(
+            &decode_bf16_le(&native_prefix_k),
+            &decode_bf16_le(&oracle_prefix_k),
+        ));
+        native_prefix_v_delta = Some(validate::max_abs_delta(
+            &decode_bf16_le(&native_prefix_v),
+            &decode_bf16_le(&oracle_prefix_v),
+        ));
+    }
     engine.reset()?;
     engine.load_prefill_state(&prefix_oracle)?;
 
@@ -3401,6 +3431,73 @@ fn trace_oracle_prefill_layer(
     eprintln!(
         "[trace-oracle-prefill-layer] layer={trace_layer} attn_delta={attn_delta:.6} post_norm_delta={post_delta:.6} mlp_delta={mlp_delta:.6} hidden_delta={hidden_delta:.6}"
     );
+    if let (Some(k_delta), Some(v_delta)) = (native_prefix_k_delta, native_prefix_v_delta) {
+        eprintln!(
+            "[trace-oracle-prefix-kv] layer={trace_layer} k_delta={k_delta:.6} v_delta={v_delta:.6}"
+        );
+    }
+
+    if engine.weights().config.is_full_attention(trace_layer)
+        && oracle_full.traced_full_attn_layer == Some(trace_layer)
+    {
+        let decode_opt_bf16 = |field: &Option<String>, label: &str| -> Result<Vec<f32>> {
+            let bytes = b64
+                .decode(field.as_ref().ok_or_else(|| anyhow::anyhow!("oracle output missing {label}"))?)
+                .map_err(|e| anyhow::anyhow!("decode oracle {label}: {e}"))?;
+            Ok(decode_bf16_le(&bytes))
+        };
+        let oracle_normed = decode_opt_bf16(&oracle_full.traced_full_attn_normed, "traced_full_attn_normed")?;
+        let oracle_q_proj = decode_opt_bf16(&oracle_full.traced_full_attn_q_proj, "traced_full_attn_q_proj")?;
+        let oracle_gate = decode_opt_bf16(&oracle_full.traced_full_attn_gate_proj, "traced_full_attn_gate_proj")?;
+        let oracle_k_proj = decode_opt_bf16(&oracle_full.traced_full_attn_k_proj, "traced_full_attn_k_proj")?;
+        let oracle_v_proj = decode_opt_bf16(&oracle_full.traced_full_attn_v_proj, "traced_full_attn_v_proj")?;
+        let oracle_q_rope = decode_opt_bf16(&oracle_full.traced_full_attn_q_rope, "traced_full_attn_q_rope")?;
+        let oracle_k_rope = decode_opt_bf16(&oracle_full.traced_full_attn_k_rope, "traced_full_attn_k_rope")?;
+        let oracle_pre_gate = decode_opt_bf16(&oracle_full.traced_full_attn_pre_gate, "traced_full_attn_pre_gate")?;
+        let oracle_gated = decode_opt_bf16(&oracle_full.traced_full_attn_gated, "traced_full_attn_gated")?;
+        let oracle_gated_actual = decode_opt_bf16(
+            &oracle_full.traced_full_attn_gated_actual,
+            "traced_full_attn_gated_actual",
+        )?;
+
+        let stage = engine.trace_full_attention_stages_from_hidden(trace_layer, &oracle_input_bytes, prefix_ids.len())?;
+        let stage_out = engine.trace_full_attention_layer_output_from_hidden_current_state(
+            trace_layer,
+            0,
+            &oracle_input_bytes,
+            prefix_ids.len(),
+        )?;
+        let normed_delta = validate::max_abs_delta(&decode_bf16_le(&stage.normed), &oracle_normed);
+        let q_proj_delta = validate::max_abs_delta(&decode_bf16_le(&stage.q_proj), &oracle_q_proj);
+        let gate_proj_delta = validate::max_abs_delta(&decode_bf16_le(&stage.gate_proj), &oracle_gate);
+        let k_proj_delta = validate::max_abs_delta(&decode_bf16_le(&stage.k_proj), &oracle_k_proj);
+        let v_proj_delta = validate::max_abs_delta(&decode_bf16_le(&stage.v_proj), &oracle_v_proj);
+        let q_rope_delta = validate::max_abs_delta(&decode_bf16_le(&stage.q_rope), &oracle_q_rope);
+        let k_rope_delta = validate::max_abs_delta(&decode_bf16_le(&stage.k_rope), &oracle_k_rope);
+        let pre_gate_stage_delta =
+            validate::max_abs_delta(&decode_bf16_le(&stage_out.pre_gate), &oracle_pre_gate);
+        let gated_stage_delta =
+            validate::max_abs_delta(&decode_bf16_le(&stage_out.gated), &oracle_gated);
+        let gated_actual_delta =
+            validate::max_abs_delta(&decode_bf16_le(&stage_out.gated), &oracle_gated_actual);
+        let gated_reconstruct_delta =
+            validate::max_abs_delta(&oracle_gated, &oracle_gated_actual);
+        let head_dim = engine.weights().config.head_dim;
+        let num_heads = engine.weights().config.num_attention_heads;
+        let pre_gate_host = decode_bf16_le(&stage_out.pre_gate);
+        let mut head_deltas = Vec::with_capacity(num_heads);
+        for head in 0..num_heads {
+            let start = head * head_dim;
+            let end = start + head_dim;
+            head_deltas.push(validate::max_abs_delta(
+                &pre_gate_host[start..end],
+                &oracle_pre_gate[start..end],
+            ));
+        }
+        eprintln!(
+            "[trace-oracle-full-attn] layer={trace_layer} normed_delta={normed_delta:.6} q_proj_delta={q_proj_delta:.6} gate_proj_delta={gate_proj_delta:.6} k_proj_delta={k_proj_delta:.6} v_proj_delta={v_proj_delta:.6} q_rope_delta={q_rope_delta:.6} k_rope_delta={k_rope_delta:.6} pre_gate_delta={pre_gate_stage_delta:.6} gated_delta={gated_stage_delta:.6} gated_actual_delta={gated_actual_delta:.6} gated_reconstruct_delta={gated_reconstruct_delta:.6} pre_gate_head_deltas={head_deltas:?}"
+        );
+    }
     Ok(())
 }
 

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -268,8 +268,8 @@ pub(crate) struct Cli {
     #[arg(long, hide = true)]
     force_replay_decode: bool,
 
-    /// Debug-only: allow unstable CUDA KV-FP8 experiments on the 4B kernel path.
-    /// This is intentionally hidden until the path is validated.
+    /// Legacy compatibility switch for older CUDA KV-FP8 bring-up commands.
+    /// No longer required now that the validated 4B sm86 lane is public.
     #[arg(long, hide = true)]
     allow_unstable_cuda_kv_fp8: bool,
 
@@ -717,17 +717,17 @@ fn main() -> Result<()> {
             anyhow::bail!("CUDA v1 does not support --fp8-runtime yet");
         }
         if cli.kv_fp8 {
-            if !cli.allow_unstable_cuda_kv_fp8 {
-                anyhow::bail!("CUDA v1 does not support --kv-fp8 yet");
+            if model_variant != ModelVariant::Qwen3_5_4B || gpu_arch != GpuArch::Sm86 {
+                anyhow::bail!("CUDA --kv-fp8 currently supports only qwen3.5-4b on sm86");
             }
-            if !params.use_4b_kernel {
-                anyhow::bail!(
-                    "--allow-unstable-cuda-kv-fp8 only supports the CUDA 4B kernel path"
+            if env::var_os("SUPERSONIC_DEBUG_ENABLE_CUDA_KV_FP8_BF16_SIDECAR").is_none() {
+                env::set_var("SUPERSONIC_DEBUG_KV_FP8_BF16_SIDECAR_WINDOW", "128");
+                eprintln!(
+                    "[cuda] KV-FP8 BF16 sidecar window capped to the most recent 128 tokens on CUDA; \
+                     set SUPERSONIC_DEBUG_ENABLE_CUDA_KV_FP8_BF16_SIDECAR=1 \
+                     to restore full-prefix debug sidecar coverage"
                 );
             }
-            eprintln!(
-                "[cuda] WARNING: enabling unstable CUDA KV-FP8 debug path; correctness is not guaranteed"
-            );
         }
     }
 
@@ -1259,7 +1259,7 @@ fn main() -> Result<()> {
         && !cli.kv_fp8;
     let replay_kv_fp8_enabled = params.use_4b_kernel
         && cli.kv_fp8
-        && cli.allow_unstable_cuda_kv_fp8
+        && cli.batch_size == 1
         && !cli.force_kernel_decode;
     let component_single_decode_enabled =
         cli.batch_size == 1 && params.use_4b_kernel && cli.force_component_decode;
@@ -1302,15 +1302,15 @@ fn main() -> Result<()> {
     if replay_decode_enabled {
         eprintln!("[decode] single-sequence 4B uses replayed GPU prefill for correctness");
     } else if replay_kv_fp8_enabled && cli.batch_size == 1 {
-        eprintln!("[decode] experimental single-sequence KV-FP8 uses replayed GPU prefill for correctness");
-    } else if replay_kv_fp8_enabled && cli.batch_size > 1 {
-        eprintln!("[decode] experimental batched KV-FP8 rebuilds state from replayed GPU prefill each step");
+        eprintln!("[decode] single-sequence CUDA KV-FP8 uses replayed GPU prefill for correctness");
+    } else if cli.batch_size > 1 && params.use_4b_kernel && cli.kv_fp8 {
+        eprintln!("[decode] batched CUDA KV-FP8 uses the persistent kernel path");
     } else if component_single_decode_enabled {
         eprintln!("[decode] WARNING: forcing single-sequence 4B onto the component decode path");
     } else if cli.batch_size == 1 && params.use_4b_kernel && cli.force_kernel_decode {
         eprintln!("[decode] WARNING: forcing single-sequence 4B onto the kernel decode path");
     } else if cli.batch_size == 1 && params.use_4b_kernel && cli.kv_fp8 {
-        eprintln!("[decode] WARNING: experimental single-sequence KV-FP8 uses the b=1 kernel path");
+        eprintln!("[decode] WARNING: single-sequence CUDA KV-FP8 uses the b=1 kernel path");
     } else if cuda_08b_hero_enabled {
         eprintln!("[decode] CUDA 0.8B sm86 hero path enabled (fused lm_head argmax)");
     } else if cuda_fast_greedy_enabled {

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -1658,6 +1658,7 @@ fn main() -> Result<()> {
         } else {
             // Single-sequence decode (original path)
             let mut maybe_fast_token = None;
+            let mut can_rescore_with_normed = false;
             let logits = if cuda_fast_greedy_enabled {
                 let (token, timings) = engine.decode_step_cuda_fast_greedy(next_token, seqlen_offset)?;
                 native_decode_timings.add_assign(timings);
@@ -1869,22 +1870,26 @@ fn main() -> Result<()> {
                         engine.decode_step_4b_single_kernel_with_timings(next_token, seqlen_offset)?;
                     native_decode_timings.add_assign(timings);
                     native_decode_timing_steps += 1;
+                    can_rescore_with_normed = true;
                     logits
                 } else {
+                    can_rescore_with_normed = true;
                     engine.decode_step_batch(&[next_token], seqlen_offset)?.remove(0)
                 }
             } else if cli.emit_stage_timings {
                 let (logits, timings) = engine.decode_step_with_timings(next_token, seqlen_offset)?;
                 native_decode_timings.add_assign(timings);
                 native_decode_timing_steps += 1;
+                can_rescore_with_normed = true;
                 logits
             } else {
+                can_rescore_with_normed = true;
                 engine.decode_step(next_token, seqlen_offset)?
             };
             let native_token = if let Some(token) = maybe_fast_token {
                 token
             } else {
-                let normed = if host_lm_head_rescorer.is_some() {
+                let normed = if can_rescore_with_normed && host_lm_head_rescorer.is_some() {
                     Some(engine.last_normed_host_f32()?)
                 } else {
                     None

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -3289,6 +3289,16 @@ fn trace_persistent_linear_layer(
     engine.rebuild_prefill_state(prefix_ids, true)?;
     let native_hidden_out = engine
         .decode_step_batch_trace_hidden_after_layers(trace_tokens, seqlen_offset, trace_layer + 1, 0)?;
+    let native_partial_conv = engine
+        .state_for_batch(0)
+        .layers
+        .get(trace_layer)
+        .ok_or_else(|| anyhow::anyhow!("missing native partial layer {trace_layer}"))?
+        .conv_state
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("missing native partial conv state for layer {trace_layer}"))?
+        .to_host_bytes()
+        .map_err(|e| anyhow::anyhow!("native partial conv D2H layer {trace_layer}: {e}"))?;
     let cfg = engine.weights().config.clone();
     let qkv_dim = cfg.linear_num_key_heads * cfg.linear_key_head_dim * 2
         + cfg.linear_num_value_heads * cfg.linear_value_head_dim;
@@ -3475,6 +3485,7 @@ fn trace_persistent_linear_layer(
     let step_b_debug = {
         let debug = decode_f32_le(&step_b_debug_raw);
         let native = decode_bf16_le(&native_conv);
+        let partial = decode_bf16_le(&native_partial_conv);
         let start = decode_bf16_le(&pre_step_conv);
         let base = max_append_channel * conv_state_len;
         let idx = base + (conv_state_len - 1);
@@ -3490,16 +3501,178 @@ fn trace_persistent_linear_layer(
             .unwrap_or_default();
         let step_b_vs_expected = (step_b_last - expected_conv_tail[idx]).abs();
         let final_vs_step_b = (native[idx] - step_b_last).abs();
+        let partial_vs_step_b = (partial[idx] - step_b_last).abs();
+        let partial_vs_expected = (partial[idx] - expected_conv_tail[idx]).abs();
         format!(
-            "channel={max_append_channel},state=[{state_values}],qkv={:.6},conv_out={:.6},shift0_expected={:.6},shift1_expected={:.6},append_expected={:.6},step_b_vs_expected={:.6},final_vs_step_b={:.6}",
+            "channel={max_append_channel},state=[{state_values}],qkv={:.6},conv_out={:.6},shift0_expected={:.6},shift1_expected={:.6},append_expected={:.6},step_b_vs_expected={:.6},partial_last={:.6},partial_vs_step_b={:.6},partial_vs_expected={:.6},final_vs_step_b={:.6}",
             debug.get(conv_state_len).copied().unwrap_or_default(),
             debug.get(conv_state_len + 1).copied().unwrap_or_default(),
             start.get(base + 1).copied().unwrap_or_default(),
             start.get(base + 2).copied().unwrap_or_default(),
             expected_conv_tail[idx],
             step_b_vs_expected,
+            partial[idx],
+            partial_vs_step_b,
+            partial_vs_expected,
             final_vs_step_b,
         )
+    };
+    let first_later_clobber = {
+        let native = decode_bf16_le(&native_conv);
+        let partial = decode_bf16_le(&native_partial_conv);
+        let base = max_append_channel * conv_state_len;
+        let idx = base + (conv_state_len - 1);
+        let step_b_last = partial[idx];
+        if (native[idx] - step_b_last).abs() == 0.0 || trace_layer + 1 >= text_config.num_hidden_layers {
+            "none".to_string()
+        } else {
+            let mut lo = trace_layer + 1;
+            let mut hi = text_config.num_hidden_layers;
+            let mut hi_last = native[idx];
+            while lo + 1 < hi {
+                let mid = lo + (hi - lo) / 2;
+                engine.rebuild_prefill_state(prefix_ids, true)?;
+                let _ = engine.decode_step_batch_trace_hidden_after_layers(
+                    trace_tokens,
+                    seqlen_offset,
+                    mid,
+                    0,
+                )?;
+                let mid_conv = engine
+                    .state_for_batch(0)
+                    .layers
+                    .get(trace_layer)
+                    .ok_or_else(|| anyhow::anyhow!("missing binary-search layer {trace_layer}"))?
+                    .conv_state
+                    .as_ref()
+                    .ok_or_else(|| anyhow::anyhow!("missing binary-search conv state for layer {trace_layer}"))?
+                    .to_host_bytes()
+                    .map_err(|e| anyhow::anyhow!("binary-search conv D2H layer {trace_layer}: {e}"))?;
+                let mid_vals = decode_bf16_le(&mid_conv);
+                let mid_last = mid_vals[idx];
+                if (mid_last - step_b_last).abs() > 0.0 {
+                    hi = mid;
+                    hi_last = mid_last;
+                } else {
+                    lo = mid;
+                }
+            }
+            format!(
+                "after_layers={hi},clobber_layer={},partial_last={:.6},clobbered_last={:.6},delta={:.6}",
+                hi - 1,
+                step_b_last,
+                hi_last,
+                (hi_last - step_b_last).abs()
+            )
+        }
+    };
+    let pointer_debug = {
+        let state0 = engine.state_for_batch(0);
+        let trace_layer_state = state0
+            .layers
+            .get(trace_layer)
+            .ok_or_else(|| anyhow::anyhow!("missing trace layer state {trace_layer}"))?;
+        let final_layer_idx = text_config.num_hidden_layers.saturating_sub(1);
+        let final_layer_state = state0
+            .layers
+            .get(final_layer_idx)
+            .ok_or_else(|| anyhow::anyhow!("missing final layer state {final_layer_idx}"))?;
+        let trace_conv = trace_layer_state
+            .conv_state
+            .as_ref()
+            .map(|b| b.as_ptr() as usize)
+            .unwrap_or(0);
+        let trace_rec = trace_layer_state
+            .recurrent_state
+            .as_ref()
+            .map(|b| b.as_ptr() as usize)
+            .unwrap_or(0);
+        let final_k = final_layer_state
+            .kv_cache_k
+            .as_ref()
+            .map(|b| b.as_ptr() as usize)
+            .unwrap_or(0);
+        let final_v = final_layer_state
+            .kv_cache_v
+            .as_ref()
+            .map(|b| b.as_ptr() as usize)
+            .unwrap_or(0);
+        let final_shadow_k = final_layer_state
+            .kv_shadow_k
+            .as_ref()
+            .map(|b| b.as_ptr() as usize)
+            .unwrap_or(0);
+        let final_shadow_v = final_layer_state
+            .kv_shadow_v
+            .as_ref()
+            .map(|b| b.as_ptr() as usize)
+            .unwrap_or(0);
+        format!(
+            "trace_conv=0x{trace_conv:x},trace_rec=0x{trace_rec:x},final_k=0x{final_k:x},final_v=0x{final_v:x},final_shadow_k=0x{final_shadow_k:x},final_shadow_v=0x{final_shadow_v:x},workspace=0x{:x}",
+            engine.scratch_debug_ptr(),
+        )
+    };
+    let isolated_tail_windows = {
+        let final_layer_idx = text_config.num_hidden_layers.saturating_sub(1);
+        let starts = [
+            final_layer_idx,
+            final_layer_idx.saturating_sub(1),
+            final_layer_idx.saturating_sub(3),
+            final_layer_idx.saturating_sub(7),
+            final_layer_idx.saturating_sub(15),
+        ];
+        let mut samples = Vec::new();
+        for &start_layer in &starts {
+            if start_layer >= text_config.num_hidden_layers {
+                continue;
+            }
+            let window_layers = text_config.num_hidden_layers - start_layer;
+            engine.rebuild_prefill_state(prefix_ids, true)?;
+            let pre_hidden = engine.decode_step_batch_trace_hidden_after_layers(
+                trace_tokens,
+                seqlen_offset,
+                start_layer,
+                0,
+            )?;
+            let before_conv = engine
+                .state_for_batch(0)
+                .layers
+                .get(trace_layer)
+                .ok_or_else(|| anyhow::anyhow!("missing pre-window layer {trace_layer}"))?
+                .conv_state
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("missing pre-window conv state for layer {trace_layer}"))?
+                .to_host_bytes()
+                .map_err(|e| anyhow::anyhow!("pre-window conv D2H layer {trace_layer}: {e}"))?;
+            let _ = engine.debug_decode_window_from_hidden_bf16(
+                &pre_hidden,
+                seqlen_offset,
+                start_layer,
+                window_layers,
+                0,
+            )?;
+            let after_conv = engine
+                .state_for_batch(0)
+                .layers
+                .get(trace_layer)
+                .ok_or_else(|| anyhow::anyhow!("missing post-window layer {trace_layer}"))?
+                .conv_state
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("missing post-window conv state for layer {trace_layer}"))?
+                .to_host_bytes()
+                .map_err(|e| anyhow::anyhow!("post-window conv D2H layer {trace_layer}: {e}"))?;
+            let before_vals = decode_bf16_le(&before_conv);
+            let after_vals = decode_bf16_le(&after_conv);
+            let base = max_append_channel * conv_state_len;
+            let idx = base + (conv_state_len - 1);
+            samples.push(format!(
+                "{}:{}:{:.6}",
+                start_layer,
+                window_layers,
+                (after_vals[idx] - before_vals[idx]).abs()
+            ));
+        }
+        samples.join(",")
     };
     let append_mismatch_samples = {
         let native = decode_bf16_le(&native_conv);
@@ -3590,7 +3763,7 @@ fn trace_persistent_linear_layer(
     let sample_z_comp = comp_z_proj_f32.iter().take(4).map(|v| format!("{v:.4}")).collect::<Vec<_>>().join(",");
 
     eprintln!(
-        "[trace-persistent-linear] layer={trace_layer} hidden_delta={hidden_delta:.6} comp_vs_replay_conv={comp_vs_replay_conv:.6} comp_vs_replay_recurrent={comp_vs_replay_recurrent:.6} comp_linear_hidden_vs_replay={comp_vs_replay_hidden:.6} native_vs_comp_qkv_proj={native_vs_comp_qkv_proj:.6} native_vs_replay_qkv_proj={native_vs_replay_qkv_proj:.6} native_vs_comp_z_proj={native_vs_comp_z_proj:.6} native_vs_replay_z_proj={native_vs_replay_z_proj:.6} native_vs_comp_b_proj={native_vs_comp_b_proj:.6} native_vs_replay_b_proj={native_vs_replay_b_proj:.6} native_vs_comp_a_proj={native_vs_comp_a_proj:.6} native_vs_replay_a_proj={native_vs_replay_a_proj:.6} native_vs_comp_conv={native_vs_comp_conv:.6} native_vs_comp_recurrent={native_vs_comp_recurrent:.6} native_conv_vs_expected_tail={native_conv_vs_expected_tail:.6} comp_conv_vs_expected_tail={comp_conv_vs_expected_tail:.6} replay_conv_vs_expected_tail={replay_conv_vs_expected_tail:.6} native_conv_tap_deltas=[{native_conv_tap_deltas}] comp_conv_tap_deltas=[{comp_conv_tap_deltas}] max_append_mismatch=({max_append_mismatch}) step_b_debug=({step_b_debug}) append_mismatch_samples=[{append_mismatch_samples}] native_vs_comp_token_mixer={native_vs_comp_token_mixer:.6} native_vs_replay_token_mixer={native_vs_replay_token_mixer:.6} native_vs_comp_post_norm={native_vs_comp_post_norm:.6} native_vs_replay_post_norm={native_vs_replay_post_norm:.6} native_vs_comp_gated={native_vs_comp_gated:.6} native_vs_replay_gated={native_vs_replay_gated:.6} native_vs_comp_swiglu={native_vs_comp_swiglu:.6} native_vs_replay_swiglu={native_vs_replay_swiglu:.6} native_vs_comp_mlp_down={native_vs_comp_mlp_down:.6} native_vs_replay_mlp_down={native_vs_replay_mlp_down:.6} native_vs_comp_proj_residual={native_vs_comp_proj_residual:.6} comp_layer_hidden_vs_replay={comp_layer_vs_replay_hidden:.6} native_vs_comp_layer_hidden={native_vs_comp_layer_hidden:.6} native_vs_replay_hidden={native_vs_replay_hidden:.6} sample_qkv_native=[{sample_qkv_native}] sample_qkv_comp=[{sample_qkv_comp}] sample_z_native=[{sample_z_native}] sample_z_comp=[{sample_z_comp}]"
+        "[trace-persistent-linear] layer={trace_layer} hidden_delta={hidden_delta:.6} comp_vs_replay_conv={comp_vs_replay_conv:.6} comp_vs_replay_recurrent={comp_vs_replay_recurrent:.6} comp_linear_hidden_vs_replay={comp_vs_replay_hidden:.6} native_vs_comp_qkv_proj={native_vs_comp_qkv_proj:.6} native_vs_replay_qkv_proj={native_vs_replay_qkv_proj:.6} native_vs_comp_z_proj={native_vs_comp_z_proj:.6} native_vs_replay_z_proj={native_vs_replay_z_proj:.6} native_vs_comp_b_proj={native_vs_comp_b_proj:.6} native_vs_replay_b_proj={native_vs_replay_b_proj:.6} native_vs_comp_a_proj={native_vs_comp_a_proj:.6} native_vs_replay_a_proj={native_vs_replay_a_proj:.6} native_vs_comp_conv={native_vs_comp_conv:.6} native_vs_comp_recurrent={native_vs_comp_recurrent:.6} native_conv_vs_expected_tail={native_conv_vs_expected_tail:.6} comp_conv_vs_expected_tail={comp_conv_vs_expected_tail:.6} replay_conv_vs_expected_tail={replay_conv_vs_expected_tail:.6} native_conv_tap_deltas=[{native_conv_tap_deltas}] comp_conv_tap_deltas=[{comp_conv_tap_deltas}] max_append_mismatch=({max_append_mismatch}) step_b_debug=({step_b_debug}) first_later_clobber=({first_later_clobber}) pointer_debug=({pointer_debug}) isolated_tail_windows=[{isolated_tail_windows}] append_mismatch_samples=[{append_mismatch_samples}] native_vs_comp_token_mixer={native_vs_comp_token_mixer:.6} native_vs_replay_token_mixer={native_vs_replay_token_mixer:.6} native_vs_comp_post_norm={native_vs_comp_post_norm:.6} native_vs_replay_post_norm={native_vs_replay_post_norm:.6} native_vs_comp_gated={native_vs_comp_gated:.6} native_vs_replay_gated={native_vs_replay_gated:.6} native_vs_comp_swiglu={native_vs_comp_swiglu:.6} native_vs_replay_swiglu={native_vs_replay_swiglu:.6} native_vs_comp_mlp_down={native_vs_comp_mlp_down:.6} native_vs_replay_mlp_down={native_vs_replay_mlp_down:.6} native_vs_comp_proj_residual={native_vs_comp_proj_residual:.6} comp_layer_hidden_vs_replay={comp_layer_vs_replay_hidden:.6} native_vs_comp_layer_hidden={native_vs_comp_layer_hidden:.6} native_vs_replay_hidden={native_vs_replay_hidden:.6} sample_qkv_native=[{sample_qkv_native}] sample_qkv_comp=[{sample_qkv_comp}] sample_z_native=[{sample_z_native}] sample_z_comp=[{sample_z_comp}]"
     );
     Ok(())
 }

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -3461,6 +3461,39 @@ fn trace_persistent_linear_layer(
             best.1
         )
     };
+    let append_mismatch_samples = {
+        let native = decode_bf16_le(&native_conv);
+        let mut mismatches = Vec::with_capacity(qkv_dim);
+        for c in 0..qkv_dim {
+            let idx = c * conv_state_len + (conv_state_len - 1);
+            mismatches.push((c, native[idx], expected_conv_tail[idx], (native[idx] - expected_conv_tail[idx]).abs()));
+        }
+        mismatches.sort_by(|a, b| b.3.partial_cmp(&a.3).unwrap_or(std::cmp::Ordering::Equal));
+        mismatches
+            .into_iter()
+            .take(8)
+            .map(|(channel, native_last, expected_last, delta)| {
+                let mut nearest_qkv = (0usize, f32::INFINITY);
+                for (i, &v) in native_qkv_proj_f32.iter().enumerate() {
+                    let qkv_delta = (v - native_last).abs();
+                    if qkv_delta < nearest_qkv.1 {
+                        nearest_qkv = (i, qkv_delta);
+                    }
+                }
+                format!(
+                    "c{channel}->q{} native={:.6} expected={:.6} self_q={:.6} match_q={:.6} match_delta={:.6} delta={:.6}",
+                    nearest_qkv.0,
+                    native_last,
+                    expected_last,
+                    native_qkv_proj_f32[channel],
+                    native_qkv_proj_f32[nearest_qkv.0],
+                    nearest_qkv.1,
+                    delta
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(" | ")
+    };
     let comp_conv_tap_deltas = {
         let comp = decode_bf16_le(&native_comp_conv);
         let mut deltas = vec![0.0f32; conv_state_len];
@@ -3517,7 +3550,7 @@ fn trace_persistent_linear_layer(
     let sample_z_comp = comp_z_proj_f32.iter().take(4).map(|v| format!("{v:.4}")).collect::<Vec<_>>().join(",");
 
     eprintln!(
-        "[trace-persistent-linear] layer={trace_layer} hidden_delta={hidden_delta:.6} comp_vs_replay_conv={comp_vs_replay_conv:.6} comp_vs_replay_recurrent={comp_vs_replay_recurrent:.6} comp_linear_hidden_vs_replay={comp_vs_replay_hidden:.6} native_vs_comp_qkv_proj={native_vs_comp_qkv_proj:.6} native_vs_replay_qkv_proj={native_vs_replay_qkv_proj:.6} native_vs_comp_z_proj={native_vs_comp_z_proj:.6} native_vs_replay_z_proj={native_vs_replay_z_proj:.6} native_vs_comp_b_proj={native_vs_comp_b_proj:.6} native_vs_replay_b_proj={native_vs_replay_b_proj:.6} native_vs_comp_a_proj={native_vs_comp_a_proj:.6} native_vs_replay_a_proj={native_vs_replay_a_proj:.6} native_vs_comp_conv={native_vs_comp_conv:.6} native_vs_comp_recurrent={native_vs_comp_recurrent:.6} native_conv_vs_expected_tail={native_conv_vs_expected_tail:.6} comp_conv_vs_expected_tail={comp_conv_vs_expected_tail:.6} replay_conv_vs_expected_tail={replay_conv_vs_expected_tail:.6} native_conv_tap_deltas=[{native_conv_tap_deltas}] comp_conv_tap_deltas=[{comp_conv_tap_deltas}] max_append_mismatch=({max_append_mismatch}) native_vs_comp_token_mixer={native_vs_comp_token_mixer:.6} native_vs_replay_token_mixer={native_vs_replay_token_mixer:.6} native_vs_comp_post_norm={native_vs_comp_post_norm:.6} native_vs_replay_post_norm={native_vs_replay_post_norm:.6} native_vs_comp_gated={native_vs_comp_gated:.6} native_vs_replay_gated={native_vs_replay_gated:.6} native_vs_comp_swiglu={native_vs_comp_swiglu:.6} native_vs_replay_swiglu={native_vs_replay_swiglu:.6} native_vs_comp_mlp_down={native_vs_comp_mlp_down:.6} native_vs_replay_mlp_down={native_vs_replay_mlp_down:.6} native_vs_comp_proj_residual={native_vs_comp_proj_residual:.6} comp_layer_hidden_vs_replay={comp_layer_vs_replay_hidden:.6} native_vs_comp_layer_hidden={native_vs_comp_layer_hidden:.6} native_vs_replay_hidden={native_vs_replay_hidden:.6} sample_qkv_native=[{sample_qkv_native}] sample_qkv_comp=[{sample_qkv_comp}] sample_z_native=[{sample_z_native}] sample_z_comp=[{sample_z_comp}]"
+        "[trace-persistent-linear] layer={trace_layer} hidden_delta={hidden_delta:.6} comp_vs_replay_conv={comp_vs_replay_conv:.6} comp_vs_replay_recurrent={comp_vs_replay_recurrent:.6} comp_linear_hidden_vs_replay={comp_vs_replay_hidden:.6} native_vs_comp_qkv_proj={native_vs_comp_qkv_proj:.6} native_vs_replay_qkv_proj={native_vs_replay_qkv_proj:.6} native_vs_comp_z_proj={native_vs_comp_z_proj:.6} native_vs_replay_z_proj={native_vs_replay_z_proj:.6} native_vs_comp_b_proj={native_vs_comp_b_proj:.6} native_vs_replay_b_proj={native_vs_replay_b_proj:.6} native_vs_comp_a_proj={native_vs_comp_a_proj:.6} native_vs_replay_a_proj={native_vs_replay_a_proj:.6} native_vs_comp_conv={native_vs_comp_conv:.6} native_vs_comp_recurrent={native_vs_comp_recurrent:.6} native_conv_vs_expected_tail={native_conv_vs_expected_tail:.6} comp_conv_vs_expected_tail={comp_conv_vs_expected_tail:.6} replay_conv_vs_expected_tail={replay_conv_vs_expected_tail:.6} native_conv_tap_deltas=[{native_conv_tap_deltas}] comp_conv_tap_deltas=[{comp_conv_tap_deltas}] max_append_mismatch=({max_append_mismatch}) append_mismatch_samples=[{append_mismatch_samples}] native_vs_comp_token_mixer={native_vs_comp_token_mixer:.6} native_vs_replay_token_mixer={native_vs_replay_token_mixer:.6} native_vs_comp_post_norm={native_vs_comp_post_norm:.6} native_vs_replay_post_norm={native_vs_replay_post_norm:.6} native_vs_comp_gated={native_vs_comp_gated:.6} native_vs_replay_gated={native_vs_replay_gated:.6} native_vs_comp_swiglu={native_vs_comp_swiglu:.6} native_vs_replay_swiglu={native_vs_replay_swiglu:.6} native_vs_comp_mlp_down={native_vs_comp_mlp_down:.6} native_vs_replay_mlp_down={native_vs_replay_mlp_down:.6} native_vs_comp_proj_residual={native_vs_comp_proj_residual:.6} comp_layer_hidden_vs_replay={comp_layer_vs_replay_hidden:.6} native_vs_comp_layer_hidden={native_vs_comp_layer_hidden:.6} native_vs_replay_hidden={native_vs_replay_hidden:.6} sample_qkv_native=[{sample_qkv_native}] sample_qkv_comp=[{sample_qkv_comp}] sample_z_native=[{sample_z_native}] sample_z_comp=[{sample_z_comp}]"
     );
     Ok(())
 }

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -3525,6 +3525,21 @@ fn trace_oracle_prefill_layer(
             &oracle_full.traced_full_attn_gated_actual,
             "traced_full_attn_gated_actual",
         )?;
+        let (prefix_k_bytes, prefix_v_bytes, prefix_len) =
+            engine.full_attention_prefix_cache_bf16_host(trace_layer, 0)?;
+        let oracle_prefix_kv = prefix_oracle
+            .kv_caches
+            .as_ref()
+            .and_then(|caches| caches.iter().find(|kv| kv.layer == trace_layer))
+            .ok_or_else(|| anyhow::anyhow!("prefix oracle missing kv cache for layer {trace_layer}"))?;
+        let oracle_prefix_k = decode_bf16_le(
+            &b64.decode(&oracle_prefix_kv.k)
+                .map_err(|e| anyhow::anyhow!("decode prefix oracle K cache layer {trace_layer}: {e}"))?,
+        );
+        let oracle_prefix_v = decode_bf16_le(
+            &b64.decode(&oracle_prefix_kv.v)
+                .map_err(|e| anyhow::anyhow!("decode prefix oracle V cache layer {trace_layer}: {e}"))?,
+        );
 
         let stage = engine.trace_full_attention_stages_from_hidden(trace_layer, &oracle_input_bytes, prefix_ids.len())?;
         let stage_out = engine.trace_full_attention_layer_output_from_hidden_current_state(
@@ -3550,7 +3565,124 @@ fn trace_oracle_prefill_layer(
             validate::max_abs_delta(&oracle_gated, &oracle_gated_actual);
         let head_dim = engine.weights().config.head_dim;
         let num_heads = engine.weights().config.num_attention_heads;
+        let num_kv_heads = engine.weights().config.num_key_value_heads;
+        let kv_groups = num_heads / num_kv_heads;
         let pre_gate_host = decode_bf16_le(&stage_out.pre_gate);
+        let q_rope_host = decode_bf16_le(&stage.q_rope);
+        let k_rope_step = decode_bf16_le(&stage.k_rope);
+        let v_step = decode_bf16_le(&stage.v_proj);
+        let prefix_k = decode_bf16_le(&prefix_k_bytes);
+        let prefix_v = decode_bf16_le(&prefix_v_bytes);
+        anyhow::ensure!(
+            prefix_len == prefix_ids.len(),
+            "trace layer {trace_layer} prefix len {} != prompt prefix len {}",
+            prefix_len,
+            prefix_ids.len(),
+        );
+        let kv_len = prefix_len + 1;
+        let mut full_k = vec![0.0f32; num_kv_heads * kv_len * head_dim];
+        let mut full_v = vec![0.0f32; num_kv_heads * kv_len * head_dim];
+        for kvh in 0..num_kv_heads {
+            let prefix_base = kvh * prefix_len * head_dim;
+            let full_base = kvh * kv_len * head_dim;
+            let step_base = kvh * head_dim;
+            full_k[full_base..full_base + prefix_len * head_dim]
+                .copy_from_slice(&prefix_k[prefix_base..prefix_base + prefix_len * head_dim]);
+            full_v[full_base..full_base + prefix_len * head_dim]
+                .copy_from_slice(&prefix_v[prefix_base..prefix_base + prefix_len * head_dim]);
+            full_k[full_base + prefix_len * head_dim..full_base + kv_len * head_dim]
+                .copy_from_slice(&k_rope_step[step_base..step_base + head_dim]);
+            full_v[full_base + prefix_len * head_dim..full_base + kv_len * head_dim]
+                .copy_from_slice(&v_step[step_base..step_base + head_dim]);
+        }
+        let mut host_attn_pre_gate = vec![0.0f32; num_heads * head_dim];
+        let scale = 1.0f32 / (head_dim as f32).sqrt();
+        for qh in 0..num_heads {
+            let kvh = qh / kv_groups;
+            let q_base = qh * head_dim;
+            let mut scores = vec![0.0f32; kv_len];
+            for (t, score) in scores.iter_mut().enumerate() {
+                let k_base = (kvh * kv_len + t) * head_dim;
+                let mut acc = 0.0f32;
+                for d in 0..head_dim {
+                    acc += q_rope_host[q_base + d] * full_k[k_base + d];
+                }
+                *score = acc * scale;
+            }
+            let row_max = scores.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+            let mut denom = 0.0f32;
+            let mut weights = vec![0.0f32; kv_len];
+            for (idx, score) in scores.iter().copied().enumerate() {
+                let w = (score - row_max).exp();
+                weights[idx] = w;
+                denom += w;
+            }
+            let out_base = qh * head_dim;
+            for d in 0..head_dim {
+                let mut acc = 0.0f32;
+                for (t, &w) in weights.iter().enumerate() {
+                    let v_base = (kvh * kv_len + t) * head_dim;
+                    acc += w * full_v[v_base + d];
+                }
+                host_attn_pre_gate[out_base + d] = if denom > 0.0 { acc / denom } else { 0.0 };
+            }
+        }
+        let mut oracle_host_pre_gate = vec![0.0f32; num_heads * head_dim];
+        let mut oracle_full_k = vec![0.0f32; num_kv_heads * kv_len * head_dim];
+        let mut oracle_full_v = vec![0.0f32; num_kv_heads * kv_len * head_dim];
+        for kvh in 0..num_kv_heads {
+            let prefix_base = kvh * prefix_len * head_dim;
+            let full_base = kvh * kv_len * head_dim;
+            let step_base = kvh * head_dim;
+            oracle_full_k[full_base..full_base + prefix_len * head_dim]
+                .copy_from_slice(&oracle_prefix_k[prefix_base..prefix_base + prefix_len * head_dim]);
+            oracle_full_v[full_base..full_base + prefix_len * head_dim]
+                .copy_from_slice(&oracle_prefix_v[prefix_base..prefix_base + prefix_len * head_dim]);
+            oracle_full_k[full_base + prefix_len * head_dim..full_base + kv_len * head_dim]
+                .copy_from_slice(&oracle_k_rope[step_base..step_base + head_dim]);
+            oracle_full_v[full_base + prefix_len * head_dim..full_base + kv_len * head_dim]
+                .copy_from_slice(&oracle_v_proj[step_base..step_base + head_dim]);
+        }
+        for qh in 0..num_heads {
+            let kvh = qh / kv_groups;
+            let q_base = qh * head_dim;
+            let mut scores = vec![0.0f32; kv_len];
+            for (t, score) in scores.iter_mut().enumerate() {
+                let k_base = (kvh * kv_len + t) * head_dim;
+                let mut acc = 0.0f32;
+                for d in 0..head_dim {
+                    acc += oracle_q_rope[q_base + d] * oracle_full_k[k_base + d];
+                }
+                *score = acc * scale;
+            }
+            let row_max = scores.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+            let mut denom = 0.0f32;
+            let mut weights = vec![0.0f32; kv_len];
+            for (idx, score) in scores.iter().copied().enumerate() {
+                let w = (score - row_max).exp();
+                weights[idx] = w;
+                denom += w;
+            }
+            let out_base = qh * head_dim;
+            for d in 0..head_dim {
+                let mut acc = 0.0f32;
+                for (t, &w) in weights.iter().enumerate() {
+                    let v_base = (kvh * kv_len + t) * head_dim;
+                    acc += w * oracle_full_v[v_base + d];
+                }
+                oracle_host_pre_gate[out_base + d] = if denom > 0.0 { acc / denom } else { 0.0 };
+            }
+        }
+        let host_pre_gate_vs_stage =
+            validate::max_abs_delta(&host_attn_pre_gate, &pre_gate_host);
+        let host_pre_gate_vs_oracle =
+            validate::max_abs_delta(&host_attn_pre_gate, &oracle_pre_gate);
+        let oracle_host_pre_gate_vs_oracle =
+            validate::max_abs_delta(&oracle_host_pre_gate, &oracle_pre_gate);
+        let loaded_prefix_k_vs_oracle =
+            validate::max_abs_delta(&prefix_k, &oracle_prefix_k);
+        let loaded_prefix_v_vs_oracle =
+            validate::max_abs_delta(&prefix_v, &oracle_prefix_v);
         let mut head_deltas = Vec::with_capacity(num_heads);
         for head in 0..num_heads {
             let start = head * head_dim;
@@ -3561,7 +3693,7 @@ fn trace_oracle_prefill_layer(
             ));
         }
         eprintln!(
-            "[trace-oracle-full-attn] layer={trace_layer} normed_delta={normed_delta:.6} q_proj_delta={q_proj_delta:.6} gate_proj_delta={gate_proj_delta:.6} k_proj_delta={k_proj_delta:.6} v_proj_delta={v_proj_delta:.6} q_rope_delta={q_rope_delta:.6} k_rope_delta={k_rope_delta:.6} pre_gate_delta={pre_gate_stage_delta:.6} gated_delta={gated_stage_delta:.6} gated_actual_delta={gated_actual_delta:.6} gated_reconstruct_delta={gated_reconstruct_delta:.6} pre_gate_head_deltas={head_deltas:?}"
+            "[trace-oracle-full-attn] layer={trace_layer} normed_delta={normed_delta:.6} q_proj_delta={q_proj_delta:.6} gate_proj_delta={gate_proj_delta:.6} k_proj_delta={k_proj_delta:.6} v_proj_delta={v_proj_delta:.6} q_rope_delta={q_rope_delta:.6} k_rope_delta={k_rope_delta:.6} pre_gate_delta={pre_gate_stage_delta:.6} host_pre_gate_vs_stage={host_pre_gate_vs_stage:.6} host_pre_gate_vs_oracle={host_pre_gate_vs_oracle:.6} oracle_host_pre_gate_vs_oracle={oracle_host_pre_gate_vs_oracle:.6} loaded_prefix_k_vs_oracle={loaded_prefix_k_vs_oracle:.6} loaded_prefix_v_vs_oracle={loaded_prefix_v_vs_oracle:.6} gated_delta={gated_stage_delta:.6} gated_actual_delta={gated_actual_delta:.6} gated_reconstruct_delta={gated_reconstruct_delta:.6} pre_gate_head_deltas={head_deltas:?}"
         );
     }
     Ok(())

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -9,6 +9,7 @@ mod registry;
 mod validate;
 
 use std::env;
+use std::path::Path;
 use std::path::PathBuf;
 use std::time::Instant;
 
@@ -234,6 +235,11 @@ pub(crate) struct Cli {
     /// Debug-only path intended to localize long-context divergence.
     #[arg(long)]
     trace_prefill_layers: bool,
+
+    /// Debug-only: run one prompt-prefill layer from the oracle's exact prefix
+    /// state and compare our component layer outputs against the oracle.
+    #[arg(long, hide = true)]
+    trace_oracle_prefill_layer: Option<usize>,
 
     /// Batch size for decode (number of sequences decoded in parallel).
     /// Default 1. Supported on Qwen3.5 (requires 4B kernel: 2B/4B/9B models)
@@ -949,6 +955,9 @@ fn main() -> Result<()> {
     if cli.trace_prefill_layers && !cli.validate {
         anyhow::bail!("--trace-prefill-layers requires --validate");
     }
+    if cli.trace_oracle_prefill_layer.is_some() && !cli.validate {
+        anyhow::bail!("--trace-oracle-prefill-layer requires --validate");
+    }
 
     // Run prefill (native GPU or oracle)
     let prefill_start = Instant::now();
@@ -1014,6 +1023,7 @@ fn main() -> Result<()> {
             .unwrap()
             .join("oracle/run_oracle.py");
 
+        let emit_state = cli.trace_prefill_layers || cli.trace_oracle_prefill_layer.is_some();
         let output = oracle::run_oracle(
             &oracle_script,
             &model_id,
@@ -1021,7 +1031,7 @@ fn main() -> Result<()> {
             cli.max_new_tokens,
             &cli.oracle_dtype,
             &oracle_device,
-            cli.trace_prefill_layers,
+            emit_state,
             fp8_oracle_dir.as_deref(),
         )?;
 
@@ -1139,6 +1149,20 @@ fn main() -> Result<()> {
             } else {
                 eprintln!("[trace-prefill] missing native or oracle layer trace data");
             }
+        }
+
+        if let Some(trace_layer) = cli.trace_oracle_prefill_layer {
+            trace_oracle_prefill_layer(
+                &mut engine,
+                trace_layer,
+                &prompt_ids,
+                &oracle_script,
+                &model_id,
+                &cli.oracle_dtype,
+                &oracle_device,
+                fp8_oracle_dir.as_deref(),
+                &output,
+            )?;
         }
 
         Some(output)
@@ -3279,6 +3303,103 @@ fn trace_component_layer(
     let hidden_delta = validate::max_abs_delta(&decode_bf16_le(&native.layer_hidden), &decode_bf16_le(hidden));
     eprintln!(
         "[trace-component-layer] layer={trace_layer} attn_delta={attn_delta:.6} post_norm_delta={post_delta:.6} mlp_delta={mlp_delta:.6} hidden_delta={hidden_delta:.6}"
+    );
+    Ok(())
+}
+
+fn trace_oracle_prefill_layer(
+    engine: &mut DecodeEngine,
+    trace_layer: usize,
+    prompt_ids: &[u32],
+    oracle_script: &Path,
+    model_id: &str,
+    oracle_dtype: &str,
+    oracle_device: &str,
+    fp8_oracle_dir: Option<&Path>,
+    oracle_full: &oracle::OracleOutput,
+) -> Result<()> {
+    anyhow::ensure!(trace_layer > 0, "--trace-oracle-prefill-layer currently requires layer > 0");
+    anyhow::ensure!(prompt_ids.len() >= 2, "prompt must contain at least 2 tokens for oracle prefix trace");
+    let prefix_ids = &prompt_ids[..prompt_ids.len() - 1];
+    let prefix_oracle = oracle::run_oracle(
+        oracle_script,
+        model_id,
+        prefix_ids,
+        1,
+        oracle_dtype,
+        oracle_device,
+        true,
+        fp8_oracle_dir,
+    )?;
+    engine.reset()?;
+    engine.load_prefill_state(&prefix_oracle)?;
+
+    let b64 = base64::engine::general_purpose::STANDARD;
+    let oracle_inputs = oracle_full
+        .layer_hidden_states
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("oracle output missing layer_hidden_states"))?;
+    let oracle_attn = oracle_full
+        .layer_attn_residual_states
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("oracle output missing layer_attn_residual_states"))?;
+    let oracle_post = oracle_full
+        .layer_post_attn_norm_states
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("oracle output missing layer_post_attn_norm_states"))?;
+    let oracle_mlp = oracle_full
+        .layer_mlp_outputs
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("oracle output missing layer_mlp_outputs"))?;
+
+    let oracle_input_bytes = b64
+        .decode(
+            oracle_inputs
+                .get(trace_layer - 1)
+                .ok_or_else(|| anyhow::anyhow!("oracle layer_hidden_states missing layer {}", trace_layer - 1))?,
+        )
+        .map_err(|e| anyhow::anyhow!("decode oracle input hidden for layer {trace_layer}: {e}"))?;
+    let oracle_attn_bytes = b64
+        .decode(
+            oracle_attn
+                .get(trace_layer)
+                .ok_or_else(|| anyhow::anyhow!("oracle layer_attn_residual_states missing layer {trace_layer}"))?,
+        )
+        .map_err(|e| anyhow::anyhow!("decode oracle attn for layer {trace_layer}: {e}"))?;
+    let oracle_post_bytes = b64
+        .decode(
+            oracle_post
+                .get(trace_layer)
+                .ok_or_else(|| anyhow::anyhow!("oracle layer_post_attn_norm_states missing layer {trace_layer}"))?,
+        )
+        .map_err(|e| anyhow::anyhow!("decode oracle post-norm for layer {trace_layer}: {e}"))?;
+    let oracle_mlp_bytes = b64
+        .decode(
+            oracle_mlp
+                .get(trace_layer)
+                .ok_or_else(|| anyhow::anyhow!("oracle layer_mlp_outputs missing layer {trace_layer}"))?,
+        )
+        .map_err(|e| anyhow::anyhow!("decode oracle mlp for layer {trace_layer}: {e}"))?;
+    let oracle_hidden_bytes = b64
+        .decode(
+            oracle_inputs
+                .get(trace_layer)
+                .ok_or_else(|| anyhow::anyhow!("oracle layer_hidden_states missing layer {trace_layer}"))?,
+        )
+        .map_err(|e| anyhow::anyhow!("decode oracle hidden for layer {trace_layer}: {e}"))?;
+
+    engine.set_hidden_from_bytes(&oracle_input_bytes)?;
+    let trace = engine.component_trace_full_layer_from_current_hidden(trace_layer)?;
+    let attn_delta =
+        validate::max_abs_delta(&decode_bf16_le(&trace.attn_hidden), &decode_bf16_le(&oracle_attn_bytes));
+    let post_delta =
+        validate::max_abs_delta(&decode_bf16_le(&trace.post_attn_norm), &decode_bf16_le(&oracle_post_bytes));
+    let mlp_delta =
+        validate::max_abs_delta(&decode_bf16_le(&trace.mlp_out), &decode_bf16_le(&oracle_mlp_bytes));
+    let hidden_delta =
+        validate::max_abs_delta(&decode_bf16_le(&trace.layer_hidden), &decode_bf16_le(&oracle_hidden_bytes));
+    eprintln!(
+        "[trace-oracle-prefill-layer] layer={trace_layer} attn_delta={attn_delta:.6} post_norm_delta={post_delta:.6} mlp_delta={mlp_delta:.6} hidden_delta={hidden_delta:.6}"
     );
     Ok(())
 }

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -1086,6 +1086,8 @@ fn main() -> Result<()> {
         cli.kv_fp8,
         cli.batch_size,
     )?;
+    let allow_host_lm_head_rescore =
+        cli.no_bake && !engine.weights().is_fp8 && !engine.weights().is_int4;
 
     // When using FP8 runtime weights, tell the oracle to use the same FP8 weights
     // (dequanted to BF16) so we compare apples-to-apples.
@@ -1138,7 +1140,9 @@ fn main() -> Result<()> {
         let first = sample_qwen_logits_with_rescore(
             &prefill_result.logits,
             prefill_normed.as_deref(),
-            host_lm_head_rescorer.as_ref(),
+            host_lm_head_rescorer
+                .as_ref()
+                .filter(|_| allow_host_lm_head_rescore),
         )?;
         eprintln!("[prefill] native GPU prefill done in {:.0}ms", prefill_start.elapsed().as_millis());
         (
@@ -1889,7 +1893,7 @@ fn main() -> Result<()> {
             let native_token = if let Some(token) = maybe_fast_token {
                 token
             } else {
-                let normed = if can_rescore_with_normed && host_lm_head_rescorer.is_some() {
+                let normed = if can_rescore_with_normed && allow_host_lm_head_rescore {
                     Some(engine.last_normed_host_f32()?)
                 } else {
                     None
@@ -1897,7 +1901,9 @@ fn main() -> Result<()> {
                 sample_qwen_logits_with_rescore(
                     &logits,
                     normed.as_deref(),
-                    host_lm_head_rescorer.as_ref(),
+                    host_lm_head_rescorer
+                        .as_ref()
+                        .filter(|_| allow_host_lm_head_rescore),
                 )?
             };
 

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -3396,10 +3396,27 @@ fn trace_persistent_linear_layer(
             .collect::<Vec<_>>()
             .join(",")
     };
+    let native_qkv_proj_f32 = decode_f32_le(&native_qkv_proj);
+    let native_z_proj_f32 = decode_f32_le(&native_z_proj);
+    let comp_qkv_proj_f32 = decode_bf16_le(&native_comp_trace.qkv);
+    let comp_z_proj_f32 = decode_bf16_le(&native_comp_trace.z);
     let max_append_mismatch = {
         let native = decode_bf16_le(&native_conv);
         let start = decode_bf16_le(&pre_step_conv);
         let qkv = decode_bf16_le(&native_comp_trace.qkv);
+        let conv_w = decode_bf16_le(
+            &engine
+                .weights()
+                .layers
+                .get(trace_layer)
+                .ok_or_else(|| anyhow::anyhow!("missing weights for layer {trace_layer}"))?
+                .linear
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("layer {trace_layer} is not linear"))?
+                .conv1d_w
+                .to_host_bytes()
+                .map_err(|e| anyhow::anyhow!("conv1d_w D2H layer {trace_layer}: {e}"))?,
+        );
         let mut best = (0usize, 0.0f32);
         for c in 0..qkv_dim {
             let idx = c * conv_state_len + (conv_state_len - 1);
@@ -3410,12 +3427,37 @@ fn trace_persistent_linear_layer(
         }
         let channel = best.0;
         let idx = channel * conv_state_len + (conv_state_len - 1);
+        let weight_base = channel * cfg.linear_conv_kernel_dim;
+        let state_base = channel * conv_state_len;
+        let mut conv_acc = 0.0f32;
+        for tap in 0..cfg.linear_conv_kernel_dim {
+            let x = if tap + 1 == cfg.linear_conv_kernel_dim {
+                qkv[channel]
+            } else {
+                start[state_base + tap]
+            };
+            conv_acc += x * conv_w[weight_base + tap];
+        }
+        let conv_out = bf16_round(conv_acc * sigmoid_fast(conv_acc));
+        let native_last = native[idx];
+        let mut nearest_qkv = (0usize, f32::INFINITY);
+        for (i, &v) in native_qkv_proj_f32.iter().enumerate() {
+            let delta = (v - native_last).abs();
+            if delta < nearest_qkv.1 {
+                nearest_qkv = (i, delta);
+            }
+        }
         format!(
-            "channel={channel},native={:.6},expected={:.6},prev_last={:.6},qkv={:.6},delta={:.6}",
+            "channel={channel},native={:.6},expected={:.6},prev_last={:.6},qkv_comp={:.6},qkv_native={:.6},conv_out={:.6},nearest_qkv=(channel={},value={:.6},delta={:.6}),delta={:.6}",
             native[idx],
             expected_conv_tail[idx],
             start[idx],
             qkv[channel],
+            native_qkv_proj_f32[channel],
+            conv_out,
+            nearest_qkv.0,
+            native_qkv_proj_f32[nearest_qkv.0],
+            nearest_qkv.1,
             best.1
         )
     };
@@ -3469,10 +3511,6 @@ fn trace_persistent_linear_layer(
         validate::max_abs_delta(&decode_bf16_le(&native_hidden_out), &decode_bf16_le(&native_comp_layer.layer_hidden));
     let native_vs_replay_hidden =
         validate::max_abs_delta(&decode_bf16_le(&native_hidden_out), &decode_bf16_le(replay_hidden_out));
-    let native_qkv_proj_f32 = decode_f32_le(&native_qkv_proj);
-    let native_z_proj_f32 = decode_f32_le(&native_z_proj);
-    let comp_qkv_proj_f32 = decode_bf16_le(&native_comp_trace.qkv);
-    let comp_z_proj_f32 = decode_bf16_le(&native_comp_trace.z);
     let sample_qkv_native = native_qkv_proj_f32.iter().take(4).map(|v| format!("{v:.4}")).collect::<Vec<_>>().join(",");
     let sample_qkv_comp = comp_qkv_proj_f32.iter().take(4).map(|v| format!("{v:.4}")).collect::<Vec<_>>().join(",");
     let sample_z_native = native_z_proj_f32.iter().take(4).map(|v| format!("{v:.4}")).collect::<Vec<_>>().join(",");

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -1413,7 +1413,6 @@ fn main() -> Result<()> {
         && !cli.force_replay_decode
         && !cli.force_component_decode;
     let cuda_08b_hero_disabled = env::var_os("SUPERSONIC_DISABLE_CUDA_08B_HERO").is_some();
-    let cuda_08b_hero_opt_in = env::var_os("SUPERSONIC_ENABLE_CUDA_08B_HERO").is_some();
     let cuda_08b_hero_enabled = backend == Backend::Cuda
         && gpu_arch == GpuArch::Sm86
         && model_variant == ModelVariant::Qwen3_5_0_8B
@@ -1427,7 +1426,6 @@ fn main() -> Result<()> {
         && oracle_output.is_none()
         && !engine.weights().is_fp8
         && !engine.weights().is_int4
-        && cuda_08b_hero_opt_in
         && !cuda_08b_hero_disabled;
     let cuda_fast_greedy_disabled = env::var_os("SUPERSONIC_DISABLE_CUDA_FAST_GREEDY").is_some();
     let cuda_fast_greedy_enabled = backend == Backend::Cuda
@@ -1460,7 +1458,7 @@ fn main() -> Result<()> {
     } else if cli.batch_size == 1 && params.use_4b_kernel && cli.kv_fp8 {
         eprintln!("[decode] WARNING: single-sequence CUDA KV-FP8 uses the b=1 kernel path");
     } else if cuda_08b_hero_enabled {
-        eprintln!("[decode] CUDA 0.8B sm86 hero path enabled (experimental opt-in)");
+        eprintln!("[decode] CUDA 0.8B sm86 hero path enabled");
     } else if cuda_fast_greedy_enabled {
         eprintln!("[decode] CUDA fast greedy sampling enabled for the non-4B native decode path");
     }

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -3195,7 +3195,10 @@ fn trace_persistent_linear_layer(
         engine.component_trace_linear_layer_from_current_hidden(trace_layer)?;
     engine.rebuild_prefill_state(prefix_ids, true)?;
     engine.set_hidden_from_bytes(&native_hidden)?;
-    let native_comp_layer = engine.component_trace_full_layer_from_current_hidden(trace_layer)?;
+    let native_comp_layer = engine.component_trace_full_layer_from_current_hidden_with_seqlen(
+        trace_layer,
+        seqlen_offset,
+    )?;
 
     engine.rebuild_prefill_state(prefix_ids, true)?;
     let native_hidden_out = engine
@@ -3485,7 +3488,10 @@ fn trace_oracle_prefill_layer(
         .map_err(|e| anyhow::anyhow!("decode oracle hidden for layer {trace_layer}: {e}"))?;
 
     engine.set_hidden_from_bytes(&oracle_input_bytes)?;
-    let trace = engine.component_trace_full_layer_from_current_hidden(trace_layer)?;
+    let trace = engine.component_trace_full_layer_from_current_hidden_with_seqlen(
+        trace_layer,
+        prefix_ids.len(),
+    )?;
     let attn_delta =
         validate::max_abs_delta(&decode_bf16_le(&trace.attn_hidden), &decode_bf16_le(&oracle_attn_bytes));
     let post_delta =
@@ -3506,6 +3512,13 @@ fn trace_oracle_prefill_layer(
     if engine.weights().config.is_full_attention(trace_layer)
         && oracle_full.traced_full_attn_layer == Some(trace_layer)
     {
+        // `component_trace_full_layer_from_current_hidden()` reuses the mutable
+        // component decode path and overwrites slot 0 of the full-attention KV
+        // cache for `trace_layer`. Reload the prefix oracle state so the deeper
+        // attention trace below sees the original prefix cache, not the
+        // trace-mutated one.
+        engine.reset()?;
+        engine.load_prefill_state(&prefix_oracle)?;
         let decode_opt_bf16 = |field: &Option<String>, label: &str| -> Result<Vec<f32>> {
             let bytes = b64
                 .decode(field.as_ref().ok_or_else(|| anyhow::anyhow!("oracle output missing {label}"))?)
@@ -3573,6 +3586,27 @@ fn trace_oracle_prefill_layer(
         let v_step = decode_bf16_le(&stage.v_proj);
         let prefix_k = decode_bf16_le(&prefix_k_bytes);
         let prefix_v = decode_bf16_le(&prefix_v_bytes);
+        let loaded_layer = engine
+            .state_for_batch(0)
+            .layers
+            .get(trace_layer)
+            .ok_or_else(|| anyhow::anyhow!("missing loaded layer {trace_layer}"))?;
+        let loaded_raw_k = decode_bf16_le(
+            &loaded_layer
+                .kv_cache_k
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("loaded layer {trace_layer} missing K cache"))?
+                .to_host_bytes()
+                .map_err(|e| anyhow::anyhow!("loaded layer {trace_layer} K cache D2H: {e}"))?,
+        );
+        let loaded_raw_v = decode_bf16_le(
+            &loaded_layer
+                .kv_cache_v
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("loaded layer {trace_layer} missing V cache"))?
+                .to_host_bytes()
+                .map_err(|e| anyhow::anyhow!("loaded layer {trace_layer} V cache D2H: {e}"))?,
+        );
         anyhow::ensure!(
             prefix_len == prefix_ids.len(),
             "trace layer {trace_layer} prefix len {} != prompt prefix len {}",
@@ -3679,10 +3713,70 @@ fn trace_oracle_prefill_layer(
             validate::max_abs_delta(&host_attn_pre_gate, &oracle_pre_gate);
         let oracle_host_pre_gate_vs_oracle =
             validate::max_abs_delta(&oracle_host_pre_gate, &oracle_pre_gate);
+        let kernel_pre_gate_direct = {
+            let ordinal = engine.ordinal();
+            let q_gpu = gpu_hal::GpuBuffer::from_host_bytes(
+                ordinal,
+                gpu_hal::ScalarType::BF16,
+                &[num_heads, 1, head_dim],
+                &f32_to_bf16_bytes(q_rope_host.iter().copied()),
+            )
+            .map_err(|e| anyhow::anyhow!("trace direct attn q H2D: {e}"))?;
+            let k_gpu = gpu_hal::GpuBuffer::from_host_bytes(
+                ordinal,
+                gpu_hal::ScalarType::BF16,
+                &[num_kv_heads, kv_len, head_dim],
+                &f32_to_bf16_bytes(full_k.iter().copied()),
+            )
+            .map_err(|e| anyhow::anyhow!("trace direct attn k H2D: {e}"))?;
+            let v_gpu = gpu_hal::GpuBuffer::from_host_bytes(
+                ordinal,
+                gpu_hal::ScalarType::BF16,
+                &[num_kv_heads, kv_len, head_dim],
+                &f32_to_bf16_bytes(full_v.iter().copied()),
+            )
+            .map_err(|e| anyhow::anyhow!("trace direct attn v H2D: {e}"))?;
+            let mut out_gpu = gpu_hal::GpuBuffer::zeros(
+                ordinal,
+                gpu_hal::ScalarType::F32,
+                &[num_heads, 1, head_dim],
+            )
+            .map_err(|e| anyhow::anyhow!("trace direct attn out alloc: {e}"))?;
+            kernel_ffi::prefill_ffi::full_attention_prefill(
+                ordinal,
+                gpu_hal::ScalarType::BF16,
+                1,
+                num_heads,
+                num_kv_heads,
+                1,
+                kv_len,
+                head_dim,
+                scale,
+                prefix_len,
+                &q_gpu,
+                &k_gpu,
+                &v_gpu,
+                &mut out_gpu,
+            )
+            .map_err(|e| anyhow::anyhow!("trace direct attn kernel: {e}"))?;
+            decode_f32_le(
+                &out_gpu
+                    .to_host_bytes()
+                    .map_err(|e| anyhow::anyhow!("trace direct attn out D2H: {e}"))?,
+            )
+        };
+        let direct_kernel_vs_host =
+            validate::max_abs_delta(&kernel_pre_gate_direct, &host_attn_pre_gate);
+        let direct_kernel_vs_oracle =
+            validate::max_abs_delta(&kernel_pre_gate_direct, &oracle_pre_gate);
         let loaded_prefix_k_vs_oracle =
             validate::max_abs_delta(&prefix_k, &oracle_prefix_k);
         let loaded_prefix_v_vs_oracle =
             validate::max_abs_delta(&prefix_v, &oracle_prefix_v);
+        let loaded_raw_k_vs_oracle =
+            validate::max_abs_delta(&loaded_raw_k, &oracle_prefix_k);
+        let loaded_raw_v_vs_oracle =
+            validate::max_abs_delta(&loaded_raw_v, &oracle_prefix_v);
         let mut head_deltas = Vec::with_capacity(num_heads);
         for head in 0..num_heads {
             let start = head * head_dim;
@@ -3693,7 +3787,7 @@ fn trace_oracle_prefill_layer(
             ));
         }
         eprintln!(
-            "[trace-oracle-full-attn] layer={trace_layer} normed_delta={normed_delta:.6} q_proj_delta={q_proj_delta:.6} gate_proj_delta={gate_proj_delta:.6} k_proj_delta={k_proj_delta:.6} v_proj_delta={v_proj_delta:.6} q_rope_delta={q_rope_delta:.6} k_rope_delta={k_rope_delta:.6} pre_gate_delta={pre_gate_stage_delta:.6} host_pre_gate_vs_stage={host_pre_gate_vs_stage:.6} host_pre_gate_vs_oracle={host_pre_gate_vs_oracle:.6} oracle_host_pre_gate_vs_oracle={oracle_host_pre_gate_vs_oracle:.6} loaded_prefix_k_vs_oracle={loaded_prefix_k_vs_oracle:.6} loaded_prefix_v_vs_oracle={loaded_prefix_v_vs_oracle:.6} gated_delta={gated_stage_delta:.6} gated_actual_delta={gated_actual_delta:.6} gated_reconstruct_delta={gated_reconstruct_delta:.6} pre_gate_head_deltas={head_deltas:?}"
+            "[trace-oracle-full-attn] layer={trace_layer} normed_delta={normed_delta:.6} q_proj_delta={q_proj_delta:.6} gate_proj_delta={gate_proj_delta:.6} k_proj_delta={k_proj_delta:.6} v_proj_delta={v_proj_delta:.6} q_rope_delta={q_rope_delta:.6} k_rope_delta={k_rope_delta:.6} pre_gate_delta={pre_gate_stage_delta:.6} host_pre_gate_vs_stage={host_pre_gate_vs_stage:.6} host_pre_gate_vs_oracle={host_pre_gate_vs_oracle:.6} oracle_host_pre_gate_vs_oracle={oracle_host_pre_gate_vs_oracle:.6} direct_kernel_vs_host={direct_kernel_vs_host:.6} direct_kernel_vs_oracle={direct_kernel_vs_oracle:.6} loaded_prefix_k_vs_oracle={loaded_prefix_k_vs_oracle:.6} loaded_prefix_v_vs_oracle={loaded_prefix_v_vs_oracle:.6} loaded_raw_k_vs_oracle={loaded_raw_k_vs_oracle:.6} loaded_raw_v_vs_oracle={loaded_raw_v_vs_oracle:.6} gated_delta={gated_stage_delta:.6} gated_actual_delta={gated_actual_delta:.6} gated_reconstruct_delta={gated_reconstruct_delta:.6} pre_gate_head_deltas={head_deltas:?}"
         );
     }
     Ok(())

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -3400,7 +3400,7 @@ fn trace_persistent_linear_layer(
     let native_z_proj_f32 = decode_f32_le(&native_z_proj);
     let comp_qkv_proj_f32 = decode_bf16_le(&native_comp_trace.qkv);
     let comp_z_proj_f32 = decode_bf16_le(&native_comp_trace.z);
-    let max_append_mismatch = {
+    let (max_append_channel, max_append_mismatch) = {
         let native = decode_bf16_le(&native_conv);
         let start = decode_bf16_le(&pre_step_conv);
         let qkv = decode_bf16_le(&native_comp_trace.qkv);
@@ -3447,18 +3447,58 @@ fn trace_persistent_linear_layer(
                 nearest_qkv = (i, delta);
             }
         }
+        (
+            channel,
+            format!(
+                "channel={channel},native={:.6},expected={:.6},prev_last={:.6},qkv_comp={:.6},qkv_native={:.6},conv_out={:.6},nearest_qkv=(channel={},value={:.6},delta={:.6}),delta={:.6}",
+                native[idx],
+                expected_conv_tail[idx],
+                start[idx],
+                qkv[channel],
+                native_qkv_proj_f32[channel],
+                conv_out,
+                nearest_qkv.0,
+                native_qkv_proj_f32[nearest_qkv.0],
+                nearest_qkv.1,
+                best.1
+            )
+        )
+    };
+    engine.rebuild_prefill_state(prefix_ids, true)?;
+    let step_b_debug_raw = engine.trace_persistent_linear_step_b_after_layers(
+        trace_tokens,
+        seqlen_offset,
+        trace_layer + 1,
+        trace_layer,
+        max_append_channel,
+    )?;
+    let step_b_debug = {
+        let debug = decode_f32_le(&step_b_debug_raw);
+        let native = decode_bf16_le(&native_conv);
+        let start = decode_bf16_le(&pre_step_conv);
+        let base = max_append_channel * conv_state_len;
+        let idx = base + (conv_state_len - 1);
+        let state_values = debug
+            .iter()
+            .take(conv_state_len)
+            .map(|v| format!("{v:.6}"))
+            .collect::<Vec<_>>()
+            .join(",");
+        let step_b_last = debug
+            .get(conv_state_len - 1)
+            .copied()
+            .unwrap_or_default();
+        let step_b_vs_expected = (step_b_last - expected_conv_tail[idx]).abs();
+        let final_vs_step_b = (native[idx] - step_b_last).abs();
         format!(
-            "channel={channel},native={:.6},expected={:.6},prev_last={:.6},qkv_comp={:.6},qkv_native={:.6},conv_out={:.6},nearest_qkv=(channel={},value={:.6},delta={:.6}),delta={:.6}",
-            native[idx],
+            "channel={max_append_channel},state=[{state_values}],qkv={:.6},conv_out={:.6},shift0_expected={:.6},shift1_expected={:.6},append_expected={:.6},step_b_vs_expected={:.6},final_vs_step_b={:.6}",
+            debug.get(conv_state_len).copied().unwrap_or_default(),
+            debug.get(conv_state_len + 1).copied().unwrap_or_default(),
+            start.get(base + 1).copied().unwrap_or_default(),
+            start.get(base + 2).copied().unwrap_or_default(),
             expected_conv_tail[idx],
-            start[idx],
-            qkv[channel],
-            native_qkv_proj_f32[channel],
-            conv_out,
-            nearest_qkv.0,
-            native_qkv_proj_f32[nearest_qkv.0],
-            nearest_qkv.1,
-            best.1
+            step_b_vs_expected,
+            final_vs_step_b,
         )
     };
     let append_mismatch_samples = {
@@ -3550,7 +3590,7 @@ fn trace_persistent_linear_layer(
     let sample_z_comp = comp_z_proj_f32.iter().take(4).map(|v| format!("{v:.4}")).collect::<Vec<_>>().join(",");
 
     eprintln!(
-        "[trace-persistent-linear] layer={trace_layer} hidden_delta={hidden_delta:.6} comp_vs_replay_conv={comp_vs_replay_conv:.6} comp_vs_replay_recurrent={comp_vs_replay_recurrent:.6} comp_linear_hidden_vs_replay={comp_vs_replay_hidden:.6} native_vs_comp_qkv_proj={native_vs_comp_qkv_proj:.6} native_vs_replay_qkv_proj={native_vs_replay_qkv_proj:.6} native_vs_comp_z_proj={native_vs_comp_z_proj:.6} native_vs_replay_z_proj={native_vs_replay_z_proj:.6} native_vs_comp_b_proj={native_vs_comp_b_proj:.6} native_vs_replay_b_proj={native_vs_replay_b_proj:.6} native_vs_comp_a_proj={native_vs_comp_a_proj:.6} native_vs_replay_a_proj={native_vs_replay_a_proj:.6} native_vs_comp_conv={native_vs_comp_conv:.6} native_vs_comp_recurrent={native_vs_comp_recurrent:.6} native_conv_vs_expected_tail={native_conv_vs_expected_tail:.6} comp_conv_vs_expected_tail={comp_conv_vs_expected_tail:.6} replay_conv_vs_expected_tail={replay_conv_vs_expected_tail:.6} native_conv_tap_deltas=[{native_conv_tap_deltas}] comp_conv_tap_deltas=[{comp_conv_tap_deltas}] max_append_mismatch=({max_append_mismatch}) append_mismatch_samples=[{append_mismatch_samples}] native_vs_comp_token_mixer={native_vs_comp_token_mixer:.6} native_vs_replay_token_mixer={native_vs_replay_token_mixer:.6} native_vs_comp_post_norm={native_vs_comp_post_norm:.6} native_vs_replay_post_norm={native_vs_replay_post_norm:.6} native_vs_comp_gated={native_vs_comp_gated:.6} native_vs_replay_gated={native_vs_replay_gated:.6} native_vs_comp_swiglu={native_vs_comp_swiglu:.6} native_vs_replay_swiglu={native_vs_replay_swiglu:.6} native_vs_comp_mlp_down={native_vs_comp_mlp_down:.6} native_vs_replay_mlp_down={native_vs_replay_mlp_down:.6} native_vs_comp_proj_residual={native_vs_comp_proj_residual:.6} comp_layer_hidden_vs_replay={comp_layer_vs_replay_hidden:.6} native_vs_comp_layer_hidden={native_vs_comp_layer_hidden:.6} native_vs_replay_hidden={native_vs_replay_hidden:.6} sample_qkv_native=[{sample_qkv_native}] sample_qkv_comp=[{sample_qkv_comp}] sample_z_native=[{sample_z_native}] sample_z_comp=[{sample_z_comp}]"
+        "[trace-persistent-linear] layer={trace_layer} hidden_delta={hidden_delta:.6} comp_vs_replay_conv={comp_vs_replay_conv:.6} comp_vs_replay_recurrent={comp_vs_replay_recurrent:.6} comp_linear_hidden_vs_replay={comp_vs_replay_hidden:.6} native_vs_comp_qkv_proj={native_vs_comp_qkv_proj:.6} native_vs_replay_qkv_proj={native_vs_replay_qkv_proj:.6} native_vs_comp_z_proj={native_vs_comp_z_proj:.6} native_vs_replay_z_proj={native_vs_replay_z_proj:.6} native_vs_comp_b_proj={native_vs_comp_b_proj:.6} native_vs_replay_b_proj={native_vs_replay_b_proj:.6} native_vs_comp_a_proj={native_vs_comp_a_proj:.6} native_vs_replay_a_proj={native_vs_replay_a_proj:.6} native_vs_comp_conv={native_vs_comp_conv:.6} native_vs_comp_recurrent={native_vs_comp_recurrent:.6} native_conv_vs_expected_tail={native_conv_vs_expected_tail:.6} comp_conv_vs_expected_tail={comp_conv_vs_expected_tail:.6} replay_conv_vs_expected_tail={replay_conv_vs_expected_tail:.6} native_conv_tap_deltas=[{native_conv_tap_deltas}] comp_conv_tap_deltas=[{comp_conv_tap_deltas}] max_append_mismatch=({max_append_mismatch}) step_b_debug=({step_b_debug}) append_mismatch_samples=[{append_mismatch_samples}] native_vs_comp_token_mixer={native_vs_comp_token_mixer:.6} native_vs_replay_token_mixer={native_vs_replay_token_mixer:.6} native_vs_comp_post_norm={native_vs_comp_post_norm:.6} native_vs_replay_post_norm={native_vs_replay_post_norm:.6} native_vs_comp_gated={native_vs_comp_gated:.6} native_vs_replay_gated={native_vs_replay_gated:.6} native_vs_comp_swiglu={native_vs_comp_swiglu:.6} native_vs_replay_swiglu={native_vs_replay_swiglu:.6} native_vs_comp_mlp_down={native_vs_comp_mlp_down:.6} native_vs_replay_mlp_down={native_vs_replay_mlp_down:.6} native_vs_comp_proj_residual={native_vs_comp_proj_residual:.6} comp_layer_hidden_vs_replay={comp_layer_vs_replay_hidden:.6} native_vs_comp_layer_hidden={native_vs_comp_layer_hidden:.6} native_vs_replay_hidden={native_vs_replay_hidden:.6} sample_qkv_native=[{sample_qkv_native}] sample_qkv_comp=[{sample_qkv_comp}] sample_z_native=[{sample_z_native}] sample_z_comp=[{sample_z_comp}]"
     );
     Ok(())
 }

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -1612,6 +1612,26 @@ fn main() -> Result<()> {
                     )?;
                     engine.rebuild_prefill_state(&trace_token_ids, false)?;
                 }
+                if let Some(trace_layer) = cli.trace_persistent_full_attn_layer {
+                    let trace_token_ids: Vec<u32> = prompt_ids
+                        .iter()
+                        .copied()
+                        .chain(generated_ids.iter().copied())
+                        .chain(std::iter::once(next_token))
+                        .collect();
+                    trace_persistent_full_attn_layer(
+                        &mut engine,
+                        trace_layer,
+                        trace_token_ids.as_slice(),
+                        &[next_token],
+                        seqlen_offset,
+                        ordinal,
+                        params.kv_chunk_size,
+                        cli.prefill_chunk_size,
+                        params.use_4b_kernel,
+                    )?;
+                    engine.rebuild_prefill_state(&trace_token_ids, false)?;
+                }
                 if cli.emit_stage_timings {
                     let (logits, timings) =
                         engine.decode_step_4b_single_kernel_with_timings(next_token, seqlen_offset)?;
@@ -2734,6 +2754,29 @@ fn trace_persistent_full_attn_layer(
         .map(|v| format!("{v:.6}"))
         .collect::<Vec<_>>()
         .join(",");
+    let pre_gate_best_match = (0..num_q_heads)
+        .map(|h| {
+            let start = h * head_dim;
+            let end = start + head_dim;
+            let native_head = &native_pre_gate_f32[start..end];
+            let (best_idx, best_delta) = (0..num_q_heads)
+                .map(|cand| {
+                    let cand_start = cand * head_dim;
+                    let cand_end = cand_start + head_dim;
+                    (
+                        cand,
+                        validate::max_abs_delta(
+                            native_head,
+                            &native_comp_pre_gate_f32[cand_start..cand_end],
+                        ),
+                    )
+                })
+                .min_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
+                .unwrap_or((h, f32::INFINITY));
+            format!("{h}->{best_idx}:{best_delta:.6}")
+        })
+        .collect::<Vec<_>>()
+        .join(",");
     let per_head_q = (0..num_q_heads)
         .map(|h| {
             let start = h * head_dim;
@@ -2744,6 +2787,29 @@ fn trace_persistent_full_attn_layer(
     let per_head_q_str = per_head_q
         .iter()
         .map(|v| format!("{v:.6}"))
+        .collect::<Vec<_>>()
+        .join(",");
+    let q_best_match = (0..num_q_heads)
+        .map(|h| {
+            let start = h * head_dim;
+            let end = start + head_dim;
+            let native_head = &native_q_f32[start..end];
+            let (best_idx, best_delta) = (0..num_q_heads)
+                .map(|cand| {
+                    let cand_start = cand * head_dim;
+                    let cand_end = cand_start + head_dim;
+                    (
+                        cand,
+                        validate::max_abs_delta(
+                            native_head,
+                            &native_q_rope_f32[cand_start..cand_end],
+                        ),
+                    )
+                })
+                .min_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
+                .unwrap_or((h, f32::INFINITY));
+            format!("{h}->{best_idx}:{best_delta:.6}")
+        })
         .collect::<Vec<_>>()
         .join(",");
     let (score_row_delta, per_head_score_str) = if let (Some(scale_k), Some(k_cache)) = (
@@ -3011,7 +3077,7 @@ fn trace_persistent_full_attn_layer(
             .map(|vals| vals.iter().map(|v| format!("{v:.6}")).collect::<Vec<_>>().join(","))
             .unwrap_or_default();
         eprintln!(
-            "[trace-persistent-full-attn] layer={trace_layer} hidden_delta={hidden_delta:.6} normed_delta={normed_delta:.6} q_proj_delta={q_proj_delta:.6} gate_proj_delta={gate_proj_delta:.6} k_proj_delta={k_proj_delta:.6} v_proj_delta={v_proj_delta:.6} q_rope_delta={q_rope_delta:.6} native_vs_component_q={native_vs_component_q:.6} per_head_q=[{per_head_q_str}] native_comp_vs_replay_k={native_vs_replay_k:.6} native_comp_vs_replay_v={native_vs_replay_v:.6} native_vs_component_saved_gate={native_vs_component_saved_gate:.6} native_vs_component_pre_gate={native_vs_component_pre_gate:.6} native_vs_host_pre_gate={native_vs_host_pre_gate:.6} kv_vs_bf16_hidden={kv_vs_bf16_hidden:.6} kv_vs_bf16_cache_k={kv_vs_bf16_cache_k:.6} kv_vs_bf16_cache_v={kv_vs_bf16_cache_v:.6} kv_vs_bf16_q={kv_vs_bf16_q:.6} kv_vs_bf16_saved_gate={kv_vs_bf16_saved_gate:.6} kv_vs_bf16_scores={kv_vs_bf16_scores:.6} kv_vs_bf16_scores_heads=[{kv_vs_bf16_scores_heads_str}] kv_vs_bf16_pre_gate={kv_vs_bf16_pre_gate:.6} per_head_host_pre_gate=[{per_head_host_pre_gate_str}] native_score_row_delta={score_row_delta:.6} per_head_score=[{per_head_score_str}] native_vs_component_gated={native_vs_component_gated:.6} native_vs_host_gated={native_vs_host_gated:.6} kv_vs_bf16_gated={kv_vs_bf16_gated:.6} native_vs_component_attn_hidden={native_vs_component_attn_hidden:.6} native_vs_host_o_proj={native_vs_host_o_proj:.6} kv_vs_bf16_attn_hidden={kv_vs_bf16_attn_hidden:.6} native_vs_replay_attn_hidden={native_vs_replay_attn_hidden:.6} native_cache_vs_replay_cache_attn_hidden={native_cache_vs_replay_cache_attn_hidden:.6} component_vs_replay_attn_hidden={component_vs_replay_attn_hidden:.6} per_head_pre_gate=[{per_head_pre_gate_str}] cache_vs_quant_k_mismatches={cache_vs_quant_k} cache_vs_quant_v_mismatches={cache_vs_quant_v} cache_vs_quant_k_scale_delta={scale_vs_quant_k:.6} cache_vs_quant_v_scale_delta={scale_vs_quant_v:.6}"
+            "[trace-persistent-full-attn] layer={trace_layer} hidden_delta={hidden_delta:.6} normed_delta={normed_delta:.6} q_proj_delta={q_proj_delta:.6} gate_proj_delta={gate_proj_delta:.6} k_proj_delta={k_proj_delta:.6} v_proj_delta={v_proj_delta:.6} q_rope_delta={q_rope_delta:.6} native_vs_component_q={native_vs_component_q:.6} per_head_q=[{per_head_q_str}] q_best_match=[{q_best_match}] native_comp_vs_replay_k={native_vs_replay_k:.6} native_comp_vs_replay_v={native_vs_replay_v:.6} native_vs_component_saved_gate={native_vs_component_saved_gate:.6} native_vs_component_pre_gate={native_vs_component_pre_gate:.6} native_vs_host_pre_gate={native_vs_host_pre_gate:.6} kv_vs_bf16_hidden={kv_vs_bf16_hidden:.6} kv_vs_bf16_cache_k={kv_vs_bf16_cache_k:.6} kv_vs_bf16_cache_v={kv_vs_bf16_cache_v:.6} kv_vs_bf16_q={kv_vs_bf16_q:.6} kv_vs_bf16_saved_gate={kv_vs_bf16_saved_gate:.6} kv_vs_bf16_scores={kv_vs_bf16_scores:.6} kv_vs_bf16_scores_heads=[{kv_vs_bf16_scores_heads_str}] kv_vs_bf16_pre_gate={kv_vs_bf16_pre_gate:.6} per_head_host_pre_gate=[{per_head_host_pre_gate_str}] native_score_row_delta={score_row_delta:.6} per_head_score=[{per_head_score_str}] native_vs_component_gated={native_vs_component_gated:.6} native_vs_host_gated={native_vs_host_gated:.6} kv_vs_bf16_gated={kv_vs_bf16_gated:.6} native_vs_component_attn_hidden={native_vs_component_attn_hidden:.6} native_vs_host_o_proj={native_vs_host_o_proj:.6} kv_vs_bf16_attn_hidden={kv_vs_bf16_attn_hidden:.6} native_vs_replay_attn_hidden={native_vs_replay_attn_hidden:.6} native_cache_vs_replay_cache_attn_hidden={native_cache_vs_replay_cache_attn_hidden:.6} component_vs_replay_attn_hidden={component_vs_replay_attn_hidden:.6} per_head_pre_gate=[{per_head_pre_gate_str}] pre_gate_best_match=[{pre_gate_best_match}] cache_vs_quant_k_mismatches={cache_vs_quant_k} cache_vs_quant_v_mismatches={cache_vs_quant_v} cache_vs_quant_k_scale_delta={scale_vs_quant_k:.6} cache_vs_quant_v_scale_delta={scale_vs_quant_v:.6}"
         );
     } else {
         let native_cache = engine.full_attention_cache_step_bytes(trace_layer, 0, seqlen_offset)?;
@@ -3022,7 +3088,7 @@ fn trace_persistent_full_attn_layer(
         let cache_vs_replay_k = validate::max_abs_delta(&native_cache_k_f32, &replay_comp_k_f32);
         let cache_vs_replay_v = validate::max_abs_delta(&native_cache_v_f32, &replay_comp_v_f32);
         eprintln!(
-            "[trace-persistent-full-attn] layer={trace_layer} hidden_delta={hidden_delta:.6} normed_delta={normed_delta:.6} q_proj_delta={q_proj_delta:.6} gate_proj_delta={gate_proj_delta:.6} k_proj_delta={k_proj_delta:.6} v_proj_delta={v_proj_delta:.6} q_rope_delta={q_rope_delta:.6} native_vs_component_q={native_vs_component_q:.6} per_head_q=[{per_head_q_str}] native_comp_vs_replay_k={native_vs_replay_k:.6} native_comp_vs_replay_v={native_vs_replay_v:.6} native_vs_component_saved_gate={native_vs_component_saved_gate:.6} native_vs_component_pre_gate={native_vs_component_pre_gate:.6} native_score_row_delta={score_row_delta:.6} per_head_score=[{per_head_score_str}] native_vs_component_gated={native_vs_component_gated:.6} native_vs_component_attn_hidden={native_vs_component_attn_hidden:.6} native_vs_host_o_proj={native_vs_host_o_proj:.6} native_vs_replay_attn_hidden={native_vs_replay_attn_hidden:.6} native_cache_vs_replay_cache_attn_hidden={native_cache_vs_replay_cache_attn_hidden:.6} component_vs_replay_attn_hidden={component_vs_replay_attn_hidden:.6} per_head_pre_gate=[{per_head_pre_gate_str}] cache_vs_component_k={cache_vs_component_k:.6} cache_vs_component_v={cache_vs_component_v:.6} cache_vs_replay_k={cache_vs_replay_k:.6} cache_vs_replay_v={cache_vs_replay_v:.6}"
+            "[trace-persistent-full-attn] layer={trace_layer} hidden_delta={hidden_delta:.6} normed_delta={normed_delta:.6} q_proj_delta={q_proj_delta:.6} gate_proj_delta={gate_proj_delta:.6} k_proj_delta={k_proj_delta:.6} v_proj_delta={v_proj_delta:.6} q_rope_delta={q_rope_delta:.6} native_vs_component_q={native_vs_component_q:.6} per_head_q=[{per_head_q_str}] q_best_match=[{q_best_match}] native_comp_vs_replay_k={native_vs_replay_k:.6} native_comp_vs_replay_v={native_vs_replay_v:.6} native_vs_component_saved_gate={native_vs_component_saved_gate:.6} native_vs_component_pre_gate={native_vs_component_pre_gate:.6} native_score_row_delta={score_row_delta:.6} per_head_score=[{per_head_score_str}] native_vs_component_gated={native_vs_component_gated:.6} native_vs_component_attn_hidden={native_vs_component_attn_hidden:.6} native_vs_host_o_proj={native_vs_host_o_proj:.6} native_vs_replay_attn_hidden={native_vs_replay_attn_hidden:.6} native_cache_vs_replay_cache_attn_hidden={native_cache_vs_replay_cache_attn_hidden:.6} component_vs_replay_attn_hidden={component_vs_replay_attn_hidden:.6} per_head_pre_gate=[{per_head_pre_gate_str}] pre_gate_best_match=[{pre_gate_best_match}] cache_vs_component_k={cache_vs_component_k:.6} cache_vs_component_v={cache_vs_component_v:.6} cache_vs_replay_k={cache_vs_replay_k:.6} cache_vs_replay_v={cache_vs_replay_v:.6}"
         );
     }
     Ok(())

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -1413,6 +1413,7 @@ fn main() -> Result<()> {
         && !cli.force_replay_decode
         && !cli.force_component_decode;
     let cuda_08b_hero_disabled = env::var_os("SUPERSONIC_DISABLE_CUDA_08B_HERO").is_some();
+    let cuda_08b_hero_opt_in = env::var_os("SUPERSONIC_ENABLE_CUDA_08B_HERO").is_some();
     let cuda_08b_hero_enabled = backend == Backend::Cuda
         && gpu_arch == GpuArch::Sm86
         && model_variant == ModelVariant::Qwen3_5_0_8B
@@ -1426,6 +1427,7 @@ fn main() -> Result<()> {
         && oracle_output.is_none()
         && !engine.weights().is_fp8
         && !engine.weights().is_int4
+        && cuda_08b_hero_opt_in
         && !cuda_08b_hero_disabled;
     let cuda_fast_greedy_disabled = env::var_os("SUPERSONIC_DISABLE_CUDA_FAST_GREEDY").is_some();
     let cuda_fast_greedy_enabled = backend == Backend::Cuda
@@ -1458,7 +1460,7 @@ fn main() -> Result<()> {
     } else if cli.batch_size == 1 && params.use_4b_kernel && cli.kv_fp8 {
         eprintln!("[decode] WARNING: single-sequence CUDA KV-FP8 uses the b=1 kernel path");
     } else if cuda_08b_hero_enabled {
-        eprintln!("[decode] CUDA 0.8B sm86 hero path enabled (fused lm_head argmax)");
+        eprintln!("[decode] CUDA 0.8B sm86 hero path enabled (experimental opt-in)");
     } else if cuda_fast_greedy_enabled {
         eprintln!("[decode] CUDA fast greedy sampling enabled for the non-4B native decode path");
     }

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -3614,13 +3614,7 @@ fn trace_persistent_linear_layer(
     };
     let isolated_tail_windows = {
         let final_layer_idx = text_config.num_hidden_layers.saturating_sub(1);
-        let starts = [
-            final_layer_idx,
-            final_layer_idx.saturating_sub(1),
-            final_layer_idx.saturating_sub(3),
-            final_layer_idx.saturating_sub(7),
-            final_layer_idx.saturating_sub(15),
-        ];
+        let starts = [4usize, 5, 6, 7, 8];
         let mut samples = Vec::new();
         for &start_layer in &starts {
             if start_layer >= text_config.num_hidden_layers {

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -9,6 +9,7 @@ mod registry;
 mod validate;
 
 use std::env;
+use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
 use std::time::Instant;
@@ -18,6 +19,7 @@ use base64::Engine as _;
 use clap::Parser;
 
 use decode_engine::{DecodeEngine, DecodeStageTimings};
+use qwen35::loader::WeightLoader;
 use qwen35::state::{LayerState, ModelState};
 use registry::{Backend, FamilyParams, GpuArch, ModelFamily, ModelVariant};
 
@@ -142,6 +144,136 @@ fn resolve_oracle_device(spec: &str, backend: Backend, ordinal: usize) -> String
         },
         other => other.to_string(),
     }
+}
+
+fn model_dir_has_raw_safetensors(model_dir: &Path) -> bool {
+    let Ok(entries) = fs::read_dir(model_dir) else {
+        return false;
+    };
+    entries.filter_map(Result::ok).any(|entry| {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        name.ends_with(".safetensors") || name.ends_with(".safetensors.index.json")
+    })
+}
+
+fn resolve_qwen_oracle_model_id(
+    explicit_model_id: Option<&str>,
+    model_dir: &Path,
+    model_variant: &ModelVariant,
+) -> String {
+    if let Some(model_id) = explicit_model_id {
+        return model_id.to_string();
+    }
+    if model_dir_has_raw_safetensors(model_dir) {
+        return model_dir.to_string_lossy().into_owned();
+    }
+    model_variant.hf_model_id().to_string()
+}
+
+struct HostLmHeadRescorer {
+    loader: WeightLoader,
+    tensor_name: String,
+}
+
+impl HostLmHeadRescorer {
+    fn from_model_dir(model_dir: &Path) -> Result<Option<Self>> {
+        if !model_dir_has_raw_safetensors(model_dir) {
+            return Ok(None);
+        }
+        let loader = WeightLoader::from_dir(model_dir)
+            .map_err(|e| anyhow::anyhow!("open raw lm_head weights: {e}"))?;
+        let tensor_name = if loader.contains("lm_head.weight") {
+            "lm_head.weight".to_string()
+        } else if loader.contains("model.embed_tokens.weight") {
+            "model.embed_tokens.weight".to_string()
+        } else {
+            return Ok(None);
+        };
+        Ok(Some(Self { loader, tensor_name }))
+    }
+
+    fn rescore(&self, normed: &[f32], candidate_ids: &[usize]) -> Result<u32> {
+        let mut best_idx = 0usize;
+        let mut best_val = f32::NEG_INFINITY;
+        for &candidate in candidate_ids {
+            let row = self
+                .loader
+                .load_bf16_row_f32(&self.tensor_name, candidate)
+                .map_err(|e| anyhow::anyhow!("load lm_head row {candidate}: {e}"))?;
+            anyhow::ensure!(
+                row.len() == normed.len(),
+                "lm_head row len {} != normed len {}",
+                row.len(),
+                normed.len()
+            );
+            let score = row
+                .iter()
+                .zip(normed.iter())
+                .map(|(w, x)| w * x)
+                .sum::<f32>();
+            if score > best_val {
+                best_val = score;
+                best_idx = candidate;
+            }
+        }
+        Ok(best_idx as u32)
+    }
+}
+
+fn top_k_candidate_ids(logits: &[f32], k: usize) -> Vec<usize> {
+    let mut best: Vec<(usize, f32)> = Vec::new();
+    for (idx, &val) in logits.iter().enumerate() {
+        let pos = best
+            .iter()
+            .position(|&(_, best_val)| val > best_val)
+            .unwrap_or(best.len());
+        if pos < k {
+            best.insert(pos, (idx, val));
+            if best.len() > k {
+                best.pop();
+            }
+        }
+    }
+    best.into_iter().map(|(idx, _)| idx).collect()
+}
+
+fn sample_qwen_logits_with_rescore(
+    logits: &[f32],
+    normed: Option<&[f32]>,
+    rescorer: Option<&HostLmHeadRescorer>,
+) -> Result<u32> {
+    let greedy = DecodeEngine::greedy_sample(logits);
+    let Some(normed) = normed else {
+        return Ok(greedy);
+    };
+    let Some(rescorer) = rescorer else {
+        return Ok(greedy);
+    };
+
+    const RESCORE_MARGIN: f32 = 0.25;
+    const RESCORE_TOP_K: usize = 4;
+
+    let candidates = top_k_candidate_ids(logits, RESCORE_TOP_K);
+    if candidates.len() < 2 {
+        return Ok(greedy);
+    }
+    let top0 = logits[candidates[0]];
+    let top1 = logits[candidates[1]];
+    if top0 - top1 > RESCORE_MARGIN {
+        return Ok(greedy);
+    }
+
+    let rescored = rescorer.rescore(normed, &candidates)?;
+    if rescored != greedy {
+        eprintln!(
+            "[sample-rescore] token {} -> {} (top_margin={:.4})",
+            greedy,
+            rescored,
+            top0 - top1
+        );
+    }
+    Ok(rescored)
 }
 
 #[derive(Parser)]
@@ -651,6 +783,7 @@ fn main() -> Result<()> {
         FamilyParams::Gemma4(_) => unreachable!("gemma4 handled above"),
         FamilyParams::Phi4(_) => unreachable!("phi4 handled above"),
     };
+    let host_lm_head_rescorer = HostLmHeadRescorer::from_model_dir(&cli.model_dir)?;
 
     if cli.trace_kv_fp8_cache && !cli.kv_fp8 {
         anyhow::bail!("--trace-kv-fp8-cache requires --kv-fp8");
@@ -962,10 +1095,11 @@ fn main() -> Result<()> {
     // Run prefill (native GPU or oracle)
     let prefill_start = Instant::now();
     let (prefill_logits, native_prefill_trace, mut next_token) = if cli.oracle_prefill {
-        let model_id = cli
-            .model_id
-            .clone()
-            .unwrap_or_else(|| model_variant.hf_model_id().to_string());
+        let model_id = resolve_qwen_oracle_model_id(
+            cli.model_id.as_deref(),
+            &cli.model_dir,
+            &model_variant,
+        );
         let oracle_script = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .parent()
             .and_then(|p| p.parent())
@@ -985,19 +1119,17 @@ fn main() -> Result<()> {
         let prefill_result = if cli.trace_prefill_layers {
             engine.prefill_native_with_trace(&prompt_ids)?
         } else {
-            prefill_engine::PrefillResult {
-                logits: engine.prefill_native(&prompt_ids)?,
-                final_norm_trace: None,
-                layer_attn_trace: None,
-                layer_post_attn_norm_trace: None,
-                layer_mlp_swiglu_trace: None,
-                layer_mlp_out_trace: None,
-                layer_hidden_trace: None,
-                tap_hiddens: None,
-                linear_debug_trace: None,
-            }
+            engine.prefill_native_with_final_norm(&prompt_ids)?
         };
-        let first = DecodeEngine::greedy_sample(&prefill_result.logits);
+        let prefill_normed = prefill_result
+            .final_norm_trace
+            .as_deref()
+            .map(decode_bf16_le);
+        let first = sample_qwen_logits_with_rescore(
+            &prefill_result.logits,
+            prefill_normed.as_deref(),
+            host_lm_head_rescorer.as_ref(),
+        )?;
         eprintln!("[prefill] native GPU prefill done in {:.0}ms", prefill_start.elapsed().as_millis());
         (
             prefill_result.logits,
@@ -1014,10 +1146,11 @@ fn main() -> Result<()> {
 
     // Optionally run oracle for validation
     let oracle_output = if cli.validate {
-        let model_id = cli
-            .model_id
-            .clone()
-            .unwrap_or_else(|| model_variant.hf_model_id().to_string());
+        let model_id = resolve_qwen_oracle_model_id(
+            cli.model_id.as_deref(),
+            &cli.model_dir,
+            &model_variant,
+        );
         let oracle_script = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .parent()
             .and_then(|p| p.parent())
@@ -1251,9 +1384,16 @@ fn main() -> Result<()> {
     // the megakernel; --force-replay-decode re-enables the replay path for
     // the rare case where someone genuinely wants to reproduce the older
     // numeric semantics.
+    let cuda_qwen2b_replay_default = backend == Backend::Cuda
+        && model_variant == ModelVariant::Qwen3_5_2B
+        && cli.batch_size == 1
+        && params.use_4b_kernel
+        && !cli.kv_fp8
+        && !cli.force_kernel_decode
+        && !cli.force_component_decode;
     let replay_decode_enabled = cli.batch_size == 1
         && params.use_4b_kernel
-        && cli.force_replay_decode
+        && (cli.force_replay_decode || cuda_qwen2b_replay_default)
         && !cli.force_kernel_decode
         && !cli.force_component_decode
         && !cli.kv_fp8;
@@ -1300,7 +1440,13 @@ fn main() -> Result<()> {
         && !cuda_08b_hero_enabled
         && !cuda_fast_greedy_disabled;
     if replay_decode_enabled {
-        eprintln!("[decode] single-sequence 4B uses replayed GPU prefill for correctness");
+        if cuda_qwen2b_replay_default {
+            eprintln!(
+                "[decode] single-sequence CUDA qwen3.5-2b uses replayed GPU prefill for correctness"
+            );
+        } else {
+            eprintln!("[decode] single-sequence 4B uses replayed GPU prefill for correctness");
+        }
     } else if replay_kv_fp8_enabled && cli.batch_size == 1 {
         eprintln!("[decode] single-sequence CUDA KV-FP8 uses replayed GPU prefill for correctness");
     } else if cli.batch_size > 1 && params.use_4b_kernel && cli.kv_fp8 {
@@ -1725,7 +1871,20 @@ fn main() -> Result<()> {
             } else {
                 engine.decode_step(next_token, seqlen_offset)?
             };
-            let native_token = maybe_fast_token.unwrap_or_else(|| DecodeEngine::greedy_sample(&logits));
+            let native_token = if let Some(token) = maybe_fast_token {
+                token
+            } else {
+                let normed = if host_lm_head_rescorer.is_some() {
+                    Some(engine.last_normed_host_f32()?)
+                } else {
+                    None
+                };
+                sample_qwen_logits_with_rescore(
+                    &logits,
+                    normed.as_deref(),
+                    host_lm_head_rescorer.as_ref(),
+                )?
+            };
 
             if let Some(ref oracle) = oracle_output {
                 if step < oracle.decode_logits.len() {

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -3381,6 +3381,59 @@ fn trace_persistent_linear_layer(
         validate::max_abs_delta(&decode_bf16_le(&native_comp_conv), &expected_conv_tail);
     let replay_conv_vs_expected_tail =
         validate::max_abs_delta(&decode_bf16_le(&replay_conv), &expected_conv_tail);
+    let native_conv_tap_deltas = {
+        let native = decode_bf16_le(&native_conv);
+        let mut deltas = vec![0.0f32; conv_state_len];
+        for c in 0..qkv_dim {
+            let base = c * conv_state_len;
+            for t in 0..conv_state_len {
+                deltas[t] = deltas[t].max((native[base + t] - expected_conv_tail[base + t]).abs());
+            }
+        }
+        deltas
+            .iter()
+            .map(|v| format!("{v:.6}"))
+            .collect::<Vec<_>>()
+            .join(",")
+    };
+    let max_append_mismatch = {
+        let native = decode_bf16_le(&native_conv);
+        let start = decode_bf16_le(&pre_step_conv);
+        let qkv = decode_bf16_le(&native_comp_trace.qkv);
+        let mut best = (0usize, 0.0f32);
+        for c in 0..qkv_dim {
+            let idx = c * conv_state_len + (conv_state_len - 1);
+            let delta = (native[idx] - expected_conv_tail[idx]).abs();
+            if delta > best.1 {
+                best = (c, delta);
+            }
+        }
+        let channel = best.0;
+        let idx = channel * conv_state_len + (conv_state_len - 1);
+        format!(
+            "channel={channel},native={:.6},expected={:.6},prev_last={:.6},qkv={:.6},delta={:.6}",
+            native[idx],
+            expected_conv_tail[idx],
+            start[idx],
+            qkv[channel],
+            best.1
+        )
+    };
+    let comp_conv_tap_deltas = {
+        let comp = decode_bf16_le(&native_comp_conv);
+        let mut deltas = vec![0.0f32; conv_state_len];
+        for c in 0..qkv_dim {
+            let base = c * conv_state_len;
+            for t in 0..conv_state_len {
+                deltas[t] = deltas[t].max((comp[base + t] - expected_conv_tail[base + t]).abs());
+            }
+        }
+        deltas
+            .iter()
+            .map(|v| format!("{v:.6}"))
+            .collect::<Vec<_>>()
+            .join(",")
+    };
     let native_vs_replay_post_norm =
         validate::max_abs_delta(&decode_f32_le(&native_post_norm), &decode_bf16_le(replay_post));
     let native_vs_replay_gated =
@@ -3426,7 +3479,7 @@ fn trace_persistent_linear_layer(
     let sample_z_comp = comp_z_proj_f32.iter().take(4).map(|v| format!("{v:.4}")).collect::<Vec<_>>().join(",");
 
     eprintln!(
-        "[trace-persistent-linear] layer={trace_layer} hidden_delta={hidden_delta:.6} comp_vs_replay_conv={comp_vs_replay_conv:.6} comp_vs_replay_recurrent={comp_vs_replay_recurrent:.6} comp_linear_hidden_vs_replay={comp_vs_replay_hidden:.6} native_vs_comp_qkv_proj={native_vs_comp_qkv_proj:.6} native_vs_replay_qkv_proj={native_vs_replay_qkv_proj:.6} native_vs_comp_z_proj={native_vs_comp_z_proj:.6} native_vs_replay_z_proj={native_vs_replay_z_proj:.6} native_vs_comp_b_proj={native_vs_comp_b_proj:.6} native_vs_replay_b_proj={native_vs_replay_b_proj:.6} native_vs_comp_a_proj={native_vs_comp_a_proj:.6} native_vs_replay_a_proj={native_vs_replay_a_proj:.6} native_vs_comp_conv={native_vs_comp_conv:.6} native_vs_comp_recurrent={native_vs_comp_recurrent:.6} native_conv_vs_expected_tail={native_conv_vs_expected_tail:.6} comp_conv_vs_expected_tail={comp_conv_vs_expected_tail:.6} replay_conv_vs_expected_tail={replay_conv_vs_expected_tail:.6} native_vs_comp_token_mixer={native_vs_comp_token_mixer:.6} native_vs_replay_token_mixer={native_vs_replay_token_mixer:.6} native_vs_comp_post_norm={native_vs_comp_post_norm:.6} native_vs_replay_post_norm={native_vs_replay_post_norm:.6} native_vs_comp_gated={native_vs_comp_gated:.6} native_vs_replay_gated={native_vs_replay_gated:.6} native_vs_comp_swiglu={native_vs_comp_swiglu:.6} native_vs_replay_swiglu={native_vs_replay_swiglu:.6} native_vs_comp_mlp_down={native_vs_comp_mlp_down:.6} native_vs_replay_mlp_down={native_vs_replay_mlp_down:.6} native_vs_comp_proj_residual={native_vs_comp_proj_residual:.6} comp_layer_hidden_vs_replay={comp_layer_vs_replay_hidden:.6} native_vs_comp_layer_hidden={native_vs_comp_layer_hidden:.6} native_vs_replay_hidden={native_vs_replay_hidden:.6} sample_qkv_native=[{sample_qkv_native}] sample_qkv_comp=[{sample_qkv_comp}] sample_z_native=[{sample_z_native}] sample_z_comp=[{sample_z_comp}]"
+        "[trace-persistent-linear] layer={trace_layer} hidden_delta={hidden_delta:.6} comp_vs_replay_conv={comp_vs_replay_conv:.6} comp_vs_replay_recurrent={comp_vs_replay_recurrent:.6} comp_linear_hidden_vs_replay={comp_vs_replay_hidden:.6} native_vs_comp_qkv_proj={native_vs_comp_qkv_proj:.6} native_vs_replay_qkv_proj={native_vs_replay_qkv_proj:.6} native_vs_comp_z_proj={native_vs_comp_z_proj:.6} native_vs_replay_z_proj={native_vs_replay_z_proj:.6} native_vs_comp_b_proj={native_vs_comp_b_proj:.6} native_vs_replay_b_proj={native_vs_replay_b_proj:.6} native_vs_comp_a_proj={native_vs_comp_a_proj:.6} native_vs_replay_a_proj={native_vs_replay_a_proj:.6} native_vs_comp_conv={native_vs_comp_conv:.6} native_vs_comp_recurrent={native_vs_comp_recurrent:.6} native_conv_vs_expected_tail={native_conv_vs_expected_tail:.6} comp_conv_vs_expected_tail={comp_conv_vs_expected_tail:.6} replay_conv_vs_expected_tail={replay_conv_vs_expected_tail:.6} native_conv_tap_deltas=[{native_conv_tap_deltas}] comp_conv_tap_deltas=[{comp_conv_tap_deltas}] max_append_mismatch=({max_append_mismatch}) native_vs_comp_token_mixer={native_vs_comp_token_mixer:.6} native_vs_replay_token_mixer={native_vs_replay_token_mixer:.6} native_vs_comp_post_norm={native_vs_comp_post_norm:.6} native_vs_replay_post_norm={native_vs_replay_post_norm:.6} native_vs_comp_gated={native_vs_comp_gated:.6} native_vs_replay_gated={native_vs_replay_gated:.6} native_vs_comp_swiglu={native_vs_comp_swiglu:.6} native_vs_replay_swiglu={native_vs_replay_swiglu:.6} native_vs_comp_mlp_down={native_vs_comp_mlp_down:.6} native_vs_replay_mlp_down={native_vs_replay_mlp_down:.6} native_vs_comp_proj_residual={native_vs_comp_proj_residual:.6} comp_layer_hidden_vs_replay={comp_layer_vs_replay_hidden:.6} native_vs_comp_layer_hidden={native_vs_comp_layer_hidden:.6} native_vs_replay_hidden={native_vs_replay_hidden:.6} sample_qkv_native=[{sample_qkv_native}] sample_qkv_comp=[{sample_qkv_comp}] sample_z_native=[{sample_z_native}] sample_z_comp=[{sample_z_comp}]"
     );
     Ok(())
 }

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -3266,6 +3266,16 @@ fn trace_persistent_linear_layer(
         .get(..token_ids.len().saturating_sub(1))
         .ok_or_else(|| anyhow::anyhow!("missing prefix token ids for persistent linear trace"))?;
     engine.rebuild_prefill_state(prefix_ids, true)?;
+    let pre_step_conv = engine
+        .state_for_batch(0)
+        .layers
+        .get(trace_layer)
+        .ok_or_else(|| anyhow::anyhow!("missing pre-step layer {trace_layer}"))?
+        .conv_state
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("missing pre-step conv state for layer {trace_layer}"))?
+        .to_host_bytes()
+        .map_err(|e| anyhow::anyhow!("pre-step conv D2H layer {trace_layer}: {e}"))?;
     engine.set_hidden_from_bytes(&native_hidden)?;
     let (native_comp_trace, native_comp_conv, native_comp_recurrent, native_comp_hidden) =
         engine.component_trace_linear_layer_from_current_hidden(trace_layer)?;
@@ -3351,6 +3361,26 @@ fn trace_persistent_linear_layer(
         validate::max_abs_delta(&decode_f32_le(&native_token_mixer), &decode_bf16_le(&native_comp_layer.attn_hidden));
     let native_vs_comp_mlp_down =
         validate::max_abs_delta(&decode_f32_le(&native_mlp_down), &decode_bf16_le(&native_comp_layer.mlp_out));
+    let conv_state_len = cfg.linear_conv_kernel_dim - 1;
+    let expected_conv_tail = {
+        let start = decode_bf16_le(&pre_step_conv);
+        let qkv = decode_bf16_le(&native_comp_trace.qkv);
+        let mut expected = vec![0.0f32; qkv_dim * conv_state_len];
+        for c in 0..qkv_dim {
+            let base = c * conv_state_len;
+            for t in 0..conv_state_len.saturating_sub(1) {
+                expected[base + t] = start[base + t + 1];
+            }
+            expected[base + conv_state_len - 1] = qkv[c];
+        }
+        expected
+    };
+    let native_conv_vs_expected_tail =
+        validate::max_abs_delta(&decode_bf16_le(&native_conv), &expected_conv_tail);
+    let comp_conv_vs_expected_tail =
+        validate::max_abs_delta(&decode_bf16_le(&native_comp_conv), &expected_conv_tail);
+    let replay_conv_vs_expected_tail =
+        validate::max_abs_delta(&decode_bf16_le(&replay_conv), &expected_conv_tail);
     let native_vs_replay_post_norm =
         validate::max_abs_delta(&decode_f32_le(&native_post_norm), &decode_bf16_le(replay_post));
     let native_vs_replay_gated =
@@ -3396,7 +3426,7 @@ fn trace_persistent_linear_layer(
     let sample_z_comp = comp_z_proj_f32.iter().take(4).map(|v| format!("{v:.4}")).collect::<Vec<_>>().join(",");
 
     eprintln!(
-        "[trace-persistent-linear] layer={trace_layer} hidden_delta={hidden_delta:.6} comp_vs_replay_conv={comp_vs_replay_conv:.6} comp_vs_replay_recurrent={comp_vs_replay_recurrent:.6} comp_linear_hidden_vs_replay={comp_vs_replay_hidden:.6} native_vs_comp_qkv_proj={native_vs_comp_qkv_proj:.6} native_vs_replay_qkv_proj={native_vs_replay_qkv_proj:.6} native_vs_comp_z_proj={native_vs_comp_z_proj:.6} native_vs_replay_z_proj={native_vs_replay_z_proj:.6} native_vs_comp_b_proj={native_vs_comp_b_proj:.6} native_vs_replay_b_proj={native_vs_replay_b_proj:.6} native_vs_comp_a_proj={native_vs_comp_a_proj:.6} native_vs_replay_a_proj={native_vs_replay_a_proj:.6} native_vs_comp_conv={native_vs_comp_conv:.6} native_vs_comp_recurrent={native_vs_comp_recurrent:.6} native_vs_comp_token_mixer={native_vs_comp_token_mixer:.6} native_vs_replay_token_mixer={native_vs_replay_token_mixer:.6} native_vs_comp_post_norm={native_vs_comp_post_norm:.6} native_vs_replay_post_norm={native_vs_replay_post_norm:.6} native_vs_comp_gated={native_vs_comp_gated:.6} native_vs_replay_gated={native_vs_replay_gated:.6} native_vs_comp_swiglu={native_vs_comp_swiglu:.6} native_vs_replay_swiglu={native_vs_replay_swiglu:.6} native_vs_comp_mlp_down={native_vs_comp_mlp_down:.6} native_vs_replay_mlp_down={native_vs_replay_mlp_down:.6} native_vs_comp_proj_residual={native_vs_comp_proj_residual:.6} comp_layer_hidden_vs_replay={comp_layer_vs_replay_hidden:.6} native_vs_comp_layer_hidden={native_vs_comp_layer_hidden:.6} native_vs_replay_hidden={native_vs_replay_hidden:.6} sample_qkv_native=[{sample_qkv_native}] sample_qkv_comp=[{sample_qkv_comp}] sample_z_native=[{sample_z_native}] sample_z_comp=[{sample_z_comp}]"
+        "[trace-persistent-linear] layer={trace_layer} hidden_delta={hidden_delta:.6} comp_vs_replay_conv={comp_vs_replay_conv:.6} comp_vs_replay_recurrent={comp_vs_replay_recurrent:.6} comp_linear_hidden_vs_replay={comp_vs_replay_hidden:.6} native_vs_comp_qkv_proj={native_vs_comp_qkv_proj:.6} native_vs_replay_qkv_proj={native_vs_replay_qkv_proj:.6} native_vs_comp_z_proj={native_vs_comp_z_proj:.6} native_vs_replay_z_proj={native_vs_replay_z_proj:.6} native_vs_comp_b_proj={native_vs_comp_b_proj:.6} native_vs_replay_b_proj={native_vs_replay_b_proj:.6} native_vs_comp_a_proj={native_vs_comp_a_proj:.6} native_vs_replay_a_proj={native_vs_replay_a_proj:.6} native_vs_comp_conv={native_vs_comp_conv:.6} native_vs_comp_recurrent={native_vs_comp_recurrent:.6} native_conv_vs_expected_tail={native_conv_vs_expected_tail:.6} comp_conv_vs_expected_tail={comp_conv_vs_expected_tail:.6} replay_conv_vs_expected_tail={replay_conv_vs_expected_tail:.6} native_vs_comp_token_mixer={native_vs_comp_token_mixer:.6} native_vs_replay_token_mixer={native_vs_replay_token_mixer:.6} native_vs_comp_post_norm={native_vs_comp_post_norm:.6} native_vs_replay_post_norm={native_vs_replay_post_norm:.6} native_vs_comp_gated={native_vs_comp_gated:.6} native_vs_replay_gated={native_vs_replay_gated:.6} native_vs_comp_swiglu={native_vs_comp_swiglu:.6} native_vs_replay_swiglu={native_vs_replay_swiglu:.6} native_vs_comp_mlp_down={native_vs_comp_mlp_down:.6} native_vs_replay_mlp_down={native_vs_replay_mlp_down:.6} native_vs_comp_proj_residual={native_vs_comp_proj_residual:.6} comp_layer_hidden_vs_replay={comp_layer_vs_replay_hidden:.6} native_vs_comp_layer_hidden={native_vs_comp_layer_hidden:.6} native_vs_replay_hidden={native_vs_replay_hidden:.6} sample_qkv_native=[{sample_qkv_native}] sample_qkv_comp=[{sample_qkv_comp}] sample_z_native=[{sample_z_native}] sample_z_comp=[{sample_z_comp}]"
     );
     Ok(())
 }

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -1100,9 +1100,12 @@ fn main() -> Result<()> {
                     native_layer_trace.as_ref(),
                 )
                 {
-                let b64 = base64::engine::general_purpose::STANDARD;
-                let mut first_bad = None;
-                for layer in 0..native_layer_trace.len().min(oracle_layer_trace.len()) {
+	                let b64 = base64::engine::general_purpose::STANDARD;
+	                let oracle_kv = output.kv_caches.as_ref();
+	                let oracle_conv = output.conv_states.as_ref();
+	                let oracle_recurrent = output.recurrent_states.as_ref();
+	                let mut first_bad = None;
+	                for layer in 0..native_layer_trace.len().min(oracle_layer_trace.len()) {
                     let decode_bf16 = |bytes: &[u8]| -> Vec<f32> {
                         bytes.chunks_exact(2)
                             .map(|b| half::bf16::from_le_bytes([b[0], b[1]]).to_f32())
@@ -1128,17 +1131,70 @@ fn main() -> Result<()> {
                     let oracle_post_norm_f32 = decode_bf16(&oracle_post_norm_bytes);
                     let oracle_mlp_out_f32 = decode_bf16(&oracle_mlp_out_bytes);
                     let oracle_layer_f32 = decode_bf16(&oracle_layer_bytes);
-                    let attn_delta = validate::max_abs_delta(&native_attn_f32, &oracle_attn_f32);
-                    let post_norm_delta = validate::max_abs_delta(&native_post_norm_f32, &oracle_post_norm_f32);
-                    let mlp_out_delta = validate::max_abs_delta(&native_mlp_out_f32, &oracle_mlp_out_f32);
-                    let layer_delta = validate::max_abs_delta(&native_layer_f32, &oracle_layer_f32);
-                    if first_bad.is_none() && layer_delta > 0.5 {
-                        first_bad = Some((layer, attn_delta, post_norm_delta, mlp_out_delta, layer_delta));
-                    }
-                    eprintln!(
-                        "[trace-prefill] layer={layer} attn_delta={attn_delta:.4} post_norm_delta={post_norm_delta:.4} mlp_out_delta={mlp_out_delta:.4} layer_delta={layer_delta:.4}"
-                    );
-                }
+	                    let attn_delta = validate::max_abs_delta(&native_attn_f32, &oracle_attn_f32);
+	                    let post_norm_delta = validate::max_abs_delta(&native_post_norm_f32, &oracle_post_norm_f32);
+	                    let mlp_out_delta = validate::max_abs_delta(&native_mlp_out_f32, &oracle_mlp_out_f32);
+	                    let layer_delta = validate::max_abs_delta(&native_layer_f32, &oracle_layer_f32);
+	                    let state_delta = if text_config.is_full_attention(layer) {
+	                        let native = engine.full_attention_prefix_cache_bf16_host(layer, 0);
+	                        match (native, oracle_kv.and_then(|caches| caches.iter().find(|kv| kv.layer == layer))) {
+	                            (Ok((native_k, native_v, _)), Some(oracle_kv)) => {
+	                                let oracle_k = b64
+	                                    .decode(&oracle_kv.k)
+	                                    .map_err(|e| anyhow::anyhow!("decode oracle kv k[{layer}]: {e}"))?;
+	                                let oracle_v = b64
+	                                    .decode(&oracle_kv.v)
+	                                    .map_err(|e| anyhow::anyhow!("decode oracle kv v[{layer}]: {e}"))?;
+	                                format!(
+	                                    " kv_k_delta={:.4} kv_v_delta={:.4}",
+	                                    validate::max_abs_delta(&decode_bf16_le(&native_k), &decode_bf16_le(&oracle_k)),
+	                                    validate::max_abs_delta(&decode_bf16_le(&native_v), &decode_bf16_le(&oracle_v)),
+	                                )
+	                            }
+	                            _ => String::new(),
+	                        }
+	                    } else {
+	                        let native_layer = engine.state_for_batch(0).layers.get(layer);
+	                        match (
+	                            native_layer,
+	                            oracle_conv.and_then(|states| states.iter().find(|state| state.layer == layer)),
+	                            oracle_recurrent.and_then(|states| states.iter().find(|state| state.layer == layer)),
+	                        ) {
+	                            (Some(native_layer), Some(oracle_conv), Some(oracle_recurrent)) => {
+	                                let native_conv = native_layer
+	                                    .conv_state
+	                                    .as_ref()
+	                                    .ok_or_else(|| anyhow::anyhow!("native linear layer {layer} missing conv_state"))?
+	                                    .to_host_bytes()
+	                                    .map_err(|e| anyhow::anyhow!("native conv D2H layer {layer}: {e}"))?;
+	                                let native_recurrent = native_layer
+	                                    .recurrent_state
+	                                    .as_ref()
+	                                    .ok_or_else(|| anyhow::anyhow!("native linear layer {layer} missing recurrent_state"))?
+	                                    .to_host_bytes()
+	                                    .map_err(|e| anyhow::anyhow!("native recurrent D2H layer {layer}: {e}"))?;
+	                                let oracle_conv = b64
+	                                    .decode(&oracle_conv.data)
+	                                    .map_err(|e| anyhow::anyhow!("decode oracle conv[{layer}]: {e}"))?;
+	                                let oracle_recurrent = b64
+	                                    .decode(&oracle_recurrent.data)
+	                                    .map_err(|e| anyhow::anyhow!("decode oracle recurrent[{layer}]: {e}"))?;
+	                                format!(
+	                                    " conv_delta={:.4} recurrent_delta={:.4}",
+	                                    validate::max_abs_delta(&decode_bf16_le(&native_conv), &decode_bf16_le(&oracle_conv)),
+	                                    validate::max_abs_delta(&decode_f32_le(&native_recurrent), &decode_f32_le(&oracle_recurrent)),
+	                                )
+	                            }
+	                            _ => String::new(),
+	                        }
+	                    };
+	                    if first_bad.is_none() && layer_delta > 0.5 {
+	                        first_bad = Some((layer, attn_delta, post_norm_delta, mlp_out_delta, layer_delta));
+	                    }
+	                    eprintln!(
+	                        "[trace-prefill] layer={layer} attn_delta={attn_delta:.4} post_norm_delta={post_norm_delta:.4} mlp_out_delta={mlp_out_delta:.4} layer_delta={layer_delta:.4}{state_delta}"
+	                    );
+	                }
                 if let Some((layer, attn_delta, post_norm_delta, mlp_out_delta, layer_delta)) = first_bad {
                     eprintln!(
                         "[trace-prefill] first_bad_layer={layer} attn_delta={attn_delta:.4} post_norm_delta={post_norm_delta:.4} mlp_out_delta={mlp_out_delta:.4} layer_delta={layer_delta:.4}"
@@ -1620,6 +1676,26 @@ fn main() -> Result<()> {
                         .chain(std::iter::once(next_token))
                         .collect();
                     trace_persistent_full_attn_layer(
+                        &mut engine,
+                        trace_layer,
+                        trace_token_ids.as_slice(),
+                        &[next_token],
+                        seqlen_offset,
+                        ordinal,
+                        params.kv_chunk_size,
+                        cli.prefill_chunk_size,
+                        params.use_4b_kernel,
+                    )?;
+                    engine.rebuild_prefill_state(&trace_token_ids, false)?;
+                }
+                if let Some(trace_layer) = cli.trace_persistent_linear_layer {
+                    let trace_token_ids: Vec<u32> = prompt_ids
+                        .iter()
+                        .copied()
+                        .chain(generated_ids.iter().copied())
+                        .chain(std::iter::once(next_token))
+                        .collect();
+                    trace_persistent_linear_layer(
                         &mut engine,
                         trace_layer,
                         trace_token_ids.as_slice(),
@@ -3391,22 +3467,29 @@ fn trace_oracle_prefill_layer(
     oracle_full: &oracle::OracleOutput,
 ) -> Result<()> {
     anyhow::ensure!(trace_layer > 0, "--trace-oracle-prefill-layer currently requires layer > 0");
-    anyhow::ensure!(prompt_ids.len() >= 2, "prompt must contain at least 2 tokens for oracle prefix trace");
+    let row_bytes = engine.weights().config.hidden_size * 2;
     let prefix_ids = &prompt_ids[..prompt_ids.len() - 1];
-    let prefix_oracle = oracle::run_oracle(
-        oracle_script,
-        model_id,
-        prefix_ids,
-        1,
-        oracle_dtype,
-        oracle_device,
-        true,
-        fp8_oracle_dir,
-        None,
-    )?;
+    let prefix_oracle = if prefix_ids.is_empty() {
+        None
+    } else {
+        Some(oracle::run_oracle(
+            oracle_script,
+            model_id,
+            prefix_ids,
+            1,
+            oracle_dtype,
+            oracle_device,
+            true,
+            fp8_oracle_dir,
+            None,
+        )?)
+    };
     let mut native_prefix_k_delta = None;
     let mut native_prefix_v_delta = None;
+    let mut native_prefix_conv_delta = None;
+    let mut native_prefix_recurrent_delta = None;
     if engine.weights().config.is_full_attention(trace_layer) {
+        if let Some(prefix_oracle) = prefix_oracle.as_ref() {
         engine.reset()?;
         let _ = engine.prefill_native(prefix_ids)?;
         let (native_prefix_k, native_prefix_v, native_prefix_len) =
@@ -3429,11 +3512,78 @@ fn trace_oracle_prefill_layer(
             &decode_bf16_le(&native_prefix_v),
             &decode_bf16_le(&oracle_prefix_v),
         ));
+        }
+    } else {
+        if let Some(prefix_oracle) = prefix_oracle.as_ref() {
+        engine.reset()?;
+        let _ = engine.prefill_native(prefix_ids)?;
+        let native_layer = engine
+            .state_for_batch(0)
+            .layers
+            .get(trace_layer)
+            .ok_or_else(|| anyhow::anyhow!("missing native prefix layer {trace_layer}"))?;
+        let native_conv = native_layer
+            .conv_state
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("native prefix layer {trace_layer} missing conv_state"))?
+            .to_host_bytes()
+            .map_err(|e| anyhow::anyhow!("native prefix conv D2H layer {trace_layer}: {e}"))?;
+        let native_recurrent = native_layer
+            .recurrent_state
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("native prefix layer {trace_layer} missing recurrent_state"))?
+            .to_host_bytes()
+            .map_err(|e| anyhow::anyhow!("native prefix recurrent D2H layer {trace_layer}: {e}"))?;
+
+        engine.reset()?;
+        engine.load_prefill_state(&prefix_oracle)?;
+        let oracle_layer = engine
+            .state_for_batch(0)
+            .layers
+            .get(trace_layer)
+            .ok_or_else(|| anyhow::anyhow!("missing oracle prefix layer {trace_layer}"))?;
+        let oracle_conv = oracle_layer
+            .conv_state
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("oracle prefix layer {trace_layer} missing conv_state"))?
+            .to_host_bytes()
+            .map_err(|e| anyhow::anyhow!("oracle prefix conv D2H layer {trace_layer}: {e}"))?;
+        let oracle_recurrent = oracle_layer
+            .recurrent_state
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("oracle prefix layer {trace_layer} missing recurrent_state"))?
+            .to_host_bytes()
+            .map_err(|e| anyhow::anyhow!("oracle prefix recurrent D2H layer {trace_layer}: {e}"))?;
+
+        native_prefix_conv_delta = Some(validate::max_abs_delta(
+            &decode_bf16_le(&native_conv),
+            &decode_bf16_le(&oracle_conv),
+        ));
+        native_prefix_recurrent_delta = Some(validate::max_abs_delta(
+            &decode_f32_le(&native_recurrent),
+            &decode_f32_le(&oracle_recurrent),
+        ));
+        }
     }
     engine.reset()?;
-    engine.load_prefill_state(&prefix_oracle)?;
+    if let Some(prefix_oracle) = prefix_oracle.as_ref() {
+        engine.load_prefill_state(prefix_oracle)?;
+    }
 
     let b64 = base64::engine::general_purpose::STANDARD;
+    let last_row = |bytes: Vec<u8>, label: &str| -> Result<Vec<u8>> {
+        anyhow::ensure!(
+            bytes.len() % row_bytes == 0,
+            "{label} bytes {} not divisible by row_bytes {}",
+            bytes.len(),
+            row_bytes,
+        );
+        if bytes.len() == row_bytes {
+            return Ok(bytes);
+        }
+        let start = bytes.len() - row_bytes;
+        Ok(bytes[start..].to_vec())
+    };
     let oracle_inputs = oracle_full
         .layer_hidden_states
         .as_ref()
@@ -3451,41 +3601,51 @@ fn trace_oracle_prefill_layer(
         .as_ref()
         .ok_or_else(|| anyhow::anyhow!("oracle output missing layer_mlp_outputs"))?;
 
-    let oracle_input_bytes = b64
-        .decode(
+    let oracle_input_bytes = last_row(
+        b64.decode(
             oracle_inputs
                 .get(trace_layer - 1)
                 .ok_or_else(|| anyhow::anyhow!("oracle layer_hidden_states missing layer {}", trace_layer - 1))?,
         )
-        .map_err(|e| anyhow::anyhow!("decode oracle input hidden for layer {trace_layer}: {e}"))?;
-    let oracle_attn_bytes = b64
-        .decode(
+        .map_err(|e| anyhow::anyhow!("decode oracle input hidden for layer {trace_layer}: {e}"))?,
+        "oracle input hidden",
+    )?;
+    let oracle_attn_bytes = last_row(
+        b64.decode(
             oracle_attn
                 .get(trace_layer)
                 .ok_or_else(|| anyhow::anyhow!("oracle layer_attn_residual_states missing layer {trace_layer}"))?,
         )
-        .map_err(|e| anyhow::anyhow!("decode oracle attn for layer {trace_layer}: {e}"))?;
-    let oracle_post_bytes = b64
-        .decode(
+        .map_err(|e| anyhow::anyhow!("decode oracle attn for layer {trace_layer}: {e}"))?,
+        "oracle attn",
+    )?;
+    let oracle_post_bytes = last_row(
+        b64.decode(
             oracle_post
                 .get(trace_layer)
                 .ok_or_else(|| anyhow::anyhow!("oracle layer_post_attn_norm_states missing layer {trace_layer}"))?,
         )
-        .map_err(|e| anyhow::anyhow!("decode oracle post-norm for layer {trace_layer}: {e}"))?;
-    let oracle_mlp_bytes = b64
-        .decode(
+        .map_err(|e| anyhow::anyhow!("decode oracle post-norm for layer {trace_layer}: {e}"))?,
+        "oracle post-norm",
+    )?;
+    let oracle_mlp_bytes = last_row(
+        b64.decode(
             oracle_mlp
                 .get(trace_layer)
                 .ok_or_else(|| anyhow::anyhow!("oracle layer_mlp_outputs missing layer {trace_layer}"))?,
         )
-        .map_err(|e| anyhow::anyhow!("decode oracle mlp for layer {trace_layer}: {e}"))?;
-    let oracle_hidden_bytes = b64
-        .decode(
+        .map_err(|e| anyhow::anyhow!("decode oracle mlp for layer {trace_layer}: {e}"))?,
+        "oracle mlp",
+    )?;
+    let oracle_hidden_bytes = last_row(
+        b64.decode(
             oracle_inputs
                 .get(trace_layer)
                 .ok_or_else(|| anyhow::anyhow!("oracle layer_hidden_states missing layer {trace_layer}"))?,
         )
-        .map_err(|e| anyhow::anyhow!("decode oracle hidden for layer {trace_layer}: {e}"))?;
+        .map_err(|e| anyhow::anyhow!("decode oracle hidden for layer {trace_layer}: {e}"))?,
+        "oracle hidden",
+    )?;
 
     engine.set_hidden_from_bytes(&oracle_input_bytes)?;
     let trace = engine.component_trace_full_layer_from_current_hidden_with_seqlen(
@@ -3508,17 +3668,29 @@ fn trace_oracle_prefill_layer(
             "[trace-oracle-prefix-kv] layer={trace_layer} k_delta={k_delta:.6} v_delta={v_delta:.6}"
         );
     }
+    if let (Some(conv_delta), Some(recurrent_delta)) =
+        (native_prefix_conv_delta, native_prefix_recurrent_delta)
+    {
+        eprintln!(
+            "[trace-oracle-prefix-linear] layer={trace_layer} conv_delta={conv_delta:.6} recurrent_delta={recurrent_delta:.6}"
+        );
+    }
 
     if engine.weights().config.is_full_attention(trace_layer)
         && oracle_full.traced_full_attn_layer == Some(trace_layer)
     {
+        let prefix_oracle = if let Some(prefix_oracle) = prefix_oracle.as_ref() {
+            prefix_oracle
+        } else {
+            return Ok(());
+        };
         // `component_trace_full_layer_from_current_hidden()` reuses the mutable
         // component decode path and overwrites slot 0 of the full-attention KV
         // cache for `trace_layer`. Reload the prefix oracle state so the deeper
         // attention trace below sees the original prefix cache, not the
         // trace-mutated one.
         engine.reset()?;
-        engine.load_prefill_state(&prefix_oracle)?;
+        engine.load_prefill_state(prefix_oracle)?;
         let decode_opt_bf16 = |field: &Option<String>, label: &str| -> Result<Vec<f32>> {
             let bytes = b64
                 .decode(field.as_ref().ok_or_else(|| anyhow::anyhow!("oracle output missing {label}"))?)

--- a/crates/runner/src/oracle.rs
+++ b/crates/runner/src/oracle.rs
@@ -57,6 +57,28 @@ pub struct OracleOutput {
     /// validator skip implementing `project_per_layer_inputs` itself.
     #[serde(default)]
     pub per_layer_inputs_by_step: Option<Vec<String>>,
+    #[serde(default)]
+    pub traced_full_attn_layer: Option<usize>,
+    #[serde(default)]
+    pub traced_full_attn_normed: Option<String>,
+    #[serde(default)]
+    pub traced_full_attn_q_proj: Option<String>,
+    #[serde(default)]
+    pub traced_full_attn_gate_proj: Option<String>,
+    #[serde(default)]
+    pub traced_full_attn_k_proj: Option<String>,
+    #[serde(default)]
+    pub traced_full_attn_v_proj: Option<String>,
+    #[serde(default)]
+    pub traced_full_attn_q_rope: Option<String>,
+    #[serde(default)]
+    pub traced_full_attn_k_rope: Option<String>,
+    #[serde(default)]
+    pub traced_full_attn_pre_gate: Option<String>,
+    #[serde(default)]
+    pub traced_full_attn_gated: Option<String>,
+    #[serde(default)]
+    pub traced_full_attn_gated_actual: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -85,6 +107,7 @@ pub fn run_oracle(
     device: &str,
     emit_state: bool,
     fp8_model_dir: Option<&Path>,
+    trace_full_attn_layer: Option<usize>,
 ) -> Result<OracleOutput> {
     let ids_str = prompt_ids
         .iter()
@@ -105,9 +128,15 @@ pub fn run_oracle(
     if let Some(dir) = fp8_model_dir {
         cmd.arg("--fp8-model-dir").arg(dir);
     }
+    if let Some(layer) = trace_full_attn_layer {
+        cmd.arg("--trace-full-attn-layer").arg(layer.to_string());
+    }
 
     let fp8_flag = fp8_model_dir.map(|d| format!(" --fp8-model-dir {}", d.display())).unwrap_or_default();
-    eprintln!("[oracle] running: python3 {} --model-id {model_id} --prompt-ids {ids_str} --max-new-tokens {max_new_tokens} --dtype {dtype} --device {device}{}{fp8_flag}",
+    let trace_flag = trace_full_attn_layer
+        .map(|layer| format!(" --trace-full-attn-layer {layer}"))
+        .unwrap_or_default();
+    eprintln!("[oracle] running: python3 {} --model-id {model_id} --prompt-ids {ids_str} --max-new-tokens {max_new_tokens} --dtype {dtype} --device {device}{}{fp8_flag}{trace_flag}",
         oracle_script.display(),
         if emit_state { " --emit-state" } else { "" }
     );

--- a/crates/runner/src/prefill_engine.rs
+++ b/crates/runner/src/prefill_engine.rs
@@ -10,7 +10,7 @@ use gpu_hal::{GpuBuffer, ScalarType};
 
 use qwen35::config::TextConfig;
 use qwen35::rotary::RotaryTables;
-use qwen35::state::{kv_fp8_bf16_sidecar_enabled, ModelState};
+use qwen35::state::{kv_fp8_bf16_sidecar_enabled, kv_fp8_bf16_sidecar_window_tokens, ModelState};
 use qwen35::weights::Qwen35Weights;
 
 use kernel_ffi::prefill_ffi;
@@ -813,7 +813,9 @@ pub fn convert_kv_caches_to_fp8(
         if kv_fp8_bf16_sidecar_enabled() {
             ls.kv_shadow_k = Some(bf16_k);
             ls.kv_shadow_v = Some(bf16_v);
-            ls.kv_shadow_start = 0;
+            ls.kv_shadow_start = kv_fp8_bf16_sidecar_window_tokens()
+                .map(|window| kv_len.saturating_sub(window))
+                .unwrap_or(0);
         } else {
             ls.kv_shadow_k = None;
             ls.kv_shadow_v = None;

--- a/crates/runner/src/prefill_engine.rs
+++ b/crates/runner/src/prefill_engine.rs
@@ -97,7 +97,7 @@ pub fn compute_logits_for_range(
     config: &TextConfig,
     start: usize,
     count: usize,
-    use_4b_kernel: bool,
+    _use_4b_kernel: bool,
     ordinal: usize,
 ) -> Result<(Vec<Vec<f32>>, GpuBuffer)> {
     if count == 0 {
@@ -129,11 +129,12 @@ pub fn compute_logits_for_range(
     )
     .map_err(|e| anyhow::anyhow!("range final norm: {e}"))?;
 
-    // lm_head projection. For count=1 the standalone matvec is competitive with
-    // the tiled path on gfx1150; for count>1 we must use the tiled matmul.
+    // lm_head projection. For count=1, prefer the standalone matvec even on
+    // 4B-capable models: it avoids the tiled matmul path's extra packing and
+    // keeps the single-row score path numerically aligned with decode.
     let mut logits_buf = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[count, vocab_size])
         .map_err(|e| anyhow::anyhow!("range logits alloc: {e}"))?;
-    if use_4b_kernel || count > 1 {
+    if count > 1 {
         kernel_ffi::matmul_rhs_transposed_4b(
             ordinal, ScalarType::BF16,
             1,         // batch

--- a/crates/runner/src/prefill_engine.rs
+++ b/crates/runner/src/prefill_engine.rs
@@ -705,15 +705,11 @@ fn prefill_inner(
         ordinal,
     )?;
     let logits = logits_per_pos.pop().expect("count=1 produces exactly one row");
-    let final_norm_trace = if trace_layers {
-        Some(
-            normed_last
-                .to_host_bytes()
-                .map_err(|e| anyhow::anyhow!("final norm D2H: {e}"))?,
-        )
-    } else {
-        None
-    };
+    let final_norm_trace = Some(
+        normed_last
+            .to_host_bytes()
+            .map_err(|e| anyhow::anyhow!("final norm D2H: {e}"))?,
+    );
 
     // Post-prefill: convert BF16 KV caches to FP8 if requested.
     // During prefill we use BF16 KV so the attention kernel can read them directly.

--- a/crates/runner/src/registry.rs
+++ b/crates/runner/src/registry.rs
@@ -250,11 +250,43 @@ static REGISTRY: &[RegistryEntry] = &[
         }),
     },
     RegistryEntry {
+        model: ModelVariant::Qwen3_5_2B,
+        backend: Backend::Cuda,
+        arch: GpuArch::Sm86,
+        vram: VramBudget {
+            fixed_bytes: 5 * GIB,
+            overhead_factor: 1.1,
+        },
+        params: FamilyParams::Qwen35(Qwen35KernelParams {
+            proj_buf_floats: 8224,
+            attn_scratch_floats: 16384,
+            weight_prefix: "model.language_model",
+            kv_chunk_size: 256,
+            use_4b_kernel: true,
+        }),
+    },
+    RegistryEntry {
         model: ModelVariant::Qwen3_5_4B,
         backend: Backend::Cuda,
         arch: GpuArch::Sm86,
         vram: VramBudget {
             fixed_bytes: 10 * GIB,
+            overhead_factor: 1.1,
+        },
+        params: FamilyParams::Qwen35(Qwen35KernelParams {
+            proj_buf_floats: 12352,
+            attn_scratch_floats: 16384,
+            weight_prefix: "model.language_model",
+            kv_chunk_size: 256,
+            use_4b_kernel: true,
+        }),
+    },
+    RegistryEntry {
+        model: ModelVariant::Qwen3_5_9B,
+        backend: Backend::Cuda,
+        arch: GpuArch::Sm86,
+        vram: VramBudget {
+            fixed_bytes: 18 * GIB,
             overhead_factor: 1.1,
         },
         params: FamilyParams::Qwen35(Qwen35KernelParams {
@@ -343,4 +375,25 @@ pub fn supported_archs_for(model: &ModelVariant, backend: &Backend) -> Vec<Strin
         .filter(|e| e.model == *model && e.backend == *backend)
         .map(|e| e.arch.to_string())
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cuda_sm86_qwen_registry_includes_2b_and_9b() {
+        assert!(lookup(
+            &ModelVariant::Qwen3_5_2B,
+            &Backend::Cuda,
+            &GpuArch::Sm86,
+        )
+        .is_some());
+        assert!(lookup(
+            &ModelVariant::Qwen3_5_9B,
+            &Backend::Cuda,
+            &GpuArch::Sm86,
+        )
+        .is_some());
+    }
 }

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -39,23 +39,34 @@ set — add them here when next measured.
 
 ## CUDA — `sm86` (NVIDIA RTX 3090-class)
 
-24 GB VRAM, 936 GB/s memory bandwidth. Current behavior depends on whether
-the path is using replayed prefill for correctness.
+24 GB VRAM, 936 GB/s memory bandwidth. Measurements below were refreshed on
+2026-04-22 at commit `5a34190`.
 
 Quick checked paths (`PROMPT_REPEAT=8`, `MAX_NEW_TOKENS=8`, `RUNS=1`):
 
 | Model                       | Path                         | Prefill   | Decode     |
 |----------------------------|------------------------------|-----------|------------|
-| qwen3.5-0.8b              | default (hero)               | 563 tok/s | 29.9 tok/s |
-| qwen3.5-4b `--batch-size 2` | default (batched)            | 124 tok/s | 21.6 tok/s |
-| qwen3.5-4b `--batch-size 1` | replay-prefill correctness   | 124 tok/s | 1.1 tok/s  |
+| qwen3.5-0.8b              | default (hero)               | 544 tok/s | 106.7 tok/s |
+| qwen3.5-4b `--batch-size 1` | default (single kernel)      | 124.7 tok/s | 26.0 tok/s |
+| qwen3.5-4b `--batch-size 2` | default (batched kernel)     | 122.9 tok/s | 15.4 tok/s¹ |
 
 Warmed native single-stream `4B` hero lane
-(`./tests/sm86/bench_qwen4b_single.sh`, `pp533 / tg128`, commit `e5f244d`):
+(`./tests/sm86/bench_qwen4b_single.sh`, `pp533 / tg16`, commit `5a34190`):
 
 | Model                       | Path                    | Prefill   | Decode     | Persistent |
 |----------------------------|-------------------------|-----------|------------|------------|
-| qwen3.5-4b `--batch-size 1` | `--force-kernel-decode` | 118.5 tok/s | 15.2 tok/s | 7714 ms    |
+| qwen3.5-4b `--batch-size 1` | `--force-kernel-decode` | 101.5 tok/s | 22.0 tok/s | 654.6 ms   |
+
+Notes:
+
+- `qwen3.5-4b` batch-1 CUDA decode now defaults to the kernel path. The older
+  replayed-prefill decode path is legacy debugging behavior and must be
+  requested explicitly with `--force-replay-decode`.
+- The warmed `4B` hero-lane benchmark above also recorded these stage means:
+  `full_attn_core=121.1 ms`, `linear_proj=35.1 ms`, `linear_out=78.7 ms`,
+  `mlp_gate_up=160.6 ms`, `mlp_down=212.9 ms`.
+- ¹ The batched decode figure is aggregate tokens/second across
+  `--batch-size 2`.
 
 CUDA `sm86` tracks detailed kernel-level optimization history for both the
 `0.8B` and `4B` hero lanes in
@@ -76,4 +87,8 @@ cargo build --release --bin supersonic
 # CUDA / sm86
 SUPERSONIC_BACKENDS=cuda ./tests/sm86/bench.sh \
   /path/to/Qwen3.5-0.8B /path/to/Qwen3.5-4B
+
+# CUDA / sm86 warmed 4B single-sequence hero lane
+SUPERSONIC_BACKENDS=cuda ./tests/sm86/bench_qwen4b_single.sh \
+  /path/to/Qwen3.5-4B
 ```

--- a/docs/qwen35-sm86-optimization.md
+++ b/docs/qwen35-sm86-optimization.md
@@ -208,15 +208,15 @@ Exact lane:
 
 Current best verified commit:
 
-- `e5f244d` `Specialize qwen4b sm86 single-stream decode`
+- `d8124c8` `cuda: parallelize qwen35 4b recurrent head pairs`
 
 Current warmed result on this box:
 
-- prefill: `118.5 tok/s`
-- decode: `15.2 tok/s`
-- decode wall time: `8443.0 ms`
-- persistent decode stage: `7714.213 ms`
-- `linear_core_recurrent`: `3080.145 ms`
+- prefill: `119.0 tok/s`
+- decode: `19.9 tok/s`
+- decode wall time: `804.7 ms`
+- persistent decode stage: `731.951 ms`
+- `linear_core_recurrent`: `24.775 ms`
 
 Validated behavior at this checkpoint:
 
@@ -233,15 +233,15 @@ Kept progression on the `4B` hero lane:
 | `db26c08` | parallelize the single-stream full-attention hero schedule across warps | established the first kept 4B attention-side win |
 | `553c292` | trim recurrent-state traffic in the serial linear-attention core | reduced warmed `linear_core` and persistent time |
 | `e5f244d` | add a true CUDA-only single-stream BF16 specialized 4B kernel entrypoint | improved warmed decode from about `14.5 tok/s` to `15.2 tok/s` |
+| `d8124c8` | parallelize recurrent head-pair work across hero blocks | improved warmed decode to about `19.9 tok/s` and cut `linear_core_recurrent` to about `24.8 ms` |
 
 What the latest kept pass changed structurally:
 
-- added a dedicated CUDA-only 4B specialized bridge for the exact single-stream
-  BF16 lane
-- compiled out dead batch / FP8 / INT4 / trace control flow for that
-  instantiation
-- reduced the specialized kernel resource line from `REG:175 STACK:128` to
-  `REG:147 STACK:0`
+- moved the single-stream BF16 hero recurrent update from one block onto a
+  head-pair-per-block schedule
+- kept the generic block-0-only recurrent implementation as the fallback path
+- disabled the decayless-store shortcut only in the cross-block recurrent hero
+  split, where it was not numerically safe enough
 
 Things tried on the `4B` hero lane and not kept:
 
@@ -255,10 +255,11 @@ Things tried on the `4B` hero lane and not kept:
 Current 4B bottleneck read:
 
 - the dominant remaining cost is still inside the persistent kernel
-- `linear_core_recurrent` is still the largest single timing bucket
-- after ruling out a few “cleaner SASS” recurrent rewrites, the next likely
-  meaningful gain is a different lever, not more of the same register-pruning
-  inside that loop
+- the recurrent bottleneck is no longer dominant after `d8124c8`
+- the biggest remaining timing buckets are now `mlp_down`, `mlp_gate_up`,
+  `full_attn_core`, `linear_proj`, and `linear_out`
+- the next likely win is another hero-lane scheduling change on one of those
+  wide row-dot families, not more surgery on the recurrent body
 
 ## Commands
 

--- a/docs/qwen35-sm86-optimization.md
+++ b/docs/qwen35-sm86-optimization.md
@@ -14,7 +14,7 @@ Current hero lanes:
 - backend: CUDA
 - arch: `sm86`
 - `qwen3.5-0.8b`: batch-1, BF16, normal generation
-- `qwen3.5-4b`: batch-1, BF16, baked load, `--force-kernel-decode`
+- `qwen3.5-4b`: batch-1, BF16, baked load, native single-kernel decode
 
 These lanes are intentionally specialized. Validation, tracing, replay-based
 correctness, and other models still keep their fallback paths.
@@ -208,15 +208,16 @@ Exact lane:
 
 Current best verified commit:
 
-- `d8124c8` `cuda: parallelize qwen35 4b recurrent head pairs`
+- `5a34190` `cuda: cache qwen35 4b hero inputs in bf16`
 
 Current warmed result on this box:
 
-- prefill: `119.0 tok/s`
-- decode: `19.9 tok/s`
-- decode wall time: `804.7 ms`
-- persistent decode stage: `731.951 ms`
-- `linear_core_recurrent`: `24.775 ms`
+- prefill: `101.5 tok/s`
+- decode: `22.0 tok/s`
+- decode wall time: `727.0 ms`
+- persistent decode stage: `654.628 ms`
+- `linear_proj`: `35.132 ms`
+- `linear_core_recurrent`: `24.803 ms`
 
 Validated behavior at this checkpoint:
 
@@ -234,14 +235,16 @@ Kept progression on the `4B` hero lane:
 | `553c292` | trim recurrent-state traffic in the serial linear-attention core | reduced warmed `linear_core` and persistent time |
 | `e5f244d` | add a true CUDA-only single-stream BF16 specialized 4B kernel entrypoint | improved warmed decode from about `14.5 tok/s` to `15.2 tok/s` |
 | `d8124c8` | parallelize recurrent head-pair work across hero blocks | improved warmed decode to about `19.9 tok/s` and cut `linear_core_recurrent` to about `24.8 ms` |
+| `5a34190` | cache single-stream 4B hero inputs in BF16 shared memory for `linear_proj` | improved warmed decode to about `22.0 tok/s` and cut `linear_proj` to about `35.1 ms` |
 
 What the latest kept pass changed structurally:
 
-- moved the single-stream BF16 hero recurrent update from one block onto a
-  head-pair-per-block schedule
-- kept the generic block-0-only recurrent implementation as the fallback path
-- disabled the decayless-store shortcut only in the cross-block recurrent hero
-  split, where it was not numerically safe enough
+- added a BF16 shared-activation cache for the single-stream 4B hero
+  `linear_proj` family
+- moved the single-stream BF16 hero `linear_proj` rows onto a warp-per-row dot
+  path instead of a full-block reduction
+- extended the specialized 4B CUDA bridge shared-memory sizing so the hero
+  BF16 cache fits correctly on launch
 
 Things tried on the `4B` hero lane and not kept:
 
@@ -251,13 +254,21 @@ Things tried on the `4B` hero lane and not kept:
   wall-clock decode
 - corrected single-stream BF16 MLP specializations that still regressed the
   short warmed lane
+- BF16-cache warp-per-row rewrites for `mlp_gate_up`, `mlp_down`, and
+  `linear_out`
+  - produced attractive local timing deltas
+  - did not meet the parity gate (`decode_max_delta` rose to about `5-8` on the
+    `Hello` smoke prompt, and the `mlp_down`-only cut changed generated tokens)
+  - reverted rather than carried as a “fast but wrong” path
 
 Current 4B bottleneck read:
 
 - the dominant remaining cost is still inside the persistent kernel
 - the recurrent bottleneck is no longer dominant after `d8124c8`
 - the biggest remaining timing buckets are now `mlp_down`, `mlp_gate_up`,
-  `full_attn_core`, `linear_proj`, and `linear_out`
+  `full_attn_core`, and `linear_out`
+- the easy 0.8B-style warp-reduction copy path is not numerically free on 4B;
+  future work should be trace-driven rather than blind hero-path cloning
 - the next likely win is another hero-lane scheduling change on one of those
   wide row-dot families, not more surgery on the recurrent body
 

--- a/kernels/full_attention.hip
+++ b/kernels/full_attention.hip
@@ -62,6 +62,8 @@ struct Qwen35DecodeLayerDesc {
     void* kv_shadow_k;                 // optional BF16 KV sidecar for KV-FP8 bring-up / parity-sensitive reads
     void* kv_shadow_v;                 // optional BF16 KV sidecar for KV-FP8 bring-up / parity-sensitive reads
     int kv_shadow_start;               // first position covered by the sidecar, -1 when disabled
+    void* debug_linear_trace_out;      // optional F32[(kern-1)+2] export for one linear channel's Step-B state
+    int debug_linear_trace_channel;    // selected linear channel for debug_linear_trace_out, -1 disables
 };
 
 template <typename T>
@@ -3127,4 +3129,3 @@ __device__ inline void block_rms_norm_global(
     }
     __syncthreads();
 }
-

--- a/kernels/full_attention_4b.hip
+++ b/kernels/full_attention_4b.hip
@@ -82,6 +82,8 @@ struct Qwen35DecodeLayerDesc {
     void* kv_shadow_k;                 // optional BF16 KV sidecar for KV-FP8 bring-up / parity-sensitive reads
     void* kv_shadow_v;                 // optional BF16 KV sidecar for KV-FP8 bring-up / parity-sensitive reads
     int kv_shadow_start;               // first position covered by the sidecar, -1 when disabled
+    void* debug_linear_trace_out;      // optional F32[(kern-1)+2] export for one linear channel's Step-B state
+    int debug_linear_trace_channel;    // selected linear channel for debug_linear_trace_out, -1 disables
 };
 
 // =============================================================================
@@ -4864,6 +4866,17 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
                             cs[c * (kern-1) + t] = cs[c * (kern-1) + t + 1];
                         }
                         cs[c * (kern-1) + (kern-2)] = qkv_bf16;
+
+                        if (L.debug_linear_trace_out != nullptr &&
+                            c == L.debug_linear_trace_channel) {
+                            float* debug = static_cast<float*>(L.debug_linear_trace_out);
+                            const int state_base = c * (kern - 1);
+                            for (int t = 0; t < kern - 1; ++t) {
+                                debug[t] = dotcache_qwen35_to_float(cs[state_base + t]);
+                            }
+                            debug[kern - 1] = dotcache_qwen35_to_float(qkv_bf16);
+                            debug[kern] = conv_out[c];
+                        }
                     }
                     __syncthreads();
 

--- a/kernels/full_attention_4b.hip
+++ b/kernels/full_attention_4b.hip
@@ -4282,9 +4282,9 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
                     const size_t cos_off =
                         static_cast<size_t>(seq_off_b) * half_rot;
 
-                    if (tid < nh * half_rot) {
-                        const int h = tid / half_rot;
-                        const int i = tid % half_rot;
+                    for (int idx = tid; idx < nh * half_rot; idx += bs) {
+                        const int h = idx / half_rot;
+                        const int i = idx % half_rot;
                         float* qh = q_f32 + h * hd * 2;
                         float c = dotcache_qwen35_to_float(cos_table[cos_off + i]);
                         float s = dotcache_qwen35_to_float(sin_table[cos_off + i]);
@@ -4295,9 +4295,9 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
                     }
                     __syncthreads();
 
-                    if (tid < nkv * half_rot) {
-                        const int h = tid / half_rot;
-                        const int i = tid % half_rot;
+                    for (int idx = tid; idx < nkv * half_rot; idx += bs) {
+                        const int h = idx / half_rot;
+                        const int i = idx % half_rot;
                         float* kh = k_f32 + h * hd;
                         float c = dotcache_qwen35_to_float(cos_table[cos_off + i]);
                         float s = dotcache_qwen35_to_float(sin_table[cos_off + i]);

--- a/kernels/full_attention_4b_cuda.cuh
+++ b/kernels/full_attention_4b_cuda.cuh
@@ -5345,7 +5345,7 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
                                 __syncthreads();
                             }
                             if (tid == 0)
-                                proj_buf[b * proj_buf_floats + sr] = bf16_round_rne_f32_finite(lds[0]);
+                                proj_buf[b * proj_buf_floats + sr] = lds[0];
                             __syncthreads();
                         }
                     }

--- a/kernels/full_attention_4b_cuda.cuh
+++ b/kernels/full_attention_4b_cuda.cuh
@@ -4490,7 +4490,6 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
                     const T* cv = static_cast<const T*>(kv_v_b);
                     const size_t kv_head_base =
                         static_cast<size_t>(kvh) * kv_max_b * hd;
-
                     float my_acc = 0.0f;
                     float my_max = -1e30f;
                     float my_sum = 0.0f;
@@ -5007,7 +5006,6 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
                         for (int qh = 0; qh < nh; ++qh) {
                             const int kvh = qh / kv_groups;
                             const float* q_head = q_f32 + qh * hd * 2;
-
                             float my_acc = 0.0f;
                             float my_max = -1e30f;
                             float my_sum = 0.0f;
@@ -5257,7 +5255,7 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
                             __syncthreads();
                         }
                         if (tid == 0)
-                            proj_buf[sr] = bf16_round_rne_f32_finite(lds[0]);
+                            proj_buf[sr] = lds[0];
                         __syncthreads();
                     } else {
                     const void* w_raw;

--- a/kernels/full_attention_4b_cuda.cuh
+++ b/kernels/full_attention_4b_cuda.cuh
@@ -4606,9 +4606,9 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
                     const size_t cos_off =
                         static_cast<size_t>(seq_off_b) * half_rot;
 
-                    if (tid < nh * half_rot) {
-                        const int h = tid / half_rot;
-                        const int i = tid % half_rot;
+                    for (int idx = tid; idx < nh * half_rot; idx += bs) {
+                        const int h = idx / half_rot;
+                        const int i = idx % half_rot;
                         float* qh = q_f32 + h * hd * 2;
                         float c = dotcache_qwen35_to_float(cos_table[cos_off + i]);
                         float s = dotcache_qwen35_to_float(sin_table[cos_off + i]);
@@ -4619,9 +4619,9 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
                     }
                     __syncthreads();
 
-                    if (tid < nkv * half_rot) {
-                        const int h = tid / half_rot;
-                        const int i = tid % half_rot;
+                    for (int idx = tid; idx < nkv * half_rot; idx += bs) {
+                        const int h = idx / half_rot;
+                        const int i = idx % half_rot;
                         float* kh = k_f32 + h * hd;
                         float c = dotcache_qwen35_to_float(cos_table[cos_off + i]);
                         float s = dotcache_qwen35_to_float(sin_table[cos_off + i]);

--- a/kernels/full_attention_4b_cuda.cuh
+++ b/kernels/full_attention_4b_cuda.cuh
@@ -3967,7 +3967,10 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
     const int nb = gridDim.x;
     constexpr bool hero_specialized = SINGLE_STREAM_BF16_SPECIALIZED;
     const int B = hero_specialized ? 1 : batch_size;
-    const bool emit_attention_trace = hero_specialized ? false : (enable_attention_trace != 0);
+    // Keep the hot single-stream hero path unchanged for normal execution, but
+    // allow debug tracing to force the trace-capable fallback path in this same
+    // kernel so the exported attention scratch is valid on 4B CUDA.
+    const bool emit_attention_trace = (enable_attention_trace != 0);
     const bool runtime_qwen35_4b_shape =
         hidden_dim == 2560 &&
         intermediate_size == 9216 &&

--- a/kernels/full_attention_4b_cuda.cuh
+++ b/kernels/full_attention_4b_cuda.cuh
@@ -3804,6 +3804,44 @@ __device__ inline float wave_reduce_sum_f32(float val) {
     return val;
 }
 
+template <typename T>
+__device__ inline float dotcache_qwen35_dot_row_input_bf16_warp_hero_4b(
+    const T* lhs,
+    const T* rhs,
+    int size
+) {
+    float dot = 0.0f;
+    const int lane = threadIdx.x & (warpSize - 1);
+    for (int idx = lane; idx < size; idx += warpSize) {
+        dot += dotcache_qwen35_to_float(lhs[idx]) * dotcache_qwen35_to_float(rhs[idx]);
+    }
+    return wave_reduce_sum_f32(dot);
+}
+
+template <>
+__device__ inline float dotcache_qwen35_dot_row_input_bf16_warp_hero_4b<hip_bfloat16>(
+    const hip_bfloat16* lhs,
+    const hip_bfloat16* rhs,
+    int size
+) {
+    float dot = 0.0f;
+    const int lane = threadIdx.x & (warpSize - 1);
+    for (int idx = lane * 2; idx + 1 < size; idx += warpSize * 2) {
+        const __nv_bfloat162 packed_lhs =
+            *reinterpret_cast<const __nv_bfloat162*>(lhs + idx);
+        const __nv_bfloat162 packed_rhs =
+            *reinterpret_cast<const __nv_bfloat162*>(rhs + idx);
+        const float2 w = __bfloat1622float2(packed_lhs);
+        const float2 x = __bfloat1622float2(packed_rhs);
+        dot += w.x * x.x + w.y * x.y;
+    }
+    if ((size & 1) != 0 && lane == 0) {
+        dot += dotcache_qwen35_to_float(lhs[size - 1]) *
+               dotcache_qwen35_to_float(rhs[size - 1]);
+    }
+    return wave_reduce_sum_f32(dot);
+}
+
 // Packed 2×BF16 vector type for v_dot2_f32_bf16 instruction.
 // On GFX11 (RDNA 3.0+), v_dot2_f32_bf16 computes:
 //   acc += (a.x * b.x) + (a.y * b.y)  where a,b are packed BF16 pairs
@@ -4001,7 +4039,8 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
     float* proj_buf     = token_out + B * hidden_dim;                    // [B * proj_buf_floats]
     float* attn_scratch = proj_buf + B * proj_buf_floats;                // [B * attn_scratch_floats]
 
-    extern __shared__ float lds[];
+    extern __shared__ __align__(16) unsigned char shared_raw[];
+    float* lds = reinterpret_cast<float*>(shared_raw);
     // LDS layout: lds[0..bs-1] = reduction scratch, lds[bs..] = input vector cache (F32)
     float* lds_input = lds + bs;
 
@@ -4010,6 +4049,9 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
     // LDS is sized by the bridge as: block_size + max(B*hidden_dim, intermediate_size).
     // The LUT sits after the input cache region.
     const int lds_input_size = (B * hidden_dim > intermediate_size) ? B * hidden_dim : intermediate_size;
+    T* lds_input_bf16 = hero_specialized
+        ? reinterpret_cast<T*>(lds_input + lds_input_size)
+        : nullptr;
     float* fp8_lut = hero_specialized ? nullptr : (lds + bs + lds_input_size);
 
     // Populate FP8 LUT: thread i fills entry i (256 threads → 256 entries, one pass).
@@ -5256,16 +5298,18 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
             const int nv_heads = L.linear_num_v_heads;
             const int total_proj = L.qkv_out_dim + L.z_out_dim + nv_heads + nv_heads;
             {
-                for (;;) {
-                    unsigned int sr;
-                    if (tid == 0) sr = atomicAdd(&counters[0], 1u);
-                    __shared__ unsigned int shared_sr;
-                    if (tid == 0) shared_sr = sr;
+                if constexpr (SINGLE_STREAM_BF16_SPECIALIZED) {
+                    for (int c = tid; c < hidden_dim; c += bs) {
+                        lds_input_bf16[c] = dotcache_qwen35_from_float<T>(lds_input[c]);
+                    }
                     __syncthreads();
-                    sr = shared_sr;
-                    if (sr >= static_cast<unsigned int>(total_proj)) break;
 
-                    if constexpr (SINGLE_STREAM_BF16_SPECIALIZED) {
+                    const int lane_p = tid & (warpSize - 1);
+                    const int warp_p = tid / warpSize;
+                    const int warps_per_block = bs / warpSize;
+                    for (int sr = blockIdx.x * warps_per_block + warp_p;
+                         sr < total_proj;
+                         sr += nb * warps_per_block) {
                         const T* w_rows;
                         int row;
                         if (sr < static_cast<unsigned int>(L.qkv_out_dim)) {
@@ -5282,108 +5326,102 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
                             row = sr - L.qkv_out_dim - L.z_out_dim - nv_heads;
                         }
                         const T* wr = w_rows + static_cast<size_t>(row) * hidden_dim;
-                        float p = 0.0f;
-                        const int vd4 = hidden_dim & ~3;
-                        for (int c = tid * 4; c < vd4; c += bs * 4) {
-                            float w0 = dotcache_qwen35_to_float(wr[c]);
-                            float w1 = dotcache_qwen35_to_float(wr[c+1]);
-                            float w2 = dotcache_qwen35_to_float(wr[c+2]);
-                            float w3 = dotcache_qwen35_to_float(wr[c+3]);
-                            p += w0 * lds_input[c] + w1 * lds_input[c+1] + w2 * lds_input[c+2] + w3 * lds_input[c+3];
-                        }
-                        for (int c = vd4 + tid; c < hidden_dim; c += bs) {
-                            float w = dotcache_qwen35_to_float(wr[c]);
-                            p += w * lds_input[c];
-                        }
-                        lds[tid] = p;
-                        __syncthreads();
-                        for (int stride = bs / 2; stride > 0; stride >>= 1) {
-                            if (tid < stride) lds[tid] += lds[tid + stride];
-                            __syncthreads();
-                        }
-                        if (tid == 0)
-                            proj_buf[sr] = lds[0];
-                        __syncthreads();
-                    } else {
-                    const void* w_raw;
-                    const void* w_scale = nullptr;
-                    const void* w_i4_scale = nullptr;
-                    const void* w_i4_zero = nullptr;
-                    int row;
-                    if (sr < static_cast<unsigned int>(L.qkv_out_dim)) {
-                        w_raw = L.qkv_proj_w;
-                        row = sr;
-                        if (fp8_scales) w_scale = fp8_scales[layer].qkv_proj_scale;
-                        if (int4_scales) { w_i4_scale = int4_scales[layer].qkv_proj_scale; w_i4_zero = int4_scales[layer].qkv_proj_zero; }
-                    } else if (sr < static_cast<unsigned int>(L.qkv_out_dim + L.z_out_dim)) {
-                        w_raw = L.z_proj_w;
-                        row = sr - L.qkv_out_dim;
-                        if (fp8_scales) w_scale = fp8_scales[layer].z_proj_scale;
-                        if (int4_scales) { w_i4_scale = int4_scales[layer].z_proj_scale; w_i4_zero = int4_scales[layer].z_proj_zero; }
-                    } else if (sr < static_cast<unsigned int>(L.qkv_out_dim + L.z_out_dim + nv_heads)) {
-                        w_raw = L.b_proj_w;
-                        row = sr - L.qkv_out_dim - L.z_out_dim;
-                        if (fp8_scales) w_scale = fp8_scales[layer].b_proj_scale;
-                        // b_proj: keep BF16 (only 16 rows, no INT4)
-                    } else {
-                        w_raw = L.a_proj_w;
-                        row = sr - L.qkv_out_dim - L.z_out_dim - nv_heads;
-                        if (fp8_scales) w_scale = fp8_scales[layer].a_proj_scale;
-                        // a_proj: keep BF16 (only 16 rows, no INT4)
+                        const float sum =
+                            dotcache_qwen35_dot_row_input_bf16_warp_hero_4b(
+                                wr, lds_input_bf16, hidden_dim);
+                        if (lane_p == 0)
+                            proj_buf[sr] = sum;
                     }
+                    __syncthreads();
+                } else {
+                    for (;;) {
+                        unsigned int sr;
+                        if (tid == 0) sr = atomicAdd(&counters[0], 1u);
+                        __shared__ unsigned int shared_sr;
+                        if (tid == 0) shared_sr = sr;
+                        __syncthreads();
+                        sr = shared_sr;
+                        if (sr >= static_cast<unsigned int>(total_proj)) break;
 
-                    float p[MAX_BATCH_SIZE];
-                    for (int b = 0; b < B; b++) p[b] = 0.0f;
-                    if (int4_scales != nullptr && w_i4_scale != nullptr) {
-                        // INT4 dequant path for qkv/z projections
-                        const int gsz = int4_scales[layer].group_size;
-                        const int byte_cols = hidden_dim / 2;
-                        const uint8_t* i4_row = static_cast<const uint8_t*>(w_raw) + static_cast<size_t>(row) * byte_cols;
-                        const hip_bfloat16* sc = static_cast<const hip_bfloat16*>(w_i4_scale);
-                        const hip_bfloat16* zr = static_cast<const hip_bfloat16*>(w_i4_zero);
-                        const int sr_g = row / gsz;
-                        const int sc_cols = (hidden_dim + gsz - 1) / gsz;
-                        const int vd8 = hidden_dim & ~7;
-                        for (int c = tid * 8; c < vd8; c += bs * 8) {
-                            uint32_t pk = *reinterpret_cast<const uint32_t*>(&i4_row[c / 2]);
-                            float w[8];
-                            int4_dequant_8(pk, sc, zr, sr_g, c, sc_cols, gsz, w);
-                            for (int b = 0; b < B; b++) {
-                                const float* inp = lds_input + b * hidden_dim + c;
-                                p[b] += w[0]*inp[0] + w[1]*inp[1] + w[2]*inp[2] + w[3]*inp[3]
-                                      + w[4]*inp[4] + w[5]*inp[5] + w[6]*inp[6] + w[7]*inp[7];
+                        const void* w_raw;
+                        const void* w_scale = nullptr;
+                        const void* w_i4_scale = nullptr;
+                        const void* w_i4_zero = nullptr;
+                        int row;
+                        if (sr < static_cast<unsigned int>(L.qkv_out_dim)) {
+                            w_raw = L.qkv_proj_w;
+                            row = sr;
+                            if (fp8_scales) w_scale = fp8_scales[layer].qkv_proj_scale;
+                            if (int4_scales) { w_i4_scale = int4_scales[layer].qkv_proj_scale; w_i4_zero = int4_scales[layer].qkv_proj_zero; }
+                        } else if (sr < static_cast<unsigned int>(L.qkv_out_dim + L.z_out_dim)) {
+                            w_raw = L.z_proj_w;
+                            row = sr - L.qkv_out_dim;
+                            if (fp8_scales) w_scale = fp8_scales[layer].z_proj_scale;
+                            if (int4_scales) { w_i4_scale = int4_scales[layer].z_proj_scale; w_i4_zero = int4_scales[layer].z_proj_zero; }
+                        } else if (sr < static_cast<unsigned int>(L.qkv_out_dim + L.z_out_dim + nv_heads)) {
+                            w_raw = L.b_proj_w;
+                            row = sr - L.qkv_out_dim - L.z_out_dim;
+                            if (fp8_scales) w_scale = fp8_scales[layer].b_proj_scale;
+                            // b_proj: keep BF16 (only 16 rows, no INT4)
+                        } else {
+                            w_raw = L.a_proj_w;
+                            row = sr - L.qkv_out_dim - L.z_out_dim - nv_heads;
+                            if (fp8_scales) w_scale = fp8_scales[layer].a_proj_scale;
+                            // a_proj: keep BF16 (only 16 rows, no INT4)
+                        }
+
+                        float p[MAX_BATCH_SIZE];
+                        for (int b = 0; b < B; b++) p[b] = 0.0f;
+                        if (int4_scales != nullptr && w_i4_scale != nullptr) {
+                            // INT4 dequant path for qkv/z projections
+                            const int gsz = int4_scales[layer].group_size;
+                            const int byte_cols = hidden_dim / 2;
+                            const uint8_t* i4_row = static_cast<const uint8_t*>(w_raw) + static_cast<size_t>(row) * byte_cols;
+                            const hip_bfloat16* sc = static_cast<const hip_bfloat16*>(w_i4_scale);
+                            const hip_bfloat16* zr = static_cast<const hip_bfloat16*>(w_i4_zero);
+                            const int sr_g = row / gsz;
+                            const int sc_cols = (hidden_dim + gsz - 1) / gsz;
+                            const int vd8 = hidden_dim & ~7;
+                            for (int c = tid * 8; c < vd8; c += bs * 8) {
+                                uint32_t pk = *reinterpret_cast<const uint32_t*>(&i4_row[c / 2]);
+                                float w[8];
+                                int4_dequant_8(pk, sc, zr, sr_g, c, sc_cols, gsz, w);
+                                for (int b = 0; b < B; b++) {
+                                    const float* inp = lds_input + b * hidden_dim + c;
+                                    p[b] += w[0]*inp[0] + w[1]*inp[1] + w[2]*inp[2] + w[3]*inp[3]
+                                          + w[4]*inp[4] + w[5]*inp[5] + w[6]*inp[6] + w[7]*inp[7];
+                                }
+                            }
+                            for (int c = vd8 + tid; c < hidden_dim; c += bs) {
+                                float w = int4_dequant_scalar(w_raw, w_i4_scale, w_i4_zero, row, c, hidden_dim, gsz);
+                                for (int b = 0; b < B; b++)
+                                    p[b] += w * lds_input[b * hidden_dim + c];
+                            }
+                        } else if (fp8_scales != nullptr && w_scale != nullptr) {
+                            for (int c = tid; c < hidden_dim; c += bs) {
+                                float w = fp8_dequant_weight_lut(w_raw, w_scale, row, c, hidden_dim, fp8_scales[layer].block_size, fp8_lut);
+                                for (int b = 0; b < B; b++)
+                                    p[b] += w * lds_input[b * hidden_dim + c];
+                            }
+                        } else {
+                            const T* wr = static_cast<const T*>(w_raw) + static_cast<size_t>(row) * hidden_dim;
+                            const int vd4 = hidden_dim & ~3;
+                            for (int c = tid * 4; c < vd4; c += bs * 4) {
+                                float w0 = dotcache_qwen35_to_float(wr[c]);
+                                float w1 = dotcache_qwen35_to_float(wr[c+1]);
+                                float w2 = dotcache_qwen35_to_float(wr[c+2]);
+                                float w3 = dotcache_qwen35_to_float(wr[c+3]);
+                                for (int b = 0; b < B; b++) {
+                                    const float* inp = lds_input + b * hidden_dim + c;
+                                    p[b] += w0 * inp[0] + w1 * inp[1] + w2 * inp[2] + w3 * inp[3];
+                                }
+                            }
+                            for (int c = vd4 + tid; c < hidden_dim; c += bs) {
+                                float w = dotcache_qwen35_to_float(wr[c]);
+                                for (int b = 0; b < B; b++)
+                                    p[b] += w * lds_input[b * hidden_dim + c];
                             }
                         }
-                        for (int c = vd8 + tid; c < hidden_dim; c += bs) {
-                            float w = int4_dequant_scalar(w_raw, w_i4_scale, w_i4_zero, row, c, hidden_dim, gsz);
-                            for (int b = 0; b < B; b++)
-                                p[b] += w * lds_input[b * hidden_dim + c];
-                        }
-                    } else if (fp8_scales != nullptr && w_scale != nullptr) {
-                        for (int c = tid; c < hidden_dim; c += bs) {
-                            float w = fp8_dequant_weight_lut(w_raw, w_scale, row, c, hidden_dim, fp8_scales[layer].block_size, fp8_lut);
-                            for (int b = 0; b < B; b++)
-                                p[b] += w * lds_input[b * hidden_dim + c];
-                        }
-                    } else {
-                        const T* wr = static_cast<const T*>(w_raw) + static_cast<size_t>(row) * hidden_dim;
-                        const int vd4 = hidden_dim & ~3;
-                        for (int c = tid * 4; c < vd4; c += bs * 4) {
-                            float w0 = dotcache_qwen35_to_float(wr[c]);
-                            float w1 = dotcache_qwen35_to_float(wr[c+1]);
-                            float w2 = dotcache_qwen35_to_float(wr[c+2]);
-                            float w3 = dotcache_qwen35_to_float(wr[c+3]);
-                            for (int b = 0; b < B; b++) {
-                                const float* inp = lds_input + b * hidden_dim + c;
-                                p[b] += w0 * inp[0] + w1 * inp[1] + w2 * inp[2] + w3 * inp[3];
-                            }
-                        }
-                        for (int c = vd4 + tid; c < hidden_dim; c += bs) {
-                            float w = dotcache_qwen35_to_float(wr[c]);
-                            for (int b = 0; b < B; b++)
-                                p[b] += w * lds_input[b * hidden_dim + c];
-                        }
-                    }
                         for (int b = 0; b < B; b++) {
                             lds[tid] = p[b];
                             __syncthreads();

--- a/kernels/full_attention_4b_cuda.cuh
+++ b/kernels/full_attention_4b_cuda.cuh
@@ -3968,6 +3968,10 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
     constexpr bool hero_specialized = SINGLE_STREAM_BF16_SPECIALIZED;
     const int B = hero_specialized ? 1 : batch_size;
     const bool emit_attention_trace = hero_specialized ? false : (enable_attention_trace != 0);
+    const bool runtime_qwen35_4b_shape =
+        hidden_dim == 2560 &&
+        intermediate_size == 9216 &&
+        num_layers == 32;
 
     // Workspace layout (F32 unless noted).
     // Each section is multiplied by batch_size. Per-batch offset: section + b * section_size.
@@ -4350,6 +4354,7 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
 
                 float* proj_b = proj_buf + b * proj_buf_floats;
                 const bool qwen4b_full_attn_core_hero =
+                    runtime_qwen35_4b_shape &&
                     B == 2 &&
                     bs == 256 &&
                     hd == 256 &&
@@ -4805,6 +4810,7 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
                     const T* cv = static_cast<const T*>(kv_v_b);
                     T* q_head_bf16 = reinterpret_cast<T*>(lds_input);
                     const bool qwen4b_single_bf16_attn_core_hero =
+                        runtime_qwen35_4b_shape &&
                         B == 1 && bs == 256 && hd == 256 && !emit_attention_trace;
 
                     if (qwen4b_single_bf16_attn_core_hero) {
@@ -5506,6 +5512,7 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
                     const int v_val_offset = key_dim * 2;
                     const int v = tid % hvd;          // v-dimension for this thread
                     const bool qwen4b_single_linear_decayless_store_hero =
+                        runtime_qwen35_4b_shape &&
                         B == 1 && bs == 256 && kern == 4 &&
                         nv == 16 && nk == 16 && hkd == 128 && hvd == 128;
 

--- a/kernels/full_attention_4b_cuda.cuh
+++ b/kernels/full_attention_4b_cuda.cuh
@@ -5412,25 +5412,23 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
             void* conv_b = hero_specialized ? L.conv_state : (batch_descs ? batch_descs[layer].conv_state[b] : L.conv_state);
             void* rec_b  = hero_specialized ? L.recurrent_state : (batch_descs ? batch_descs[layer].recurrent_state[b] : L.recurrent_state);
             float* proj_b = proj_buf + b * proj_buf_floats;
+            float* gate_up_b = gate_up + b * intermediate_size * 2;
+            float* attn_scratch_b = attn_scratch + b * attn_scratch_floats;
+            float* mlp_out_b = mlp_out + b * hidden_dim;
+            const int conv_dim = L.qkv_out_dim;
+            const int kern = L.conv_kernel_size;
+            const int nv = L.linear_num_v_heads;
+            const int nk = (L.qkv_out_dim - nv * L.linear_head_v_dim) / (2 * L.linear_head_k_dim);
+            const int hkd = L.linear_head_k_dim;
+            const int hvd = L.linear_head_v_dim;
+            const int key_dim = nk * hkd;         // num_k_heads * k_head_dim
+            const int val_dim = L.linear_value_dim; // 2048
 
             if (blockIdx.x == 0) {
                 float* qkv_f32 = proj_b;
                 float* z_f32 = proj_b + L.qkv_out_dim;
                 float* b_f32 = proj_b + L.qkv_out_dim + L.z_out_dim;
                 float* a_f32 = b_f32 + nv_heads;
-                // Batch-strided scratch aliases
-                float* gate_up_b = gate_up + b * intermediate_size * 2;
-                float* attn_scratch_b = attn_scratch + b * attn_scratch_floats;
-                float* mlp_out_b = mlp_out + b * hidden_dim;
-
-                const int conv_dim = L.qkv_out_dim;
-                const int kern = L.conv_kernel_size;
-                const int nv = L.linear_num_v_heads;
-                const int nk = (L.qkv_out_dim - nv * L.linear_head_v_dim) / (2 * L.linear_head_k_dim);
-                const int hkd = L.linear_head_k_dim;
-                const int hvd = L.linear_head_v_dim;
-                const int key_dim = nk * hkd;         // num_k_heads * k_head_dim
-                const int val_dim = L.linear_value_dim; // 2048
                 const unsigned long long linear_conv_clock = clock64();
 
                 // Step B: Conv1d stateful update
@@ -5547,21 +5545,22 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
                     layer_timing_slots,
                     QWEN35_4B_TIMING_LINEAR_CORE_CONV_BASE + min(b, 1),
                     linear_conv_clock);
+            } // end if (blockIdx.x == 0) conv/qk prep
 
-                const unsigned long long linear_recurrent_clock = clock64();
+            // Grid barrier: block 0 wrote normalized Q/K/V scratch needed below.
+            __threadfence();
+            grid_barrier(barrier_counter, barrier_flag, nb);
 
-                // Step C: Parallel delta recurrent state update
-                // state: [nv, hkd, hvd] F32 — the recurrent memory
-                // 256 threads process 2 heads at a time: threads 0-127 → head h,
-                // threads 128-255 → head h+1. Each thread owns one v-dimension.
-                // Per head: kv_mem = state @ key, delta = (val - kv_mem) * beta,
-                //           state += outer(key, delta), output = state @ query
-                {
+            const unsigned long long linear_recurrent_clock = clock64();
+            // Step C: Parallel delta recurrent state update
+            // Hero lane spreads one head-pair per block; the generic path keeps
+            // the existing block-0-only implementation.
+            if constexpr (SINGLE_STREAM_BF16_SPECIALIZED) {
+                const int hero_pairs = (nv + 1) / 2;
+                if (blockIdx.x < hero_pairs) {
+                    const int hp = static_cast<int>(blockIdx.x) * 2;
                     float* conv_out = gate_up_b;  // reused
                     float* state = static_cast<float*>(rec_b);
-                    // Reuse the front of lds_input as a tiny per-head staging area
-                    // so the recurrent body does not keep reloading the same Q/K
-                    // vectors from global scratch.
                     float* q_stage = lds_input;
                     float* k_stage = q_stage + 2 * hkd;
 
@@ -5571,106 +5570,164 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
                     const int q_key_offset = 0;
                     const int k_key_offset = key_dim;
                     const int v_val_offset = key_dim * 2;
-                    const int v = tid % hvd;          // v-dimension for this thread
-                    const bool qwen4b_single_linear_decayless_store_hero =
-                        runtime_qwen35_4b_shape &&
-                        B == 1 && bs == 256 && kern == 4 &&
-                        nv == 16 && nk == 16 && hkd == 128 && hvd == 128;
+                    const int v = tid % hvd;
+                    // Keep the cross-block recurrent split conservative: the
+                    // single-block decayless-store shortcut is numerically
+                    // safe on the original hero path, but it changes long-
+                    // context behavior once head pairs are distributed across
+                    // blocks. Re-evaluate it only after parity is restored.
+                    const bool qwen4b_single_linear_decayless_store_hero = false;
 
-                    // Process 2 heads per iteration (256 threads / 128 hvd)
-                    for (int hp = 0; hp < nv; hp += 2) {
-                        if (tid < 2 * hkd) {
-                            const int pair_head = tid / hkd;
-                            const int d = tid % hkd;
-                            const int staged_h = hp + pair_head;
-                            if (staged_h < nv) {
-                                const int staged_hk = staged_h * nk / nv;
-                                q_stage[tid] =
-                                    conv_out[q_key_offset + staged_hk * hkd + d];
-                                k_stage[tid] =
-                                    conv_out[k_key_offset + staged_hk * hkd + d];
-                            }
+                    if (tid < 2 * hkd) {
+                        const int pair_head = tid / hkd;
+                        const int d = tid % hkd;
+                        const int staged_h = hp + pair_head;
+                        if (staged_h < nv) {
+                            const int staged_hk = staged_h * nk / nv;
+                            q_stage[tid] =
+                                conv_out[q_key_offset + staged_hk * hkd + d];
+                            k_stage[tid] =
+                                conv_out[k_key_offset + staged_hk * hkd + d];
                         }
-                        __syncthreads();
-
-                        const int h = hp + (tid >= hvd ? 1 : 0);
-
-                        if (h < nv) {
-                            float* sh = state + h * hkd * hvd;
-                            // b/a/dt_bias/a_log are indexed by value head (nv elements each)
-                            const float beta = 1.0f / (1.0f + expf(-b_f32[h]));
-                            float decay = 1.0f;
-                            if (dt_bw != nullptr && ale_w != nullptr) {
-                                const float sp = logf(1.0f + expf(
-                                    a_f32[h] + dotcache_qwen35_to_float(dt_bw[h])));
-                                decay = expf(-sp * dotcache_qwen35_to_float(ale_w[h]));
-                            }
-
-                            // Map value head to key head for Q/K indexing
-                            // nk key heads shared among nv value heads
-                            const int pair_head = h - hp;
-                            const float* qh = q_stage + pair_head * hkd;
-                            const float* kh = k_stage + pair_head * hkd;
-
-                            // First pass: accumulate kv_mem from the decayed state.
-                            // On the single-stream hero lane we skip the intermediate
-                            // "write decayed state" step and apply decay only when the
-                            // final updated state is written back in the second pass.
-                            float kv_mem_v = 0.0f;
-                            if (qwen4b_single_linear_decayless_store_hero) {
-                                for (int k = 0; k < 128; ++k) {
-                                    const float state_orig = sh[k * 128 + v];
-                                    const float state_decay = state_orig * decay;
-                                    kv_mem_v += state_decay * kh[k];
-                                }
-                            } else {
-                                for (int k = 0; k < hkd; ++k) {
-                                    float* state_kv = sh + k * hvd + v;
-                                    const float state_decay = (*state_kv) * decay;
-                                    *state_kv = state_decay;
-                                    kv_mem_v += state_decay * kh[k];
-                                }
-                            }
-
-                            // delta = (value - kv_mem) * beta
-                            const float val = conv_out[v_val_offset + h * hvd + v];
-                            const float delta = (val - kv_mem_v) * beta;
-
-                            // Second pass: update the state and accumulate the output
-                            // from the updated value in the same walk.
-                            float out_v = 0.0f;
-                            if (qwen4b_single_linear_decayless_store_hero) {
-                                for (int k = 0; k < 128; ++k) {
-                                    float* state_kv = sh + k * 128 + v;
-                                    const float state_orig = *state_kv;
-                                    const float state_decay = state_orig * decay;
-                                    const float state_update =
-                                        state_decay + kh[k] * delta;
-                                    *state_kv = state_update;
-                                    out_v += state_update * qh[k];
-                                }
-                            } else {
-                                for (int k = 0; k < hkd; ++k) {
-                                    float* state_kv = sh + k * hvd + v;
-                                    const float state_update = (*state_kv) + kh[k] * delta;
-                                    *state_kv = state_update;
-                                    out_v += state_update * qh[k];
-                                }
-                            }
-
-                            attn_scratch_b[h * hvd + v] = bf16_round_rne_f32_finite(out_v);
-                        }
-                        __syncthreads();
                     }
-                }
+                    __syncthreads();
 
-                __syncthreads();
+                    const int h = hp + (tid >= hvd ? 1 : 0);
+                    if (h < nv) {
+                        float* sh = state + h * hkd * hvd;
+                        const float* b_f32 = proj_b + L.qkv_out_dim + L.z_out_dim;
+                        const float* a_f32 = b_f32 + nv_heads;
+                        const float beta = 1.0f / (1.0f + expf(-b_f32[h]));
+                        float decay = 1.0f;
+                        if (dt_bw != nullptr && ale_w != nullptr) {
+                            const float sp = logf(1.0f + expf(
+                                a_f32[h] + dotcache_qwen35_to_float(dt_bw[h])));
+                            decay = expf(-sp * dotcache_qwen35_to_float(ale_w[h]));
+                        }
+
+                        const int pair_head = h - hp;
+                        const float* qh = q_stage + pair_head * hkd;
+                        const float* kh = k_stage + pair_head * hkd;
+
+                        float kv_mem_v = 0.0f;
+                        if (qwen4b_single_linear_decayless_store_hero) {
+                            for (int k = 0; k < 128; ++k) {
+                                const float state_orig = sh[k * 128 + v];
+                                const float state_decay = state_orig * decay;
+                                kv_mem_v += state_decay * kh[k];
+                            }
+                        } else {
+                            for (int k = 0; k < hkd; ++k) {
+                                float* state_kv = sh + k * hvd + v;
+                                const float state_decay = (*state_kv) * decay;
+                                *state_kv = state_decay;
+                                kv_mem_v += state_decay * kh[k];
+                            }
+                        }
+
+                        const float val = conv_out[v_val_offset + h * hvd + v];
+                        const float delta = (val - kv_mem_v) * beta;
+                        float out_v = 0.0f;
+                        if (qwen4b_single_linear_decayless_store_hero) {
+                            for (int k = 0; k < 128; ++k) {
+                                float* state_kv = sh + k * 128 + v;
+                                const float state_orig = *state_kv;
+                                const float state_decay = state_orig * decay;
+                                const float state_update = state_decay + kh[k] * delta;
+                                *state_kv = state_update;
+                                out_v += state_update * qh[k];
+                            }
+                        } else {
+                            for (int k = 0; k < hkd; ++k) {
+                                float* state_kv = sh + k * hvd + v;
+                                const float state_update = (*state_kv) + kh[k] * delta;
+                                *state_kv = state_update;
+                                out_v += state_update * qh[k];
+                            }
+                        }
+                        attn_scratch_b[h * hvd + v] = bf16_round_rne_f32_finite(out_v);
+                    }
+                    __syncthreads();
+                }
+            } else if (blockIdx.x == 0) {
+                float* conv_out = gate_up_b;  // reused
+                float* state = static_cast<float*>(rec_b);
+                float* q_stage = lds_input;
+                float* k_stage = q_stage + 2 * hkd;
+
+                const T* dt_bw = static_cast<const T*>(L.dt_bias_w);
+                const T* ale_w = static_cast<const T*>(L.a_log_exp_w);
+
+                const int q_key_offset = 0;
+                const int k_key_offset = key_dim;
+                const int v_val_offset = key_dim * 2;
+                const int v = tid % hvd;
+
+                for (int hp = 0; hp < nv; hp += 2) {
+                    if (tid < 2 * hkd) {
+                        const int pair_head = tid / hkd;
+                        const int d = tid % hkd;
+                        const int staged_h = hp + pair_head;
+                        if (staged_h < nv) {
+                            const int staged_hk = staged_h * nk / nv;
+                            q_stage[tid] =
+                                conv_out[q_key_offset + staged_hk * hkd + d];
+                            k_stage[tid] =
+                                conv_out[k_key_offset + staged_hk * hkd + d];
+                        }
+                    }
+                    __syncthreads();
+
+                    const int h = hp + (tid >= hvd ? 1 : 0);
+                    if (h < nv) {
+                        float* sh = state + h * hkd * hvd;
+                        const float* b_f32 = proj_b + L.qkv_out_dim + L.z_out_dim;
+                        const float* a_f32 = b_f32 + nv_heads;
+                        const float beta = 1.0f / (1.0f + expf(-b_f32[h]));
+                        float decay = 1.0f;
+                        if (dt_bw != nullptr && ale_w != nullptr) {
+                            const float sp = logf(1.0f + expf(
+                                a_f32[h] + dotcache_qwen35_to_float(dt_bw[h])));
+                            decay = expf(-sp * dotcache_qwen35_to_float(ale_w[h]));
+                        }
+
+                        const int pair_head = h - hp;
+                        const float* qh = q_stage + pair_head * hkd;
+                        const float* kh = k_stage + pair_head * hkd;
+                        float kv_mem_v = 0.0f;
+                        for (int k = 0; k < hkd; ++k) {
+                            float* state_kv = sh + k * hvd + v;
+                            const float state_decay = (*state_kv) * decay;
+                            *state_kv = state_decay;
+                            kv_mem_v += state_decay * kh[k];
+                        }
+
+                        const float val = conv_out[v_val_offset + h * hvd + v];
+                        const float delta = (val - kv_mem_v) * beta;
+                        float out_v = 0.0f;
+                        for (int k = 0; k < hkd; ++k) {
+                            float* state_kv = sh + k * hvd + v;
+                            const float state_update = (*state_kv) + kh[k] * delta;
+                            *state_kv = state_update;
+                            out_v += state_update * qh[k];
+                        }
+                        attn_scratch_b[h * hvd + v] = bf16_round_rne_f32_finite(out_v);
+                    }
+                    __syncthreads();
+                }
+            }
+
+            __threadfence();
+            grid_barrier(barrier_counter, barrier_flag, nb);
+
+            if (blockIdx.x == 0) {
                 qwen35_record_persistent_4b_timing(
                     layer_timing_slots,
                     QWEN35_4B_TIMING_LINEAR_CORE_RECURRENT_BASE + min(b, 1),
                     linear_recurrent_clock);
 
                 const unsigned long long linear_post_clock = clock64();
+                float* z_f32 = proj_b + L.qkv_out_dim;
 
                 // Step D: Per-head RMSNorm + weight + SiLU(z) gating
                 {
@@ -5700,9 +5757,8 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
                     layer_timing_slots,
                     QWEN35_4B_TIMING_LINEAR_CORE_POST_BASE + min(b, 1),
                     linear_post_clock);
-
-            } // end if (blockIdx.x == 0) for linear attention core
-            // Grid barrier: block 0 wrote attn_scratch_b, all blocks need it for out_proj
+            }
+            // Grid barrier: recurrent/post wrote attn_scratch_b, all blocks need it for out_proj
             qwen35_record_persistent_4b_timing(
                 layer_timing_slots, QWEN35_4B_TIMING_LINEAR_CORE_BASE + b, linear_core_clock);
             grid_barrier(barrier_counter, barrier_flag, nb);

--- a/kernels/full_attention_4b_cuda.cuh
+++ b/kernels/full_attention_4b_cuda.cuh
@@ -20,6 +20,13 @@ enum Qwen35Persistent4BTimingSlot {
     QWEN35_4B_TIMING_FULL_ATTN = 0,
     QWEN35_4B_TIMING_FULL_ATTN_PROJ = 1,
     QWEN35_4B_TIMING_FULL_ATTN_CORE_BASE = 2,
+    // Slots 3..7 are otherwise unused on the validated single-batch CUDA 4B
+    // hero lane. Reuse them there for deeper full-attention-core attribution.
+    QWEN35_4B_TIMING_FULL_ATTN_HERO_PREP = 3,
+    QWEN35_4B_TIMING_FULL_ATTN_HERO_UNUSED = 4,
+    QWEN35_4B_TIMING_FULL_ATTN_HERO_LOOP = 5,
+    QWEN35_4B_TIMING_FULL_ATTN_HERO_MERGE = 6,
+    QWEN35_4B_TIMING_FULL_ATTN_HERO_GATE = 7,
     QWEN35_4B_TIMING_FULL_ATTN_OUT_BASE = 10,
     QWEN35_4B_TIMING_LINEAR_PROJ = 18,
     QWEN35_4B_TIMING_LINEAR_CORE_BASE = 19,
@@ -3973,10 +3980,13 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
     // allow debug tracing to force the trace-capable fallback path in this same
     // kernel so the exported attention scratch is valid on 4B CUDA.
     const bool emit_attention_trace = (enable_attention_trace != 0);
+    // The validated CUDA 4B lane runs in split windows on long context, so
+    // `num_layers` is the current window size there rather than the full model
+    // depth. Gate the 4B specializations on the stable hidden/intermediate
+    // geometry instead of the launch window length.
     const bool runtime_qwen35_4b_shape =
         hidden_dim == 2560 &&
-        intermediate_size == 9216 &&
-        num_layers == 32;
+        intermediate_size == 9216;
 
     // Workspace layout (F32 unless noted).
     // Each section is multiplied by batch_size. Per-batch offset: section + b * section_size.
@@ -4549,6 +4559,11 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
                 float* q_f32 = proj_b;
                 float* k_f32 = proj_b + L.q_out_dim;
                 float* v_f32 = proj_b + L.q_out_dim + L.k_out_dim;
+                const bool qwen4b_single_bf16_attn_core_hero =
+                    runtime_qwen35_4b_shape &&
+                    B == 1 && bs == 256 && hd == 256 && !emit_attention_trace;
+                const unsigned long long hero_prep_clock =
+                    qwen4b_single_bf16_attn_core_hero ? clock64() : 0;
 
                 // Step B: QK-norm — RMSNorm per head on head_dim
                 // Wave-level reduce + cross-wave LDS reduce (2 syncthreads vs 8)
@@ -4725,6 +4740,12 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
                         q_f32[h * hd * 2 + hd + d]);
                 }
                 __syncthreads();
+                if (qwen4b_single_bf16_attn_core_hero) {
+                    qwen35_record_persistent_4b_timing(
+                        layer_timing_slots,
+                        QWEN35_4B_TIMING_FULL_ATTN_HERO_PREP,
+                        hero_prep_clock);
+                }
 
                 // Step E: Parallel attention — Flash-style online softmax
                 float* attn_flat = proj_b;  // reuse projection buffer
@@ -4813,9 +4834,6 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
                     const T* ck = static_cast<const T*>(kv_k_b);
                     const T* cv = static_cast<const T*>(kv_v_b);
                     T* q_head_bf16 = reinterpret_cast<T*>(lds_input);
-                    const bool qwen4b_single_bf16_attn_core_hero =
-                        runtime_qwen35_4b_shape &&
-                        B == 1 && bs == 256 && hd == 256 && !emit_attention_trace;
 
                     if (qwen4b_single_bf16_attn_core_hero) {
                         for (int qh = 0; qh < nh; ++qh) {
@@ -4823,10 +4841,15 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
                             const float* q_head = q_f32 + qh * hd * 2;
                             const size_t kv_head_base =
                                 static_cast<size_t>(kvh) * kv_max_b * hd;
-                            const int hero_warps = bs / warpSize;
+                            // Short contexts were stable with the original 8-warp striping,
+                            // while long contexts needed a tighter 4-warp merge to keep the
+                            // softmax numerics on the right side of the token boundary.
+                            const int hero_warps = (kv_len_b >= 256) ? 4 : (bs / warpSize);
                             const int hero_warp = tid / warpSize;
                             const int hero_lane = tid % warpSize;
-                            const bool attn_lane_active = hero_lane < (hd / 8);
+                            const bool hero_warp_active = hero_warp < hero_warps;
+                            const bool attn_lane_active =
+                                hero_warp_active && hero_lane < (hd / 8);
 
                             if (tid < hd) {
                                 saved_gate[qh * hd + tid] = bf16_round_rne_f32_finite(
@@ -4845,6 +4868,7 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
                             }
                             __syncthreads();
 
+                            const unsigned long long hero_loop_clock = clock64();
                             float2 qv0 = make_float2(0.0f, 0.0f);
                             float2 qv1 = make_float2(0.0f, 0.0f);
                             float2 qv2 = make_float2(0.0f, 0.0f);
@@ -4928,7 +4952,14 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
                                     my_sum = my_sum * rescale + w;
                                 }
                             }
+                            if (qh == 0) {
+                                qwen35_record_persistent_4b_timing(
+                                    layer_timing_slots,
+                                    QWEN35_4B_TIMING_FULL_ATTN_HERO_LOOP,
+                                    hero_loop_clock);
+                            }
 
+                            const unsigned long long hero_merge_clock = clock64();
                             float* hero_max_buf = lds_input;
                             float* hero_sum_buf = hero_max_buf + hero_warps * warpSize;
                             float* hero_acc0_buf = hero_sum_buf + hero_warps * warpSize;
@@ -4939,17 +4970,19 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
                             float* hero_acc5_buf = hero_acc4_buf + hero_warps * warpSize;
                             float* hero_acc6_buf = hero_acc5_buf + hero_warps * warpSize;
                             float* hero_acc7_buf = hero_acc6_buf + hero_warps * warpSize;
-                            const int hero_idx = hero_warp * warpSize + hero_lane;
-                            hero_max_buf[hero_idx] = my_max;
-                            hero_sum_buf[hero_idx] = my_sum;
-                            hero_acc0_buf[hero_idx] = my_acc0;
-                            hero_acc1_buf[hero_idx] = my_acc1;
-                            hero_acc2_buf[hero_idx] = my_acc2;
-                            hero_acc3_buf[hero_idx] = my_acc3;
-                            hero_acc4_buf[hero_idx] = my_acc4;
-                            hero_acc5_buf[hero_idx] = my_acc5;
-                            hero_acc6_buf[hero_idx] = my_acc6;
-                            hero_acc7_buf[hero_idx] = my_acc7;
+                            if (hero_warp_active) {
+                                const int hero_idx = hero_warp * warpSize + hero_lane;
+                                hero_max_buf[hero_idx] = my_max;
+                                hero_sum_buf[hero_idx] = my_sum;
+                                hero_acc0_buf[hero_idx] = my_acc0;
+                                hero_acc1_buf[hero_idx] = my_acc1;
+                                hero_acc2_buf[hero_idx] = my_acc2;
+                                hero_acc3_buf[hero_idx] = my_acc3;
+                                hero_acc4_buf[hero_idx] = my_acc4;
+                                hero_acc5_buf[hero_idx] = my_acc5;
+                                hero_acc6_buf[hero_idx] = my_acc6;
+                                hero_acc7_buf[hero_idx] = my_acc7;
+                            }
                             __syncthreads();
 
                             if (hero_warp == 0) {
@@ -5001,6 +5034,12 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
                                     bf16_round_rne_f32_finite(final_acc7 * inv_sum);
                             }
                             __syncthreads();
+                            if (qh == 0) {
+                                qwen35_record_persistent_4b_timing(
+                                    layer_timing_slots,
+                                    QWEN35_4B_TIMING_FULL_ATTN_HERO_MERGE,
+                                    hero_merge_clock);
+                            }
                         }
                     } else {
                         for (int qh = 0; qh < nh; ++qh) {
@@ -5063,12 +5102,20 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
                 __syncthreads();
 
                 // Step F: Gate
+                const unsigned long long hero_gate_clock =
+                    qwen4b_single_bf16_attn_core_hero ? clock64() : 0;
                 for (int i = tid; i < nh * hd; i += bs) {
                     float gate_val = saved_gate[i];
                     float sigmoid_gate = dotcache_qwen35_sigmoid_fast(gate_val);
                     attn_flat[i] = bf16_round_rne_f32_finite(attn_flat[i] * sigmoid_gate);
                 }
                 __syncthreads();
+                if (qwen4b_single_bf16_attn_core_hero) {
+                    qwen35_record_persistent_4b_timing(
+                        layer_timing_slots,
+                        QWEN35_4B_TIMING_FULL_ATTN_HERO_GATE,
+                        hero_gate_clock);
+                }
 
                 } // end if (blockIdx.x == 0)
                 // Grid barrier: block 0 wrote attn_flat, all blocks need it for o_proj

--- a/kernels/full_attention_4b_cuda.cuh
+++ b/kernels/full_attention_4b_cuda.cuh
@@ -88,6 +88,8 @@ struct Qwen35DecodeLayerDesc {
     void* kv_shadow_k;                 // optional BF16 KV sidecar for KV-FP8 bring-up / parity-sensitive reads
     void* kv_shadow_v;                 // optional BF16 KV sidecar for KV-FP8 bring-up / parity-sensitive reads
     int kv_shadow_start;               // first position covered by the sidecar, -1 when disabled
+    void* debug_linear_trace_out;      // optional F32[(kern-1)+2] export for one linear channel's Step-B state
+    int debug_linear_trace_channel;    // selected linear channel for debug_linear_trace_out, -1 disables
 };
 
 // =============================================================================
@@ -5432,6 +5434,17 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
                             cs[c * (kern-1) + t] = cs[c * (kern-1) + t + 1];
                         }
                         cs[c * (kern-1) + (kern-2)] = qkv_bf16;
+
+                        if (L.debug_linear_trace_out != nullptr &&
+                            c == L.debug_linear_trace_channel) {
+                            float* debug = static_cast<float*>(L.debug_linear_trace_out);
+                            const int state_base = c * (kern - 1);
+                            for (int t = 0; t < kern - 1; ++t) {
+                                debug[t] = dotcache_qwen35_to_float(cs[state_base + t]);
+                            }
+                            debug[kern - 1] = dotcache_qwen35_to_float(qkv_bf16);
+                            debug[kern] = conv_out[c];
+                        }
                     }
                     __syncthreads();
 

--- a/kernels/full_attention_bridge_4b_cuda.cu
+++ b/kernels/full_attention_bridge_4b_cuda.cu
@@ -4601,7 +4601,15 @@ int persistent_decode_device(
         ? static_cast<size_t>(hidden_dim) * effective_batch_size
         : static_cast<size_t>(intermediate_size);
     const size_t fp8_lut_size = SINGLE_STREAM_BF16_SPECIALIZED ? 0 : 256;  // FP8 E4M3 → F32 lookup table
-    const size_t shared_bytes = (block_size + input_cache + fp8_lut_size) * sizeof(float);
+    size_t shared_bytes = (block_size + input_cache + fp8_lut_size) * sizeof(float);
+    if constexpr (SINGLE_STREAM_BF16_SPECIALIZED) {
+        shared_bytes += static_cast<size_t>(intermediate_size) * sizeof(T);
+        cudaError_t attr_err = cudaFuncSetAttribute(
+            HIP_KERNEL_NAME(dotcache_qwen35_persistent_decode_kernel<T, SINGLE_STREAM_BF16_SPECIALIZED>),
+            cudaFuncAttributeMaxDynamicSharedMemorySize,
+            static_cast<int>(shared_bytes));
+        if (attr_err != cudaSuccess) return 253;
+    }
 
     hipLaunchKernelGGL(
         HIP_KERNEL_NAME(dotcache_qwen35_persistent_decode_kernel<T, SINGLE_STREAM_BF16_SPECIALIZED>),

--- a/kernels/full_attention_bridge_cuda.cu
+++ b/kernels/full_attention_bridge_cuda.cu
@@ -67,6 +67,19 @@ int qwen08_hero_blocks_override() {
     return static_cast<int>(parsed);
 }
 
+int qwen35_persistent_blocks_override() {
+    const char* value = std::getenv("SUPERSONIC_QWEN35_PERSISTENT_BLOCKS");
+    if (value == nullptr || *value == '\0') {
+        return 0;
+    }
+    char* end = nullptr;
+    const long parsed = std::strtol(value, &end, 10);
+    if (end == value || parsed <= 0) {
+        return 0;
+    }
+    return static_cast<int>(parsed);
+}
+
 template <typename T>
 int full_attention_prefill_device(
     int device_ordinal,
@@ -4506,7 +4519,8 @@ extern "C" int dotcache_qwen35_hip_persistent_decode(
             static_cast<int>(seqlen_offset),
             layers, hidden_io, workspace, counters,
             barrier_counter, barrier_flag,
-            cos_table, sin_table, static_cast<int>(rotary_dim), 0);
+            cos_table, sin_table, static_cast<int>(rotary_dim),
+            qwen35_persistent_blocks_override());
     default:
         return 256;
     }

--- a/kernels/full_attention_cuda.cuh
+++ b/kernels/full_attention_cuda.cuh
@@ -3397,7 +3397,10 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
             // Step B-G: QK-norm, RoPE, KV cache, attention, gating, o_proj
             // Block 0 handles the per-head sequential ops.
             // O_proj uses all blocks via work-stealing.
-            const bool qwen08_attn_hero = qwen08_hero && nb >= 8;
+            // The 0.8B full-attention hero subpath is intentionally disabled:
+            // it regressed golden-corpus parity even though the surrounding
+            // hero specializations are correct and materially faster.
+            const bool qwen08_attn_hero = false;
 
             if (qwen08_attn_hero) {
                 float* q_f32 = proj_buf;

--- a/kernels/full_attention_cuda.cuh
+++ b/kernels/full_attention_cuda.cuh
@@ -72,6 +72,8 @@ struct Qwen35DecodeLayerDesc {
     void* kv_shadow_k;                 // optional BF16 KV sidecar for KV-FP8 bring-up / parity-sensitive reads
     void* kv_shadow_v;                 // optional BF16 KV sidecar for KV-FP8 bring-up / parity-sensitive reads
     int kv_shadow_start;               // first position covered by the sidecar, -1 when disabled
+    void* debug_linear_trace_out;      // optional F32[(kern-1)+2] export for one linear channel's Step-B state
+    int debug_linear_trace_channel;    // selected linear channel for debug_linear_trace_out, -1 disables
 };
 
 template <typename T>

--- a/kernels/full_attention_cuda.cuh
+++ b/kernels/full_attention_cuda.cuh
@@ -3600,10 +3600,9 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
                     const size_t cos_off =
                         static_cast<size_t>(seqlen_offset) * half_rot;
 
-                    // Apply to all Q heads in parallel (nh * half_rot <= 256)
-                    if (tid < nh * half_rot) {
-                        const int h = tid / half_rot;
-                        const int i = tid % half_rot;
+                    for (int idx = tid; idx < nh * half_rot; idx += bs) {
+                        const int h = idx / half_rot;
+                        const int i = idx % half_rot;
                         float* qh = q_f32 + h * hd * 2;
                         float c = dotcache_qwen35_to_float(cos_table[cos_off + i]);
                         float s = dotcache_qwen35_to_float(sin_table[cos_off + i]);
@@ -3614,10 +3613,9 @@ __global__ void dotcache_qwen35_persistent_decode_kernel(
                     }
                     __syncthreads();
 
-                    // Apply to all K heads (nkv * half_rot threads)
-                    if (tid < nkv * half_rot) {
-                        const int h = tid / half_rot;
-                        const int i = tid % half_rot;
+                    for (int idx = tid; idx < nkv * half_rot; idx += bs) {
+                        const int h = idx / half_rot;
+                        const int i = idx % half_rot;
                         float* kh = k_f32 + h * hd;
                         float c = dotcache_qwen35_to_float(cos_table[cos_off + i]);
                         float s = dotcache_qwen35_to_float(sin_table[cos_off + i]);

--- a/oracle/run_oracle.py
+++ b/oracle/run_oracle.py
@@ -98,6 +98,8 @@ def main():
     parser.add_argument("--fp8-model-dir",
                         help="Path to FP8 safetensors dir. Weights are dequanted to BF16 "
                              "and injected into --model-id's architecture.")
+    parser.add_argument("--trace-full-attn-layer", type=int,
+                        help="Emit internal tensors for one full-attention layer at the last prompt token")
     args = parser.parse_args()
 
     prompt_ids = [int(x) for x in args.prompt_ids.split(",") if x]
@@ -137,8 +139,39 @@ def main():
         post_attn_norm_states = [None] * len(model.model.layers)
         mlp_outputs = [None] * len(model.model.layers)
         layer_outputs = [None] * len(model.model.layers)
+        trace_layer_input = None
+        trace_normed_input = None
+        trace_gated_actual = None
         hooks = []
         for layer_idx, layer in enumerate(model.model.layers):
+            if args.trace_full_attn_layer == layer_idx:
+                def capture_layer_input(module, inputs):
+                    nonlocal trace_layer_input
+                    trace_layer_input = inputs[0].detach()
+                def capture_normed_input(module, inputs, kwargs):
+                    nonlocal trace_normed_input
+                    hidden_states = kwargs.get("hidden_states")
+                    if hidden_states is None and len(inputs) > 0:
+                        hidden_states = inputs[0]
+                    if hidden_states is None:
+                        raise RuntimeError(
+                            f"Failed to capture self_attn hidden_states for layer {args.trace_full_attn_layer}"
+                        )
+                    trace_normed_input = hidden_states.detach()
+                def capture_gated_actual(module, inputs):
+                    nonlocal trace_gated_actual
+                    if len(inputs) == 0:
+                        raise RuntimeError(
+                            f"Failed to capture o_proj input for layer {args.trace_full_attn_layer}"
+                        )
+                    trace_gated_actual = inputs[0].detach()
+                hooks.append(layer.register_forward_pre_hook(capture_layer_input))
+                hooks.append(
+                    layer.self_attn.register_forward_pre_hook(
+                        capture_normed_input, with_kwargs=True
+                    )
+                )
+                hooks.append(layer.self_attn.o_proj.register_forward_pre_hook(capture_gated_actual))
             def make_pre_hook(idx):
                 def hook(module, inputs):
                     attn_residual_states[idx] = inputs[0][:, -1:, :].detach().to(torch_dtype).cpu()
@@ -220,6 +253,90 @@ def main():
         state_payload["kv_caches"] = kv_caches
         state_payload["conv_states"] = conv_states
         state_payload["recurrent_states"] = recurrent_states
+
+        if args.trace_full_attn_layer is not None:
+            if trace_layer_input is None or trace_normed_input is None:
+                raise RuntimeError(f"Failed to capture full-attention trace inputs for layer {args.trace_full_attn_layer}")
+            from transformers.models.qwen3_5.modeling_qwen3_5 import (
+                ALL_ATTENTION_FUNCTIONS,
+                apply_rotary_pos_emb,
+                create_causal_mask,
+                eager_attention_forward,
+            )
+
+            layer_idx = args.trace_full_attn_layer
+            layer = model.model.layers[layer_idx]
+            attn = layer.self_attn
+            input_shape = trace_normed_input.shape[:-1]
+            hidden_shape = (*input_shape, -1, attn.head_dim)
+            seq_len = trace_layer_input.shape[1]
+            position_ids = torch.arange(seq_len, device=device).view(1, 1, -1).expand(
+                4, trace_layer_input.shape[0], -1
+            )
+            text_position_ids = position_ids[0]
+            rope_position_ids = position_ids[1:]
+            causal_mask = create_causal_mask(
+                config=model.model.config,
+                inputs_embeds=trace_layer_input,
+                attention_mask=None,
+                past_key_values=None,
+                position_ids=text_position_ids,
+            )
+            position_embeddings = model.model.rotary_emb(trace_normed_input, rope_position_ids)
+            q_raw, gate = torch.chunk(
+                attn.q_proj(trace_normed_input).view(*input_shape, -1, attn.head_dim * 2), 2, dim=-1
+            )
+            gate = gate.reshape(*input_shape, -1)
+            query_states = attn.q_norm(q_raw.view(hidden_shape)).transpose(1, 2)
+            key_states = attn.k_norm(attn.k_proj(trace_normed_input).view(hidden_shape)).transpose(1, 2)
+            value_states = attn.v_proj(trace_normed_input).view(hidden_shape).transpose(1, 2)
+            q_pre_rope = query_states
+            k_pre_rope = key_states
+            cos, sin = position_embeddings
+            query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin)
+            attention_interface = ALL_ATTENTION_FUNCTIONS.get_interface(
+                attn.config._attn_implementation, eager_attention_forward
+            )
+            attn_output, _ = attention_interface(
+                attn,
+                query_states,
+                key_states,
+                value_states,
+                causal_mask,
+                dropout=0.0,
+                scaling=attn.scaling,
+            )
+            attn_output = attn_output.reshape(*input_shape, -1).contiguous()
+            gate_last = gate[:, -1:, :]
+            pre_gate_last = attn_output[:, -1:, :]
+            gated_last = pre_gate_last * torch.sigmoid(gate_last)
+            state_payload["traced_full_attn_layer"] = layer_idx
+            state_payload["traced_full_attn_normed"] = tensor_to_b64(trace_normed_input[:, -1:, :].to(torch_dtype))
+            state_payload["traced_full_attn_q_proj"] = tensor_to_b64(
+                q_pre_rope.transpose(1, 2).reshape(*input_shape, -1)[:, -1:, :].to(torch_dtype)
+            )
+            state_payload["traced_full_attn_gate_proj"] = tensor_to_b64(gate_last.to(torch_dtype))
+            state_payload["traced_full_attn_k_proj"] = tensor_to_b64(
+                k_pre_rope.transpose(1, 2).reshape(*input_shape, -1)[:, -1:, :].to(torch_dtype)
+            )
+            state_payload["traced_full_attn_v_proj"] = tensor_to_b64(
+                value_states.transpose(1, 2).reshape(*input_shape, -1)[:, -1:, :].to(torch_dtype)
+            )
+            state_payload["traced_full_attn_q_rope"] = tensor_to_b64(
+                query_states.transpose(1, 2).reshape(*input_shape, -1)[:, -1:, :].to(torch_dtype)
+            )
+            state_payload["traced_full_attn_k_rope"] = tensor_to_b64(
+                key_states.transpose(1, 2).reshape(*input_shape, -1)[:, -1:, :].to(torch_dtype)
+            )
+            state_payload["traced_full_attn_pre_gate"] = tensor_to_b64(pre_gate_last.to(torch_dtype))
+            state_payload["traced_full_attn_gated"] = tensor_to_b64(gated_last.to(torch_dtype))
+            if trace_gated_actual is None:
+                raise RuntimeError(
+                    f"Failed to capture actual gated tensor for layer {args.trace_full_attn_layer}"
+                )
+            state_payload["traced_full_attn_gated_actual"] = tensor_to_b64(
+                trace_gated_actual[:, -1:, :].to(torch_dtype)
+            )
 
     # Decode
     decode_logits = []

--- a/tests/corpus/golden_4b.json
+++ b/tests/corpus/golden_4b.json
@@ -325,16 +325,16 @@
       "prompt_tokens": 542,
       "max_new_tokens": 8,
       "expected_token_ids": [
+        561,
+        23513,
+        15698,
+        369,
         796,
         529,
         2176,
-        13,
-        28732,
-        4202,
-        20956,
-        16067
+        13
       ],
-      "expected_text": " saffron. Archive entry gamma describes",
+      "expected_text": " The audit keyword is saffron.",
       "prefill_top5": []
     },
     {

--- a/tests/corpus/golden_4b_batch2.json
+++ b/tests/corpus/golden_4b_batch2.json
@@ -325,16 +325,16 @@
       "prompt_tokens": 542,
       "max_new_tokens": 8,
       "expected_token_ids": [
+        561,
+        23513,
+        15698,
+        369,
         796,
         529,
         2176,
-        13,
-        28732,
-        4202,
-        20956,
-        16067
+        13
       ],
-      "expected_text": " saffron. Archive entry gamma describes",
+      "expected_text": " The audit keyword is saffron.",
       "prefill_top5": []
     },
     {

--- a/tests/corpus/golden_4b_long.json
+++ b/tests/corpus/golden_4b_long.json
@@ -51,16 +51,16 @@
       "prompt_tokens": 542,
       "max_new_tokens": 8,
       "expected_token_ids": [
+        561,
+        23513,
+        15698,
+        369,
         796,
         529,
         2176,
-        13,
-        28732,
-        4202,
-        20956,
-        16067
+        13
       ],
-      "expected_text": " saffron. Archive entry gamma describes",
+      "expected_text": " The audit keyword is saffron.",
       "prefill_top5": []
     },
     {

--- a/tests/sm86/profile_qwen08_decode.sh
+++ b/tests/sm86/profile_qwen08_decode.sh
@@ -42,14 +42,17 @@ export SUPERSONIC_BACKENDS="${SUPERSONIC_BACKENDS:-cuda}"
 
 case "$PROFILE_MODE" in
     hero)
+        export SUPERSONIC_ENABLE_CUDA_08B_HERO=1
         unset SUPERSONIC_DISABLE_CUDA_08B_HERO || true
         unset SUPERSONIC_DISABLE_CUDA_FAST_GREEDY || true
         ;;
     fast)
+        unset SUPERSONIC_ENABLE_CUDA_08B_HERO || true
         export SUPERSONIC_DISABLE_CUDA_08B_HERO=1
         unset SUPERSONIC_DISABLE_CUDA_FAST_GREEDY || true
         ;;
     legacy)
+        unset SUPERSONIC_ENABLE_CUDA_08B_HERO || true
         export SUPERSONIC_DISABLE_CUDA_08B_HERO=1
         export SUPERSONIC_DISABLE_CUDA_FAST_GREEDY=1
         ;;

--- a/tests/sm86/profile_qwen08_decode.sh
+++ b/tests/sm86/profile_qwen08_decode.sh
@@ -7,7 +7,7 @@
 #   ./tests/sm86/profile_qwen08_decode.sh [model_dir]
 #
 # Environment:
-#   PROFILE_MODE=hero        hero path (default)
+#   PROFILE_MODE=hero        default CUDA 0.8B hero path
 #   PROFILE_MODE=fast        disable hero, keep CUDA fast-greedy
 #   PROFILE_MODE=legacy      disable hero and fast-greedy
 #   PROMPT=Hello             prompt text
@@ -42,7 +42,7 @@ export SUPERSONIC_BACKENDS="${SUPERSONIC_BACKENDS:-cuda}"
 
 case "$PROFILE_MODE" in
     hero)
-        export SUPERSONIC_ENABLE_CUDA_08B_HERO=1
+        unset SUPERSONIC_ENABLE_CUDA_08B_HERO || true
         unset SUPERSONIC_DISABLE_CUDA_08B_HERO || true
         unset SUPERSONIC_DISABLE_CUDA_FAST_GREEDY || true
         ;;

--- a/tests/sm86/run_2b.sh
+++ b/tests/sm86/run_2b.sh
@@ -150,16 +150,27 @@ else
 fi
 
 GOLDEN="$REPO_ROOT/tests/corpus/golden_2b.json"
+GOLDEN_MODEL_ID=""
+GOLDEN_MODEL_MATCH=0
 if [ -f "$GOLDEN" ]; then
+    GOLDEN_MODEL_ID="$(python3 -c "import json; print(json.load(open('$GOLDEN')).get('model_id', ''))")"
+    GOLDEN_MODEL_BASENAME="$(basename "$GOLDEN_MODEL_ID")"
+    if [ "$GOLDEN_MODEL_ID" = "Qwen/Qwen3.5-2B" ] || [ "$GOLDEN_MODEL_BASENAME" = "Qwen3.5-2B" ]; then
+        GOLDEN_MODEL_MATCH=1
+    fi
+fi
+if [ -f "$GOLDEN" ] && [ "$GOLDEN_MODEL_MATCH" -eq 1 ]; then
     CORPUS_TIMEOUT="${CORPUS_TIMEOUT:-600}" \
         "$REPO_ROOT/tests/corpus/run_golden.sh" \
         qwen3.5-2b "$MODEL_DIR" "$GOLDEN" "$SUPERSONIC" \
         --backend cuda --oracle-device cuda:0
+elif [ -f "$GOLDEN" ]; then
+    echo "--- Skipping golden corpus: $GOLDEN targets $GOLDEN_MODEL_ID, not Qwen/Qwen3.5-2B ---"
 else
     echo "--- Skipping golden corpus (not found: $GOLDEN) ---"
 fi
 
-if [ -f "$GOLDEN" ] && [ "$HAS_SAFETENSORS" -eq 1 ]; then
+if [ -f "$GOLDEN" ] && [ "$GOLDEN_MODEL_MATCH" -eq 1 ] && [ "$HAS_SAFETENSORS" -eq 1 ]; then
     CORPUS_TIMEOUT="${CORPUS_TIMEOUT:-600}" \
         "$REPO_ROOT/tests/corpus/run_golden.sh" \
         qwen3.5-2b "$MODEL_DIR" "$GOLDEN" "$SUPERSONIC" \

--- a/tests/sm86/run_2b.sh
+++ b/tests/sm86/run_2b.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+#
+# E2E validation test for SuperSonic on NVIDIA sm86 (RTX 3090-class)
+# Model: Qwen3.5-2B
+#
+# Usage:
+#   ./tests/sm86/run_2b.sh [model_dir]
+#
+set -euo pipefail
+
+MODEL_DIR="${1:-${SUPERSONIC_MODEL_DIR_2B:-}}"
+if [ -z "$MODEL_DIR" ]; then
+    echo "Usage: $0 <path-to-Qwen3.5-2B>"
+    echo "  or set SUPERSONIC_MODEL_DIR_2B environment variable"
+    exit 1
+fi
+
+if [ ! -f "$MODEL_DIR/config.json" ]; then
+    echo "ERROR: $MODEL_DIR/config.json not found — is this a valid model directory?"
+    exit 1
+fi
+
+HAS_SAFETENSORS=0
+if find "$MODEL_DIR" -maxdepth 1 -type f \( -name "*.safetensors" -o -name "*.safetensors.index.json" \) | grep -q .; then
+    HAS_SAFETENSORS=1
+fi
+HAS_BAKE=0
+if [ -f "$MODEL_DIR/.supersonic/v1/manifest.json" ]; then
+    HAS_BAKE=1
+fi
+if [ "$HAS_SAFETENSORS" -eq 0 ] && [ "$HAS_BAKE" -eq 0 ]; then
+    echo "ERROR: $MODEL_DIR has config/tokenizer files but no raw safetensors and no BF16 bake."
+    echo "Need one of:"
+    echo "  - local HuggingFace safetensors under $MODEL_DIR"
+    echo "  - a published/local BF16 bake under $MODEL_DIR/.supersonic/v1/"
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+if [ -f /root/.cargo/env ]; then
+    . /root/.cargo/env
+fi
+MAX_DELTA_THRESHOLD="${MAX_DELTA_THRESHOLD:-1.0}"
+GPU_VALIDATE_DELTA_THRESHOLD="${GPU_VALIDATE_DELTA_THRESHOLD:-0.5}"
+TIMEOUT="${TIMEOUT:-600}"
+PROMPT="Hello"
+MAX_NEW_TOKENS=4
+TMPOUT=$(mktemp)
+trap "rm -f $TMPOUT" EXIT
+
+echo "=== SuperSonic E2E Test: sm86 / qwen3.5-2b ==="
+echo "Model dir:  $MODEL_DIR"
+echo "Threshold:  $MAX_DELTA_THRESHOLD"
+echo "GPU validate threshold:  $GPU_VALIDATE_DELTA_THRESHOLD"
+echo ""
+
+echo "--- Building (release) ---"
+SUPERSONIC_BACKENDS="${SUPERSONIC_BACKENDS:-cuda}" cargo build --release --manifest-path "$REPO_ROOT/Cargo.toml" --bin supersonic 2>&1
+echo ""
+
+SUPERSONIC="$REPO_ROOT/target/release/supersonic"
+
+run_test() {
+    local label="$1"
+    shift
+    echo "--- $label ---"
+    if ! timeout "$TIMEOUT" "$SUPERSONIC" \
+        --backend cuda \
+        --oracle-device cuda:0 \
+        --model qwen3.5-2b \
+        --model-dir "$MODEL_DIR" \
+        --prompt "$PROMPT" \
+        --max-new-tokens "$MAX_NEW_TOKENS" \
+        --validate \
+        "$@" \
+        > "$TMPOUT" 2>&1 </dev/null; then
+        cat "$TMPOUT"
+        echo ""
+        echo "FAIL: process exited non-zero or timed out (${TIMEOUT}s limit)"
+        return 1
+    fi
+    cat "$TMPOUT"
+
+    DELTA=$(grep -oP 'decode_max_delta=\K[0-9.]+' "$TMPOUT" || echo "MISSING")
+    if [ "$DELTA" = "MISSING" ]; then
+        echo "FAIL: could not extract decode_max_delta from output"
+        return 1
+    fi
+    echo ""
+    echo "Max delta ($label): $DELTA"
+    PASS=$(python3 -c "print('PASS' if float('$DELTA') <= float('$MAX_DELTA_THRESHOLD') else 'FAIL')")
+    echo "Result: $PASS (threshold=$MAX_DELTA_THRESHOLD)"
+    if [ "$PASS" != "PASS" ]; then
+        return 1
+    fi
+    echo ""
+}
+
+run_gpu_validate_test() {
+    local label="$1"
+    shift
+    echo "--- $label ---"
+    if ! timeout "$TIMEOUT" "$SUPERSONIC" \
+        --backend cuda \
+        --model qwen3.5-2b \
+        --model-dir "$MODEL_DIR" \
+        --prompt "2 + 2 =" \
+        --max-new-tokens 4 \
+        --gpu-validate \
+        "$@" \
+        > "$TMPOUT" 2>&1 </dev/null; then
+        cat "$TMPOUT"
+        echo ""
+        echo "FAIL: process exited non-zero or timed out (${TIMEOUT}s limit)"
+        return 1
+    fi
+    cat "$TMPOUT"
+
+    DELTA=$(grep -oP 'gpu_oracle_max_delta=\K[0-9.]+' "$TMPOUT" || echo "MISSING")
+    if [ "$DELTA" = "MISSING" ]; then
+        echo "FAIL: could not extract gpu_oracle_max_delta from output"
+        return 1
+    fi
+    if grep -q 'MISMATCH' "$TMPOUT"; then
+        echo "FAIL: gpu-validate reported token mismatch"
+        return 1
+    fi
+    echo ""
+    echo "GPU validate delta ($label): $DELTA"
+    PASS=$(python3 -c "print('PASS' if float('$DELTA') <= float('$GPU_VALIDATE_DELTA_THRESHOLD') else 'FAIL')")
+    echo "Result: $PASS (threshold=$GPU_VALIDATE_DELTA_THRESHOLD)"
+    if [ "$PASS" != "PASS" ]; then
+        return 1
+    fi
+    echo ""
+}
+
+run_test "Test 1: Baked path"
+if [ "$HAS_SAFETENSORS" -eq 1 ]; then
+    run_test "Test 2: Safetensors path (--no-bake)" --no-bake
+else
+    echo "--- Skipping safetensors path (--no-bake): no raw safetensors in $MODEL_DIR ---"
+fi
+run_gpu_validate_test "Test 3: GPU validate replay path"
+if [ "$HAS_SAFETENSORS" -eq 1 ]; then
+    run_gpu_validate_test "Test 4: GPU validate replay path (--no-bake)" --no-bake
+else
+    echo "--- Skipping GPU validate (--no-bake): no raw safetensors in $MODEL_DIR ---"
+fi
+
+GOLDEN="$REPO_ROOT/tests/corpus/golden_2b.json"
+if [ -f "$GOLDEN" ]; then
+    CORPUS_TIMEOUT="${CORPUS_TIMEOUT:-600}" \
+        "$REPO_ROOT/tests/corpus/run_golden.sh" \
+        qwen3.5-2b "$MODEL_DIR" "$GOLDEN" "$SUPERSONIC" \
+        --backend cuda --oracle-device cuda:0
+else
+    echo "--- Skipping golden corpus (not found: $GOLDEN) ---"
+fi
+
+if [ -f "$GOLDEN" ] && [ "$HAS_SAFETENSORS" -eq 1 ]; then
+    CORPUS_TIMEOUT="${CORPUS_TIMEOUT:-600}" \
+        "$REPO_ROOT/tests/corpus/run_golden.sh" \
+        qwen3.5-2b "$MODEL_DIR" "$GOLDEN" "$SUPERSONIC" \
+        --backend cuda --oracle-device cuda:0 --no-bake
+fi
+
+echo "=== All tests passed ==="

--- a/tests/sm86/run_9b.sh
+++ b/tests/sm86/run_9b.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+#
+# E2E validation test for SuperSonic on NVIDIA sm86 (RTX 3090-class)
+# Model: Qwen3.5-9B BF16
+#
+# Usage:
+#   ./tests/sm86/run_9b.sh [model_dir]
+#
+set -euo pipefail
+
+MODEL_DIR="${1:-${SUPERSONIC_MODEL_DIR_9B:-}}"
+if [ -z "$MODEL_DIR" ]; then
+    echo "Usage: $0 <path-to-Qwen3.5-9B>"
+    echo "  or set SUPERSONIC_MODEL_DIR_9B environment variable"
+    exit 1
+fi
+
+if [ ! -f "$MODEL_DIR/config.json" ]; then
+    echo "ERROR: $MODEL_DIR/config.json not found — is this a valid model directory?"
+    exit 1
+fi
+
+HAS_SAFETENSORS=0
+if find "$MODEL_DIR" -maxdepth 1 -type f \( -name "*.safetensors" -o -name "*.safetensors.index.json" \) | grep -q .; then
+    HAS_SAFETENSORS=1
+fi
+HAS_BAKE=0
+if [ -f "$MODEL_DIR/.supersonic/v1/manifest.json" ]; then
+    HAS_BAKE=1
+fi
+if [ "$HAS_SAFETENSORS" -eq 0 ] && [ "$HAS_BAKE" -eq 0 ]; then
+    echo "ERROR: $MODEL_DIR has config/tokenizer files but no raw safetensors and no BF16 bake."
+    echo "Need one of:"
+    echo "  - local HuggingFace safetensors under $MODEL_DIR"
+    echo "  - a published/local BF16 bake under $MODEL_DIR/.supersonic/v1/"
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+if [ -f /root/.cargo/env ]; then
+    . /root/.cargo/env
+fi
+MAX_DELTA_THRESHOLD="${MAX_DELTA_THRESHOLD:-1.5}"
+GPU_VALIDATE_DELTA_THRESHOLD="${GPU_VALIDATE_DELTA_THRESHOLD:-0.75}"
+TIMEOUT="${TIMEOUT:-900}"
+PROMPT="Hello"
+MAX_NEW_TOKENS=4
+TMPOUT=$(mktemp)
+trap "rm -f $TMPOUT" EXIT
+
+echo "=== SuperSonic E2E Test: sm86 / qwen3.5-9b ==="
+echo "Model dir:  $MODEL_DIR"
+echo "Threshold:  $MAX_DELTA_THRESHOLD"
+echo "GPU validate threshold:  $GPU_VALIDATE_DELTA_THRESHOLD"
+echo ""
+
+echo "--- Building (release) ---"
+SUPERSONIC_BACKENDS="${SUPERSONIC_BACKENDS:-cuda}" cargo build --release --manifest-path "$REPO_ROOT/Cargo.toml" --bin supersonic 2>&1
+echo ""
+
+SUPERSONIC="$REPO_ROOT/target/release/supersonic"
+
+run_test() {
+    local label="$1"
+    shift
+    echo "--- $label ---"
+    if ! timeout "$TIMEOUT" "$SUPERSONIC" \
+        --backend cuda \
+        --oracle-device cuda:0 \
+        --model qwen3.5-9b \
+        --model-dir "$MODEL_DIR" \
+        --prompt "$PROMPT" \
+        --max-new-tokens "$MAX_NEW_TOKENS" \
+        --validate \
+        "$@" \
+        > "$TMPOUT" 2>&1 </dev/null; then
+        cat "$TMPOUT"
+        echo ""
+        echo "FAIL: process exited non-zero or timed out (${TIMEOUT}s limit)"
+        return 1
+    fi
+    cat "$TMPOUT"
+
+    DELTA=$(grep -oP 'decode_max_delta=\K[0-9.]+' "$TMPOUT" || echo "MISSING")
+    if [ "$DELTA" = "MISSING" ]; then
+        echo "FAIL: could not extract decode_max_delta from output"
+        return 1
+    fi
+    echo ""
+    echo "Max delta ($label): $DELTA"
+    PASS=$(python3 -c "print('PASS' if float('$DELTA') <= float('$MAX_DELTA_THRESHOLD') else 'FAIL')")
+    echo "Result: $PASS (threshold=$MAX_DELTA_THRESHOLD)"
+    if [ "$PASS" != "PASS" ]; then
+        return 1
+    fi
+    echo ""
+}
+
+run_gpu_validate_test() {
+    local label="$1"
+    shift
+    echo "--- $label ---"
+    if ! timeout "$TIMEOUT" "$SUPERSONIC" \
+        --backend cuda \
+        --model qwen3.5-9b \
+        --model-dir "$MODEL_DIR" \
+        --prompt "2 + 2 =" \
+        --max-new-tokens 4 \
+        --gpu-validate \
+        "$@" \
+        > "$TMPOUT" 2>&1 </dev/null; then
+        cat "$TMPOUT"
+        echo ""
+        echo "FAIL: process exited non-zero or timed out (${TIMEOUT}s limit)"
+        return 1
+    fi
+    cat "$TMPOUT"
+
+    DELTA=$(grep -oP 'gpu_oracle_max_delta=\K[0-9.]+' "$TMPOUT" || echo "MISSING")
+    if [ "$DELTA" = "MISSING" ]; then
+        echo "FAIL: could not extract gpu_oracle_max_delta from output"
+        return 1
+    fi
+    if grep -q 'MISMATCH' "$TMPOUT"; then
+        echo "FAIL: gpu-validate reported token mismatch"
+        return 1
+    fi
+    echo ""
+    echo "GPU validate delta ($label): $DELTA"
+    PASS=$(python3 -c "print('PASS' if float('$DELTA') <= float('$GPU_VALIDATE_DELTA_THRESHOLD') else 'FAIL')")
+    echo "Result: $PASS (threshold=$GPU_VALIDATE_DELTA_THRESHOLD)"
+    if [ "$PASS" != "PASS" ]; then
+        return 1
+    fi
+    echo ""
+}
+
+run_test "Test 1: Baked path"
+if [ "$HAS_SAFETENSORS" -eq 1 ]; then
+    run_test "Test 2: Safetensors path (--no-bake)" --no-bake
+else
+    echo "--- Skipping safetensors path (--no-bake): no raw safetensors in $MODEL_DIR ---"
+fi
+run_gpu_validate_test "Test 3: GPU validate replay path"
+if [ "$HAS_SAFETENSORS" -eq 1 ]; then
+    run_gpu_validate_test "Test 4: GPU validate replay path (--no-bake)" --no-bake
+else
+    echo "--- Skipping GPU validate (--no-bake): no raw safetensors in $MODEL_DIR ---"
+fi
+
+echo "--- Skipping golden corpus: no BF16 qwen3.5-9b sm86 golden file yet ---"
+echo "=== All tests passed ==="

--- a/tests/sm86/run_9b.sh
+++ b/tests/sm86/run_9b.sh
@@ -43,6 +43,7 @@ if [ -f /root/.cargo/env ]; then
 fi
 MAX_DELTA_THRESHOLD="${MAX_DELTA_THRESHOLD:-1.5}"
 GPU_VALIDATE_DELTA_THRESHOLD="${GPU_VALIDATE_DELTA_THRESHOLD:-0.75}"
+ORACLE_DEVICE="${ORACLE_DEVICE:-cpu}"
 TIMEOUT="${TIMEOUT:-900}"
 PROMPT="Hello"
 MAX_NEW_TOKENS=4
@@ -53,6 +54,7 @@ echo "=== SuperSonic E2E Test: sm86 / qwen3.5-9b ==="
 echo "Model dir:  $MODEL_DIR"
 echo "Threshold:  $MAX_DELTA_THRESHOLD"
 echo "GPU validate threshold:  $GPU_VALIDATE_DELTA_THRESHOLD"
+echo "Oracle device:  $ORACLE_DEVICE"
 echo ""
 
 echo "--- Building (release) ---"
@@ -67,7 +69,7 @@ run_test() {
     echo "--- $label ---"
     if ! timeout "$TIMEOUT" "$SUPERSONIC" \
         --backend cuda \
-        --oracle-device cuda:0 \
+        --oracle-device "$ORACLE_DEVICE" \
         --model qwen3.5-9b \
         --model-dir "$MODEL_DIR" \
         --prompt "$PROMPT" \

--- a/tests/sm86/run_all.sh
+++ b/tests/sm86/run_all.sh
@@ -7,6 +7,7 @@
 #   - Qwen3.5-4B
 #   - Qwen3.5-4B long-context CPU oracle
 #   - Qwen3.5-4B batch_size=2
+#   - Qwen3.5-4B KV-FP8 batch_size=2
 #   - negative CUDA v1 coverage
 #
 # Usage:
@@ -45,5 +46,7 @@ echo ""
 TIMEOUT="${TIMEOUT:-1200}" "$SCRIPT_DIR/run_4b_long.sh" "$MODEL_DIR_4B"
 echo ""
 TIMEOUT="${TIMEOUT:-900}" "$SCRIPT_DIR/run_batch.sh" "$MODEL_DIR_4B"
+echo ""
+TIMEOUT="${TIMEOUT:-900}" CORPUS_TIMEOUT="${CORPUS_TIMEOUT:-1200}" "$SCRIPT_DIR/run_kv_fp8.sh" "$MODEL_DIR_4B"
 echo ""
 TIMEOUT="${TIMEOUT:-120}" "$SCRIPT_DIR/run_negative.sh" "$MODEL_DIR_0_8B" "$MODEL_DIR_4B"

--- a/tests/sm86/run_kv_fp8.sh
+++ b/tests/sm86/run_kv_fp8.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# E2E validation test for CUDA KV-FP8 on NVIDIA sm86 (RTX 3090-class)
+# Model: Qwen3.5-4B
+#
+# Usage:
+#   ./tests/sm86/run_kv_fp8.sh [model_dir]
+#
+set -euo pipefail
+
+MODEL_DIR="${1:-${SUPERSONIC_MODEL_DIR_4B:-}}"
+if [ -z "$MODEL_DIR" ]; then
+    echo "Usage: $0 <path-to-Qwen3.5-4B>"
+    echo "  or set SUPERSONIC_MODEL_DIR_4B environment variable"
+    exit 1
+fi
+
+if [ ! -f "$MODEL_DIR/config.json" ]; then
+    echo "ERROR: $MODEL_DIR/config.json not found — is this a valid model directory?"
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+if [ -f /root/.cargo/env ]; then
+    . /root/.cargo/env
+fi
+MAX_DELTA_THRESHOLD="${MAX_DELTA_THRESHOLD:-1.0}"
+TIMEOUT="${TIMEOUT:-300}"
+CORPUS_TIMEOUT="${CORPUS_TIMEOUT:-1200}"
+TMPOUT=$(mktemp)
+trap "rm -f $TMPOUT" EXIT
+
+echo "=== SuperSonic CUDA KV-FP8 Test: sm86 / qwen3.5-4b ==="
+echo "Model dir:  $MODEL_DIR"
+echo "Batch size: 2"
+echo "Threshold:  $MAX_DELTA_THRESHOLD"
+echo ""
+
+echo "--- Building (release) ---"
+SUPERSONIC_BACKENDS="${SUPERSONIC_BACKENDS:-cuda}" cargo build --release --manifest-path "$REPO_ROOT/Cargo.toml" --bin supersonic 2>&1
+echo ""
+
+SUPERSONIC="$REPO_ROOT/target/release/supersonic"
+
+run_test() {
+    local label="$1"
+    shift
+    echo "--- $label ---"
+    if ! timeout "$TIMEOUT" "$SUPERSONIC" \
+        --backend cuda \
+        --oracle-device cpu \
+        --model qwen3.5-4b \
+        --model-dir "$MODEL_DIR" \
+        --prompt "中国的首都是" \
+        --max-new-tokens 8 \
+        --batch-size 2 \
+        --kv-fp8 \
+        --validate \
+        "$@" \
+        > "$TMPOUT" 2>&1 </dev/null; then
+        cat "$TMPOUT"
+        echo ""
+        echo "FAIL: process exited non-zero or timed out (${TIMEOUT}s limit)"
+        return 1
+    fi
+    cat "$TMPOUT"
+
+    DELTA=$(grep -oP 'decode_max_delta=\K[0-9.]+' "$TMPOUT" || echo "MISSING")
+    if [ "$DELTA" = "MISSING" ]; then
+        echo "FAIL: could not extract decode_max_delta from output"
+        return 1
+    fi
+    echo ""
+    echo "Max delta ($label): $DELTA"
+    PASS=$(python3 -c "print('PASS' if float('$DELTA') <= float('$MAX_DELTA_THRESHOLD') else 'FAIL')")
+    echo "Result: $PASS (threshold=$MAX_DELTA_THRESHOLD)"
+    if [ "$PASS" != "PASS" ]; then
+        return 1
+    fi
+    echo ""
+}
+
+run_test "Test 1: Baked path"
+run_test "Test 2: Safetensors path (--no-bake)" --no-bake
+
+GOLDEN="$REPO_ROOT/tests/corpus/golden_4b_batch2.json"
+if [ -f "$GOLDEN" ]; then
+    CORPUS_TIMEOUT="$CORPUS_TIMEOUT" \
+        "$REPO_ROOT/tests/corpus/run_golden.sh" \
+        qwen3.5-4b "$MODEL_DIR" "$GOLDEN" "$SUPERSONIC" \
+        --backend cuda --oracle-device cpu --batch-size 2 --kv-fp8
+else
+    echo "--- Skipping batch golden corpus (not found: $GOLDEN) ---"
+fi
+
+if [ -f "$GOLDEN" ]; then
+    CORPUS_TIMEOUT="$CORPUS_TIMEOUT" \
+        "$REPO_ROOT/tests/corpus/run_golden.sh" \
+        qwen3.5-4b "$MODEL_DIR" "$GOLDEN" "$SUPERSONIC" \
+        --backend cuda --oracle-device cpu --batch-size 2 --kv-fp8 --no-bake
+fi
+
+echo "=== All CUDA KV-FP8 tests passed ==="

--- a/tests/sm86/run_negative.sh
+++ b/tests/sm86/run_negative.sh
@@ -81,9 +81,9 @@ run_fail "Test 2: CUDA rejects --fp8-runtime" \
     "CUDA v1 does not support --fp8-runtime yet" \
     "${COMMON_4B[@]}" --fp8-runtime
 
-run_fail "Test 3: CUDA rejects --kv-fp8" \
-    "CUDA v1 does not support --kv-fp8 yet" \
-    "${COMMON_4B[@]}" --kv-fp8
+run_fail "Test 3: CUDA rejects --kv-fp8 on unsupported model" \
+    "CUDA --kv-fp8 currently supports only qwen3.5-4b on sm86" \
+    "${COMMON_0_8B[@]}" --kv-fp8
 
 run_fail "Test 4: CUDA rejects batch on non-4B kernel" \
     "--batch-size > 1 requires 4B kernel" \
@@ -94,10 +94,10 @@ run_fail "Test 5: CUDA rejects out-of-range batch size" \
     "${COMMON_4B[@]}" --batch-size 0
 
 run_fail "Test 6: unknown CUDA override stays explicit on unsupported model" \
-    "--allow-untested-gpu=sm999: no registry entry for model=qwen3.5-2b backend=CUDA arch=sm999" \
+    "--allow-untested-gpu=sm999: no registry entry for model=gemma4-e2b backend=CUDA arch=sm999" \
     --backend cuda \
     --allow-untested-gpu sm999 \
-    --model qwen3.5-2b \
+    --model gemma4-e2b \
     --model-dir "$MODEL_DIR_4B" \
     --prompt "Hello" \
     --max-new-tokens 1


### PR DESCRIPTION
## What changed

This branch expands the validated CUDA `sm86` Qwen surface and carries the follow-on 4B hero-lane work that was kept after measurement.

Key changes:

- wire CUDA `sm86` registry/runtime support for `qwen3.5-2b` and `qwen3.5-9b`
- stabilize the CUDA `qwen3.5-4b` decode path across short, long-context, batched, and KV-FP8 validation flows
- add/extend CUDA tracing and oracle reconstruction tools for localizing 4B persistent-kernel parity issues
- refresh the 4B NIAH/golden test data and add dedicated `sm86` test scripts for `2b`, `9b`, KV-FP8, and negative cases
- restore the kept `qwen3.5-0.8b` hero path after parity fixes
- land the kept 4B hero optimization that caches single-stream hero inputs in BF16 shared memory for `linear_proj`
- refresh README and CUDA performance/optimization docs with the current validated behavior and measured numbers

## Why it changed

The CUDA branch had diverged from the actual validated surface in two ways:

- runtime support and test coverage had grown beyond what the docs claimed
- the `qwen3.5-4b` hero work needed a measured checkpoint that preserved correctness rather than carrying speculative fast-but-wrong kernel rewrites

This PR brings the repo state back into alignment: the branch ships only the measured 4B CUDA wins, keeps the failed MLP/`linear_out` warp-reduction experiments reverted, and records the current `sm86` behavior in the docs.

## User impact

- CUDA `sm86` users now have explicit checked BF16 lanes for `qwen3.5-0.8b`, `qwen3.5-2b`, `qwen3.5-4b`, and `qwen3.5-9b`
- `qwen3.5-4b` single-sequence BF16 CUDA decode now defaults to the kernel path; replayed-prefill decode is legacy debug behavior behind `--force-replay-decode`
- `qwen3.5-4b` remains the only CUDA KV-FP8 lane on `sm86`
- the latest kept 4B hero checkpoint improves the warmed single-stream native-kernel lane to about `22.0 tok/s` on this RTX 3090-class box

## Root cause / technical notes

The big 4B bring-up issue was not one isolated bug. It was a mix of:

- decode-path routing mismatches between replay/component/kernel flows
- parity-sensitive persistent-kernel state handling on the 4B path
- stale docs that still described older replay-prefill behavior and pre-optimization timings

The branch also confirmed an important negative result: straightforward 0.8B-style BF16-cache warp-reduction rewrites for 4B `mlp_gate_up`, `mlp_down`, and `linear_out` are not numerically free on this model. Those experiments were measured, failed parity, and were reverted.

## Validation

Checked locally on this machine:

- `SUPERSONIC_BACKENDS=cuda ./tests/sm86/run_4b.sh /workspace/models/Qwen3.5-4B`
- `SUPERSONIC_BACKENDS=cuda ./tests/sm86/run_4b_long.sh /workspace/models/Qwen3.5-4B`
- `SUPERSONIC_BACKENDS=cuda ./tests/sm86/run_batch.sh /workspace/models/Qwen3.5-4B`
- `SUPERSONIC_BACKENDS=cuda RUNS=1 MAX_NEW_TOKENS=8 PROMPT_REPEAT=8 ./tests/sm86/bench.sh /workspace/models/Qwen3.5-0.8B /workspace/models/Qwen3.5-4B`
- `SUPERSONIC_BACKENDS=cuda WARMUP_RUNS=2 TIMED_RUNS=3 MAX_NEW_TOKENS=16 ./tests/sm86/bench_qwen4b_single.sh /workspace/models/Qwen3.5-4B`

Recorded CUDA snapshot on commit `5a34190`:

- `qwen3.5-0.8b`: `544 tok/s` prefill, `106.7 tok/s` decode
- `qwen3.5-4b --batch-size 1`: `124.7 tok/s` prefill, `26.0 tok/s` decode
- warmed 4B single-stream hero lane: `101.5 tok/s` prefill, `22.0 tok/s` decode, `654.6 ms` persistent
