### PR TITLE
[codex] Add Qwen3.6 Q4KM bake support

### DIFF
--- a/crates/model-store/src/fetch.rs
+++ b/crates/model-store/src/fetch.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::manifest::{CONVERTER_VERSION, FORMAT_VERSION};
-use crate::{bake_dir, bake_dir_fp8, bake_dir_int4, bake_dir_q4km, version_ok};
+use crate::{bake_dir, bake_dir_fp8, bake_dir_int4, bake_dir_q4km, bake_dir_q4km_gptq, version_ok};
 
 /// Default GitHub repo that hosts release assets.
 pub const DEFAULT_REPO: &str = "DeanoC/SuperSonic";
@@ -47,6 +47,8 @@ pub enum BakeVariant {
     Int4Gptq,
     /// GGUF Q4_K_M-compatible raw GGML K-block weights.
     Q4Km,
+    /// Q4KM-sourced GPTQ/native INT4 weights.
+    Q4KmGptq,
 }
 
 impl BakeVariant {
@@ -56,6 +58,7 @@ impl BakeVariant {
             Self::Fp8Native => "fp8-native",
             Self::Int4Gptq => "int4-gptq",
             Self::Q4Km => "q4km",
+            Self::Q4KmGptq => "q4km-gptq",
         }
     }
 
@@ -66,6 +69,7 @@ impl BakeVariant {
             Self::Fp8Native => bake_dir_fp8(model_dir),
             Self::Int4Gptq => bake_dir_int4(model_dir),
             Self::Q4Km => bake_dir_q4km(model_dir),
+            Self::Q4KmGptq => bake_dir_q4km_gptq(model_dir),
         }
     }
 }
@@ -844,8 +848,16 @@ mod tests {
             BakeVariant::Q4Km.bake_dir(md)
         );
         assert_ne!(
+            BakeVariant::Bf16.bake_dir(md),
+            BakeVariant::Q4KmGptq.bake_dir(md)
+        );
+        assert_ne!(
             BakeVariant::Int4Gptq.bake_dir(md),
             BakeVariant::Q4Km.bake_dir(md)
+        );
+        assert_ne!(
+            BakeVariant::Q4Km.bake_dir(md),
+            BakeVariant::Q4KmGptq.bake_dir(md)
         );
         assert_ne!(
             BakeVariant::Fp8Native.bake_dir(md),

--- a/crates/model-store/src/lib.rs
+++ b/crates/model-store/src/lib.rs
@@ -66,6 +66,13 @@ pub fn bake_dir_q4km(model_dir: &Path) -> PathBuf {
         .join(format!("v{FORMAT_VERSION}-q4km"))
 }
 
+/// Return the bake directory for Q4KM-sourced GPTQ/native INT4 weights.
+pub fn bake_dir_q4km_gptq(model_dir: &Path) -> PathBuf {
+    model_dir
+        .join(".supersonic")
+        .join(format!("v{FORMAT_VERSION}-q4km-gptq"))
+}
+
 /// Return the bake directory for INT8 BitsAndBytes-style weights.
 /// Uses a separate directory so BF16/FP8/INT4/INT8 baked packages coexist.
 pub fn bake_dir_int8(model_dir: &Path) -> PathBuf {
@@ -130,6 +137,15 @@ pub fn version_ok(bake_dir: &Path) -> bool {
 
 /// Check if a valid Q4KM GGML K-block baked package exists at the given bake directory.
 pub fn version_ok_q4km(bake_dir: &Path) -> bool {
+    version_ok_with_quant_profile(bake_dir, "q4km-ggml-v1")
+}
+
+/// Check if a valid Q4KM GPTQ baked package exists at the given bake directory.
+pub fn version_ok_q4km_gptq(bake_dir: &Path) -> bool {
+    version_ok_with_quant_profile(bake_dir, "q4km-gptq-v1")
+}
+
+fn version_ok_with_quant_profile(bake_dir: &Path, quant_profile: &str) -> bool {
     let mp = manifest_path(bake_dir);
     let Ok(text) = std::fs::read_to_string(&mp) else {
         return false;
@@ -139,6 +155,6 @@ pub fn version_ok_q4km(bake_dir: &Path) -> bool {
     };
     m.format_version == FORMAT_VERSION
         && m.converter_version == CONVERTER_VERSION
-        && m.quant_profile.as_deref() == Some("q4km-ggml-v1")
+        && m.quant_profile.as_deref() == Some(quant_profile)
         && weights_bin_path(bake_dir).exists()
 }

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -781,9 +781,31 @@ fn should_fetch_bake(
     (download_bake && !bootstrap_downloaded) || !local_version_ok
 }
 
+fn effective_fixed_vram(
+    fixed_bytes: u64,
+    q4km: bool,
+    q4km_gptq: bool,
+    int4: bool,
+    fp8_runtime: bool,
+) -> u64 {
+    if q4km {
+        (fixed_bytes as f64 * 0.30) as u64
+    } else if q4km_gptq || int4 {
+        // INT4: weights ~= fixed * 0.9, scratch ~= fixed * 0.1
+        // INT4 weights = weights / 4 + ~5% scale/zero overhead
+        // total ≈ fixed * 0.9 * 0.3 + fixed * 0.1 = fixed * 0.37
+        (fixed_bytes as f64 * 0.37) as u64
+    } else if fp8_runtime {
+        // FP8: weights / 2
+        (fixed_bytes as f64 * 0.55) as u64
+    } else {
+        fixed_bytes
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::should_fetch_bake;
+    use super::{effective_fixed_vram, should_fetch_bake};
 
     #[test]
     fn bootstrap_download_satisfies_forced_bake_download() {
@@ -798,6 +820,11 @@ mod tests {
     #[test]
     fn invalid_local_bake_fetches_even_after_bootstrap_attempt() {
         assert!(should_fetch_bake(false, true, false));
+    }
+
+    #[test]
+    fn q4km_gptq_uses_int4_vram_estimate() {
+        assert_eq!(effective_fixed_vram(100, false, true, false, false), 37);
     }
 }
 
@@ -1345,19 +1372,13 @@ fn main() -> Result<()> {
     // matmul weights but keep embeddings/lm_head and scratch in higher
     // precision. Q4KM is measured from real 27B GGUF bakes at ~0.30x fixed;
     // GPTQ INT4 keeps the older conservative 0.37x estimate.
-    let effective_fixed = if q4km_like {
-        (entry.vram.fixed_bytes as f64 * 0.30) as u64
-    } else if cli.int4 {
-        // INT4: weights ~= fixed * 0.9, scratch ~= fixed * 0.1
-        // INT4 weights = weights / 4 + ~5% scale/zero overhead
-        // total ≈ fixed * 0.9 * 0.3 + fixed * 0.1 = fixed * 0.37
-        (entry.vram.fixed_bytes as f64 * 0.37) as u64
-    } else if cli.fp8_runtime {
-        // FP8: weights / 2
-        (entry.vram.fixed_bytes as f64 * 0.55) as u64
-    } else {
-        entry.vram.fixed_bytes
-    };
+    let effective_fixed = effective_fixed_vram(
+        entry.vram.fixed_bytes,
+        cli.q4km,
+        cli.q4km_gptq,
+        cli.int4,
+        cli.fp8_runtime,
+    );
     let estimated_vram = {
         let kv_bytes = kv_per_token * context_tokens as u64;
         ((effective_fixed + kv_bytes) as f64 * entry.vram.overhead_factor) as u64

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -773,6 +773,34 @@ fn variant_version_ok(
     }
 }
 
+fn should_fetch_bake(
+    download_bake: bool,
+    bootstrap_downloaded: bool,
+    local_version_ok: bool,
+) -> bool {
+    (download_bake && !bootstrap_downloaded) || !local_version_ok
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_fetch_bake;
+
+    #[test]
+    fn bootstrap_download_satisfies_forced_bake_download() {
+        assert!(!should_fetch_bake(true, true, true));
+    }
+
+    #[test]
+    fn forced_bake_download_still_fetches_without_bootstrap() {
+        assert!(should_fetch_bake(true, false, true));
+    }
+
+    #[test]
+    fn invalid_local_bake_fetches_even_after_bootstrap_attempt() {
+        assert!(should_fetch_bake(false, true, false));
+    }
+}
+
 fn repo_root() -> Result<PathBuf> {
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     manifest_dir
@@ -1114,8 +1142,11 @@ fn main() -> Result<()> {
             let bake_dir = variant.bake_dir(&cli.model_dir);
             let _lock = model_store::BakeLock::acquire(&cli.model_dir)
                 .map_err(|e| anyhow::anyhow!("acquire bake lock: {e}"))?;
-            if (cli.download_bake && !bootstrap_downloaded) || !model_store::version_ok(&bake_dir)
-            {
+            if should_fetch_bake(
+                cli.download_bake,
+                bootstrap_downloaded,
+                model_store::version_ok(&bake_dir),
+            ) {
                 let canonical_model = model_variant.to_string();
                 match try_download_bake(&cli, variant, &canonical_model, &bake_dir) {
                     Ok(true) => {
@@ -1375,7 +1406,11 @@ fn main() -> Result<()> {
         let _lock = model_store::BakeLock::acquire(&cli.model_dir)
             .map_err(|e| anyhow::anyhow!("acquire bake lock: {e}"))?;
 
-        if (cli.download_bake && !bootstrap_downloaded) || !variant_version_ok(variant, &bake_dir) {
+        if should_fetch_bake(
+            cli.download_bake,
+            bootstrap_downloaded,
+            variant_version_ok(variant, &bake_dir),
+        ) {
             let local_bake_ok = matches!(
                 variant,
                 model_store::fetch::BakeVariant::Bf16 | model_store::fetch::BakeVariant::Fp8Native
@@ -2726,9 +2761,11 @@ fn run_gemma4(
         let target = gemma4_int4_engine::int4_bake_dir(&cli.model_dir);
         let _lock = model_store::BakeLock::acquire(&cli.model_dir)
             .map_err(|e| anyhow::anyhow!("acquire bake lock: {e}"))?;
-        if (cli.download_bake && !bootstrap_downloaded)
-            || !gemma4_int4_engine::int4_bake_ok(&cli.model_dir)
-        {
+        if should_fetch_bake(
+            cli.download_bake,
+            bootstrap_downloaded,
+            gemma4_int4_engine::int4_bake_ok(&cli.model_dir),
+        ) {
             let canonical_model = model_variant.to_string();
             match try_download_bake(
                 cli,

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -781,6 +781,10 @@ fn should_fetch_bake(
     (download_bake && !bootstrap_downloaded) || !local_version_ok
 }
 
+fn should_fetch_exact_bake(download_bake: bool, local_version_ok: bool) -> bool {
+    download_bake || !local_version_ok
+}
+
 fn effective_fixed_vram(
     fixed_bytes: u64,
     q4km: bool,
@@ -805,7 +809,7 @@ fn effective_fixed_vram(
 
 #[cfg(test)]
 mod tests {
-    use super::{effective_fixed_vram, should_fetch_bake};
+    use super::{effective_fixed_vram, should_fetch_bake, should_fetch_exact_bake};
 
     #[test]
     fn bootstrap_download_satisfies_forced_bake_download() {
@@ -820,6 +824,11 @@ mod tests {
     #[test]
     fn invalid_local_bake_fetches_even_after_bootstrap_attempt() {
         assert!(should_fetch_bake(false, true, false));
+    }
+
+    #[test]
+    fn forced_exact_bake_fetch_ignores_metadata_bootstrap() {
+        assert!(should_fetch_exact_bake(true, true));
     }
 
     #[test]
@@ -1163,17 +1172,13 @@ fn main() -> Result<()> {
         // machine: ensure_hf_metadata_present fetches HF metadata from the
         // bake tarball if config.json is missing, then we verify or download
         // the INT4 bake itself.
-        let bootstrap_downloaded = ensure_hf_metadata_present(&cli, &model_variant)?;
+        ensure_hf_metadata_present(&cli, &model_variant)?;
         if !cli.no_bake {
             let variant = model_store::fetch::BakeVariant::Int4Gptq;
             let bake_dir = variant.bake_dir(&cli.model_dir);
             let _lock = model_store::BakeLock::acquire(&cli.model_dir)
                 .map_err(|e| anyhow::anyhow!("acquire bake lock: {e}"))?;
-            if should_fetch_bake(
-                cli.download_bake,
-                bootstrap_downloaded,
-                model_store::version_ok(&bake_dir),
-            ) {
+            if should_fetch_exact_bake(cli.download_bake, model_store::version_ok(&bake_dir)) {
                 let canonical_model = model_variant.to_string();
                 match try_download_bake(&cli, variant, &canonical_model, &bake_dir) {
                     Ok(true) => {

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -405,6 +405,10 @@ pub(crate) struct Cli {
     #[arg(long)]
     q4km: bool,
 
+    /// Use a Q4KM-sourced GPTQ bake in SuperSonic's native INT4 runtime layout.
+    #[arg(long)]
+    q4km_gptq: bool,
+
     /// Optional GGUF source file to translate into a native q4km bake.
     #[arg(long)]
     gguf_file: Option<PathBuf>,
@@ -743,7 +747,9 @@ fn try_download_bake(
 /// Pick the variant the CLI flags imply, using the same INT4 > FP8 > BF16
 /// priority order as the rest of the runner.
 fn cli_variant(cli: &Cli) -> model_store::fetch::BakeVariant {
-    if cli.q4km {
+    if cli.q4km_gptq {
+        model_store::fetch::BakeVariant::Q4KmGptq
+    } else if cli.q4km {
         model_store::fetch::BakeVariant::Q4Km
     } else if cli.int4 {
         model_store::fetch::BakeVariant::Int4Gptq
@@ -760,6 +766,8 @@ fn variant_version_ok(
 ) -> bool {
     if variant == model_store::fetch::BakeVariant::Q4Km {
         model_store::version_ok_q4km(bake_dir)
+    } else if variant == model_store::fetch::BakeVariant::Q4KmGptq {
+        model_store::version_ok_q4km_gptq(bake_dir)
     } else {
         model_store::version_ok(bake_dir)
     }
@@ -943,25 +951,31 @@ fn main() -> Result<()> {
         )
     })?;
 
-    if cli.q4km && (cli.int4 || cli.int8 || cli.fp8_runtime) {
-        anyhow::bail!("--q4km is mutually exclusive with --int4, --int8, and --fp8-runtime");
+    let q4km_like = cli.q4km || cli.q4km_gptq;
+    if cli.q4km && cli.q4km_gptq {
+        anyhow::bail!("--q4km is mutually exclusive with --q4km-gptq");
     }
-    if cli.q4km
+    if q4km_like && (cli.int4 || cli.int8 || cli.fp8_runtime) {
+        anyhow::bail!(
+            "--q4km/--q4km-gptq are mutually exclusive with --int4, --int8, and --fp8-runtime"
+        );
+    }
+    if q4km_like
         && !matches!(
             model_variant.family(),
             ModelFamily::Qwen35 | ModelFamily::Qwen36Moe
         )
     {
-        anyhow::bail!("--q4km is currently supported only for Qwen models");
+        anyhow::bail!("--q4km/--q4km-gptq are currently supported only for Qwen models");
     }
-    if cli.q4km && backend != Backend::Cuda {
-        anyhow::bail!("--q4km is currently supported only on CUDA");
+    if q4km_like && backend != Backend::Cuda {
+        anyhow::bail!("--q4km/--q4km-gptq are currently supported only on CUDA");
     }
     if cli.gguf_file.is_some() && !cli.q4km {
         anyhow::bail!("--gguf-file requires --q4km");
     }
-    if cli.no_bake && cli.q4km {
-        anyhow::bail!("--q4km requires a baked package; omit --no-bake");
+    if cli.no_bake && q4km_like {
+        anyhow::bail!("--q4km/--q4km-gptq require a baked package; omit --no-bake");
     }
     if cli.int8 && (cli.int4 || cli.fp8_runtime) {
         anyhow::bail!("--int8 is mutually exclusive with --int4 and --fp8-runtime");
@@ -1235,8 +1249,8 @@ fn main() -> Result<()> {
         ) {
             anyhow::bail!("Metal only supports --model qwen3.5-0.8b or qwen3.5-2b");
         }
-        if cli.q4km {
-            anyhow::bail!("Metal does not support --q4km on Qwen3.5 yet");
+        if q4km_like {
+            anyhow::bail!("Metal does not support --q4km/--q4km-gptq on Qwen3.5 yet");
         }
         if cli.fp8_runtime {
             anyhow::bail!("Metal does not support --fp8-runtime on Qwen3.5 yet");
@@ -1299,7 +1313,7 @@ fn main() -> Result<()> {
     // matmul weights but keep embeddings/lm_head and scratch in higher
     // precision. Q4KM is measured from real 27B GGUF bakes at ~0.30x fixed;
     // GPTQ INT4 keeps the older conservative 0.37x estimate.
-    let effective_fixed = if cli.q4km {
+    let effective_fixed = if q4km_like {
         (entry.vram.fixed_bytes as f64 * 0.30) as u64
     } else if cli.int4 {
         // INT4: weights ~= fixed * 0.9, scratch ~= fixed * 0.1
@@ -1349,14 +1363,12 @@ fn main() -> Result<()> {
         )
         .map_err(|e| anyhow::anyhow!("load weights: {e}"))?
     } else {
-        let variant = if cli.q4km {
-            model_store::fetch::BakeVariant::Q4Km
-        } else if cli.int4 {
+        let variant = if cli.int4 {
             model_store::fetch::BakeVariant::Int4Gptq
         } else if cli.fp8_runtime {
             model_store::fetch::BakeVariant::Fp8Native
         } else {
-            model_store::fetch::BakeVariant::Bf16
+            cli_variant(&cli)
         };
         let mut bake_dir = variant.bake_dir(&cli.model_dir);
         let _lock = model_store::BakeLock::acquire(&cli.model_dir)
@@ -1375,10 +1387,11 @@ fn main() -> Result<()> {
                 }
                 Ok(false) => {
                     if !local_bake_ok {
-                        if cli.q4km {
+                        if q4km_like {
                             anyhow::bail!(
                                 "no {variant} bake at {} and --no-download set.\n\
-                                 Rerun with --gguf-file /path/to/model.gguf to create a local raw GGML q4km bake.",
+                                 Rerun with --gguf-file /path/to/model.gguf to create a local raw GGML q4km bake, \
+                                 or provide/download a q4km-gptq bake.",
                                 bake_dir.display(),
                             );
                         } else {
@@ -1395,10 +1408,11 @@ fn main() -> Result<()> {
                     if local_bake_ok {
                         eprintln!("[fetch] {e}; falling back to local bake");
                     } else {
-                        if cli.q4km {
+                        if q4km_like {
                             anyhow::bail!(
                                 "could not obtain {variant} bake: {e}\n\n\
-                                 Rerun with --gguf-file /path/to/model.gguf to create a local raw GGML q4km bake.",
+                                 Rerun with --gguf-file /path/to/model.gguf to create a local raw GGML q4km bake, \
+                                 or provide/download a q4km-gptq bake.",
                             );
                         } else {
                             anyhow::bail!(

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -817,12 +817,12 @@ fn run_q4km_baker(cli: &Cli, bake_dir: &std::path::Path) -> Result<()> {
 /// metadata under `hf/`, which the downloader extracts into `--model-dir`
 /// before anything else reads from it. This is the "fresh empty model dir"
 /// path that makes release-hosted bakes self-sufficient.
-fn ensure_hf_metadata_present(cli: &Cli, model_variant: &ModelVariant) -> Result<()> {
+fn ensure_hf_metadata_present(cli: &Cli, model_variant: &ModelVariant) -> Result<bool> {
     if cli.no_bake || cli.no_download {
-        return Ok(());
+        return Ok(false);
     }
     if cli.model_dir.join("config.json").exists() {
-        return Ok(());
+        return Ok(false);
     }
     let variant = cli_variant(cli);
     let bake_dir = variant.bake_dir(&cli.model_dir);
@@ -831,7 +831,7 @@ fn ensure_hf_metadata_present(cli: &Cli, model_variant: &ModelVariant) -> Result
     // Race: another process might have populated config between our check
     // above and the lock acquisition.
     if cli.model_dir.join("config.json").exists() {
-        return Ok(());
+        return Ok(false);
     }
     let canonical_model = model_variant.to_string();
     eprintln!(
@@ -839,7 +839,7 @@ fn ensure_hf_metadata_present(cli: &Cli, model_variant: &ModelVariant) -> Result
          HF metadata and weights in one pass"
     );
     try_download_bake(cli, variant, &canonical_model, &bake_dir)?;
-    Ok(())
+    Ok(true)
 }
 
 /// RAII scope that enables Metal/HAL profiling when SUPERSONIC_METAL_PROFILE
@@ -1108,13 +1108,14 @@ fn main() -> Result<()> {
         // machine: ensure_hf_metadata_present fetches HF metadata from the
         // bake tarball if config.json is missing, then we verify or download
         // the INT4 bake itself.
-        ensure_hf_metadata_present(&cli, &model_variant)?;
+        let bootstrap_downloaded = ensure_hf_metadata_present(&cli, &model_variant)?;
         if !cli.no_bake {
             let variant = model_store::fetch::BakeVariant::Int4Gptq;
             let bake_dir = variant.bake_dir(&cli.model_dir);
             let _lock = model_store::BakeLock::acquire(&cli.model_dir)
                 .map_err(|e| anyhow::anyhow!("acquire bake lock: {e}"))?;
-            if cli.download_bake || !model_store::version_ok(&bake_dir) {
+            if (cli.download_bake && !bootstrap_downloaded) || !model_store::version_ok(&bake_dir)
+            {
                 let canonical_model = model_variant.to_string();
                 match try_download_bake(&cli, variant, &canonical_model, &bake_dir) {
                     Ok(true) => {
@@ -1270,7 +1271,7 @@ fn main() -> Result<()> {
 
     // If --model-dir is pristine (no config.json), fetch a bake first so the
     // downloader can populate HF metadata before we try to read it.
-    ensure_hf_metadata_present(&cli, &model_variant)?;
+    let bootstrap_downloaded = ensure_hf_metadata_present(&cli, &model_variant)?;
 
     // Load config
     let config = qwen35::config::load_config(&cli.model_dir)
@@ -1374,7 +1375,7 @@ fn main() -> Result<()> {
         let _lock = model_store::BakeLock::acquire(&cli.model_dir)
             .map_err(|e| anyhow::anyhow!("acquire bake lock: {e}"))?;
 
-        if cli.download_bake || !variant_version_ok(variant, &bake_dir) {
+        if (cli.download_bake && !bootstrap_downloaded) || !variant_version_ok(variant, &bake_dir) {
             let local_bake_ok = matches!(
                 variant,
                 model_store::fetch::BakeVariant::Bf16 | model_store::fetch::BakeVariant::Fp8Native
@@ -2629,7 +2630,7 @@ fn run_gemma4(
     }
 
     // Fetch first if --model-dir is pristine so HF metadata lands before config load.
-    ensure_hf_metadata_present(cli, model_variant)?;
+    let bootstrap_downloaded = ensure_hf_metadata_present(cli, model_variant)?;
 
     let cfg = gemma4::config::load_config(&cli.model_dir)
         .map_err(|e| anyhow::anyhow!("loading Gemma 4 config.json: {e}"))?;
@@ -2725,7 +2726,9 @@ fn run_gemma4(
         let target = gemma4_int4_engine::int4_bake_dir(&cli.model_dir);
         let _lock = model_store::BakeLock::acquire(&cli.model_dir)
             .map_err(|e| anyhow::anyhow!("acquire bake lock: {e}"))?;
-        if cli.download_bake || !gemma4_int4_engine::int4_bake_ok(&cli.model_dir) {
+        if (cli.download_bake && !bootstrap_downloaded)
+            || !gemma4_int4_engine::int4_bake_ok(&cli.model_dir)
+        {
             let canonical_model = model_variant.to_string();
             match try_download_bake(
                 cli,

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -46,6 +46,10 @@ struct Cli {
     #[arg(long)]
     q4km: bool,
 
+    /// Use a Q4KM-sourced GPTQ bake in SuperSonic's native INT4 runtime layout.
+    #[arg(long)]
+    q4km_gptq: bool,
+
     /// Keep FP8 weights on GPU and dequant at runtime (Qwen3.5 only).
     #[arg(long)]
     fp8_runtime: bool,
@@ -91,6 +95,7 @@ fn main() -> Result<()> {
         max_context: cli.max_context,
         int4: cli.int4,
         q4km: cli.q4km,
+        q4km_gptq: cli.q4km_gptq,
         fp8_runtime: cli.fp8_runtime,
         kv_fp8: cli.kv_fp8,
         api_key: cli.api_key,

--- a/crates/server/src/state.rs
+++ b/crates/server/src/state.rs
@@ -43,6 +43,7 @@ pub struct LoaderConfig {
     pub max_context: usize,
     pub int4: bool,
     pub q4km: bool,
+    pub q4km_gptq: bool,
     pub fp8_runtime: bool,
     pub kv_fp8: bool,
     pub api_key: Option<String>,
@@ -52,8 +53,12 @@ pub struct LoaderConfig {
 }
 
 pub fn build(cfg: LoaderConfig) -> Result<ServerState> {
-    if cfg.q4km && (cfg.int4 || cfg.fp8_runtime) {
-        bail!("--q4km is mutually exclusive with --int4 and --fp8-runtime");
+    let q4km_like = cfg.q4km || cfg.q4km_gptq;
+    if cfg.q4km && cfg.q4km_gptq {
+        bail!("--q4km is mutually exclusive with --q4km-gptq");
+    }
+    if q4km_like && (cfg.int4 || cfg.fp8_runtime) {
+        bail!("--q4km/--q4km-gptq are mutually exclusive with --int4 and --fp8-runtime");
     }
     /* ---- backend + GPU detection ---- */
     let backend = resolve_backend(&cfg.backend, cfg.device)?;
@@ -66,16 +71,16 @@ pub fn build(cfg: LoaderConfig) -> Result<ServerState> {
             registry::supported_models_list().join(", ")
         )
     })?;
-    if cfg.q4km
+    if q4km_like
         && !matches!(
             variant.family(),
             ModelFamily::Qwen35 | ModelFamily::Qwen36Moe
         )
     {
-        bail!("--q4km is currently supported only for Qwen models");
+        bail!("--q4km/--q4km-gptq are currently supported only for Qwen models");
     }
-    if cfg.q4km && backend != Backend::Cuda {
-        bail!("--q4km is currently supported only on CUDA");
+    if q4km_like && backend != Backend::Cuda {
+        bail!("--q4km/--q4km-gptq are currently supported only on CUDA");
     }
 
     if backend == Backend::Metal {
@@ -190,7 +195,9 @@ fn ensure_hf_metadata_present(cfg: &LoaderConfig, variant: &ModelVariant) -> Res
     if cfg.model_dir.join("config.json").exists() {
         return Ok(());
     }
-    let bake_variant = if cfg.q4km {
+    let bake_variant = if cfg.q4km_gptq {
+        model_store::fetch::BakeVariant::Q4KmGptq
+    } else if cfg.q4km {
         model_store::fetch::BakeVariant::Q4Km
     } else if cfg.int4 {
         model_store::fetch::BakeVariant::Int4Gptq
@@ -342,7 +349,9 @@ fn build_qwen(
     // Prefer the baked format; auto-bake BF16/FP8 if missing, fail with a
     // clear message for INT4 (calibration must happen offline).
     let t0 = Instant::now();
-    let variant_bake = if cfg.q4km {
+    let variant_bake = if cfg.q4km_gptq {
+        model_store::fetch::BakeVariant::Q4KmGptq
+    } else if cfg.q4km {
         model_store::fetch::BakeVariant::Q4Km
     } else if cfg.int4 {
         model_store::fetch::BakeVariant::Int4Gptq
@@ -355,12 +364,10 @@ fn build_qwen(
     let _lock = model_store::BakeLock::acquire(&cfg.model_dir)
         .map_err(|e| anyhow!("acquire bake lock: {e}"))?;
 
-    let bake_ok = || {
-        if variant_bake == model_store::fetch::BakeVariant::Q4Km {
-            model_store::version_ok_q4km(&bake_dir)
-        } else {
-            model_store::version_ok(&bake_dir)
-        }
+    let bake_ok = || match variant_bake {
+        model_store::fetch::BakeVariant::Q4Km => model_store::version_ok_q4km(&bake_dir),
+        model_store::fetch::BakeVariant::Q4KmGptq => model_store::version_ok_q4km_gptq(&bake_dir),
+        _ => model_store::version_ok(&bake_dir),
     };
     if !bake_ok() {
         let local_bake_ok = matches!(

--- a/oracle/bake_all.sh
+++ b/oracle/bake_all.sh
@@ -10,6 +10,10 @@
 #   QWEN_2B_DIR=/models/Qwen3.5-2B \
 #   QWEN_4B_DIR=/models/Qwen3.5-4B \
 #   QWEN_9B_DIR=/models/Qwen3.5-9B \
+#   QWEN_36_27B_DIR=/models/Qwen3.6-27B \
+#   QWEN_36_27B_GGUF=/models/Qwen3.6-27B-Q4_K_M.gguf \
+#   QWEN_36_27B_ACTIVATION_DIR=/models/Qwen3.6-27B-FP8 \
+#   Q4KM_GPTQ_EXTRA_ARGS='--device-map auto --max-memory {"0":"22GiB","cpu":"48GiB"} --offload-folder /tmp/qwen36-offload' \
 #   GEMMA_E2B_DIR=/models/gemma-4-E2B \
 #   GEMMA_E4B_DIR=/models/gemma-4-E4B \
 #   PHI4_MINI_DIR=/models/Phi-4-mini-instruct \
@@ -24,6 +28,8 @@
 #                   has no FP8-native bake format.
 #   --q4km          Also produce Q4KM bakes (Qwen only; Gemma/Phi4 not yet
 #                   supported by oracle/bake_q4km.py).
+#   --q4km-gptq     Also produce Q4KM-sourced GPTQ/native INT4 bakes (Qwen
+#                   only; requires the matching ${ENV_VAR%_DIR}_GGUF path).
 #   --no-int4       Skip INT4 bakes (useful with --bf16 for a BF16-only run).
 #   --force         Re-bake even if a valid bake already exists.
 #   --stop-on-error Abort the whole batch if any single bake fails.
@@ -54,6 +60,7 @@ INCLUDE_BF16=0
 INCLUDE_FP8=0
 INCLUDE_INT4=1
 INCLUDE_Q4KM=0
+INCLUDE_Q4KM_GPTQ=0
 FORCE=0
 STOP_ON_ERROR=0
 SKIP_LM_HEAD_INT4_REFRESH=0
@@ -64,6 +71,7 @@ while [[ $# -gt 0 ]]; do
         --bf16) INCLUDE_BF16=1 ;;
         --fp8-native) INCLUDE_FP8=1 ;;
         --q4km) INCLUDE_Q4KM=1 ;;
+        --q4km-gptq) INCLUDE_Q4KM_GPTQ=1 ;;
         --no-int4) INCLUDE_INT4=0 ;;
         --force) FORCE=1 ;;
         --skip-lm-head-int4-refresh) SKIP_LM_HEAD_INT4_REFRESH=1 ;;
@@ -80,12 +88,14 @@ MODELS=(
     "qwen3.5-2b:QWEN_2B_DIR:qwen"
     "qwen3.5-4b:QWEN_4B_DIR:qwen"
     "qwen3.5-9b:QWEN_9B_DIR:qwen"
+    "qwen3.6-27b:QWEN_36_27B_DIR:qwen"
+    "qwen3.6-35b-a3b:QWEN_36_35B_A3B_DIR:qwen"
     "gemma4-e2b:GEMMA_E2B_DIR:gemma"
     "gemma4-e4b:GEMMA_E4B_DIR:gemma"
     "phi4-mini:PHI4_MINI_DIR:phi4"
 )
 
-FORMAT_VERSION=1   # must match crates/model-store/src/manifest.rs
+FORMAT_VERSION=2   # must match crates/model-store/src/manifest.rs
 
 declare -a SUCCEEDED FAILED SKIPPED
 
@@ -116,6 +126,35 @@ bake_has_lm_head_int4() {
     local dir="$1"
     [[ -f "$dir/manifest.json" ]] || return 1
     grep -q '"name": *"lm_head.weight_int4_scale"' "$dir/manifest.json"
+}
+
+gguf_file_for() {
+    local env_var="$1"
+    local gguf_env="${env_var%_DIR}_GGUF"
+    local gguf_file="${!gguf_env:-}"
+    if [[ -z "$gguf_file" ]]; then
+        echo "missing $gguf_env; set it to the matching GGUF source" >&2
+        return 1
+    fi
+    if [[ ! -f "$gguf_file" ]]; then
+        echo "$gguf_env=$gguf_file is not a file" >&2
+        return 1
+    fi
+    echo "$gguf_file"
+}
+
+activation_dir_for() {
+    local env_var="$1"
+    local activation_env="${env_var%_DIR}_ACTIVATION_DIR"
+    local activation_dir="${!activation_env:-}"
+    if [[ -z "$activation_dir" ]]; then
+        return 1
+    fi
+    if [[ ! -d "$activation_dir" ]]; then
+        echo "$activation_env=$activation_dir is not a directory" >&2
+        return 1
+    fi
+    echo "$activation_dir"
 }
 
 run_or_record() {
@@ -186,7 +225,7 @@ bake_int4() {
 }
 
 bake_q4km() {
-    local cli_name="$1" model_dir="$2" family="$3"
+    local cli_name="$1" model_dir="$2" family="$3" env_var="$4"
     if [[ "$family" != "qwen" ]]; then
         echo "[skip] $cli_name q4km — Q4KM bake supports Qwen only"
         SKIPPED+=("$cli_name q4km")
@@ -207,11 +246,61 @@ bake_q4km() {
         SKIPPED+=("$label")
         return 0
     fi
+    local gguf_file ; gguf_file="$(gguf_file_for "$env_var")" || {
+        echo "[skip] $label — no GGUF source configured"
+        SKIPPED+=("$label")
+        return 0
+    }
     run_or_record "$label" python3 "$SCRIPT_DIR/bake_q4km.py" \
-        --model-dir "$model_dir" || return $?
+        --model "$cli_name" \
+        --model-dir "$model_dir" \
+        --gguf-file "$gguf_file" || return $?
     if [[ $UPLOAD -eq 1 ]]; then
         run_or_record "$label upload" python3 "$SCRIPT_DIR/upload_bake.py" \
             --model "$cli_name" --q4km --model-dir "$model_dir"
+    fi
+}
+
+bake_q4km_gptq() {
+    local cli_name="$1" model_dir="$2" family="$3" env_var="$4"
+    if [[ "$family" != "qwen" ]]; then
+        echo "[skip] $cli_name q4km-gptq — Q4KM-GPTQ bake supports Qwen only"
+        SKIPPED+=("$cli_name q4km-gptq")
+        return 0
+    fi
+    local dir ; dir="$(bake_dir_for "$model_dir" q4km-gptq)" || return 2
+    local label="$cli_name q4km-gptq"
+    if [[ $FORCE -eq 0 ]] && bake_exists_and_valid "$dir"; then
+        echo "[skip] $label — valid bake at $dir"
+        SKIPPED+=("$label")
+        return 0
+    fi
+    local gguf_file ; gguf_file="$(gguf_file_for "$env_var")" || {
+        echo "[skip] $label — no GGUF source configured"
+        SKIPPED+=("$label")
+        return 0
+    }
+    local -a cmd=(
+        python3 "$SCRIPT_DIR/q4km_stream_gptq_bake.py"
+        --model "$cli_name" \
+        --model-dir "$model_dir" \
+        --gguf-file "$gguf_file"
+    )
+    local activation_dir
+    if activation_dir="$(activation_dir_for "$env_var")"; then
+        cmd+=(--activation-model-dir "$activation_dir")
+    else
+        cmd+=(--use-gguf-loader)
+    fi
+    if [[ -n "${Q4KM_GPTQ_EXTRA_ARGS:-}" ]]; then
+        # shellcheck disable=SC2206
+        local -a extra_args=( $Q4KM_GPTQ_EXTRA_ARGS )
+        cmd+=("${extra_args[@]}")
+    fi
+    run_or_record "$label" "${cmd[@]}" || return $?
+    if [[ $UPLOAD -eq 1 ]]; then
+        run_or_record "$label upload" python3 "$SCRIPT_DIR/upload_bake.py" \
+            --model "$cli_name" --q4km-gptq --model-dir "$model_dir"
     fi
 }
 
@@ -277,17 +366,26 @@ bake_fp8_native() {
 }
 
 print_summary() {
-    local succeeded_count=${#SUCCEEDED[@]}
-    local skipped_count=${#SKIPPED[@]}
-    local failed_count=${#FAILED[@]}
+    local succeeded_count=0
+    local skipped_count=0
+    local failed_count=0
+    [[ ${SUCCEEDED+x} ]] && succeeded_count=${#SUCCEEDED[@]}
+    [[ ${SKIPPED+x} ]] && skipped_count=${#SKIPPED[@]}
+    [[ ${FAILED+x} ]] && failed_count=${#FAILED[@]}
     echo
     echo "==== bake_all summary ===="
     echo "succeeded: $succeeded_count"
-    for s in "${SUCCEEDED[@]:-}"; do [[ -n "$s" ]] && echo "  OK   $s"; done
+    if [[ $succeeded_count -gt 0 ]]; then
+        for s in "${SUCCEEDED[@]}"; do echo "  OK   $s"; done
+    fi
     echo "skipped:   $skipped_count"
-    for s in "${SKIPPED[@]:-}"; do [[ -n "$s" ]] && echo "  --   $s"; done
+    if [[ $skipped_count -gt 0 ]]; then
+        for s in "${SKIPPED[@]}"; do echo "  --   $s"; done
+    fi
     echo "failed:    $failed_count"
-    for s in "${FAILED[@]:-}"; do [[ -n "$s" ]] && echo "  FAIL $s"; done
+    if [[ $failed_count -gt 0 ]]; then
+        for s in "${FAILED[@]}"; do echo "  FAIL $s"; done
+    fi
 }
 
 any_configured=0
@@ -314,7 +412,10 @@ for entry in "${MODELS[@]}"; do
         bake_int4 "$cli_name" "$model_dir" "$family" || true
     fi
     if [[ $INCLUDE_Q4KM -eq 1 ]]; then
-        bake_q4km "$cli_name" "$model_dir" "$family" || true
+        bake_q4km "$cli_name" "$model_dir" "$family" "$env_var" || true
+    fi
+    if [[ $INCLUDE_Q4KM_GPTQ -eq 1 ]]; then
+        bake_q4km_gptq "$cli_name" "$model_dir" "$family" "$env_var" || true
     fi
 done
 
@@ -325,4 +426,6 @@ fi
 
 print_summary
 # Exit non-zero iff anything failed, so CI can gate on the script's return.
-[[ ${#FAILED[@]} -eq 0 ]]
+failed_count=0
+[[ ${FAILED+x} ]] && failed_count=${#FAILED[@]}
+[[ $failed_count -eq 0 ]]

--- a/oracle/bake_int4.py
+++ b/oracle/bake_int4.py
@@ -56,6 +56,16 @@ def log(msg: str) -> None:
     print(msg, flush=True)
 
 
+def copy_weight_in_row_chunks(dst: torch.Tensor, src: torch.Tensor, rows_per_chunk: int = 4096) -> None:
+    """Copy a large CPU weight into an existing module parameter without a full-device clone."""
+    with torch.no_grad():
+        for start in range(0, src.shape[0], rows_per_chunk):
+            end = min(start + rows_per_chunk, src.shape[0])
+            dst[start:end].copy_(
+                src[start:end].to(device=dst.device, dtype=dst.dtype, non_blocking=True)
+            )
+
+
 # ---------------------------------------------------------------------------
 # Target-tensor selection (mirrors crates/model-store/src/baker.rs::is_int4_target)
 # ---------------------------------------------------------------------------
@@ -531,6 +541,7 @@ def quantize_model(
             elapsed = time.perf_counter() - t0
             log(f"[gptq]   lm_head: shape={tuple(W.shape)} "
                 f"H_N={hook.N} took {elapsed:.1f}s")
+            copy_weight_in_row_chunks(lm_head.weight.data, Q_dq)
             quantized["lm_head.weight"] = (nibbles.cpu(), scale_t.cpu(), zero_t.cpu())
             del W, Q_dq, nibbles, scale_t, zero_t, H
 

--- a/oracle/bake_int4.py
+++ b/oracle/bake_int4.py
@@ -39,8 +39,8 @@ import torch
 import torch.nn as nn
 
 # -- constants mirrored from crates/model-store/src/manifest.rs --
-FORMAT_VERSION = 1
-CONVERTER_VERSION = 2
+FORMAT_VERSION = 2
+CONVERTER_VERSION = 1
 
 # LayoutTag strings must match the Rust enum variants exactly (serde default).
 LAYOUT_RAW = "Raw"

--- a/oracle/bake_int4.py
+++ b/oracle/bake_int4.py
@@ -522,14 +522,15 @@ def quantize_model(
             log("[gptq]   lm_head: WARNING no activations captured, skipping")
         else:
             t0 = time.perf_counter()
-            W = lm_head.weight.data.to(torch.float32)
+            # The output head is huge on 9B-class checkpoints. Quantize it on
+            # CPU to avoid requiring an extra multi-GiB clone on an already-full
+            # producer GPU after the layer sweep.
+            W = lm_head.weight.data.detach().to(device="cpu", dtype=torch.float32)
+            H = H.detach().to(device="cpu", dtype=torch.float32)
             Q_dq, nibbles, scale_t, zero_t = gptq_quantize(W, H, group_size, damp)
             elapsed = time.perf_counter() - t0
             log(f"[gptq]   lm_head: shape={tuple(W.shape)} "
                 f"H_N={hook.N} took {elapsed:.1f}s")
-            # Swap in dequantized weights so the perplexity check below sees the
-            # quantized lm_head too.
-            lm_head.weight.data.copy_(Q_dq.to(lm_head.weight.dtype))
             quantized["lm_head.weight"] = (nibbles.cpu(), scale_t.cpu(), zero_t.cpu())
             del W, Q_dq, nibbles, scale_t, zero_t, H
 

--- a/oracle/bake_int4_gemma4.py
+++ b/oracle/bake_int4_gemma4.py
@@ -46,8 +46,8 @@ import torch
 import torch.nn as nn
 
 # -- constants mirrored from crates/model-store/src/manifest.rs --
-FORMAT_VERSION = 1
-CONVERTER_VERSION = 2
+FORMAT_VERSION = 2
+CONVERTER_VERSION = 1
 
 LAYOUT_RAW = "Raw"
 LAYOUT_INT4 = "Int4Quantized"

--- a/oracle/bake_int4_phi4.py
+++ b/oracle/bake_int4_phi4.py
@@ -42,8 +42,8 @@ import torch
 import torch.nn as nn
 
 # -- constants mirrored from crates/model-store/src/manifest.rs --
-FORMAT_VERSION = 1
-CONVERTER_VERSION = 2
+FORMAT_VERSION = 2
+CONVERTER_VERSION = 1
 
 # LayoutTag strings must match the Rust enum variants exactly.
 LAYOUT_RAW = "Raw"

--- a/oracle/q4km_bake_oracle.py
+++ b/oracle/q4km_bake_oracle.py
@@ -212,6 +212,8 @@ def main() -> int:
                 actual = dequant_int4_tensor(by_name, weights, mapped)
             else:
                 actual = load_baked_raw(by_name, weights, mapped)
+                if meta["dtype"] == "bf16":
+                    expected = torch.from_numpy(expected).to(torch.bfloat16).to(torch.float32).cpu().numpy()
             max_abs, mean_abs, rel_rmse, samples = compare_arrays(actual, expected, args.max_items)
             checks.append(TensorCheck(mapped, info.name, meta["layout"], max_abs, mean_abs, rel_rmse, samples))
 

--- a/oracle/q4km_stream_gptq_bake.py
+++ b/oracle/q4km_stream_gptq_bake.py
@@ -43,6 +43,8 @@ def log(msg: str) -> None:
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description="Stream a GGUF -> Q4KM-GPTQ SuperSonic bake")
     p.add_argument("--model-dir", required=True, type=Path)
+    p.add_argument("--activation-model-dir", type=Path, default=None,
+                   help="Optional HF/Transformers model directory used only for activation collection")
     p.add_argument("--gguf-file", required=True, type=Path)
     p.add_argument("--out-dir", type=Path, default=None)
     p.add_argument("--model", default="qwen3.6-27b")
@@ -224,7 +226,8 @@ def load_model(args: argparse.Namespace, device: torch.device) -> nn.Module:
     if args.offload_folder:
         kwargs["offload_folder"] = str(args.offload_folder)
 
-    model = AutoModelForCausalLM.from_pretrained(str(args.model_dir), **kwargs)
+    model_dir = args.activation_model_dir or args.model_dir
+    model = AutoModelForCausalLM.from_pretrained(str(model_dir), **kwargs)
     if not args.device_map:
         model = model.to(device)
     model.eval()

--- a/oracle/q4km_stream_gptq_bake.py
+++ b/oracle/q4km_stream_gptq_bake.py
@@ -90,7 +90,9 @@ class CpuHessianHook:
         self._handle = linear.register_forward_pre_hook(self._pre)
 
     def _pre(self, module: nn.Module, inputs: tuple[torch.Tensor, ...]) -> None:
-        x = inputs[0]
+        self.observe(inputs[0])
+
+    def observe(self, x: torch.Tensor) -> None:
         if x.dim() > 2:
             x = x.reshape(-1, x.shape[-1])
         x = x.detach().to(device="cpu", dtype=torch.float32)
@@ -401,7 +403,7 @@ def main() -> int:
                     for s in range(len(hidden_cpu)):
                         hs = hidden_cpu[s].to(device)
                         normed = final_norm(hs)
-                        _ = lm_head(normed)
+                        hook.observe(normed)
                         del hs, normed
                     if hook.H is None:
                         log("[stream-gptq]   lm_head: WARNING no activations captured, emitting source tensor")
@@ -438,10 +440,6 @@ def main() -> int:
                             )
                         writer.write_entries(entries)
                         emitted.add("lm_head.weight")
-                        if tuple(lm_head.weight.shape) == tuple(q_dq_cpu.shape):
-                            lm_head.weight.data.copy_(
-                                q_dq_cpu.to(device=lm_head.weight.device, dtype=lm_head.weight.dtype)
-                            )
                         log(f"[stream-gptq]   lm_head.weight: H_N={hook.N} emitted")
                 finally:
                     hook.close()

--- a/oracle/q4km_stream_gptq_bake.py
+++ b/oracle/q4km_stream_gptq_bake.py
@@ -176,16 +176,14 @@ def encode_raw_or_minmax(
 
 
 @torch.no_grad()
-def quantize_target_from_gguf(
-    gguf: bake_q4km.GgufFile,
-    info: bake_q4km.GgufTensorInfo,
+def quantize_target_tensor(
     raw_name: str,
+    W: torch.Tensor,
     H: torch.Tensor,
     group_size: int,
     damp: float,
     device: torch.device,
 ) -> tuple[list[tuple[str, bytes, list[int], str, str]], torch.Tensor]:
-    W, _, _ = load_transformed_gguf_tensor(gguf, info, raw_name)
     if W.ndim != 2:
         raise SystemExit(f"{raw_name}: GPTQ target must be 2D, got {tuple(W.shape)}")
     rows, cols = W.shape
@@ -204,6 +202,20 @@ def quantize_target_from_gguf(
         (f"{raw_name}_int4_zero", bake_q4km.bf16_to_bytes(zeros.cpu()), list(zeros.shape), "bf16", bake_q4km.LAYOUT_RAW),
     ]
     return entries, Q_dq.detach().cpu()
+
+
+@torch.no_grad()
+def quantize_target_from_gguf(
+    gguf: bake_q4km.GgufFile,
+    info: bake_q4km.GgufTensorInfo,
+    raw_name: str,
+    H: torch.Tensor,
+    group_size: int,
+    damp: float,
+    device: torch.device,
+) -> tuple[list[tuple[str, bytes, list[int], str, str]], torch.Tensor]:
+    W, _, _ = load_transformed_gguf_tensor(gguf, info, raw_name)
+    return quantize_target_tensor(raw_name, W, H, group_size, damp, device)
 
 
 def load_model(args: argparse.Namespace, device: torch.device) -> nn.Module:
@@ -292,6 +304,8 @@ def main() -> int:
             for raw_name in sorted(source_by_raw):
                 if layer_idx_from_name(raw_name, args.weight_prefix) is not None:
                     continue
+                if raw_name == "lm_head.weight" and is_int4_target("lm_head.weight"):
+                    continue
                 writer.write_entries(encode_raw_or_minmax(
                     gguf, source_by_raw[raw_name], raw_name,
                     args.weight_prefix, layer_types, args.group_size,
@@ -371,6 +385,66 @@ def main() -> int:
                         out = out[0]
                     hidden_cpu[s] = out.detach().cpu()
                     del hs, out
+                if device.type == "cuda":
+                    torch.cuda.empty_cache()
+
+            final_norm = getattr(inner, "norm", None)
+            lm_head = getattr(model, "lm_head", None)
+            if (
+                isinstance(lm_head, nn.Linear)
+                and final_norm is not None
+                and is_int4_target("lm_head.weight")
+            ):
+                log(f"[stream-gptq] lm_head: collecting Hessian over {len(hidden_cpu)} samples")
+                hook = CpuHessianHook(lm_head)
+                try:
+                    for s in range(len(hidden_cpu)):
+                        hs = hidden_cpu[s].to(device)
+                        normed = final_norm(hs)
+                        _ = lm_head(normed)
+                        del hs, normed
+                    if hook.H is None:
+                        log("[stream-gptq]   lm_head: WARNING no activations captured, emitting source tensor")
+                    else:
+                        if "lm_head.weight" in source_by_raw:
+                            entries, q_dq_cpu = quantize_target_from_gguf(
+                                gguf,
+                                source_by_raw["lm_head.weight"],
+                                "lm_head.weight",
+                                hook.H,
+                                args.group_size,
+                                args.damp,
+                                gptq_device,
+                            )
+                        else:
+                            embed_name = f"{args.weight_prefix}.embed_tokens.weight"
+                            if embed_name not in source_by_raw:
+                                raise SystemExit(
+                                    "lm_head.weight is missing from GGUF and tied embedding source "
+                                    f"{embed_name} was not found"
+                                )
+                            W, _, _ = load_transformed_gguf_tensor(
+                                gguf,
+                                source_by_raw[embed_name],
+                                embed_name,
+                            )
+                            entries, q_dq_cpu = quantize_target_tensor(
+                                "lm_head.weight",
+                                W,
+                                hook.H,
+                                args.group_size,
+                                args.damp,
+                                gptq_device,
+                            )
+                        writer.write_entries(entries)
+                        emitted.add("lm_head.weight")
+                        if tuple(lm_head.weight.shape) == tuple(q_dq_cpu.shape):
+                            lm_head.weight.data.copy_(
+                                q_dq_cpu.to(device=lm_head.weight.device, dtype=lm_head.weight.dtype)
+                            )
+                        log(f"[stream-gptq]   lm_head.weight: H_N={hook.N} emitted")
+                finally:
+                    hook.close()
                 if device.type == "cuda":
                     torch.cuda.empty_cache()
 

--- a/oracle/upload_bake.py
+++ b/oracle/upload_bake.py
@@ -66,6 +66,7 @@ VARIANT_DIR_SUFFIX = {
     "fp8-native": "-fp8",
     "int4-gptq": "-int4-gptq",
     "q4km": "-q4km",
+    "q4km-gptq": "-q4km-gptq",
 }
 
 FAMILY_FOR = {
@@ -125,10 +126,12 @@ def validate_bake(bake_dir: Path, variant: str) -> dict:
     # where a user points --int4 at a BF16 bake directory.
     layouts = {t.get("layout") for t in manifest.get("tensors", [])}
     lowbit_layouts = {"Int4Quantized", "GgmlQ4K", "GgmlQ5K", "GgmlQ6K"}
-    if variant in ("int4-gptq", "q4km") and not (layouts & lowbit_layouts):
+    if variant in ("int4-gptq", "q4km", "q4km-gptq") and not (layouts & lowbit_layouts):
         sys.exit(f"error: {bake_dir} has no Int4Quantized tensors — wrong variant?")
     if variant == "q4km" and manifest.get("quant_profile") != "q4km-ggml-v1":
         sys.exit(f"error: {bake_dir} is missing quant_profile=q4km-ggml-v1")
+    if variant == "q4km-gptq" and manifest.get("quant_profile") != "q4km-gptq-v1":
+        sys.exit(f"error: {bake_dir} is missing quant_profile=q4km-gptq-v1")
     if variant == "fp8-native" and "Fp8Native" not in layouts:
         sys.exit(f"error: {bake_dir} has no Fp8Native tensors — wrong variant?")
     return manifest
@@ -371,6 +374,8 @@ def main() -> None:
     variant_group.add_argument("--fp8-native", action="store_true", dest="fp8_native")
     variant_group.add_argument("--int4", action="store_true", help="INT4 GPTQ bake")
     variant_group.add_argument("--q4km", action="store_true", help="GGUF q4km raw GGML K-block bake")
+    variant_group.add_argument("--q4km-gptq", action="store_true", dest="q4km_gptq",
+                               help="Q4KM-sourced GPTQ/native INT4 bake")
     ap.add_argument("--tag", default=f"bakes-v{FORMAT_VERSION}")
     ap.add_argument("--dry-run", action="store_true", help="Print gh commands, don't upload")
     ap.add_argument("--prune-old-cvt", action="store_true",
@@ -383,6 +388,8 @@ def main() -> None:
         variant = "fp8-native"
     elif args.q4km:
         variant = "q4km"
+    elif args.q4km_gptq:
+        variant = "q4km-gptq"
     else:
         variant = "int4-gptq"
 


### PR DESCRIPTION
## Summary
- add Qwen3.6 27B Q4KM and Q4KM-GPTQ bake/runtime plumbing for CUDA sm86
- extend bake upload/regeneration scripts for the new variants and lm_head GPTQ path
- avoid duplicate release-bake fetch after metadata bootstrap and add regression coverage

## Validation
- cargo build --release --bin supersonic
- cargo test -p model-store fetch
- cargo test -p runner registry
- cargo test -p runner bootstrap_download_satisfies_forced_bake_download
- cargo test -p runner forced_bake_download_still_fetches_without_bootstrap
- cargo test -p runner invalid_local_bake_fetches_even_after_bootstrap_attempt
- qwen3.6-27b --q4km fresh download on RTX 3090 / CUDA sm86: loaded bake and generated 1 token
- qwen3.6-27b --q4km-gptq fresh download on RTX 3090 / CUDA sm86: loaded bake and generated 1 token
- qwen3.6-27b --q4km-gptq --no-download with installed bake on RTX 3090 / CUDA sm86: generated 1 token

## Published bakes
Uploaded to GitHub release bakes-v2:
- qwen3.6-27b q4km
- qwen3.6-27b q4km-gptq
- regenerated INT4 GPTQ bakes for Qwen3.5, Phi4 mini, and Gemma4 variants

## Known limitations
- Qwen3.5 --int4 is still gated on CUDA
- Gemma/Phi CUDA runtime registry entries are still absent
- Qwen3.6 35B-A3B MoE runtime is not implemented in this branch
