### PR TITLE
Gemma 4 FP8 runtime scaffolding: struct + helper + binary contract

### DIFF
--- a/crates/kernel-ffi/src/gemma4.rs
+++ b/crates/kernel-ffi/src/gemma4.rs
@@ -401,6 +401,7 @@ unsafe extern "C" {
         scale: f32,
         layers: *const c_void,
         kv_fp8_descs: *const c_void,
+        fp8_scales: *const c_void,
         hidden_io: *mut c_void,
         per_layer_inputs: *const c_void,
         workspace: *mut c_void,
@@ -489,7 +490,7 @@ gemma4_stub! {
     fn dotcache_gemma4_hip_gather_layer_slice(dtype: c_int, device_ordinal: usize, seq_len: usize, num_layers: usize, ple_hidden: usize, layer_idx: usize, src: *const c_void, out: *mut c_void) -> c_int;
     fn dotcache_gemma4_hip_embed_gather_scaled(dtype: c_int, device_ordinal: usize, seq_len: usize, hidden_size: usize, vocab_size: usize, scale: f32, token_ids: *const c_uint, table: *const c_void, out: *mut c_void) -> c_int;
     fn dotcache_gemma4_hip_persistent_decode_int4(dtype: c_int, device_ordinal: usize, num_layers: usize, hidden_size: usize, ple_hidden: usize, position: usize, eps: f32, scale: f32, layers: *const c_void, int4_scales: *const c_void, hidden_io: *mut c_void, per_layer_inputs: *const c_void, workspace: *mut c_void, matvec_counter: *mut c_uint, barrier_counter: *mut c_uint, barrier_flag: *mut c_uint) -> c_int;
-    fn dotcache_gemma4_hip_persistent_decode(dtype: c_int, device_ordinal: usize, num_layers: usize, hidden_size: usize, ple_hidden: usize, position: usize, eps: f32, scale: f32, layers: *const c_void, kv_fp8_descs: *const c_void, hidden_io: *mut c_void, per_layer_inputs: *const c_void, workspace: *mut c_void, matvec_counter: *mut c_uint, barrier_counter: *mut c_uint, barrier_flag: *mut c_uint) -> c_int;
+    fn dotcache_gemma4_hip_persistent_decode(dtype: c_int, device_ordinal: usize, num_layers: usize, hidden_size: usize, ple_hidden: usize, position: usize, eps: f32, scale: f32, layers: *const c_void, kv_fp8_descs: *const c_void, fp8_scales: *const c_void, hidden_io: *mut c_void, per_layer_inputs: *const c_void, workspace: *mut c_void, matvec_counter: *mut c_uint, barrier_counter: *mut c_uint, barrier_flag: *mut c_uint) -> c_int;
     fn dotcache_gemma4_hip_persistent_decode_batch(dtype: c_int, device_ordinal: usize, num_layers: usize, hidden_size: usize, ple_hidden: usize, eps: f32, scale: f32, batch_size: usize, ws_stride: usize, layers: *const c_void, batch_descs: *const c_void, hidden_io: *mut c_void, per_layer_inputs: *const c_void, workspace: *mut c_void, matvec_counter: *mut c_uint, barrier_counter: *mut c_uint, barrier_flag: *mut c_uint) -> c_int;
     fn dotcache_gemma4_hip_persistent_decode_batch_int4(dtype: c_int, device_ordinal: usize, num_layers: usize, hidden_size: usize, ple_hidden: usize, eps: f32, scale: f32, batch_size: usize, ws_stride: usize, layers: *const c_void, int4_scales: *const c_void, batch_descs: *const c_void, hidden_io: *mut c_void, per_layer_inputs: *const c_void, workspace: *mut c_void, matvec_counter: *mut c_uint, barrier_counter: *mut c_uint, barrier_flag: *mut c_uint) -> c_int;
 }
@@ -1760,6 +1761,46 @@ impl Default for Gemma4KVCacheFp8Desc {
     }
 }
 
+/// Per-layer FP8-E4M3-FN weight scale-inv tensors for Gemma 4. Parallel-struct
+/// to [`Gemma4DecodeLayerDesc`] — when `--fp8-runtime` is active the main
+/// desc's projection slots (`q/k/v/o_proj_w`, `gate/up/down_proj_w`,
+/// `per_layer_input_gate_w`, `per_layer_projection_w`) hold u8-packed FP8
+/// bytes (reinterpreted at the kernel site) and this struct carries the
+/// matching BF16 per-block (typically 128×128) scale_inv tables.
+///
+/// Mirrors the Phi-4 layout (`Phi4FP8ScaleDesc`). Shared-KV layers do not
+/// need k/v scale entries (the `*_proj_w` slots themselves are null on those
+/// layers), but the kernel reads from this struct unconditionally — entries
+/// for skipped projections may be null.
+#[repr(C)]
+#[derive(Debug, Clone)]
+pub struct Gemma4FP8ScaleDesc {
+    // --- Attention projections ---
+    pub q_proj_scale: *const c_void,
+    pub k_proj_scale: *const c_void, // null when shared_kv
+    pub v_proj_scale: *const c_void, // null when shared_kv
+    pub o_proj_scale: *const c_void,
+    // --- MLP projections ---
+    pub gate_proj_scale: *const c_void,
+    pub up_proj_scale: *const c_void,
+    pub down_proj_scale: *const c_void,
+    // --- PLE projections ---
+    pub per_layer_input_gate_scale: *const c_void,
+    pub per_layer_projection_scale: *const c_void,
+    /// Per-block scale tile dimension (typically 128). Same value across
+    /// all projections in a bake.
+    pub block_size: c_int,
+}
+
+unsafe impl Send for Gemma4FP8ScaleDesc {}
+unsafe impl Sync for Gemma4FP8ScaleDesc {}
+
+impl Default for Gemma4FP8ScaleDesc {
+    fn default() -> Self {
+        unsafe { std::mem::zeroed() }
+    }
+}
+
 /// Per-sequence state pointers for batched Gemma 4 decode.
 ///
 /// One `Gemma4BatchSeqDesc` per layer (parallel array to
@@ -1838,6 +1879,7 @@ pub fn persistent_decode(
     dtype: ScalarType,
     layers: &GpuBuffer,
     kv_fp8_descs: Option<&GpuBuffer>,
+    fp8_scales: Option<&GpuBuffer>,
     hidden_io: &mut GpuBuffer,
     per_layer_inputs: &GpuBuffer,
     workspace: &mut GpuBuffer,
@@ -1854,6 +1896,9 @@ pub fn persistent_decode(
     let kv_fp8_ptr = kv_fp8_descs
         .map(|b| b.as_ptr())
         .unwrap_or(std::ptr::null());
+    let fp8_scales_ptr = fp8_scales
+        .map(|b| b.as_ptr())
+        .unwrap_or(std::ptr::null());
     let status = unsafe {
         dotcache_gemma4_hip_persistent_decode(
             dtype.kernel_dtype_code(),
@@ -1866,6 +1911,7 @@ pub fn persistent_decode(
             scale,
             layers.as_ptr(),
             kv_fp8_ptr,
+            fp8_scales_ptr,
             hidden_io.as_mut_ptr(),
             per_layer_inputs.as_ptr(),
             workspace.as_mut_ptr(),

--- a/crates/runner/src/bin/gemma4_bench.rs
+++ b/crates/runner/src/bin/gemma4_bench.rs
@@ -871,6 +871,7 @@ fn main() -> Result<()> {
             dtype,
             &layers_gpu,
             None,
+            None,
             h_io,
             &pli_gpu,
             &mut mega_workspace,

--- a/crates/runner/src/bin/gemma4_mega_decode_validate.rs
+++ b/crates/runner/src/bin/gemma4_mega_decode_validate.rs
@@ -831,6 +831,7 @@ fn main() -> Result<()> {
             dtype,
             &layers_gpu,
             None,
+            None,
             &mut h_running,
             &pli_gpu,
             &mut mega_workspace,

--- a/crates/runner/src/gemma4_engine.rs
+++ b/crates/runner/src/gemma4_engine.rs
@@ -487,6 +487,12 @@ pub struct Gemma4Engine {
     /// Per-sequence GPU array of `Gemma4KVCacheFp8Desc` (one entry per layer).
     /// `None` when KV cache is BF16. Plumbed through to `persistent_decode`.
     kv_fp8_descs_gpu: Option<Vec<GpuBuffer>>,
+    /// Single GPU array of `Gemma4FP8ScaleDesc` (one entry per layer; same
+    /// across sequences since weights are shared). `None` when weights are
+    /// BF16. The kernel-side body that consumes this lands in the FP8-runtime
+    /// follow-up PR; for now the contract is plumbed but the buffer is None.
+    #[allow(dead_code)]
+    fp8_scale_descs_gpu: Option<GpuBuffer>,
 }
 
 impl Gemma4Engine {
@@ -863,6 +869,7 @@ impl Gemma4Engine {
             kv_scale_k: if kv_fp8 { Some(kv_scale_k_buf) } else { None },
             kv_scale_v: if kv_fp8 { Some(kv_scale_v_buf) } else { None },
             kv_fp8_descs_gpu,
+            fp8_scale_descs_gpu: None,
         })
     }
 
@@ -1540,6 +1547,7 @@ impl Gemma4Engine {
             self.kv_fp8_descs_gpu
                 .as_ref()
                 .map(|v| &v[seq_idx]),
+            self.fp8_scale_descs_gpu.as_ref(),
             &mut h_running,
             &pli_gpu,
             &mut self.mega_workspace,

--- a/kernels/gemma4.hip
+++ b/kernels/gemma4.hip
@@ -113,6 +113,29 @@ __device__ inline float g4_fp8_e4m3_to_float(uint8_t byte) {
     return sign ? -val : val;
 }
 
+// Per-block FP8 weight dequant via an LDS lookup table. `lut[i]` precomputes
+// `g4_fp8_e4m3_to_float(i)` for i in 0..256, eliminating the branchy decoder
+// from the matmul hot loop. Caller fills the LUT once at kernel entry (one
+// thread per byte). `block_size` is typically 128 (matches the bake script).
+//
+// Returns the BF16-rounded F32 weight matching what `bake_fp8_gemma4.py`
+// emits — preserving the round trip `bf16 → fp8 → bf16` so dequant agrees
+// with PyTorch's reference. Mirrors `phi4.hip`'s `fp8_dequant_weight_lut`.
+__device__ inline float g4_fp8_dequant_weight_lut(
+    const void* w_ptr, const void* scale_ptr,
+    int row, int col, int cols, int block_size,
+    const float* __restrict__ lut
+) {
+    const uint8_t* fp8 = static_cast<const uint8_t*>(w_ptr);
+    const float val = lut[fp8[static_cast<size_t>(row) * cols + col]];
+    const hip_bfloat16* scales = static_cast<const hip_bfloat16*>(scale_ptr);
+    const int scale_row = row / block_size;
+    const int scale_col = col / block_size;
+    const int scale_cols = (cols + block_size - 1) / block_size;
+    const float scale = static_cast<float>(scales[scale_row * scale_cols + scale_col]);
+    return g4_bf16_round_rne_f32_finite(val * scale);
+}
+
 __device__ inline uint8_t g4_float_to_fp8_e4m3(float val) {
     uint8_t sign = 0;
     if (val < 0.0f) { sign = 0x80; val = -val; }
@@ -3263,6 +3286,23 @@ struct Gemma4KVCacheFp8Desc {
     void* kv_scale_v;  // [num_kv_heads, max_T] F32, or nullptr for BF16 KV
 };
 
+// Mirror of `Gemma4FP8ScaleDesc` in `crates/kernel-ffi/src/gemma4.rs`.
+// Parallel-struct to `Gemma4DecodeLayerDesc` — under --fp8-runtime the main
+// desc's projection slots hold u8-packed FP8 bytes (reinterpreted at the
+// matmul site) and this struct carries the matching BF16 scale_inv tiles.
+struct Gemma4FP8ScaleDesc {
+    const void* q_proj_scale;
+    const void* k_proj_scale;  // null when shared_kv
+    const void* v_proj_scale;  // null when shared_kv
+    const void* o_proj_scale;
+    const void* gate_proj_scale;
+    const void* up_proj_scale;
+    const void* down_proj_scale;
+    const void* per_layer_input_gate_scale;
+    const void* per_layer_projection_scale;
+    int         block_size;
+};
+
 template <typename T>
 __global__ void g4_persistent_decode_kernel(
     int num_layers,
@@ -3273,6 +3313,7 @@ __global__ void g4_persistent_decode_kernel(
     float scale,
     const Gemma4DecodeLayerDesc* __restrict__ layers,
     const Gemma4KVCacheFp8Desc* __restrict__ kv_fp8_descs, // null = BF16 KV
+    const Gemma4FP8ScaleDesc* __restrict__ fp8_scales,     // null = BF16 weights
     T* __restrict__ hidden_io,                          // [hidden_size] BF16 in/out
     const T* __restrict__ per_layer_inputs,              // [num_layers, ple_hidden] BF16
     float* __restrict__ workspace,
@@ -3280,6 +3321,11 @@ __global__ void g4_persistent_decode_kernel(
     unsigned int* __restrict__ barrier_counter,
     unsigned int* __restrict__ barrier_flag
 ) __attribute__((launch_bounds(256, 1))) {
+    // FP8-runtime weight dequant LUT — populated once per launch when active.
+    // Body wiring in PR-B; for now `fp8_scales` is parameter-only so the
+    // binary contract is stable and the engine PR can flip the flag without
+    // another bridge/FFI change. Reads of `fp8_scales` are no-ops here.
+    (void)fp8_scales;
     const int tid = threadIdx.x;
     const int bs = blockDim.x;
     const int nb = gridDim.x;

--- a/kernels/gemma4_bridge.cpp
+++ b/kernels/gemma4_bridge.cpp
@@ -839,6 +839,7 @@ int persistent_decode_device(int device_ordinal,
                              int position, float eps, float scale,
                              const void* layers,
                              const void* kv_fp8_descs,
+                             const void* fp8_scales,
                              void* hidden_io, const void* per_layer_inputs,
                              void* workspace,
                              unsigned int* matvec_counter,
@@ -862,6 +863,7 @@ int persistent_decode_device(int device_ordinal,
         num_layers, hidden_size, ple_hidden, position, eps, scale,
         static_cast<const Gemma4DecodeLayerDesc*>(layers),
         static_cast<const Gemma4KVCacheFp8Desc*>(kv_fp8_descs),
+        static_cast<const Gemma4FP8ScaleDesc*>(fp8_scales),
         static_cast<T*>(hidden_io),
         static_cast<const T*>(per_layer_inputs),
         static_cast<float*>(workspace),
@@ -1540,6 +1542,7 @@ extern "C" int dotcache_gemma4_hip_persistent_decode(
     size_t position, float eps, float scale,
     const void* layers,
     const void* kv_fp8_descs,
+    const void* fp8_scales,
     void* hidden_io, const void* per_layer_inputs,
     void* workspace,
     unsigned int* matvec_counter,
@@ -1550,8 +1553,9 @@ extern "C" int dotcache_gemma4_hip_persistent_decode(
         static_cast<int>(device_ordinal),                                      \
         static_cast<int>(num_layers), static_cast<int>(hidden_size),           \
         static_cast<int>(ple_hidden), static_cast<int>(position),              \
-        eps, scale, layers, kv_fp8_descs, hidden_io, per_layer_inputs,         \
-        workspace, matvec_counter, barrier_counter, barrier_flag
+        eps, scale, layers, kv_fp8_descs, fp8_scales, hidden_io,               \
+        per_layer_inputs, workspace,                                           \
+        matvec_counter, barrier_counter, barrier_flag
     switch (dtype) {
     case 0: return persistent_decode_device<__half>(G4_PERSIST_ARGS);
     case 1: return persistent_decode_device<float>(G4_PERSIST_ARGS);


### PR DESCRIPTION
## Summary

- Lays down the kernel- and FFI-side binary contract for a future Gemma 4 \`--fp8-runtime\` (FP8-weight) path.
- Body wiring (matmul-with-FP8-dequant inner loops) + engine + baker land in the follow-up PR; this PR is **no-op at runtime** (\`fp8_scales\` is always nullptr) but stabilizes the bridge/FFI surface.
- Mirrors how the Gemma 4 KV-FP8 work was split (#48 scaffold → #49 engine).

## What's in this PR

**Kernel (\`kernels/gemma4.hip\`):**
- New \`Gemma4FP8ScaleDesc\` C struct (parallel-struct to \`Gemma4DecodeLayerDesc\`) with all 9 per-projection scale_inv pointers (q/k/v/o + gate/up/down + per_layer_input_gate + per_layer_projection) + block_size.
- New \`g4_fp8_dequant_weight_lut(...)\` helper — mirrors \`phi4.hip\`'s pattern (LDS-LUT-driven FP8→F32, BF16-rounded to match Python bake's stored dequant).
- Single-batch \`g4_persistent_decode_kernel\` gains \`fp8_scales\` parameter (\`(void)fp8_scales\` in body for now; PR-B consumes it).

**Bridge / Rust FFI:**
- \`dotcache_gemma4_hip_persistent_decode\` + \`persistent_decode\` Rust wrapper extend with \`fp8_scales\`/\`Option<&GpuBuffer>\`.
- All three existing callers (engine, \`gemma4_bench\`, \`gemma4_mega_decode_validate\`) pass \`None\` so behavior is unchanged.

**Engine:**
- \`Gemma4Engine\` gains \`fp8_scale_descs_gpu: Option<GpuBuffer>\` placeholder field, \`None\` until PR-B.

## What's NOT in this PR (lands in PR-B)

- Matmul inner-loop branches that consume \`fp8_scales\` (6 sites: A2 QKV, A7 o_proj, B2 gate+up, B4 down, B7 PLI gate, B9 PLI projection).
- LUT init at kernel entry.
- \`oracle/bake_fp8_gemma4.py\` baker.
- \`Gemma4Engine\` weight-FP8 alloc + load_baked extension.
- Drop the \`--fp8-runtime\` bail in \`run_gemma4\`.
- VRAM admission scaling for FP8 weights.

## Test plan

- [x] Full release build succeeds (HIP + Rust).
- [x] BF16 gemma4-e2b on gfx1100: \`The quick brown fox jumps over the\` → \`lazy dog.\` (unchanged).
- [x] \`--kv-fp8\` gemma4-e2b on gfx1100: same output (unchanged).
- [ ] PR-B will validate \`--fp8-runtime\` against BF16 oracle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)