### PR TITLE
Gemma 4 KV-FP8 scaffolding: kernel + FFI + bridge

### DIFF
--- a/crates/kernel-ffi/src/gemma4.rs
+++ b/crates/kernel-ffi/src/gemma4.rs
@@ -400,6 +400,7 @@ unsafe extern "C" {
         eps: f32,
         scale: f32,
         layers: *const c_void,
+        kv_fp8_descs: *const c_void,
         hidden_io: *mut c_void,
         per_layer_inputs: *const c_void,
         workspace: *mut c_void,
@@ -488,7 +489,7 @@ gemma4_stub! {
     fn dotcache_gemma4_hip_gather_layer_slice(dtype: c_int, device_ordinal: usize, seq_len: usize, num_layers: usize, ple_hidden: usize, layer_idx: usize, src: *const c_void, out: *mut c_void) -> c_int;
     fn dotcache_gemma4_hip_embed_gather_scaled(dtype: c_int, device_ordinal: usize, seq_len: usize, hidden_size: usize, vocab_size: usize, scale: f32, token_ids: *const c_uint, table: *const c_void, out: *mut c_void) -> c_int;
     fn dotcache_gemma4_hip_persistent_decode_int4(dtype: c_int, device_ordinal: usize, num_layers: usize, hidden_size: usize, ple_hidden: usize, position: usize, eps: f32, scale: f32, layers: *const c_void, int4_scales: *const c_void, hidden_io: *mut c_void, per_layer_inputs: *const c_void, workspace: *mut c_void, matvec_counter: *mut c_uint, barrier_counter: *mut c_uint, barrier_flag: *mut c_uint) -> c_int;
-    fn dotcache_gemma4_hip_persistent_decode(dtype: c_int, device_ordinal: usize, num_layers: usize, hidden_size: usize, ple_hidden: usize, position: usize, eps: f32, scale: f32, layers: *const c_void, hidden_io: *mut c_void, per_layer_inputs: *const c_void, workspace: *mut c_void, matvec_counter: *mut c_uint, barrier_counter: *mut c_uint, barrier_flag: *mut c_uint) -> c_int;
+    fn dotcache_gemma4_hip_persistent_decode(dtype: c_int, device_ordinal: usize, num_layers: usize, hidden_size: usize, ple_hidden: usize, position: usize, eps: f32, scale: f32, layers: *const c_void, kv_fp8_descs: *const c_void, hidden_io: *mut c_void, per_layer_inputs: *const c_void, workspace: *mut c_void, matvec_counter: *mut c_uint, barrier_counter: *mut c_uint, barrier_flag: *mut c_uint) -> c_int;
     fn dotcache_gemma4_hip_persistent_decode_batch(dtype: c_int, device_ordinal: usize, num_layers: usize, hidden_size: usize, ple_hidden: usize, eps: f32, scale: f32, batch_size: usize, ws_stride: usize, layers: *const c_void, batch_descs: *const c_void, hidden_io: *mut c_void, per_layer_inputs: *const c_void, workspace: *mut c_void, matvec_counter: *mut c_uint, barrier_counter: *mut c_uint, barrier_flag: *mut c_uint) -> c_int;
     fn dotcache_gemma4_hip_persistent_decode_batch_int4(dtype: c_int, device_ordinal: usize, num_layers: usize, hidden_size: usize, ple_hidden: usize, eps: f32, scale: f32, batch_size: usize, ws_stride: usize, layers: *const c_void, int4_scales: *const c_void, batch_descs: *const c_void, hidden_io: *mut c_void, per_layer_inputs: *const c_void, workspace: *mut c_void, matvec_counter: *mut c_uint, barrier_counter: *mut c_uint, barrier_flag: *mut c_uint) -> c_int;
 }
@@ -1728,6 +1729,37 @@ impl Default for Gemma4Int4ScaleDesc {
     }
 }
 
+/// Per-layer FP8 KV-cache scale-buffer pointers for Gemma 4. Parallel-struct
+/// to [`Gemma4DecodeLayerDesc`] — when `--kv-fp8` is active the main desc's
+/// `kv_cache_k`/`kv_cache_v` slots hold u8-packed FP8-E4M3 bytes, and this
+/// struct carries the matching per-(head, position) F32 absmax scales.
+///
+/// Mirrors the Phi-4 pattern (`Phi4KVCacheFp8Desc`). Shared-KV layers (Gemma
+/// 4 aliases earlier layers' caches via pointer equality) must alias scale
+/// buffers too — both fields point at the source layer's scale tensors so
+/// dequant reads stay self-consistent.
+///
+/// Both fields are null for layers that didn't allocate KV-FP8 (i.e. the
+/// kernel runs in BF16 KV mode); the kernel uses non-null as the dispatch
+/// signal.
+#[repr(C)]
+#[derive(Debug, Clone)]
+pub struct Gemma4KVCacheFp8Desc {
+    /// `[num_kv_heads, max_T]` F32 absmax scales for K cache. Null = BF16 K.
+    pub kv_scale_k: *mut c_void,
+    /// `[num_kv_heads, max_T]` F32 absmax scales for V cache. Null = BF16 V.
+    pub kv_scale_v: *mut c_void,
+}
+
+unsafe impl Send for Gemma4KVCacheFp8Desc {}
+unsafe impl Sync for Gemma4KVCacheFp8Desc {}
+
+impl Default for Gemma4KVCacheFp8Desc {
+    fn default() -> Self {
+        unsafe { std::mem::zeroed() }
+    }
+}
+
 /// Per-sequence state pointers for batched Gemma 4 decode.
 ///
 /// One `Gemma4BatchSeqDesc` per layer (parallel array to
@@ -1805,6 +1837,7 @@ pub fn persistent_decode(
     ordinal: usize,
     dtype: ScalarType,
     layers: &GpuBuffer,
+    kv_fp8_descs: Option<&GpuBuffer>,
     hidden_io: &mut GpuBuffer,
     per_layer_inputs: &GpuBuffer,
     workspace: &mut GpuBuffer,
@@ -1818,6 +1851,9 @@ pub fn persistent_decode(
     eps: f32,
     scale: f32,
 ) -> Result<(), GpuError> {
+    let kv_fp8_ptr = kv_fp8_descs
+        .map(|b| b.as_ptr())
+        .unwrap_or(std::ptr::null());
     let status = unsafe {
         dotcache_gemma4_hip_persistent_decode(
             dtype.kernel_dtype_code(),
@@ -1829,6 +1865,7 @@ pub fn persistent_decode(
             eps,
             scale,
             layers.as_ptr(),
+            kv_fp8_ptr,
             hidden_io.as_mut_ptr(),
             per_layer_inputs.as_ptr(),
             workspace.as_mut_ptr(),

--- a/crates/runner/src/bin/gemma4_bench.rs
+++ b/crates/runner/src/bin/gemma4_bench.rs
@@ -870,6 +870,7 @@ fn main() -> Result<()> {
             0,
             dtype,
             &layers_gpu,
+            None,
             h_io,
             &pli_gpu,
             &mut mega_workspace,

--- a/crates/runner/src/bin/gemma4_mega_decode_validate.rs
+++ b/crates/runner/src/bin/gemma4_mega_decode_validate.rs
@@ -830,6 +830,7 @@ fn main() -> Result<()> {
             0,
             dtype,
             &layers_gpu,
+            None,
             &mut h_running,
             &pli_gpu,
             &mut mega_workspace,

--- a/crates/runner/src/gemma4_engine.rs
+++ b/crates/runner/src/gemma4_engine.rs
@@ -475,6 +475,18 @@ pub struct Gemma4Engine {
 
     // Shared counter reused across one-shot primitives (matvec row-steal).
     counter: GpuBuffer,
+
+    /// Per-(seq, layer) F32 absmax scale buffers for FP8 KV cache. Populated
+    /// only when `--kv-fp8` is active (alloc path lands in the engine-wiring
+    /// PR). Layout: `[batch_size][num_layers]`, each `[num_kv_heads, max_t]`.
+    /// Shared-KV layers alias the source layer's `Arc`/buffer.
+    #[allow(dead_code)]
+    kv_scale_k: Option<Vec<Vec<GpuBuffer>>>,
+    #[allow(dead_code)]
+    kv_scale_v: Option<Vec<Vec<GpuBuffer>>>,
+    /// Per-sequence GPU array of `Gemma4KVCacheFp8Desc` (one entry per layer).
+    /// `None` when KV cache is BF16. Plumbed through to `persistent_decode`.
+    kv_fp8_descs_gpu: Option<Vec<GpuBuffer>>,
 }
 
 impl Gemma4Engine {
@@ -770,6 +782,9 @@ impl Gemma4Engine {
             mega_barrier_counter,
             mega_barrier_flag,
             counter,
+            kv_scale_k: None,
+            kv_scale_v: None,
+            kv_fp8_descs_gpu: None,
         })
     }
 
@@ -1418,6 +1433,9 @@ impl Gemma4Engine {
             device,
             dtype,
             &self.layers_gpu[seq_idx],
+            self.kv_fp8_descs_gpu
+                .as_ref()
+                .map(|v| &v[seq_idx]),
             &mut h_running,
             &pli_gpu,
             &mut self.mega_workspace,

--- a/kernels/gemma4.hip
+++ b/kernels/gemma4.hip
@@ -90,6 +90,55 @@ __device__ __forceinline__ float g4_bf16_round_rne_f32_finite(float x) {
     return y;
 }
 
+// -----------------------------------------------------------------------------
+// FP8-E4M3-FN helpers for KV-cache quantization. Mirrors phi4.hip's
+// `fp8_e4m3_to_float` / `float_to_fp8_e4m3` — duplicated here to keep
+// gemma4.hip a standalone TU (per CLAUDE.md, hipcc on gfx11xx is fragile to
+// cross-TU contamination, so we never #include another model's .hip).
+// E4M3-FN encoding: 1 sign + 4 exponent + 3 mantissa, bias=7, no inf,
+// NaN encoded at 0x7F / 0xFF, max representable absolute value = 448.
+// -----------------------------------------------------------------------------
+__device__ inline float g4_fp8_e4m3_to_float(uint8_t byte) {
+    int sign = (byte >> 7) & 1;
+    int exp = (byte >> 3) & 0xF;
+    int mantissa = byte & 0x7;
+    if (byte == 0x7F || byte == 0xFF) return 0.0f;  // NaN → 0
+    float val;
+    if (exp == 0) {
+        val = static_cast<float>(mantissa) / 8.0f * 1.52587890625e-2f;
+    } else {
+        val = (1.0f + static_cast<float>(mantissa) / 8.0f)
+              * exp2f(static_cast<float>(exp - 7));
+    }
+    return sign ? -val : val;
+}
+
+__device__ inline uint8_t g4_float_to_fp8_e4m3(float val) {
+    uint8_t sign = 0;
+    if (val < 0.0f) { sign = 0x80; val = -val; }
+    if (val >= 448.0f) return sign | 0x7E;
+    if (val < 1.52587890625e-2f * 0.125f) return sign;
+    if (val < 0.015625f) {
+        int mantissa = __float2int_rn(val / 1.52587890625e-2f * 8.0f);
+        if (mantissa < 0) mantissa = 0;
+        if (mantissa >= 8) return sign | 0x08;
+        return sign | static_cast<uint8_t>(mantissa);
+    }
+    float log2_val = log2f(val);
+    int exp = static_cast<int>(floorf(log2_val)) + 7;
+    if (exp < 1) exp = 1;
+    if (exp > 14) exp = 14;
+    float pow2 = exp2f(static_cast<float>(exp - 7));
+    int mantissa = __float2int_rn((val / pow2 - 1.0f) * 8.0f);
+    if (mantissa < 0) mantissa = 0;
+    if (mantissa >= 8) {
+        mantissa = 0;
+        exp += 1;
+        if (exp > 14) return sign | 0x7E;
+    }
+    return sign | (static_cast<uint8_t>(exp) << 3) | static_cast<uint8_t>(mantissa);
+}
+
 // Dequantize 8 INT4 weights from 4 packed bytes = 1 packed uint32.
 // `col` is the starting weight column (must be 2-aligned; always is since
 // we step by 8 across a row whose byte stride is `in_dim/2`).
@@ -1782,6 +1831,86 @@ __device__ inline void g4_block_kv_append_f32_to_bf16(
     __syncthreads();
 }
 
+// FP8-E4M3 variant of the KV append. Quantizes one decode token's K/V into
+// the cache at position `pos`, with a per-(head, position) F32 absmax scale.
+// The cache buffers are reinterpreted as `uint8_t*` (1 byte per element);
+// `kv_scale_k` / `kv_scale_v` hold one F32 scale per (head, position).
+//
+// Block-collaborative absmax: one wave-wide reduction per K head, then per V
+// head. `lds[bs]` is a scratch buffer in shared memory.
+//
+// Caller must call this from a single block. Threads cooperate; output is
+// written at `kv_cache_{k,v}[h * max_T + pos][d]` and
+// `kv_scale_{k,v}[h * max_T + pos]`.
+__device__ inline void g4_block_kv_append_f32_to_fp8(
+    const float* __restrict__ k_f32,
+    const float* __restrict__ v_f32,
+    uint8_t* __restrict__ k_cache,
+    uint8_t* __restrict__ v_cache,
+    float* __restrict__ k_scale_buf,
+    float* __restrict__ v_scale_buf,
+    int num_kv_heads,
+    int head_dim,
+    int pos,
+    int max_T,
+    float* __restrict__ lds
+) {
+    const int tid = threadIdx.x;
+    const int bs = blockDim.x;
+
+    for (int h = 0; h < num_kv_heads; ++h) {
+        // Per-head absmax over [head_dim] — bf16-rounded values match the
+        // BF16-round in the existing append path, keeping the FP8 dequant
+        // numerically aligned with the BF16 reference.
+        float my_k = 0.0f, my_v = 0.0f;
+        if (tid < head_dim) {
+            const float k_bf16 =
+                g4_bf16_round_rne_f32_finite(k_f32[h * head_dim + tid]);
+            const float v_bf16 =
+                g4_bf16_round_rne_f32_finite(v_f32[h * head_dim + tid]);
+            my_k = fabsf(k_bf16);
+            my_v = fabsf(v_bf16);
+        }
+        lds[tid] = my_k;
+        __syncthreads();
+        for (int s = bs / 2; s > 0; s >>= 1) {
+            if (tid < s) lds[tid] = fmaxf(lds[tid], lds[tid + s]);
+            __syncthreads();
+        }
+        const float k_scale = fmaxf(lds[0] / 448.0f, 1e-12f);
+        const float k_inv = 1.0f / k_scale;
+        if (tid == 0) {
+            k_scale_buf[static_cast<size_t>(h) * max_T + pos] = k_scale;
+        }
+        __syncthreads();
+
+        lds[tid] = my_v;
+        __syncthreads();
+        for (int s = bs / 2; s > 0; s >>= 1) {
+            if (tid < s) lds[tid] = fmaxf(lds[tid], lds[tid + s]);
+            __syncthreads();
+        }
+        const float v_scale = fmaxf(lds[0] / 448.0f, 1e-12f);
+        const float v_inv = 1.0f / v_scale;
+        if (tid == 0) {
+            v_scale_buf[static_cast<size_t>(h) * max_T + pos] = v_scale;
+        }
+        __syncthreads();
+
+        for (int d = tid; d < head_dim; d += bs) {
+            const size_t off =
+                (static_cast<size_t>(h) * max_T + pos) * head_dim + d;
+            const float k_store =
+                g4_bf16_round_rne_f32_finite(k_f32[h * head_dim + d]);
+            const float v_store =
+                g4_bf16_round_rne_f32_finite(v_f32[h * head_dim + d]);
+            k_cache[off] = g4_float_to_fp8_e4m3(k_store * k_inv);
+            v_cache[off] = g4_float_to_fp8_e4m3(v_store * v_inv);
+        }
+        __syncthreads();
+    }
+}
+
 // Fused attention-block persistent kernel. Single launch per Gemma 4
 // decoder-layer attention half. Orchestration:
 //   0. All blocks: hidden BF16 → hidden_f32 (residual copy).
@@ -3116,6 +3245,17 @@ struct Gemma4BatchSeqDesc {
     int   kv_max_t[G4_MAX_BATCH_SIZE];
 };
 
+// Mirror of `Gemma4KVCacheFp8Desc` in `crates/kernel-ffi/src/gemma4.rs`.
+// Parallel-struct to `Gemma4DecodeLayerDesc` — when --kv-fp8 is active the
+// main desc's `kv_cache_k` / `kv_cache_v` slots hold u8-packed FP8-E4M3
+// bytes; this struct carries the matching per-(head, position) F32 absmax
+// scales. Both fields are nullptr in BF16 KV mode (current single-batch
+// kernel uses non-null as the dispatch signal).
+struct Gemma4KVCacheFp8Desc {
+    void* kv_scale_k;  // [num_kv_heads, max_T] F32, or nullptr for BF16 KV
+    void* kv_scale_v;  // [num_kv_heads, max_T] F32, or nullptr for BF16 KV
+};
+
 template <typename T>
 __global__ void g4_persistent_decode_kernel(
     int num_layers,
@@ -3125,6 +3265,7 @@ __global__ void g4_persistent_decode_kernel(
     float eps,
     float scale,
     const Gemma4DecodeLayerDesc* __restrict__ layers,
+    const Gemma4KVCacheFp8Desc* __restrict__ kv_fp8_descs, // null = BF16 KV
     T* __restrict__ hidden_io,                          // [hidden_size] BF16 in/out
     const T* __restrict__ per_layer_inputs,              // [num_layers, ple_hidden] BF16
     float* __restrict__ workspace,
@@ -3150,6 +3291,18 @@ __global__ void g4_persistent_decode_kernel(
         const int q_dim = num_q_heads * head_dim;
         const int kv_dim = num_kv_heads * head_dim;
 
+        // FP8 KV cache scales for THIS layer. Shared-KV layers receive scale
+        // pointers aliased to the source layer's scale tensors via the engine,
+        // matching how `kv_cache_k` / `kv_cache_v` are aliased. nullptr in
+        // BF16 KV mode (and on layers we never wrote scales for).
+        const float* kv_scale_k = (kv_fp8_descs != nullptr)
+            ? static_cast<const float*>(kv_fp8_descs[layer].kv_scale_k)
+            : nullptr;
+        const float* kv_scale_v = (kv_fp8_descs != nullptr)
+            ? static_cast<const float*>(kv_fp8_descs[layer].kv_scale_v)
+            : nullptr;
+        const bool use_fp8_kv = (kv_scale_k != nullptr) && (kv_scale_v != nullptr);
+
         const T* input_norm_w = static_cast<const T*>(L.input_norm_w);
         const T* q_proj_w = static_cast<const T*>(L.q_proj_w);
         const T* k_proj_w = static_cast<const T*>(L.k_proj_w);
@@ -3160,6 +3313,9 @@ __global__ void g4_persistent_decode_kernel(
         const T* post_attn_norm_w = static_cast<const T*>(L.post_attn_norm_w);
         const T* cos_table = static_cast<const T*>(L.cos_table);
         const T* sin_table = static_cast<const T*>(L.sin_table);
+        // When use_fp8_kv is true, kv_cache_k/v hold u8 FP8-E4M3 bytes; we
+        // reinterpret at the read/write sites to keep the BF16 path's
+        // template `T*` typing untouched everywhere else.
         T* k_cache = static_cast<T*>(L.kv_cache_k);
         T* v_cache = static_cast<T*>(L.kv_cache_v);
 
@@ -3263,8 +3419,18 @@ __global__ void g4_persistent_decode_kernel(
                 num_q_heads, head_dim, rotary_dim, position);
             g4_block_rope_f32<T>(k_f32, cos_table, sin_table,
                 num_kv_heads, head_dim, rotary_dim, position);
-            g4_block_kv_append_f32_to_bf16<T>(k_f32, v_f32, k_cache, v_cache,
-                num_kv_heads, head_dim, position, max_T);
+            if (use_fp8_kv) {
+                g4_block_kv_append_f32_to_fp8(
+                    k_f32, v_f32,
+                    reinterpret_cast<uint8_t*>(k_cache),
+                    reinterpret_cast<uint8_t*>(v_cache),
+                    const_cast<float*>(kv_scale_k),
+                    const_cast<float*>(kv_scale_v),
+                    num_kv_heads, head_dim, position, max_T, lds);
+            } else {
+                g4_block_kv_append_f32_to_bf16<T>(k_f32, v_f32, k_cache, v_cache,
+                    num_kv_heads, head_dim, position, max_T);
+            }
         } else if (shared_kv && blockIdx.x == 0) {
             g4_block_rms_norm_per_head_f32<T>(q_f32, q_norm_w,
                 num_q_heads, head_dim, eps, lds);
@@ -3280,6 +3446,9 @@ __global__ void g4_persistent_decode_kernel(
         const int num_q_per_kv = num_q_heads / num_kv_heads;
         {
             const int total_items = num_q_heads * kv_len;
+            const uint8_t* k_cache_fp8 = use_fp8_kv
+                ? reinterpret_cast<const uint8_t*>(L.kv_cache_k)
+                : nullptr;
             for (int item = blockIdx.x * bs + tid;
                  item < total_items; item += nb * bs) {
                 const int t = item % kv_len;
@@ -3291,11 +3460,21 @@ __global__ void g4_persistent_decode_kernel(
                     const int kv_h = q_h / num_q_per_kv;
                     const float* qr = q_f32 +
                         static_cast<size_t>(q_h) * head_dim;
-                    const T* kr = k_cache +
-                        (static_cast<size_t>(kv_h) * max_T + t) * head_dim;
                     float acc = 0.0f;
-                    for (int d = 0; d < head_dim; ++d) {
-                        acc += qr[d] * g4_to_float(kr[d]);
+                    if (use_fp8_kv) {
+                        const uint8_t* kr_fp8 = k_cache_fp8 +
+                            (static_cast<size_t>(kv_h) * max_T + t) * head_dim;
+                        const float k_s =
+                            kv_scale_k[static_cast<size_t>(kv_h) * max_T + t];
+                        for (int d = 0; d < head_dim; ++d) {
+                            acc += qr[d] * (g4_fp8_e4m3_to_float(kr_fp8[d]) * k_s);
+                        }
+                    } else {
+                        const T* kr = k_cache +
+                            (static_cast<size_t>(kv_h) * max_T + t) * head_dim;
+                        for (int d = 0; d < head_dim; ++d) {
+                            acc += qr[d] * g4_to_float(kr[d]);
+                        }
                     }
                     val = acc * scale;
                 }
@@ -3339,6 +3518,9 @@ __global__ void g4_persistent_decode_kernel(
         // A6: value aggregation.
         {
             const int total_items = num_q_heads * head_dim;
+            const uint8_t* v_cache_fp8 = use_fp8_kv
+                ? reinterpret_cast<const uint8_t*>(L.kv_cache_v)
+                : nullptr;
             for (int item = blockIdx.x * bs + tid;
                  item < total_items; item += nb * bs) {
                 const int d = item % head_dim;
@@ -3347,10 +3529,20 @@ __global__ void g4_persistent_decode_kernel(
                 const float* pr = scores_f32 +
                     static_cast<size_t>(q_h) * max_T;
                 float acc = 0.0f;
-                for (int t = 0; t < kv_len; ++t) {
-                    const T* vr = v_cache +
-                        (static_cast<size_t>(kv_h) * max_T + t) * head_dim;
-                    acc += pr[t] * g4_to_float(vr[d]);
+                if (use_fp8_kv) {
+                    for (int t = 0; t < kv_len; ++t) {
+                        const uint8_t* vr_fp8 = v_cache_fp8 +
+                            (static_cast<size_t>(kv_h) * max_T + t) * head_dim;
+                        const float v_s =
+                            kv_scale_v[static_cast<size_t>(kv_h) * max_T + t];
+                        acc += pr[t] * (g4_fp8_e4m3_to_float(vr_fp8[d]) * v_s);
+                    }
+                } else {
+                    for (int t = 0; t < kv_len; ++t) {
+                        const T* vr = v_cache +
+                            (static_cast<size_t>(kv_h) * max_T + t) * head_dim;
+                        acc += pr[t] * g4_to_float(vr[d]);
+                    }
                 }
                 attn_out_f32[static_cast<size_t>(q_h) * head_dim + d] = acc;
             }

--- a/kernels/gemma4.hip
+++ b/kernels/gemma4.hip
@@ -1862,14 +1862,21 @@ __device__ inline void g4_block_kv_append_f32_to_fp8(
         // Per-head absmax over [head_dim] — bf16-rounded values match the
         // BF16-round in the existing append path, keeping the FP8 dequant
         // numerically aligned with the BF16 reference.
+        //
+        // Strided local max FIRST, then block reduce. Gemma 4 full-attention
+        // layers have head_dim=512 with blockDim.x=256, so each thread must
+        // walk all its lanes before reducing — otherwise dimensions >= bs
+        // (i.e. half the head on full-attn) silently drop out of the absmax
+        // and the chosen scale undershoots, causing widespread FP8
+        // saturation/clamping. (Reported by Codex review on PR #48.)
         float my_k = 0.0f, my_v = 0.0f;
-        if (tid < head_dim) {
+        for (int d = tid; d < head_dim; d += bs) {
             const float k_bf16 =
-                g4_bf16_round_rne_f32_finite(k_f32[h * head_dim + tid]);
+                g4_bf16_round_rne_f32_finite(k_f32[h * head_dim + d]);
             const float v_bf16 =
-                g4_bf16_round_rne_f32_finite(v_f32[h * head_dim + tid]);
-            my_k = fabsf(k_bf16);
-            my_v = fabsf(v_bf16);
+                g4_bf16_round_rne_f32_finite(v_f32[h * head_dim + d]);
+            my_k = fmaxf(my_k, fabsf(k_bf16));
+            my_v = fmaxf(my_v, fabsf(v_bf16));
         }
         lds[tid] = my_k;
         __syncthreads();

--- a/kernels/gemma4_bridge.cpp
+++ b/kernels/gemma4_bridge.cpp
@@ -838,6 +838,7 @@ int persistent_decode_device(int device_ordinal,
                              int num_layers, int hidden_size, int ple_hidden,
                              int position, float eps, float scale,
                              const void* layers,
+                             const void* kv_fp8_descs,
                              void* hidden_io, const void* per_layer_inputs,
                              void* workspace,
                              unsigned int* matvec_counter,
@@ -860,6 +861,7 @@ int persistent_decode_device(int device_ordinal,
         dim3(num_blocks), dim3(BLOCK), lds_bytes, 0,
         num_layers, hidden_size, ple_hidden, position, eps, scale,
         static_cast<const Gemma4DecodeLayerDesc*>(layers),
+        static_cast<const Gemma4KVCacheFp8Desc*>(kv_fp8_descs),
         static_cast<T*>(hidden_io),
         static_cast<const T*>(per_layer_inputs),
         static_cast<float*>(workspace),
@@ -1536,7 +1538,9 @@ extern "C" int dotcache_gemma4_hip_persistent_decode(
     int dtype, size_t device_ordinal,
     size_t num_layers, size_t hidden_size, size_t ple_hidden,
     size_t position, float eps, float scale,
-    const void* layers, void* hidden_io, const void* per_layer_inputs,
+    const void* layers,
+    const void* kv_fp8_descs,
+    void* hidden_io, const void* per_layer_inputs,
     void* workspace,
     unsigned int* matvec_counter,
     unsigned int* barrier_counter,
@@ -1546,8 +1550,8 @@ extern "C" int dotcache_gemma4_hip_persistent_decode(
         static_cast<int>(device_ordinal),                                      \
         static_cast<int>(num_layers), static_cast<int>(hidden_size),           \
         static_cast<int>(ple_hidden), static_cast<int>(position),              \
-        eps, scale, layers, hidden_io, per_layer_inputs, workspace,            \
-        matvec_counter, barrier_counter, barrier_flag
+        eps, scale, layers, kv_fp8_descs, hidden_io, per_layer_inputs,         \
+        workspace, matvec_counter, barrier_counter, barrier_flag
     switch (dtype) {
     case 0: return persistent_decode_device<__half>(G4_PERSIST_ARGS);
     case 1: return persistent_decode_device<float>(G4_PERSIST_ARGS);


### PR DESCRIPTION
## Summary

- Wires kernel- and FFI-side machinery for an FP8-E4M3 K/V cache in the Gemma 4 single-batch persistent decode kernel.
- Engine alloc + descriptor build + \`--kv-fp8\` bail-drop ride in a follow-up PR; this change is **no-op at runtime** (\`kv_fp8_descs\` always null), but lands the binary-stable contract the engine PR will fill in.
- Mirrors the Phi-4 KV-FP8 layout — per-(head, position) F32 absmax scales, BF16-rounded source values, FP8-E4M3-FN bytes in the cache buffer.

## Kernel changes (\`kernels/gemma4.hip\`)

- New mirror struct \`Gemma4KVCacheFp8Desc { kv_scale_k, kv_scale_v }\`.
- New FP8 helpers (\`g4_fp8_e4m3_to_float\`, \`g4_float_to_fp8_e4m3\`) duplicated from \`phi4.hip\` — gemma4.hip stays a standalone TU per the CLAUDE.md hipcc-codegen-fragility note.
- New \`g4_block_kv_append_f32_to_fp8\` primitive (per-(head, position) absmax → FP8 quant + scale write).
- Single-batch \`g4_persistent_decode_kernel\` takes \`kv_fp8_descs: const Gemma4KVCacheFp8Desc*\` (nullptr = BF16 KV). Branches in A3 (KV append), A4 (K read for QK scores), A6 (V read for attention output). Sliding/full layers share the same branch.
- Batched + INT4 variants are unchanged — matching FP8 paths there land later if needed.

## Bridge / FFI

- \`dotcache_gemma4_hip_persistent_decode\` extends with \`kv_fp8_descs\` (nullable).
- Rust \`persistent_decode\` wrapper now takes \`Option<&GpuBuffer>\`; the three existing callers (engine, \`gemma4_bench\`, \`gemma4_mega_decode_validate\`) pass \`None\` so behavior is unchanged.
- \`Gemma4Engine\` gains \`kv_scale_{k,v}\` + \`kv_fp8_descs_gpu\` placeholder fields, all \`None\` until the follow-up engine PR.

## Test plan

- [x] Full release build succeeds (HIP + Rust).
- [x] BF16 gemma4-e2b on gfx1100: \`The quick brown fox jumps over the\` → \`lazy dog. ...\` (unchanged decode quality).
- [x] Decode timing unchanged at ~39 ms/step.
- [ ] Engine PR will validate FP8-KV decode against BF16 oracle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)