### PR TITLE
Add gfx1100 HIP bring-up support

### DIFF
--- a/crates/kernel-ffi/src/ffi.rs
+++ b/crates/kernel-ffi/src/ffi.rs
@@ -1740,9 +1740,35 @@ pub fn qwen_rms_norm_standalone_matvec_host_f32(
 
 /// Query GPU architecture name and total VRAM for a given device ordinal.
 pub fn query_gpu_info(ordinal: usize) -> Result<(String, u64), GpuError> {
-    let backend = gpu_hal::current_backend();
-    let info = gpu_hal::query_device_info(backend, ordinal)?;
-    Ok((info.arch_name, info.total_vram_bytes))
+    #[cfg(not(supersonic_backend_hip))]
+    {
+        let _ = ordinal;
+        return Err(GpuError::InvalidArg("HIP backend not compiled".into()));
+    }
+    #[cfg(supersonic_backend_hip)]
+    {
+        let mut arch_name = vec![0u8; 64];
+        let mut total_vram = 0u64;
+        let status = unsafe {
+            dotcache_query_gpu_info(
+                ordinal as c_int,
+                arch_name.as_mut_ptr(),
+                arch_name.len(),
+                &mut total_vram,
+            )
+        };
+        if status != 0 {
+            return Err(ffi_error(format!(
+                "dotcache_query_gpu_info failed with status {status}"
+            )));
+        }
+        let nul_pos = arch_name
+            .iter()
+            .position(|&byte| byte == 0)
+            .unwrap_or(arch_name.len());
+        let arch_name = String::from_utf8_lossy(&arch_name[..nul_pos]).into_owned();
+        Ok((arch_name, total_vram))
+    }
 }
 
 /// Query the HIP device clock rate (kHz) for cycle→ms conversion in `--emit-stage-timings`.

--- a/crates/runner/src/registry.rs
+++ b/crates/runner/src/registry.rs
@@ -107,6 +107,7 @@ impl fmt::Display for ModelVariant {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GpuArch {
+    Gfx1100,
     Gfx1150,
     Sm86,
     AppleM4,
@@ -117,6 +118,7 @@ impl GpuArch {
     pub fn from_backend_name(backend: &Backend, name: &str) -> Self {
         match backend {
             Backend::Hip => match name.trim() {
+                "gfx1100" => Self::Gfx1100,
                 "gfx1150" => Self::Gfx1150,
                 other => Self::Unknown(other.to_owned()),
             },
@@ -135,6 +137,7 @@ impl GpuArch {
 impl fmt::Display for GpuArch {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::Gfx1100 => write!(f, "gfx1100"),
             Self::Gfx1150 => write!(f, "gfx1150"),
             Self::Sm86 => write!(f, "sm86"),
             Self::AppleM4 => write!(f, "apple-m4"),
@@ -208,6 +211,74 @@ pub struct RegistryEntry {
 const GIB: u64 = 1024 * 1024 * 1024;
 
 static REGISTRY: &[RegistryEntry] = &[
+    RegistryEntry {
+        model: ModelVariant::Qwen3_5_0_8B,
+        backend: Backend::Hip,
+        arch: GpuArch::Gfx1100,
+        vram: VramBudget {
+            fixed_bytes: 2 * GIB,
+            overhead_factor: 1.1,
+        },
+        params: FamilyParams::Qwen35(Qwen35KernelParams {
+            proj_buf_floats: 8224,
+            attn_scratch_floats: 16384,
+            weight_prefix: "model.language_model",
+            kv_chunk_size: 256,
+            use_4b_kernel: true,
+            hip_launch_preset: None,
+        }),
+    },
+    RegistryEntry {
+        model: ModelVariant::Qwen3_5_2B,
+        backend: Backend::Hip,
+        arch: GpuArch::Gfx1100,
+        vram: VramBudget {
+            fixed_bytes: 5 * GIB,
+            overhead_factor: 1.1,
+        },
+        params: FamilyParams::Qwen35(Qwen35KernelParams {
+            proj_buf_floats: 8224,
+            attn_scratch_floats: 16384,
+            weight_prefix: "model.language_model",
+            kv_chunk_size: 256,
+            use_4b_kernel: true,
+            hip_launch_preset: None,
+        }),
+    },
+    RegistryEntry {
+        model: ModelVariant::Qwen3_5_4B,
+        backend: Backend::Hip,
+        arch: GpuArch::Gfx1100,
+        vram: VramBudget {
+            fixed_bytes: 10 * GIB,
+            overhead_factor: 1.1,
+        },
+        params: FamilyParams::Qwen35(Qwen35KernelParams {
+            proj_buf_floats: 12352,
+            attn_scratch_floats: 16384,
+            weight_prefix: "model.language_model",
+            kv_chunk_size: 256,
+            use_4b_kernel: true,
+            hip_launch_preset: None,
+        }),
+    },
+    RegistryEntry {
+        model: ModelVariant::Qwen3_5_9B,
+        backend: Backend::Hip,
+        arch: GpuArch::Gfx1100,
+        vram: VramBudget {
+            fixed_bytes: 18 * GIB,
+            overhead_factor: 1.1,
+        },
+        params: FamilyParams::Qwen35(Qwen35KernelParams {
+            proj_buf_floats: 12352,
+            attn_scratch_floats: 16384,
+            weight_prefix: "model.language_model",
+            kv_chunk_size: 256,
+            use_4b_kernel: true,
+            hip_launch_preset: None,
+        }),
+    },
     RegistryEntry {
         model: ModelVariant::Qwen3_5_0_8B,
         backend: Backend::Hip,
@@ -413,6 +484,32 @@ static REGISTRY: &[RegistryEntry] = &[
     RegistryEntry {
         model: ModelVariant::Gemma4_E2B,
         backend: Backend::Hip,
+        arch: GpuArch::Gfx1100,
+        vram: VramBudget {
+            fixed_bytes: 11 * GIB,
+            overhead_factor: 1.1,
+        },
+        params: FamilyParams::Gemma4(Gemma4KernelParams {
+            weight_prefix: "model.language_model",
+            kv_chunk_size: 256,
+        }),
+    },
+    RegistryEntry {
+        model: ModelVariant::Gemma4_E4B,
+        backend: Backend::Hip,
+        arch: GpuArch::Gfx1100,
+        vram: VramBudget {
+            fixed_bytes: 10 * GIB,
+            overhead_factor: 1.1,
+        },
+        params: FamilyParams::Gemma4(Gemma4KernelParams {
+            weight_prefix: "model.language_model",
+            kv_chunk_size: 256,
+        }),
+    },
+    RegistryEntry {
+        model: ModelVariant::Gemma4_E2B,
+        backend: Backend::Hip,
         arch: GpuArch::Gfx1150,
         vram: VramBudget {
             fixed_bytes: 11 * GIB,
@@ -439,6 +536,19 @@ static REGISTRY: &[RegistryEntry] = &[
     // Phi-4-mini: 3.8B dense, full-attention all 32 layers, LongRoPE.
     // BF16 weights ≈ 7.6 GiB; KV cache at 4K ctx ≈ 520 MiB (32 layers × 2 × 8 kv_heads × 128 head_dim × 2 B).
     // Fits gfx1150 with headroom. Weight prefix is bare `model` (Phi stores tensors as `model.*`).
+    RegistryEntry {
+        model: ModelVariant::Phi4_Mini,
+        backend: Backend::Hip,
+        arch: GpuArch::Gfx1100,
+        vram: VramBudget {
+            fixed_bytes: 8 * GIB,
+            overhead_factor: 1.1,
+        },
+        params: FamilyParams::Phi4(Phi4KernelParams {
+            weight_prefix: "model",
+            kv_chunk_size: 256,
+        }),
+    },
     RegistryEntry {
         model: ModelVariant::Phi4_Mini,
         backend: Backend::Hip,
@@ -514,6 +624,25 @@ mod tests {
     fn cuda_sm86_qwen_registry_includes_2b_and_9b() {
         assert!(lookup(&ModelVariant::Qwen3_5_2B, &Backend::Cuda, &GpuArch::Sm86,).is_some());
         assert!(lookup(&ModelVariant::Qwen3_5_9B, &Backend::Cuda, &GpuArch::Sm86,).is_some());
+    }
+
+    #[test]
+    fn hip_gfx1100_registry_includes_rdna3_targets() {
+        assert_eq!(
+            GpuArch::from_backend_name(&Backend::Hip, "gfx1100"),
+            GpuArch::Gfx1100
+        );
+        for model in [
+            ModelVariant::Qwen3_5_0_8B,
+            ModelVariant::Qwen3_5_2B,
+            ModelVariant::Qwen3_5_4B,
+            ModelVariant::Qwen3_5_9B,
+            ModelVariant::Gemma4_E2B,
+            ModelVariant::Gemma4_E4B,
+            ModelVariant::Phi4_Mini,
+        ] {
+            assert!(lookup(&model, &Backend::Hip, &GpuArch::Gfx1100).is_some());
+        }
     }
 
     #[test]

--- a/kernels/prefill_helpers.hip
+++ b/kernels/prefill_helpers.hip
@@ -5,6 +5,7 @@
 #include <hip/hip_runtime.h>
 #include <hip/hip_fp16.h>
 #include <hip/hip_bfloat16.h>
+#include <math.h>
 
 // ---- Type conversion helpers (matching the megakernel's conventions) ----
 
@@ -42,6 +43,13 @@ __device__ inline float pfx_from_float<float>(float value) {
 template <>
 __device__ inline hip_bfloat16 pfx_from_float<hip_bfloat16>(float value) {
     return hip_bfloat16(value);
+}
+
+__device__ inline float pfx_wave_sum(float value) {
+    for (int offset = warpSize / 2; offset > 0; offset /= 2) {
+        value += __shfl_down(value, offset);
+    }
+    return value;
 }
 
 // ---- Kernel 1: Element-wise addition ----
@@ -302,4 +310,95 @@ __global__ void pfx_repeat_interleave_heads_kernel(
     const size_t src_off = static_cast<size_t>(s) * n_heads * head_dim
                          + static_cast<size_t>(src_h) * head_dim + d;
     dst[idx] = src[src_off];
+}
+
+// ---- Kernel 11: Decode-only full attention for q_len=1 ----
+// query: [B, QH, D], key/value: [B, KVH, T, D], out: [B, QH, D].
+
+template <typename T>
+__global__ void pfx_full_attention_decode_flat_kernel(
+    int batch_size,
+    int q_heads,
+    int kv_heads,
+    int kv_len,
+    int head_dim,
+    int num_kv_groups,
+    float scale,
+    const T* query,
+    const T* key,
+    const T* value,
+    T* out
+) {
+    const int lane = threadIdx.x;
+    if (lane >= warpSize) return;
+
+    const int total_rows = batch_size * q_heads;
+    const int row = blockIdx.x;
+    if (row >= total_rows) return;
+
+    const int q_head = row % q_heads;
+    const int batch = row / q_heads;
+    const int kv_head = q_head / num_kv_groups;
+
+    const T* q_row = query + (static_cast<size_t>(batch) * q_heads + q_head) * head_dim;
+    const T* k_head = key + (static_cast<size_t>(batch) * kv_heads + kv_head) * kv_len * head_dim;
+    const T* v_head = value + (static_cast<size_t>(batch) * kv_heads + kv_head) * kv_len * head_dim;
+    T* out_row = out + (static_cast<size_t>(batch) * q_heads + q_head) * head_dim;
+
+    float local_acc[8] = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+    int local_dims[8] = {-1, -1, -1, -1, -1, -1, -1, -1};
+    int local_count = 0;
+    for (int d = lane; d < head_dim && local_count < 8; d += warpSize) {
+        local_dims[local_count++] = d;
+    }
+
+    __shared__ float shared_max;
+    __shared__ float shared_denom;
+    __shared__ float shared_weight;
+    __shared__ float shared_inv_denom;
+
+    if (lane == 0) shared_max = -INFINITY;
+    __syncthreads();
+
+    for (int k_pos = 0; k_pos < kv_len; ++k_pos) {
+        const T* k_row = k_head + static_cast<size_t>(k_pos) * head_dim;
+        float partial = 0.0f;
+        for (int d = lane; d < head_dim; d += warpSize) {
+            partial += pfx_to_float(q_row[d]) * pfx_to_float(k_row[d]);
+        }
+        const float score = pfx_wave_sum(partial) * scale;
+        if (lane == 0 && score > shared_max) shared_max = score;
+        __syncthreads();
+    }
+
+    if (lane == 0) shared_denom = 0.0f;
+    __syncthreads();
+
+    for (int k_pos = 0; k_pos < kv_len; ++k_pos) {
+        const T* k_row = k_head + static_cast<size_t>(k_pos) * head_dim;
+        const T* v_row = v_head + static_cast<size_t>(k_pos) * head_dim;
+        float partial = 0.0f;
+        for (int d = lane; d < head_dim; d += warpSize) {
+            partial += pfx_to_float(q_row[d]) * pfx_to_float(k_row[d]);
+        }
+        const float score = pfx_wave_sum(partial) * scale;
+
+        if (lane == 0) {
+            shared_weight = expf(score - shared_max);
+            shared_denom += shared_weight;
+        }
+        __syncthreads();
+
+        for (int i = 0; i < local_count; ++i) {
+            local_acc[i] += shared_weight * pfx_to_float(v_row[local_dims[i]]);
+        }
+        __syncthreads();
+    }
+
+    if (lane == 0) shared_inv_denom = shared_denom > 0.0f ? 1.0f / shared_denom : 0.0f;
+    __syncthreads();
+
+    for (int i = 0; i < local_count; ++i) {
+        out_row[local_dims[i]] = pfx_from_float<T>(local_acc[i] * shared_inv_denom);
+    }
 }

--- a/kernels/prefill_helpers_bridge.cpp
+++ b/kernels/prefill_helpers_bridge.cpp
@@ -242,6 +242,38 @@ int repeat_interleave_heads_device(int device_ordinal,
     return 0;
 }
 
+// ---- full_attention_decode_flat ----
+
+template <typename T>
+int full_attention_decode_flat_device(int device_ordinal,
+                                      int batch_size,
+                                      int q_heads,
+                                      int kv_heads,
+                                      int kv_len,
+                                      int head_dim,
+                                      int num_kv_groups,
+                                      float scale,
+                                      const void* query,
+                                      const void* key,
+                                      const void* value,
+                                      void* out) {
+    ScopedHipDevice scoped(device_ordinal);
+    constexpr int block = 32;
+    if (head_dim > block * 8) return 401;
+    const int rows = batch_size * q_heads;
+    hipLaunchKernelGGL(
+        HIP_KERNEL_NAME(pfx_full_attention_decode_flat_kernel<T>),
+        dim3(rows), dim3(block), 0, 0,
+        batch_size, q_heads, kv_heads, kv_len, head_dim, num_kv_groups, scale,
+        static_cast<const T*>(query),
+        static_cast<const T*>(key),
+        static_cast<const T*>(value),
+        static_cast<T*>(out));
+    if (hipGetLastError() != hipSuccess) return 402;
+    if (hipDeviceSynchronize() != hipSuccess) return 403;
+    return 0;
+}
+
 } // namespace
 
 // ---- extern "C" wrappers ----
@@ -406,5 +438,35 @@ extern "C" int dotcache_qwen35_hip_repeat_interleave_heads(
                 static_cast<int>(S), static_cast<int>(n_heads), static_cast<int>(head_dim),
                 static_cast<int>(repeats), src, dst);
     default: return 390;
+    }
+}
+
+extern "C" int dotcache_qwen35_hip_full_attention_decode_flat(
+    int dtype,
+    size_t device_ordinal,
+    size_t batch_size,
+    size_t q_heads,
+    size_t kv_heads,
+    size_t kv_len,
+    size_t head_dim,
+    size_t num_kv_groups,
+    float scale,
+    const void* query,
+    const void* key,
+    const void* value,
+    void* out
+) {
+    switch (dtype) {
+    case 0: return full_attention_decode_flat_device<half>(
+                static_cast<int>(device_ordinal), static_cast<int>(batch_size),
+                static_cast<int>(q_heads), static_cast<int>(kv_heads),
+                static_cast<int>(kv_len), static_cast<int>(head_dim),
+                static_cast<int>(num_kv_groups), scale, query, key, value, out);
+    case 2: return full_attention_decode_flat_device<hip_bfloat16>(
+                static_cast<int>(device_ordinal), static_cast<int>(batch_size),
+                static_cast<int>(q_heads), static_cast<int>(kv_heads),
+                static_cast<int>(kv_len), static_cast<int>(head_dim),
+                static_cast<int>(num_kv_groups), scale, query, key, value, out);
+    default: return 400;
     }
 }


### PR DESCRIPTION
## Summary
- add first-class HIP `gfx1100` registry entries for RDNA3 targets on RX 7900 XTX-class GPUs
- route HIP GPU info queries through the HIP bridge instead of `gpu-hal`
- add the missing HIP `full_attention_decode_flat` helper symbol used by the prefill/decode FFI path

## Validation
- `HIP_ARCH=gfx1100 cargo build --release --bin supersonic`
- `HIP_ARCH=gfx1100 cargo build --release --bin supersonic-serve`
- `HIP_ARCH=gfx1100 cargo test -p runner registry::tests --lib`
- real HIP smoke run on RX 7900 XTX / `gfx1100` with `Qwen/Qwen3.5-0.8B`:
  - `target/release/supersonic --backend hip --model qwen3.5-0.8b --model-dir /mnt/data/models/Qwen3.5-0.8B --prompt "Hello, world" --max-new-tokens 4`
  - observed `arch=gfx1100`, native GPU prefill completed, and decode reported `ms_per_tok=10`
