### PR TITLE
phi4: wire --kv-fp8

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Four backend surfaces are validated today:
 | qwen3.5-9b       |  ✅  |  ✅  |      ✅     |   ✅   |
 | gemma4-e2b       |  ✅  |  ✅  |      —      |   —    |
 | gemma4-e4b       |  ✅  |  ✅¹ |      —      |   —    |
-| phi4-mini        |  ✅  |  ✅  |      —      |   —    |
+| phi4-mini        |  ✅  |  ✅  |      —      |   ✅   |
 
 ¹ Gemma E4B INT4 needs `--group-size 64` at calibration time (the default
   128 produces gibberish — see fix in `oracle/bake_all.sh`). The published

--- a/crates/phi4/src/state.rs
+++ b/crates/phi4/src/state.rs
@@ -4,9 +4,16 @@ use crate::config::Phi4Config;
 
 /// Per-layer mutable state for Phi-4. Only full-attention KV caches — no
 /// conv/recurrent state because Phi-4-mini has no linear attention layers.
+///
+/// When `kv_fp8` is set at allocation time, `kv_cache_k`/`kv_cache_v` hold
+/// FP8-E4M3 bytes (`ScalarType::U8`) instead of BF16, and `kv_scale_k`/
+/// `kv_scale_v` hold the per-head, per-position F32 absmax scale used by the
+/// kernel for dequantization.
 pub struct Phi4LayerState {
     pub kv_cache_k: Option<GpuBuffer>,
     pub kv_cache_v: Option<GpuBuffer>,
+    pub kv_scale_k: Option<GpuBuffer>,
+    pub kv_scale_v: Option<GpuBuffer>,
     pub kv_filled: usize,
 }
 
@@ -15,22 +22,32 @@ impl Phi4LayerState {
         Self {
             kv_cache_k: None,
             kv_cache_v: None,
+            kv_scale_k: None,
+            kv_scale_v: None,
             kv_filled: 0,
         }
     }
 
     /// Allocate or grow KV caches to hold `needed` positions. Caches grow in
-    /// chunks of `kv_chunk_size` tokens to amortize reallocation.
+    /// chunks of `kv_chunk_size` tokens to amortize reallocation. When
+    /// `kv_fp8` is true the cache itself is FP8 (u8) and a parallel
+    /// `[num_kv_heads, max_T]` F32 scale buffer is grown alongside.
     pub fn ensure_kv_capacity(
         &mut self,
         needed: usize,
         ordinal: usize,
         config: &Phi4Config,
         kv_chunk_size: usize,
+        kv_fp8: bool,
     ) -> Result<(), GpuError> {
         let needed = needed + 1;
         let nkv = config.num_key_value_heads;
         let hd = config.head_dim();
+        let kv_dtype = if kv_fp8 {
+            ScalarType::U8
+        } else {
+            ScalarType::BF16
+        };
         if let (Some(ref k), Some(ref v)) = (&self.kv_cache_k, &self.kv_cache_v) {
             let current_cap = k.shape()[2];
             if current_cap >= needed {
@@ -39,18 +56,20 @@ impl Phi4LayerState {
             let new_cap = ((needed + kv_chunk_size - 1) / kv_chunk_size) * kv_chunk_size;
             self.kv_cache_k = Some(k.grow_seq_dim(2, new_cap)?);
             self.kv_cache_v = Some(v.grow_seq_dim(2, new_cap)?);
+            if kv_fp8 {
+                if let (Some(ref sk), Some(ref sv)) = (&self.kv_scale_k, &self.kv_scale_v) {
+                    self.kv_scale_k = Some(sk.grow_seq_dim(1, new_cap)?);
+                    self.kv_scale_v = Some(sv.grow_seq_dim(1, new_cap)?);
+                }
+            }
         } else {
             let cap = ((needed + kv_chunk_size - 1) / kv_chunk_size) * kv_chunk_size;
-            self.kv_cache_k = Some(GpuBuffer::zeros(
-                ordinal,
-                ScalarType::BF16,
-                &[1, nkv, cap, hd],
-            )?);
-            self.kv_cache_v = Some(GpuBuffer::zeros(
-                ordinal,
-                ScalarType::BF16,
-                &[1, nkv, cap, hd],
-            )?);
+            self.kv_cache_k = Some(GpuBuffer::zeros(ordinal, kv_dtype, &[1, nkv, cap, hd])?);
+            self.kv_cache_v = Some(GpuBuffer::zeros(ordinal, kv_dtype, &[1, nkv, cap, hd])?);
+            if kv_fp8 {
+                self.kv_scale_k = Some(GpuBuffer::zeros(ordinal, ScalarType::F32, &[nkv, cap])?);
+                self.kv_scale_v = Some(GpuBuffer::zeros(ordinal, ScalarType::F32, &[nkv, cap])?);
+            }
         }
         Ok(())
     }

--- a/crates/runner/src/phi4_engine.rs
+++ b/crates/runner/src/phi4_engine.rs
@@ -38,8 +38,8 @@ pub fn run_phi4(
         }
     };
 
-    if cli.fp8_runtime || cli.kv_fp8 {
-        bail!("Phi-4 has no --fp8-runtime / --kv-fp8 path yet");
+    if cli.fp8_runtime {
+        bail!("Phi-4 has no --fp8-runtime path yet");
     }
     if cli.batch_size != 1 {
         bail!("Phi-4 engine is single-sequence at launch (--batch-size must be 1)");
@@ -289,6 +289,20 @@ pub fn run_phi4(
     let mut desc_device = GpuBuffer::zeros(ordinal, ScalarType::U8, &[desc_size_bytes])
         .map_err(|e| anyhow!("alloc desc_device: {e}"))?;
 
+    // Pre-allocate the per-layer KV-FP8 scale descriptor buffer when --kv-fp8
+    // is set. Rebuilt + h2d'd every step like the main descs because the
+    // scale-buffer pointers can move when ensure_kv_capacity grows the cache.
+    let mut kv_fp8_desc_device: Option<GpuBuffer> = if cli.kv_fp8 {
+        let kv_fp8_desc_bytes =
+            num_layers * std::mem::size_of::<phi4_ffi::Phi4KVCacheFp8Desc>();
+        Some(
+            GpuBuffer::zeros(ordinal, ScalarType::U8, &[kv_fp8_desc_bytes])
+                .map_err(|e| anyhow!("alloc kv_fp8 desc_device: {e}"))?,
+        )
+    } else {
+        None
+    };
+
     // INT4 scale/zero descriptor array — built once, uploaded once. Pointers
     // into the (already-resident) weight buffers stay valid for the engine's
     // lifetime. Empty when weights aren't INT4.
@@ -340,7 +354,7 @@ pub fn run_phi4(
 
         // 2. Ensure KV capacity for every layer (Phi-4 is pure full-attention).
         for ls in state.layers.iter_mut() {
-            ls.ensure_kv_capacity(pos, ordinal, &config, kv_chunk)
+            ls.ensure_kv_capacity(pos, ordinal, &config, kv_chunk, cli.kv_fp8)
                 .map_err(|e| anyhow!("ensure KV capacity at step {step}: {e}"))?;
         }
 
@@ -356,6 +370,28 @@ pub fn run_phi4(
             desc_bytes.len(),
         )
         .map_err(|e| anyhow!("upload layer descs at step {step}: {e}"))?;
+
+        // KV-FP8 scale descs (parallel to layer descs). Pointers can shift
+        // whenever ensure_kv_capacity grows the cache, so rebuild every step.
+        if cli.kv_fp8 {
+            let kv_fp8_descs = build_kv_fp8_descs(&state);
+            let bytes: &[u8] = unsafe {
+                std::slice::from_raw_parts(
+                    kv_fp8_descs.as_ptr() as *const u8,
+                    kv_fp8_descs.len() * std::mem::size_of::<phi4_ffi::Phi4KVCacheFp8Desc>(),
+                )
+            };
+            let buf = kv_fp8_desc_device
+                .as_mut()
+                .expect("kv_fp8_desc_device allocated when --kv-fp8 set");
+            gpu_hal::copy_h2d(
+                ordinal,
+                buf.as_mut_ptr(),
+                bytes.as_ptr() as *const c_void,
+                bytes.len(),
+            )
+            .map_err(|e| anyhow!("upload kv_fp8 descs at step {step}: {e}"))?;
+        }
 
         // 4. Reset per-step scratch (workspace + counters/barrier).
         gpu_hal::memset_zeros(ordinal, workspace.as_mut_ptr(), workspace.len_bytes())
@@ -383,7 +419,7 @@ pub fn run_phi4(
             proj_buf_floats,
             attn_scratch_floats,
             None,
-            None,
+            kv_fp8_desc_device.as_ref(),
             1,
             None,
             int4_scale_device.as_ref(),
@@ -608,6 +644,27 @@ fn build_descs(
 fn descriptor_bytes(descs: &[phi4_ffi::Phi4DecodeLayerDesc]) -> &[u8] {
     let len_bytes = descs.len() * std::mem::size_of::<phi4_ffi::Phi4DecodeLayerDesc>();
     unsafe { std::slice::from_raw_parts(descs.as_ptr() as *const u8, len_bytes) }
+}
+
+/// Build the per-layer parallel-struct array of KV-FP8 scale-buffer pointers.
+/// Pointers reference the per-layer scale buffers held by `state`; struct must
+/// remain alive only as long as those buffers do (the engine owns both).
+/// Caller is responsible for only invoking this when `state` was allocated
+/// with `kv_fp8 = true` (otherwise the scale buffers are `None`).
+fn build_kv_fp8_descs(state: &Phi4ModelState) -> Vec<phi4_ffi::Phi4KVCacheFp8Desc> {
+    use std::ffi::c_void;
+    let mut descs = Vec::with_capacity(state.layers.len());
+    for ls in &state.layers {
+        let mut d = phi4_ffi::Phi4KVCacheFp8Desc::default();
+        if let Some(ref sk) = ls.kv_scale_k {
+            d.kv_scale_k = sk.as_ptr() as *mut c_void;
+        }
+        if let Some(ref sv) = ls.kv_scale_v {
+            d.kv_scale_v = sv.as_ptr() as *mut c_void;
+        }
+        descs.push(d);
+    }
+    descs
 }
 
 /// Build the per-layer parallel-struct array of INT4 scale/zero pointers.

--- a/crates/runner/src/phi4_engine.rs
+++ b/crates/runner/src/phi4_engine.rs
@@ -97,7 +97,24 @@ pub fn run_phi4(
         );
     }
 
-    let kv_per_token = config.kv_bytes_per_token(ScalarType::BF16.size_in_bytes());
+    // KV cache cost per token: under --kv-fp8 the cache stores K/V at 1
+    // byte/elem (half BF16's 2) plus an F32 absmax scale per (head, position)
+    // for both K and V. Falling back to BF16 sizing under --kv-fp8 was
+    // overestimating by ~2× and could spuriously abort runs that would
+    // actually fit on a memory-constrained GPU.
+    let kv_dtype_bytes = if cli.kv_fp8 {
+        ScalarType::U8.size_in_bytes()
+    } else {
+        ScalarType::BF16.size_in_bytes()
+    };
+    let mut kv_per_token = config.kv_bytes_per_token(kv_dtype_bytes);
+    if cli.kv_fp8 {
+        // Two F32 scale buffers (K + V), one entry per (head, position),
+        // per layer.
+        let scale_bytes_per_layer =
+            (2 * config.num_key_value_heads * ScalarType::F32.size_in_bytes()) as u64;
+        kv_per_token += scale_bytes_per_layer * config.num_hidden_layers as u64;
+    }
     let kv_bytes = kv_per_token * context_tokens as u64;
     let estimated_vram =
         ((entry.vram.fixed_bytes + kv_bytes) as f64 * entry.vram.overhead_factor) as u64;


### PR DESCRIPTION
## Summary

The `phi4.hip` megakernel already had the Phi-4 KV-FP8 path (per-layer `Phi4KVCacheFp8Desc`, FP8-E4M3 quant on K/V write, dequant on attention read at lines 4179 / 4257); the Rust engine just rejected `--kv-fp8` at startup with a generic "no FP8 path yet" error. Wired the runner so the existing kernel path is reachable.

## Changes

- `crates/phi4/src/state.rs` — `Phi4LayerState` gains `kv_scale_k` / `kv_scale_v` `Option<GpuBuffer>` (`[num_kv_heads, max_T]` F32, per-head per-position absmax scale). `ensure_kv_capacity` now takes a `kv_fp8: bool`; when set, the K/V cache itself is `ScalarType::U8` (FP8-E4M3 bytes) instead of BF16, and the scale buffers grow in lock-step with the cache on chunk boundaries.
- `crates/runner/src/phi4_engine.rs` — drops the `--kv-fp8` bail (`--fp8-runtime` stays for now, see below), allocates and h2d-uploads a per-layer `Phi4KVCacheFp8Desc` array once per step (scale-buffer pointers shift when the cache grows), passes it to `phi4_ffi::persistent_decode`.
- `README.md` — gfx1100 matrix unfooted: `phi4-mini` FP8 KV is now ✅.

## Validation on gfx1100 (RX 7900 XTX)

```
$ supersonic --model phi4-mini --kv-fp8 --validate \
    --prompt "The quick brown fox" --max-new-tokens 6
The quick brown fox jumps over the lazy dog.
[validate] step=0 pos=4 delta=5.3750 token=1072
…
[validate] max_delta=7.5000 token_mismatches=0
```

`max_delta=7.5` against the BF16 oracle is in the expected FP8-KV quantization-noise range; **zero token mismatches** over 6 generated tokens. Decode is ~2× slower than BF16 (74 ms/step vs 36 ms/step) from the FP8 quant/dequant overhead in the attention loop — same characteristic as Qwen3.5 KV-FP8 on this hardware.

Combines cleanly with `--int4`:
```
$ supersonic --model phi4-mini --int4 --kv-fp8 ...
The quick brown fox jumps over the lazy dog.
```

## Why not also `--fp8-runtime`

Qwen3.5's `--fp8-runtime` is effectively a no-op when the source is BF16 (the kernel falls back to BF16 when no `fp8_scales` descs are passed; the bake just routes BF16 into `v2-fp8/`). It's only meaningful when the upstream checkpoint ships FP8-E4M3 (Qwen 3.6).

For Phi-4 the upstream is BF16, so two options exist for `--fp8-runtime`:
1. Wire it as a no-op flag matching Qwen3.5 semantics (cosmetic ✅, no real benefit).
2. Add a Phi-4 FP8 calibration baker (similar effort to `bake_int4_phi4.py`).

Punting that decision to a follow-up — `--fp8-runtime` still bails for Phi-4 in this PR.

## Test plan

- [x] `phi4-mini --kv-fp8` produces the canonical "lazy dog" sentence on gfx1100
- [x] `phi4-mini --kv-fp8 --validate`: zero token mismatches vs BF16 CPU oracle
- [x] `phi4-mini --int4 --kv-fp8`: combined path also generates correctly
- [x] BF16 path regression-tested (`max_delta=0.5000, token_mismatches=0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)