### PR TITLE
Gemma 4 --fp8-runtime: kernel body + baker + engine + drop bail

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,18 +23,18 @@ Four backend surfaces are validated today:
 | qwen3.5-2b       |  ✅  |  ✅  |      ✅     |   ✅   |
 | qwen3.5-4b       |  ✅  |  ✅  |      ✅     |   ✅   |
 | qwen3.5-9b       |  ✅  |  ✅  |      ✅     |   ✅   |
-| gemma4-e2b       |  ✅  |  ✅  |      —      |   ✅²  |
-| gemma4-e4b       |  ✅  |  ✅¹ |      —      |   ✅²  |
+| gemma4-e2b       |  ✅  |  ✅  |     ✅²    |   ✅²  |
+| gemma4-e4b       |  ✅  |  ✅¹ |     ✅²    |   ✅²  |
 | phi4-mini        |  ✅  |  ✅  |      ✅     |   ✅   |
 
 ¹ Gemma E4B INT4 needs `--group-size 64` at calibration time (the default
   128 produces gibberish — see fix in `oracle/bake_all.sh`). The published
   release bake is the gs=64 version; consumers fetch it automatically.
-² Gemma 4 `--kv-fp8` is wired into the single-batch persistent decode
-  kernel only — it requires `--batch-size=1` and cannot combine with
-  `--int4` (the INT4 kernel doesn't yet route the FP8-KV path). Prefill
-  for FP8-KV runs per-token through the same persistent kernel rather
-  than the BF16 prefill primitive chain.
+² Gemma 4 `--kv-fp8` and `--fp8-runtime` are wired into the single-batch
+  persistent decode kernel only — both require `--batch-size=1` and
+  cannot combine with `--int4` (the INT4 kernel doesn't yet route the
+  FP8 paths). Prefill under either FP8 mode runs per-token through the
+  same persistent kernel rather than the BF16 prefill primitive chain.
 
 ### HIP on `gfx1150`
 

--- a/crates/runner/src/gemma4_engine.rs
+++ b/crates/runner/src/gemma4_engine.rs
@@ -650,6 +650,27 @@ impl Gemma4Engine {
                 kernel_ffi::MAX_BATCH_SIZE
             );
         }
+        // Engine-level FP8 guards. The CLI in `run_gemma4` rejects these
+        // combos with explanatory messages, but other callers of the
+        // public API (server crate, validators, integration tests) bypass
+        // that guard. The batched persistent-decode kernel has no FP8
+        // scale descriptor parameter, so running it with FP8 byte buffers
+        // would silently dispatch BF16 matmul against FP8-packed weights
+        // / KV bytes — corrupt logits, possible OOB reads. Reject here.
+        if fp8_runtime && batch_size > 1 {
+            bail!(
+                "Gemma4Engine: --fp8-runtime requires batch_size = 1 (FP8 \
+                 weight dequant is wired into the single-batch persistent \
+                 decode kernel only; got batch_size = {batch_size})"
+            );
+        }
+        if kv_fp8 && batch_size > 1 {
+            bail!(
+                "Gemma4Engine: --kv-fp8 requires batch_size = 1 (FP8 KV cache \
+                 path is wired into the single-batch persistent decode kernel \
+                 only; got batch_size = {batch_size})"
+            );
+        }
         gpu_hal::set_device(device).map_err(|e| anyhow!("set_device: {e}"))?;
         let config: Config =
             ::gemma4::config::load_config(model_dir).map_err(|e| anyhow!("load_config: {e}"))?;

--- a/crates/runner/src/gemma4_engine.rs
+++ b/crates/runner/src/gemma4_engine.rs
@@ -22,7 +22,9 @@ use anyhow::{anyhow, bail, Context, Result};
 use gpu_hal::{GpuBuffer, ScalarType};
 use half::bf16;
 use kernel_ffi::gemma4 as g4;
-use kernel_ffi::gemma4::{Gemma4BatchSeqDesc, Gemma4DecodeLayerDesc, Gemma4KVCacheFp8Desc};
+use kernel_ffi::gemma4::{
+    Gemma4BatchSeqDesc, Gemma4DecodeLayerDesc, Gemma4FP8ScaleDesc, Gemma4KVCacheFp8Desc,
+};
 use memmap2::Mmap;
 use safetensors::SafeTensors;
 
@@ -343,6 +345,20 @@ struct LayerWeights {
     per_layer_input_gate_w: GpuBuffer,
     per_layer_projection_w: GpuBuffer,
     post_per_layer_input_norm_w: GpuBuffer,
+
+    // Per-block FP8 scale_inv tensors. None on BF16 layers; populated when
+    // the engine loaded this layer from a v2-fp8 bake. Each is BF16
+    // [rows/block, cols/block] matching the kernel's expected layout for
+    // `g4_fp8_dequant_weight_lut`.
+    q_proj_fp8_scale: Option<GpuBuffer>,
+    k_proj_fp8_scale: Option<GpuBuffer>,
+    v_proj_fp8_scale: Option<GpuBuffer>,
+    o_proj_fp8_scale: Option<GpuBuffer>,
+    gate_proj_fp8_scale: Option<GpuBuffer>,
+    up_proj_fp8_scale: Option<GpuBuffer>,
+    down_proj_fp8_scale: Option<GpuBuffer>,
+    per_layer_input_gate_fp8_scale: Option<GpuBuffer>,
+    per_layer_projection_fp8_scale: Option<GpuBuffer>,
 }
 
 fn load_layer_weights(
@@ -416,7 +432,85 @@ fn load_layer_weights(
             .load_bf16_to_gpu(device, &want("per_layer_projection.weight")?)?,
         post_per_layer_input_norm_w: loader
             .load_bf16_to_gpu(device, &want("post_per_layer_input_norm.weight")?)?,
+        // FP8 scales — populated only by `apply_fp8_overlay` post-load.
+        q_proj_fp8_scale: None,
+        k_proj_fp8_scale: None,
+        v_proj_fp8_scale: None,
+        o_proj_fp8_scale: None,
+        gate_proj_fp8_scale: None,
+        up_proj_fp8_scale: None,
+        down_proj_fp8_scale: None,
+        per_layer_input_gate_fp8_scale: None,
+        per_layer_projection_fp8_scale: None,
     })
+}
+
+/// Replace each layer's projection BF16 buffers with their FP8 byte
+/// counterparts and load the matching `*_scale_inv` tensors. Run once
+/// after the BF16 load when `--fp8-runtime` is active. The peak memory
+/// is BF16 + FP8 briefly held across the swap, but each BF16 buffer is
+/// dropped immediately after its FP8 replacement is loaded so the steady
+/// state stays at ~half the BF16 footprint.
+fn apply_fp8_overlay(
+    layers: &mut [LayerWeights],
+    store: &model_store::BakedStore,
+    weight_prefix: &str,
+    ordinal: usize,
+) -> Result<usize> {
+    let mut block_size: usize = 0;
+    let infer_block = |store: &model_store::BakedStore, scale_name: &str, weight_cols: usize| -> Result<usize> {
+        let s = store
+            .shape(scale_name)
+            .ok_or_else(|| anyhow!("missing scale tensor {scale_name}"))?;
+        if s.len() != 2 {
+            bail!("{scale_name} shape {:?} not 2D", s);
+        }
+        Ok(weight_cols / s[1])
+    };
+
+    for (idx, w) in layers.iter_mut().enumerate() {
+        let lp = format!("{weight_prefix}.layers.{idx}");
+        // Helper closure shorthand to swap BF16 → FP8 + load scale_inv.
+        let mut swap = |buf: &mut GpuBuffer, name: &str| -> Result<GpuBuffer> {
+            let scale_name = format!("{name}_scale_inv");
+            let new_w = store.load_to_gpu(name, ordinal)?;
+            let scale = store.load_to_gpu(&scale_name, ordinal)?;
+            *buf = new_w;
+            Ok(scale)
+        };
+
+        w.q_proj_fp8_scale = Some(swap(&mut w.q_proj, &format!("{lp}.self_attn.q_proj.weight"))?);
+        w.o_proj_fp8_scale = Some(swap(&mut w.o_proj, &format!("{lp}.self_attn.o_proj.weight"))?);
+        if !w.shared_kv {
+            // k/v_proj exist on owned layers only.
+            let kp = w.k_proj.as_mut().ok_or_else(|| anyhow!("layer {idx}: missing k_proj"))?;
+            let vp = w.v_proj.as_mut().ok_or_else(|| anyhow!("layer {idx}: missing v_proj"))?;
+            w.k_proj_fp8_scale = Some(swap(kp, &format!("{lp}.self_attn.k_proj.weight"))?);
+            w.v_proj_fp8_scale = Some(swap(vp, &format!("{lp}.self_attn.v_proj.weight"))?);
+        }
+        w.gate_proj_fp8_scale = Some(swap(&mut w.gate_proj, &format!("{lp}.mlp.gate_proj.weight"))?);
+        w.up_proj_fp8_scale = Some(swap(&mut w.up_proj, &format!("{lp}.mlp.up_proj.weight"))?);
+        w.down_proj_fp8_scale = Some(swap(&mut w.down_proj, &format!("{lp}.mlp.down_proj.weight"))?);
+        w.per_layer_input_gate_fp8_scale = Some(swap(
+            &mut w.per_layer_input_gate_w,
+            &format!("{lp}.per_layer_input_gate.weight"),
+        )?);
+        w.per_layer_projection_fp8_scale = Some(swap(
+            &mut w.per_layer_projection_w,
+            &format!("{lp}.per_layer_projection.weight"),
+        )?);
+
+        if block_size == 0 {
+            // Infer block_size from the q_proj scale shape (cols / scale_cols).
+            let q_w_cols = w.q_proj.shape()[1];
+            block_size = infer_block(
+                store,
+                &format!("{lp}.self_attn.q_proj.weight_scale_inv"),
+                q_w_cols,
+            )?;
+        }
+    }
+    Ok(block_size)
 }
 
 pub struct Gemma4Engine {
@@ -540,6 +634,24 @@ impl Gemma4Engine {
         batch_size: usize,
         kv_fp8: bool,
     ) -> Result<Self> {
+        Self::load_with_quant(model_dir, weight_prefix, max_t, device, batch_size, kv_fp8, false)
+    }
+
+    /// `load_with_options` plus an explicit `--fp8-runtime` toggle. Set
+    /// `fp8_runtime = true` to load the v2-fp8 baked package (produced by
+    /// `oracle/bake_fp8_gemma4.py`); the engine swaps each layer's projection
+    /// BF16 buffers with their FP8 byte counterparts and uploads the
+    /// per-layer `Gemma4FP8ScaleDesc` array consumed by the kernel.
+    #[allow(clippy::too_many_arguments)]
+    pub fn load_with_quant(
+        model_dir: &Path,
+        weight_prefix: &'static str,
+        max_t: usize,
+        device: usize,
+        batch_size: usize,
+        kv_fp8: bool,
+        fp8_runtime: bool,
+    ) -> Result<Self> {
         if batch_size == 0 {
             bail!("Gemma4Engine: batch_size must be >= 1");
         }
@@ -582,6 +694,30 @@ impl Gemma4Engine {
             device,
             &format!("{weight_prefix}.per_layer_projection_norm.weight"),
         )?;
+
+        // FP8-runtime overlay — swap projection BF16 buffers for FP8 bytes
+        // and load the matching scale_inv tiles. Engines that pass
+        // `fp8_runtime = false` keep the BF16 buffers loaded above.
+        let fp8_block_size: usize = if fp8_runtime {
+            let bake_dir = model_store::fetch::BakeVariant::Fp8Native.bake_dir(model_dir);
+            if !model_store::version_ok(&bake_dir) {
+                bail!(
+                    "Gemma 4 FP8 bake not found at {} — run: \
+                     python3 oracle/bake_fp8_gemma4.py --model-dir {}",
+                    bake_dir.display(),
+                    model_dir.display(),
+                );
+            }
+            eprintln!(
+                "[gemma4] loading FP8 baked package from {}",
+                bake_dir.display()
+            );
+            let store = model_store::BakedStore::open(&bake_dir)
+                .map_err(|e| anyhow!("open Gemma 4 FP8 bake: {e}"))?;
+            apply_fp8_overlay(&mut layers, &store, weight_prefix, device)?
+        } else {
+            0
+        };
 
         let num_kv_heads = tcfg.num_key_value_heads;
         let num_q_heads = tcfg.num_attention_heads;
@@ -743,6 +879,49 @@ impl Gemma4Engine {
         // layer's scale buffers (matching how kv_cache_k/v aliases work in
         // the main desc), so the kernel's read sites never need to look up
         // the mapping.
+        // Per-layer Gemma4FP8ScaleDesc array on GPU, populated only when
+        // `--fp8-runtime` is active. Weights are shared across sequences,
+        // so this is a single buffer (not batched). Shared-KV layers leave
+        // their `k/v_proj_scale` slots null because the matmul sites for
+        // those projections are bypassed (k/v_proj_w is also null in the
+        // main descriptor).
+        let fp8_scale_descs_gpu: Option<GpuBuffer> = if fp8_runtime {
+            let null_p = std::ptr::null::<c_void>();
+            let mut layer_descs: Vec<Gemma4FP8ScaleDesc> = Vec::with_capacity(num_layers);
+            for l in 0..num_layers {
+                let w = &layers[l];
+                let take = |b: &Option<GpuBuffer>| -> *const c_void {
+                    b.as_ref().map(|x| x.as_ptr()).unwrap_or(null_p)
+                };
+                layer_descs.push(Gemma4FP8ScaleDesc {
+                    q_proj_scale: take(&w.q_proj_fp8_scale),
+                    k_proj_scale: take(&w.k_proj_fp8_scale),
+                    v_proj_scale: take(&w.v_proj_fp8_scale),
+                    o_proj_scale: take(&w.o_proj_fp8_scale),
+                    gate_proj_scale: take(&w.gate_proj_fp8_scale),
+                    up_proj_scale: take(&w.up_proj_fp8_scale),
+                    down_proj_scale: take(&w.down_proj_fp8_scale),
+                    per_layer_input_gate_scale: take(&w.per_layer_input_gate_fp8_scale),
+                    per_layer_projection_scale: take(&w.per_layer_projection_fp8_scale),
+                    block_size: fp8_block_size as c_int,
+                });
+            }
+            let bytes: &[u8] = unsafe {
+                std::slice::from_raw_parts(
+                    layer_descs.as_ptr() as *const u8,
+                    layer_descs.len() * std::mem::size_of::<Gemma4FP8ScaleDesc>(),
+                )
+            };
+            Some(GpuBuffer::from_host_bytes(
+                device,
+                ScalarType::U8,
+                &[bytes.len()],
+                bytes,
+            )?)
+        } else {
+            None
+        };
+
         let kv_fp8_descs_gpu: Option<Vec<GpuBuffer>> = if kv_fp8 {
             let mut bufs: Vec<GpuBuffer> = Vec::with_capacity(batch_size);
             for seq in 0..batch_size {
@@ -869,7 +1048,7 @@ impl Gemma4Engine {
             kv_scale_k: if kv_fp8 { Some(kv_scale_k_buf) } else { None },
             kv_scale_v: if kv_fp8 { Some(kv_scale_v_buf) } else { None },
             kv_fp8_descs_gpu,
-            fp8_scale_descs_gpu: None,
+            fp8_scale_descs_gpu,
         })
     }
 
@@ -977,24 +1156,28 @@ impl Gemma4Engine {
         if seq_len > self.max_t {
             bail!("prefill: prompt_len {seq_len} > max_t {}", self.max_t);
         }
-        // Under --kv-fp8 the K/V cache buffers are u8 (FP8-E4M3), so the
-        // BF16-typed prefill primitive chain (`kv_append_prefill`,
-        // `attn_prefill`, `copy_kv_slots_range`) can't write into them
-        // correctly. Route prefill through the same persistent decode
-        // kernel that decode uses — one call per prompt token. Slower than
-        // batched prefill but the FP8 path is only wired into the
-        // single-batch persistent kernel today, so this stays consistent
-        // with the kernel's contract.
+        // Under --kv-fp8 (u8 K/V cache) OR --fp8-runtime (u8 projection
+        // weights) the BF16 prefill primitive chain (`kv_append_prefill`,
+        // `attn_prefill`, `copy_kv_slots_range`, `matvec_batched` against
+        // BF16-typed buffers) reads element widths that no longer match
+        // the actual byte layout. Route prefill through the same
+        // persistent decode kernel that decode uses — one call per prompt
+        // token. Slower than batched prefill but the FP8 paths are only
+        // wired into the single-batch persistent kernel today, so this
+        // stays consistent with the kernel's contract.
         //
         // `capture` (per-layer activation capture for diagnostic tooling)
         // is intentionally rejected here: the per-token persistent decode
         // path doesn't expose the prefill primitive intermediates the
         // capture struct needs.
-        if self.kv_fp8_descs_gpu.is_some() {
+        let needs_persistent_prefill =
+            self.kv_fp8_descs_gpu.is_some() || self.fp8_scale_descs_gpu.is_some();
+        if needs_persistent_prefill {
             if capture {
                 bail!(
-                    "Gemma 4 --kv-fp8 prefill cannot also capture per-layer \
-                     activations (no FP8-aware capture path yet)"
+                    "Gemma 4 FP8 modes (--kv-fp8 / --fp8-runtime) prefill cannot \
+                     also capture per-layer activations (no FP8-aware capture \
+                     path yet)"
                 );
             }
             let mut last_logits: Vec<f32> = Vec::new();

--- a/crates/runner/src/gemma4_engine.rs
+++ b/crates/runner/src/gemma4_engine.rs
@@ -363,6 +363,7 @@ struct LayerWeights {
 
 fn load_layer_weights(
     loader: &UnbakedLoader,
+    fp8_store: Option<&model_store::BakedStore>,
     device: usize,
     tcfg: &TextConfig,
     weight_prefix: &str,
@@ -386,6 +387,27 @@ fn load_layer_weights(
             .ok_or_else(|| anyhow!("no tensor spec matching *.{short}"))
     };
 
+    // Helper: load a quantizable projection. Under `fp8_store`, returns
+    // (FP8 byte buffer, Some(scale_inv buffer)); otherwise returns the
+    // raw BF16 buffer with no scale. This is the key invariant for the
+    // VRAM admission match — under `--fp8-runtime` we MUST NOT first
+    // allocate the BF16 weights and then swap, because preflight has
+    // already lowered the budget to FP8-scaled.
+    let load_proj = |name: &str| -> Result<(GpuBuffer, Option<GpuBuffer>)> {
+        if let Some(store) = fp8_store {
+            let w = store
+                .load_to_gpu(name, device)
+                .map_err(|e| anyhow!("load FP8 weight {name}: {e}"))?;
+            let scale_name = format!("{name}_scale_inv");
+            let s = store
+                .load_to_gpu(&scale_name, device)
+                .map_err(|e| anyhow!("load FP8 scale {scale_name}: {e}"))?;
+            Ok((w, Some(s)))
+        } else {
+            Ok((loader.load_bf16_to_gpu(device, name)?, None))
+        }
+    };
+
     let layer_scalar_value: f32 = {
         let (shape, bytes) = loader.tensor_bytes(&want("layer_scalar")?)?;
         if shape != [1] {
@@ -394,14 +416,25 @@ fn load_layer_weights(
         bf16_bytes_to_f32(bytes)[0]
     };
 
-    let (k_proj, v_proj, k_norm) = if shared_kv {
-        (None, None, None)
+    let (q_proj, q_proj_fp8_scale) = load_proj(&want("self_attn.q_proj.weight")?)?;
+    let (o_proj, o_proj_fp8_scale) = load_proj(&want("self_attn.o_proj.weight")?)?;
+    let (gate_proj, gate_proj_fp8_scale) = load_proj(&want("mlp.gate_proj.weight")?)?;
+    let (up_proj, up_proj_fp8_scale) = load_proj(&want("mlp.up_proj.weight")?)?;
+    let (down_proj, down_proj_fp8_scale) = load_proj(&want("mlp.down_proj.weight")?)?;
+    let (per_layer_input_gate_w, per_layer_input_gate_fp8_scale) =
+        load_proj(&want("per_layer_input_gate.weight")?)?;
+    let (per_layer_projection_w, per_layer_projection_fp8_scale) =
+        load_proj(&want("per_layer_projection.weight")?)?;
+
+    let (k_proj, v_proj, k_norm, k_proj_fp8_scale, v_proj_fp8_scale) = if shared_kv {
+        (None, None, None, None, None)
     } else {
-        (
-            Some(loader.load_bf16_to_gpu(device, &want("self_attn.k_proj.weight")?)?),
-            Some(loader.load_bf16_to_gpu(device, &want("self_attn.v_proj.weight")?)?),
-            Some(loader.load_bf16_to_gpu(device, &want("self_attn.k_norm.weight")?)?),
-        )
+        let (kp, kps) = load_proj(&want("self_attn.k_proj.weight")?)?;
+        let (vp, vps) = load_proj(&want("self_attn.v_proj.weight")?)?;
+        // k_norm is BF16 in both modes (it's a [head_dim] vector, not a
+        // matmul-input projection — not quantized in the bake).
+        let kn = loader.load_bf16_to_gpu(device, &want("self_attn.k_norm.weight")?)?;
+        (Some(kp), Some(vp), Some(kn), kps, vps)
     };
 
     Ok(LayerWeights {
@@ -411,106 +444,61 @@ fn load_layer_weights(
         shared_kv,
         kv_source,
         layer_scalar: layer_scalar_value,
+        // Norms / scalars are unquantized in the FP8 bake — always BF16.
         input_norm: loader.load_bf16_to_gpu(device, &want("input_layernorm.weight")?)?,
-        q_proj: loader.load_bf16_to_gpu(device, &want("self_attn.q_proj.weight")?)?,
+        q_proj,
         q_norm: loader.load_bf16_to_gpu(device, &want("self_attn.q_norm.weight")?)?,
         k_proj,
         v_proj,
         k_norm,
-        o_proj: loader.load_bf16_to_gpu(device, &want("self_attn.o_proj.weight")?)?,
+        o_proj,
         post_attn_norm: loader
             .load_bf16_to_gpu(device, &want("post_attention_layernorm.weight")?)?,
         pre_ff_norm: loader.load_bf16_to_gpu(device, &want("pre_feedforward_layernorm.weight")?)?,
         post_ff_norm: loader
             .load_bf16_to_gpu(device, &want("post_feedforward_layernorm.weight")?)?,
-        gate_proj: loader.load_bf16_to_gpu(device, &want("mlp.gate_proj.weight")?)?,
-        up_proj: loader.load_bf16_to_gpu(device, &want("mlp.up_proj.weight")?)?,
-        down_proj: loader.load_bf16_to_gpu(device, &want("mlp.down_proj.weight")?)?,
-        per_layer_input_gate_w: loader
-            .load_bf16_to_gpu(device, &want("per_layer_input_gate.weight")?)?,
-        per_layer_projection_w: loader
-            .load_bf16_to_gpu(device, &want("per_layer_projection.weight")?)?,
+        gate_proj,
+        up_proj,
+        down_proj,
+        per_layer_input_gate_w,
+        per_layer_projection_w,
         post_per_layer_input_norm_w: loader
             .load_bf16_to_gpu(device, &want("post_per_layer_input_norm.weight")?)?,
-        // FP8 scales — populated only by `apply_fp8_overlay` post-load.
-        q_proj_fp8_scale: None,
-        k_proj_fp8_scale: None,
-        v_proj_fp8_scale: None,
-        o_proj_fp8_scale: None,
-        gate_proj_fp8_scale: None,
-        up_proj_fp8_scale: None,
-        down_proj_fp8_scale: None,
-        per_layer_input_gate_fp8_scale: None,
-        per_layer_projection_fp8_scale: None,
+        q_proj_fp8_scale,
+        k_proj_fp8_scale,
+        v_proj_fp8_scale,
+        o_proj_fp8_scale,
+        gate_proj_fp8_scale,
+        up_proj_fp8_scale,
+        down_proj_fp8_scale,
+        per_layer_input_gate_fp8_scale,
+        per_layer_projection_fp8_scale,
     })
 }
 
-/// Replace each layer's projection BF16 buffers with their FP8 byte
-/// counterparts and load the matching `*_scale_inv` tensors. Run once
-/// after the BF16 load when `--fp8-runtime` is active. The peak memory
-/// is BF16 + FP8 briefly held across the swap, but each BF16 buffer is
-/// dropped immediately after its FP8 replacement is loaded so the steady
-/// state stays at ~half the BF16 footprint.
-fn apply_fp8_overlay(
-    layers: &mut [LayerWeights],
+/// Infer the per-block FP8 quantization tile dimension from the shape
+/// of any q_proj scale tensor (`weight_cols / scale_cols`). Same value
+/// across all projections in a bake (bake_fp8_gemma4.py uses 128).
+fn infer_fp8_block_size(
     store: &model_store::BakedStore,
     weight_prefix: &str,
-    ordinal: usize,
 ) -> Result<usize> {
-    let mut block_size: usize = 0;
-    let infer_block = |store: &model_store::BakedStore, scale_name: &str, weight_cols: usize| -> Result<usize> {
-        let s = store
-            .shape(scale_name)
-            .ok_or_else(|| anyhow!("missing scale tensor {scale_name}"))?;
-        if s.len() != 2 {
-            bail!("{scale_name} shape {:?} not 2D", s);
-        }
-        Ok(weight_cols / s[1])
-    };
-
-    for (idx, w) in layers.iter_mut().enumerate() {
-        let lp = format!("{weight_prefix}.layers.{idx}");
-        // Helper closure shorthand to swap BF16 → FP8 + load scale_inv.
-        let mut swap = |buf: &mut GpuBuffer, name: &str| -> Result<GpuBuffer> {
-            let scale_name = format!("{name}_scale_inv");
-            let new_w = store.load_to_gpu(name, ordinal)?;
-            let scale = store.load_to_gpu(&scale_name, ordinal)?;
-            *buf = new_w;
-            Ok(scale)
-        };
-
-        w.q_proj_fp8_scale = Some(swap(&mut w.q_proj, &format!("{lp}.self_attn.q_proj.weight"))?);
-        w.o_proj_fp8_scale = Some(swap(&mut w.o_proj, &format!("{lp}.self_attn.o_proj.weight"))?);
-        if !w.shared_kv {
-            // k/v_proj exist on owned layers only.
-            let kp = w.k_proj.as_mut().ok_or_else(|| anyhow!("layer {idx}: missing k_proj"))?;
-            let vp = w.v_proj.as_mut().ok_or_else(|| anyhow!("layer {idx}: missing v_proj"))?;
-            w.k_proj_fp8_scale = Some(swap(kp, &format!("{lp}.self_attn.k_proj.weight"))?);
-            w.v_proj_fp8_scale = Some(swap(vp, &format!("{lp}.self_attn.v_proj.weight"))?);
-        }
-        w.gate_proj_fp8_scale = Some(swap(&mut w.gate_proj, &format!("{lp}.mlp.gate_proj.weight"))?);
-        w.up_proj_fp8_scale = Some(swap(&mut w.up_proj, &format!("{lp}.mlp.up_proj.weight"))?);
-        w.down_proj_fp8_scale = Some(swap(&mut w.down_proj, &format!("{lp}.mlp.down_proj.weight"))?);
-        w.per_layer_input_gate_fp8_scale = Some(swap(
-            &mut w.per_layer_input_gate_w,
-            &format!("{lp}.per_layer_input_gate.weight"),
-        )?);
-        w.per_layer_projection_fp8_scale = Some(swap(
-            &mut w.per_layer_projection_w,
-            &format!("{lp}.per_layer_projection.weight"),
-        )?);
-
-        if block_size == 0 {
-            // Infer block_size from the q_proj scale shape (cols / scale_cols).
-            let q_w_cols = w.q_proj.shape()[1];
-            block_size = infer_block(
-                store,
-                &format!("{lp}.self_attn.q_proj.weight_scale_inv"),
-                q_w_cols,
-            )?;
-        }
+    let q_name = format!("{weight_prefix}.layers.0.self_attn.q_proj.weight");
+    let scale_name = format!("{q_name}_scale_inv");
+    let w_shape = store
+        .shape(&q_name)
+        .ok_or_else(|| anyhow!("FP8 bake missing {q_name}"))?;
+    let s_shape = store
+        .shape(&scale_name)
+        .ok_or_else(|| anyhow!("FP8 bake missing {scale_name}"))?;
+    if w_shape.len() != 2 || s_shape.len() != 2 {
+        bail!(
+            "FP8 bake q_proj shapes not 2D: weight {:?}, scale {:?}",
+            w_shape,
+            s_shape
+        );
     }
-    Ok(block_size)
+    Ok(w_shape[1] / s_shape[1])
 }
 
 pub struct Gemma4Engine {
@@ -671,10 +659,45 @@ impl Gemma4Engine {
         let num_layers = tcfg.num_hidden_layers;
         let dtype = ScalarType::BF16;
 
+        // Open the v2-fp8 BakedStore upfront under `--fp8-runtime` so each
+        // layer can load its FP8 projections directly from the bake — never
+        // allocating BF16 projection buffers. This keeps the GPU memory
+        // peak in line with the FP8-scaled VRAM admission budget set in
+        // `run_gemma4`. Without this, preflight would lower the budget for
+        // FP8 but the constructor would still allocate BF16 weights and
+        // OOM mid-load on memory-constrained cards. (Codex review #51.)
+        let fp8_store: Option<model_store::BakedStore> = if fp8_runtime {
+            let bake_dir = model_store::fetch::BakeVariant::Fp8Native.bake_dir(model_dir);
+            if !model_store::version_ok(&bake_dir) {
+                bail!(
+                    "Gemma 4 FP8 bake not found at {} — run: \
+                     python3 oracle/bake_fp8_gemma4.py --model-dir {}",
+                    bake_dir.display(),
+                    model_dir.display(),
+                );
+            }
+            eprintln!(
+                "[gemma4] loading FP8 baked package from {}",
+                bake_dir.display()
+            );
+            Some(
+                model_store::BakedStore::open(&bake_dir)
+                    .map_err(|e| anyhow!("open Gemma 4 FP8 bake: {e}"))?,
+            )
+        } else {
+            None
+        };
+        let fp8_block_size: usize = if let Some(store) = fp8_store.as_ref() {
+            infer_fp8_block_size(store, weight_prefix)?
+        } else {
+            0
+        };
+
         let mut layers: Vec<LayerWeights> = Vec::with_capacity(num_layers);
         for i in 0..num_layers {
             layers.push(load_layer_weights(
                 &loader,
+                fp8_store.as_ref(),
                 device,
                 &tcfg,
                 weight_prefix,
@@ -694,30 +717,6 @@ impl Gemma4Engine {
             device,
             &format!("{weight_prefix}.per_layer_projection_norm.weight"),
         )?;
-
-        // FP8-runtime overlay — swap projection BF16 buffers for FP8 bytes
-        // and load the matching scale_inv tiles. Engines that pass
-        // `fp8_runtime = false` keep the BF16 buffers loaded above.
-        let fp8_block_size: usize = if fp8_runtime {
-            let bake_dir = model_store::fetch::BakeVariant::Fp8Native.bake_dir(model_dir);
-            if !model_store::version_ok(&bake_dir) {
-                bail!(
-                    "Gemma 4 FP8 bake not found at {} — run: \
-                     python3 oracle/bake_fp8_gemma4.py --model-dir {}",
-                    bake_dir.display(),
-                    model_dir.display(),
-                );
-            }
-            eprintln!(
-                "[gemma4] loading FP8 baked package from {}",
-                bake_dir.display()
-            );
-            let store = model_store::BakedStore::open(&bake_dir)
-                .map_err(|e| anyhow!("open Gemma 4 FP8 bake: {e}"))?;
-            apply_fp8_overlay(&mut layers, &store, weight_prefix, device)?
-        } else {
-            0
-        };
 
         let num_kv_heads = tcfg.num_key_value_heads;
         let num_q_heads = tcfg.num_attention_heads;

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -2669,8 +2669,17 @@ fn run_gemma4(
         FamilyParams::Llama31(_) => unreachable!("dispatch filtered to Gemma4"),
     };
 
-    if cli.fp8_runtime {
-        anyhow::bail!("Gemma 4 does not yet support --fp8-runtime");
+    if cli.fp8_runtime && cli.int4 {
+        anyhow::bail!(
+            "Gemma 4 --fp8-runtime cannot combine with --int4 (the INT4 kernel \
+             does not yet route the FP8 weight-dequant path)"
+        );
+    }
+    if cli.fp8_runtime && cli.batch_size != 1 {
+        anyhow::bail!(
+            "Gemma 4 --fp8-runtime currently requires --batch-size=1 (FP8 weight \
+             dequant is wired into the single-batch persistent decode kernel only)"
+        );
     }
     if cli.kv_fp8 && cli.int4 {
         anyhow::bail!(
@@ -2786,13 +2795,33 @@ fn run_gemma4(
     let kv_bytes_per_seq =
         kv_elems_per_token * context_tokens as u64 * kv_dtype_bytes + scale_bytes_per_seq;
     let kv_bytes = kv_bytes_per_seq * batch_size_u64;
+    // The registry's `fixed_bytes` budget is sized for BF16 weights + scratch.
+    // Under `--int4` the weight footprint drops to ~1/4 BF16; under
+    // `--fp8-runtime` to ~1/2 (plus a tiny scale_inv overhead). Mirror the
+    // 0.37× / 0.6× scaling used in phi4_engine.rs so memory-constrained cards
+    // can actually run these flags.
+    let quant_fixed_bytes: u64 = if cli.int4 {
+        (entry.vram.fixed_bytes as f64 * 0.37) as u64
+    } else if cli.fp8_runtime {
+        (entry.vram.fixed_bytes as f64 * 0.6) as u64
+    } else {
+        entry.vram.fixed_bytes
+    };
     let estimated_vram =
-        ((entry.vram.fixed_bytes + kv_bytes) as f64 * entry.vram.overhead_factor) as u64;
+        ((quant_fixed_bytes + kv_bytes) as f64 * entry.vram.overhead_factor) as u64;
     let gib = |b: u64| b as f64 / (1024.0 * 1024.0 * 1024.0);
+    let weight_label = if cli.int4 {
+        "weights+scratch (INT4-scaled)"
+    } else if cli.fp8_runtime {
+        "weights+scratch (FP8-scaled)"
+    } else {
+        "weights+scratch"
+    };
     eprintln!(
-        "[vram] estimated={:.2}GiB (weights+scratch={:.2}GiB + kv_cache={:.2}GiB for {}tok x B={}) available={:.1}GiB",
+        "[vram] estimated={:.2}GiB ({}={:.2}GiB + kv_cache={:.2}GiB for {}tok x B={}) available={:.1}GiB",
         gib(estimated_vram),
-        gib(entry.vram.fixed_bytes),
+        weight_label,
+        gib(quant_fixed_bytes),
         gib(kv_bytes),
         context_tokens,
         cli.batch_size,
@@ -2859,13 +2888,14 @@ fn run_gemma4(
             cli.batch_size,
         )?)
     } else {
-        Gemma4Runtime::Bf16(gemma4_engine::Gemma4Engine::load_with_options(
+        Gemma4Runtime::Bf16(gemma4_engine::Gemma4Engine::load_with_quant(
             &cli.model_dir,
             params.weight_prefix,
             context_tokens,
             ordinal,
             cli.batch_size,
             cli.kv_fp8,
+            cli.fp8_runtime,
         )?)
     };
     eprintln!("[weights] loaded in {:.0}ms", t0.elapsed().as_millis());

--- a/kernels/gemma4.hip
+++ b/kernels/gemma4.hip
@@ -3321,16 +3321,24 @@ __global__ void g4_persistent_decode_kernel(
     unsigned int* __restrict__ barrier_counter,
     unsigned int* __restrict__ barrier_flag
 ) __attribute__((launch_bounds(256, 1))) {
-    // FP8-runtime weight dequant LUT — populated once per launch when active.
-    // Body wiring in PR-B; for now `fp8_scales` is parameter-only so the
-    // binary contract is stable and the engine PR can flip the flag without
-    // another bridge/FFI change. Reads of `fp8_scales` are no-ops here.
-    (void)fp8_scales;
     const int tid = threadIdx.x;
     const int bs = blockDim.x;
     const int nb = gridDim.x;
 
+    // LDS layout: lds[0..bs] for block-wide reductions, lds[bs..bs+256] for
+    // the FP8-runtime weight-dequant LUT. Bridge always allocates the full
+    // `(bs + 256) * 4 B` so the layout is constant whether `fp8_scales` is
+    // null or not.
     extern __shared__ float lds[];
+    float* fp8_lut = lds + bs;
+    if (fp8_scales != nullptr) {
+        if (tid < 256) {
+            fp8_lut[tid] = g4_fp8_e4m3_to_float(static_cast<uint8_t>(tid));
+        }
+        __syncthreads();
+    }
+    const int fp8_block_size =
+        (fp8_scales != nullptr) ? fp8_scales[0].block_size : 0;
 
     for (int layer = 0; layer < num_layers; ++layer) {
         const Gemma4DecodeLayerDesc L = layers[layer];
@@ -3372,6 +3380,14 @@ __global__ void g4_persistent_decode_kernel(
         T* k_cache = static_cast<T*>(L.kv_cache_k);
         T* v_cache = static_cast<T*>(L.kv_cache_v);
 
+        // FP8-weights for THIS layer. When `use_fp8_w` is true, the
+        // matmul sites below interpret the `*_proj_w` pointers as u8 FP8
+        // bytes and apply per-block dequant via `g4_fp8_dequant_weight_lut`.
+        const bool use_fp8_w = (fp8_scales != nullptr);
+        const Gemma4FP8ScaleDesc Sfp8 = use_fp8_w
+            ? fp8_scales[layer]
+            : Gemma4FP8ScaleDesc{};
+
         // =========================================================
         // Phase A — attention block. Mirrors g4_fused_attn_block_kernel.
         // Workspace layout (from offset 0):
@@ -3411,44 +3427,74 @@ __global__ void g4_persistent_decode_kernel(
         g4_grid_barrier(barrier_counter, barrier_flag, nb);
 
         // Wave-per-row QKV matmul: each wave independently steals a row via
-        // atomicAdd + __shfl broadcast, accumulates with 4-wide BF16 loads,
-        // reduces with wave shuffle. No __syncthreads per row.
+        // atomicAdd + __shfl broadcast, accumulates with 4-wide BF16 loads
+        // (or per-block FP8 dequant when use_fp8_w), reduces with wave
+        // shuffle. No __syncthreads per row.
         {
             const int lane = tid % warpSize;
             const int total_qkv = shared_kv ? q_dim : (q_dim + 2 * kv_dim);
+            const int vd4 = hidden_size & ~3;
             while (true) {
                 unsigned int row;
                 if (lane == 0) row = atomicAdd(matvec_counter, 1u);
                 row = __shfl(row, 0);
                 if (row >= static_cast<unsigned int>(total_qkv)) break;
 
-                const T* w;
                 int weight_row;
+                const T* w_bf16;
+                const void* wbase_fp8 = nullptr;
+                const void* sbase_fp8 = nullptr;
                 if (row < static_cast<unsigned int>(q_dim)) {
-                    w = q_proj_w;
+                    w_bf16 = q_proj_w;
                     weight_row = static_cast<int>(row);
+                    if (use_fp8_w) {
+                        wbase_fp8 = static_cast<const void*>(q_proj_w);
+                        sbase_fp8 = Sfp8.q_proj_scale;
+                    }
                 } else if (row < static_cast<unsigned int>(q_dim + kv_dim)) {
-                    w = k_proj_w;
+                    w_bf16 = k_proj_w;
                     weight_row = static_cast<int>(row - q_dim);
+                    if (use_fp8_w) {
+                        wbase_fp8 = static_cast<const void*>(k_proj_w);
+                        sbase_fp8 = Sfp8.k_proj_scale;
+                    }
                 } else {
-                    w = v_proj_w;
+                    w_bf16 = v_proj_w;
                     weight_row = static_cast<int>(row - q_dim - kv_dim);
+                    if (use_fp8_w) {
+                        wbase_fp8 = static_cast<const void*>(v_proj_w);
+                        sbase_fp8 = Sfp8.v_proj_scale;
+                    }
                 }
-                const T* w_row =
-                    w + static_cast<size_t>(weight_row) * hidden_size;
 
                 float p = 0.0f;
-                const int vd4 = hidden_size & ~3;
-                for (int c = lane * 4; c < vd4; c += warpSize * 4) {
-                    float w0 = g4_to_float(w_row[c]);
-                    float w1 = g4_to_float(w_row[c+1]);
-                    float w2 = g4_to_float(w_row[c+2]);
-                    float w3 = g4_to_float(w_row[c+3]);
-                    p += w0 * normed_f32[c]   + w1 * normed_f32[c+1]
-                       + w2 * normed_f32[c+2] + w3 * normed_f32[c+3];
-                }
-                for (int c = vd4 + lane; c < hidden_size; c += warpSize) {
-                    p += g4_to_float(w_row[c]) * normed_f32[c];
+                if (use_fp8_w) {
+                    for (int c = lane * 4; c < vd4; c += warpSize * 4) {
+                        float w0 = g4_fp8_dequant_weight_lut(wbase_fp8, sbase_fp8, weight_row, c,   hidden_size, fp8_block_size, fp8_lut);
+                        float w1 = g4_fp8_dequant_weight_lut(wbase_fp8, sbase_fp8, weight_row, c+1, hidden_size, fp8_block_size, fp8_lut);
+                        float w2 = g4_fp8_dequant_weight_lut(wbase_fp8, sbase_fp8, weight_row, c+2, hidden_size, fp8_block_size, fp8_lut);
+                        float w3 = g4_fp8_dequant_weight_lut(wbase_fp8, sbase_fp8, weight_row, c+3, hidden_size, fp8_block_size, fp8_lut);
+                        p += w0 * normed_f32[c]   + w1 * normed_f32[c+1]
+                           + w2 * normed_f32[c+2] + w3 * normed_f32[c+3];
+                    }
+                    for (int c = vd4 + lane; c < hidden_size; c += warpSize) {
+                        p += g4_fp8_dequant_weight_lut(wbase_fp8, sbase_fp8, weight_row, c, hidden_size, fp8_block_size, fp8_lut)
+                             * normed_f32[c];
+                    }
+                } else {
+                    const T* w_row =
+                        w_bf16 + static_cast<size_t>(weight_row) * hidden_size;
+                    for (int c = lane * 4; c < vd4; c += warpSize * 4) {
+                        float w0 = g4_to_float(w_row[c]);
+                        float w1 = g4_to_float(w_row[c+1]);
+                        float w2 = g4_to_float(w_row[c+2]);
+                        float w3 = g4_to_float(w_row[c+3]);
+                        p += w0 * normed_f32[c]   + w1 * normed_f32[c+1]
+                           + w2 * normed_f32[c+2] + w3 * normed_f32[c+3];
+                    }
+                    for (int c = vd4 + lane; c < hidden_size; c += warpSize) {
+                        p += g4_to_float(w_row[c]) * normed_f32[c];
+                    }
                 }
                 float result = g4_wave_reduce_sum_f32(p);
                 if (lane == 0) proj_f32[row] = result;
@@ -3611,24 +3657,41 @@ __global__ void g4_persistent_decode_kernel(
         // A7 wave-per-row.
         {
             const int lane = tid % warpSize;
+            const int vd4 = q_dim & ~3;
             while (true) {
                 unsigned int row;
                 if (lane == 0) row = atomicAdd(matvec_counter, 1u);
                 row = __shfl(row, 0);
                 if (row >= static_cast<unsigned int>(hidden_size)) break;
-                const T* wr = o_proj_w + static_cast<size_t>(row) * q_dim;
                 float p = 0.0f;
-                const int vd4 = q_dim & ~3;
-                for (int c = lane * 4; c < vd4; c += warpSize * 4) {
-                    float w0 = g4_to_float(wr[c]);
-                    float w1 = g4_to_float(wr[c+1]);
-                    float w2 = g4_to_float(wr[c+2]);
-                    float w3 = g4_to_float(wr[c+3]);
-                    p += w0 * attn_out_f32[c]   + w1 * attn_out_f32[c+1]
-                       + w2 * attn_out_f32[c+2] + w3 * attn_out_f32[c+3];
-                }
-                for (int c = vd4 + lane; c < q_dim; c += warpSize) {
-                    p += g4_to_float(wr[c]) * attn_out_f32[c];
+                if (use_fp8_w) {
+                    const void* wbase = static_cast<const void*>(o_proj_w);
+                    const void* sbase = Sfp8.o_proj_scale;
+                    for (int c = lane * 4; c < vd4; c += warpSize * 4) {
+                        float w0 = g4_fp8_dequant_weight_lut(wbase, sbase, row, c,   q_dim, fp8_block_size, fp8_lut);
+                        float w1 = g4_fp8_dequant_weight_lut(wbase, sbase, row, c+1, q_dim, fp8_block_size, fp8_lut);
+                        float w2 = g4_fp8_dequant_weight_lut(wbase, sbase, row, c+2, q_dim, fp8_block_size, fp8_lut);
+                        float w3 = g4_fp8_dequant_weight_lut(wbase, sbase, row, c+3, q_dim, fp8_block_size, fp8_lut);
+                        p += w0 * attn_out_f32[c]   + w1 * attn_out_f32[c+1]
+                           + w2 * attn_out_f32[c+2] + w3 * attn_out_f32[c+3];
+                    }
+                    for (int c = vd4 + lane; c < q_dim; c += warpSize) {
+                        p += g4_fp8_dequant_weight_lut(wbase, sbase, row, c, q_dim, fp8_block_size, fp8_lut)
+                             * attn_out_f32[c];
+                    }
+                } else {
+                    const T* wr = o_proj_w + static_cast<size_t>(row) * q_dim;
+                    for (int c = lane * 4; c < vd4; c += warpSize * 4) {
+                        float w0 = g4_to_float(wr[c]);
+                        float w1 = g4_to_float(wr[c+1]);
+                        float w2 = g4_to_float(wr[c+2]);
+                        float w3 = g4_to_float(wr[c+3]);
+                        p += w0 * attn_out_f32[c]   + w1 * attn_out_f32[c+1]
+                           + w2 * attn_out_f32[c+2] + w3 * attn_out_f32[c+3];
+                    }
+                    for (int c = vd4 + lane; c < q_dim; c += warpSize) {
+                        p += g4_to_float(wr[c]) * attn_out_f32[c];
+                    }
                 }
                 float result = g4_wave_reduce_sum_f32(p);
                 if (lane == 0) oproj_f32[row] = result;
@@ -3715,32 +3778,48 @@ __global__ void g4_persistent_decode_kernel(
         {
             const int lane = tid % warpSize;
             const int total_mlp1 = 2 * intermediate_size;
+            const int vd4 = hidden_size & ~3;
             while (true) {
                 unsigned int row;
                 if (lane == 0) row = atomicAdd(matvec_counter, 1u);
                 row = __shfl(row, 0);
                 if (row >= static_cast<unsigned int>(total_mlp1)) break;
 
-                const T* w = (row < static_cast<unsigned int>(intermediate_size))
-                    ? gate_proj_w : up_proj_w;
-                const int weight_row =
-                    (row < static_cast<unsigned int>(intermediate_size))
-                        ? static_cast<int>(row)
-                        : static_cast<int>(row - intermediate_size);
-                const T* wr = w + static_cast<size_t>(weight_row) * hidden_size;
+                const bool is_gate = row < static_cast<unsigned int>(intermediate_size);
+                const T* w_bf16 = is_gate ? gate_proj_w : up_proj_w;
+                const int weight_row = is_gate
+                    ? static_cast<int>(row)
+                    : static_cast<int>(row - intermediate_size);
 
                 float p = 0.0f;
-                const int vd4 = hidden_size & ~3;
-                for (int c = lane * 4; c < vd4; c += warpSize * 4) {
-                    float w0 = g4_to_float(wr[c]);
-                    float w1 = g4_to_float(wr[c+1]);
-                    float w2 = g4_to_float(wr[c+2]);
-                    float w3 = g4_to_float(wr[c+3]);
-                    p += w0 * b_normed_ff[c]   + w1 * b_normed_ff[c+1]
-                       + w2 * b_normed_ff[c+2] + w3 * b_normed_ff[c+3];
-                }
-                for (int c = vd4 + lane; c < hidden_size; c += warpSize) {
-                    p += g4_to_float(wr[c]) * b_normed_ff[c];
+                if (use_fp8_w) {
+                    const void* wbase = static_cast<const void*>(w_bf16);
+                    const void* sbase = is_gate ? Sfp8.gate_proj_scale : Sfp8.up_proj_scale;
+                    for (int c = lane * 4; c < vd4; c += warpSize * 4) {
+                        float w0 = g4_fp8_dequant_weight_lut(wbase, sbase, weight_row, c,   hidden_size, fp8_block_size, fp8_lut);
+                        float w1 = g4_fp8_dequant_weight_lut(wbase, sbase, weight_row, c+1, hidden_size, fp8_block_size, fp8_lut);
+                        float w2 = g4_fp8_dequant_weight_lut(wbase, sbase, weight_row, c+2, hidden_size, fp8_block_size, fp8_lut);
+                        float w3 = g4_fp8_dequant_weight_lut(wbase, sbase, weight_row, c+3, hidden_size, fp8_block_size, fp8_lut);
+                        p += w0 * b_normed_ff[c]   + w1 * b_normed_ff[c+1]
+                           + w2 * b_normed_ff[c+2] + w3 * b_normed_ff[c+3];
+                    }
+                    for (int c = vd4 + lane; c < hidden_size; c += warpSize) {
+                        p += g4_fp8_dequant_weight_lut(wbase, sbase, weight_row, c, hidden_size, fp8_block_size, fp8_lut)
+                             * b_normed_ff[c];
+                    }
+                } else {
+                    const T* wr = w_bf16 + static_cast<size_t>(weight_row) * hidden_size;
+                    for (int c = lane * 4; c < vd4; c += warpSize * 4) {
+                        float w0 = g4_to_float(wr[c]);
+                        float w1 = g4_to_float(wr[c+1]);
+                        float w2 = g4_to_float(wr[c+2]);
+                        float w3 = g4_to_float(wr[c+3]);
+                        p += w0 * b_normed_ff[c]   + w1 * b_normed_ff[c+1]
+                           + w2 * b_normed_ff[c+2] + w3 * b_normed_ff[c+3];
+                    }
+                    for (int c = vd4 + lane; c < hidden_size; c += warpSize) {
+                        p += g4_to_float(wr[c]) * b_normed_ff[c];
+                    }
                 }
                 float result = g4_wave_reduce_sum_f32(p);
                 if (lane == 0) b_gate_up[row] = result;
@@ -3768,26 +3847,43 @@ __global__ void g4_persistent_decode_kernel(
         // B4 wave-per-row.
         {
             const int lane = tid % warpSize;
+            const int vd4 = intermediate_size & ~3;
             while (true) {
                 unsigned int row;
                 if (lane == 0) row = atomicAdd(matvec_counter, 1u);
                 row = __shfl(row, 0);
                 if (row >= static_cast<unsigned int>(hidden_size)) break;
 
-                const T* wr = down_proj_w +
-                    static_cast<size_t>(row) * intermediate_size;
                 float p = 0.0f;
-                const int vd4 = intermediate_size & ~3;
-                for (int c = lane * 4; c < vd4; c += warpSize * 4) {
-                    float w0 = g4_to_float(wr[c]);
-                    float w1 = g4_to_float(wr[c+1]);
-                    float w2 = g4_to_float(wr[c+2]);
-                    float w3 = g4_to_float(wr[c+3]);
-                    p += w0 * b_gated_proj[c]   + w1 * b_gated_proj[c+1]
-                       + w2 * b_gated_proj[c+2] + w3 * b_gated_proj[c+3];
-                }
-                for (int c = vd4 + lane; c < intermediate_size; c += warpSize) {
-                    p += g4_to_float(wr[c]) * b_gated_proj[c];
+                if (use_fp8_w) {
+                    const void* wbase = static_cast<const void*>(down_proj_w);
+                    const void* sbase = Sfp8.down_proj_scale;
+                    for (int c = lane * 4; c < vd4; c += warpSize * 4) {
+                        float w0 = g4_fp8_dequant_weight_lut(wbase, sbase, row, c,   intermediate_size, fp8_block_size, fp8_lut);
+                        float w1 = g4_fp8_dequant_weight_lut(wbase, sbase, row, c+1, intermediate_size, fp8_block_size, fp8_lut);
+                        float w2 = g4_fp8_dequant_weight_lut(wbase, sbase, row, c+2, intermediate_size, fp8_block_size, fp8_lut);
+                        float w3 = g4_fp8_dequant_weight_lut(wbase, sbase, row, c+3, intermediate_size, fp8_block_size, fp8_lut);
+                        p += w0 * b_gated_proj[c]   + w1 * b_gated_proj[c+1]
+                           + w2 * b_gated_proj[c+2] + w3 * b_gated_proj[c+3];
+                    }
+                    for (int c = vd4 + lane; c < intermediate_size; c += warpSize) {
+                        p += g4_fp8_dequant_weight_lut(wbase, sbase, row, c, intermediate_size, fp8_block_size, fp8_lut)
+                             * b_gated_proj[c];
+                    }
+                } else {
+                    const T* wr = down_proj_w +
+                        static_cast<size_t>(row) * intermediate_size;
+                    for (int c = lane * 4; c < vd4; c += warpSize * 4) {
+                        float w0 = g4_to_float(wr[c]);
+                        float w1 = g4_to_float(wr[c+1]);
+                        float w2 = g4_to_float(wr[c+2]);
+                        float w3 = g4_to_float(wr[c+3]);
+                        p += w0 * b_gated_proj[c]   + w1 * b_gated_proj[c+1]
+                           + w2 * b_gated_proj[c+2] + w3 * b_gated_proj[c+3];
+                    }
+                    for (int c = vd4 + lane; c < intermediate_size; c += warpSize) {
+                        p += g4_to_float(wr[c]) * b_gated_proj[c];
+                    }
                 }
                 float result = g4_wave_reduce_sum_f32(p);
                 if (lane == 0) b_down_out[row] = result;
@@ -3817,26 +3913,43 @@ __global__ void g4_persistent_decode_kernel(
         // B7 wave-per-row.
         {
             const int lane = tid % warpSize;
+            const int vd4 = hidden_size & ~3;
             while (true) {
                 unsigned int row;
                 if (lane == 0) row = atomicAdd(matvec_counter, 1u);
                 row = __shfl(row, 0);
                 if (row >= static_cast<unsigned int>(ple_hidden)) break;
 
-                const T* wr = pli_gate_w +
-                    static_cast<size_t>(row) * hidden_size;
                 float p = 0.0f;
-                const int vd4 = hidden_size & ~3;
-                for (int c = lane * 4; c < vd4; c += warpSize * 4) {
-                    float w0 = g4_to_float(wr[c]);
-                    float w1 = g4_to_float(wr[c+1]);
-                    float w2 = g4_to_float(wr[c+2]);
-                    float w3 = g4_to_float(wr[c+3]);
-                    p += w0 * b_h_pre_ple[c]   + w1 * b_h_pre_ple[c+1]
-                       + w2 * b_h_pre_ple[c+2] + w3 * b_h_pre_ple[c+3];
-                }
-                for (int c = vd4 + lane; c < hidden_size; c += warpSize) {
-                    p += g4_to_float(wr[c]) * b_h_pre_ple[c];
+                if (use_fp8_w) {
+                    const void* wbase = static_cast<const void*>(pli_gate_w);
+                    const void* sbase = Sfp8.per_layer_input_gate_scale;
+                    for (int c = lane * 4; c < vd4; c += warpSize * 4) {
+                        float w0 = g4_fp8_dequant_weight_lut(wbase, sbase, row, c,   hidden_size, fp8_block_size, fp8_lut);
+                        float w1 = g4_fp8_dequant_weight_lut(wbase, sbase, row, c+1, hidden_size, fp8_block_size, fp8_lut);
+                        float w2 = g4_fp8_dequant_weight_lut(wbase, sbase, row, c+2, hidden_size, fp8_block_size, fp8_lut);
+                        float w3 = g4_fp8_dequant_weight_lut(wbase, sbase, row, c+3, hidden_size, fp8_block_size, fp8_lut);
+                        p += w0 * b_h_pre_ple[c]   + w1 * b_h_pre_ple[c+1]
+                           + w2 * b_h_pre_ple[c+2] + w3 * b_h_pre_ple[c+3];
+                    }
+                    for (int c = vd4 + lane; c < hidden_size; c += warpSize) {
+                        p += g4_fp8_dequant_weight_lut(wbase, sbase, row, c, hidden_size, fp8_block_size, fp8_lut)
+                             * b_h_pre_ple[c];
+                    }
+                } else {
+                    const T* wr = pli_gate_w +
+                        static_cast<size_t>(row) * hidden_size;
+                    for (int c = lane * 4; c < vd4; c += warpSize * 4) {
+                        float w0 = g4_to_float(wr[c]);
+                        float w1 = g4_to_float(wr[c+1]);
+                        float w2 = g4_to_float(wr[c+2]);
+                        float w3 = g4_to_float(wr[c+3]);
+                        p += w0 * b_h_pre_ple[c]   + w1 * b_h_pre_ple[c+1]
+                           + w2 * b_h_pre_ple[c+2] + w3 * b_h_pre_ple[c+3];
+                    }
+                    for (int c = vd4 + lane; c < hidden_size; c += warpSize) {
+                        p += g4_to_float(wr[c]) * b_h_pre_ple[c];
+                    }
                 }
                 float result = g4_wave_reduce_sum_f32(p);
                 if (lane == 0) b_gated_ple[row] = result;
@@ -3860,26 +3973,43 @@ __global__ void g4_persistent_decode_kernel(
         // B9 wave-per-row.
         {
             const int lane = tid % warpSize;
+            const int vd4 = ple_hidden & ~3;
             while (true) {
                 unsigned int row;
                 if (lane == 0) row = atomicAdd(matvec_counter, 1u);
                 row = __shfl(row, 0);
                 if (row >= static_cast<unsigned int>(hidden_size)) break;
 
-                const T* wr = pli_proj_w +
-                    static_cast<size_t>(row) * ple_hidden;
                 float p = 0.0f;
-                const int vd4 = ple_hidden & ~3;
-                for (int c = lane * 4; c < vd4; c += warpSize * 4) {
-                    float w0 = g4_to_float(wr[c]);
-                    float w1 = g4_to_float(wr[c+1]);
-                    float w2 = g4_to_float(wr[c+2]);
-                    float w3 = g4_to_float(wr[c+3]);
-                    p += w0 * b_gated_act[c]   + w1 * b_gated_act[c+1]
-                       + w2 * b_gated_act[c+2] + w3 * b_gated_act[c+3];
-                }
-                for (int c = vd4 + lane; c < ple_hidden; c += warpSize) {
-                    p += g4_to_float(wr[c]) * b_gated_act[c];
+                if (use_fp8_w) {
+                    const void* wbase = static_cast<const void*>(pli_proj_w);
+                    const void* sbase = Sfp8.per_layer_projection_scale;
+                    for (int c = lane * 4; c < vd4; c += warpSize * 4) {
+                        float w0 = g4_fp8_dequant_weight_lut(wbase, sbase, row, c,   ple_hidden, fp8_block_size, fp8_lut);
+                        float w1 = g4_fp8_dequant_weight_lut(wbase, sbase, row, c+1, ple_hidden, fp8_block_size, fp8_lut);
+                        float w2 = g4_fp8_dequant_weight_lut(wbase, sbase, row, c+2, ple_hidden, fp8_block_size, fp8_lut);
+                        float w3 = g4_fp8_dequant_weight_lut(wbase, sbase, row, c+3, ple_hidden, fp8_block_size, fp8_lut);
+                        p += w0 * b_gated_act[c]   + w1 * b_gated_act[c+1]
+                           + w2 * b_gated_act[c+2] + w3 * b_gated_act[c+3];
+                    }
+                    for (int c = vd4 + lane; c < ple_hidden; c += warpSize) {
+                        p += g4_fp8_dequant_weight_lut(wbase, sbase, row, c, ple_hidden, fp8_block_size, fp8_lut)
+                             * b_gated_act[c];
+                    }
+                } else {
+                    const T* wr = pli_proj_w +
+                        static_cast<size_t>(row) * ple_hidden;
+                    for (int c = lane * 4; c < vd4; c += warpSize * 4) {
+                        float w0 = g4_to_float(wr[c]);
+                        float w1 = g4_to_float(wr[c+1]);
+                        float w2 = g4_to_float(wr[c+2]);
+                        float w3 = g4_to_float(wr[c+3]);
+                        p += w0 * b_gated_act[c]   + w1 * b_gated_act[c+1]
+                           + w2 * b_gated_act[c+2] + w3 * b_gated_act[c+3];
+                    }
+                    for (int c = vd4 + lane; c < ple_hidden; c += warpSize) {
+                        p += g4_to_float(wr[c]) * b_gated_act[c];
+                    }
                 }
                 float result = g4_wave_reduce_sum_f32(p);
                 if (lane == 0) b_projected[row] = result;

--- a/kernels/gemma4_bridge.cpp
+++ b/kernels/gemma4_bridge.cpp
@@ -852,7 +852,12 @@ int persistent_decode_device(int device_ordinal,
     const int num_blocks =
         props.multiProcessorCount > 0 ? props.multiProcessorCount : 1;
     constexpr int BLOCK = 256;
-    const size_t lds_bytes = BLOCK * sizeof(float);
+    // Allocate `BLOCK` floats for block-wide reductions plus `256` floats for
+    // the FP8-runtime LUT (`fp8_lut[256]` populated at kernel entry only when
+    // `fp8_scales` is non-null). The extra LDS is wasted in BF16 mode (1 KiB)
+    // but stays a constant across modes — keeping the launch parameters
+    // mode-agnostic avoids cross-contamination between BF16 and FP8 codegen.
+    const size_t lds_bytes = (BLOCK + 256) * sizeof(float);
 
     if (hipMemset(barrier_counter, 0, sizeof(unsigned int)) != hipSuccess) return 702;
     if (hipMemset(barrier_flag, 0, sizeof(unsigned int)) != hipSuccess) return 703;

--- a/oracle/bake_all.sh
+++ b/oracle/bake_all.sh
@@ -346,11 +346,6 @@ bake_bf16() {
 
 bake_fp8_native() {
     local cli_name="$1" model_dir="$2" family="$3"
-    if [[ "$family" == "gemma" ]]; then
-        echo "[skip] $cli_name fp8-native — Gemma 4 has no FP8-native bake format"
-        SKIPPED+=("$cli_name fp8-native")
-        return 0
-    fi
     local dir ; dir="$(bake_dir_for "$model_dir" fp8-native)" || return 2
     local label="$cli_name fp8-native"
     if [[ $FORCE -eq 0 ]] && bake_exists_and_valid "$dir"; then
@@ -370,6 +365,10 @@ bake_fp8_native() {
             ;;
         phi4)
             run_or_record "$label" python3 "$SCRIPT_DIR/bake_fp8_phi4.py" \
+                --model-dir "$model_dir" || return $?
+            ;;
+        gemma)
+            run_or_record "$label" python3 "$SCRIPT_DIR/bake_fp8_gemma4.py" \
                 --model-dir "$model_dir" || return $?
             ;;
         *)

--- a/oracle/bake_fp8_gemma4.py
+++ b/oracle/bake_fp8_gemma4.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""
+Per-block FP8-E4M3 calibration bake for SuperSonic — Gemma 4.
+
+Sister script to `oracle/bake_fp8.py` (Qwen 3.5) and
+`oracle/bake_fp8_phi4.py` (Phi-4). Differences from those:
+
+  * Gemma 4 weights live under `model.language_model.*` (not `model.*`).
+  * No fused projections — q/k/v_proj, gate/up_proj, o_proj, down_proj
+    are all distinct tensors in the safetensors. We can quantize them
+    in-place without splitting.
+  * Adds two PLE projections per layer (`per_layer_input_gate.weight`,
+    `per_layer_projection.weight`) that the runtime kernel also reads
+    via FP8 dequant. These are simple 2D Linear weights — same baker.
+  * Shared-KV layers (the runtime aliases earlier layers' caches) do
+    NOT contain k_proj / v_proj / k_norm in the safetensors at all,
+    so the matcher naturally skips them.
+
+Output mirrors the Phi-4 baker: `name` (FP8-E4M3, Fp8Native) +
+`name_scale_inv` (BF16, Raw, [rows/128, cols/128]) per quantized
+projection. The runtime FP8-dequant path lights up automatically from
+the existing `Gemma4FP8ScaleDesc` plumbing (kernel side already wired).
+
+Usage:
+    python3 oracle/bake_fp8_gemma4.py --model-dir /path/to/gemma-4-E2B
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+import torch
+from safetensors import safe_open
+
+# Mirrored from oracle/bake_fp8.py / crates/model-store/src/manifest.rs.
+FORMAT_VERSION = 2
+CONVERTER_VERSION = 1
+
+LAYOUT_RAW = "Raw"
+LAYOUT_FP8_NATIVE = "Fp8Native"
+
+ALIGN = 4096
+BLOCK_SIZE = 128
+MAX_E4M3 = 448.0
+
+
+def log(msg: str) -> None:
+    print(msg, flush=True)
+
+
+def align_up(x: int, a: int = ALIGN) -> int:
+    return (x + a - 1) // a * a
+
+
+# ---------------------------------------------------------------------------
+# FP8 quantization (identical to bake_fp8_phi4.py)
+# ---------------------------------------------------------------------------
+def quantize_bf16_to_fp8(
+    weight: torch.Tensor, block_size: int = BLOCK_SIZE
+) -> tuple[torch.Tensor, torch.Tensor]:
+    assert weight.dim() == 2, f"expected 2D, got {tuple(weight.shape)}"
+    rows, cols = weight.shape
+    assert rows % block_size == 0 and cols % block_size == 0, \
+        f"shape {tuple(weight.shape)} not divisible by {block_size}"
+
+    w_f32 = weight.float()
+    sr = rows // block_size
+    sc = cols // block_size
+    blocks = w_f32.view(sr, block_size, sc, block_size).permute(0, 2, 1, 3).contiguous()
+    absmax = blocks.abs().amax(dim=(2, 3))
+    scale = (absmax / MAX_E4M3).clamp_min(torch.finfo(torch.float32).tiny)
+    scale_full = (
+        scale.repeat_interleave(block_size, dim=0)
+              .repeat_interleave(block_size, dim=1)
+    )
+    q_e4m3 = (w_f32 / scale_full).to(torch.float8_e4m3fn)
+    q_bytes = q_e4m3.view(torch.uint8)
+    return q_bytes.contiguous(), scale.to(torch.bfloat16).contiguous()
+
+
+# ---------------------------------------------------------------------------
+# Tensor classification (Gemma 4 specific)
+# ---------------------------------------------------------------------------
+QUANT_PROJ_SUFFIXES = (
+    ".q_proj.weight",
+    ".k_proj.weight",
+    ".v_proj.weight",
+    ".o_proj.weight",
+    ".gate_proj.weight",
+    ".up_proj.weight",
+    ".down_proj.weight",
+    ".per_layer_input_gate.weight",
+    ".per_layer_projection.weight",
+)
+
+
+def is_fp8_quant_target(
+    name: str, shape: tuple[int, ...], block_size: int = BLOCK_SIZE
+) -> bool:
+    """True if a 2D weight should be FP8-quantized.
+
+    Gemma 4 splits projections out of the box (no fused qkv / gate_up
+    tensors), so we just match by suffix. PLE projections are included.
+
+    Skip:
+      * Embeddings (BF16, also tied to lm_head).
+      * Norms (`*_layernorm.weight`, `.norm.weight`, `q_norm`, `k_norm`,
+        `post_per_layer_input_norm`, `per_layer_projection_norm`).
+      * `per_layer_model_projection.weight` — different shape, not a
+        per-layer Linear; the runtime treats it as raw BF16.
+      * lm_head (tied to embeddings on Gemma 4 dense variants — no
+        standalone tensor exists).
+    """
+    if len(shape) != 2:
+        return False
+    if not any(name.endswith(suf) for suf in QUANT_PROJ_SUFFIXES):
+        return False
+    return shape[0] % block_size == 0 and shape[1] % block_size == 0
+
+
+# ---------------------------------------------------------------------------
+# Manifest dtype names
+# ---------------------------------------------------------------------------
+def torch_dtype_to_str(dt: torch.dtype) -> str:
+    if dt == torch.bfloat16:
+        return "bf16"
+    if dt == torch.float32:
+        return "f32"
+    if dt == torch.float16:
+        return "f16"
+    if dt == torch.uint8:
+        return "u8"
+    if dt == torch.float8_e4m3fn:
+        return "f8_e4m3"
+    raise ValueError(f"unsupported dtype: {dt}")
+
+
+def tensor_to_bytes(t: torch.Tensor, dtype_str: str) -> bytes:
+    if dtype_str == "f8_e4m3":
+        if t.dtype == torch.float8_e4m3fn:
+            t = t.view(torch.uint8)
+        elif t.dtype != torch.uint8:
+            raise AssertionError(
+                f"f8_e4m3 must be uint8 or float8_e4m3fn, got {t.dtype}"
+            )
+        return t.contiguous().cpu().numpy().tobytes()
+    expected = {
+        "bf16": torch.bfloat16,
+        "f32": torch.float32,
+        "f16": torch.float16,
+        "u8": torch.uint8,
+    }[dtype_str]
+    if t.dtype != expected:
+        t = t.to(expected)
+    # `.view(torch.uint8)` requires a non-scalar tensor; some Gemma 4
+    # safetensors include 0-d scalars (e.g. `model.dummy_token_index`).
+    # `.reshape((-1,))` materializes a 1-d view that can be re-viewed.
+    flat = t.contiguous().cpu().reshape((-1,))
+    return flat.view(torch.uint8).numpy().tobytes()
+
+
+# ---------------------------------------------------------------------------
+# Streaming writer
+# ---------------------------------------------------------------------------
+class StreamingTensorWriter:
+    def __init__(self, out_dir: Path) -> None:
+        out_dir.mkdir(parents=True, exist_ok=True)
+        self.out_dir = out_dir
+        self.weights_path = out_dir / "weights.bin"
+        self.f = open(self.weights_path, "wb")
+        self.entries: list[dict] = []
+        self.cursor = 0
+
+    def add(
+        self, name: str, data: bytes, shape: list[int], dtype_str: str, layout: str
+    ) -> None:
+        offset = align_up(self.cursor)
+        if offset > self.cursor:
+            self.f.write(b"\x00" * (offset - self.cursor))
+        self.f.write(data)
+        self.entries.append({
+            "name": name,
+            "shape": shape,
+            "dtype": dtype_str,
+            "layout": layout,
+            "offset": offset,
+            "byte_len": len(data),
+        })
+        self.cursor = offset + len(data)
+
+    def close(self, model_family: str = "gemma4") -> None:
+        self.f.close()
+        sorted_entries = sorted(self.entries, key=lambda e: e["name"])
+        manifest = {
+            "format_version": FORMAT_VERSION,
+            "converter_version": CONVERTER_VERSION,
+            "model_family": model_family,
+            "tensors": sorted_entries,
+        }
+        with open(self.out_dir / "manifest.json", "w") as f:
+            json.dump(manifest, f, indent=2)
+        log(
+            f"[bake-fp8-gemma4] wrote {self.cursor / (1024 * 1024):.1f} MiB "
+            f"to {self.weights_path}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+def collect_tensor_index(model_dir: Path) -> tuple[list[Path], dict[str, int]]:
+    shards = sorted(model_dir.glob("*.safetensors"))
+    if not shards:
+        raise SystemExit(f"no .safetensors found in {model_dir}")
+    index: dict[str, int] = {}
+    for i, sf in enumerate(shards):
+        with safe_open(str(sf), framework="pt") as f:
+            for key in f.keys():
+                index[key] = i
+    return shards, index
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Per-block FP8 bake for Gemma 4")
+    ap.add_argument("--model-dir", required=True, type=Path)
+    ap.add_argument(
+        "--out-dir",
+        default=None,
+        type=Path,
+        help="Override output dir (default: {model-dir}/.supersonic/v{FORMAT_VERSION}-fp8)",
+    )
+    ap.add_argument(
+        "--block-size",
+        type=int,
+        default=BLOCK_SIZE,
+        help=f"Per-tile FP8 block size (default {BLOCK_SIZE}; the Rust "
+             f"runtime currently only supports 128).",
+    )
+    ap.add_argument(
+        "--model-family",
+        default="gemma4",
+        help="Override the manifest model_family field (default: gemma4).",
+    )
+    args = ap.parse_args()
+
+    block_size: int = args.block_size
+    if block_size != BLOCK_SIZE:
+        log(
+            f"[bake-fp8-gemma4] WARNING: --block-size={block_size} is non-default; "
+            "the Rust runtime currently assumes 128 — use only for "
+            "calibration experiments, not production bakes."
+        )
+
+    model_dir: Path = args.model_dir.resolve()
+    out_dir: Path = args.out_dir or (model_dir / ".supersonic" / f"v{FORMAT_VERSION}-fp8")
+
+    config_path = model_dir / "config.json"
+    if not config_path.exists():
+        raise SystemExit(f"missing config.json under {model_dir}")
+    cfg = json.load(open(config_path))
+    # Gemma 4 dense models nest the language model config under
+    # `text_config`; multimodal wrappers add an extra `language_model`
+    # name level under `model.`. Either way, the safetensor keys reflect
+    # the on-disk layout.
+    log(f"[bake-fp8-gemma4] model_dir={model_dir}")
+
+    shards, index = collect_tensor_index(model_dir)
+    log(f"[bake-fp8-gemma4] {len(shards)} shard(s), {len(index)} tensors")
+
+    eligible = sorted(index.keys())
+    log(f"[bake-fp8-gemma4] {len(eligible)} eligible tensors")
+
+    writer = StreamingTensorWriter(out_dir)
+    open_shards: dict[int, Any] = {}
+
+    def get_handle(idx: int):
+        h = open_shards.get(idx)
+        if h is None:
+            h = safe_open(str(shards[idx]), framework="pt")
+            h.__enter__()
+            open_shards[idx] = h
+        return h
+
+    def emit_quantized(name: str, t: torch.Tensor) -> None:
+        packed, scale_bf16 = quantize_bf16_to_fp8(t, block_size)
+        writer.add(
+            name,
+            tensor_to_bytes(packed, "f8_e4m3"),
+            list(t.shape),
+            "f8_e4m3",
+            LAYOUT_FP8_NATIVE,
+        )
+        writer.add(
+            f"{name}_scale_inv",
+            tensor_to_bytes(scale_bf16, "bf16"),
+            list(scale_bf16.shape),
+            "bf16",
+            LAYOUT_RAW,
+        )
+
+    def emit_raw(name: str, t: torch.Tensor) -> None:
+        writer.add(
+            name,
+            tensor_to_bytes(t, torch_dtype_to_str(t.dtype)),
+            list(t.shape),
+            torch_dtype_to_str(t.dtype),
+            LAYOUT_RAW,
+        )
+
+    t0 = time.perf_counter()
+    n_quant = 0
+    n_raw = 0
+    try:
+        for name in eligible:
+            shard_idx = index[name]
+            t = get_handle(shard_idx).get_tensor(name)
+            shape = tuple(t.shape)
+
+            if is_fp8_quant_target(name, shape, block_size):
+                if t.dtype == torch.bfloat16:
+                    emit_quantized(name, t)
+                    n_quant += 1
+                    continue
+                if t.dtype == torch.float8_e4m3fn:
+                    # Pre-quantized FP8 source — Gemma 4 upstream is BF16
+                    # today, so this path is only exercised by future
+                    # checkpoints. Fail fast here rather than emit FP8 bytes
+                    # without a companion scale_inv tensor (mirrors the
+                    # Phi-4 baker fix from PR #47).
+                    raise SystemExit(
+                        f"Gemma 4 FP8 baker: source {name} is already "
+                        f"float8_e4m3fn but no companion scale_inv tensor "
+                        f"is available — pre-quantized FP8 sources are not "
+                        f"yet supported. Re-export from a BF16 checkpoint."
+                    )
+                log(
+                    f"[bake-fp8-gemma4] WARNING: quant target {name} has "
+                    f"unexpected dtype {t.dtype}; storing raw"
+                )
+
+            emit_raw(name, t)
+            n_raw += 1
+    finally:
+        for h in open_shards.values():
+            try:
+                h.__exit__(None, None, None)
+            except Exception:
+                pass
+
+    writer.close(model_family=args.model_family)
+    elapsed = time.perf_counter() - t0
+    log(
+        f"[bake-fp8-gemma4] quantized {n_quant}, passed through {n_raw} "
+        f"tensors in {elapsed:.1f}s"
+    )
+    log(f"[bake-fp8-gemma4] done. Output: {out_dir}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Lights up \`--fp8-runtime\` end-to-end on Gemma 4 (single-batch BF16 KV or combined with \`--kv-fp8\`). Builds on the kernel/FFI scaffolding merged in #50.
- This is the last of the four FP8/KV-FP8 tasks the user lined up after the gfx1100 bring-up; mirrors the Phi-4 FP8 runtime in #47.

## Kernel (\`kernels/gemma4.hip\`)

- LUT init at kernel entry: bridge always allocates \`(BLOCK + 256) * 4 B\` LDS; threads \`tid < 256\` populate \`fp8_lut[tid]\` once per launch when \`fp8_scales != nullptr\`.
- All six weight matmul sites in the BF16 single-batch persistent decode kernel (A2 QKV, A7 o_proj, B2 gate+up, B4 down_proj, B7 PLI input_gate, B9 PLI projection) branch on \`use_fp8_w\` and call \`g4_fp8_dequant_weight_lut\` with the matching per-projection scale.
- BF16 path is unchanged when \`fp8_scales == nullptr\`. Batched + INT4 kernels are unmodified.

## Baker (\`oracle/bake_fp8_gemma4.py\`, NEW)

- Per-block (128×128) absmax FP8 quantization for all 9 per-layer projection types. Emits \`name\` (FP8-E4M3, Fp8Native) + \`name_scale_inv\` (BF16, Raw) pairs.
- Auto-skips shared-KV layers and rejects pre-quantized FP8 source weights (matches the Phi-4 baker fix from #47).
- \`bake_all.sh bake_fp8_native\` now routes \`gemma\` family to this script.

## Engine (\`crates/runner/src/gemma4_engine.rs\`)

- New \`Gemma4Engine::load_with_quant(.., kv_fp8, fp8_runtime)\` constructor.
- \`apply_fp8_overlay\` swaps each layer's projection BF16 buffer for its FP8 byte counterpart and loads the matching \`*_scale_inv\` tensor.
- Builds the per-layer \`Gemma4FP8ScaleDesc\` GPU array (shared-KV layers leave k/v scale slots null).
- Prefill bypass extended: under EITHER --kv-fp8 OR --fp8-runtime, prefill runs per-token through \`decode_step_seq\` (the BF16 primitive chain reads element widths that don't match the FP8 byte layout).

## Runner (\`crates/runner/src/main.rs\`)

- Drop the unconditional \`--fp8-runtime\` bail in \`run_gemma4\`.
- New gates: \`--fp8-runtime + --int4\` and \`--fp8-runtime + --batch-size>1\` bail with explanatory messages.
- VRAM admission applies the 0.6× weight scale under \`--fp8-runtime\` (mirrors phi4_engine).

## Test plan

- [x] BF16 gemma4-e2b on gfx1100: \`The quick brown fox jumps over the\` → \`lazy dog. ...\` (33 ms/step).
- [x] \`--kv-fp8\` gemma4-e2b: same output (34 ms/step).
- [x] \`--fp8-runtime\` gemma4-e2b: same output (41 ms/step) — VRAM 6.6 GiB vs 11.0 GiB BF16.
- [x] \`--fp8-runtime --kv-fp8\` combined: same output (40 ms/step).
- [x] \`--fp8-runtime --int4\` rejects with clear message.
- [x] \`--fp8-runtime --batch-size 2\` rejects with clear message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)