### PR TITLE
phi4: real FP8-runtime weight quantization

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Four backend surfaces are validated today:
 | qwen3.5-9b       |  ✅  |  ✅  |      ✅     |   ✅   |
 | gemma4-e2b       |  ✅  |  ✅  |      —      |   —    |
 | gemma4-e4b       |  ✅  |  ✅¹ |      —      |   —    |
-| phi4-mini        |  ✅  |  ✅  |      —      |   ✅   |
+| phi4-mini        |  ✅  |  ✅  |      ✅     |   ✅   |
 
 ¹ Gemma E4B INT4 needs `--group-size 64` at calibration time (the default
   128 produces gibberish — see fix in `oracle/bake_all.sh`). The published

--- a/crates/phi4/src/weights.rs
+++ b/crates/phi4/src/weights.rs
@@ -216,6 +216,15 @@ impl Phi4Weights {
         let mut int4_group_size: usize = 0;
         let mut is_fp8 = false;
         let mut fp8_block_size: usize = 0;
+        // Track FP8 completeness across the full bake. The kernel keys FP8
+        // dispatch off non-null scale pointers per projection, so a partial
+        // bake (some projections missing `*_scale_inv`) would silently send
+        // FP8-packed bytes through the BF16 matmul path → corrupt logits /
+        // OOB reads. We require all-or-nothing: 7 scales per layer (q, k,
+        // v, o, gate, up, down) × num_hidden_layers, or zero.
+        let mut fp8_scale_found: usize = 0;
+        let mut fp8_scale_missing: Vec<String> = Vec::new();
+        let expected_fp8_scales_per_layer: usize = 7;
 
         let mut layers = Vec::with_capacity(config.num_hidden_layers);
         for idx in 0..config.num_hidden_layers {
@@ -256,6 +265,21 @@ impl Phi4Weights {
             let gate_fp8_s = load_fp8_scale(&gate_name)?;
             let up_fp8_s = load_fp8_scale(&up_name)?;
             let down_fp8_s = load_fp8_scale(&down_name)?;
+            for (proj_name, scale_opt) in [
+                (&q_name, &q_fp8_s),
+                (&k_name, &k_fp8_s),
+                (&v_name, &v_fp8_s),
+                (&o_name, &o_fp8_s),
+                (&gate_name, &gate_fp8_s),
+                (&up_name, &up_fp8_s),
+                (&down_name, &down_fp8_s),
+            ] {
+                if scale_opt.is_some() {
+                    fp8_scale_found += 1;
+                } else {
+                    fp8_scale_missing.push(proj_name.clone());
+                }
+            }
 
             if !is_int4 {
                 if let Some(ref i4_scale) = q_i4s {
@@ -318,6 +342,24 @@ impl Phi4Weights {
                 up_proj_fp8_scale: up_fp8_s,
                 down_proj_fp8_scale: down_fp8_s,
             });
+        }
+
+        let expected_fp8_total = config.num_hidden_layers * expected_fp8_scales_per_layer;
+        if fp8_scale_found != 0 && fp8_scale_found != expected_fp8_total {
+            // Partial / mixed FP8 bake — refuse to load. Without all scales,
+            // the kernel's per-projection null-pointer fallback would dispatch
+            // BF16 matmul against FP8-packed bytes for the missing projections.
+            let sample: Vec<&String> = fp8_scale_missing.iter().take(5).collect();
+            let extra = if fp8_scale_missing.len() > 5 {
+                format!(" (and {} more)", fp8_scale_missing.len() - 5)
+            } else {
+                String::new()
+            };
+            return Err(model_store::Error::Other(format!(
+                "Phi-4 FP8 bake is incomplete: found {fp8_scale_found}/{expected_fp8_total} \
+                 *_scale_inv tensors. Missing examples: {sample:?}{extra}. \
+                 Re-bake with: python3 oracle/bake_fp8_phi4.py --model-dir <model-dir>",
+            )));
         }
 
         Ok(Self {

--- a/crates/phi4/src/weights.rs
+++ b/crates/phi4/src/weights.rs
@@ -27,6 +27,11 @@ pub struct Phi4Weights {
     pub layers: Vec<Phi4LayerWeights>,
     pub is_int4: bool,
     pub int4_group_size: usize,
+    /// True when the bake stored projection weights as FP8-E4M3 with per-block
+    /// `_scale_inv` companions (produced by `oracle/bake_fp8_phi4.py`).
+    pub is_fp8: bool,
+    /// Per-block scale tile dimension (typically 128). Only valid when `is_fp8`.
+    pub fp8_block_size: usize,
 }
 
 pub struct Phi4LayerWeights {
@@ -53,6 +58,15 @@ pub struct Phi4LayerWeights {
     pub up_proj_int4_zero: Option<GpuBuffer>,
     pub down_proj_int4_scale: Option<GpuBuffer>,
     pub down_proj_int4_zero: Option<GpuBuffer>,
+    /// Per-projection FP8 `_scale_inv` tile (BF16, shape `[rows/block, cols/block]`).
+    /// `None` for BF16 / INT4 modes.
+    pub q_proj_fp8_scale: Option<GpuBuffer>,
+    pub k_proj_fp8_scale: Option<GpuBuffer>,
+    pub v_proj_fp8_scale: Option<GpuBuffer>,
+    pub o_proj_fp8_scale: Option<GpuBuffer>,
+    pub gate_proj_fp8_scale: Option<GpuBuffer>,
+    pub up_proj_fp8_scale: Option<GpuBuffer>,
+    pub down_proj_fp8_scale: Option<GpuBuffer>,
 }
 
 impl Phi4Weights {
@@ -134,6 +148,13 @@ impl Phi4Weights {
                 up_proj_int4_zero: None,
                 down_proj_int4_scale: None,
                 down_proj_int4_zero: None,
+                q_proj_fp8_scale: None,
+                k_proj_fp8_scale: None,
+                v_proj_fp8_scale: None,
+                o_proj_fp8_scale: None,
+                gate_proj_fp8_scale: None,
+                up_proj_fp8_scale: None,
+                down_proj_fp8_scale: None,
             });
         }
 
@@ -145,6 +166,8 @@ impl Phi4Weights {
             layers,
             is_int4: false,
             int4_group_size: 0,
+            is_fp8: false,
+            fp8_block_size: 0,
         })
     }
 
@@ -171,6 +194,14 @@ impl Phi4Weights {
                     Ok((None, None))
                 }
             };
+        let load_fp8_scale = |name: &str| -> Result<Option<GpuBuffer>, model_store::Error> {
+            let scale_name = format!("{name}_scale_inv");
+            if store.contains(&scale_name) {
+                Ok(Some(store.load_to_gpu(&scale_name, ordinal)?))
+            } else {
+                Ok(None)
+            }
+        };
 
         let embed_tokens =
             Arc::new(store.load_to_gpu(&format!("{prefix}.embed_tokens.weight"), ordinal)?);
@@ -183,6 +214,8 @@ impl Phi4Weights {
 
         let mut is_int4 = false;
         let mut int4_group_size: usize = 0;
+        let mut is_fp8 = false;
+        let mut fp8_block_size: usize = 0;
 
         let mut layers = Vec::with_capacity(config.num_hidden_layers);
         for idx in 0..config.num_hidden_layers {
@@ -216,6 +249,14 @@ impl Phi4Weights {
             let (up_i4s, up_i4z) = load_int4(&up_name)?;
             let (down_i4s, down_i4z) = load_int4(&down_name)?;
 
+            let q_fp8_s = load_fp8_scale(&q_name)?;
+            let k_fp8_s = load_fp8_scale(&k_name)?;
+            let v_fp8_s = load_fp8_scale(&v_name)?;
+            let o_fp8_s = load_fp8_scale(&o_name)?;
+            let gate_fp8_s = load_fp8_scale(&gate_name)?;
+            let up_fp8_s = load_fp8_scale(&up_name)?;
+            let down_fp8_s = load_fp8_scale(&down_name)?;
+
             if !is_int4 {
                 if let Some(ref i4_scale) = q_i4s {
                     is_int4 = true;
@@ -224,6 +265,21 @@ impl Phi4Weights {
                     let original_cols = packed_cols * 2;
                     int4_group_size = if s_shape.len() == 2 && s_shape[1] > 0 {
                         original_cols / s_shape[1]
+                    } else {
+                        128
+                    };
+                }
+            }
+            if !is_fp8 {
+                if let Some(ref fp8_scale) = q_fp8_s {
+                    is_fp8 = true;
+                    // Scale shape is [rows/block, cols/block]; derive block
+                    // from the q_proj weight (FP8 storage is u8, so cols
+                    // already match the original BF16 width 1:1).
+                    let s_shape = fp8_scale.shape();
+                    let cols = q_proj_w.shape()[1];
+                    fp8_block_size = if s_shape.len() == 2 && s_shape[1] > 0 {
+                        cols / s_shape[1]
                     } else {
                         128
                     };
@@ -254,6 +310,13 @@ impl Phi4Weights {
                 up_proj_int4_zero: up_i4z,
                 down_proj_int4_scale: down_i4s,
                 down_proj_int4_zero: down_i4z,
+                q_proj_fp8_scale: q_fp8_s,
+                k_proj_fp8_scale: k_fp8_s,
+                v_proj_fp8_scale: v_fp8_s,
+                o_proj_fp8_scale: o_fp8_s,
+                gate_proj_fp8_scale: gate_fp8_s,
+                up_proj_fp8_scale: up_fp8_s,
+                down_proj_fp8_scale: down_fp8_s,
             });
         }
 
@@ -265,6 +328,8 @@ impl Phi4Weights {
             layers,
             is_int4,
             int4_group_size,
+            is_fp8,
+            fp8_block_size,
         })
     }
 }

--- a/crates/runner/src/phi4_engine.rs
+++ b/crates/runner/src/phi4_engine.rs
@@ -116,13 +116,36 @@ pub fn run_phi4(
         kv_per_token += scale_bytes_per_layer * config.num_hidden_layers as u64;
     }
     let kv_bytes = kv_per_token * context_tokens as u64;
+    // The registry's `fixed_bytes` budget is sized for BF16 weights + scratch.
+    // Under --int4 / --fp8-runtime the weight footprint shrinks to ~1/4 / ~1/2
+    // (plus a tiny scale/zero overhead), so applying the BF16 budget verbatim
+    // would reject valid runs on memory-constrained cards — the exact scenario
+    // these flags are meant to unlock. Mirror the 0.37× scaling that
+    // qwen35_dflash_engine.rs already uses for INT4 targets, and pick a
+    // conservative 0.6× for FP8 (≈ half-bytes weights + small scale_inv +
+    // unchanged scratch).
+    let quant_fixed_bytes = if cli.int4 {
+        (entry.vram.fixed_bytes as f64 * 0.37) as u64
+    } else if cli.fp8_runtime {
+        (entry.vram.fixed_bytes as f64 * 0.6) as u64
+    } else {
+        entry.vram.fixed_bytes
+    };
     let estimated_vram =
-        ((entry.vram.fixed_bytes + kv_bytes) as f64 * entry.vram.overhead_factor) as u64;
+        ((quant_fixed_bytes + kv_bytes) as f64 * entry.vram.overhead_factor) as u64;
     let gib = |b: u64| b as f64 / (1024.0 * 1024.0 * 1024.0);
+    let weight_label = if cli.int4 {
+        "weights+scratch (INT4-scaled)"
+    } else if cli.fp8_runtime {
+        "weights+scratch (FP8-scaled)"
+    } else {
+        "weights+scratch"
+    };
     eprintln!(
-        "[vram] estimated={:.2}GiB (weights+scratch={:.2}GiB + kv_cache={:.2}GiB for {}tok) available={:.1}GiB",
+        "[vram] estimated={:.2}GiB ({}={:.2}GiB + kv_cache={:.2}GiB for {}tok) available={:.1}GiB",
         gib(estimated_vram),
-        gib(entry.vram.fixed_bytes),
+        weight_label,
+        gib(quant_fixed_bytes),
         gib(kv_bytes),
         context_tokens,
         gib(total_vram),

--- a/crates/runner/src/phi4_engine.rs
+++ b/crates/runner/src/phi4_engine.rs
@@ -38,8 +38,8 @@ pub fn run_phi4(
         }
     };
 
-    if cli.fp8_runtime {
-        bail!("Phi-4 has no --fp8-runtime path yet");
+    if cli.fp8_runtime && cli.int4 {
+        bail!("Phi-4 --fp8-runtime cannot combine with --int4 (pick one weight quantization)");
     }
     if cli.batch_size != 1 {
         bail!("Phi-4 engine is single-sequence at launch (--batch-size must be 1)");
@@ -210,6 +210,40 @@ pub fn run_phi4(
             .map_err(|e| anyhow!("open Phi-4 INT4 bake: {e}"))?;
         Phi4Weights::load_baked(&store, &config, ordinal, params.weight_prefix)
             .map_err(|e| anyhow!("load Phi-4 INT4 weights: {e}"))?
+    } else if cli.fp8_runtime {
+        // FP8-runtime path: load v2-fp8 bake (produced by oracle/bake_fp8_phi4.py).
+        // Mirrors the INT4 lock + fetch dance — no auto-bake at runtime, since
+        // BF16 → FP8 calibration is a Python-side producer step.
+        let variant = model_store::fetch::BakeVariant::Fp8Native;
+        let bake_dir = variant.bake_dir(&cli.model_dir);
+        let _lock = model_store::BakeLock::acquire(&cli.model_dir)
+            .map_err(|e| anyhow!("acquire bake lock: {e}"))?;
+        if !cli.no_download
+            && should_fetch_exact_bake(cli.download_bake, model_store::version_ok(&bake_dir))
+        {
+            let canonical_model = model_variant.to_string();
+            match try_download_bake(cli, variant, &canonical_model, &bake_dir) {
+                Ok(true) => eprintln!(
+                    "[fetch] installed Phi-4 FP8 bake at {}",
+                    bake_dir.display()
+                ),
+                Ok(false) => {}
+                Err(e) => eprintln!("[fetch] Phi-4 FP8 bake fetch failed: {e}"),
+            }
+        }
+        if !model_store::version_ok(&bake_dir) {
+            bail!(
+                "Phi-4 FP8 bake not found at {} and download disabled / failed.\n\
+                 Run: python3 oracle/bake_fp8_phi4.py --model-dir {}",
+                bake_dir.display(),
+                cli.model_dir.display(),
+            );
+        }
+        eprintln!("[weights] loading FP8 baked package from {}", bake_dir.display());
+        let store = model_store::BakedStore::open(&bake_dir)
+            .map_err(|e| anyhow!("open Phi-4 FP8 bake: {e}"))?;
+        Phi4Weights::load_baked(&store, &config, ordinal, params.weight_prefix)
+            .map_err(|e| anyhow!("load Phi-4 FP8 weights: {e}"))?
     } else if cli.no_bake {
         eprintln!("[weights] loading from raw safetensors (--no-bake)");
         Phi4Weights::load(&cli.model_dir, &config, ordinal, params.weight_prefix)
@@ -248,6 +282,12 @@ pub fn run_phi4(
         eprintln!(
             "[weights] INT4 runtime dequant active (group_size={})",
             weights.int4_group_size
+        );
+    }
+    if weights.is_fp8 {
+        eprintln!(
+            "[weights] FP8 runtime dequant active (block_size={})",
+            weights.fp8_block_size
         );
     }
     eprintln!("[weights] loaded in {:.0}ms", t0.elapsed().as_millis());
@@ -334,6 +374,25 @@ pub fn run_phi4(
         Some(
             GpuBuffer::from_host_bytes(ordinal, ScalarType::U8, &[bytes.len()], bytes)
                 .map_err(|e| anyhow!("upload phi4 int4 scale descs: {e}"))?,
+        )
+    } else {
+        None
+    };
+
+    // FP8 weight scale descriptor array — built and uploaded once. Each entry
+    // points at the per-projection `_scale_inv` GPU buffer that
+    // `Phi4Weights::load_baked` parked alongside the FP8 weight bytes.
+    let fp8_scale_device: Option<GpuBuffer> = if weights.is_fp8 {
+        let descs = build_fp8_descs(&weights, weights.fp8_block_size);
+        let bytes: &[u8] = unsafe {
+            std::slice::from_raw_parts(
+                descs.as_ptr() as *const u8,
+                descs.len() * std::mem::size_of::<phi4_ffi::Phi4FP8ScaleDesc>(),
+            )
+        };
+        Some(
+            GpuBuffer::from_host_bytes(ordinal, ScalarType::U8, &[bytes.len()], bytes)
+                .map_err(|e| anyhow!("upload phi4 fp8 scale descs: {e}"))?,
         )
     } else {
         None
@@ -435,7 +494,7 @@ pub fn run_phi4(
             sin_table,
             proj_buf_floats,
             attn_scratch_floats,
-            None,
+            fp8_scale_device.as_ref(),
             kv_fp8_desc_device.as_ref(),
             1,
             None,
@@ -687,6 +746,34 @@ fn build_kv_fp8_descs(state: &Phi4ModelState) -> Vec<phi4_ffi::Phi4KVCacheFp8Des
 /// Build the per-layer parallel-struct array of INT4 scale/zero pointers.
 /// Pointers reference GPU buffers held by `weights`; struct must remain
 /// alive only as long as those buffers do (the engine owns both).
+/// Build the per-layer parallel-struct array of FP8 `_scale_inv` pointers.
+/// Pointers reference GPU buffers held by `weights`; struct must remain alive
+/// only as long as those buffers do (the engine owns both).
+fn build_fp8_descs(
+    weights: &Phi4Weights,
+    block_size: usize,
+) -> Vec<phi4_ffi::Phi4FP8ScaleDesc> {
+    use std::ffi::c_void;
+    let ptr = |opt: &Option<GpuBuffer>| -> *const c_void {
+        opt.as_ref().map(|b| b.as_ptr()).unwrap_or(std::ptr::null())
+    };
+    let block_size_c = block_size as std::ffi::c_int;
+    let mut descs = Vec::with_capacity(weights.layers.len());
+    for lw in &weights.layers {
+        descs.push(phi4_ffi::Phi4FP8ScaleDesc {
+            gate_proj_scale: ptr(&lw.gate_proj_fp8_scale),
+            up_proj_scale: ptr(&lw.up_proj_fp8_scale),
+            down_proj_scale: ptr(&lw.down_proj_fp8_scale),
+            q_proj_scale: ptr(&lw.q_proj_fp8_scale),
+            k_proj_scale: ptr(&lw.k_proj_fp8_scale),
+            v_proj_scale: ptr(&lw.v_proj_fp8_scale),
+            o_proj_scale: ptr(&lw.o_proj_fp8_scale),
+            block_size: block_size_c,
+        });
+    }
+    descs
+}
+
 fn build_int4_descs(weights: &Phi4Weights) -> Vec<phi4_ffi::Phi4INT4ScaleDesc> {
     use std::ffi::c_void;
     let ptr = |opt: &Option<GpuBuffer>| -> *const c_void {

--- a/crates/runner/src/phi4_engine.rs
+++ b/crates/runner/src/phi4_engine.rs
@@ -265,8 +265,24 @@ pub fn run_phi4(
         eprintln!("[weights] loading FP8 baked package from {}", bake_dir.display());
         let store = model_store::BakedStore::open(&bake_dir)
             .map_err(|e| anyhow!("open Phi-4 FP8 bake: {e}"))?;
-        Phi4Weights::load_baked(&store, &config, ordinal, params.weight_prefix)
-            .map_err(|e| anyhow!("load Phi-4 FP8 weights: {e}"))?
+        let fp8_weights = Phi4Weights::load_baked(&store, &config, ordinal, params.weight_prefix)
+            .map_err(|e| anyhow!("load Phi-4 FP8 weights: {e}"))?;
+        // `version_ok` only checks the manifest header — a stale or
+        // partial bake could ship FP8 projection bytes without the
+        // companion `*_scale_inv` tensors. The loader silently leaves
+        // `is_fp8 = false` in that case, after which the kernel would
+        // dispatch the BF16 matmul path against FP8-packed bytes
+        // (corrupt logits / OOB reads). Refuse to proceed.
+        if !fp8_weights.is_fp8 {
+            bail!(
+                "Phi-4 FP8 bake at {} is missing FP8 scale tensors — refusing to \
+                 run --fp8-runtime against a partial bake.\n\
+                 Re-bake with: python3 oracle/bake_fp8_phi4.py --model-dir {}",
+                bake_dir.display(),
+                cli.model_dir.display(),
+            );
+        }
+        fp8_weights
     } else if cli.no_bake {
         eprintln!("[weights] loading from raw safetensors (--no-bake)");
         Phi4Weights::load(&cli.model_dir, &config, ordinal, params.weight_prefix)

--- a/oracle/bake_all.sh
+++ b/oracle/bake_all.sh
@@ -351,11 +351,6 @@ bake_fp8_native() {
         SKIPPED+=("$cli_name fp8-native")
         return 0
     fi
-    if [[ "$family" == "phi4" ]]; then
-        echo "[skip] $cli_name fp8-native — Phi-4 FP8 baker not implemented yet"
-        SKIPPED+=("$cli_name fp8-native")
-        return 0
-    fi
     local dir ; dir="$(bake_dir_for "$model_dir" fp8-native)" || return 2
     local label="$cli_name fp8-native"
     if [[ $FORCE -eq 0 ]] && bake_exists_and_valid "$dir"; then
@@ -366,10 +361,23 @@ bake_fp8_native() {
     # Per-block FP8-E4M3 calibration from the BF16 source. Produces FP8
     # weights + BF16 scale_inv tensors at v{FORMAT_VERSION}-fp8/, the same
     # layout the Rust runtime uses for Qwen 3.6 native FP8 checkpoints. The
-    # `bake_fp8.py` quantizer reads BF16 source safetensors and writes the
-    # bake directly — no need to round-trip through the Rust auto-baker.
-    run_or_record "$label" python3 "$SCRIPT_DIR/bake_fp8.py" \
-        --model-dir "$model_dir" || return $?
+    # bake scripts read BF16 source safetensors and write the bake directly
+    # — no need to round-trip through the Rust auto-baker.
+    case "$family" in
+        qwen)
+            run_or_record "$label" python3 "$SCRIPT_DIR/bake_fp8.py" \
+                --model-dir "$model_dir" || return $?
+            ;;
+        phi4)
+            run_or_record "$label" python3 "$SCRIPT_DIR/bake_fp8_phi4.py" \
+                --model-dir "$model_dir" || return $?
+            ;;
+        *)
+            echo "[skip] $label — no FP8 baker for family '$family'"
+            SKIPPED+=("$label")
+            return 0
+            ;;
+    esac
     if [[ $UPLOAD -eq 1 ]]; then
         run_or_record "$label upload" python3 "$SCRIPT_DIR/upload_bake.py" \
             --model "$cli_name" --fp8-native --model-dir "$model_dir"

--- a/oracle/bake_fp8_phi4.py
+++ b/oracle/bake_fp8_phi4.py
@@ -375,11 +375,20 @@ def main() -> None:
                     n_quant += 1
                     continue
                 if t.dtype == torch.float8_e4m3fn:
-                    # Future-proofing; Phi-4-mini upstream is BF16 today.
-                    fp8_bytes = t.contiguous().cpu().view(torch.uint8).numpy().tobytes()
-                    writer.add(name, fp8_bytes, list(shape), "f8_e4m3", LAYOUT_FP8_NATIVE)
-                    n_quant += 1
-                    continue
+                    # Phi-4-mini upstream is BF16 today; if a future checkpoint
+                    # ships pre-quantized FP8 projections we'd also need their
+                    # companion `*_scale_inv` tensors so the runtime FP8 path
+                    # has scales to dequantize against. Without them the
+                    # runtime would either silently fall back to BF16 matmul
+                    # against FP8-packed bytes (corrupt results / OOB reads)
+                    # or skip FP8 dispatch entirely. Fail fast until that
+                    # plumbing exists.
+                    raise SystemExit(
+                        f"Phi-4 FP8 baker: source {name} is already "
+                        f"float8_e4m3fn but no companion scale_inv tensor "
+                        f"is available — pre-quantized FP8 sources are not "
+                        f"yet supported. Re-export from a BF16 checkpoint."
+                    )
                 log(f"[bake-fp8-phi4] WARNING: quant target {name} has unexpected "
                     f"dtype {t.dtype}; storing raw")
 

--- a/oracle/bake_fp8_phi4.py
+++ b/oracle/bake_fp8_phi4.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+"""
+Per-block FP8-E4M3 calibration bake for SuperSonic — Phi-4-mini.
+
+Sister script to `oracle/bake_fp8.py` (Qwen3.5). Differences from the Qwen
+baker:
+
+  * Phi-4 ships **fused** projections `self_attn.qkv_proj.weight` and
+    `mlp.gate_up_proj.weight`. The runtime expects them split into
+    q_proj / k_proj / v_proj and gate_proj / up_proj (matching the BF16
+    Rust baker `bake_phi4`). This script splits along dim 0 first, then
+    quantizes each shard independently. Phi-4-mini's projection sizes
+    (q=3072, kv=1024, intermediate=8192) are all multiples of 128 so the
+    splits land on block boundaries.
+
+  * No linear-attention layers, so no `conv1d` / `dt_bias` / `A_log`
+    layout transforms. Everything that isn't a quantization target is
+    stored Raw.
+
+Output mirrors `bake_fp8.py`: `name` (FP8-E4M3, Fp8Native) +
+`name_scale_inv` (BF16, Raw, [rows/128, cols/128]) per quantized projection.
+The runtime FP8-dequant path lights up automatically from the existing
+`Phi4FP8ScaleDesc` plumbing (kernel side already wired).
+
+Usage:
+    python3 oracle/bake_fp8_phi4.py --model-dir /path/to/Phi-4-mini-instruct
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import torch
+from safetensors import safe_open
+
+# Mirrored from oracle/bake_fp8.py / crates/model-store/src/manifest.rs.
+FORMAT_VERSION = 2
+CONVERTER_VERSION = 1
+
+LAYOUT_RAW = "Raw"
+LAYOUT_FP8_NATIVE = "Fp8Native"
+
+ALIGN = 4096
+BLOCK_SIZE = 128
+MAX_E4M3 = 448.0
+
+
+def log(msg: str) -> None:
+    print(msg, flush=True)
+
+
+def align_up(x: int, a: int = ALIGN) -> int:
+    return (x + a - 1) // a * a
+
+
+# ---------------------------------------------------------------------------
+# FP8 quantization (identical to bake_fp8.py — kept inline so this script
+# stays a single-file producer)
+# ---------------------------------------------------------------------------
+def quantize_bf16_to_fp8(
+    weight: torch.Tensor, block_size: int = BLOCK_SIZE
+) -> tuple[torch.Tensor, torch.Tensor]:
+    assert weight.dim() == 2, f"expected 2D, got {tuple(weight.shape)}"
+    rows, cols = weight.shape
+    assert rows % block_size == 0 and cols % block_size == 0, \
+        f"shape {tuple(weight.shape)} not divisible by {block_size}"
+
+    w_f32 = weight.float()
+    sr = rows // block_size
+    sc = cols // block_size
+    blocks = w_f32.view(sr, block_size, sc, block_size).permute(0, 2, 1, 3).contiguous()
+    absmax = blocks.abs().amax(dim=(2, 3))
+    scale = (absmax / MAX_E4M3).clamp_min(torch.finfo(torch.float32).tiny)
+    scale_full = (
+        scale.repeat_interleave(block_size, dim=0)
+              .repeat_interleave(block_size, dim=1)
+    )
+    q_e4m3 = (w_f32 / scale_full).to(torch.float8_e4m3fn)
+    q_bytes = q_e4m3.view(torch.uint8)
+    return q_bytes.contiguous(), scale.to(torch.bfloat16).contiguous()
+
+
+# ---------------------------------------------------------------------------
+# Tensor classification (Phi-4 specific)
+# ---------------------------------------------------------------------------
+def is_fp8_quant_target(
+    name: str, shape: tuple[int, ...], block_size: int = BLOCK_SIZE
+) -> bool:
+    """True if a 2D weight should be quantized to FP8.
+
+    Phi-4 has no linear-attention layers, so the matcher is simpler than the
+    Qwen3.5 sister. Quantize every leaf module name containing `_proj`:
+
+      * `gate_proj` / `up_proj` / `down_proj`     (MLP, post-split)
+      * `q_proj` / `k_proj` / `v_proj` / `o_proj` (attention, post-split)
+
+    The fused source tensors `qkv_proj` and `gate_up_proj` are NOT matched
+    here — they're split into shards before this function ever sees them.
+
+    Skip lm_head: the runtime's lm_head matmul is BF16-only (same as the
+    Qwen3.5 case in bake_fp8.py). On Phi-4-mini this is also moot because
+    embeddings are tied — there's no standalone `lm_head.weight`.
+    """
+    if len(shape) != 2:
+        return False
+    if not name.endswith(".weight"):
+        return False
+    if "embed_tokens" in name or name == "lm_head.weight":
+        return False
+    if "layernorm" in name or name.endswith(".norm.weight"):
+        return False
+    if "_proj" not in name:
+        return False
+    return shape[0] % block_size == 0 and shape[1] % block_size == 0
+
+
+# ---------------------------------------------------------------------------
+# Manifest dtype names
+# ---------------------------------------------------------------------------
+def torch_dtype_to_str(dt: torch.dtype) -> str:
+    if dt == torch.bfloat16:
+        return "bf16"
+    if dt == torch.float32:
+        return "f32"
+    if dt == torch.float16:
+        return "f16"
+    if dt == torch.uint8:
+        return "u8"
+    if dt == torch.float8_e4m3fn:
+        return "f8_e4m3"
+    raise ValueError(f"unsupported dtype: {dt}")
+
+
+def tensor_to_bytes(t: torch.Tensor, dtype_str: str) -> bytes:
+    if dtype_str == "f8_e4m3":
+        if t.dtype == torch.float8_e4m3fn:
+            t = t.view(torch.uint8)
+        elif t.dtype != torch.uint8:
+            raise AssertionError(
+                f"f8_e4m3 must be uint8 or float8_e4m3fn, got {t.dtype}"
+            )
+        return t.contiguous().cpu().numpy().tobytes()
+    expected = {"bf16": torch.bfloat16, "f32": torch.float32, "f16": torch.float16, "u8": torch.uint8}[dtype_str]
+    if t.dtype != expected:
+        t = t.to(expected)
+    return t.contiguous().cpu().view(torch.uint8).numpy().tobytes()
+
+
+# ---------------------------------------------------------------------------
+# Streaming writer
+# ---------------------------------------------------------------------------
+class StreamingTensorWriter:
+    def __init__(self, out_dir: Path) -> None:
+        out_dir.mkdir(parents=True, exist_ok=True)
+        self.out_dir = out_dir
+        self.weights_path = out_dir / "weights.bin"
+        self.f = open(self.weights_path, "wb")
+        self.entries: list[dict] = []
+        self.cursor = 0
+
+    def add(self, name: str, data: bytes, shape: list[int], dtype_str: str, layout: str) -> None:
+        offset = align_up(self.cursor)
+        if offset > self.cursor:
+            self.f.write(b"\x00" * (offset - self.cursor))
+        self.f.write(data)
+        self.entries.append({
+            "name": name,
+            "shape": shape,
+            "dtype": dtype_str,
+            "layout": layout,
+            "offset": offset,
+            "byte_len": len(data),
+        })
+        self.cursor = offset + len(data)
+
+    def close(self, model_family: str = "phi4") -> None:
+        self.f.close()
+        sorted_entries = sorted(self.entries, key=lambda e: e["name"])
+        manifest = {
+            "format_version": FORMAT_VERSION,
+            "converter_version": CONVERTER_VERSION,
+            "model_family": model_family,
+            "tensors": sorted_entries,
+        }
+        with open(self.out_dir / "manifest.json", "w") as f:
+            json.dump(manifest, f, indent=2)
+        log(f"[bake-fp8-phi4] wrote {self.cursor / (1024 * 1024):.1f} MiB to {self.weights_path}")
+
+
+# ---------------------------------------------------------------------------
+# Phi-4 fused-tensor splitting
+# ---------------------------------------------------------------------------
+def parse_phi4_qkv_name(name: str) -> str | None:
+    """If `name` is a Phi-4 fused qkv_proj, return its layer-prefix; else None."""
+    if name.endswith(".self_attn.qkv_proj.weight"):
+        return name[: -len(".qkv_proj.weight")]
+    return None
+
+
+def parse_phi4_gate_up_name(name: str) -> str | None:
+    if name.endswith(".mlp.gate_up_proj.weight"):
+        return name[: -len(".gate_up_proj.weight")]
+    return None
+
+
+def split_qkv(
+    t: torch.Tensor, q_rows: int, k_rows: int, v_rows: int
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    assert t.dim() == 2, f"qkv split: expected 2D, got {tuple(t.shape)}"
+    assert t.shape[0] == q_rows + k_rows + v_rows, (
+        f"qkv split: dim0 {t.shape[0]} != q {q_rows} + k {k_rows} + v {v_rows}"
+    )
+    q = t[:q_rows].contiguous()
+    k = t[q_rows : q_rows + k_rows].contiguous()
+    v = t[q_rows + k_rows :].contiguous()
+    return q, k, v
+
+
+def split_gate_up(
+    t: torch.Tensor, intermediate: int
+) -> tuple[torch.Tensor, torch.Tensor]:
+    assert t.dim() == 2, f"gate_up split: expected 2D, got {tuple(t.shape)}"
+    assert t.shape[0] == 2 * intermediate, (
+        f"gate_up split: dim0 {t.shape[0]} != 2 * intermediate ({2 * intermediate})"
+    )
+    return t[:intermediate].contiguous(), t[intermediate:].contiguous()
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+def collect_tensor_index(model_dir: Path) -> tuple[list[Path], dict[str, int]]:
+    shards = sorted(model_dir.glob("*.safetensors"))
+    if not shards:
+        raise SystemExit(f"no .safetensors found in {model_dir}")
+    index: dict[str, int] = {}
+    for i, sf in enumerate(shards):
+        with safe_open(str(sf), framework="pt") as f:
+            for key in f.keys():
+                index[key] = i
+    return shards, index
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Per-block FP8 bake for Phi-4-mini")
+    ap.add_argument("--model-dir", required=True, type=Path)
+    ap.add_argument("--out-dir", default=None, type=Path,
+                    help="Override output dir (default: {model-dir}/.supersonic/v{FORMAT_VERSION}-fp8)")
+    ap.add_argument("--block-size", type=int, default=BLOCK_SIZE,
+                    help=f"Per-tile FP8 block size (default {BLOCK_SIZE}; "
+                         f"the Rust runtime currently only supports 128).")
+    ap.add_argument("--model-family", default="phi4",
+                    help="Override the manifest model_family field (default: phi4).")
+    args = ap.parse_args()
+
+    block_size: int = args.block_size
+    if block_size != BLOCK_SIZE:
+        log(f"[bake-fp8-phi4] WARNING: --block-size={block_size} is non-default; "
+            "the Rust runtime currently assumes 128 — use only for "
+            "calibration experiments, not production bakes.")
+
+    model_dir: Path = args.model_dir.resolve()
+    out_dir: Path = args.out_dir or (model_dir / ".supersonic" / f"v{FORMAT_VERSION}-fp8")
+
+    config_path = model_dir / "config.json"
+    if not config_path.exists():
+        raise SystemExit(f"missing config.json under {model_dir}")
+    cfg = json.load(open(config_path))
+    num_attention_heads = int(cfg["num_attention_heads"])
+    num_kv_heads = int(cfg["num_key_value_heads"])
+    head_dim = int(cfg.get("head_dim", cfg["hidden_size"] // num_attention_heads))
+    intermediate_size = int(cfg["intermediate_size"])
+    q_rows = num_attention_heads * head_dim
+    k_rows = num_kv_heads * head_dim
+    v_rows = k_rows
+    log(f"[bake-fp8-phi4] q_rows={q_rows} k_rows={k_rows} v_rows={v_rows} "
+        f"intermediate={intermediate_size}")
+
+    shards, index = collect_tensor_index(model_dir)
+    log(f"[bake-fp8-phi4] {len(shards)} shard(s), {len(index)} tensors")
+
+    # Phi-4 weights live under `model.*` (no `language_model` indirection).
+    eligible = sorted(
+        n for n in index
+        if n.startswith("model.") or n == "lm_head.weight"
+    )
+    log(f"[bake-fp8-phi4] {len(eligible)} eligible tensors")
+
+    writer = StreamingTensorWriter(out_dir)
+    open_shards: dict[int, Any] = {}
+
+    def get_handle(idx: int):
+        h = open_shards.get(idx)
+        if h is None:
+            h = safe_open(str(shards[idx]), framework="pt")
+            h.__enter__()
+            open_shards[idx] = h
+        return h
+
+    def emit_quantized(name: str, t: torch.Tensor) -> None:
+        """Quantize a 2D BF16 tensor → emit (FP8 weight, scale_inv) pair."""
+        packed, scale_bf16 = quantize_bf16_to_fp8(t, block_size)
+        writer.add(
+            name,
+            tensor_to_bytes(packed, "f8_e4m3"),
+            list(t.shape),
+            "f8_e4m3",
+            LAYOUT_FP8_NATIVE,
+        )
+        writer.add(
+            f"{name}_scale_inv",
+            tensor_to_bytes(scale_bf16, "bf16"),
+            list(scale_bf16.shape),
+            "bf16",
+            LAYOUT_RAW,
+        )
+
+    def emit_raw(name: str, t: torch.Tensor) -> None:
+        writer.add(
+            name,
+            tensor_to_bytes(t, torch_dtype_to_str(t.dtype)),
+            list(t.shape),
+            torch_dtype_to_str(t.dtype),
+            LAYOUT_RAW,
+        )
+
+    t0 = time.perf_counter()
+    n_quant = 0
+    n_split_quant = 0
+    n_raw = 0
+    try:
+        for name in eligible:
+            shard_idx = index[name]
+            t = get_handle(shard_idx).get_tensor(name)
+            shape = tuple(t.shape)
+
+            # Fused QKV → split into q/k/v shards, quantize each.
+            qkv_prefix = parse_phi4_qkv_name(name)
+            if qkv_prefix is not None:
+                q, k, v = split_qkv(t, q_rows, k_rows, v_rows)
+                if t.dtype != torch.bfloat16:
+                    raise SystemExit(
+                        f"Phi-4 FP8 baker only supports BF16 source for "
+                        f"projections; {name} is {t.dtype}"
+                    )
+                emit_quantized(f"{qkv_prefix}.q_proj.weight", q)
+                emit_quantized(f"{qkv_prefix}.k_proj.weight", k)
+                emit_quantized(f"{qkv_prefix}.v_proj.weight", v)
+                n_split_quant += 3
+                continue
+
+            # Fused gate_up → split into gate/up, quantize each.
+            gu_prefix = parse_phi4_gate_up_name(name)
+            if gu_prefix is not None:
+                gate, up = split_gate_up(t, intermediate_size)
+                if t.dtype != torch.bfloat16:
+                    raise SystemExit(
+                        f"Phi-4 FP8 baker only supports BF16 source for "
+                        f"projections; {name} is {t.dtype}"
+                    )
+                emit_quantized(f"{gu_prefix}.gate_proj.weight", gate)
+                emit_quantized(f"{gu_prefix}.up_proj.weight", up)
+                n_split_quant += 2
+                continue
+
+            # Plain projection (o_proj, down_proj) — BF16 → quantize directly.
+            if is_fp8_quant_target(name, shape, block_size):
+                if t.dtype == torch.bfloat16:
+                    emit_quantized(name, t)
+                    n_quant += 1
+                    continue
+                if t.dtype == torch.float8_e4m3fn:
+                    # Future-proofing; Phi-4-mini upstream is BF16 today.
+                    fp8_bytes = t.contiguous().cpu().view(torch.uint8).numpy().tobytes()
+                    writer.add(name, fp8_bytes, list(shape), "f8_e4m3", LAYOUT_FP8_NATIVE)
+                    n_quant += 1
+                    continue
+                log(f"[bake-fp8-phi4] WARNING: quant target {name} has unexpected "
+                    f"dtype {t.dtype}; storing raw")
+
+            # Norms / embeddings / lm_head / anything else — pass through.
+            emit_raw(name, t)
+            n_raw += 1
+    finally:
+        for h in open_shards.values():
+            try:
+                h.__exit__(None, None, None)
+            except Exception:
+                pass
+
+    writer.close(model_family=args.model_family)
+    elapsed = time.perf_counter() - t0
+    log(f"[bake-fp8-phi4] split+quantized {n_split_quant} shards, "
+        f"directly-quantized {n_quant}, passed through {n_raw} tensors "
+        f"in {elapsed:.1f}s")
+    log(f"[bake-fp8-phi4] done. Output: {out_dir}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Lights up `--fp8-runtime` end-to-end for Phi-4-mini, mirroring the Qwen3.5 baker pattern from #46. The kernel-side `Phi4FP8ScaleDesc` path was already in `phi4.hip` (wired in alongside KV-FP8); this PR adds the producer + runtime plumbing the engine was missing.

## What changes

**Producer**
- `oracle/bake_fp8_phi4.py` — per-block (128×128) absmax FP8-E4M3-FN quantization. Phi-4 ships fused `qkv_proj.weight` and `gate_up_proj.weight`; the baker splits along dim 0 first (Phi-4-mini sizes q=3072 / kv=1024 / intermediate=8192 are all multiples of 128 — splits land on block boundaries) then quantizes each shard. Output names match the runtime's expected `q_proj.weight` / `k_proj.weight` / etc. Skips `lm_head` (runtime lm_head matmul is BF16-only — same constraint as `bake_fp8.py`).
- `oracle/bake_all.sh` routes the `phi4` family in `bake_fp8_native` through the new script; the previous "[skip] not implemented" branch is gone.

**Runtime**
- `Phi4Weights` gains `is_fp8` + `fp8_block_size` flags and per-projection `*_proj_fp8_scale: Option<GpuBuffer>` fields. `load_baked` picks up `_scale_inv` companions when present and infers `fp8_block_size` from the q_proj scale shape (parallel to the INT4 group_size detection already there).
- `phi4_engine.rs`:
  - Drops the `--fp8-runtime` bail. `--fp8-runtime --int4` is rejected with a clear message (pick one weight quantization).
  - New `--fp8-runtime` weight-loading branch fetches/loads the `v2-fp8` bake under `BakeLock` (parallel to the `--int4` lane).
  - `build_fp8_descs` constructs the per-layer `Phi4FP8ScaleDesc` array; uploaded once into a GPU buffer at engine start.
  - Plumbs `fp8_scale_device` into `phi4_ffi::persistent_decode` (was hardcoded `None`).

## Verification on gfx1100

```
$ supersonic --model phi4-mini --fp8-runtime --validate \
    --prompt "The quick brown fox" --max-new-tokens 6
[weights] FP8 runtime dequant active (block_size=128)
The quick brown fox jumps over the lazy dog.
[validate] max_delta=2.0000 token_mismatches=0
```

`max_delta=2.0` is the expected FP8 quantization-noise range against the BF16 CPU oracle; **zero token mismatches** over 6 generated tokens.

Bake size: **4245.6 MiB** vs **7316.8 MiB** BF16 (42% reduction — embeddings stay BF16, hence below the theoretical 50%).

Combines cleanly with `--kv-fp8`. `--fp8-runtime --int4` is now rejected explicitly.

## Test plan

- [x] `phi4-mini --fp8-runtime` produces canonical "lazy dog" sentence on gfx1100
- [x] `phi4-mini --fp8-runtime --validate` — 0 token mismatches vs BF16 oracle, deltas ≤ 2.0
- [x] `phi4-mini --fp8-runtime --kv-fp8` combined — still produces canonical output
- [x] `phi4-mini --fp8-runtime --int4` correctly rejected with a helpful message
- [x] BF16 path regression-tested — unchanged behavior
- [x] INT4 path regression-tested — unchanged behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)