### PR TITLE
runner: scratch opt-in pass — tmp_k/tmp_v in KV-shadow restore + survey doc

### DIFF
--- a/crates/gpu-hal/tests/buffer_kind_round_trip.rs
+++ b/crates/gpu-hal/tests/buffer_kind_round_trip.rs
@@ -1,0 +1,97 @@
+//! Round-trip integration tests for the `BufferKind` / `BufferPolicy`
+//! plumbing.
+//!
+//! These exercise the same access pattern used by
+//! `decode_engine::load_kv_shadow_for_state_static`:
+//!
+//!   1. allocate a `Scratch` buffer via `from_host_bytes_with_kind`
+//!      (writes via H2D copy through the policy-resolved allocator)
+//!   2. allocate a `Persistent` destination via `zeros_with_kind`
+//!   3. `copy_d2d` between them
+//!   4. read the destination back and bit-compare against the input
+//!   5. drop both buffers — the two distinct allocator kinds get freed
+//!      via their matching free path (`hipFree` for Default,
+//!      `hipHostFree(host_ptr)` for `HostMapped`).
+//!
+//! Run twice: once under the `gfx1150` policy
+//! (`{Persistent: Default, Scratch: HostMapped}`) so the host-mapped
+//! branch in `ops::alloc` actually executes, and once under the
+//! all-`Default` policy used by `gfx1100` / `sm86` / unmeasured arches
+//! so the `Default` branch round-trips for every kind. Functional
+//! correctness is the contract — perf is measured separately
+//! (`tests/gfx1150/membench_l2_bypass.hip`).
+
+#![cfg(supersonic_backend_hip)]
+
+use gpu_hal::{
+    copy_d2d, set_backend, set_buffer_policy, sync, AllocStrategy, Backend, BufferKind,
+    BufferPolicy, GpuBuffer, ScalarType,
+};
+
+fn host_bf16_pattern(n: usize) -> Vec<u8> {
+    // Distinct-per-element BF16 bit pattern; bit-exact comparison only
+    // works because we never go through any cast.
+    let mut out = Vec::with_capacity(n * 2);
+    for i in 0..n {
+        let bits = (0x3f00u16).wrapping_add(i as u16);
+        out.extend_from_slice(&bits.to_le_bytes());
+    }
+    out
+}
+
+fn round_trip_under_policy(policy: BufferPolicy, src_kind: BufferKind, dst_kind: BufferKind) {
+    set_backend(Backend::Hip);
+    set_buffer_policy(policy);
+
+    let ordinal = 0usize;
+    let n_elems = 4096;
+    let host = host_bf16_pattern(n_elems);
+
+    let src =
+        GpuBuffer::from_host_bytes_with_kind(ordinal, ScalarType::BF16, &[n_elems], &host, src_kind)
+            .expect("alloc + H2D src");
+    let mut dst = GpuBuffer::zeros_with_kind(ordinal, ScalarType::BF16, &[n_elems], dst_kind)
+        .expect("alloc dst");
+
+    copy_d2d(ordinal, dst.as_mut_ptr(), src.as_ptr(), src.len_bytes()).expect("copy_d2d");
+    sync(ordinal).expect("sync after copy_d2d");
+
+    let copied = dst.to_host_bytes().expect("D2H readback");
+    assert_eq!(copied, host, "round-trip bytes mismatch");
+    // Drop sequence: dst then src, exercises both allocator-kind free paths
+    // back-to-back when the policy maps them to different mechanisms.
+}
+
+#[test]
+fn gfx1150_policy_scratch_round_trip() {
+    // Mirrors the gfx1150 entry in registry::ArchProfile::for_arch:
+    // Persistent stays on the classic device allocator, Scratch opts
+    // into hipHostMalloc(MAPPED) + hipHostGetDevicePointer.
+    let policy = BufferPolicy {
+        persistent: AllocStrategy::Default,
+        scratch: AllocStrategy::HostMapped,
+    };
+    round_trip_under_policy(policy, BufferKind::Scratch, BufferKind::Persistent);
+}
+
+#[test]
+fn gfx1150_policy_persistent_round_trip() {
+    // Same policy, but route the source through Persistent — confirms
+    // the Default branch still works when the policy table has a
+    // HostMapped entry available for Scratch.
+    let policy = BufferPolicy {
+        persistent: AllocStrategy::Default,
+        scratch: AllocStrategy::HostMapped,
+    };
+    round_trip_under_policy(policy, BufferKind::Persistent, BufferKind::Persistent);
+}
+
+#[test]
+fn discrete_policy_round_trip_for_both_kinds() {
+    // Mirrors gfx1100 / sm86 / unmeasured arches: every kind maps to
+    // Default. Both branches in the policy lookup take the same path,
+    // and Scratch is a no-op opt-in.
+    let policy = BufferPolicy::all_default();
+    round_trip_under_policy(policy, BufferKind::Scratch, BufferKind::Scratch);
+    round_trip_under_policy(policy, BufferKind::Persistent, BufferKind::Persistent);
+}

--- a/crates/runner/src/decode_engine.rs
+++ b/crates/runner/src/decode_engine.rs
@@ -2236,18 +2236,24 @@ impl DecodeEngine {
             let cap_stride = cap * head_dim * elem_bytes;
             let contig_stride = prefix_len * head_dim * elem_bytes;
 
-            let tmp_k = GpuBuffer::from_host_bytes(
+            // One-shot scratch: written once via H2D, DMA'd into shadow_k/v
+            // exactly once, then dropped at end of this iteration. No
+            // re-read, so GPU L2 is irrelevant — Scratch lets gfx1150 skip
+            // the H2D driver call (host-mapped pointer = host data target).
+            let tmp_k = GpuBuffer::from_host_bytes_with_kind(
                 ordinal,
                 ScalarType::BF16,
                 &[num_kv_heads, prefix_len, head_dim],
                 &prefix_k_host,
+                gpu_hal::BufferKind::Scratch,
             )
             .map_err(|e| anyhow::anyhow!("layer {layer_idx} shadow K H2D: {e}"))?;
-            let tmp_v = GpuBuffer::from_host_bytes(
+            let tmp_v = GpuBuffer::from_host_bytes_with_kind(
                 ordinal,
                 ScalarType::BF16,
                 &[num_kv_heads, prefix_len, head_dim],
                 &prefix_v_host,
+                gpu_hal::BufferKind::Scratch,
             )
             .map_err(|e| anyhow::anyhow!("layer {layer_idx} shadow V H2D: {e}"))?;
 

--- a/docs/gfx1150-l2-bypass.md
+++ b/docs/gfx1150-l2-bypass.md
@@ -120,3 +120,41 @@ echo auto | sudo tee /sys/class/drm/card1/device/power_dpm_force_performance_lev
 If the cache-fitting rates equalize on a future stack (newer ROCm,
 RDNA4, etc.), revisit `ArchProfile::buffer_policy` — the Scratch-only
 opt-in could become a Persistent default.
+
+## Survey: where is `Scratch` actually a win?
+
+A pass over the ~1100 `GpuBuffer` allocation sites (2026-04-30) looked
+for one-shot patterns where `BufferKind::Scratch` could capture the
+H2D driver-call savings without losing cache reuse. The honest answer
+on gfx1150: **almost nowhere on the hot path.**
+
+Categories surveyed:
+- **Weights, KV cache, scratch workspaces** (the bulk of allocations
+  in `decode_engine.rs`, `gemma4_engine.rs`, `prefill_engine.rs`,
+  `kernel-ffi/src/certified_kv.rs`): all read repeatedly across decode
+  steps. `Persistent` is correct.
+- **Per-step decode input IDs** (a few bytes uploaded each token):
+  cost is dominated by allocation/free, not the H2D copy. No clean
+  win, and per-token churn risks regression.
+- **KV-shadow restore buffers** in `decode_engine::load_kv_shadow_for_state_static`
+  (`tmp_k` / `tmp_v`): genuinely one-shot — written once via H2D,
+  DMA'd into the shadow buffer once, dropped at end of the layer
+  iteration. Marked as `Scratch` as a working demonstration. Saves
+  driver overhead at session-start KV restore (a few ms one-time
+  across all layers); not a per-token win.
+- **`trace_*` diagnostic functions**: only run with debug flags;
+  perf-irrelevant either way.
+
+The microbench evidence also tempers the optimism: even cache-irrelevant
+access patterns (the 1024-buffer scatter test) show host-mapped 3×
+slower than `hipMalloc`, likely TLB / page-walk overhead. A
+write-once-read-once buffer saves ~88 µs in driver call but pays
+some-µs-per-read in slower DMA — a wash at small sizes, possibly net
+loss at larger ones.
+
+**Conclusion**: the `BufferKind` API is the right shape (other arches
+may have different mappings), but on gfx1150 specifically there isn't
+a meaningful per-token win to mine from `Scratch` opt-ins. The
+demonstration marking on `tmp_k` / `tmp_v` shows the API works in
+real usage; future opt-ins should be measurement-driven, not
+speculative.


### PR DESCRIPTION
## Summary

Follow-up to #56 — a pass over the ~1100 `GpuBuffer` allocation sites looking for one-shot patterns where `BufferKind::Scratch` could capture H2D driver-call savings without losing cache reuse.

## Honest finding: almost nothing on the hot path

Categories surveyed:

- **Weights, KV cache, scratch workspaces** (the bulk of allocations across `decode_engine.rs`, `gemma4_engine.rs`, `prefill_engine.rs`, `kernel-ffi/src/certified_kv.rs`) — all read repeatedly across decode steps. `Persistent` is correct.
- **Per-step decode input IDs** — cost is dominated by alloc/free, not the H2D copy. Per-token churn risks regression.
- **KV-shadow restore `tmp_k`/`tmp_v`** in `load_kv_shadow_for_state_static` — genuinely one-shot. Written once via H2D, DMA'd into the shadow buffer once, dropped at end of the layer iteration. **Marked as `Scratch`** — saves driver overhead at session-start KV restore (a few ms one-time across all layers).
- **`trace_*` diagnostic functions** — only run with debug flags, perf-irrelevant.

The microbench evidence tempers the optimism too: even cache-irrelevant access patterns (the 1024-buffer scatter test) show host-mapped 3× slower than `hipMalloc`, likely TLB / page-walk overhead. A write-once-read-once buffer saves ~88 µs in the driver call but pays some-µs-per-read in slower DMA — wash at small sizes, possibly net loss at larger ones.

## What this PR is for

1. **Demonstrate the API works in real usage** — the `tmp_k`/`tmp_v` marking is a clean reference for future contributors.
2. **Document the survey methodology** so subsequent opt-in attempts are measurement-driven, not speculative. `docs/gfx1150-l2-bypass.md` gains a "Survey: where is `Scratch` actually a win?" section.

## Verification (gfx1150, peak clocks)

- `cargo build --release` — clean.
- Qwen3.5-0.8B INT4 decode: 45 ms/tok ×3 warm, bit-exact (`gpu_oracle_max_delta=0.0000`).
- The marked path (`load_kv_shadow_for_state_static`) doesn't execute on `--prompt "Hello, world"` — KV-state restore is only hit when resuming from a prior session — so this smoke test mostly confirms no compile-time or runtime regression.

## Test plan

- [x] `cargo build --release` clean
- [x] gfx1150 Qwen3.5-0.8B INT4 smoke: bit-exact, no perf regression on the unaffected hot path
- [ ] (Future) End-to-end test with a session-restore path that actually exercises `load_kv_shadow_for_state_static` to measure the few-ms one-time savings

🤖 Generated with [Claude Code](https://claude.com/claude-code)