### PR TITLE
Fix CUDA main compatibility build regressions

### DIFF
--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -3,6 +3,10 @@ name = "runner"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+default = []
+bughunt = []
+
 [[bin]]
 name = "supersonic"
 path = "src/main.rs"
@@ -62,6 +66,7 @@ path = "src/bin/gemma4_int4_layer_diag.rs"
 [[bin]]
 name = "qwen35_bughunt"
 path = "src/bin/qwen35_bughunt.rs"
+required-features = ["bughunt"]
 
 [dependencies]
 gpu-hal = { path = "../gpu-hal" }

--- a/crates/runner/src/decode_engine.rs
+++ b/crates/runner/src/decode_engine.rs
@@ -4878,6 +4878,7 @@ impl DecodeEngine {
                     PersistentTimingCalibration::ClockRateKhz(khz)
                 }
                 gpu_hal::Backend::Hip => PersistentTimingCalibration::WallClockMs(0.0),
+                gpu_hal::Backend::Metal => PersistentTimingCalibration::WallClockMs(0.0),
             })
         } else {
             None

--- a/crates/runner/src/lib.rs
+++ b/crates/runner/src/lib.rs
@@ -9,6 +9,7 @@
 //! root present, the same files get compiled once into the library crate
 //! (`runner::…`) for external consumers.
 
+#[cfg(feature = "bughunt")]
 pub mod bughunt;
 pub mod decode_engine;
 pub mod gemma4_engine;

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -142,9 +142,26 @@ fn resolve_oracle_device(spec: &str, backend: Backend, ordinal: usize) -> String
         "auto" => match backend {
             Backend::Cuda => format!("cuda:{ordinal}"),
             Backend::Hip => "cpu".to_string(),
+            Backend::Metal => "cpu".to_string(),
         },
         other => other.to_string(),
     }
+}
+
+fn load_tokenizer(tokenizer_path: &Path) -> Result<tokenizers::Tokenizer> {
+    tokenizers::Tokenizer::from_file(tokenizer_path)
+        .map_err(|e| anyhow::anyhow!("loading tokenizer {}: {e}", tokenizer_path.display()))
+}
+
+fn resolve_prompt_token_ids(cli: &Cli, tokenizer: &tokenizers::Tokenizer) -> Result<Vec<u32>> {
+    let encoding = tokenizer
+        .encode(cli.prompt.as_str(), true)
+        .map_err(|e| anyhow::anyhow!("tokenizer encode failed: {e}"))?;
+    let prompt_ids: Vec<u32> = encoding.get_ids().to_vec();
+    if prompt_ids.is_empty() {
+        anyhow::bail!("prompt tokenization produced 0 tokens");
+    }
+    Ok(prompt_ids)
 }
 
 fn model_dir_has_raw_safetensors(model_dir: &Path) -> bool {
@@ -670,6 +687,11 @@ fn main() -> Result<()> {
             (arch_name, total_vram, 32)
         }
         Backend::Cuda => {
+            let info = gpu_hal::query_device_info(backend, ordinal)
+                .map_err(|e| anyhow::anyhow!("GPU query failed for device {ordinal}: {e}"))?;
+            (info.arch_name, info.total_vram_bytes, info.warp_size)
+        }
+        Backend::Metal => {
             let info = gpu_hal::query_device_info(backend, ordinal)
                 .map_err(|e| anyhow::anyhow!("GPU query failed for device {ordinal}: {e}"))?;
             (info.arch_name, info.total_vram_bytes, info.warp_size)

--- a/crates/runner/src/phi4_engine.rs
+++ b/crates/runner/src/phi4_engine.rs
@@ -127,25 +127,14 @@ pub fn run_phi4(
             .join("oracle/phi4_oracle.py");
         let oracle_device =
             crate::resolve_oracle_device(&cli.oracle_device, entry.backend, ordinal);
-        let oracle = if cli.prompt_ids.is_some() {
-            oracle_mod::run_phi4_oracle_ids(
-                &oracle_script,
-                &cli.model_dir,
-                &prompt_ids,
-                cli.max_new_tokens,
-                &cli.oracle_dtype,
-                &oracle_device,
-            )?
-        } else {
-            oracle_mod::run_phi4_oracle(
-                &oracle_script,
-                &cli.model_dir,
-                cli.prompt.as_deref().unwrap_or_default(),
-                cli.max_new_tokens,
-                &cli.oracle_dtype,
-                &oracle_device,
-            )?
-        };
+        let oracle = oracle_mod::run_phi4_oracle(
+            &oracle_script,
+            &cli.model_dir,
+            &cli.prompt,
+            cli.max_new_tokens,
+            &cli.oracle_dtype,
+            &oracle_device,
+        )?;
         if let Some(ref oracle_ids) = oracle.prompt_token_ids {
             if oracle_ids != &prompt_ids {
                 bail!(


### PR DESCRIPTION
## Summary

Fixes current `main` compatibility regressions that were breaking CUDA `supersonic` builds.

- Makes `bughunt` opt-in to avoid hard coupling in default builds.
- Adds missing `Backend::Metal` match handling in shared paths.
- Restores shared tokenizer/prompt-id helper usage expected by runtime engines.
- Aligns Phi4 oracle call path with current CLI shape.

## Validation

- `SUPERSONIC_BACKENDS=cuda cargo build --release --bin supersonic` passes on this machine.

## Commit

- `753243e` on `fix/main-compat-build`