### PR TITLE
[codex] Improve Metal Qwen incremental decode

### DIFF
--- a/crates/kernel-ffi/src/ffi.rs
+++ b/crates/kernel-ffi/src/ffi.rs
@@ -826,6 +826,82 @@ pub fn metal_lm_head_argmax_bf16_into(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
+pub fn metal_lm_head_argmax_bf16_with_partials_into(
+    hidden: &GpuBuffer,
+    weight: &GpuBuffer,
+    mut partial_values: &mut GpuBuffer,
+    mut partial_indices: &mut GpuBuffer,
+    mut out_index: &mut GpuBuffer,
+    hidden_dim: usize,
+    vocab_size: usize,
+) -> Result<(), GpuError> {
+    if hidden.backend() != Backend::Metal
+        || weight.backend() != Backend::Metal
+        || partial_values.backend() != Backend::Metal
+        || partial_indices.backend() != Backend::Metal
+        || out_index.backend() != Backend::Metal
+    {
+        return Err(GpuError::InvalidArg(
+            "metal_lm_head_argmax_bf16_with_partials_into requires Metal buffers".into(),
+        ));
+    }
+    if hidden.dtype() != ScalarType::BF16 || weight.dtype() != ScalarType::BF16 {
+        return Err(GpuError::InvalidArg(format!(
+            "metal_lm_head_argmax_bf16_with_partials_into requires BF16 hidden/weight, got {:?}/{:?}",
+            hidden.dtype(),
+            weight.dtype()
+        )));
+    }
+    let partial_count = vocab_size.div_ceil(256);
+    if partial_values.dtype() != ScalarType::F32 || partial_values.elem_count() < partial_count {
+        return Err(GpuError::InvalidArg(format!(
+            "metal_lm_head_argmax_bf16_with_partials_into requires F32 partial_values[{partial_count}], got {:?}[{}]",
+            partial_values.dtype(),
+            partial_values.elem_count()
+        )));
+    }
+    if partial_indices.dtype() != ScalarType::U32 || partial_indices.elem_count() < partial_count {
+        return Err(GpuError::InvalidArg(format!(
+            "metal_lm_head_argmax_bf16_with_partials_into requires U32 partial_indices[{partial_count}], got {:?}[{}]",
+            partial_indices.dtype(),
+            partial_indices.elem_count()
+        )));
+    }
+    if out_index.dtype() != ScalarType::U32 || out_index.elem_count() != 1 {
+        return Err(GpuError::InvalidArg(
+            "metal_lm_head_argmax_bf16_with_partials_into requires a U32[1] output buffer".into(),
+        ));
+    }
+    #[cfg(all(target_os = "macos", supersonic_backend_metal))]
+    {
+        crate::prefill_ffi::metal_profile_time("lm_head_argmax", "native", || {
+            crate::metal_native::lm_head_argmax_bf16_with_partials(
+                hidden,
+                weight,
+                &mut out_index,
+                Some(&mut partial_values),
+                Some(&mut partial_indices),
+                hidden_dim,
+                vocab_size,
+            )
+        })
+    }
+    #[cfg(not(all(target_os = "macos", supersonic_backend_metal)))]
+    {
+        let _ = (
+            hidden,
+            weight,
+            partial_values,
+            partial_indices,
+            out_index,
+            hidden_dim,
+            vocab_size,
+        );
+        Err(GpuError::InvalidArg("Metal backend not compiled".into()))
+    }
+}
+
 pub fn metal_argmax_bf16_into(
     logits: &GpuBuffer,
     mut out_index: &mut GpuBuffer,

--- a/crates/kernel-ffi/src/lib.rs
+++ b/crates/kernel-ffi/src/lib.rs
@@ -9,7 +9,8 @@ pub mod prefill_ffi;
 
 pub use ffi::{
     cuda_argmax_bf16, cuda_lm_head_argmax_bf16, matmul_rhs_transposed_4b, metal_argmax_bf16_into,
-    metal_lm_head_argmax_bf16, metal_lm_head_argmax_bf16_into, persistent_decode,
+    metal_lm_head_argmax_bf16, metal_lm_head_argmax_bf16_into,
+    metal_lm_head_argmax_bf16_with_partials_into, persistent_decode,
     persistent_decode_4b,
     persistent_decode_4b_qwen35_sm86_specialized, persistent_decode_qwen08_sm86_specialized,
     query_gpu_info, query_hip_device_clock_khz, qwen_rms_norm_standalone_matvec_host_f32, rms_norm,

--- a/crates/kernel-ffi/src/metal_native.mm
+++ b/crates/kernel-ffi/src/metal_native.mm
@@ -1032,23 +1032,38 @@ kernel void supersonic_qwen_mlp_down_residual_bf16(
     return pipeline;
 }
 
-id<MTLComputePipelineState> qwen_linear_out_residual_pipeline_f32_bf16(NSError** error_out) {
+id<MTLComputePipelineState> qwen_linear_out_residual_pipeline(NSString* function_name, NSError** error_out) {
     static std::mutex mutex;
-    static bool attempted = false;
-    static __strong id<MTLComputePipelineState> pipeline = nil;
-    static __strong NSError* build_error = nil;
+    static __strong NSMutableDictionary<NSString*, id<MTLComputePipelineState>>* pipelines = nil;
+    static __strong NSMutableDictionary<NSString*, NSError*>* errors = nil;
 
     std::lock_guard<std::mutex> lock(mutex);
-    if (!attempted) {
-        attempted = true;
-        @autoreleasepool {
-            id<MTLDevice> device = metal_device();
-            if (device == nil) {
-                build_error = [NSError errorWithDomain:@"SuperSonicMetal"
-                                                   code:385
-                                               userInfo:@{NSLocalizedDescriptionKey : @"No Metal device"}];
-            } else {
-                static const char* kSource = R"QWENLINEAROUT(
+    if (pipelines == nil) {
+        pipelines = [[NSMutableDictionary alloc] init];
+        errors = [[NSMutableDictionary alloc] init];
+    }
+    id<MTLComputePipelineState> cached = pipelines[function_name];
+    if (cached != nil) {
+        return cached;
+    }
+    NSError* cached_error = errors[function_name];
+    if (cached_error != nil) {
+        if (error_out != nullptr) {
+            *error_out = cached_error;
+        }
+        return nil;
+    }
+
+    NSError* build_error = nil;
+    id<MTLComputePipelineState> pipeline = nil;
+    @autoreleasepool {
+        id<MTLDevice> device = metal_device();
+        if (device == nil) {
+            build_error = [NSError errorWithDomain:@"SuperSonicMetal"
+                                               code:385
+                                           userInfo:@{NSLocalizedDescriptionKey : @"No Metal device"}];
+        } else {
+            static const char* kSource = R"QWENLINEAROUT(
 #include <metal_stdlib>
 using namespace metal;
 
@@ -1092,54 +1107,93 @@ kernel void supersonic_qwen_linear_out_residual_f32_bf16(
     }
     out[gid] = bfloat(float(bfloat(acc)) + float(residual[gid]));
 }
+
+kernel void supersonic_qwen_linear_out_residual_bf16_bf16(
+    device const bfloat* attn [[buffer(0)]],
+    device const bfloat* gate [[buffer(1)]],
+    device const bfloat* norm_weight [[buffer(2)]],
+    device const bfloat* out_proj [[buffer(3)]],
+    device const bfloat* residual [[buffer(4)]],
+    device bfloat* out [[buffer(5)]],
+    constant QwenLinearOutParams& params [[buffer(6)]],
+    uint gid [[thread_position_in_grid]]
+) {
+    if (gid >= params.hidden_dim) {
+        return;
+    }
+    float acc = 0.0f;
+    for (uint row = 0; row < params.num_rows; ++row) {
+        uint row_base = row * params.row_dim;
+        float mean_sq = 0.0f;
+        for (uint col = 0; col < params.row_dim; ++col) {
+            float value = float(attn[row_base + col]);
+            mean_sq = fma(value, value, mean_sq);
+        }
+        float inv_rms = rsqrt((mean_sq / float(params.row_dim)) + params.eps);
+        for (uint col = 0; col < params.row_dim; ++col) {
+            uint idx = row_base + col;
+            float gate_v = float(gate[idx]);
+            float sig = 1.0f / (1.0f + exp(-gate_v));
+            bfloat gated =
+                bfloat(float(attn[idx]) * inv_rms * float(norm_weight[col]) * (gate_v * sig));
+            acc += float(gated) * float(out_proj[gid * (params.num_rows * params.row_dim) + idx]);
+        }
+    }
+    out[gid] = bfloat(float(bfloat(acc)) + float(residual[gid]));
+}
 )QWENLINEAROUT";
 
-                NSString* source = [NSString stringWithUTF8String:kSource];
-                MTLCompileOptions* options = [[MTLCompileOptions alloc] init];
-                configure_precise_math(options);
-                NSError* library_error = nil;
-                id<MTLLibrary> library = [device newLibraryWithSource:source
-                                                              options:options
-                                                                error:&library_error];
-                if (library == nil || library_error != nil) {
-                    build_error = library_error ?: [NSError errorWithDomain:@"SuperSonicMetal"
-                                                                       code:386
-                                                                   userInfo:@{
-                                                                       NSLocalizedDescriptionKey :
-                                                                           @"Failed to compile Qwen linear out library"
-                                                                   }];
+            NSString* source = [NSString stringWithUTF8String:kSource];
+            MTLCompileOptions* options = [[MTLCompileOptions alloc] init];
+            configure_precise_math(options);
+            NSError* library_error = nil;
+            id<MTLLibrary> library = [device newLibraryWithSource:source
+                                                          options:options
+                                                            error:&library_error];
+            if (library == nil || library_error != nil) {
+                build_error = library_error ?: [NSError errorWithDomain:@"SuperSonicMetal"
+                                                                   code:386
+                                                               userInfo:@{
+                                                                   NSLocalizedDescriptionKey :
+                                                                       @"Failed to compile Qwen linear out library"
+                                                               }];
+            } else {
+                id<MTLFunction> function = [library newFunctionWithName:function_name];
+                if (function == nil) {
+                    build_error = [NSError errorWithDomain:@"SuperSonicMetal"
+                                                       code:387
+                                                   userInfo:@{
+                                                       NSLocalizedDescriptionKey :
+                                                           @"Failed to load Qwen linear out function"
+                                                   }];
                 } else {
-                    id<MTLFunction> function =
-                        [library newFunctionWithName:@"supersonic_qwen_linear_out_residual_f32_bf16"];
-                    if (function == nil) {
-                        build_error = [NSError errorWithDomain:@"SuperSonicMetal"
-                                                           code:387
-                                                       userInfo:@{
-                                                           NSLocalizedDescriptionKey :
-                                                               @"Failed to load Qwen linear out function"
-                                                       }];
-                    } else {
-                        NSError* pipeline_error = nil;
-                        pipeline = [device newComputePipelineStateWithFunction:function
-                                                                         error:&pipeline_error];
-                        if (pipeline == nil || pipeline_error != nil) {
-                            build_error = pipeline_error ?: [NSError errorWithDomain:@"SuperSonicMetal"
-                                                                                 code:388
-                                                                             userInfo:@{
-                                                                                 NSLocalizedDescriptionKey :
-                                                                                     @"Failed to create Qwen linear out pipeline"
-                                                                             }];
-                        }
+                    NSError* pipeline_error = nil;
+                    pipeline = [device newComputePipelineStateWithFunction:function
+                                                                     error:&pipeline_error];
+                    if (pipeline == nil || pipeline_error != nil) {
+                        build_error = pipeline_error ?: [NSError errorWithDomain:@"SuperSonicMetal"
+                                                                             code:388
+                                                                         userInfo:@{
+                                                                             NSLocalizedDescriptionKey :
+                                                                                 @"Failed to create Qwen linear out pipeline"
+                                                                         }];
                     }
                 }
             }
         }
     }
 
-    if (pipeline == nil && error_out != nullptr) {
+    if (pipeline != nil) {
+        pipelines[function_name] = pipeline;
+        return pipeline;
+    }
+    if (build_error != nil) {
+        errors[function_name] = build_error;
+    }
+    if (error_out != nullptr) {
         *error_out = build_error;
     }
-    return pipeline;
+    return nil;
 }
 
 id<MTLComputePipelineState> qwen_full_projection_pipeline_bf16(NSError** error_out) {
@@ -7847,7 +7901,10 @@ extern "C" int supersonic_metal_qwen_linear_out_residual_f32_bf16(
 
         NSError* pipeline_error = nil;
         id<MTLComputePipelineState> pipeline =
-            qwen_linear_out_residual_pipeline_f32_bf16(&pipeline_error);
+            qwen_linear_out_residual_pipeline(
+                @"supersonic_qwen_linear_out_residual_f32_bf16",
+                &pipeline_error
+            );
         if (pipeline == nil) {
             return 400;
         }
@@ -7911,6 +7968,97 @@ extern "C" int supersonic_metal_qwen_linear_out_residual_f32_bf16(
             MTLSize threads_per_grid = MTLSizeMake(hidden_dim, 1, 1);
             [encoder dispatchThreads:threads_per_grid threadsPerThreadgroup:threads_per_group];
         }, 407, 408, 409, 410);
+    }
+}
+
+extern "C" int supersonic_metal_qwen_linear_out_residual_bf16_bf16(
+    size_t hidden_dim,
+    size_t num_rows,
+    size_t row_dim,
+    float eps,
+    const void* attn_ptr,
+    const void* gate_ptr,
+    const void* weight_ptr,
+    const void* out_proj_ptr,
+    const void* residual_ptr,
+    void* out_ptr
+) {
+    @autoreleasepool {
+        if (hidden_dim == 0 || num_rows == 0 || row_dim == 0 || attn_ptr == nullptr ||
+            gate_ptr == nullptr || weight_ptr == nullptr || out_proj_ptr == nullptr ||
+            residual_ptr == nullptr || out_ptr == nullptr) {
+            return 411;
+        }
+
+        NSError* pipeline_error = nil;
+        id<MTLComputePipelineState> pipeline =
+            qwen_linear_out_residual_pipeline(
+                @"supersonic_qwen_linear_out_residual_bf16_bf16",
+                &pipeline_error
+            );
+        if (pipeline == nil) {
+            return 412;
+        }
+
+        id<MTLBuffer> attn = nil;
+        id<MTLBuffer> gate = nil;
+        id<MTLBuffer> weight = nil;
+        id<MTLBuffer> out_proj = nil;
+        id<MTLBuffer> residual = nil;
+        id<MTLBuffer> out = nil;
+        size_t attn_offset = 0;
+        size_t gate_offset = 0;
+        size_t weight_offset = 0;
+        size_t out_proj_offset = 0;
+        size_t residual_offset = 0;
+        size_t out_offset = 0;
+        if (lookup_buffer(attn_ptr, &attn, &attn_offset) != 0) {
+            return 413;
+        }
+        if (lookup_buffer(gate_ptr, &gate, &gate_offset) != 0) {
+            return 414;
+        }
+        if (lookup_buffer(weight_ptr, &weight, &weight_offset) != 0) {
+            return 415;
+        }
+        if (lookup_buffer(out_proj_ptr, &out_proj, &out_proj_offset) != 0) {
+            return 416;
+        }
+        if (lookup_buffer(residual_ptr, &residual, &residual_offset) != 0) {
+            return 417;
+        }
+        if (lookup_buffer(out_ptr, &out, &out_offset) != 0) {
+            return 418;
+        }
+
+        struct QwenLinearOutParams {
+            uint32_t hidden_dim;
+            uint32_t num_rows;
+            uint32_t row_dim;
+            float eps;
+        } params = {
+            static_cast<uint32_t>(hidden_dim),
+            static_cast<uint32_t>(num_rows),
+            static_cast<uint32_t>(row_dim),
+            eps,
+        };
+
+        return encode_or_submit([&](id<MTLComputeCommandEncoder> encoder) {
+            [encoder setComputePipelineState:pipeline];
+            [encoder setBuffer:attn offset:attn_offset atIndex:0];
+            [encoder setBuffer:gate offset:gate_offset atIndex:1];
+            [encoder setBuffer:weight offset:weight_offset atIndex:2];
+            [encoder setBuffer:out_proj offset:out_proj_offset atIndex:3];
+            [encoder setBuffer:residual offset:residual_offset atIndex:4];
+            [encoder setBuffer:out offset:out_offset atIndex:5];
+            [encoder setBytes:&params length:sizeof(params) atIndex:6];
+
+            NSUInteger tg_width =
+                std::min<NSUInteger>(256, std::max<NSUInteger>(1, pipeline.maxTotalThreadsPerThreadgroup));
+            MTLSize threads_per_group = MTLSizeMake(tg_width, 1, 1);
+            MTLSize threads_per_grid = MTLSizeMake(hidden_dim, 1, 1);
+            [encoder dispatchThreads:threads_per_grid threadsPerThreadgroup:threads_per_group];
+        }, 419, 420, 421, 422);
     }
 }
 

--- a/crates/kernel-ffi/src/metal_native.mm
+++ b/crates/kernel-ffi/src/metal_native.mm
@@ -87,6 +87,15 @@ struct FullAttentionParams {
     float scale;
 };
 
+struct FullAttentionDecodeParams {
+    uint32_t q_heads;
+    uint32_t kv_heads;
+    uint32_t kv_len;
+    uint32_t kv_stride;
+    uint32_t head_dim;
+    float scale;
+};
+
 struct EmbeddingLookupParams {
     uint32_t token_count;
     uint32_t vocab_size;
@@ -1787,6 +1796,179 @@ kernel void supersonic_full_attention_prefill_bf16_f32(
                                                                              userInfo:@{
                                                                                  NSLocalizedDescriptionKey :
                                                                                      @"Failed to create full-attention pipeline"
+                                                                             }];
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (pipeline == nil && error_out != nullptr) {
+        *error_out = build_error;
+    }
+    return pipeline;
+}
+
+id<MTLComputePipelineState> full_attention_decode_pipeline_bf16_f32(NSError** error_out) {
+    static std::mutex mutex;
+    static bool attempted = false;
+    static __strong id<MTLComputePipelineState> pipeline = nil;
+    static __strong NSError* build_error = nil;
+
+    std::lock_guard<std::mutex> lock(mutex);
+    if (!attempted) {
+        attempted = true;
+        @autoreleasepool {
+            id<MTLDevice> device = metal_device();
+            if (device == nil) {
+                build_error = [NSError errorWithDomain:@"SuperSonicMetal"
+                                                   code:501
+                                               userInfo:@{NSLocalizedDescriptionKey : @"No Metal device"}];
+            } else {
+                static const char* kSource = R"FATTNDECODE(
+#include <metal_stdlib>
+using namespace metal;
+
+struct FullAttentionDecodeParams {
+    uint q_heads;
+    uint kv_heads;
+    uint kv_len;
+    uint kv_stride;
+    uint head_dim;
+    float scale;
+};
+
+inline void reduce_sum_256(threadgroup float* scratch, uint tid) {
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (tid < 128) { scratch[tid] += scratch[tid + 128]; }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (tid < 64) { scratch[tid] += scratch[tid + 64]; }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (tid < 32) { scratch[tid] += scratch[tid + 32]; }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (tid < 16) { scratch[tid] += scratch[tid + 16]; }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (tid < 8) { scratch[tid] += scratch[tid + 8]; }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (tid < 4) { scratch[tid] += scratch[tid + 4]; }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (tid < 2) { scratch[tid] += scratch[tid + 2]; }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (tid < 1) { scratch[tid] += scratch[tid + 1]; }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+}
+
+kernel void supersonic_full_attention_decode_bf16_f32(
+    device const bfloat* query [[buffer(0)]],
+    device const bfloat* key [[buffer(1)]],
+    device const bfloat* value [[buffer(2)]],
+    device float* out [[buffer(3)]],
+    constant FullAttentionDecodeParams& params [[buffer(4)]],
+    uint q_head [[threadgroup_position_in_grid]],
+    uint tid [[thread_index_in_threadgroup]]
+) {
+    threadgroup float scratch[256];
+    threadgroup float max_score;
+    threadgroup float denom;
+    threadgroup float weight;
+
+    if (q_head >= params.q_heads) {
+        return;
+    }
+
+    uint num_kv_groups = params.q_heads / params.kv_heads;
+    uint kv_head = q_head / num_kv_groups;
+    uint query_base = q_head * params.head_dim;
+
+    if (tid == 0) {
+        max_score = -INFINITY;
+        denom = 0.0f;
+        weight = 0.0f;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    for (uint kv_pos = 0; kv_pos < params.kv_len; ++kv_pos) {
+        uint key_base = (kv_head * params.kv_stride + kv_pos) * params.head_dim;
+        scratch[tid] = tid < params.head_dim
+            ? float(query[query_base + tid]) * float(key[key_base + tid])
+            : 0.0f;
+        reduce_sum_256(scratch, tid);
+        if (tid == 0) {
+            max_score = max(max_score, scratch[0] * params.scale);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    for (uint kv_pos = 0; kv_pos < params.kv_len; ++kv_pos) {
+        uint key_base = (kv_head * params.kv_stride + kv_pos) * params.head_dim;
+        scratch[tid] = tid < params.head_dim
+            ? float(query[query_base + tid]) * float(key[key_base + tid])
+            : 0.0f;
+        reduce_sum_256(scratch, tid);
+        if (tid == 0) {
+            denom += exp((scratch[0] * params.scale) - max_score);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    float numer = 0.0f;
+    for (uint kv_pos = 0; kv_pos < params.kv_len; ++kv_pos) {
+        uint key_base = (kv_head * params.kv_stride + kv_pos) * params.head_dim;
+        scratch[tid] = tid < params.head_dim
+            ? float(query[query_base + tid]) * float(key[key_base + tid])
+            : 0.0f;
+        reduce_sum_256(scratch, tid);
+        if (tid == 0) {
+            weight = exp((scratch[0] * params.scale) - max_score);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        if (tid < params.head_dim) {
+            uint value_base = (kv_head * params.kv_stride + kv_pos) * params.head_dim;
+            numer += weight * float(value[value_base + tid]);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    if (tid < params.head_dim) {
+        out[q_head * params.head_dim + tid] = numer / denom;
+    }
+}
+)FATTNDECODE";
+                NSString* source = [NSString stringWithUTF8String:kSource];
+                MTLCompileOptions* options = [[MTLCompileOptions alloc] init];
+                configure_precise_math(options);
+                NSError* library_error = nil;
+                id<MTLLibrary> library = [device newLibraryWithSource:source
+                                                              options:options
+                                                                error:&library_error];
+                if (library == nil || library_error != nil) {
+                    build_error = library_error ?: [NSError errorWithDomain:@"SuperSonicMetal"
+                                                                       code:502
+                                                                   userInfo:@{
+                                                                       NSLocalizedDescriptionKey :
+                                                                           @"Failed to compile full-attention decode library"
+                                                                   }];
+                } else {
+                    id<MTLFunction> function =
+                        [library newFunctionWithName:@"supersonic_full_attention_decode_bf16_f32"];
+                    if (function == nil) {
+                        build_error = [NSError errorWithDomain:@"SuperSonicMetal"
+                                                           code:503
+                                                       userInfo:@{
+                                                           NSLocalizedDescriptionKey :
+                                                               @"Failed to load full-attention decode function"
+                                                       }];
+                    } else {
+                        NSError* pipeline_error = nil;
+                        pipeline = [device newComputePipelineStateWithFunction:function
+                                                                         error:&pipeline_error];
+                        if (pipeline == nil || pipeline_error != nil) {
+                            build_error = pipeline_error ?: [NSError errorWithDomain:@"SuperSonicMetal"
+                                                                                 code:504
+                                                                             userInfo:@{
+                                                                                 NSLocalizedDescriptionKey :
+                                                                                     @"Failed to create full-attention decode pipeline"
                                                                              }];
                         }
                     }
@@ -8589,6 +8771,77 @@ extern "C" int supersonic_metal_full_attention_prefill_bf16_f32(
             MTLSize threads_per_grid = MTLSizeMake(head_dim, q_len, q_heads);
             [encoder dispatchThreads:threads_per_grid threadsPerThreadgroup:threads_per_group];
         }, 27, 28, 29, 30);
+    }
+}
+
+extern "C" int supersonic_metal_full_attention_decode_bf16_f32(
+    size_t q_heads,
+    size_t kv_heads,
+    size_t kv_len,
+    size_t kv_stride,
+    size_t head_dim,
+    float scale,
+    const void* query_ptr,
+    const void* key_ptr,
+    const void* value_ptr,
+    void* out_ptr
+) {
+    @autoreleasepool {
+        if (q_heads == 0 || kv_heads == 0 || kv_len == 0 || kv_stride < kv_len || head_dim == 0 ||
+            head_dim > 256 || query_ptr == nullptr || key_ptr == nullptr || value_ptr == nullptr ||
+            out_ptr == nullptr) {
+            return 511;
+        }
+
+        NSError* pipeline_error = nil;
+        id<MTLComputePipelineState> pipeline =
+            full_attention_decode_pipeline_bf16_f32(&pipeline_error);
+        if (pipeline == nil) {
+            return 512;
+        }
+
+        id<MTLBuffer> query = nil;
+        id<MTLBuffer> key = nil;
+        id<MTLBuffer> value = nil;
+        id<MTLBuffer> out = nil;
+        size_t query_offset = 0;
+        size_t key_offset = 0;
+        size_t value_offset = 0;
+        size_t out_offset = 0;
+        if (lookup_buffer(query_ptr, &query, &query_offset) != 0) {
+            return 513;
+        }
+        if (lookup_buffer(key_ptr, &key, &key_offset) != 0) {
+            return 514;
+        }
+        if (lookup_buffer(value_ptr, &value, &value_offset) != 0) {
+            return 515;
+        }
+        if (lookup_buffer(out_ptr, &out, &out_offset) != 0) {
+            return 516;
+        }
+
+        FullAttentionDecodeParams params = {
+            static_cast<uint32_t>(q_heads),
+            static_cast<uint32_t>(kv_heads),
+            static_cast<uint32_t>(kv_len),
+            static_cast<uint32_t>(kv_stride),
+            static_cast<uint32_t>(head_dim),
+            scale,
+        };
+
+        return encode_or_submit([&](id<MTLComputeCommandEncoder> encoder) {
+            [encoder setComputePipelineState:pipeline];
+            [encoder setBuffer:query offset:query_offset atIndex:0];
+            [encoder setBuffer:key offset:key_offset atIndex:1];
+            [encoder setBuffer:value offset:value_offset atIndex:2];
+            [encoder setBuffer:out offset:out_offset atIndex:3];
+            [encoder setBytes:&params length:sizeof(params) atIndex:4];
+
+            MTLSize groups = MTLSizeMake(q_heads, 1, 1);
+            MTLSize threads = MTLSizeMake(256, 1, 1);
+            [encoder dispatchThreadgroups:groups threadsPerThreadgroup:threads];
+        }, 517, 518, 519, 520);
     }
 }
 

--- a/crates/kernel-ffi/src/metal_native.mm
+++ b/crates/kernel-ffi/src/metal_native.mm
@@ -3530,6 +3530,95 @@ kernel void supersonic_sigmoid_mul_f32(
     return pipeline;
 }
 
+id<MTLComputePipelineState> full_attention_gate_pipeline(NSError** error_out) {
+    static std::mutex mutex;
+    static bool attempted = false;
+    static __strong id<MTLComputePipelineState> pipeline = nil;
+    static __strong NSError* build_error = nil;
+
+    std::lock_guard<std::mutex> lock(mutex);
+    if (!attempted) {
+        attempted = true;
+        @autoreleasepool {
+            id<MTLDevice> device = metal_device();
+            if (device == nil) {
+                build_error = [NSError errorWithDomain:@"SuperSonicMetal"
+                                                   code:204
+                                               userInfo:@{NSLocalizedDescriptionKey : @"No Metal device"}];
+            } else {
+                static const char* kSource = R"FGATE(
+#include <metal_stdlib>
+using namespace metal;
+
+struct ElementwiseParams {
+    uint total_elems;
+};
+
+kernel void supersonic_full_attention_gate_bf16(
+    device const float* attn [[buffer(0)]],
+    device const bfloat* gate [[buffer(1)]],
+    device bfloat* out [[buffer(2)]],
+    constant ElementwiseParams& params [[buffer(3)]],
+    uint gid [[thread_position_in_grid]]
+) {
+    if (gid >= params.total_elems) {
+        return;
+    }
+    bfloat attn_bf = bfloat(attn[gid]);
+    float gv = float(gate[gid]);
+    float sig = 1.0f / (1.0f + exp(-gv));
+    out[gid] = bfloat(float(attn_bf) * sig);
+}
+)FGATE";
+
+                NSString* source = [NSString stringWithUTF8String:kSource];
+                MTLCompileOptions* options = [[MTLCompileOptions alloc] init];
+                configure_precise_math(options);
+                NSError* library_error = nil;
+                id<MTLLibrary> library = [device newLibraryWithSource:source
+                                                              options:options
+                                                                error:&library_error];
+                if (library == nil || library_error != nil) {
+                    build_error = library_error ?: [NSError errorWithDomain:@"SuperSonicMetal"
+                                                                       code:205
+                                                                   userInfo:@{
+                                                                       NSLocalizedDescriptionKey :
+                                                                           @"Failed to compile full-attention gate library"
+                                                                   }];
+                } else {
+                    id<MTLFunction> function =
+                        [library newFunctionWithName:@"supersonic_full_attention_gate_bf16"];
+                    if (function == nil) {
+                        build_error = [NSError errorWithDomain:@"SuperSonicMetal"
+                                                           code:206
+                                                       userInfo:@{
+                                                           NSLocalizedDescriptionKey :
+                                                               @"Failed to load full-attention gate function"
+                                                       }];
+                    } else {
+                        NSError* pipeline_error = nil;
+                        pipeline = [device newComputePipelineStateWithFunction:function
+                                                                         error:&pipeline_error];
+                        if (pipeline == nil || pipeline_error != nil) {
+                            build_error = pipeline_error ?: [NSError errorWithDomain:@"SuperSonicMetal"
+                                                                                 code:207
+                                                                             userInfo:@{
+                                                                                 NSLocalizedDescriptionKey :
+                                                                                     @"Failed to create full-attention gate pipeline"
+                                                                             }];
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (pipeline == nil && error_out != nullptr) {
+        *error_out = build_error;
+    }
+    return pipeline;
+}
+
 id<MTLComputePipelineState> swiglu_mul_pipeline(NSString* function_name, NSError** error_out) {
     static std::mutex mutex;
     static bool attempted_bf16 = false;
@@ -5846,6 +5935,61 @@ extern "C" int supersonic_metal_sigmoid_mul_f32(
         out_ptr,
         @"supersonic_sigmoid_mul_f32"
     );
+}
+
+extern "C" int supersonic_metal_full_attention_gate_bf16(
+    size_t total_elems,
+    const void* attn_f32_ptr,
+    const void* gate_ptr,
+    void* out_ptr
+) {
+    @autoreleasepool {
+        if (total_elems == 0) {
+            return 0;
+        }
+        if (total_elems > UINT32_MAX || attn_f32_ptr == nullptr || gate_ptr == nullptr ||
+            out_ptr == nullptr) {
+            return 208;
+        }
+
+        NSError* pipeline_error = nil;
+        id<MTLComputePipelineState> pipeline = full_attention_gate_pipeline(&pipeline_error);
+        if (pipeline == nil) {
+            return 209;
+        }
+
+        id<MTLBuffer> attn = nil;
+        id<MTLBuffer> gate = nil;
+        id<MTLBuffer> out = nil;
+        size_t attn_offset = 0;
+        size_t gate_offset = 0;
+        size_t out_offset = 0;
+        if (lookup_buffer(attn_f32_ptr, &attn, &attn_offset) != 0) {
+            return 210;
+        }
+        if (lookup_buffer(gate_ptr, &gate, &gate_offset) != 0) {
+            return 211;
+        }
+        if (lookup_buffer(out_ptr, &out, &out_offset) != 0) {
+            return 212;
+        }
+
+        ElementwiseParams params = {static_cast<uint32_t>(total_elems)};
+
+        return encode_or_submit([&](id<MTLComputeCommandEncoder> encoder) {
+            [encoder setComputePipelineState:pipeline];
+            [encoder setBuffer:attn offset:attn_offset atIndex:0];
+            [encoder setBuffer:gate offset:gate_offset atIndex:1];
+            [encoder setBuffer:out offset:out_offset atIndex:2];
+            [encoder setBytes:&params length:sizeof(params) atIndex:3];
+
+            NSUInteger tg_width =
+                std::min<NSUInteger>(256, std::max<NSUInteger>(1, pipeline.maxTotalThreadsPerThreadgroup));
+            MTLSize threads_per_group = MTLSizeMake(tg_width, 1, 1);
+            MTLSize threads_per_grid = MTLSizeMake(total_elems, 1, 1);
+            [encoder dispatchThreads:threads_per_grid threadsPerThreadgroup:threads_per_group];
+        }, 213, 214, 215, 216);
+    }
 }
 
 static int supersonic_metal_swiglu_mul_impl(

--- a/crates/kernel-ffi/src/metal_native.mm
+++ b/crates/kernel-ffi/src/metal_native.mm
@@ -944,6 +944,109 @@ kernel void supersonic_qwen_mlp_gate_up_bf16(
     return pipeline;
 }
 
+id<MTLComputePipelineState> qwen_mlp_gate_up_swiglu_pipeline_bf16(NSError** error_out) {
+    static std::mutex mutex;
+    static bool attempted = false;
+    static __strong id<MTLComputePipelineState> pipeline = nil;
+    static __strong NSError* build_error = nil;
+
+    std::lock_guard<std::mutex> lock(mutex);
+    if (!attempted) {
+        attempted = true;
+        @autoreleasepool {
+            id<MTLDevice> device = metal_device();
+            if (device == nil) {
+                build_error = [NSError errorWithDomain:@"SuperSonicMetal"
+                                                   code:421
+                                               userInfo:@{NSLocalizedDescriptionKey : @"No Metal device"}];
+            } else {
+                static const char* kSource = R"QMLPSWIGLU(
+#include <metal_stdlib>
+using namespace metal;
+
+struct QwenMlpParams {
+    uint hidden_dim;
+    uint intermediate_dim;
+};
+
+kernel void supersonic_qwen_mlp_gate_up_swiglu_bf16(
+    device const bfloat* input [[buffer(0)]],
+    device const bfloat* gate_weight [[buffer(1)]],
+    device const bfloat* up_weight [[buffer(2)]],
+    device bfloat* mlp_out [[buffer(3)]],
+    constant QwenMlpParams& params [[buffer(4)]],
+    uint gid [[thread_position_in_grid]]
+) {
+    if (gid >= params.intermediate_dim) {
+        return;
+    }
+    float gate_acc = 0.0f;
+    float up_acc = 0.0f;
+    uint weight_base = gid * params.hidden_dim;
+    for (uint kk = 0; kk < params.hidden_dim; ++kk) {
+        float x = float(input[kk]);
+        gate_acc += x * float(gate_weight[weight_base + kk]);
+        up_acc += x * float(up_weight[weight_base + kk]);
+    }
+
+    // Match the existing two-kernel path: gate/up projections are rounded to
+    // BF16 before SiLU, then the SiLU product is rounded to BF16.
+    bfloat gate_bf = bfloat(gate_acc);
+    bfloat up_bf = bfloat(up_acc);
+    float gate_v = float(gate_bf);
+    float sig = 1.0f / (1.0f + exp(-gate_v));
+    mlp_out[gid] = bfloat(gate_v * sig * float(up_bf));
+}
+)QMLPSWIGLU";
+
+                NSString* source = [NSString stringWithUTF8String:kSource];
+                MTLCompileOptions* options = [[MTLCompileOptions alloc] init];
+                configure_precise_math(options);
+                NSError* library_error = nil;
+                id<MTLLibrary> library = [device newLibraryWithSource:source
+                                                              options:options
+                                                                error:&library_error];
+                if (library == nil || library_error != nil) {
+                    build_error = library_error ?: [NSError errorWithDomain:@"SuperSonicMetal"
+                                                                       code:422
+                                                                   userInfo:@{
+                                                                       NSLocalizedDescriptionKey :
+                                                                           @"Failed to compile Qwen MLP gate/up/swiglu library"
+                                                                   }];
+                } else {
+                    id<MTLFunction> function =
+                        [library newFunctionWithName:@"supersonic_qwen_mlp_gate_up_swiglu_bf16"];
+                    if (function == nil) {
+                        build_error = [NSError errorWithDomain:@"SuperSonicMetal"
+                                                           code:423
+                                                       userInfo:@{
+                                                           NSLocalizedDescriptionKey :
+                                                               @"Failed to load Qwen MLP gate/up/swiglu function"
+                                                       }];
+                    } else {
+                        NSError* pipeline_error = nil;
+                        pipeline = [device newComputePipelineStateWithFunction:function
+                                                                         error:&pipeline_error];
+                        if (pipeline == nil || pipeline_error != nil) {
+                            build_error = pipeline_error ?: [NSError errorWithDomain:@"SuperSonicMetal"
+                                                                                 code:424
+                                                                             userInfo:@{
+                                                                                 NSLocalizedDescriptionKey :
+                                                                                     @"Failed to create Qwen MLP gate/up/swiglu pipeline"
+                                                                             }];
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (pipeline == nil && error_out != nullptr) {
+        *error_out = build_error;
+    }
+    return pipeline;
+}
+
 id<MTLComputePipelineState> qwen_mlp_down_residual_pipeline_bf16(NSError** error_out) {
     static std::mutex mutex;
     static bool attempted = false;
@@ -7986,6 +8089,72 @@ extern "C" int supersonic_metal_qwen_mlp_gate_up_bf16(
             MTLSize threads_per_grid = MTLSizeMake(intermediate_dim, 1, 1);
             [encoder dispatchThreads:threads_per_grid threadsPerThreadgroup:threads_per_group];
         }, 383, 384, 385, 386);
+    }
+}
+
+extern "C" int supersonic_metal_qwen_mlp_gate_up_swiglu_bf16(
+    size_t hidden_dim,
+    size_t intermediate_dim,
+    const void* input_ptr,
+    const void* gate_weight_ptr,
+    const void* up_weight_ptr,
+    void* mlp_out_ptr
+) {
+    @autoreleasepool {
+        if (hidden_dim == 0 || intermediate_dim == 0 || input_ptr == nullptr ||
+            gate_weight_ptr == nullptr || up_weight_ptr == nullptr || mlp_out_ptr == nullptr) {
+            return 425;
+        }
+        if (hidden_dim > UINT32_MAX || intermediate_dim > UINT32_MAX) {
+            return 426;
+        }
+
+        NSError* pipeline_error = nil;
+        id<MTLComputePipelineState> pipeline = qwen_mlp_gate_up_swiglu_pipeline_bf16(&pipeline_error);
+        if (pipeline == nil) {
+            return 427;
+        }
+
+        id<MTLBuffer> input = nil;
+        id<MTLBuffer> gate_weight = nil;
+        id<MTLBuffer> up_weight = nil;
+        id<MTLBuffer> mlp_out = nil;
+        size_t input_offset = 0;
+        size_t gate_weight_offset = 0;
+        size_t up_weight_offset = 0;
+        size_t mlp_out_offset = 0;
+        if (lookup_buffer(input_ptr, &input, &input_offset) != 0) {
+            return 428;
+        }
+        if (lookup_buffer(gate_weight_ptr, &gate_weight, &gate_weight_offset) != 0) {
+            return 429;
+        }
+        if (lookup_buffer(up_weight_ptr, &up_weight, &up_weight_offset) != 0) {
+            return 430;
+        }
+        if (lookup_buffer(mlp_out_ptr, &mlp_out, &mlp_out_offset) != 0) {
+            return 431;
+        }
+
+        QwenMlpParams params = {
+            static_cast<uint32_t>(hidden_dim),
+            static_cast<uint32_t>(intermediate_dim),
+        };
+
+        return encode_or_submit([&](id<MTLComputeCommandEncoder> encoder) {
+            [encoder setComputePipelineState:pipeline];
+            [encoder setBuffer:input offset:input_offset atIndex:0];
+            [encoder setBuffer:gate_weight offset:gate_weight_offset atIndex:1];
+            [encoder setBuffer:up_weight offset:up_weight_offset atIndex:2];
+            [encoder setBuffer:mlp_out offset:mlp_out_offset atIndex:3];
+            [encoder setBytes:&params length:sizeof(params) atIndex:4];
+
+            NSUInteger tg_width =
+                std::min<NSUInteger>(256, std::max<NSUInteger>(1, pipeline.maxTotalThreadsPerThreadgroup));
+            MTLSize threads_per_group = MTLSizeMake(tg_width, 1, 1);
+            MTLSize threads_per_grid = MTLSizeMake(intermediate_dim, 1, 1);
+            [encoder dispatchThreads:threads_per_grid threadsPerThreadgroup:threads_per_group];
+        }, 432, 433, 434, 435);
     }
 }
 

--- a/crates/kernel-ffi/src/metal_native.rs
+++ b/crates/kernel-ffi/src/metal_native.rs
@@ -124,6 +124,18 @@ unsafe extern "C" {
         residual_ptr: *const c_void,
         out_ptr: *mut c_void,
     ) -> c_int;
+    fn supersonic_metal_qwen_linear_out_residual_bf16_bf16(
+        hidden_dim: usize,
+        num_rows: usize,
+        row_dim: usize,
+        eps: f32,
+        attn_ptr: *const c_void,
+        gate_ptr: *const c_void,
+        weight_ptr: *const c_void,
+        out_proj_ptr: *const c_void,
+        residual_ptr: *const c_void,
+        out_ptr: *mut c_void,
+    ) -> c_int;
     fn supersonic_metal_qwen_full_projections_bf16(
         hidden_dim: usize,
         q_proj_dim: usize,
@@ -1106,6 +1118,67 @@ pub(crate) fn qwen_linear_out_residual_f32_bf16(
     if status != 0 {
         return Err(GpuError::Metal(format!(
             "metal native qwen_linear_out_residual_f32_bf16 failed with status {status}"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(all(target_os = "macos", supersonic_backend_metal))]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn qwen_linear_out_residual_bf16_bf16(
+    hidden_dim: usize,
+    num_rows: usize,
+    row_dim: usize,
+    eps: f32,
+    attn: &GpuBuffer,
+    gate: &GpuBuffer,
+    weight: &GpuBuffer,
+    out_proj: &GpuBuffer,
+    residual: &GpuBuffer,
+    out: &mut GpuBuffer,
+) -> Result<(), GpuError> {
+    let dtypes = [
+        attn.dtype(),
+        gate.dtype(),
+        weight.dtype(),
+        out_proj.dtype(),
+        residual.dtype(),
+        out.dtype(),
+    ];
+    if dtypes != [
+        ScalarType::BF16,
+        ScalarType::BF16,
+        ScalarType::BF16,
+        ScalarType::BF16,
+        ScalarType::BF16,
+        ScalarType::BF16,
+    ] {
+        return Err(GpuError::InvalidArg(format!(
+            "metal native qwen_linear_out_residual_bf16_bf16 expects BF16 buffers, got {dtypes:?}"
+        )));
+    }
+    if hidden_dim == 0 || num_rows == 0 || row_dim == 0 {
+        return Err(GpuError::InvalidArg(format!(
+            "metal native qwen_linear_out_residual_bf16_bf16 invalid shape: hidden_dim={hidden_dim} num_rows={num_rows} row_dim={row_dim}"
+        )));
+    }
+    let status = unsafe {
+        supersonic_metal_qwen_linear_out_residual_bf16_bf16(
+            hidden_dim,
+            num_rows,
+            row_dim,
+            eps,
+            attn.as_ptr(),
+            gate.as_ptr(),
+            weight.as_ptr(),
+            out_proj.as_ptr(),
+            residual.as_ptr(),
+            out.as_mut_ptr(),
+        )
+    };
+    if status != 0 {
+        return Err(GpuError::Metal(format!(
+            "metal native qwen_linear_out_residual_bf16_bf16 failed with status {status}"
         )));
     }
     Ok(())
@@ -3136,6 +3209,25 @@ pub(crate) fn qwen_linear_out_residual_f32_bf16(
 ) -> Result<(), GpuError> {
     Err(GpuError::Metal(
         "metal native qwen_linear_out_residual_f32_bf16 is not compiled".into(),
+    ))
+}
+
+#[cfg(not(all(target_os = "macos", supersonic_backend_metal)))]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn qwen_linear_out_residual_bf16_bf16(
+    _hidden_dim: usize,
+    _num_rows: usize,
+    _row_dim: usize,
+    _eps: f32,
+    _attn: &GpuBuffer,
+    _gate: &GpuBuffer,
+    _weight: &GpuBuffer,
+    _out_proj: &GpuBuffer,
+    _residual: &GpuBuffer,
+    _out: &mut GpuBuffer,
+) -> Result<(), GpuError> {
+    Err(GpuError::Metal(
+        "metal native qwen_linear_out_residual_bf16_bf16 is not compiled".into(),
     ))
 }
 

--- a/crates/kernel-ffi/src/metal_native.rs
+++ b/crates/kernel-ffi/src/metal_native.rs
@@ -111,6 +111,12 @@ unsafe extern "C" {
         up_weight_ptr: *const c_void,
         mlp_out_ptr: *mut c_void,
     ) -> c_int;
+    fn supersonic_metal_full_attention_gate_bf16(
+        total_elems: usize,
+        attn_f32_ptr: *const c_void,
+        gate_ptr: *const c_void,
+        out_ptr: *mut c_void,
+    ) -> c_int;
     fn supersonic_metal_qwen_mlp_down_residual_bf16(
         hidden_dim: usize,
         intermediate_dim: usize,
@@ -1892,6 +1898,46 @@ pub(crate) fn sigmoid_mul(
 }
 
 #[cfg(all(target_os = "macos", supersonic_backend_metal))]
+pub(crate) fn full_attention_gate_bf16(
+    total_elems: usize,
+    attn_f32: &GpuBuffer,
+    gate: &GpuBuffer,
+    out: &mut GpuBuffer,
+) -> Result<(), GpuError> {
+    if total_elems > u32::MAX as usize {
+        return Err(GpuError::InvalidArg(format!(
+            "metal native full_attention_gate_bf16 supports at most {} elements, got {total_elems}",
+            u32::MAX
+        )));
+    }
+    if attn_f32.dtype() != ScalarType::F32
+        || gate.dtype() != ScalarType::BF16
+        || out.dtype() != ScalarType::BF16
+    {
+        return Err(GpuError::InvalidArg(format!(
+            "metal native full_attention_gate_bf16 expects F32/BF16/BF16 buffers, got {:?}/{:?}/{:?}",
+            attn_f32.dtype(),
+            gate.dtype(),
+            out.dtype()
+        )));
+    }
+    let status = unsafe {
+        supersonic_metal_full_attention_gate_bf16(
+            total_elems,
+            attn_f32.as_ptr(),
+            gate.as_ptr(),
+            out.as_mut_ptr(),
+        )
+    };
+    if status != 0 {
+        return Err(GpuError::Metal(format!(
+            "metal native full_attention_gate_bf16 failed with status {status}"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(all(target_os = "macos", supersonic_backend_metal))]
 pub(crate) fn swiglu_mul(
     dtype: ScalarType,
     total_elems: usize,
@@ -3610,6 +3656,18 @@ pub(crate) fn sigmoid_mul(
 }
 
 #[cfg(not(all(target_os = "macos", supersonic_backend_metal)))]
+pub(crate) fn full_attention_gate_bf16(
+    _total_elems: usize,
+    _attn_f32: &GpuBuffer,
+    _gate: &GpuBuffer,
+    _out: &mut GpuBuffer,
+) -> Result<(), GpuError> {
+    Err(GpuError::Metal(
+        "metal native full_attention_gate_bf16 is not compiled".into(),
+    ))
+}
+
+#[cfg(not(all(target_os = "macos", supersonic_backend_metal)))]
 pub(crate) fn swiglu_mul(
     _dtype: ScalarType,
     _total_elems: usize,
@@ -5111,6 +5169,46 @@ mod tests {
             assert!(
                 delta <= 1e-6,
                 "f32 idx {idx}: expected {e}, got {a}, delta {delta}"
+            );
+        }
+    }
+
+    #[test]
+    fn metal_native_full_attention_gate_matches_reference() {
+        set_backend(Backend::Metal);
+        let ordinal = 0usize;
+
+        let attn_vals = [1.125f32, -2.75, 0.03125, 8.5, -0.5];
+        let gate_vals = [0.0f32, 1.0, -1.0, 3.0, -3.0];
+        let attn =
+            GpuBuffer::from_host_bytes(ordinal, ScalarType::F32, &[5], &f32_bytes(&attn_vals))
+                .expect("upload f32 attn");
+        let gate =
+            GpuBuffer::from_host_bytes(ordinal, ScalarType::BF16, &[5], &bf16_bytes(&gate_vals))
+                .expect("upload bf16 gate");
+        let mut attn_bf16 =
+            GpuBuffer::zeros(ordinal, ScalarType::BF16, &[5]).expect("allocate cast out");
+        let mut out_ref =
+            GpuBuffer::zeros(ordinal, ScalarType::BF16, &[5]).expect("allocate ref out");
+        let mut out_native =
+            GpuBuffer::zeros(ordinal, ScalarType::BF16, &[5]).expect("allocate native out");
+
+        crate::metal_host::cast(ScalarType::F32, ScalarType::BF16, 5, &attn, &mut attn_bf16)
+            .expect("host cast attention");
+        crate::metal_host::sigmoid_mul(ScalarType::BF16, 5, &attn_bf16, &gate, &mut out_ref)
+            .expect("host gate attention");
+        full_attention_gate_bf16(5, &attn, &gate, &mut out_native)
+            .expect("native full attention gate");
+
+        for (idx, (a, e)) in read_bf16(&out_native)
+            .iter()
+            .zip(read_bf16(&out_ref).iter())
+            .enumerate()
+        {
+            let delta = (a - e).abs();
+            assert!(
+                delta <= 0.02,
+                "bf16 idx {idx}: expected {e}, got {a}, delta {delta}"
             );
         }
     }

--- a/crates/kernel-ffi/src/metal_native.rs
+++ b/crates/kernel-ffi/src/metal_native.rs
@@ -103,6 +103,14 @@ unsafe extern "C" {
         gate_out_ptr: *mut c_void,
         up_out_ptr: *mut c_void,
     ) -> c_int;
+    fn supersonic_metal_qwen_mlp_gate_up_swiglu_bf16(
+        hidden_dim: usize,
+        intermediate_dim: usize,
+        input_ptr: *const c_void,
+        gate_weight_ptr: *const c_void,
+        up_weight_ptr: *const c_void,
+        mlp_out_ptr: *mut c_void,
+    ) -> c_int;
     fn supersonic_metal_qwen_mlp_down_residual_bf16(
         hidden_dim: usize,
         intermediate_dim: usize,
@@ -1022,6 +1030,50 @@ pub(crate) fn qwen_mlp_gate_up_bf16(
     if status != 0 {
         return Err(GpuError::Metal(format!(
             "metal native qwen_mlp_gate_up_bf16 failed with status {status}"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(all(target_os = "macos", supersonic_backend_metal))]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn qwen_mlp_gate_up_swiglu_bf16(
+    hidden_dim: usize,
+    intermediate_dim: usize,
+    input: &GpuBuffer,
+    gate_weight: &GpuBuffer,
+    up_weight: &GpuBuffer,
+    mlp_out: &mut GpuBuffer,
+) -> Result<(), GpuError> {
+    let dtypes = [
+        input.dtype(),
+        gate_weight.dtype(),
+        up_weight.dtype(),
+        mlp_out.dtype(),
+    ];
+    if dtypes.iter().any(|dtype| *dtype != ScalarType::BF16) {
+        return Err(GpuError::InvalidArg(format!(
+            "metal native qwen_mlp_gate_up_swiglu_bf16 expects BF16 buffers, got {dtypes:?}"
+        )));
+    }
+    if hidden_dim == 0 || intermediate_dim == 0 {
+        return Err(GpuError::InvalidArg(format!(
+            "metal native qwen_mlp_gate_up_swiglu_bf16 invalid shape: hidden_dim={hidden_dim} intermediate_dim={intermediate_dim}"
+        )));
+    }
+    let status = unsafe {
+        supersonic_metal_qwen_mlp_gate_up_swiglu_bf16(
+            hidden_dim,
+            intermediate_dim,
+            input.as_ptr(),
+            gate_weight.as_ptr(),
+            up_weight.as_ptr(),
+            mlp_out.as_mut_ptr(),
+        )
+    };
+    if status != 0 {
+        return Err(GpuError::Metal(format!(
+            "metal native qwen_mlp_gate_up_swiglu_bf16 failed with status {status}"
         )));
     }
     Ok(())
@@ -3254,6 +3306,21 @@ pub(crate) fn qwen_mlp_gate_up_bf16(
 
 #[cfg(not(all(target_os = "macos", supersonic_backend_metal)))]
 #[allow(clippy::too_many_arguments)]
+pub(crate) fn qwen_mlp_gate_up_swiglu_bf16(
+    _hidden_dim: usize,
+    _intermediate_dim: usize,
+    _input: &GpuBuffer,
+    _gate_weight: &GpuBuffer,
+    _up_weight: &GpuBuffer,
+    _mlp_out: &mut GpuBuffer,
+) -> Result<(), GpuError> {
+    Err(GpuError::Metal(
+        "metal native qwen_mlp_gate_up_swiglu_bf16 is not compiled".into(),
+    ))
+}
+
+#[cfg(not(all(target_os = "macos", supersonic_backend_metal)))]
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn qwen_mlp_down_residual_bf16(
     _hidden_dim: usize,
     _intermediate_dim: usize,
@@ -4063,6 +4130,8 @@ mod tests {
             GpuBuffer::zeros(ordinal, ScalarType::BF16, &[1, intermediate]).expect("gate");
         let mut up =
             GpuBuffer::zeros(ordinal, ScalarType::BF16, &[1, intermediate]).expect("up");
+        let mut mlp =
+            GpuBuffer::zeros(ordinal, ScalarType::BF16, &[1, intermediate]).expect("mlp");
         let mut out =
             GpuBuffer::zeros(ordinal, ScalarType::BF16, &[1, hidden_dim]).expect("out");
 
@@ -4114,6 +4183,15 @@ mod tests {
             &mut up,
         )
         .expect("native gate/up");
+        qwen_mlp_gate_up_swiglu_bf16(
+            hidden_dim,
+            intermediate,
+            &input,
+            &gate_w,
+            &up_w,
+            &mut mlp,
+        )
+        .expect("native gate/up/swiglu");
         qwen_mlp_down_residual_bf16(
             hidden_dim,
             intermediate,
@@ -4128,6 +4206,7 @@ mod tests {
         for (label, actual, expected) in [
             ("gate", read_bf16(&gate), read_bf16(&gate_ref)),
             ("up", read_bf16(&up), read_bf16(&up_ref)),
+            ("mlp", read_bf16(&mlp), read_bf16(&mlp_ref)),
             ("out", read_bf16(&out), read_bf16(&out_ref)),
         ] {
             for (idx, (a, e)) in actual.iter().zip(expected.iter()).enumerate() {

--- a/crates/kernel-ffi/src/metal_native.rs
+++ b/crates/kernel-ffi/src/metal_native.rs
@@ -176,6 +176,18 @@ unsafe extern "C" {
         value_ptr: *const c_void,
         out_ptr: *mut c_void,
     ) -> c_int;
+    fn supersonic_metal_full_attention_decode_bf16_f32(
+        q_heads: usize,
+        kv_heads: usize,
+        kv_len: usize,
+        kv_stride: usize,
+        head_dim: usize,
+        scale: f32,
+        query_ptr: *const c_void,
+        key_ptr: *const c_void,
+        value_ptr: *const c_void,
+        out_ptr: *mut c_void,
+    ) -> c_int;
     fn supersonic_metal_rms_norm_rows_bf16(
         n_rows: usize,
         n_cols: usize,
@@ -1326,6 +1338,69 @@ pub(crate) fn full_attention_prefill_strided_bf16_f32(
     if status != 0 {
         return Err(GpuError::Metal(format!(
             "metal native full_attention_prefill_bf16_f32 failed with status {status}"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(all(target_os = "macos", supersonic_backend_metal))]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn full_attention_decode_bf16_f32(
+    q_heads: usize,
+    kv_heads: usize,
+    kv_len: usize,
+    kv_stride: usize,
+    head_dim: usize,
+    scale: f32,
+    query: &GpuBuffer,
+    key: &GpuBuffer,
+    value: &GpuBuffer,
+    out: &mut GpuBuffer,
+) -> Result<(), GpuError> {
+    if query.dtype() != ScalarType::BF16
+        || key.dtype() != ScalarType::BF16
+        || value.dtype() != ScalarType::BF16
+    {
+        return Err(GpuError::InvalidArg(format!(
+            "metal native full_attention_decode expects BF16 query/key/value, got {:?}/{:?}/{:?}",
+            query.dtype(),
+            key.dtype(),
+            value.dtype()
+        )));
+    }
+    if out.dtype() != ScalarType::F32 {
+        return Err(GpuError::InvalidArg(format!(
+            "metal native full_attention_decode expects F32 output, got {:?}",
+            out.dtype()
+        )));
+    }
+    if kv_stride < kv_len {
+        return Err(GpuError::InvalidArg(format!(
+            "metal native full_attention_decode requires kv_stride >= kv_len, got {kv_stride} < {kv_len}"
+        )));
+    }
+    if head_dim > 256 {
+        return Err(GpuError::InvalidArg(format!(
+            "metal native full_attention_decode supports head_dim <= 256, got {head_dim}"
+        )));
+    }
+    let status = unsafe {
+        supersonic_metal_full_attention_decode_bf16_f32(
+            q_heads,
+            kv_heads,
+            kv_len,
+            kv_stride,
+            head_dim,
+            scale,
+            query.as_ptr(),
+            key.as_ptr(),
+            value.as_ptr(),
+            out.as_mut_ptr(),
+        )
+    };
+    if status != 0 {
+        return Err(GpuError::Metal(format!(
+            "metal native full_attention_decode_bf16_f32 failed with status {status}"
         )));
     }
     Ok(())
@@ -3311,6 +3386,25 @@ pub(crate) fn full_attention_prefill_strided_bf16_f32(
 ) -> Result<(), GpuError> {
     Err(GpuError::Metal(
         "metal native full_attention_prefill_strided_bf16_f32 is not compiled".into(),
+    ))
+}
+
+#[cfg(not(all(target_os = "macos", supersonic_backend_metal)))]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn full_attention_decode_bf16_f32(
+    _q_heads: usize,
+    _kv_heads: usize,
+    _kv_len: usize,
+    _kv_stride: usize,
+    _head_dim: usize,
+    _scale: f32,
+    _query: &GpuBuffer,
+    _key: &GpuBuffer,
+    _value: &GpuBuffer,
+    _out: &mut GpuBuffer,
+) -> Result<(), GpuError> {
+    Err(GpuError::Metal(
+        "metal native full_attention_decode_bf16_f32 is not compiled".into(),
     ))
 }
 

--- a/crates/kernel-ffi/src/prefill_ffi.rs
+++ b/crates/kernel-ffi/src/prefill_ffi.rs
@@ -415,6 +415,27 @@ pub fn metal_qwen_mlp_gate_up_bf16(
 }
 
 #[allow(clippy::too_many_arguments)]
+pub fn metal_qwen_mlp_gate_up_swiglu_bf16(
+    hidden_dim: usize,
+    intermediate_dim: usize,
+    input: &GpuBuffer,
+    gate_weight: &GpuBuffer,
+    up_weight: &GpuBuffer,
+    mlp_out: &mut GpuBuffer,
+) -> Result<(), GpuError> {
+    metal_profile_time("qwen_mlp_gate_up_swiglu", "native", || {
+        metal_native::qwen_mlp_gate_up_swiglu_bf16(
+            hidden_dim,
+            intermediate_dim,
+            input,
+            gate_weight,
+            up_weight,
+            mlp_out,
+        )
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
 pub fn metal_qwen_mlp_down_residual_bf16(
     hidden_dim: usize,
     intermediate_dim: usize,

--- a/crates/kernel-ffi/src/prefill_ffi.rs
+++ b/crates/kernel-ffi/src/prefill_ffi.rs
@@ -458,6 +458,26 @@ pub fn metal_qwen_linear_out_residual_f32_bf16(
 }
 
 #[allow(clippy::too_many_arguments)]
+pub fn metal_qwen_linear_out_residual_bf16_bf16(
+    hidden_dim: usize,
+    num_rows: usize,
+    row_dim: usize,
+    eps: f32,
+    attn: &GpuBuffer,
+    gate: &GpuBuffer,
+    weight: &GpuBuffer,
+    out_proj: &GpuBuffer,
+    residual: &GpuBuffer,
+    out: &mut GpuBuffer,
+) -> Result<(), GpuError> {
+    metal_profile_time("qwen_linear_out_residual_bf16", "native", || {
+        metal_native::qwen_linear_out_residual_bf16_bf16(
+            hidden_dim, num_rows, row_dim, eps, attn, gate, weight, out_proj, residual, out,
+        )
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
 pub fn metal_rms_norm_rope_rows_bf16(
     n_rows: usize,
     n_cols: usize,

--- a/crates/kernel-ffi/src/prefill_ffi.rs
+++ b/crates/kernel-ffi/src/prefill_ffi.rs
@@ -435,6 +435,17 @@ pub fn metal_qwen_mlp_gate_up_swiglu_bf16(
     })
 }
 
+pub fn metal_full_attention_gate_bf16(
+    total_elems: usize,
+    attn_f32: &GpuBuffer,
+    gate: &GpuBuffer,
+    out: &mut GpuBuffer,
+) -> Result<(), GpuError> {
+    metal_profile_time("full_attention_gate", "native", || {
+        metal_native::full_attention_gate_bf16(total_elems, attn_f32, gate, out)
+    })
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn metal_qwen_mlp_down_residual_bf16(
     hidden_dim: usize,

--- a/crates/kernel-ffi/src/prefill_ffi.rs
+++ b/crates/kernel-ffi/src/prefill_ffi.rs
@@ -1297,6 +1297,26 @@ pub fn metal_full_attention_prefill_strided_bf16_f32(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
+pub fn metal_full_attention_decode_bf16_f32(
+    q_heads: usize,
+    kv_heads: usize,
+    kv_len: usize,
+    kv_stride: usize,
+    head_dim: usize,
+    scale: f32,
+    query: &GpuBuffer,
+    key: &GpuBuffer,
+    value: &GpuBuffer,
+    out: &mut GpuBuffer,
+) -> Result<(), GpuError> {
+    metal_profile_time("full_attention_decode", "native", || {
+        metal_native::full_attention_decode_bf16_f32(
+            q_heads, kv_heads, kv_len, kv_stride, head_dim, scale, query, key, value, out,
+        )
+    })
+}
+
 /// Decode-only full attention for q_len=1. Writes BF16/FP16 flat [batch, q_heads * head_dim].
 pub fn full_attention_decode_flat(
     ordinal: usize,

--- a/crates/runner/src/bin/qwen35_bughunt.rs
+++ b/crates/runner/src/bin/qwen35_bughunt.rs
@@ -54,6 +54,9 @@ struct Cli {
 
     #[arg(long)]
     profile_ops: bool,
+
+    #[arg(long)]
+    profile_layers: bool,
 }
 
 fn main() -> Result<()> {
@@ -67,6 +70,13 @@ fn main() -> Result<()> {
         // low-precision Metal lm-head path cannot mask or fabricate oracle
         // failures.
         std::env::set_var("SUPERSONIC_METAL_FORCE_F32_FINAL_NORM", "1");
+    }
+    if cli.backend == BackendArg::Metal
+        && matches!(cli.mode, BughuntMode::Bench)
+        && cli.profile_layers
+        && std::env::var_os("SUPERSONIC_METAL_PROFILE_FLUSH_LAYERS").is_none()
+    {
+        std::env::set_var("SUPERSONIC_METAL_PROFILE_FLUSH_LAYERS", "1");
     }
     let report = runner::bughunt::run(BughuntArgs {
         mode: cli.mode,

--- a/crates/runner/src/bughunt.rs
+++ b/crates/runner/src/bughunt.rs
@@ -38,6 +38,7 @@ impl Default for BackendArg {
 #[serde(rename_all = "snake_case")]
 pub enum BughuntMode {
     Gate,
+    DecodeGate,
     Localize,
     Dump,
     Bench,
@@ -47,6 +48,7 @@ impl BughuntMode {
     fn as_str(self) -> &'static str {
         match self {
             Self::Gate => "gate",
+            Self::DecodeGate => "decode_gate",
             Self::Localize => "localize",
             Self::Dump => "dump",
             Self::Bench => "bench",
@@ -263,6 +265,45 @@ pub struct GateRunSection {
 }
 
 #[derive(Debug, Clone, Serialize)]
+pub struct DecodeStepGateReport {
+    pub step: usize,
+    pub oracle_token: u32,
+    pub replay_token: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub component_token: Option<u32>,
+    pub replay_logit_reference: String,
+    pub replay_logit_max_abs: f32,
+    pub replay_logit_mean_abs: f32,
+    pub token_match_replay: bool,
+    pub token_match_component: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DecodeGatePromptReport {
+    pub name: String,
+    pub notes: Option<String>,
+    pub pass: bool,
+    pub prompt_len: usize,
+    pub decode_tokens: usize,
+    pub oracle_tokens: Vec<u32>,
+    pub replay_tokens: Vec<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub component_tokens: Option<Vec<u32>>,
+    pub max_replay_logit_abs: f32,
+    pub mean_replay_logit_abs: f32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub first_mismatch_step: Option<usize>,
+    pub steps: Vec<DecodeStepGateReport>,
+    pub timings: Vec<PhaseTimingReport>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DecodeGateRunSection {
+    pub pass: bool,
+    pub prompt_results: Vec<DecodeGatePromptReport>,
+}
+
+#[derive(Debug, Clone, Serialize)]
 pub struct LocalizeRunSection {
     pub pass: bool,
     pub gate_prompt: PromptGateReport,
@@ -389,6 +430,8 @@ pub struct BughuntReport {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gate: Option<GateRunSection>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub decode_gate: Option<DecodeGateRunSection>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub localize: Option<LocalizeRunSection>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dump: Option<DumpRunSection>,
@@ -402,6 +445,18 @@ impl BughuntReport {
             "gate" => {
                 if self
                     .gate
+                    .as_ref()
+                    .map(|section| section.pass)
+                    .unwrap_or(false)
+                {
+                    0
+                } else {
+                    1
+                }
+            }
+            "decode_gate" => {
+                if self
+                    .decode_gate
                     .as_ref()
                     .map(|section| section.pass)
                     .unwrap_or(false)
@@ -494,6 +549,24 @@ pub fn run(args: BughuntArgs) -> Result<BughuntReport> {
                 mode: args.mode.as_str().to_string(),
                 metadata,
                 gate: Some(reports),
+                decode_gate: None,
+                localize: None,
+                dump: None,
+                bench: None,
+            }
+        }
+        BughuntMode::DecodeGate => {
+            let section = run_decode_gate_mode(
+                &runtime,
+                &manifest,
+                args.prompt.as_deref(),
+                args.bench_decode_tokens,
+            )?;
+            BughuntReport {
+                mode: args.mode.as_str().to_string(),
+                metadata,
+                gate: None,
+                decode_gate: Some(section),
                 localize: None,
                 dump: None,
                 bench: None,
@@ -505,6 +578,7 @@ pub fn run(args: BughuntArgs) -> Result<BughuntReport> {
                 mode: args.mode.as_str().to_string(),
                 metadata,
                 gate: None,
+                decode_gate: None,
                 localize: Some(section),
                 dump: None,
                 bench: None,
@@ -523,6 +597,7 @@ pub fn run(args: BughuntArgs) -> Result<BughuntReport> {
                 mode: args.mode.as_str().to_string(),
                 metadata,
                 gate: None,
+                decode_gate: None,
                 localize: None,
                 dump: Some(section),
                 bench: None,
@@ -542,6 +617,7 @@ pub fn run(args: BughuntArgs) -> Result<BughuntReport> {
                 mode: args.mode.as_str().to_string(),
                 metadata,
                 gate: None,
+                decode_gate: None,
                 localize: None,
                 dump: None,
                 bench: Some(section),
@@ -569,6 +645,9 @@ fn validate_args(args: &BughuntArgs) -> Result<()> {
     }
     if matches!(args.mode, BughuntMode::Bench) && args.bench_iterations == 0 {
         bail!("--iters must be greater than zero in bench mode");
+    }
+    if matches!(args.mode, BughuntMode::DecodeGate) && args.bench_decode_tokens == 0 {
+        bail!("--decode-tokens must be greater than zero in decode-gate mode");
     }
     Ok(())
 }
@@ -899,6 +978,174 @@ fn run_gate_mode(
     Ok(GateRunSection {
         pass,
         prompt_results,
+    })
+}
+
+fn run_decode_gate_mode(
+    runtime: &QwenBughuntRuntime,
+    manifest: &PromptManifest,
+    selected_prompt: Option<&str>,
+    decode_tokens: usize,
+) -> Result<DecodeGateRunSection> {
+    let prompts = select_prompts(manifest, selected_prompt)?;
+    let mut prompt_results = Vec::with_capacity(prompts.len());
+    for prompt in prompts {
+        eprintln!(
+            "[bughunt] decode_gate prompt={} decode_tokens={} start",
+            prompt.name, decode_tokens
+        );
+        let report = analyze_decode_gate_prompt(runtime, prompt, decode_tokens)?;
+        eprintln!(
+            "[bughunt] decode_gate prompt={} done pass={} first_mismatch={} max_replay_logit_abs={:.4}",
+            prompt.name,
+            report.pass,
+            report
+                .first_mismatch_step
+                .map(|step| step.to_string())
+                .unwrap_or_else(|| "n/a".to_string()),
+            report.max_replay_logit_abs
+        );
+        prompt_results.push(report);
+    }
+    let pass = prompt_results.iter().all(|report| report.pass);
+    Ok(DecodeGateRunSection {
+        pass,
+        prompt_results,
+    })
+}
+
+fn analyze_decode_gate_prompt(
+    runtime: &QwenBughuntRuntime,
+    prompt: &PromptManifestEntry,
+    decode_tokens: usize,
+) -> Result<DecodeGatePromptReport> {
+    let prompt_start = Instant::now();
+    let mut timings = Vec::new();
+
+    eprintln!("[bughunt] decode_gate prompt={} oracle", prompt.name);
+    let phase_start = Instant::now();
+    let oracle_output = oracle::run_oracle(
+        &runtime.oracle_script,
+        runtime.model_variant.hf_model_id(),
+        &prompt.prompt_ids,
+        decode_tokens,
+        "bf16",
+        &runtime.oracle_device,
+        false,
+        false,
+        None,
+        None,
+    )?;
+    timings.push(phase_timing("oracle", phase_start));
+
+    if oracle_output.generated_token_ids.len() < decode_tokens {
+        bail!(
+            "oracle returned {} generated tokens, expected {}",
+            oracle_output.generated_token_ids.len(),
+            decode_tokens
+        );
+    }
+    if decode_tokens > 1 && oracle_output.decode_logits.len() + 1 < decode_tokens {
+        bail!(
+            "oracle returned {} decode logit rows, expected at least {}",
+            oracle_output.decode_logits.len(),
+            decode_tokens - 1
+        );
+    }
+
+    eprintln!("[bughunt] decode_gate prompt={} replay_forced", prompt.name);
+    let phase_start = Instant::now();
+    let mut replay_tokens = Vec::with_capacity(decode_tokens);
+    let mut steps = Vec::with_capacity(decode_tokens);
+    for step in 0..decode_tokens {
+        let mut forced_history = prompt.prompt_ids.clone();
+        forced_history.extend_from_slice(&oracle_output.generated_token_ids[..step]);
+        let native_prefill = run_native_prefill(runtime, &forced_history)
+            .with_context(|| format!("decode_gate replay forced step {step}"))?;
+        gpu_hal::sync(runtime.ordinal)
+            .with_context(|| format!("decode_gate replay forced sync step {step}"))?;
+        let replay_token = DecodeEngine::greedy_sample(&native_prefill.logits);
+        replay_tokens.push(replay_token);
+        let (reference, reference_name) = if step == 0 {
+            (&oracle_output.prefill_logits, "oracle_prefill_logits")
+        } else {
+            (
+                oracle_output.decode_logits.get(step - 1).ok_or_else(|| {
+                    anyhow::anyhow!("missing oracle decode logits for step {step}")
+                })?,
+                "oracle_decode_logits",
+            )
+        };
+        let replay_logit_max_abs = validate::max_abs_delta(&native_prefill.logits, reference);
+        let replay_logit_mean_abs = mean_abs_delta(&native_prefill.logits, reference);
+        let oracle_token = oracle_output.generated_token_ids[step];
+        steps.push(DecodeStepGateReport {
+            step,
+            oracle_token,
+            replay_token,
+            component_token: None,
+            replay_logit_reference: reference_name.to_string(),
+            replay_logit_max_abs,
+            replay_logit_mean_abs,
+            token_match_replay: replay_token == oracle_token,
+            token_match_component: runtime.backend != Backend::Metal,
+        });
+    }
+    timings.push(phase_timing("replay_forced", phase_start));
+
+    let component_tokens = if runtime.backend == Backend::Metal {
+        eprintln!("[bughunt] decode_gate prompt={} component", prompt.name);
+        let phase_start = Instant::now();
+        let tokens =
+            run_component_decode_token_sequence(runtime, &prompt.prompt_ids, decode_tokens)
+                .with_context(|| format!("decode_gate component prompt {}", prompt.name))?;
+        for (step, token) in tokens.iter().copied().enumerate() {
+            if let Some(step_report) = steps.get_mut(step) {
+                step_report.component_token = Some(token);
+                step_report.token_match_component =
+                    token == oracle_output.generated_token_ids[step];
+            }
+        }
+        timings.push(phase_timing("component", phase_start));
+        Some(tokens)
+    } else {
+        None
+    };
+
+    let max_replay_logit_abs = steps
+        .iter()
+        .map(|step| step.replay_logit_max_abs)
+        .fold(0.0_f32, f32::max);
+    let mean_replay_logit_abs = if steps.is_empty() {
+        0.0
+    } else {
+        steps
+            .iter()
+            .map(|step| step.replay_logit_mean_abs)
+            .sum::<f32>()
+            / steps.len() as f32
+    };
+    let first_mismatch_step = steps
+        .iter()
+        .find(|step| !step.token_match_replay || !step.token_match_component)
+        .map(|step| step.step);
+    let pass = first_mismatch_step.is_none();
+    timings.push(phase_timing("total", prompt_start));
+
+    Ok(DecodeGatePromptReport {
+        name: prompt.name.clone(),
+        notes: prompt.notes.clone(),
+        pass,
+        prompt_len: prompt.prompt_ids.len(),
+        decode_tokens,
+        oracle_tokens: oracle_output.generated_token_ids[..decode_tokens].to_vec(),
+        replay_tokens,
+        component_tokens,
+        max_replay_logit_abs,
+        mean_replay_logit_abs,
+        first_mismatch_step,
+        steps,
+        timings,
     })
 }
 
@@ -1311,6 +1558,31 @@ fn run_component_decode_once(
         .rebuild_prefill_state_greedy_token(prompt_ids)
         .context("bench component decode initial prefill")?;
     run_component_decode_steps(engine, token, prompt_ids.len(), decode_tokens)
+}
+
+fn run_component_decode_token_sequence(
+    runtime: &QwenBughuntRuntime,
+    prompt_ids: &[u32],
+    decode_tokens: usize,
+) -> Result<Vec<u32>> {
+    let mut engine = runtime
+        .new_component_decode_engine(prompt_ids.len() + decode_tokens)
+        .context("decode gate component decode engine")?;
+    let mut token = engine
+        .rebuild_prefill_state_greedy_token(prompt_ids)
+        .context("decode gate component initial prefill")?;
+    gpu_hal::sync(runtime.ordinal).context("decode gate component initial sync")?;
+
+    let mut tokens = Vec::with_capacity(decode_tokens);
+    tokens.push(token);
+    for step in 1..decode_tokens {
+        let (next, _) = engine
+            .decode_step_metal_component_greedy(token, prompt_ids.len() + step - 1)
+            .with_context(|| format!("decode gate component step {step}"))?;
+        token = next;
+        tokens.push(token);
+    }
+    Ok(tokens)
 }
 
 fn run_component_decode_steps(
@@ -3168,6 +3440,52 @@ fn print_report_summary(report: &BughuntReport) {
                 }
             }
         }
+        "decode_gate" => {
+            if let Some(decode_gate) = report.decode_gate.as_ref() {
+                println!(
+                    "mode=decode_gate backend={} prompts={} pass={}",
+                    report.metadata.backend,
+                    decode_gate.prompt_results.len(),
+                    decode_gate.pass
+                );
+                for prompt in &decode_gate.prompt_results {
+                    println!(
+                        "{} prompt={} tokens={} first_mismatch={} max_replay_logit_abs={:.4} oracle_tokens={:?} replay_tokens={:?} component_tokens={}",
+                        if prompt.pass { "PASS" } else { "FAIL" },
+                        prompt.name,
+                        prompt.decode_tokens,
+                        prompt
+                            .first_mismatch_step
+                            .map(|step| step.to_string())
+                            .unwrap_or_else(|| "n/a".to_string()),
+                        prompt.max_replay_logit_abs,
+                        prompt.oracle_tokens,
+                        prompt.replay_tokens,
+                        prompt
+                            .component_tokens
+                            .as_ref()
+                            .map(|tokens| format!("{tokens:?}"))
+                            .unwrap_or_else(|| "n/a".to_string()),
+                    );
+                    if let Some(step) = prompt
+                        .steps
+                        .iter()
+                        .find(|step| !step.token_match_replay || !step.token_match_component)
+                    {
+                        println!(
+                            "first_bad_step={} oracle={} replay={} component={} replay_logit_max_abs={:.4}",
+                            step.step,
+                            step.oracle_token,
+                            step.replay_token,
+                            step.component_token
+                                .map(|token| token.to_string())
+                                .unwrap_or_else(|| "n/a".to_string()),
+                            step.replay_logit_max_abs,
+                        );
+                    }
+                }
+            }
+        }
         "localize" => {
             if let Some(localize) = report.localize.as_ref() {
                 println!(
@@ -3655,6 +3973,7 @@ mod tests {
                 commit_ish: Some("abc123".to_string()),
             },
             gate: None,
+            decode_gate: None,
             localize: Some(LocalizeRunSection {
                 pass: false,
                 gate_prompt: PromptGateReport {
@@ -3724,6 +4043,7 @@ mod tests {
                 commit_ish: Some("abc123".to_string()),
             },
             gate: None,
+            decode_gate: None,
             localize: None,
             dump: None,
             bench: Some(BenchRunSection {
@@ -3811,6 +4131,65 @@ mod tests {
         );
         assert_eq!(prompt["prefill_hal_profile"]["alloc_calls"], 1);
         assert_eq!(prompt["prefill_hal_profile"]["d2h_bytes"], 2048);
+    }
+
+    #[test]
+    fn decode_gate_report_serialization_includes_token_comparisons() {
+        let report = BughuntReport {
+            mode: "decode_gate".to_string(),
+            metadata: RunMetadata {
+                mode: "decode_gate".to_string(),
+                model: "qwen3.5-0.8b".to_string(),
+                backend: "metal".to_string(),
+                device: 0,
+                arch: "apple-m4".to_string(),
+                model_dir: "/tmp/model".to_string(),
+                oracle_device: "cpu".to_string(),
+                commit_ish: Some("abc123".to_string()),
+            },
+            gate: None,
+            decode_gate: Some(DecodeGateRunSection {
+                pass: false,
+                prompt_results: vec![DecodeGatePromptReport {
+                    name: "code_prompt".to_string(),
+                    notes: Some("code".to_string()),
+                    pass: false,
+                    prompt_len: 31,
+                    decode_tokens: 2,
+                    oracle_tokens: vec![271, 16],
+                    replay_tokens: vec![271, 17],
+                    component_tokens: Some(vec![271, 16]),
+                    max_replay_logit_abs: 0.2,
+                    mean_replay_logit_abs: 0.05,
+                    first_mismatch_step: Some(1),
+                    steps: vec![DecodeStepGateReport {
+                        step: 1,
+                        oracle_token: 16,
+                        replay_token: 17,
+                        component_token: Some(16),
+                        replay_logit_reference: "oracle_decode_logits".to_string(),
+                        replay_logit_max_abs: 0.2,
+                        replay_logit_mean_abs: 0.05,
+                        token_match_replay: false,
+                        token_match_component: true,
+                    }],
+                    timings: vec![PhaseTimingReport {
+                        phase: "oracle".to_string(),
+                        elapsed_ms: 10.0,
+                    }],
+                }],
+            }),
+            localize: None,
+            dump: None,
+            bench: None,
+        };
+        let value = serde_json::to_value(&report).unwrap();
+        let prompt = &value["decode_gate"]["prompt_results"][0];
+        assert_eq!(value["mode"], "decode_gate");
+        assert_eq!(prompt["first_mismatch_step"], 1);
+        assert_eq!(prompt["oracle_tokens"][1], 16);
+        assert_eq!(prompt["replay_tokens"][1], 17);
+        assert_eq!(prompt["component_tokens"][1], 16);
     }
 
     #[test]

--- a/crates/runner/src/decode_engine.rs
+++ b/crates/runner/src/decode_engine.rs
@@ -189,6 +189,10 @@ fn metal_fused_full_qk_prep_enabled() -> bool {
     std::env::var_os("SUPERSONIC_METAL_ENABLE_FUSED_FULL_QK_PREP").is_some()
 }
 
+fn metal_fused_full_attention_gate_enabled() -> bool {
+    std::env::var_os("SUPERSONIC_METAL_ENABLE_FUSED_FULL_ATTENTION_GATE").is_some()
+}
+
 fn metal_fused_linear_out_enabled() -> bool {
     std::env::var_os("SUPERSONIC_METAL_ENABLE_FUSED_LINEAR_OUT").is_some()
 }
@@ -2618,25 +2622,37 @@ impl DecodeEngine {
             .map_err(|e| anyhow::anyhow!("layer {idx} attention: {e}"))?;
         }
 
-        kernel_ffi::prefill_ffi::cast(
-            self.ordinal,
-            ScalarType::F32,
-            ScalarType::BF16,
-            num_q_heads * head_dim,
-            attn_out_f32,
-            attn_flat,
-        )
-        .map_err(|e| anyhow::anyhow!("layer {idx} attn cast: {e}"))?;
+        if self.hidden_io.backend() == gpu_hal::Backend::Metal
+            && metal_fused_full_attention_gate_enabled()
+        {
+            kernel_ffi::prefill_ffi::metal_full_attention_gate_bf16(
+                q_dim,
+                attn_out_f32,
+                gate_buf,
+                gated,
+            )
+            .map_err(|e| anyhow::anyhow!("layer {idx} fused full gate: {e}"))?;
+        } else {
+            kernel_ffi::prefill_ffi::cast(
+                self.ordinal,
+                ScalarType::F32,
+                ScalarType::BF16,
+                num_q_heads * head_dim,
+                attn_out_f32,
+                attn_flat,
+            )
+            .map_err(|e| anyhow::anyhow!("layer {idx} attn cast: {e}"))?;
 
-        kernel_ffi::prefill_ffi::sigmoid_mul(
-            self.ordinal,
-            ScalarType::BF16,
-            q_dim,
-            attn_flat,
-            gate_buf,
-            gated,
-        )
-        .map_err(|e| anyhow::anyhow!("layer {idx} gate apply: {e}"))?;
+            kernel_ffi::prefill_ffi::sigmoid_mul(
+                self.ordinal,
+                ScalarType::BF16,
+                q_dim,
+                attn_flat,
+                gate_buf,
+                gated,
+            )
+            .map_err(|e| anyhow::anyhow!("layer {idx} gate apply: {e}"))?;
+        }
 
         matmul_proj(
             self.ordinal,

--- a/crates/runner/src/decode_engine.rs
+++ b/crates/runner/src/decode_engine.rs
@@ -45,6 +45,10 @@ fn metal_matmul_lm_head_argmax_enabled() -> bool {
     std::env::var_os("SUPERSONIC_METAL_ENABLE_MATMUL_LM_HEAD_ARGMAX").is_some()
 }
 
+fn metal_full_attention_decode_kernel_enabled() -> bool {
+    std::env::var_os("SUPERSONIC_METAL_ENABLE_FULL_ATTENTION_DECODE_KERNEL").is_some()
+}
+
 fn copy_d2d_ordered(
     ordinal: usize,
     dst: *mut c_void,
@@ -2558,7 +2562,23 @@ impl DecodeEngine {
             kv_stride = kv_len;
         }
 
-        if self.hidden_io.backend() == gpu_hal::Backend::Metal {
+        if self.hidden_io.backend() == gpu_hal::Backend::Metal
+            && metal_full_attention_decode_kernel_enabled()
+        {
+            kernel_ffi::prefill_ffi::metal_full_attention_decode_bf16_f32(
+                num_q_heads,
+                num_kv_heads,
+                kv_len,
+                kv_stride,
+                head_dim,
+                1.0 / (head_dim as f32).sqrt(),
+                attn_q,
+                attn_k_ref,
+                attn_v_ref,
+                attn_out_f32,
+            )
+            .map_err(|e| anyhow::anyhow!("layer {idx} decode attention: {e}"))?;
+        } else if self.hidden_io.backend() == gpu_hal::Backend::Metal {
             kernel_ffi::prefill_ffi::metal_full_attention_prefill_strided_bf16_f32(
                 num_q_heads,
                 num_kv_heads,

--- a/crates/runner/src/decode_engine.rs
+++ b/crates/runner/src/decode_engine.rs
@@ -185,6 +185,10 @@ fn metal_fused_linear_out_enabled() -> bool {
     std::env::var_os("SUPERSONIC_METAL_ENABLE_FUSED_LINEAR_OUT").is_some()
 }
 
+fn metal_fused_linear_out_bf16_enabled() -> bool {
+    std::env::var_os("SUPERSONIC_METAL_ENABLE_FUSED_LINEAR_OUT_BF16").is_some()
+}
+
 fn metal_fused_linear_decode_apply_inplace_disabled() -> bool {
     std::env::var_os("SUPERSONIC_METAL_DISABLE_FUSED_LINEAR_DECODE_APPLY_INPLACE").is_some()
 }
@@ -3433,7 +3437,35 @@ impl DecodeEngine {
             && lw.out_proj_scale.is_none()
             && lw.out_proj_int4_scale.is_none()
             && lw.out_proj_int4_zero.is_none();
-        let (attn_trace, gated_trace, proj_trace) = if use_fused_linear_out {
+        let use_fused_linear_out_bf16 = self.hidden_io.backend() == gpu_hal::Backend::Metal
+            && !trace_output
+            && used_fused_linear_decode_apply_inplace
+            && metal_fused_linear_out_bf16_enabled()
+            && norm_w_bf16_ref.dtype() == ScalarType::BF16
+            && z.dtype() == ScalarType::BF16
+            && attn_bf16.dtype() == ScalarType::BF16
+            && lw.out_proj_w.dtype() == ScalarType::BF16
+            && self.hidden_io.dtype() == ScalarType::BF16
+            && lw.out_proj_scale.is_none()
+            && lw.out_proj_int4_scale.is_none()
+            && lw.out_proj_int4_zero.is_none();
+        let (attn_trace, gated_trace, proj_trace) = if use_fused_linear_out_bf16 {
+            let residual: &GpuBuffer = unsafe { &*(&self.hidden_io as *const GpuBuffer) };
+            kernel_ffi::prefill_ffi::metal_qwen_linear_out_residual_bf16_bf16(
+                hidden_dim,
+                nv,
+                vhd,
+                config.rms_norm_eps as f32,
+                &attn_bf16,
+                &z,
+                norm_w_bf16_ref,
+                &lw.out_proj_w,
+                residual,
+                &mut self.hidden_io,
+            )
+            .map_err(|e| anyhow::anyhow!("layer {idx} fused BF16 linear out/residual: {e}"))?;
+            (None, None, None)
+        } else if use_fused_linear_out {
             let residual: &GpuBuffer = unsafe { &*(&self.hidden_io as *const GpuBuffer) };
             kernel_ffi::prefill_ffi::metal_qwen_linear_out_residual_f32_bf16(
                 hidden_dim,

--- a/crates/runner/src/decode_engine.rs
+++ b/crates/runner/src/decode_engine.rs
@@ -2064,9 +2064,11 @@ impl DecodeEngine {
                 kernel_ffi::metal_argmax_bf16_into(&self.logits_buf, &mut self.argmax_buf, vocab_size)
                     .map_err(|e| anyhow::anyhow!("lm_head matmul argmax reduce: {e}"))?;
             } else {
-                kernel_ffi::metal_lm_head_argmax_bf16_into(
+                kernel_ffi::metal_lm_head_argmax_bf16_with_partials_into(
                     &self.normed_buf,
                     &*self.weights.lm_head,
+                    &mut self.lm_head_block_best_vals,
+                    &mut self.lm_head_block_best_idxs,
                     &mut self.argmax_buf,
                     hidden_dim,
                     vocab_size,

--- a/crates/runner/src/decode_engine.rs
+++ b/crates/runner/src/decode_engine.rs
@@ -177,6 +177,10 @@ fn metal_fused_mlp_gate_up_enabled() -> bool {
     std::env::var_os("SUPERSONIC_METAL_DISABLE_FUSED_MLP_GATE_UP").is_none()
 }
 
+fn metal_fused_mlp_gate_up_swiglu_enabled() -> bool {
+    std::env::var_os("SUPERSONIC_METAL_DISABLE_FUSED_MLP_GATE_UP_SWIGLU").is_none()
+}
+
 fn metal_fused_full_projection_disabled() -> bool {
     std::env::var_os("SUPERSONIC_METAL_DISABLE_FUSED_FULL_PROJ").is_some()
 }
@@ -3703,7 +3707,20 @@ impl DecodeEngine {
             && self.normed_buf.dtype() == ScalarType::BF16
             && lw.gate_proj_w.dtype() == ScalarType::BF16
             && lw.up_proj_w.dtype() == ScalarType::BF16;
-        if use_fused_mlp_gate_up {
+        let use_fused_mlp_gate_up_swiglu = use_fused_mlp_gate_up
+            && !use_fused_mlp
+            && metal_fused_mlp_gate_up_swiglu_enabled();
+        if use_fused_mlp_gate_up_swiglu {
+            kernel_ffi::prefill_ffi::metal_qwen_mlp_gate_up_swiglu_bf16(
+                hidden_dim,
+                intermediate,
+                &self.normed_buf,
+                &lw.gate_proj_w,
+                &lw.up_proj_w,
+                mlp,
+            )
+            .map_err(|e| anyhow::anyhow!("layer {idx} fused mlp gate/up/swiglu: {e}"))?;
+        } else if use_fused_mlp_gate_up {
             kernel_ffi::prefill_ffi::metal_qwen_mlp_gate_up_bf16(
                 hidden_dim,
                 intermediate,
@@ -3755,7 +3772,7 @@ impl DecodeEngine {
             )
             .map_err(|e| anyhow::anyhow!("layer {idx} swiglu: {e}"))?;
         }
-        if use_fused_mlp_gate_up && !use_fused_mlp {
+        if use_fused_mlp_gate_up && !use_fused_mlp && !use_fused_mlp_gate_up_swiglu {
             kernel_ffi::prefill_ffi::swiglu_mul(
                 self.ordinal,
                 ScalarType::BF16,


### PR DESCRIPTION
## Summary

This PR continues the Metal Qwen3.5 0.8B performance prototype with a focused incremental-decode checkpoint.

It adds and validates several decode-side improvements and experiments:

- Adds a Qwen Metal decode gate path to `qwen35_bughunt` so component decode can be compared against oracle/replay outputs.
- Adds per-layer/profile visibility for Metal decode to localize cost by layer and tail stage.
- Reuses Metal lm-head argmax partial buffers to avoid repeated allocation churn.
- Adds opt-in experiments for Metal full-attention decode and full-attention gate fusion.
- Makes the MLP gate/up + SiLU fusion default-on after correctness and benchmark checks.

## Why

The Metal backend is now functionally working for Qwen3.5 0.8B, but decode performance is still below target. This branch gives us a clean checkpoint with better gates, profiling, and one default-on measured fusion before continuing into deeper lm-head or layer-block work.

## Validation

- `cargo check -p runner --bin qwen35_bughunt --features bughunt`
- `cargo test -p runner --features bughunt bughunt::tests`
- `cargo test -p kernel-ffi metal_native_qwen_mlp_fusions_match_reference -- --nocapture`
- `cargo test -p kernel-ffi metal_native_full_attention_gate_matches_reference -- --nocapture`
- `qwen35_bughunt --mode decode-gate --backend metal --prompt code_prompt --decode-tokens 8`
- A/B Metal decode benches for the MLP fusion, full-attention decode kernel, full-attention gate fusion, and lm-head tiled prototype

## Notes

The full-attention decode and gate fusion paths remain opt-in because they passed correctness but did not improve throughput on this M4 machine. The lm-head tiled prototype was tested locally and intentionally reverted because it was slower than the current direct path.
