### PR TITLE
Qwen3.6-MoE bringup: bake + 3 parity-gated kernels + dry-run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,6 @@
 __pycache__/
 *.pyc
 .env
-.venv/
+.venv*/
 .supersonic/
 .claude/scheduled_tasks.lock

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1100,6 +1100,7 @@ dependencies = [
  "cc",
  "gpu-hal",
  "half",
+ "serde_json",
  "thiserror",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1514,6 +1514,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "qwen36_moe"
+version = "0.1.0"
+dependencies = [
+ "memmap2",
+ "safetensors",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1720,6 +1731,7 @@ dependencies = [
  "phi4",
  "qwen35",
  "qwen35_dflash",
+ "qwen36_moe",
  "safetensors",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/phi4",
     "crates/qwen35",
     "crates/qwen35_dflash",
+    "crates/qwen36_moe",
     "crates/runner",
     "crates/server",
 ]

--- a/crates/kernel-ffi/Cargo.toml
+++ b/crates/kernel-ffi/Cargo.toml
@@ -10,3 +10,6 @@ thiserror = "2"
 
 [build-dependencies]
 cc = "1"
+
+[dev-dependencies]
+serde_json = "1"

--- a/crates/kernel-ffi/build.rs
+++ b/crates/kernel-ffi/build.rs
@@ -190,6 +190,11 @@ fn compile_hip(kernel_dir: &Path, out_dir: &Path) {
             "dflash_draft_hip.o",
             "building DFlash draft HIP bridge",
         ),
+        (
+            "qwen36_moe_bridge.cpp",
+            "qwen36_moe_hip.o",
+            "building Qwen3.6-MoE HIP bridge",
+        ),
     ];
     let archs = detect_hip_archs();
     if archs.is_empty() {
@@ -353,6 +358,8 @@ fn main() {
         "phi4_bridge.cpp",
         "dflash_draft.hip",
         "dflash_draft_bridge.cpp",
+        "qwen36_moe.hip",
+        "qwen36_moe_bridge.cpp",
         "full_attention_cuda.cuh",
         "full_attention_4b_cuda.cuh",
         "prefill_helpers_cuda.cuh",

--- a/crates/kernel-ffi/src/lib.rs
+++ b/crates/kernel-ffi/src/lib.rs
@@ -7,6 +7,7 @@ mod metal_host;
 mod metal_native;
 pub mod phi4;
 pub mod prefill_ffi;
+pub mod qwen36_moe;
 
 pub use qwen35::{
     cuda_accumulate_target_nll_bf16, cuda_argmax_bf16, cuda_lm_head_argmax_bf16,

--- a/crates/kernel-ffi/src/qwen36_moe.rs
+++ b/crates/kernel-ffi/src/qwen36_moe.rs
@@ -403,9 +403,9 @@ pub fn attn_step_launch(
             params.stage
         )));
     }
-    if params.stage > 2 {
+    if params.stage > 3 {
         return Err(GpuError::InvalidArg(format!(
-            "qwen36_moe::attn_step_launch: stage {} not yet implemented (PR 4b2 stages 1-2 only)",
+            "qwen36_moe::attn_step_launch: stage {} not yet implemented (PR 4b2 stages 1-3 only)",
             params.stage
         )));
     }
@@ -767,14 +767,25 @@ mod tests {
     }
 
     /// Returns workspace size sufficient for the largest staged
-    /// intermediate (currently stage 2: 2*H*d + 2*Hkv*d + H*d + Hkv*d F32).
-    /// Bumped by future stages as RoPE / attn buffers get added.
+    /// intermediate (currently stage 3: 4*H*d + 4*Hkv*d F32).
+    /// Bumped by future stages as attn / o_proj buffers get added.
     #[cfg(supersonic_backend_hip)]
     fn parity_workspace_floats(num_heads: i32, num_kv_heads: i32, head_dim: i32) -> usize {
         let h = num_heads as usize;
         let hkv = num_kv_heads as usize;
         let d = head_dim as usize;
-        2 * h * d + 2 * hkv * d + h * d + hkv * d
+        4 * h * d + 4 * hkv * d
+    }
+
+    /// Output buffer size sufficient for the largest staged intermediate.
+    /// Stage 3 publishes q_rot || k_rot, so the buffer must hold (H + Hkv)*d
+    /// BF16 elements; stages 1, 2, 4, 5 fit in a strict subset of that.
+    #[cfg(supersonic_backend_hip)]
+    fn parity_output_elems(num_heads: i32, num_kv_heads: i32, head_dim: i32) -> usize {
+        let h = num_heads as usize;
+        let hkv = num_kv_heads as usize;
+        let d = head_dim as usize;
+        h * d + hkv * d
     }
 
     #[cfg(supersonic_backend_hip)]
@@ -826,7 +837,8 @@ mod tests {
         ).expect("upload q_norm_w");
 
         let mut output = GpuBuffer::zeros(
-            ordinal, ScalarType::BF16, &[h_us * d_us],
+            ordinal, ScalarType::BF16,
+            &[parity_output_elems(geom.num_heads, geom.num_kv_heads, geom.head_dim)],
         ).expect("alloc output");
         let mut workspace = GpuBuffer::zeros(
             ordinal, ScalarType::F32,
@@ -869,10 +881,13 @@ mod tests {
         )
         .expect("attn_step_launch stage 1");
 
-        let got_bytes = output.to_host_bytes().expect("download output");
-        // BF16 ULP at magnitude 1 is ~7.8e-3; allow 4× that for matmul
-        // accumulation order drift across the 2048-wide reduction.
-        assert_parity("step1 q_normed", &got_bytes, &q_normed_expected_bytes, 0.04, 0.9999);
+        // Stage 1 publishes q_normed into the first H*d BF16 elements of
+        // the (now stage-3-sized) output buffer. Slice down to just those
+        // bytes for parity. BF16 ULP at magnitude 1 is ~7.8e-3; allow 4×
+        // that for matmul accumulation order drift over the 2048 reduction.
+        let got_bytes_full = output.to_host_bytes().expect("download output");
+        let got_bytes = &got_bytes_full[..h_us * d_us * 2];
+        assert_parity("step1 q_normed", got_bytes, &q_normed_expected_bytes, 0.04, 0.9999);
     }
 
     #[cfg(supersonic_backend_hip)]
@@ -939,7 +954,8 @@ mod tests {
         // Output is sized for the largest staged intermediate (H*d). Stage 2
         // writes Hkv*d BF16 elements at the start of the buffer.
         let mut output = GpuBuffer::zeros(
-            ordinal, ScalarType::BF16, &[h_us * d_us],
+            ordinal, ScalarType::BF16,
+            &[parity_output_elems(geom.num_heads, geom.num_kv_heads, geom.head_dim)],
         ).expect("alloc output");
         let mut workspace = GpuBuffer::zeros(
             ordinal, ScalarType::F32,
@@ -987,5 +1003,134 @@ mod tests {
         let got_bytes_full = output.to_host_bytes().expect("download output");
         let got_bytes = &got_bytes_full[..hkv_us * d_us * 2];
         assert_parity("step2 k_normed", got_bytes, &k_normed_expected_bytes, 0.04, 0.9999);
+    }
+
+    #[cfg(supersonic_backend_hip)]
+    #[test]
+    fn qwen36_moe_attn_step_3_qk_rot_matches_oracle() {
+        use gpu_hal::{set_backend, Backend, GpuBuffer, ScalarType};
+
+        let Some((json, geom)) = load_oracle_json() else {
+            eprintln!(
+                "skip: SUPERSONIC_QWEN36_ORACLE_JSON not set. \
+                 Generate at a non-zero position so RoPE is non-identity \
+                 (e.g. `python oracle/qwen36_moe_oracle.py --mode synthetic \
+                 --position 7 --out /tmp/qwen36_syn_pos7.json`)."
+            );
+            return;
+        };
+        let weights = &json["weights"];
+        let inters = &json["intermediates"];
+        let cfg = &json["config"];
+
+        let position = json["position"].as_i64().unwrap_or(0) as i32;
+        if position == 0 {
+            // RoPE at position 0 is the identity rotation — the parity
+            // test would pass even with a no-op kernel, which defeats the
+            // purpose. Refuse and tell the caller how to fix it.
+            panic!(
+                "step3 RoPE parity requires position > 0, got 0. \
+                 Re-run the oracle with `--position 7` (or any non-zero value)."
+            );
+        }
+
+        let rotary_dim = cfg["rotary_dim"].as_i64().unwrap() as i32;
+        let rope_theta = cfg["rope_theta"].as_f64().unwrap() as f32;
+
+        let input_hidden_bytes = b64_decode(weights["input_hidden"].as_str().unwrap());
+        let input_norm_w_bytes = b64_decode(weights["input_norm_w"].as_str().unwrap());
+        let q_proj_w_bytes = b64_decode(weights["q_proj_w"].as_str().unwrap());
+        let k_proj_w_bytes = b64_decode(weights["k_proj_w"].as_str().unwrap());
+        let v_proj_w_bytes = b64_decode(weights["v_proj_w"].as_str().unwrap());
+        let q_norm_w_bytes = b64_decode(weights["q_norm_w"].as_str().unwrap());
+        let k_norm_w_bytes = b64_decode(weights["k_norm_w"].as_str().unwrap());
+        let q_rot_expected_bytes = b64_decode(inters["q_rot"].as_str().unwrap());
+        let k_rot_expected_bytes = b64_decode(inters["k_rot"].as_str().unwrap());
+
+        let hidden_us = geom.hidden as usize;
+        let h_us = geom.num_heads as usize;
+        let hkv_us = geom.num_kv_heads as usize;
+        let d_us = geom.head_dim as usize;
+        assert_eq!(q_rot_expected_bytes.len(), h_us * d_us * 2);
+        assert_eq!(k_rot_expected_bytes.len(), hkv_us * d_us * 2);
+
+        set_backend(Backend::Hip);
+        let ordinal = 0usize;
+
+        let input_hidden = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_us], &input_hidden_bytes,
+        ).expect("upload input_hidden");
+        let input_norm_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_us], &input_norm_w_bytes,
+        ).expect("upload input_norm_w");
+        let q_proj_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[2 * h_us * d_us, hidden_us], &q_proj_w_bytes,
+        ).expect("upload q_proj_w");
+        let k_proj_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hkv_us * d_us, hidden_us], &k_proj_w_bytes,
+        ).expect("upload k_proj_w");
+        let v_proj_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hkv_us * d_us, hidden_us], &v_proj_w_bytes,
+        ).expect("upload v_proj_w");
+        let q_norm_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[d_us], &q_norm_w_bytes,
+        ).expect("upload q_norm_w");
+        let k_norm_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[d_us], &k_norm_w_bytes,
+        ).expect("upload k_norm_w");
+
+        let mut output = GpuBuffer::zeros(
+            ordinal, ScalarType::BF16,
+            &[parity_output_elems(geom.num_heads, geom.num_kv_heads, geom.head_dim)],
+        ).expect("alloc output");
+        let mut workspace = GpuBuffer::zeros(
+            ordinal, ScalarType::F32,
+            &[parity_workspace_floats(geom.num_heads, geom.num_kv_heads, geom.head_dim)],
+        ).expect("alloc workspace");
+        let mut sync_buf = GpuBuffer::zeros(
+            ordinal, ScalarType::U8, &[32],
+        ).expect("alloc sync buf");
+
+        let params = Qwen36MoeAttnStepParams {
+            stage: 3,
+            hidden: geom.hidden,
+            num_heads: geom.num_heads,
+            num_kv_heads: geom.num_kv_heads,
+            head_dim: geom.head_dim,
+            rotary_dim,
+            rope_theta,
+            rms_norm_eps: geom.rms_norm_eps,
+            position,
+        };
+        let weight_ptrs = Qwen36MoeAttnStepWeights {
+            input_hidden: input_hidden.as_ptr(),
+            input_norm_w: input_norm_w.as_ptr(),
+            q_proj_w: q_proj_w.as_ptr(),
+            k_proj_w: k_proj_w.as_ptr(),
+            v_proj_w: v_proj_w.as_ptr(),
+            q_norm_w: q_norm_w.as_ptr(),
+            k_norm_w: k_norm_w.as_ptr(),
+            o_proj_w: std::ptr::null(),
+        };
+
+        attn_step_launch(
+            ordinal,
+            ScalarType::BF16,
+            params,
+            &weight_ptrs,
+            &mut output,
+            &mut workspace,
+            &mut sync_buf,
+        )
+        .expect("attn_step_launch stage 3");
+
+        // Output layout: [q_rot (H*d) | k_rot (Hkv*d)] in BF16.
+        let got_bytes_full = output.to_host_bytes().expect("download output");
+        let q_end = h_us * d_us * 2;
+        let k_end = q_end + hkv_us * d_us * 2;
+        assert_parity("step3 q_rot", &got_bytes_full[..q_end],
+                      &q_rot_expected_bytes, 0.04, 0.9999);
+        assert_parity("step3 k_rot", &got_bytes_full[q_end..k_end],
+                      &k_rot_expected_bytes, 0.04, 0.9999);
     }
 }

--- a/crates/kernel-ffi/src/qwen36_moe.rs
+++ b/crates/kernel-ffi/src/qwen36_moe.rs
@@ -585,12 +585,7 @@ pub fn linear_step_launch(
             params.stage
         )));
     }
-    if params.stage > 3 {
-        return Err(GpuError::InvalidArg(format!(
-            "qwen36_moe::linear_step_launch: stage {} not yet implemented (PR 4b3 stages 1-3 only)",
-            params.stage
-        )));
-    }
+    // All five stages are wired through PR 4b3 step 6.
 
     let backend = output.backend();
     let counters = sync_buf.as_mut_ptr() as *mut c_uint;
@@ -853,6 +848,61 @@ mod tests {
             }
         }
         out
+    }
+
+    /// Convert a stream of F32 little-endian bytes to F32 values. Used
+    /// for parity-checking the recurrent state buffer (stage 4+), which
+    /// production keeps in F32 across decode steps.
+    #[cfg(supersonic_backend_hip)]
+    fn f32_bytes_to_f32(bytes: &[u8]) -> Vec<f32> {
+        assert!(bytes.len() % 4 == 0, "qwen36_moe parity: F32 bytes must be multiple of 4");
+        bytes
+            .chunks_exact(4)
+            .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect()
+    }
+
+    /// Same shape as `assert_parity` but for F32 buffers — used for the
+    /// recurrent state which never casts to BF16. Tolerances are tighter
+    /// (no BF16 rounding noise to absorb).
+    #[cfg(supersonic_backend_hip)]
+    fn assert_parity_f32(
+        label: &str,
+        got_bytes: &[u8],
+        want_bytes: &[u8],
+        max_abs_tol: f32,
+        cos_sim_floor: f64,
+    ) {
+        assert_eq!(got_bytes.len(), want_bytes.len(),
+                   "{label}: byte length mismatch");
+        let got = f32_bytes_to_f32(got_bytes);
+        let want = f32_bytes_to_f32(want_bytes);
+        let n = got.len();
+        let mut max_abs_diff = 0.0f32;
+        let mut sum_abs_diff = 0.0f32;
+        let mut dot = 0.0f64;
+        let mut got_sq = 0.0f64;
+        let mut want_sq = 0.0f64;
+        let mut exact = 0usize;
+        for i in 0..n {
+            let d = (got[i] - want[i]).abs();
+            if d == 0.0 { exact += 1; }
+            max_abs_diff = max_abs_diff.max(d);
+            sum_abs_diff += d;
+            dot += got[i] as f64 * want[i] as f64;
+            got_sq += (got[i] as f64).powi(2);
+            want_sq += (want[i] as f64).powi(2);
+        }
+        let cos_sim = dot / (got_sq.sqrt() * want_sq.sqrt() + 1e-30);
+        let mean_abs_diff = sum_abs_diff / n as f32;
+        eprintln!(
+            "[parity {label}] n={n} exact={exact} max_abs={max_abs_diff:.5e} \
+             mean_abs={mean_abs_diff:.5e} cos_sim={cos_sim:.7}"
+        );
+        assert!(max_abs_diff <= max_abs_tol,
+                "{label}: max_abs={max_abs_diff} exceeds tolerance {max_abs_tol}");
+        assert!(cos_sim >= cos_sim_floor,
+                "{label}: cos_sim {cos_sim:.7} below floor {cos_sim_floor}");
     }
 
     /// Convert a stream of BF16 little-endian bytes to F32. The oracle
@@ -2051,5 +2101,367 @@ mod tests {
                       &k_rep_expected, 0.04, 0.9999);
         assert_parity("linear step3 v_heads", &got_bytes_full[k_end..v_end],
                       &v_heads_expected, 0.04, 0.9999);
+    }
+
+    #[cfg(supersonic_backend_hip)]
+    #[test]
+    fn qwen36_moe_linear_step_4_recurrent_matches_oracle() {
+        use gpu_hal::{set_backend, Backend, GpuBuffer, ScalarType};
+
+        let Some((json, geom)) = load_linear_oracle_json() else {
+            eprintln!(
+                "skip: SUPERSONIC_QWEN36_LINEAR_ORACLE_JSON not set. \
+                 See `qwen36_moe_linear_step_1_qkv_raw_matches_oracle` for setup."
+            );
+            return;
+        };
+        let weights = &json["weights"];
+        let inters = &json["intermediates"];
+
+        // Stage 4 needs everything stage 3 needed plus dt_bias, A_log, and
+        // the prior recurrent state.
+        let input_hidden_bytes = b64_decode(weights["input_hidden"].as_str().unwrap());
+        let input_norm_w_bytes = b64_decode(weights["input_norm_w"].as_str().unwrap());
+        let in_proj_qkv_w_bytes = b64_decode(weights["in_proj_qkv_w"].as_str().unwrap());
+        let in_proj_z_w_bytes = b64_decode(weights["in_proj_z_w"].as_str().unwrap());
+        let in_proj_a_w_bytes = b64_decode(weights["in_proj_a_w"].as_str().unwrap());
+        let in_proj_b_w_bytes = b64_decode(weights["in_proj_b_w"].as_str().unwrap());
+        let conv1d_w_bytes = b64_decode(weights["conv1d_w"].as_str().unwrap());
+        let conv1d_bias_bytes = weights.get("conv1d_bias")
+            .and_then(|v| v.as_str())
+            .map(b64_decode);
+        let conv_state_before_bytes = b64_decode(weights["conv_state_before"].as_str().unwrap());
+        let dt_bias_bytes = b64_decode(weights["dt_bias"].as_str().unwrap());
+        let a_log_bytes = b64_decode(weights["a_log"].as_str().unwrap());
+        // recurrent_state_before is encoded as F32 (production layout).
+        let recurrent_state_before_bytes =
+            b64_decode(weights["recurrent_state_before"].as_str().unwrap());
+        let recurrent_out_expected = b64_decode(inters["recurrent_out"].as_str().unwrap());
+        let state_after_expected = b64_decode(inters["state_after"].as_str().unwrap());
+
+        let hidden_us = geom.hidden as usize;
+        let k_us = geom.num_k_heads as usize;
+        let v_us = geom.num_v_heads as usize;
+        let kd_us = geom.head_k_dim as usize;
+        let vd_us = geom.head_v_dim as usize;
+        let kernel = geom.conv_kernel_dim as usize;
+        let kstate = kernel - 1;
+        let key_dim = k_us * kd_us;
+        let val_dim = v_us * vd_us;
+        let qkv_dim = 2 * key_dim + val_dim;
+        let v_kdim = v_us * kd_us;
+        let v_vdim = v_us * vd_us;
+        let state_elems = v_us * kd_us * vd_us;
+
+        assert_eq!(dt_bias_bytes.len(), v_us * 2);
+        assert_eq!(a_log_bytes.len(), v_us * 2);
+        // recurrent_state encoded F32 (4 bytes/elem).
+        assert_eq!(recurrent_state_before_bytes.len(), state_elems * 4);
+        assert_eq!(recurrent_out_expected.len(), v_vdim * 2);
+        assert_eq!(state_after_expected.len(), state_elems * 4);
+
+        set_backend(Backend::Hip);
+        let ordinal = 0usize;
+
+        let input_hidden = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_us], &input_hidden_bytes,
+        ).expect("upload input_hidden");
+        let input_norm_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_us], &input_norm_w_bytes,
+        ).expect("upload input_norm_w");
+        let in_proj_qkv_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[qkv_dim, hidden_us], &in_proj_qkv_w_bytes,
+        ).expect("upload in_proj_qkv_w");
+        let in_proj_z_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[val_dim, hidden_us], &in_proj_z_w_bytes,
+        ).expect("upload in_proj_z_w");
+        let in_proj_a_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[v_us, hidden_us], &in_proj_a_w_bytes,
+        ).expect("upload in_proj_a_w");
+        let in_proj_b_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[v_us, hidden_us], &in_proj_b_w_bytes,
+        ).expect("upload in_proj_b_w");
+        let conv1d_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[qkv_dim, 1, kernel], &conv1d_w_bytes,
+        ).expect("upload conv1d_w");
+        let conv1d_bias = match &conv1d_bias_bytes {
+            Some(bytes) => Some(
+                GpuBuffer::from_host_bytes(ordinal, ScalarType::BF16, &[qkv_dim], bytes)
+                    .expect("upload conv1d_bias"),
+            ),
+            None => None,
+        };
+        let dt_bias = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[v_us], &dt_bias_bytes,
+        ).expect("upload dt_bias");
+        let a_log = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[v_us], &a_log_bytes,
+        ).expect("upload a_log");
+        let mut conv_state = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[qkv_dim, kstate], &conv_state_before_bytes,
+        ).expect("upload conv_state");
+        let mut recurrent_state = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::F32, &[state_elems], &recurrent_state_before_bytes,
+        ).expect("upload recurrent_state");
+
+        // Stage 4 publishes recurrent_out [V*v_dim] BF16. The buffer is
+        // sized for the largest staged intermediate (still stage 3's
+        // q_scaled||k_rep||v_heads = 2*V*k_dim + V*v_dim).
+        let stage_publish_max = 2 * v_kdim + v_vdim;
+        let mut output = GpuBuffer::zeros(
+            ordinal, ScalarType::BF16, &[stage_publish_max],
+        ).expect("alloc output");
+        // Workspace for stage 4 = previous + BETA + G + REC_OUT.
+        let workspace_floats =
+            qkv_dim + val_dim + 2 * v_us
+            + 2 * (k_us * kd_us)
+            + 2 * v_kdim
+            + v_us + v_us
+            + v_vdim;
+        let mut workspace = GpuBuffer::zeros(
+            ordinal, ScalarType::F32, &[workspace_floats],
+        ).expect("alloc workspace");
+        let mut sync_buf = GpuBuffer::zeros(
+            ordinal, ScalarType::U8, &[32],
+        ).expect("alloc sync buf");
+
+        let params = Qwen36MoeLinearStepParams {
+            stage: 4,
+            hidden: geom.hidden,
+            num_k_heads: geom.num_k_heads,
+            num_v_heads: geom.num_v_heads,
+            head_k_dim: geom.head_k_dim,
+            head_v_dim: geom.head_v_dim,
+            conv_kernel_dim: geom.conv_kernel_dim,
+            rms_norm_eps: geom.rms_norm_eps,
+        };
+        let weight_ptrs = Qwen36MoeLinearStepWeights {
+            input_hidden: input_hidden.as_ptr(),
+            input_norm_w: input_norm_w.as_ptr(),
+            in_proj_qkv_w: in_proj_qkv_w.as_ptr(),
+            in_proj_z_w: in_proj_z_w.as_ptr(),
+            in_proj_a_w: in_proj_a_w.as_ptr(),
+            in_proj_b_w: in_proj_b_w.as_ptr(),
+            conv1d_w: conv1d_w.as_ptr(),
+            conv1d_bias: conv1d_bias.as_ref().map(|b| b.as_ptr()).unwrap_or(std::ptr::null()),
+            dt_bias: dt_bias.as_ptr(),
+            a_log: a_log.as_ptr(),
+            norm_w: std::ptr::null(),
+            out_proj_w: std::ptr::null(),
+            conv_state: conv_state.as_mut_ptr(),
+            recurrent_state: recurrent_state.as_mut_ptr() as *mut f32,
+        };
+
+        linear_step_launch(
+            ordinal,
+            ScalarType::BF16,
+            params,
+            &weight_ptrs,
+            &mut output,
+            &mut workspace,
+            &mut sync_buf,
+        )
+        .expect("linear_step_launch stage 4");
+
+        // Stage 4 publishes recurrent_out [V*v_dim] BF16.
+        let got_bytes_full = output.to_host_bytes().expect("download output");
+        let rec_out_bytes = &got_bytes_full[..v_vdim * 2];
+        // Recurrent state mixes BF16-rounded inputs (k_rep, q_scaled,
+        // v_heads) into F32-precision math; the per-V*v_dim reduction is
+        // 128-wide so allow the same envelope as the qkv_proj reduction.
+        assert_parity(
+            "linear step4 recurrent_out",
+            rec_out_bytes,
+            &recurrent_out_expected,
+            0.04,
+            0.9999,
+        );
+
+        // Also verify state_after — the F32 recurrent state has been
+        // mutated in place by the kernel and must match the oracle's
+        // post-update state for the next decode step to work.
+        let state_after_got = recurrent_state.to_host_bytes().expect("download state");
+        // F32 throughout (no BF16 rounding); be tighter on max_abs.
+        // Per-element rounding error from F32 arithmetic + cast-from-BF16
+        // operands is at most a few ULPs of the magnitude.
+        assert_parity_f32(
+            "linear step4 state_after",
+            &state_after_got,
+            &state_after_expected,
+            5e-3,
+            0.9999,
+        );
+    }
+
+    #[cfg(supersonic_backend_hip)]
+    #[test]
+    fn qwen36_moe_linear_step_5_output_hidden_matches_oracle() {
+        use gpu_hal::{set_backend, Backend, GpuBuffer, ScalarType};
+
+        let Some((json, geom)) = load_linear_oracle_json() else {
+            eprintln!(
+                "skip: SUPERSONIC_QWEN36_LINEAR_ORACLE_JSON not set. \
+                 See `qwen36_moe_linear_step_1_qkv_raw_matches_oracle` for setup."
+            );
+            return;
+        };
+        let weights = &json["weights"];
+        let inters = &json["intermediates"];
+
+        // Stage 5 needs every weight from earlier stages plus norm_w and out_proj_w.
+        let input_hidden_bytes = b64_decode(weights["input_hidden"].as_str().unwrap());
+        let input_norm_w_bytes = b64_decode(weights["input_norm_w"].as_str().unwrap());
+        let in_proj_qkv_w_bytes = b64_decode(weights["in_proj_qkv_w"].as_str().unwrap());
+        let in_proj_z_w_bytes = b64_decode(weights["in_proj_z_w"].as_str().unwrap());
+        let in_proj_a_w_bytes = b64_decode(weights["in_proj_a_w"].as_str().unwrap());
+        let in_proj_b_w_bytes = b64_decode(weights["in_proj_b_w"].as_str().unwrap());
+        let conv1d_w_bytes = b64_decode(weights["conv1d_w"].as_str().unwrap());
+        let conv1d_bias_bytes = weights.get("conv1d_bias")
+            .and_then(|v| v.as_str())
+            .map(b64_decode);
+        let conv_state_before_bytes = b64_decode(weights["conv_state_before"].as_str().unwrap());
+        let dt_bias_bytes = b64_decode(weights["dt_bias"].as_str().unwrap());
+        let a_log_bytes = b64_decode(weights["a_log"].as_str().unwrap());
+        let recurrent_state_before_bytes =
+            b64_decode(weights["recurrent_state_before"].as_str().unwrap());
+        let norm_w_bytes = b64_decode(weights["norm_w"].as_str().unwrap());
+        let out_proj_w_bytes = b64_decode(weights["out_proj_w"].as_str().unwrap());
+        let output_hidden_expected = b64_decode(inters["output_hidden"].as_str().unwrap());
+
+        let hidden_us = geom.hidden as usize;
+        let k_us = geom.num_k_heads as usize;
+        let v_us = geom.num_v_heads as usize;
+        let kd_us = geom.head_k_dim as usize;
+        let vd_us = geom.head_v_dim as usize;
+        let kernel = geom.conv_kernel_dim as usize;
+        let kstate = kernel - 1;
+        let key_dim = k_us * kd_us;
+        let val_dim = v_us * vd_us;
+        let qkv_dim = 2 * key_dim + val_dim;
+        let v_kdim = v_us * kd_us;
+        let v_vdim = v_us * vd_us;
+        let state_elems = v_us * kd_us * vd_us;
+
+        assert_eq!(norm_w_bytes.len(), vd_us * 2);
+        assert_eq!(out_proj_w_bytes.len(), hidden_us * v_vdim * 2);
+        assert_eq!(output_hidden_expected.len(), hidden_us * 2);
+
+        set_backend(Backend::Hip);
+        let ordinal = 0usize;
+
+        let input_hidden = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_us], &input_hidden_bytes,
+        ).expect("upload input_hidden");
+        let input_norm_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_us], &input_norm_w_bytes,
+        ).expect("upload input_norm_w");
+        let in_proj_qkv_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[qkv_dim, hidden_us], &in_proj_qkv_w_bytes,
+        ).expect("upload in_proj_qkv_w");
+        let in_proj_z_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[val_dim, hidden_us], &in_proj_z_w_bytes,
+        ).expect("upload in_proj_z_w");
+        let in_proj_a_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[v_us, hidden_us], &in_proj_a_w_bytes,
+        ).expect("upload in_proj_a_w");
+        let in_proj_b_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[v_us, hidden_us], &in_proj_b_w_bytes,
+        ).expect("upload in_proj_b_w");
+        let conv1d_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[qkv_dim, 1, kernel], &conv1d_w_bytes,
+        ).expect("upload conv1d_w");
+        let conv1d_bias = match &conv1d_bias_bytes {
+            Some(bytes) => Some(
+                GpuBuffer::from_host_bytes(ordinal, ScalarType::BF16, &[qkv_dim], bytes)
+                    .expect("upload conv1d_bias"),
+            ),
+            None => None,
+        };
+        let dt_bias = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[v_us], &dt_bias_bytes,
+        ).expect("upload dt_bias");
+        let a_log = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[v_us], &a_log_bytes,
+        ).expect("upload a_log");
+        let norm_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[vd_us], &norm_w_bytes,
+        ).expect("upload norm_w");
+        let out_proj_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_us, v_vdim], &out_proj_w_bytes,
+        ).expect("upload out_proj_w");
+        let mut conv_state = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[qkv_dim, kstate], &conv_state_before_bytes,
+        ).expect("upload conv_state");
+        let mut recurrent_state = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::F32, &[state_elems], &recurrent_state_before_bytes,
+        ).expect("upload recurrent_state");
+
+        let stage_publish_max = 2 * v_kdim + v_vdim;
+        let mut output = GpuBuffer::zeros(
+            ordinal, ScalarType::BF16, &[stage_publish_max],
+        ).expect("alloc output");
+        let workspace_floats =
+            qkv_dim + val_dim + 2 * v_us
+            + 2 * (k_us * kd_us)
+            + 2 * v_kdim
+            + v_us + v_us
+            + v_vdim;
+        let mut workspace = GpuBuffer::zeros(
+            ordinal, ScalarType::F32, &[workspace_floats],
+        ).expect("alloc workspace");
+        let mut sync_buf = GpuBuffer::zeros(
+            ordinal, ScalarType::U8, &[32],
+        ).expect("alloc sync buf");
+
+        let params = Qwen36MoeLinearStepParams {
+            stage: 5,
+            hidden: geom.hidden,
+            num_k_heads: geom.num_k_heads,
+            num_v_heads: geom.num_v_heads,
+            head_k_dim: geom.head_k_dim,
+            head_v_dim: geom.head_v_dim,
+            conv_kernel_dim: geom.conv_kernel_dim,
+            rms_norm_eps: geom.rms_norm_eps,
+        };
+        let weight_ptrs = Qwen36MoeLinearStepWeights {
+            input_hidden: input_hidden.as_ptr(),
+            input_norm_w: input_norm_w.as_ptr(),
+            in_proj_qkv_w: in_proj_qkv_w.as_ptr(),
+            in_proj_z_w: in_proj_z_w.as_ptr(),
+            in_proj_a_w: in_proj_a_w.as_ptr(),
+            in_proj_b_w: in_proj_b_w.as_ptr(),
+            conv1d_w: conv1d_w.as_ptr(),
+            conv1d_bias: conv1d_bias.as_ref().map(|b| b.as_ptr()).unwrap_or(std::ptr::null()),
+            dt_bias: dt_bias.as_ptr(),
+            a_log: a_log.as_ptr(),
+            norm_w: norm_w.as_ptr(),
+            out_proj_w: out_proj_w.as_ptr(),
+            conv_state: conv_state.as_mut_ptr(),
+            recurrent_state: recurrent_state.as_mut_ptr() as *mut f32,
+        };
+
+        linear_step_launch(
+            ordinal,
+            ScalarType::BF16,
+            params,
+            &weight_ptrs,
+            &mut output,
+            &mut workspace,
+            &mut sync_buf,
+        )
+        .expect("linear_step_launch stage 5");
+
+        // Stage 5 publishes output_hidden into output[0..hidden) BF16.
+        let got_bytes_full = output.to_host_bytes().expect("download output");
+        let got_bytes = &got_bytes_full[..hidden_us * 2];
+        // out_proj reduces over V*v_dim=4096 lanes; same envelope as
+        // PR 4b2 stage 5.
+        assert_parity(
+            "linear step5 output_hidden",
+            got_bytes,
+            &output_hidden_expected,
+            0.05,
+            0.9999,
+        );
     }
 }

--- a/crates/kernel-ffi/src/qwen36_moe.rs
+++ b/crates/kernel-ffi/src/qwen36_moe.rs
@@ -3255,4 +3255,138 @@ mod tests {
             0.999,
         );
     }
+
+    #[cfg(supersonic_backend_hip)]
+    #[test]
+    fn qwen36_moe_ffn_step_5_output_hidden_matches_oracle() {
+        use gpu_hal::{set_backend, Backend, GpuBuffer, ScalarType};
+
+        let Some((json, geom)) = load_ffn_oracle_json() else {
+            eprintln!(
+                "skip: SUPERSONIC_QWEN36_FFN_ORACLE_JSON not set. \
+                 See `qwen36_moe_ffn_step_1_topk_matches_oracle` for setup."
+            );
+            return;
+        };
+        let weights = &json["weights"];
+        let inters = &json["intermediates"];
+
+        // Stage 5 is the trivial closer — same weights as stage 4 plus the
+        // residual add against `input_hidden`.
+        let input_hidden_bytes = b64_decode(weights["input_hidden"].as_str().unwrap());
+        let post_attn_norm_w_bytes = b64_decode(weights["post_attn_norm_w"].as_str().unwrap());
+        let gate_w_bytes = b64_decode(weights["gate_w"].as_str().unwrap());
+        let gate_up_proj_w_bytes =
+            b64_decode(weights["gate_up_proj_w"].as_str().unwrap());
+        let down_proj_w_bytes = b64_decode(weights["down_proj_w"].as_str().unwrap());
+        let shared_gate_proj_w_bytes =
+            b64_decode(weights["shared_gate_proj_w"].as_str().unwrap());
+        let shared_up_proj_w_bytes =
+            b64_decode(weights["shared_up_proj_w"].as_str().unwrap());
+        let shared_down_proj_w_bytes =
+            b64_decode(weights["shared_down_proj_w"].as_str().unwrap());
+        let shared_expert_gate_w_bytes =
+            b64_decode(weights["shared_expert_gate_w"].as_str().unwrap());
+        let output_hidden_expected_bytes =
+            b64_decode(inters["output_hidden"].as_str().unwrap());
+
+        let hidden_us = geom.hidden as usize;
+        let e_us = geom.num_experts as usize;
+        let i_us = geom.moe_intermediate as usize;
+        let is_us = geom.shared_intermediate as usize;
+        let k_us = geom.top_k as usize;
+
+        assert_eq!(output_hidden_expected_bytes.len(), hidden_us * 2);
+
+        set_backend(Backend::Hip);
+        let ordinal = 0usize;
+
+        let input_hidden = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_us], &input_hidden_bytes,
+        ).expect("upload input_hidden");
+        let post_attn_norm_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_us], &post_attn_norm_w_bytes,
+        ).expect("upload post_attn_norm_w");
+        let gate_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[e_us, hidden_us], &gate_w_bytes,
+        ).expect("upload gate_w");
+        let gate_up_proj_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[e_us, 2 * i_us, hidden_us], &gate_up_proj_w_bytes,
+        ).expect("upload gate_up_proj_w");
+        let down_proj_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[e_us, hidden_us, i_us], &down_proj_w_bytes,
+        ).expect("upload down_proj_w");
+        let shared_gate_proj_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[is_us, hidden_us], &shared_gate_proj_w_bytes,
+        ).expect("upload shared_gate_proj_w");
+        let shared_up_proj_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[is_us, hidden_us], &shared_up_proj_w_bytes,
+        ).expect("upload shared_up_proj_w");
+        let shared_down_proj_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_us, is_us], &shared_down_proj_w_bytes,
+        ).expect("upload shared_down_proj_w");
+        let shared_expert_gate_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[1, hidden_us], &shared_expert_gate_w_bytes,
+        ).expect("upload shared_expert_gate_w");
+
+        let mut output = GpuBuffer::zeros(
+            ordinal, ScalarType::BF16, &[ffn_parity_output_elems(&geom)],
+        ).expect("alloc output");
+        let mut output_idx = GpuBuffer::zeros(
+            ordinal, ScalarType::U32, &[k_us],
+        ).expect("alloc output_idx");
+        let mut workspace = GpuBuffer::zeros(
+            ordinal, ScalarType::F32, &[ffn_parity_workspace_floats(&geom)],
+        ).expect("alloc workspace");
+        let mut sync_buf = GpuBuffer::zeros(
+            ordinal, ScalarType::U8, &[32],
+        ).expect("alloc sync buf");
+
+        let params = Qwen36MoeFfnStepParams {
+            stage: 5,
+            hidden: geom.hidden,
+            num_experts: geom.num_experts,
+            moe_intermediate: geom.moe_intermediate,
+            shared_intermediate: geom.shared_intermediate,
+            top_k: geom.top_k,
+            rms_norm_eps: geom.rms_norm_eps,
+        };
+        let weight_ptrs = Qwen36MoeFfnStepWeights {
+            input_hidden: input_hidden.as_ptr(),
+            post_attn_norm_w: post_attn_norm_w.as_ptr(),
+            gate_w: gate_w.as_ptr(),
+            gate_up_proj_w: gate_up_proj_w.as_ptr(),
+            down_proj_w: down_proj_w.as_ptr(),
+            shared_gate_proj_w: shared_gate_proj_w.as_ptr(),
+            shared_up_proj_w: shared_up_proj_w.as_ptr(),
+            shared_down_proj_w: shared_down_proj_w.as_ptr(),
+            shared_expert_gate_w: shared_expert_gate_w.as_ptr(),
+        };
+
+        ffn_step_launch(
+            ordinal,
+            ScalarType::BF16,
+            params,
+            &weight_ptrs,
+            &mut output,
+            &mut output_idx,
+            &mut workspace,
+            &mut sync_buf,
+        )
+        .expect("ffn_step_launch stage 5");
+
+        // Stage 5 publishes output_hidden = input_hidden + moe_out +
+        // shared_out (all F32, BF16-round once at the end). The residual
+        // addition can't make accuracy worse than stage 4's moe_out, so
+        // the same envelope applies.
+        let got_full = output.to_host_bytes().expect("download output");
+        let got_bytes = &got_full[..hidden_us * 2];
+        assert_parity(
+            "ffn step5 output_hidden",
+            got_bytes,
+            &output_hidden_expected_bytes,
+            0.05,
+            0.999,
+        );
+    }
 }

--- a/crates/kernel-ffi/src/qwen36_moe.rs
+++ b/crates/kernel-ffi/src/qwen36_moe.rs
@@ -2845,4 +2845,138 @@ mod tests {
             0.9999,
         );
     }
+
+    #[cfg(supersonic_backend_hip)]
+    #[test]
+    fn qwen36_moe_ffn_step_2_shared_out_matches_oracle() {
+        use gpu_hal::{set_backend, Backend, GpuBuffer, ScalarType};
+
+        let Some((json, geom)) = load_ffn_oracle_json() else {
+            eprintln!(
+                "skip: SUPERSONIC_QWEN36_FFN_ORACLE_JSON not set. \
+                 See `qwen36_moe_ffn_step_1_topk_matches_oracle` for setup."
+            );
+            return;
+        };
+        let weights = &json["weights"];
+        let inters = &json["intermediates"];
+
+        // Stage 2 still runs the stage-1 prerequisites (rmsnorm + router
+        // gate), so the gate weight is still required. The new tensors
+        // are the four shared-expert weights; the per-expert
+        // gate_up_proj / down_proj stay null until stage 3.
+        let input_hidden_bytes = b64_decode(weights["input_hidden"].as_str().unwrap());
+        let post_attn_norm_w_bytes = b64_decode(weights["post_attn_norm_w"].as_str().unwrap());
+        let gate_w_bytes = b64_decode(weights["gate_w"].as_str().unwrap());
+        let shared_gate_proj_w_bytes =
+            b64_decode(weights["shared_gate_proj_w"].as_str().unwrap());
+        let shared_up_proj_w_bytes =
+            b64_decode(weights["shared_up_proj_w"].as_str().unwrap());
+        let shared_down_proj_w_bytes =
+            b64_decode(weights["shared_down_proj_w"].as_str().unwrap());
+        let shared_expert_gate_w_bytes =
+            b64_decode(weights["shared_expert_gate_w"].as_str().unwrap());
+        let shared_out_expected_bytes =
+            b64_decode(inters["shared_out"].as_str().unwrap());
+
+        let hidden_us = geom.hidden as usize;
+        let e_us = geom.num_experts as usize;
+        let is_us = geom.shared_intermediate as usize;
+        let k_us = geom.top_k as usize;
+
+        assert_eq!(input_hidden_bytes.len(), hidden_us * 2);
+        assert_eq!(post_attn_norm_w_bytes.len(), hidden_us * 2);
+        assert_eq!(gate_w_bytes.len(), e_us * hidden_us * 2);
+        assert_eq!(shared_gate_proj_w_bytes.len(), is_us * hidden_us * 2);
+        assert_eq!(shared_up_proj_w_bytes.len(), is_us * hidden_us * 2);
+        assert_eq!(shared_down_proj_w_bytes.len(), hidden_us * is_us * 2);
+        assert_eq!(shared_expert_gate_w_bytes.len(), 1 * hidden_us * 2);
+        assert_eq!(shared_out_expected_bytes.len(), hidden_us * 2);
+
+        set_backend(Backend::Hip);
+        let ordinal = 0usize;
+
+        let input_hidden = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_us], &input_hidden_bytes,
+        ).expect("upload input_hidden");
+        let post_attn_norm_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_us], &post_attn_norm_w_bytes,
+        ).expect("upload post_attn_norm_w");
+        let gate_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[e_us, hidden_us], &gate_w_bytes,
+        ).expect("upload gate_w");
+        let shared_gate_proj_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[is_us, hidden_us], &shared_gate_proj_w_bytes,
+        ).expect("upload shared_gate_proj_w");
+        let shared_up_proj_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[is_us, hidden_us], &shared_up_proj_w_bytes,
+        ).expect("upload shared_up_proj_w");
+        let shared_down_proj_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_us, is_us], &shared_down_proj_w_bytes,
+        ).expect("upload shared_down_proj_w");
+        let shared_expert_gate_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[1, hidden_us], &shared_expert_gate_w_bytes,
+        ).expect("upload shared_expert_gate_w");
+
+        let mut output = GpuBuffer::zeros(
+            ordinal, ScalarType::BF16, &[ffn_parity_output_elems(&geom)],
+        ).expect("alloc output");
+        let mut output_idx = GpuBuffer::zeros(
+            ordinal, ScalarType::U32, &[k_us],
+        ).expect("alloc output_idx");
+        let mut workspace = GpuBuffer::zeros(
+            ordinal, ScalarType::F32, &[ffn_parity_workspace_floats(&geom)],
+        ).expect("alloc workspace");
+        let mut sync_buf = GpuBuffer::zeros(
+            ordinal, ScalarType::U8, &[32],
+        ).expect("alloc sync buf");
+
+        let params = Qwen36MoeFfnStepParams {
+            stage: 2,
+            hidden: geom.hidden,
+            num_experts: geom.num_experts,
+            moe_intermediate: geom.moe_intermediate,
+            shared_intermediate: geom.shared_intermediate,
+            top_k: geom.top_k,
+            rms_norm_eps: geom.rms_norm_eps,
+        };
+        let weight_ptrs = Qwen36MoeFfnStepWeights {
+            input_hidden: input_hidden.as_ptr(),
+            post_attn_norm_w: post_attn_norm_w.as_ptr(),
+            gate_w: gate_w.as_ptr(),
+            gate_up_proj_w: std::ptr::null(),
+            down_proj_w: std::ptr::null(),
+            shared_gate_proj_w: shared_gate_proj_w.as_ptr(),
+            shared_up_proj_w: shared_up_proj_w.as_ptr(),
+            shared_down_proj_w: shared_down_proj_w.as_ptr(),
+            shared_expert_gate_w: shared_expert_gate_w.as_ptr(),
+        };
+
+        ffn_step_launch(
+            ordinal,
+            ScalarType::BF16,
+            params,
+            &weight_ptrs,
+            &mut output,
+            &mut output_idx,
+            &mut workspace,
+            &mut sync_buf,
+        )
+        .expect("ffn_step_launch stage 2");
+
+        // Stage 2 publishes shared_out into output[0..hidden] BF16. Tolerance
+        // is looser than stage 1 because the shared expert path stacks four
+        // matmuls (gate, up, down, plus the 1-row sigmoid gate); each one
+        // accumulates F32 reduction-order drift. Cos_sim ≥ 0.999 on a deep
+        // chain like this is the same envelope linear-attn stage 5 uses.
+        let got_full = output.to_host_bytes().expect("download output");
+        let got_bytes = &got_full[..hidden_us * 2];
+        assert_parity(
+            "ffn step2 shared_out",
+            got_bytes,
+            &shared_out_expected_bytes,
+            0.05,
+            0.999,
+        );
+    }
 }

--- a/crates/kernel-ffi/src/qwen36_moe.rs
+++ b/crates/kernel-ffi/src/qwen36_moe.rs
@@ -331,6 +331,58 @@ extern "C" {
         barrier_counter: *mut c_uint,
         barrier_flag: *mut c_uint,
     ) -> c_int;
+
+    /// PR 4b4 staged single-block MoE FFN parity launcher. Same staged-build-up
+    /// discipline as `qwen36_moe_hip_attn_step_launch` and
+    /// `qwen36_moe_hip_linear_step_launch`, but for the post-attention half
+    /// of one Qwen3.6-MoE layer. `stage` selects how far to run; the matching
+    /// staged intermediate is published to `output` (BF16) and `output_idx`
+    /// (i32, top-k indices for stages 1+):
+    ///
+    /// | stage | output buffer contents (BF16)                    |
+    /// |-------|--------------------------------------------------|
+    /// |   1   | `topk_weights[k]`           (idx via `output_idx`) |
+    /// |   2   | `shared_out[hidden]`                             |
+    /// |   3   | `expert_0_out[hidden]`      (top-1 dispatch)     |
+    /// |   4   | `moe_out[hidden]`                                |
+    /// |   5   | `output_hidden[hidden]`     (final residual)     |
+    ///
+    /// PR 4b4 step 1 wires only `stage == 1`; the kernel ignores the
+    /// gate_up_proj / down_proj / shared_expert_* pointers and the matching
+    /// arguments can be null. They're declared up front so subsequent staged
+    /// commits don't perturb the FFI ABI.
+    ///
+    /// `workspace` must be at least `hidden + 2*num_experts + 2*top_k` F32
+    /// entries for stage 1 (later stages bump that up). `output` must be at
+    /// least `top_k` BF16 entries on stage 1 and `output_idx` must be at
+    /// least `top_k` i32 entries. `sync_buf` (counters/barrier_counter/
+    /// barrier_flag) must be 32 zero bytes.
+    pub fn qwen36_moe_hip_ffn_step_launch(
+        dtype: c_int,
+        device_ordinal: usize,
+        stage: c_int,
+        hidden: c_int,
+        num_experts: c_int,
+        moe_intermediate: c_int,
+        shared_intermediate: c_int,
+        top_k: c_int,
+        rms_norm_eps: f32,
+        input_hidden: *const c_void,
+        post_attn_norm_w: *const c_void,
+        gate_w: *const c_void,
+        gate_up_proj_w: *const c_void,
+        down_proj_w: *const c_void,
+        shared_gate_proj_w: *const c_void,
+        shared_up_proj_w: *const c_void,
+        shared_down_proj_w: *const c_void,
+        shared_expert_gate_w: *const c_void,
+        output: *mut c_void,
+        output_idx: *mut c_int,
+        workspace: *mut f32,
+        counters: *mut c_uint,
+        barrier_counter: *mut c_uint,
+        barrier_flag: *mut c_uint,
+    ) -> c_int;
 }
 
 /// Safe wrapper over the stub launch. The engine pre-allocates `sync_buf`
@@ -650,6 +702,137 @@ pub fn linear_step_launch(
         return Err(GpuError::backend(
             backend,
             format!("qwen36_moe linear_step launch failed with status {status}"),
+        ));
+    }
+    Ok(())
+}
+
+/// Geometry for the staged MoE FFN parity launcher. Mirrors
+/// `Qwen36MoeAttnStepParams` / `Qwen36MoeLinearStepParams`. Bundling these
+/// keeps the safe wrapper's signature short.
+#[derive(Debug, Clone, Copy)]
+pub struct Qwen36MoeFfnStepParams {
+    pub stage: i32,
+    pub hidden: i32,
+    pub num_experts: i32,
+    pub moe_intermediate: i32,
+    pub shared_intermediate: i32,
+    pub top_k: i32,
+    pub rms_norm_eps: f32,
+}
+
+/// Weight pointers for the staged MoE FFN parity launcher. Pointers unused
+/// by the requested `stage` may be null; the kernel won't dereference them.
+/// See [`qwen36_moe_hip_ffn_step_launch`] for the per-stage matrix.
+#[derive(Debug, Clone, Copy)]
+pub struct Qwen36MoeFfnStepWeights {
+    pub input_hidden: *const c_void,
+    pub post_attn_norm_w: *const c_void,
+    pub gate_w: *const c_void,
+    pub gate_up_proj_w: *const c_void,
+    pub down_proj_w: *const c_void,
+    pub shared_gate_proj_w: *const c_void,
+    pub shared_up_proj_w: *const c_void,
+    pub shared_down_proj_w: *const c_void,
+    pub shared_expert_gate_w: *const c_void,
+}
+
+/// Safe wrapper for the PR 4b4 staged MoE FFN parity launcher.
+///
+/// `output` must be a BF16 buffer with at least `max(top_k, hidden)` elements
+/// (the size of the largest staged intermediate). `output_idx` must be an
+/// i32 buffer with at least `top_k` elements. `workspace` must be an F32
+/// buffer sized for the requested stage's footprint (see the layout comment
+/// in `kernels/qwen36_moe.hip`). `sync_buf` must be a 32-byte zero buffer
+/// (counter @ +0, barrier counter @ +16, barrier flag @ +20).
+pub fn ffn_step_launch(
+    ordinal: usize,
+    dtype: ScalarType,
+    params: Qwen36MoeFfnStepParams,
+    weights: &Qwen36MoeFfnStepWeights,
+    output: &mut GpuBuffer,
+    output_idx: &mut GpuBuffer,
+    workspace: &mut GpuBuffer,
+    sync_buf: &mut GpuBuffer,
+) -> Result<(), GpuError> {
+    if dtype != ScalarType::BF16 {
+        return Err(GpuError::InvalidArg(format!(
+            "qwen36_moe::ffn_step_launch: only BF16 is wired, got {dtype:?}"
+        )));
+    }
+    if !(1..=5).contains(&params.stage) {
+        return Err(GpuError::InvalidArg(format!(
+            "qwen36_moe::ffn_step_launch: stage must be in 1..=5, got {}",
+            params.stage
+        )));
+    }
+    if params.top_k > params.num_experts {
+        return Err(GpuError::InvalidArg(format!(
+            "qwen36_moe::ffn_step_launch: top_k ({}) > num_experts ({})",
+            params.top_k, params.num_experts,
+        )));
+    }
+    // Only stage 1 is wired through PR 4b4 step 2; stage 2..=5 will land in
+    // follow-up commits to this PR.
+
+    let backend = output.backend();
+    let counters = sync_buf.as_mut_ptr() as *mut c_uint;
+    let barrier_counter = unsafe { (counters as *mut u8).add(16) as *mut c_uint };
+    let barrier_flag = unsafe { (counters as *mut u8).add(20) as *mut c_uint };
+
+    let status = match backend {
+        Backend::Hip => {
+            #[cfg(supersonic_backend_hip)]
+            unsafe {
+                qwen36_moe_hip_ffn_step_launch(
+                    dtype.kernel_dtype_code(),
+                    ordinal,
+                    params.stage as c_int,
+                    params.hidden as c_int,
+                    params.num_experts as c_int,
+                    params.moe_intermediate as c_int,
+                    params.shared_intermediate as c_int,
+                    params.top_k as c_int,
+                    params.rms_norm_eps,
+                    weights.input_hidden,
+                    weights.post_attn_norm_w,
+                    weights.gate_w,
+                    weights.gate_up_proj_w,
+                    weights.down_proj_w,
+                    weights.shared_gate_proj_w,
+                    weights.shared_up_proj_w,
+                    weights.shared_down_proj_w,
+                    weights.shared_expert_gate_w,
+                    output.as_mut_ptr(),
+                    output_idx.as_mut_ptr() as *mut c_int,
+                    workspace.as_mut_ptr() as *mut f32,
+                    counters,
+                    barrier_counter,
+                    barrier_flag,
+                )
+            }
+            #[cfg(not(supersonic_backend_hip))]
+            {
+                return Err(GpuError::InvalidArg(
+                    "qwen36_moe::ffn_step_launch: HIP backend not compiled".into(),
+                ));
+            }
+        }
+        Backend::Cuda => {
+            return Err(GpuError::InvalidArg(
+                "qwen36_moe::ffn_step_launch: CUDA backend not yet wired".into(),
+            ));
+        }
+        Backend::Metal => {
+            return Err(GpuError::InvalidArg(
+                "qwen36_moe::ffn_step_launch: Metal backend not yet wired".into(),
+            ));
+        }
+    };
+    if status != 0 {
+        return Err(GpuError::backend(
+            backend,
+            format!("qwen36_moe ffn_step launch failed with status {status}"),
         ));
     }
     Ok(())
@@ -2461,6 +2644,204 @@ mod tests {
             got_bytes,
             &output_hidden_expected,
             0.05,
+            0.9999,
+        );
+    }
+
+    // -------------------------------------------------------------------
+    // PR 4b4 — staged MoE FFN parity tests against the Python oracle
+    // -------------------------------------------------------------------
+
+    #[cfg(supersonic_backend_hip)]
+    struct FfnOracleGeom {
+        hidden: i32,
+        num_experts: i32,
+        moe_intermediate: i32,
+        shared_intermediate: i32,
+        top_k: i32,
+        rms_norm_eps: f32,
+    }
+
+    #[cfg(supersonic_backend_hip)]
+    fn load_ffn_oracle_json() -> Option<(serde_json::Value, FfnOracleGeom)> {
+        let json_path = std::env::var("SUPERSONIC_QWEN36_FFN_ORACLE_JSON").ok()?;
+        let raw = std::fs::read_to_string(&json_path)
+            .unwrap_or_else(|e| panic!("read ffn oracle json {json_path}: {e}"));
+        let json: serde_json::Value =
+            serde_json::from_str(&raw).expect("ffn oracle json parse");
+        assert_eq!(
+            json["dtype"].as_str().unwrap_or(""),
+            "bf16",
+            "MoE FFN parity tests require the oracle to be in bf16 mode"
+        );
+        let cfg = &json["config"];
+        let geom = FfnOracleGeom {
+            hidden: cfg["hidden"].as_i64().unwrap() as i32,
+            num_experts: cfg["num_experts"].as_i64().unwrap() as i32,
+            moe_intermediate: cfg["moe_intermediate"].as_i64().unwrap() as i32,
+            shared_intermediate: cfg["shared_intermediate"].as_i64().unwrap() as i32,
+            top_k: cfg["top_k"].as_i64().unwrap() as i32,
+            rms_norm_eps: cfg["rms_norm_eps"].as_f64().unwrap() as f32,
+        };
+        Some((json, geom))
+    }
+
+    /// Decode a base64 i32 buffer (oracle uses int32 for `topk_idx`).
+    #[cfg(supersonic_backend_hip)]
+    fn i32_bytes_to_vec(bytes: &[u8]) -> Vec<i32> {
+        bytes
+            .chunks_exact(4)
+            .map(|c| {
+                let mut a = [0u8; 4];
+                a.copy_from_slice(c);
+                i32::from_le_bytes(a)
+            })
+            .collect()
+    }
+
+    /// Workspace floats sufficient for the largest staged FFN intermediate
+    /// (stage 5). Same convention as `parity_workspace_floats` for the attn
+    /// kernel — keep tight so a stage that overruns fails loudly.
+    #[cfg(supersonic_backend_hip)]
+    fn ffn_parity_workspace_floats(geom: &FfnOracleGeom) -> usize {
+        let hidden = geom.hidden as usize;
+        let e = geom.num_experts as usize;
+        let k = geom.top_k as usize;
+        let is_dim = geom.shared_intermediate as usize;
+        // hidden + 2*E + 2*k (router pieces)
+        // + is_dim (shared_mid) + hidden (shared_out)
+        // + k*hidden (expert_stack) + hidden (moe_out) + hidden (output)
+        hidden + 2 * e + 2 * k + is_dim + 3 * hidden + k * hidden
+    }
+
+    /// Output BF16 elements sufficient for the largest staged FFN
+    /// intermediate. Stages 2..=5 publish a `[hidden]` buffer; stage 1
+    /// publishes `[k]`. Sized for `hidden`.
+    #[cfg(supersonic_backend_hip)]
+    fn ffn_parity_output_elems(geom: &FfnOracleGeom) -> usize {
+        geom.hidden as usize
+    }
+
+    #[cfg(supersonic_backend_hip)]
+    #[test]
+    fn qwen36_moe_ffn_step_1_topk_matches_oracle() {
+        use gpu_hal::{set_backend, Backend, GpuBuffer, ScalarType};
+
+        let Some((json, geom)) = load_ffn_oracle_json() else {
+            eprintln!(
+                "skip: SUPERSONIC_QWEN36_FFN_ORACLE_JSON not set. \
+                 Generate a fixture with \
+                 `python oracle/qwen36_moe_ffn_oracle.py --mode synthetic \
+                 --out /tmp/qwen36_ffn.json` and re-run."
+            );
+            return;
+        };
+        let weights = &json["weights"];
+        let inters = &json["intermediates"];
+
+        let input_hidden_bytes = b64_decode(weights["input_hidden"].as_str().unwrap());
+        let post_attn_norm_w_bytes = b64_decode(weights["post_attn_norm_w"].as_str().unwrap());
+        let gate_w_bytes = b64_decode(weights["gate_w"].as_str().unwrap());
+        let topk_idx_expected = i32_bytes_to_vec(
+            &b64_decode(inters["topk_idx"].as_str().unwrap())
+        );
+        let topk_weights_expected_bytes =
+            b64_decode(inters["topk_weights"].as_str().unwrap());
+
+        let hidden_us = geom.hidden as usize;
+        let e_us = geom.num_experts as usize;
+        let k_us = geom.top_k as usize;
+
+        assert_eq!(input_hidden_bytes.len(), hidden_us * 2);
+        assert_eq!(post_attn_norm_w_bytes.len(), hidden_us * 2);
+        assert_eq!(gate_w_bytes.len(), e_us * hidden_us * 2);
+        assert_eq!(topk_idx_expected.len(), k_us);
+        assert_eq!(topk_weights_expected_bytes.len(), k_us * 2);
+
+        set_backend(Backend::Hip);
+        let ordinal = 0usize;
+
+        let input_hidden = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_us], &input_hidden_bytes,
+        ).expect("upload input_hidden");
+        let post_attn_norm_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_us], &post_attn_norm_w_bytes,
+        ).expect("upload post_attn_norm_w");
+        let gate_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[e_us, hidden_us], &gate_w_bytes,
+        ).expect("upload gate_w");
+
+        // Output sized for the largest staged intermediate (hidden BF16).
+        // Stage 1 publishes only `topk_weights[k]` into `output[0..k]`,
+        // and `topk_idx[k]` into the separate `output_idx` buffer.
+        let mut output = GpuBuffer::zeros(
+            ordinal, ScalarType::BF16, &[ffn_parity_output_elems(&geom)],
+        ).expect("alloc output");
+        // No I32 variant in `ScalarType`; U32 has the same 4-byte storage
+        // and the kernel reinterprets via the FFI signature's `*mut c_int`.
+        let mut output_idx = GpuBuffer::zeros(
+            ordinal, ScalarType::U32, &[k_us],
+        ).expect("alloc output_idx");
+        let mut workspace = GpuBuffer::zeros(
+            ordinal, ScalarType::F32, &[ffn_parity_workspace_floats(&geom)],
+        ).expect("alloc workspace");
+        let mut sync_buf = GpuBuffer::zeros(
+            ordinal, ScalarType::U8, &[32],
+        ).expect("alloc sync buf");
+
+        let params = Qwen36MoeFfnStepParams {
+            stage: 1,
+            hidden: geom.hidden,
+            num_experts: geom.num_experts,
+            moe_intermediate: geom.moe_intermediate,
+            shared_intermediate: geom.shared_intermediate,
+            top_k: geom.top_k,
+            rms_norm_eps: geom.rms_norm_eps,
+        };
+        let weight_ptrs = Qwen36MoeFfnStepWeights {
+            input_hidden: input_hidden.as_ptr(),
+            post_attn_norm_w: post_attn_norm_w.as_ptr(),
+            gate_w: gate_w.as_ptr(),
+            gate_up_proj_w: std::ptr::null(),
+            down_proj_w: std::ptr::null(),
+            shared_gate_proj_w: std::ptr::null(),
+            shared_up_proj_w: std::ptr::null(),
+            shared_down_proj_w: std::ptr::null(),
+            shared_expert_gate_w: std::ptr::null(),
+        };
+
+        ffn_step_launch(
+            ordinal,
+            ScalarType::BF16,
+            params,
+            &weight_ptrs,
+            &mut output,
+            &mut output_idx,
+            &mut workspace,
+            &mut sync_buf,
+        )
+        .expect("ffn_step_launch stage 1");
+
+        // Verify topk_idx (int32) — must match oracle exactly. Routing
+        // decisions are categorical; any disagreement is a real bug, no
+        // tolerance.
+        let got_idx_bytes = output_idx.to_host_bytes().expect("download output_idx");
+        let got_idx = i32_bytes_to_vec(&got_idx_bytes);
+        assert_eq!(
+            got_idx, topk_idx_expected,
+            "ffn step1 topk_idx mismatch: got {got_idx:?}, want {topk_idx_expected:?}"
+        );
+
+        // Verify topk_weights (BF16) — these come from softmax + renorm,
+        // so we expect bit-exactness for most elements with rare 1-ULP
+        // drift from F32 accumulation order.
+        let got_full = output.to_host_bytes().expect("download output");
+        let got_bytes = &got_full[..k_us * 2];
+        assert_parity(
+            "ffn step1 topk_weights",
+            got_bytes,
+            &topk_weights_expected_bytes,
+            0.01,
             0.9999,
         );
     }

--- a/crates/kernel-ffi/src/qwen36_moe.rs
+++ b/crates/kernel-ffi/src/qwen36_moe.rs
@@ -585,9 +585,9 @@ pub fn linear_step_launch(
             params.stage
         )));
     }
-    if params.stage > 1 {
+    if params.stage > 2 {
         return Err(GpuError::InvalidArg(format!(
-            "qwen36_moe::linear_step_launch: stage {} not yet implemented (PR 4b3 step 2 lands stage 1 only)",
+            "qwen36_moe::linear_step_launch: stage {} not yet implemented (PR 4b3 stages 1-2 only)",
             params.stage
         )));
     }
@@ -1742,6 +1742,161 @@ mod tests {
             "linear step1 qkv_raw",
             &got_bytes,
             &qkv_raw_expected_bytes,
+            0.04,
+            0.9999,
+        );
+    }
+
+    #[cfg(supersonic_backend_hip)]
+    #[test]
+    fn qwen36_moe_linear_step_2_silu_out_matches_oracle() {
+        use gpu_hal::{set_backend, Backend, GpuBuffer, ScalarType};
+
+        let Some((json, geom)) = load_linear_oracle_json() else {
+            eprintln!(
+                "skip: SUPERSONIC_QWEN36_LINEAR_ORACLE_JSON not set. \
+                 See `qwen36_moe_linear_step_1_qkv_raw_matches_oracle` for setup."
+            );
+            return;
+        };
+        let weights = &json["weights"];
+        let inters = &json["intermediates"];
+
+        // Stage 2 still walks the stage-1 prerequisite (qkv_raw is the
+        // conv1d input), so we need every weight stage 1 needed plus
+        // conv1d_w, the conv state, and (optionally) conv1d_bias.
+        let input_hidden_bytes = b64_decode(weights["input_hidden"].as_str().unwrap());
+        let input_norm_w_bytes = b64_decode(weights["input_norm_w"].as_str().unwrap());
+        let in_proj_qkv_w_bytes = b64_decode(weights["in_proj_qkv_w"].as_str().unwrap());
+        let in_proj_z_w_bytes = b64_decode(weights["in_proj_z_w"].as_str().unwrap());
+        let in_proj_a_w_bytes = b64_decode(weights["in_proj_a_w"].as_str().unwrap());
+        let in_proj_b_w_bytes = b64_decode(weights["in_proj_b_w"].as_str().unwrap());
+        let conv1d_w_bytes = b64_decode(weights["conv1d_w"].as_str().unwrap());
+        let conv1d_bias_bytes = weights.get("conv1d_bias")
+            .and_then(|v| v.as_str())
+            .map(b64_decode);
+        let conv_state_before_bytes = b64_decode(weights["conv_state_before"].as_str().unwrap());
+        let silu_out_expected_bytes = b64_decode(inters["silu_out"].as_str().unwrap());
+        let conv_state_after_expected_bytes =
+            b64_decode(inters["conv_state_after"].as_str().unwrap());
+
+        let hidden_us = geom.hidden as usize;
+        let k_us = geom.num_k_heads as usize;
+        let v_us = geom.num_v_heads as usize;
+        let kd_us = geom.head_k_dim as usize;
+        let vd_us = geom.head_v_dim as usize;
+        let kernel = geom.conv_kernel_dim as usize;
+        let kstate = kernel - 1;
+        let key_dim = k_us * kd_us;
+        let val_dim = v_us * vd_us;
+        let qkv_dim = 2 * key_dim + val_dim;
+
+        assert_eq!(conv1d_w_bytes.len(), qkv_dim * 1 * kernel * 2);
+        assert_eq!(conv_state_before_bytes.len(), qkv_dim * kstate * 2);
+        assert_eq!(silu_out_expected_bytes.len(), qkv_dim * 2);
+        assert_eq!(conv_state_after_expected_bytes.len(), qkv_dim * kstate * 2);
+
+        set_backend(Backend::Hip);
+        let ordinal = 0usize;
+
+        let input_hidden = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_us], &input_hidden_bytes,
+        ).expect("upload input_hidden");
+        let input_norm_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_us], &input_norm_w_bytes,
+        ).expect("upload input_norm_w");
+        let in_proj_qkv_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[qkv_dim, hidden_us], &in_proj_qkv_w_bytes,
+        ).expect("upload in_proj_qkv_w");
+        let in_proj_z_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[val_dim, hidden_us], &in_proj_z_w_bytes,
+        ).expect("upload in_proj_z_w");
+        let in_proj_a_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[v_us, hidden_us], &in_proj_a_w_bytes,
+        ).expect("upload in_proj_a_w");
+        let in_proj_b_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[v_us, hidden_us], &in_proj_b_w_bytes,
+        ).expect("upload in_proj_b_w");
+        let conv1d_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[qkv_dim, 1, kernel], &conv1d_w_bytes,
+        ).expect("upload conv1d_w");
+        let conv1d_bias = match &conv1d_bias_bytes {
+            Some(bytes) => Some(
+                GpuBuffer::from_host_bytes(ordinal, ScalarType::BF16, &[qkv_dim], bytes)
+                    .expect("upload conv1d_bias"),
+            ),
+            None => None,
+        };
+        let mut conv_state = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[qkv_dim, kstate], &conv_state_before_bytes,
+        ).expect("upload conv_state");
+
+        let mut output = GpuBuffer::zeros(
+            ordinal, ScalarType::BF16, &[qkv_dim],
+        ).expect("alloc output");
+        let workspace_floats = qkv_dim + val_dim + 2 * v_us;
+        let mut workspace = GpuBuffer::zeros(
+            ordinal, ScalarType::F32, &[workspace_floats],
+        ).expect("alloc workspace");
+        let mut sync_buf = GpuBuffer::zeros(
+            ordinal, ScalarType::U8, &[32],
+        ).expect("alloc sync buf");
+
+        let params = Qwen36MoeLinearStepParams {
+            stage: 2,
+            hidden: geom.hidden,
+            num_k_heads: geom.num_k_heads,
+            num_v_heads: geom.num_v_heads,
+            head_k_dim: geom.head_k_dim,
+            head_v_dim: geom.head_v_dim,
+            conv_kernel_dim: geom.conv_kernel_dim,
+            rms_norm_eps: geom.rms_norm_eps,
+        };
+        let weight_ptrs = Qwen36MoeLinearStepWeights {
+            input_hidden: input_hidden.as_ptr(),
+            input_norm_w: input_norm_w.as_ptr(),
+            in_proj_qkv_w: in_proj_qkv_w.as_ptr(),
+            in_proj_z_w: in_proj_z_w.as_ptr(),
+            in_proj_a_w: in_proj_a_w.as_ptr(),
+            in_proj_b_w: in_proj_b_w.as_ptr(),
+            conv1d_w: conv1d_w.as_ptr(),
+            conv1d_bias: conv1d_bias.as_ref().map(|b| b.as_ptr()).unwrap_or(std::ptr::null()),
+            dt_bias: std::ptr::null(),
+            a_log: std::ptr::null(),
+            norm_w: std::ptr::null(),
+            out_proj_w: std::ptr::null(),
+            conv_state: conv_state.as_mut_ptr(),
+            recurrent_state: std::ptr::null_mut(),
+        };
+
+        linear_step_launch(
+            ordinal,
+            ScalarType::BF16,
+            params,
+            &weight_ptrs,
+            &mut output,
+            &mut workspace,
+            &mut sync_buf,
+        )
+        .expect("linear_step_launch stage 2");
+
+        // Stage 2 publishes silu_out as the full output buffer.
+        let got_bytes = output.to_host_bytes().expect("download output");
+        assert_parity(
+            "linear step2 silu_out",
+            &got_bytes,
+            &silu_out_expected_bytes,
+            0.04,
+            0.9999,
+        );
+        // The kernel also updates conv_state in place; verify it matches
+        // the oracle's conv_state_after so the next decode step has the
+        // right starting state.
+        let conv_state_got = conv_state.to_host_bytes().expect("download conv_state");
+        assert_parity(
+            "linear step2 conv_state_after",
+            &conv_state_got,
+            &conv_state_after_expected_bytes,
             0.04,
             0.9999,
         );

--- a/crates/kernel-ffi/src/qwen36_moe.rs
+++ b/crates/kernel-ffi/src/qwen36_moe.rs
@@ -1,0 +1,437 @@
+//! FFI bridge for the Qwen3.6-MoE persistent decode megakernel.
+//!
+//! Status: **infrastructure only.** PR 4 (this file) lands the descriptor
+//! layout + a stub kernel that validates the launch path and descriptor
+//! read-out. Actual transformer compute (attention with `attn_output_gate`,
+//! MoE routing + work-stealing dispatch, fused expert mat-vec, shared
+//! expert, lm_head) lands in follow-up PRs.
+//!
+//! Why a stub first: the megakernel will be ~6500 LoC of HIP. Wiring the
+//! FFI/bridge/build path before any compute math means a future kernel
+//! commit can land focused-on-math code with no orchestration noise. The
+//! stub also serves as a smoke test for descriptor field layout — a
+//! Rust↔C++ struct-mismatch bug found here saves hours later.
+
+use std::ffi::{c_int, c_void};
+use std::os::raw::c_uint;
+
+use gpu_hal::{Backend, GpuBuffer, GpuError, ScalarType};
+
+use crate::layer_desc::MAX_BATCH_SIZE;
+
+/// Per-layer descriptor for the Qwen3.6-MoE megakernel. Field order and
+/// natural x86_64 alignment must match the C++ struct in
+/// `kernels/qwen36_moe.hip` exactly. The repr-C layout is fixed at PR 4
+/// time and grows by appending new fields, never reordering existing
+/// ones — see the matching `static_assert(sizeof(...))` on the C++ side.
+#[repr(C)]
+#[derive(Debug, Clone)]
+pub struct Qwen36MoeDecodeLayerDesc {
+    /// Layer index in `[0, num_hidden_layers)`. Used by the kernel to pick
+    /// the cos/sin RoPE entry and to sanity-check the descriptor pointer.
+    pub layer_idx: c_int,
+    /// 0 = linear-attention layer, 1 = full-attention layer.
+    pub is_full_attention: c_int,
+
+    // --- RMS norms --------------------------------------------------------
+    pub input_norm_w: *const c_void,
+    pub input_norm_eps: f32,
+    pub post_attn_norm_w: *const c_void,
+    pub post_attn_norm_eps: f32,
+
+    // --- Full-attention slots (read iff is_full_attention == 1) -----------
+    /// q_proj output dim. With `attn_output_gate=true` (Qwen3-Next) this is
+    /// `2 * num_heads * head_dim`; the kernel splits the upper half off as
+    /// the sigmoid output gate. With `attn_output_gate=false` it's just
+    /// `num_heads * head_dim`. The sign is captured by `attn_output_gate`.
+    pub q_proj_w: *const c_void,
+    pub q_proj_out_dim: c_int,
+    /// 0 = no output gate (q_proj_out_dim == num_heads*head_dim),
+    /// 1 = attn_output_gate fused (q_proj_out_dim == 2*num_heads*head_dim).
+    pub attn_output_gate: c_int,
+    pub k_proj_w: *const c_void,
+    pub v_proj_w: *const c_void,
+    pub o_proj_w: *const c_void,
+    pub q_norm_w: *const c_void,
+    pub k_norm_w: *const c_void,
+    pub attn_head_dim: c_int,
+    pub attn_num_heads: c_int,
+    pub attn_num_kv_heads: c_int,
+    pub kv_cache_k: *mut c_void,
+    pub kv_cache_v: *mut c_void,
+    pub kv_len: c_int,
+    pub kv_max_t: c_int,
+
+    // --- Linear-attention slots (read iff is_full_attention == 0) ---------
+    pub linear_in_proj_qkv_w: *const c_void,
+    pub linear_in_proj_z_w: *const c_void,
+    pub linear_in_proj_b_w: *const c_void,
+    pub linear_in_proj_a_w: *const c_void,
+    pub linear_out_proj_w: *const c_void,
+    pub linear_conv1d_w: *const c_void,
+    pub linear_dt_bias: *const c_void,
+    pub linear_a_log_exp: *const c_void,
+    pub linear_norm_w: *const c_void,
+    pub linear_qkv_dim: c_int,
+    pub linear_v_dim: c_int,
+    pub linear_v_heads: c_int,
+    pub linear_conv_kernel_dim: c_int,
+    /// Linear-attention conv state pointer, shape `[batch, qkv_dim,
+    /// kernel-1]`. NULL on first decode step (kernel will zero on read).
+    pub linear_conv_state: *mut c_void,
+    /// Linear-attention recurrent state, shape `[batch, V_heads, V_dim,
+    /// K_dim]`. NULL on first decode step.
+    pub linear_recurrent_state: *mut c_void,
+
+    // --- MoE block (always read, regardless of attention type) ------------
+    /// Router weight `[num_experts, hidden]`, BF16. Always BF16 (excluded
+    /// from INT4 quant by `is_int4_target`).
+    pub router_w: *const c_void,
+    /// Fused expert gate+up `[num_experts, 2*moe_intermediate_size, hidden]`.
+    /// At INT4 launch the pointer reinterprets as packed `u8` (2 nibbles
+    /// per byte), with sidecar scale/zero in `Qwen36MoeInt4ScaleDesc`.
+    pub experts_gate_up_w: *const c_void,
+    /// Fused expert down `[num_experts, hidden, moe_intermediate_size]`.
+    pub experts_down_w: *const c_void,
+    /// Shared expert (always-on). `gate_proj` and `up_proj` are
+    /// `[shared_int, hidden]`; `down_proj` is `[hidden, shared_int]`.
+    pub shared_expert_gate_proj_w: *const c_void,
+    pub shared_expert_up_proj_w: *const c_void,
+    pub shared_expert_down_proj_w: *const c_void,
+    /// Scalar shared-expert gate `[1, hidden]`, BF16. Applied as
+    /// `sigmoid(gate · x) * shared_expert(x)`.
+    pub shared_expert_gate_w: *const c_void,
+    /// Number of routed experts present in this layer. Must match
+    /// `desc.num_experts` across layers (sanity-checked by the host).
+    pub num_experts: c_int,
+    /// Top-k for routing.
+    pub top_k: c_int,
+    pub moe_intermediate_size: c_int,
+    pub shared_expert_intermediate_size: c_int,
+    /// 1 if router applies `softmax(top_k_logits)` renormalization
+    /// (`norm_topk_prob=true` in config). 0 otherwise.
+    pub norm_topk_prob: c_int,
+}
+
+unsafe impl Send for Qwen36MoeDecodeLayerDesc {}
+unsafe impl Sync for Qwen36MoeDecodeLayerDesc {}
+
+impl Default for Qwen36MoeDecodeLayerDesc {
+    fn default() -> Self {
+        unsafe { std::mem::zeroed() }
+    }
+}
+
+/// Parallel-struct to [`Qwen36MoeDecodeLayerDesc`] carrying INT4 GPTQ
+/// scale + zero pointers. When `--int4` is active, the main desc's `*_w`
+/// slots reinterpret as packed-u8 nibbles and the kernel reads the
+/// matching `*_scale` / `*_zero` from this struct.
+///
+/// Routers and scalar gates stay BF16 (`is_int4_target` excludes them);
+/// their fields here are unused but the struct keeps them at fixed offsets
+/// for ABI stability.
+#[repr(C)]
+#[derive(Debug, Clone)]
+pub struct Qwen36MoeInt4ScaleDesc {
+    pub q_proj_scale: *const c_void,
+    pub q_proj_zero: *const c_void,
+    pub k_proj_scale: *const c_void,
+    pub k_proj_zero: *const c_void,
+    pub v_proj_scale: *const c_void,
+    pub v_proj_zero: *const c_void,
+    pub o_proj_scale: *const c_void,
+    pub o_proj_zero: *const c_void,
+
+    pub linear_in_proj_qkv_scale: *const c_void,
+    pub linear_in_proj_qkv_zero: *const c_void,
+    pub linear_in_proj_z_scale: *const c_void,
+    pub linear_in_proj_z_zero: *const c_void,
+    pub linear_out_proj_scale: *const c_void,
+    pub linear_out_proj_zero: *const c_void,
+
+    pub experts_gate_up_scale: *const c_void,
+    pub experts_gate_up_zero: *const c_void,
+    pub experts_down_scale: *const c_void,
+    pub experts_down_zero: *const c_void,
+
+    pub shared_expert_gate_proj_scale: *const c_void,
+    pub shared_expert_gate_proj_zero: *const c_void,
+    pub shared_expert_up_proj_scale: *const c_void,
+    pub shared_expert_up_proj_zero: *const c_void,
+    pub shared_expert_down_proj_scale: *const c_void,
+    pub shared_expert_down_proj_zero: *const c_void,
+
+    pub group_size: c_int,
+}
+
+unsafe impl Send for Qwen36MoeInt4ScaleDesc {}
+unsafe impl Sync for Qwen36MoeInt4ScaleDesc {}
+
+impl Default for Qwen36MoeInt4ScaleDesc {
+    fn default() -> Self {
+        unsafe { std::mem::zeroed() }
+    }
+}
+
+/// Per-sequence batched-decode state, parallel to the layer descriptor
+/// array. Only the first `batch_size` slots are read.
+#[repr(C)]
+#[derive(Debug, Clone)]
+pub struct Qwen36MoeBatchSeqDesc {
+    pub seqlen_offset: [c_int; MAX_BATCH_SIZE],
+    pub kv_cache_k: [*mut c_void; MAX_BATCH_SIZE],
+    pub kv_cache_v: [*mut c_void; MAX_BATCH_SIZE],
+    pub kv_len: [c_int; MAX_BATCH_SIZE],
+    pub kv_max_t: [c_int; MAX_BATCH_SIZE],
+    pub linear_conv_state: [*mut c_void; MAX_BATCH_SIZE],
+    pub linear_recurrent_state: [*mut c_void; MAX_BATCH_SIZE],
+}
+
+unsafe impl Send for Qwen36MoeBatchSeqDesc {}
+unsafe impl Sync for Qwen36MoeBatchSeqDesc {}
+
+impl Default for Qwen36MoeBatchSeqDesc {
+    fn default() -> Self {
+        unsafe { std::mem::zeroed() }
+    }
+}
+
+#[cfg(supersonic_backend_hip)]
+extern "C" {
+    /// Stub launch entry. Walks the descriptor array, validates field
+    /// integrity by writing recognizable sentinel values into the workspace
+    /// at known offsets, grid-barriers between layers, and returns 0 on
+    /// success.
+    ///
+    /// Sentinel layout in `workspace[0..sentinel_count]` (f32):
+    /// - `[0]`: number of layers seen (must equal `num_layers`)
+    /// - `[1]`: total `num_experts` summed across layers (sanity check)
+    /// - `[2]`: total `top_k` summed across layers
+    /// - `[3]`: 1.0 if every layer's `is_full_attention` matches the
+    ///   pattern produced by `(idx + 1) % 4 == 0`, else 0.0
+    /// - `[4]`: `attn_output_gate` status — 1.0 if all full-attn layers
+    ///   set it to 1, 0.0 otherwise
+    /// - `[5..]`: reserved for future smoke-test bytes; zero on PR 4.
+    ///
+    /// Once the real kernel lands, this entry is replaced by the actual
+    /// persistent decode launcher with the same signature.
+    pub fn qwen36_moe_hip_stub_launch(
+        dtype: c_int,
+        device_ordinal: usize,
+        num_layers: usize,
+        layers: *const Qwen36MoeDecodeLayerDesc,
+        workspace: *mut f32,
+        counters: *mut c_uint,
+        barrier_counter: *mut c_uint,
+        barrier_flag: *mut c_uint,
+    ) -> c_int;
+}
+
+/// Safe wrapper over the stub launch. The engine pre-allocates `sync_buf`
+/// as a 32-byte zeroed scratch (work-stealing counter at offset 0, grid
+/// barrier counter at +16, flag at +20 — same layout as
+/// `crate::persistent_decode_4b`).
+///
+/// Returns when the kernel signals completion via `hipDeviceSynchronize`.
+/// The smoke-test path reads `workspace` back to verify descriptor
+/// integrity; the real kernel will overwrite that area with activations.
+pub fn stub_launch(
+    ordinal: usize,
+    dtype: ScalarType,
+    layer_descs_device: &GpuBuffer,
+    workspace: &mut GpuBuffer,
+    sync_buf: &mut GpuBuffer,
+    num_layers: usize,
+) -> Result<(), GpuError> {
+    if dtype != ScalarType::BF16 {
+        return Err(GpuError::InvalidArg(format!(
+            "qwen36_moe::stub_launch: only BF16 is wired, got {dtype:?}"
+        )));
+    }
+    let backend = layer_descs_device.backend();
+    let counters = sync_buf.as_mut_ptr() as *mut c_uint;
+    let barrier_counter = unsafe { (counters as *mut u8).add(16) as *mut c_uint };
+    let barrier_flag = unsafe { (counters as *mut u8).add(20) as *mut c_uint };
+
+    let status = match backend {
+        Backend::Hip => {
+            #[cfg(supersonic_backend_hip)]
+            unsafe {
+                qwen36_moe_hip_stub_launch(
+                    dtype.kernel_dtype_code(),
+                    ordinal,
+                    num_layers,
+                    layer_descs_device.as_ptr() as *const Qwen36MoeDecodeLayerDesc,
+                    workspace.as_mut_ptr() as *mut f32,
+                    counters,
+                    barrier_counter,
+                    barrier_flag,
+                )
+            }
+            #[cfg(not(supersonic_backend_hip))]
+            {
+                return Err(GpuError::InvalidArg(
+                    "qwen36_moe::stub_launch: HIP backend not compiled".into(),
+                ));
+            }
+        }
+        Backend::Cuda => {
+            return Err(GpuError::InvalidArg(
+                "qwen36_moe::stub_launch: CUDA backend not yet wired".into(),
+            ));
+        }
+        Backend::Metal => {
+            return Err(GpuError::InvalidArg(
+                "qwen36_moe::stub_launch: Metal backend not yet wired".into(),
+            ));
+        }
+    };
+    if status != 0 {
+        return Err(GpuError::backend(
+            backend,
+            format!("qwen36_moe stub launch failed with status {status}"),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::mem::size_of;
+
+    #[test]
+    fn descriptor_layout_offsets_documented() {
+        // Pin the size so a future field-reorder is loud. If you need to
+        // grow the struct, append fields and update this number — never
+        // reorder existing ones.
+        // (Numbers verified on x86_64 Linux. Pointers are 8 bytes.)
+        let sz = size_of::<Qwen36MoeDecodeLayerDesc>();
+        assert!(
+            sz >= 256 && sz <= 512,
+            "Qwen36MoeDecodeLayerDesc size drift: got {sz} bytes",
+        );
+
+        let int4_sz = size_of::<Qwen36MoeInt4ScaleDesc>();
+        assert!(
+            int4_sz >= 192 && int4_sz <= 256,
+            "Qwen36MoeInt4ScaleDesc size drift: got {int4_sz} bytes",
+        );
+    }
+
+    #[test]
+    fn descriptor_default_is_zero() {
+        let d = Qwen36MoeDecodeLayerDesc::default();
+        assert_eq!(d.layer_idx, 0);
+        assert_eq!(d.is_full_attention, 0);
+        assert!(d.input_norm_w.is_null());
+        assert!(d.kv_cache_k.is_null());
+        assert!(d.linear_recurrent_state.is_null());
+        assert!(d.experts_gate_up_w.is_null());
+    }
+
+    /// HIP smoke test: launch the stub kernel against a synthetic 40-layer
+    /// descriptor array and verify the sentinel bytes the kernel writes
+    /// match what we sent in. This exercises the entire path:
+    /// FFI struct layout → bridge launch → grid barrier → cooperative
+    /// work-stealing → host readback. The same path the real kernel will
+    /// use, minus the compute math.
+    #[cfg(supersonic_backend_hip)]
+    #[test]
+    fn hip_stub_launch_walks_descriptor_array() {
+        use gpu_hal::{set_backend, Backend, GpuBuffer, ScalarType};
+
+        set_backend(Backend::Hip);
+        let ordinal = 0usize;
+        let num_layers = 40usize;
+
+        // Synthesize a Qwen3.6-MoE-shaped descriptor array on the host.
+        // Hybrid pattern: every 4th layer is full attention; others are
+        // linear-attention. attn_output_gate is set on full layers only.
+        let mut host_descs: Vec<Qwen36MoeDecodeLayerDesc> =
+            Vec::with_capacity(num_layers);
+        let num_experts = 256;
+        let top_k = 8;
+        for idx in 0..num_layers {
+            let mut d = Qwen36MoeDecodeLayerDesc::default();
+            d.layer_idx = idx as c_int;
+            d.is_full_attention = if (idx + 1) % 4 == 0 { 1 } else { 0 };
+            d.attn_output_gate = if d.is_full_attention == 1 { 1 } else { 0 };
+            d.num_experts = num_experts;
+            d.top_k = top_k;
+            d.moe_intermediate_size = 512;
+            d.shared_expert_intermediate_size = 512;
+            d.norm_topk_prob = 1;
+            d.attn_head_dim = 256;
+            d.attn_num_heads = 16;
+            d.attn_num_kv_heads = 2;
+            host_descs.push(d);
+        }
+
+        // Upload as raw bytes; gpu-hal lets us treat the buffer as opaque
+        // u8 since the kernel only dereferences the C struct pointer.
+        let desc_bytes_per = size_of::<Qwen36MoeDecodeLayerDesc>();
+        let mut desc_bytes = Vec::with_capacity(desc_bytes_per * num_layers);
+        for d in &host_descs {
+            let p = d as *const Qwen36MoeDecodeLayerDesc as *const u8;
+            desc_bytes.extend_from_slice(unsafe {
+                std::slice::from_raw_parts(p, desc_bytes_per)
+            });
+        }
+        let layer_descs = GpuBuffer::from_host_bytes(
+            ordinal,
+            ScalarType::U8,
+            &[desc_bytes.len()],
+            &desc_bytes,
+        )
+        .expect("upload descriptor array");
+
+        // 16 floats of workspace is enough for the documented sentinel
+        // slots (5 in use, rest reserved). The real kernel will need
+        // ~MiB; keeping this tiny lets the smoke test stay fast.
+        let mut workspace = GpuBuffer::zeros(ordinal, ScalarType::F32, &[16])
+            .expect("alloc workspace");
+        let mut sync_buf = GpuBuffer::zeros(ordinal, ScalarType::U8, &[32])
+            .expect("alloc sync buf");
+
+        stub_launch(
+            ordinal,
+            ScalarType::BF16,
+            &layer_descs,
+            &mut workspace,
+            &mut sync_buf,
+            num_layers,
+        )
+        .expect("stub launch");
+
+        // Read sentinels.
+        let bytes = workspace.to_host_bytes().expect("download workspace");
+        let workspace_f32: Vec<f32> = bytes
+            .chunks_exact(4)
+            .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+            .collect();
+
+        assert_eq!(
+            workspace_f32[0] as usize, num_layers,
+            "[0] num_layers seen by kernel"
+        );
+        assert_eq!(
+            workspace_f32[1] as i32,
+            (num_experts as i32) * (num_layers as i32),
+            "[1] sum of num_experts across layers"
+        );
+        assert_eq!(
+            workspace_f32[2] as i32,
+            (top_k as i32) * (num_layers as i32),
+            "[2] sum of top_k across layers"
+        );
+        assert_eq!(
+            workspace_f32[3], 1.0,
+            "[3] hybrid pattern check (1.0 = pattern OK across all layers)"
+        );
+        assert_eq!(
+            workspace_f32[4], 1.0,
+            "[4] attn_output_gate consistency on full layers"
+        );
+    }
+}

--- a/crates/kernel-ffi/src/qwen36_moe.rs
+++ b/crates/kernel-ffi/src/qwen36_moe.rs
@@ -403,12 +403,7 @@ pub fn attn_step_launch(
             params.stage
         )));
     }
-    if params.stage > 4 {
-        return Err(GpuError::InvalidArg(format!(
-            "qwen36_moe::attn_step_launch: stage {} not yet implemented (PR 4b2 stages 1-4 only)",
-            params.stage
-        )));
-    }
+    // All five stages are wired through PR 4b2 step 5.
 
     let backend = output.backend();
     let counters = sync_buf.as_mut_ptr() as *mut c_uint;
@@ -767,14 +762,19 @@ mod tests {
     }
 
     /// Returns workspace size sufficient for the largest staged
-    /// intermediate (currently stage 4: 5*H*d + 4*Hkv*d F32).
-    /// Bumped by future stages as o_proj scratch gets added.
+    /// intermediate. Stage 5 is the final stage: 6*H*d + 4*Hkv*d + hidden F32.
     #[cfg(supersonic_backend_hip)]
-    fn parity_workspace_floats(num_heads: i32, num_kv_heads: i32, head_dim: i32) -> usize {
+    fn parity_workspace_floats(
+        num_heads: i32,
+        num_kv_heads: i32,
+        head_dim: i32,
+        hidden: i32,
+    ) -> usize {
         let h = num_heads as usize;
         let hkv = num_kv_heads as usize;
         let d = head_dim as usize;
-        5 * h * d + 4 * hkv * d
+        let hd = hidden as usize;
+        6 * h * d + 4 * hkv * d + hd
     }
 
     /// Output buffer size sufficient for the largest staged intermediate.
@@ -842,7 +842,7 @@ mod tests {
         ).expect("alloc output");
         let mut workspace = GpuBuffer::zeros(
             ordinal, ScalarType::F32,
-            &[parity_workspace_floats(geom.num_heads, geom.num_kv_heads, geom.head_dim)],
+            &[parity_workspace_floats(geom.num_heads, geom.num_kv_heads, geom.head_dim, geom.hidden)],
         ).expect("alloc workspace");
         let mut sync_buf = GpuBuffer::zeros(
             ordinal, ScalarType::U8, &[32],
@@ -959,7 +959,7 @@ mod tests {
         ).expect("alloc output");
         let mut workspace = GpuBuffer::zeros(
             ordinal, ScalarType::F32,
-            &[parity_workspace_floats(geom.num_heads, geom.num_kv_heads, geom.head_dim)],
+            &[parity_workspace_floats(geom.num_heads, geom.num_kv_heads, geom.head_dim, geom.hidden)],
         ).expect("alloc workspace");
         let mut sync_buf = GpuBuffer::zeros(
             ordinal, ScalarType::U8, &[32],
@@ -1085,7 +1085,7 @@ mod tests {
         ).expect("alloc output");
         let mut workspace = GpuBuffer::zeros(
             ordinal, ScalarType::F32,
-            &[parity_workspace_floats(geom.num_heads, geom.num_kv_heads, geom.head_dim)],
+            &[parity_workspace_floats(geom.num_heads, geom.num_kv_heads, geom.head_dim, geom.hidden)],
         ).expect("alloc workspace");
         let mut sync_buf = GpuBuffer::zeros(
             ordinal, ScalarType::U8, &[32],
@@ -1202,7 +1202,7 @@ mod tests {
         ).expect("alloc output");
         let mut workspace = GpuBuffer::zeros(
             ordinal, ScalarType::F32,
-            &[parity_workspace_floats(geom.num_heads, geom.num_kv_heads, geom.head_dim)],
+            &[parity_workspace_floats(geom.num_heads, geom.num_kv_heads, geom.head_dim, geom.hidden)],
         ).expect("alloc workspace");
         let mut sync_buf = GpuBuffer::zeros(
             ordinal, ScalarType::U8, &[32],
@@ -1248,5 +1248,131 @@ mod tests {
         // parity should be effectively bit-exact (both kernel and oracle
         // skip any precision-losing accumulation here).
         assert_parity("step4 attn", got_bytes, &attn_expected_bytes, 0.04, 0.9999);
+    }
+
+    #[cfg(supersonic_backend_hip)]
+    #[test]
+    fn qwen36_moe_attn_step_5_output_hidden_matches_oracle() {
+        use gpu_hal::{set_backend, Backend, GpuBuffer, ScalarType};
+
+        let Some((json, geom)) = load_oracle_json() else {
+            eprintln!(
+                "skip: SUPERSONIC_QWEN36_ORACLE_JSON not set. \
+                 See `qwen36_moe_attn_step_1_q_normed_matches_oracle` for setup."
+            );
+            return;
+        };
+        let weights = &json["weights"];
+        let inters = &json["intermediates"];
+        let cfg = &json["config"];
+
+        let position = json["position"].as_i64().unwrap_or(0) as i32;
+        let rotary_dim = cfg["rotary_dim"].as_i64().unwrap() as i32;
+        let rope_theta = cfg["rope_theta"].as_f64().unwrap() as f32;
+
+        let input_hidden_bytes = b64_decode(weights["input_hidden"].as_str().unwrap());
+        let input_norm_w_bytes = b64_decode(weights["input_norm_w"].as_str().unwrap());
+        let q_proj_w_bytes = b64_decode(weights["q_proj_w"].as_str().unwrap());
+        let k_proj_w_bytes = b64_decode(weights["k_proj_w"].as_str().unwrap());
+        let v_proj_w_bytes = b64_decode(weights["v_proj_w"].as_str().unwrap());
+        let q_norm_w_bytes = b64_decode(weights["q_norm_w"].as_str().unwrap());
+        let k_norm_w_bytes = b64_decode(weights["k_norm_w"].as_str().unwrap());
+        let o_proj_w_bytes = b64_decode(weights["o_proj_w"].as_str().unwrap());
+        let output_hidden_expected_bytes =
+            b64_decode(inters["output_hidden"].as_str().unwrap());
+
+        let hidden_us = geom.hidden as usize;
+        let h_us = geom.num_heads as usize;
+        let hkv_us = geom.num_kv_heads as usize;
+        let d_us = geom.head_dim as usize;
+        assert_eq!(o_proj_w_bytes.len(), hidden_us * h_us * d_us * 2);
+        assert_eq!(output_hidden_expected_bytes.len(), hidden_us * 2);
+
+        set_backend(Backend::Hip);
+        let ordinal = 0usize;
+
+        let input_hidden = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_us], &input_hidden_bytes,
+        ).expect("upload input_hidden");
+        let input_norm_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_us], &input_norm_w_bytes,
+        ).expect("upload input_norm_w");
+        let q_proj_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[2 * h_us * d_us, hidden_us], &q_proj_w_bytes,
+        ).expect("upload q_proj_w");
+        let k_proj_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hkv_us * d_us, hidden_us], &k_proj_w_bytes,
+        ).expect("upload k_proj_w");
+        let v_proj_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hkv_us * d_us, hidden_us], &v_proj_w_bytes,
+        ).expect("upload v_proj_w");
+        let q_norm_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[d_us], &q_norm_w_bytes,
+        ).expect("upload q_norm_w");
+        let k_norm_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[d_us], &k_norm_w_bytes,
+        ).expect("upload k_norm_w");
+        let o_proj_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_us, h_us * d_us], &o_proj_w_bytes,
+        ).expect("upload o_proj_w");
+
+        let mut output = GpuBuffer::zeros(
+            ordinal, ScalarType::BF16,
+            &[parity_output_elems(geom.num_heads, geom.num_kv_heads, geom.head_dim)],
+        ).expect("alloc output");
+        let mut workspace = GpuBuffer::zeros(
+            ordinal, ScalarType::F32,
+            &[parity_workspace_floats(geom.num_heads, geom.num_kv_heads, geom.head_dim, geom.hidden)],
+        ).expect("alloc workspace");
+        let mut sync_buf = GpuBuffer::zeros(
+            ordinal, ScalarType::U8, &[32],
+        ).expect("alloc sync buf");
+
+        let params = Qwen36MoeAttnStepParams {
+            stage: 5,
+            hidden: geom.hidden,
+            num_heads: geom.num_heads,
+            num_kv_heads: geom.num_kv_heads,
+            head_dim: geom.head_dim,
+            rotary_dim,
+            rope_theta,
+            rms_norm_eps: geom.rms_norm_eps,
+            position,
+        };
+        let weight_ptrs = Qwen36MoeAttnStepWeights {
+            input_hidden: input_hidden.as_ptr(),
+            input_norm_w: input_norm_w.as_ptr(),
+            q_proj_w: q_proj_w.as_ptr(),
+            k_proj_w: k_proj_w.as_ptr(),
+            v_proj_w: v_proj_w.as_ptr(),
+            q_norm_w: q_norm_w.as_ptr(),
+            k_norm_w: k_norm_w.as_ptr(),
+            o_proj_w: o_proj_w.as_ptr(),
+        };
+
+        attn_step_launch(
+            ordinal,
+            ScalarType::BF16,
+            params,
+            &weight_ptrs,
+            &mut output,
+            &mut workspace,
+            &mut sync_buf,
+        )
+        .expect("attn_step_launch stage 5");
+
+        // Stage 5 publishes output_hidden into output[0..hidden) BF16.
+        let got_bytes_full = output.to_host_bytes().expect("download output");
+        let got_bytes = &got_bytes_full[..hidden_us * 2];
+        // o_proj reduces over H*d=4096 lanes; allow more headroom on
+        // max_abs_diff than the smaller stage-1 reduction (2048 lanes).
+        // Cosine similarity is the more meaningful metric for the residual.
+        assert_parity(
+            "step5 output_hidden",
+            got_bytes,
+            &output_hidden_expected_bytes,
+            0.05,
+            0.9999,
+        );
     }
 }

--- a/crates/kernel-ffi/src/qwen36_moe.rs
+++ b/crates/kernel-ffi/src/qwen36_moe.rs
@@ -403,9 +403,9 @@ pub fn attn_step_launch(
             params.stage
         )));
     }
-    if params.stage > 1 {
+    if params.stage > 2 {
         return Err(GpuError::InvalidArg(format!(
-            "qwen36_moe::attn_step_launch: stage {} not yet implemented (PR 4b2 step 1 only)",
+            "qwen36_moe::attn_step_launch: stage {} not yet implemented (PR 4b2 stages 1-2 only)",
             params.stage
         )));
     }
@@ -683,51 +683,126 @@ mod tests {
             .collect()
     }
 
+    /// Geometry pulled from the oracle JSON's `config` block — pinned to
+    /// what every parity test in this file consumes.
+    #[cfg(supersonic_backend_hip)]
+    struct OracleGeom {
+        hidden: i32,
+        num_heads: i32,
+        num_kv_heads: i32,
+        head_dim: i32,
+        rms_norm_eps: f32,
+    }
+
+    #[cfg(supersonic_backend_hip)]
+    fn load_oracle_json() -> Option<(serde_json::Value, OracleGeom)> {
+        let json_path = std::env::var("SUPERSONIC_QWEN36_ORACLE_JSON").ok()?;
+        let raw = std::fs::read_to_string(&json_path)
+            .unwrap_or_else(|e| panic!("read oracle json {json_path}: {e}"));
+        let json: serde_json::Value = serde_json::from_str(&raw).expect("oracle json parse");
+        assert_eq!(
+            json["dtype"].as_str().unwrap_or(""),
+            "bf16",
+            "PR 4b2 parity tests require the oracle to be in bf16 mode"
+        );
+        let cfg = &json["config"];
+        let geom = OracleGeom {
+            hidden: cfg["hidden"].as_i64().unwrap() as i32,
+            num_heads: cfg["num_attention_heads"].as_i64().unwrap() as i32,
+            num_kv_heads: cfg["num_kv_heads"].as_i64().unwrap() as i32,
+            head_dim: cfg["head_dim"].as_i64().unwrap() as i32,
+            rms_norm_eps: cfg["rms_norm_eps"].as_f64().unwrap() as f32,
+        };
+        Some((json, geom))
+    }
+
+    /// Compare a kernel-produced BF16 buffer against the matching oracle
+    /// intermediate, emit a one-line summary, and assert tolerances. BF16
+    /// stores at every boundary mean most elements are bit-exact; the rare
+    /// 1-ULP misses come from F32 accumulation-order drift in the matmul.
+    #[cfg(supersonic_backend_hip)]
+    fn assert_parity(
+        label: &str,
+        got_bytes: &[u8],
+        want_bytes: &[u8],
+        max_abs_tol: f32,
+        cos_sim_floor: f64,
+    ) {
+        assert_eq!(
+            got_bytes.len(), want_bytes.len(),
+            "{label}: byte length mismatch"
+        );
+        let got = bf16_bytes_to_f32(got_bytes);
+        let want = bf16_bytes_to_f32(want_bytes);
+        let n = got.len();
+        let mut max_abs_diff = 0.0f32;
+        let mut sum_abs_diff = 0.0f32;
+        let mut dot = 0.0f64;
+        let mut got_sq = 0.0f64;
+        let mut want_sq = 0.0f64;
+        let mut exact = 0usize;
+        for i in 0..n {
+            let d = (got[i] - want[i]).abs();
+            if d == 0.0 { exact += 1; }
+            max_abs_diff = max_abs_diff.max(d);
+            sum_abs_diff += d;
+            dot += got[i] as f64 * want[i] as f64;
+            got_sq += (got[i] as f64).powi(2);
+            want_sq += (want[i] as f64).powi(2);
+        }
+        let cos_sim = dot / (got_sq.sqrt() * want_sq.sqrt() + 1e-30);
+        let mean_abs_diff = sum_abs_diff / n as f32;
+        eprintln!(
+            "[parity {label}] n={n} exact={exact} max_abs={max_abs_diff:.5e} \
+             mean_abs={mean_abs_diff:.5e} cos_sim={cos_sim:.7}"
+        );
+        assert!(
+            max_abs_diff <= max_abs_tol,
+            "{label}: max_abs={max_abs_diff} exceeds tolerance {max_abs_tol}"
+        );
+        assert!(
+            cos_sim >= cos_sim_floor,
+            "{label}: cos_sim {cos_sim:.7} below floor {cos_sim_floor}"
+        );
+    }
+
+    /// Returns workspace size sufficient for the largest staged
+    /// intermediate (currently stage 2: 2*H*d + 2*Hkv*d + H*d + Hkv*d F32).
+    /// Bumped by future stages as RoPE / attn buffers get added.
+    #[cfg(supersonic_backend_hip)]
+    fn parity_workspace_floats(num_heads: i32, num_kv_heads: i32, head_dim: i32) -> usize {
+        let h = num_heads as usize;
+        let hkv = num_kv_heads as usize;
+        let d = head_dim as usize;
+        2 * h * d + 2 * hkv * d + h * d + hkv * d
+    }
+
     #[cfg(supersonic_backend_hip)]
     #[test]
     fn qwen36_moe_attn_step_1_q_normed_matches_oracle() {
         use gpu_hal::{set_backend, Backend, GpuBuffer, ScalarType};
 
-        let json_path = match std::env::var("SUPERSONIC_QWEN36_ORACLE_JSON") {
-            Ok(v) => v,
-            Err(_) => {
-                eprintln!(
-                    "skip: SUPERSONIC_QWEN36_ORACLE_JSON not set. \
-                     Generate a fixture with \
-                     `python oracle/qwen36_moe_oracle.py --mode synthetic --out /tmp/syn.json` \
-                     and re-run."
-                );
-                return;
-            }
+        let Some((json, geom)) = load_oracle_json() else {
+            eprintln!(
+                "skip: SUPERSONIC_QWEN36_ORACLE_JSON not set. \
+                 Generate a fixture with \
+                 `python oracle/qwen36_moe_oracle.py --mode synthetic --out /tmp/syn.json` \
+                 and re-run."
+            );
+            return;
         };
-
-        let raw = std::fs::read_to_string(&json_path)
-            .unwrap_or_else(|e| panic!("read oracle json {json_path}: {e}"));
-        let json: serde_json::Value = serde_json::from_str(&raw)
-            .expect("oracle json parse");
-        let cfg = &json["config"];
         let weights = &json["weights"];
         let inters = &json["intermediates"];
-        assert_eq!(json["dtype"].as_str().unwrap_or(""), "bf16",
-                   "PR 4b2 step 1 requires the oracle to be in bf16 mode");
 
-        let hidden = cfg["hidden"].as_i64().unwrap() as i32;
-        let num_heads = cfg["num_attention_heads"].as_i64().unwrap() as i32;
-        let num_kv_heads = cfg["num_kv_heads"].as_i64().unwrap() as i32;
-        let head_dim = cfg["head_dim"].as_i64().unwrap() as i32;
-        let rms_norm_eps = cfg["rms_norm_eps"].as_f64().unwrap() as f32;
-
-        // Decode the four BF16 inputs we need for stage 1.
         let input_hidden_bytes = b64_decode(weights["input_hidden"].as_str().unwrap());
         let input_norm_w_bytes = b64_decode(weights["input_norm_w"].as_str().unwrap());
         let q_proj_w_bytes = b64_decode(weights["q_proj_w"].as_str().unwrap());
         let q_norm_w_bytes = b64_decode(weights["q_norm_w"].as_str().unwrap());
         let q_normed_expected_bytes = b64_decode(inters["q_normed"].as_str().unwrap());
 
-        // Sanity-check sizes against config-derived shapes.
-        let hidden_us = hidden as usize;
-        let h_us = num_heads as usize;
-        let d_us = head_dim as usize;
+        let hidden_us = geom.hidden as usize;
+        let h_us = geom.num_heads as usize;
+        let d_us = geom.head_dim as usize;
         assert_eq!(input_hidden_bytes.len(), hidden_us * 2);
         assert_eq!(input_norm_w_bytes.len(), hidden_us * 2);
         assert_eq!(q_proj_w_bytes.len(), 2 * h_us * d_us * hidden_us * 2);
@@ -737,9 +812,6 @@ mod tests {
         set_backend(Backend::Hip);
         let ordinal = 0usize;
 
-        // Upload all four inputs as BF16 buffers. The kernel reads them
-        // through `*const c_void` so the gpu-hal shape just needs to match
-        // element count.
         let input_hidden = GpuBuffer::from_host_bytes(
             ordinal, ScalarType::BF16, &[hidden_us], &input_hidden_bytes,
         ).expect("upload input_hidden");
@@ -757,7 +829,8 @@ mod tests {
             ordinal, ScalarType::BF16, &[h_us * d_us],
         ).expect("alloc output");
         let mut workspace = GpuBuffer::zeros(
-            ordinal, ScalarType::F32, &[2 * h_us * d_us],
+            ordinal, ScalarType::F32,
+            &[parity_workspace_floats(geom.num_heads, geom.num_kv_heads, geom.head_dim)],
         ).expect("alloc workspace");
         let mut sync_buf = GpuBuffer::zeros(
             ordinal, ScalarType::U8, &[32],
@@ -765,13 +838,13 @@ mod tests {
 
         let params = Qwen36MoeAttnStepParams {
             stage: 1,
-            hidden,
-            num_heads,
-            num_kv_heads,
-            head_dim,
+            hidden: geom.hidden,
+            num_heads: geom.num_heads,
+            num_kv_heads: geom.num_kv_heads,
+            head_dim: geom.head_dim,
             rotary_dim: 0,
             rope_theta: 0.0,
-            rms_norm_eps,
+            rms_norm_eps: geom.rms_norm_eps,
             position: 0,
         };
         let weight_ptrs = Qwen36MoeAttnStepWeights {
@@ -797,49 +870,122 @@ mod tests {
         .expect("attn_step_launch stage 1");
 
         let got_bytes = output.to_host_bytes().expect("download output");
-        assert_eq!(got_bytes.len(), q_normed_expected_bytes.len());
-
-        let got = bf16_bytes_to_f32(&got_bytes);
-        let want = bf16_bytes_to_f32(&q_normed_expected_bytes);
-
-        // BF16 q_normed parity: kernel and oracle both round to BF16 at
-        // every store boundary, so most elements should be exact. The
-        // F32-accumulation order in the matmul can cause rare 1-ULP
-        // BF16 disagreements in the lower bits; tolerate that with a tight
-        // absolute threshold and require cosine similarity ≥ 0.9999.
-        let n = got.len();
-        let mut max_abs_diff = 0.0f32;
-        let mut sum_abs_diff = 0.0f32;
-        let mut dot = 0.0f64;
-        let mut got_sq = 0.0f64;
-        let mut want_sq = 0.0f64;
-        let mut exact = 0usize;
-        for i in 0..n {
-            let d = (got[i] - want[i]).abs();
-            if d == 0.0 { exact += 1; }
-            max_abs_diff = max_abs_diff.max(d);
-            sum_abs_diff += d;
-            dot += got[i] as f64 * want[i] as f64;
-            got_sq += (got[i] as f64).powi(2);
-            want_sq += (want[i] as f64).powi(2);
-        }
-        let cos_sim = dot / (got_sq.sqrt() * want_sq.sqrt() + 1e-30);
-        let mean_abs_diff = sum_abs_diff / n as f32;
-        eprintln!(
-            "[parity step1] n={n} exact={exact} max_abs={max_abs_diff:.5e} \
-             mean_abs={mean_abs_diff:.5e} cos_sim={cos_sim:.7}"
-        );
-
-        // Tolerances: synth-mode q_normed values land in roughly [-2, 2].
         // BF16 ULP at magnitude 1 is ~7.8e-3; allow 4× that for matmul
-        // accumulation order drift.
-        assert!(
-            max_abs_diff <= 0.04,
-            "kernel q_normed diverges from oracle: max_abs={max_abs_diff} (>0.04)"
-        );
-        assert!(
-            cos_sim >= 0.9999,
-            "kernel q_normed cosine similarity {cos_sim:.7} below 0.9999"
-        );
+        // accumulation order drift across the 2048-wide reduction.
+        assert_parity("step1 q_normed", &got_bytes, &q_normed_expected_bytes, 0.04, 0.9999);
+    }
+
+    #[cfg(supersonic_backend_hip)]
+    #[test]
+    fn qwen36_moe_attn_step_2_k_normed_matches_oracle() {
+        use gpu_hal::{set_backend, Backend, GpuBuffer, ScalarType};
+
+        let Some((json, geom)) = load_oracle_json() else {
+            eprintln!(
+                "skip: SUPERSONIC_QWEN36_ORACLE_JSON not set. \
+                 See `qwen36_moe_attn_step_1_q_normed_matches_oracle` for setup."
+            );
+            return;
+        };
+        let weights = &json["weights"];
+        let inters = &json["intermediates"];
+
+        // Stage 2 still runs the stage-1 prerequisite (q_normed lives in
+        // workspace for later RoPE), so the kernel needs the q-side weights
+        // even though we only verify k_normed here.
+        let input_hidden_bytes = b64_decode(weights["input_hidden"].as_str().unwrap());
+        let input_norm_w_bytes = b64_decode(weights["input_norm_w"].as_str().unwrap());
+        let q_proj_w_bytes = b64_decode(weights["q_proj_w"].as_str().unwrap());
+        let k_proj_w_bytes = b64_decode(weights["k_proj_w"].as_str().unwrap());
+        let v_proj_w_bytes = b64_decode(weights["v_proj_w"].as_str().unwrap());
+        let q_norm_w_bytes = b64_decode(weights["q_norm_w"].as_str().unwrap());
+        let k_norm_w_bytes = b64_decode(weights["k_norm_w"].as_str().unwrap());
+        let k_normed_expected_bytes = b64_decode(inters["k_normed"].as_str().unwrap());
+
+        let hidden_us = geom.hidden as usize;
+        let h_us = geom.num_heads as usize;
+        let hkv_us = geom.num_kv_heads as usize;
+        let d_us = geom.head_dim as usize;
+        assert_eq!(k_proj_w_bytes.len(), hkv_us * d_us * hidden_us * 2);
+        assert_eq!(v_proj_w_bytes.len(), hkv_us * d_us * hidden_us * 2);
+        assert_eq!(k_norm_w_bytes.len(), d_us * 2);
+        assert_eq!(k_normed_expected_bytes.len(), hkv_us * d_us * 2);
+
+        set_backend(Backend::Hip);
+        let ordinal = 0usize;
+
+        let input_hidden = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_us], &input_hidden_bytes,
+        ).expect("upload input_hidden");
+        let input_norm_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_us], &input_norm_w_bytes,
+        ).expect("upload input_norm_w");
+        let q_proj_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[2 * h_us * d_us, hidden_us], &q_proj_w_bytes,
+        ).expect("upload q_proj_w");
+        let k_proj_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hkv_us * d_us, hidden_us], &k_proj_w_bytes,
+        ).expect("upload k_proj_w");
+        let v_proj_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hkv_us * d_us, hidden_us], &v_proj_w_bytes,
+        ).expect("upload v_proj_w");
+        let q_norm_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[d_us], &q_norm_w_bytes,
+        ).expect("upload q_norm_w");
+        let k_norm_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[d_us], &k_norm_w_bytes,
+        ).expect("upload k_norm_w");
+
+        // Output is sized for the largest staged intermediate (H*d). Stage 2
+        // writes Hkv*d BF16 elements at the start of the buffer.
+        let mut output = GpuBuffer::zeros(
+            ordinal, ScalarType::BF16, &[h_us * d_us],
+        ).expect("alloc output");
+        let mut workspace = GpuBuffer::zeros(
+            ordinal, ScalarType::F32,
+            &[parity_workspace_floats(geom.num_heads, geom.num_kv_heads, geom.head_dim)],
+        ).expect("alloc workspace");
+        let mut sync_buf = GpuBuffer::zeros(
+            ordinal, ScalarType::U8, &[32],
+        ).expect("alloc sync buf");
+
+        let params = Qwen36MoeAttnStepParams {
+            stage: 2,
+            hidden: geom.hidden,
+            num_heads: geom.num_heads,
+            num_kv_heads: geom.num_kv_heads,
+            head_dim: geom.head_dim,
+            rotary_dim: 0,
+            rope_theta: 0.0,
+            rms_norm_eps: geom.rms_norm_eps,
+            position: 0,
+        };
+        let weight_ptrs = Qwen36MoeAttnStepWeights {
+            input_hidden: input_hidden.as_ptr(),
+            input_norm_w: input_norm_w.as_ptr(),
+            q_proj_w: q_proj_w.as_ptr(),
+            k_proj_w: k_proj_w.as_ptr(),
+            v_proj_w: v_proj_w.as_ptr(),
+            q_norm_w: q_norm_w.as_ptr(),
+            k_norm_w: k_norm_w.as_ptr(),
+            o_proj_w: std::ptr::null(),
+        };
+
+        attn_step_launch(
+            ordinal,
+            ScalarType::BF16,
+            params,
+            &weight_ptrs,
+            &mut output,
+            &mut workspace,
+            &mut sync_buf,
+        )
+        .expect("attn_step_launch stage 2");
+
+        // Stage 2 publishes k_normed into the first Hkv*d BF16 elements of
+        // the output buffer. Slice down to just those bytes for parity.
+        let got_bytes_full = output.to_host_bytes().expect("download output");
+        let got_bytes = &got_bytes_full[..hkv_us * d_us * 2];
+        assert_parity("step2 k_normed", got_bytes, &k_normed_expected_bytes, 0.04, 0.9999);
     }
 }

--- a/crates/kernel-ffi/src/qwen36_moe.rs
+++ b/crates/kernel-ffi/src/qwen36_moe.rs
@@ -2979,4 +2979,146 @@ mod tests {
             0.999,
         );
     }
+
+    #[cfg(supersonic_backend_hip)]
+    #[test]
+    fn qwen36_moe_ffn_step_3_expert0_matches_oracle() {
+        use gpu_hal::{set_backend, Backend, GpuBuffer, ScalarType};
+
+        let Some((json, geom)) = load_ffn_oracle_json() else {
+            eprintln!(
+                "skip: SUPERSONIC_QWEN36_FFN_ORACLE_JSON not set. \
+                 See `qwen36_moe_ffn_step_1_topk_matches_oracle` for setup."
+            );
+            return;
+        };
+        let weights = &json["weights"];
+        let inters = &json["intermediates"];
+
+        // Stage 3 still walks stage-2 prereqs (the kernel runs the shared
+        // expert path even when only the per-expert output is wanted) plus
+        // the new fused expert weight slabs.
+        let input_hidden_bytes = b64_decode(weights["input_hidden"].as_str().unwrap());
+        let post_attn_norm_w_bytes = b64_decode(weights["post_attn_norm_w"].as_str().unwrap());
+        let gate_w_bytes = b64_decode(weights["gate_w"].as_str().unwrap());
+        let gate_up_proj_w_bytes =
+            b64_decode(weights["gate_up_proj_w"].as_str().unwrap());
+        let down_proj_w_bytes = b64_decode(weights["down_proj_w"].as_str().unwrap());
+        let shared_gate_proj_w_bytes =
+            b64_decode(weights["shared_gate_proj_w"].as_str().unwrap());
+        let shared_up_proj_w_bytes =
+            b64_decode(weights["shared_up_proj_w"].as_str().unwrap());
+        let shared_down_proj_w_bytes =
+            b64_decode(weights["shared_down_proj_w"].as_str().unwrap());
+        let shared_expert_gate_w_bytes =
+            b64_decode(weights["shared_expert_gate_w"].as_str().unwrap());
+
+        // The oracle's `expert_stack` is [K, hidden] BF16 — the first
+        // `hidden` elements are the FFN output of `topk_idx[0]`, which is
+        // the same expert stage 3 dispatches. Slice off that first chunk.
+        let expert_stack_full = b64_decode(inters["expert_stack"].as_str().unwrap());
+
+        let hidden_us = geom.hidden as usize;
+        let e_us = geom.num_experts as usize;
+        let i_us = geom.moe_intermediate as usize;
+        let is_us = geom.shared_intermediate as usize;
+        let k_us = geom.top_k as usize;
+
+        assert_eq!(input_hidden_bytes.len(), hidden_us * 2);
+        assert_eq!(gate_w_bytes.len(), e_us * hidden_us * 2);
+        assert_eq!(gate_up_proj_w_bytes.len(), e_us * 2 * i_us * hidden_us * 2);
+        assert_eq!(down_proj_w_bytes.len(), e_us * hidden_us * i_us * 2);
+        assert_eq!(expert_stack_full.len(), k_us * hidden_us * 2);
+        let expert0_expected_bytes = &expert_stack_full[..hidden_us * 2];
+
+        set_backend(Backend::Hip);
+        let ordinal = 0usize;
+
+        let input_hidden = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_us], &input_hidden_bytes,
+        ).expect("upload input_hidden");
+        let post_attn_norm_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_us], &post_attn_norm_w_bytes,
+        ).expect("upload post_attn_norm_w");
+        let gate_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[e_us, hidden_us], &gate_w_bytes,
+        ).expect("upload gate_w");
+        let gate_up_proj_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[e_us, 2 * i_us, hidden_us], &gate_up_proj_w_bytes,
+        ).expect("upload gate_up_proj_w");
+        let down_proj_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[e_us, hidden_us, i_us], &down_proj_w_bytes,
+        ).expect("upload down_proj_w");
+        let shared_gate_proj_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[is_us, hidden_us], &shared_gate_proj_w_bytes,
+        ).expect("upload shared_gate_proj_w");
+        let shared_up_proj_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[is_us, hidden_us], &shared_up_proj_w_bytes,
+        ).expect("upload shared_up_proj_w");
+        let shared_down_proj_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_us, is_us], &shared_down_proj_w_bytes,
+        ).expect("upload shared_down_proj_w");
+        let shared_expert_gate_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[1, hidden_us], &shared_expert_gate_w_bytes,
+        ).expect("upload shared_expert_gate_w");
+
+        let mut output = GpuBuffer::zeros(
+            ordinal, ScalarType::BF16, &[ffn_parity_output_elems(&geom)],
+        ).expect("alloc output");
+        let mut output_idx = GpuBuffer::zeros(
+            ordinal, ScalarType::U32, &[k_us],
+        ).expect("alloc output_idx");
+        let mut workspace = GpuBuffer::zeros(
+            ordinal, ScalarType::F32, &[ffn_parity_workspace_floats(&geom)],
+        ).expect("alloc workspace");
+        let mut sync_buf = GpuBuffer::zeros(
+            ordinal, ScalarType::U8, &[32],
+        ).expect("alloc sync buf");
+
+        let params = Qwen36MoeFfnStepParams {
+            stage: 3,
+            hidden: geom.hidden,
+            num_experts: geom.num_experts,
+            moe_intermediate: geom.moe_intermediate,
+            shared_intermediate: geom.shared_intermediate,
+            top_k: geom.top_k,
+            rms_norm_eps: geom.rms_norm_eps,
+        };
+        let weight_ptrs = Qwen36MoeFfnStepWeights {
+            input_hidden: input_hidden.as_ptr(),
+            post_attn_norm_w: post_attn_norm_w.as_ptr(),
+            gate_w: gate_w.as_ptr(),
+            gate_up_proj_w: gate_up_proj_w.as_ptr(),
+            down_proj_w: down_proj_w.as_ptr(),
+            shared_gate_proj_w: shared_gate_proj_w.as_ptr(),
+            shared_up_proj_w: shared_up_proj_w.as_ptr(),
+            shared_down_proj_w: shared_down_proj_w.as_ptr(),
+            shared_expert_gate_w: shared_expert_gate_w.as_ptr(),
+        };
+
+        ffn_step_launch(
+            ordinal,
+            ScalarType::BF16,
+            params,
+            &weight_ptrs,
+            &mut output,
+            &mut output_idx,
+            &mut workspace,
+            &mut sync_buf,
+        )
+        .expect("ffn_step_launch stage 3");
+
+        // Stage 3 publishes expert_stack[0] (BF16-rounded F32) into
+        // output[0..hidden]. Same envelope as stage 2's shared expert —
+        // four matmuls deep, F32 throughout.
+        let got_full = output.to_host_bytes().expect("download output");
+        let got_bytes = &got_full[..hidden_us * 2];
+        assert_parity(
+            "ffn step3 expert0_out",
+            got_bytes,
+            expert0_expected_bytes,
+            0.05,
+            0.999,
+        );
+    }
 }

--- a/crates/kernel-ffi/src/qwen36_moe.rs
+++ b/crates/kernel-ffi/src/qwen36_moe.rs
@@ -403,9 +403,9 @@ pub fn attn_step_launch(
             params.stage
         )));
     }
-    if params.stage > 3 {
+    if params.stage > 4 {
         return Err(GpuError::InvalidArg(format!(
-            "qwen36_moe::attn_step_launch: stage {} not yet implemented (PR 4b2 stages 1-3 only)",
+            "qwen36_moe::attn_step_launch: stage {} not yet implemented (PR 4b2 stages 1-4 only)",
             params.stage
         )));
     }
@@ -767,14 +767,14 @@ mod tests {
     }
 
     /// Returns workspace size sufficient for the largest staged
-    /// intermediate (currently stage 3: 4*H*d + 4*Hkv*d F32).
-    /// Bumped by future stages as attn / o_proj buffers get added.
+    /// intermediate (currently stage 4: 5*H*d + 4*Hkv*d F32).
+    /// Bumped by future stages as o_proj scratch gets added.
     #[cfg(supersonic_backend_hip)]
     fn parity_workspace_floats(num_heads: i32, num_kv_heads: i32, head_dim: i32) -> usize {
         let h = num_heads as usize;
         let hkv = num_kv_heads as usize;
         let d = head_dim as usize;
-        4 * h * d + 4 * hkv * d
+        5 * h * d + 4 * hkv * d
     }
 
     /// Output buffer size sufficient for the largest staged intermediate.
@@ -1132,5 +1132,121 @@ mod tests {
                       &q_rot_expected_bytes, 0.04, 0.9999);
         assert_parity("step3 k_rot", &got_bytes_full[q_end..k_end],
                       &k_rot_expected_bytes, 0.04, 0.9999);
+    }
+
+    #[cfg(supersonic_backend_hip)]
+    #[test]
+    fn qwen36_moe_attn_step_4_attn_matches_oracle() {
+        use gpu_hal::{set_backend, Backend, GpuBuffer, ScalarType};
+
+        let Some((json, geom)) = load_oracle_json() else {
+            eprintln!(
+                "skip: SUPERSONIC_QWEN36_ORACLE_JSON not set. \
+                 See `qwen36_moe_attn_step_1_q_normed_matches_oracle` for setup."
+            );
+            return;
+        };
+        let weights = &json["weights"];
+        let inters = &json["intermediates"];
+        let cfg = &json["config"];
+
+        // Stage 4 still walks the stage-3 RoPE prerequisite, so we need
+        // the same RoPE config + non-trivial position discipline as step 3.
+        let position = json["position"].as_i64().unwrap_or(0) as i32;
+        let rotary_dim = cfg["rotary_dim"].as_i64().unwrap() as i32;
+        let rope_theta = cfg["rope_theta"].as_f64().unwrap() as f32;
+
+        let input_hidden_bytes = b64_decode(weights["input_hidden"].as_str().unwrap());
+        let input_norm_w_bytes = b64_decode(weights["input_norm_w"].as_str().unwrap());
+        let q_proj_w_bytes = b64_decode(weights["q_proj_w"].as_str().unwrap());
+        let k_proj_w_bytes = b64_decode(weights["k_proj_w"].as_str().unwrap());
+        let v_proj_w_bytes = b64_decode(weights["v_proj_w"].as_str().unwrap());
+        let q_norm_w_bytes = b64_decode(weights["q_norm_w"].as_str().unwrap());
+        let k_norm_w_bytes = b64_decode(weights["k_norm_w"].as_str().unwrap());
+        let attn_expected_bytes = b64_decode(inters["attn"].as_str().unwrap());
+
+        let hidden_us = geom.hidden as usize;
+        let h_us = geom.num_heads as usize;
+        let hkv_us = geom.num_kv_heads as usize;
+        let d_us = geom.head_dim as usize;
+        assert_eq!(attn_expected_bytes.len(), h_us * d_us * 2);
+
+        set_backend(Backend::Hip);
+        let ordinal = 0usize;
+
+        let input_hidden = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_us], &input_hidden_bytes,
+        ).expect("upload input_hidden");
+        let input_norm_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_us], &input_norm_w_bytes,
+        ).expect("upload input_norm_w");
+        let q_proj_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[2 * h_us * d_us, hidden_us], &q_proj_w_bytes,
+        ).expect("upload q_proj_w");
+        let k_proj_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hkv_us * d_us, hidden_us], &k_proj_w_bytes,
+        ).expect("upload k_proj_w");
+        let v_proj_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hkv_us * d_us, hidden_us], &v_proj_w_bytes,
+        ).expect("upload v_proj_w");
+        let q_norm_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[d_us], &q_norm_w_bytes,
+        ).expect("upload q_norm_w");
+        let k_norm_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[d_us], &k_norm_w_bytes,
+        ).expect("upload k_norm_w");
+
+        let mut output = GpuBuffer::zeros(
+            ordinal, ScalarType::BF16,
+            &[parity_output_elems(geom.num_heads, geom.num_kv_heads, geom.head_dim)],
+        ).expect("alloc output");
+        let mut workspace = GpuBuffer::zeros(
+            ordinal, ScalarType::F32,
+            &[parity_workspace_floats(geom.num_heads, geom.num_kv_heads, geom.head_dim)],
+        ).expect("alloc workspace");
+        let mut sync_buf = GpuBuffer::zeros(
+            ordinal, ScalarType::U8, &[32],
+        ).expect("alloc sync buf");
+
+        let params = Qwen36MoeAttnStepParams {
+            stage: 4,
+            hidden: geom.hidden,
+            num_heads: geom.num_heads,
+            num_kv_heads: geom.num_kv_heads,
+            head_dim: geom.head_dim,
+            rotary_dim,
+            rope_theta,
+            rms_norm_eps: geom.rms_norm_eps,
+            position,
+        };
+        let weight_ptrs = Qwen36MoeAttnStepWeights {
+            input_hidden: input_hidden.as_ptr(),
+            input_norm_w: input_norm_w.as_ptr(),
+            q_proj_w: q_proj_w.as_ptr(),
+            k_proj_w: k_proj_w.as_ptr(),
+            v_proj_w: v_proj_w.as_ptr(),
+            q_norm_w: q_norm_w.as_ptr(),
+            k_norm_w: k_norm_w.as_ptr(),
+            o_proj_w: std::ptr::null(),
+        };
+
+        attn_step_launch(
+            ordinal,
+            ScalarType::BF16,
+            params,
+            &weight_ptrs,
+            &mut output,
+            &mut workspace,
+            &mut sync_buf,
+        )
+        .expect("attn_step_launch stage 4");
+
+        // Stage 4 publishes attn into output[0..H*d) BF16.
+        let got_bytes_full = output.to_host_bytes().expect("download output");
+        let got_bytes = &got_bytes_full[..h_us * d_us * 2];
+        // kv_len=1 makes softmax trivially 1.0, so attn = v_full and the
+        // parity should be effectively bit-exact (both kernel and oracle
+        // skip any precision-losing accumulation here).
+        assert_parity("step4 attn", got_bytes, &attn_expected_bytes, 0.04, 0.9999);
     }
 }

--- a/crates/kernel-ffi/src/qwen36_moe.rs
+++ b/crates/kernel-ffi/src/qwen36_moe.rs
@@ -585,9 +585,9 @@ pub fn linear_step_launch(
             params.stage
         )));
     }
-    if params.stage > 2 {
+    if params.stage > 3 {
         return Err(GpuError::InvalidArg(format!(
-            "qwen36_moe::linear_step_launch: stage {} not yet implemented (PR 4b3 stages 1-2 only)",
+            "qwen36_moe::linear_step_launch: stage {} not yet implemented (PR 4b3 stages 1-3 only)",
             params.stage
         )));
     }
@@ -1900,5 +1900,156 @@ mod tests {
             0.04,
             0.9999,
         );
+    }
+
+    #[cfg(supersonic_backend_hip)]
+    #[test]
+    fn qwen36_moe_linear_step_3_qkv_post_norm_matches_oracle() {
+        use gpu_hal::{set_backend, Backend, GpuBuffer, ScalarType};
+
+        let Some((json, geom)) = load_linear_oracle_json() else {
+            eprintln!(
+                "skip: SUPERSONIC_QWEN36_LINEAR_ORACLE_JSON not set. \
+                 See `qwen36_moe_linear_step_1_qkv_raw_matches_oracle` for setup."
+            );
+            return;
+        };
+        let weights = &json["weights"];
+        let inters = &json["intermediates"];
+
+        // Stage 3 needs everything stage 2 needed.
+        let input_hidden_bytes = b64_decode(weights["input_hidden"].as_str().unwrap());
+        let input_norm_w_bytes = b64_decode(weights["input_norm_w"].as_str().unwrap());
+        let in_proj_qkv_w_bytes = b64_decode(weights["in_proj_qkv_w"].as_str().unwrap());
+        let in_proj_z_w_bytes = b64_decode(weights["in_proj_z_w"].as_str().unwrap());
+        let in_proj_a_w_bytes = b64_decode(weights["in_proj_a_w"].as_str().unwrap());
+        let in_proj_b_w_bytes = b64_decode(weights["in_proj_b_w"].as_str().unwrap());
+        let conv1d_w_bytes = b64_decode(weights["conv1d_w"].as_str().unwrap());
+        let conv1d_bias_bytes = weights.get("conv1d_bias")
+            .and_then(|v| v.as_str())
+            .map(b64_decode);
+        let conv_state_before_bytes = b64_decode(weights["conv_state_before"].as_str().unwrap());
+        let q_rep_expected = b64_decode(inters["q_rep"].as_str().unwrap());
+        let k_rep_expected = b64_decode(inters["k_rep"].as_str().unwrap());
+        let v_heads_expected = b64_decode(inters["v_heads"].as_str().unwrap());
+        let q_scaled_expected = b64_decode(inters["q_scaled"].as_str().unwrap());
+
+        let hidden_us = geom.hidden as usize;
+        let k_us = geom.num_k_heads as usize;
+        let v_us = geom.num_v_heads as usize;
+        let kd_us = geom.head_k_dim as usize;
+        let vd_us = geom.head_v_dim as usize;
+        let kernel = geom.conv_kernel_dim as usize;
+        let kstate = kernel - 1;
+        let key_dim = k_us * kd_us;
+        let val_dim = v_us * vd_us;
+        let qkv_dim = 2 * key_dim + val_dim;
+        let v_kdim = v_us * kd_us;
+        let v_vdim = v_us * vd_us;
+
+        assert_eq!(q_rep_expected.len(), v_kdim * 2);
+        assert_eq!(k_rep_expected.len(), v_kdim * 2);
+        assert_eq!(v_heads_expected.len(), v_vdim * 2);
+        assert_eq!(q_scaled_expected.len(), v_kdim * 2);
+
+        set_backend(Backend::Hip);
+        let ordinal = 0usize;
+
+        let input_hidden = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_us], &input_hidden_bytes,
+        ).expect("upload input_hidden");
+        let input_norm_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_us], &input_norm_w_bytes,
+        ).expect("upload input_norm_w");
+        let in_proj_qkv_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[qkv_dim, hidden_us], &in_proj_qkv_w_bytes,
+        ).expect("upload in_proj_qkv_w");
+        let in_proj_z_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[val_dim, hidden_us], &in_proj_z_w_bytes,
+        ).expect("upload in_proj_z_w");
+        let in_proj_a_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[v_us, hidden_us], &in_proj_a_w_bytes,
+        ).expect("upload in_proj_a_w");
+        let in_proj_b_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[v_us, hidden_us], &in_proj_b_w_bytes,
+        ).expect("upload in_proj_b_w");
+        let conv1d_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[qkv_dim, 1, kernel], &conv1d_w_bytes,
+        ).expect("upload conv1d_w");
+        let conv1d_bias = match &conv1d_bias_bytes {
+            Some(bytes) => Some(
+                GpuBuffer::from_host_bytes(ordinal, ScalarType::BF16, &[qkv_dim], bytes)
+                    .expect("upload conv1d_bias"),
+            ),
+            None => None,
+        };
+        let mut conv_state = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[qkv_dim, kstate], &conv_state_before_bytes,
+        ).expect("upload conv_state");
+
+        // Output sized for stage 3's largest publish (q_scaled || k_rep || v_heads).
+        let stage3_publish_elems = 2 * v_kdim + v_vdim;
+        let mut output = GpuBuffer::zeros(
+            ordinal, ScalarType::BF16, &[stage3_publish_elems],
+        ).expect("alloc output");
+        // Workspace for stage 3: stage-2 footprint plus Q_NORMED, K_NORMED,
+        // Q_REP, K_REP slots.
+        let workspace_floats = qkv_dim + val_dim + 2 * v_us + 2 * (k_us * kd_us) + 2 * v_kdim;
+        let mut workspace = GpuBuffer::zeros(
+            ordinal, ScalarType::F32, &[workspace_floats],
+        ).expect("alloc workspace");
+        let mut sync_buf = GpuBuffer::zeros(
+            ordinal, ScalarType::U8, &[32],
+        ).expect("alloc sync buf");
+
+        let params = Qwen36MoeLinearStepParams {
+            stage: 3,
+            hidden: geom.hidden,
+            num_k_heads: geom.num_k_heads,
+            num_v_heads: geom.num_v_heads,
+            head_k_dim: geom.head_k_dim,
+            head_v_dim: geom.head_v_dim,
+            conv_kernel_dim: geom.conv_kernel_dim,
+            rms_norm_eps: geom.rms_norm_eps,
+        };
+        let weight_ptrs = Qwen36MoeLinearStepWeights {
+            input_hidden: input_hidden.as_ptr(),
+            input_norm_w: input_norm_w.as_ptr(),
+            in_proj_qkv_w: in_proj_qkv_w.as_ptr(),
+            in_proj_z_w: in_proj_z_w.as_ptr(),
+            in_proj_a_w: in_proj_a_w.as_ptr(),
+            in_proj_b_w: in_proj_b_w.as_ptr(),
+            conv1d_w: conv1d_w.as_ptr(),
+            conv1d_bias: conv1d_bias.as_ref().map(|b| b.as_ptr()).unwrap_or(std::ptr::null()),
+            dt_bias: std::ptr::null(),
+            a_log: std::ptr::null(),
+            norm_w: std::ptr::null(),
+            out_proj_w: std::ptr::null(),
+            conv_state: conv_state.as_mut_ptr(),
+            recurrent_state: std::ptr::null_mut(),
+        };
+
+        linear_step_launch(
+            ordinal,
+            ScalarType::BF16,
+            params,
+            &weight_ptrs,
+            &mut output,
+            &mut workspace,
+            &mut sync_buf,
+        )
+        .expect("linear_step_launch stage 3");
+
+        // Output layout: [q_scaled (V*k_dim) | k_rep (V*k_dim) | v_heads (V*v_dim)] BF16.
+        let got_bytes_full = output.to_host_bytes().expect("download output");
+        let q_end = v_kdim * 2;
+        let k_end = q_end + v_kdim * 2;
+        let v_end = k_end + v_vdim * 2;
+        assert_parity("linear step3 q_scaled", &got_bytes_full[..q_end],
+                      &q_scaled_expected, 0.04, 0.9999);
+        assert_parity("linear step3 k_rep", &got_bytes_full[q_end..k_end],
+                      &k_rep_expected, 0.04, 0.9999);
+        assert_parity("linear step3 v_heads", &got_bytes_full[k_end..v_end],
+                      &v_heads_expected, 0.04, 0.9999);
     }
 }

--- a/crates/kernel-ffi/src/qwen36_moe.rs
+++ b/crates/kernel-ffi/src/qwen36_moe.rs
@@ -3121,4 +3121,138 @@ mod tests {
             0.999,
         );
     }
+
+    #[cfg(supersonic_backend_hip)]
+    #[test]
+    fn qwen36_moe_ffn_step_4_moe_out_matches_oracle() {
+        use gpu_hal::{set_backend, Backend, GpuBuffer, ScalarType};
+
+        let Some((json, geom)) = load_ffn_oracle_json() else {
+            eprintln!(
+                "skip: SUPERSONIC_QWEN36_FFN_ORACLE_JSON not set. \
+                 See `qwen36_moe_ffn_step_1_topk_matches_oracle` for setup."
+            );
+            return;
+        };
+        let weights = &json["weights"];
+        let inters = &json["intermediates"];
+
+        // Stage 4 walks all of stage-3's path (k iterations of the per-expert
+        // FFN) and adds the final topk-weighted sum. Same weight set; the
+        // expected output is `moe_out` instead of `expert_stack[0]`.
+        let input_hidden_bytes = b64_decode(weights["input_hidden"].as_str().unwrap());
+        let post_attn_norm_w_bytes = b64_decode(weights["post_attn_norm_w"].as_str().unwrap());
+        let gate_w_bytes = b64_decode(weights["gate_w"].as_str().unwrap());
+        let gate_up_proj_w_bytes =
+            b64_decode(weights["gate_up_proj_w"].as_str().unwrap());
+        let down_proj_w_bytes = b64_decode(weights["down_proj_w"].as_str().unwrap());
+        let shared_gate_proj_w_bytes =
+            b64_decode(weights["shared_gate_proj_w"].as_str().unwrap());
+        let shared_up_proj_w_bytes =
+            b64_decode(weights["shared_up_proj_w"].as_str().unwrap());
+        let shared_down_proj_w_bytes =
+            b64_decode(weights["shared_down_proj_w"].as_str().unwrap());
+        let shared_expert_gate_w_bytes =
+            b64_decode(weights["shared_expert_gate_w"].as_str().unwrap());
+        let moe_out_expected_bytes = b64_decode(inters["moe_out"].as_str().unwrap());
+
+        let hidden_us = geom.hidden as usize;
+        let e_us = geom.num_experts as usize;
+        let i_us = geom.moe_intermediate as usize;
+        let is_us = geom.shared_intermediate as usize;
+        let k_us = geom.top_k as usize;
+
+        assert_eq!(moe_out_expected_bytes.len(), hidden_us * 2);
+
+        set_backend(Backend::Hip);
+        let ordinal = 0usize;
+
+        let input_hidden = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_us], &input_hidden_bytes,
+        ).expect("upload input_hidden");
+        let post_attn_norm_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_us], &post_attn_norm_w_bytes,
+        ).expect("upload post_attn_norm_w");
+        let gate_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[e_us, hidden_us], &gate_w_bytes,
+        ).expect("upload gate_w");
+        let gate_up_proj_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[e_us, 2 * i_us, hidden_us], &gate_up_proj_w_bytes,
+        ).expect("upload gate_up_proj_w");
+        let down_proj_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[e_us, hidden_us, i_us], &down_proj_w_bytes,
+        ).expect("upload down_proj_w");
+        let shared_gate_proj_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[is_us, hidden_us], &shared_gate_proj_w_bytes,
+        ).expect("upload shared_gate_proj_w");
+        let shared_up_proj_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[is_us, hidden_us], &shared_up_proj_w_bytes,
+        ).expect("upload shared_up_proj_w");
+        let shared_down_proj_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_us, is_us], &shared_down_proj_w_bytes,
+        ).expect("upload shared_down_proj_w");
+        let shared_expert_gate_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[1, hidden_us], &shared_expert_gate_w_bytes,
+        ).expect("upload shared_expert_gate_w");
+
+        let mut output = GpuBuffer::zeros(
+            ordinal, ScalarType::BF16, &[ffn_parity_output_elems(&geom)],
+        ).expect("alloc output");
+        let mut output_idx = GpuBuffer::zeros(
+            ordinal, ScalarType::U32, &[k_us],
+        ).expect("alloc output_idx");
+        let mut workspace = GpuBuffer::zeros(
+            ordinal, ScalarType::F32, &[ffn_parity_workspace_floats(&geom)],
+        ).expect("alloc workspace");
+        let mut sync_buf = GpuBuffer::zeros(
+            ordinal, ScalarType::U8, &[32],
+        ).expect("alloc sync buf");
+
+        let params = Qwen36MoeFfnStepParams {
+            stage: 4,
+            hidden: geom.hidden,
+            num_experts: geom.num_experts,
+            moe_intermediate: geom.moe_intermediate,
+            shared_intermediate: geom.shared_intermediate,
+            top_k: geom.top_k,
+            rms_norm_eps: geom.rms_norm_eps,
+        };
+        let weight_ptrs = Qwen36MoeFfnStepWeights {
+            input_hidden: input_hidden.as_ptr(),
+            post_attn_norm_w: post_attn_norm_w.as_ptr(),
+            gate_w: gate_w.as_ptr(),
+            gate_up_proj_w: gate_up_proj_w.as_ptr(),
+            down_proj_w: down_proj_w.as_ptr(),
+            shared_gate_proj_w: shared_gate_proj_w.as_ptr(),
+            shared_up_proj_w: shared_up_proj_w.as_ptr(),
+            shared_down_proj_w: shared_down_proj_w.as_ptr(),
+            shared_expert_gate_w: shared_expert_gate_w.as_ptr(),
+        };
+
+        ffn_step_launch(
+            ordinal,
+            ScalarType::BF16,
+            params,
+            &weight_ptrs,
+            &mut output,
+            &mut output_idx,
+            &mut workspace,
+            &mut sync_buf,
+        )
+        .expect("ffn_step_launch stage 4");
+
+        // Stage 4 publishes moe_out (= sum_j topk_w[j] * expert_stack[j],
+        // BF16-rounded once) into output[0..hidden]. Tolerance same as
+        // stage 3; the only added work is a k=8-wide reduction with
+        // BF16-cast renormed weights, which is well-conditioned.
+        let got_full = output.to_host_bytes().expect("download output");
+        let got_bytes = &got_full[..hidden_us * 2];
+        assert_parity(
+            "ffn step4 moe_out",
+            got_bytes,
+            &moe_out_expected_bytes,
+            0.05,
+            0.999,
+        );
+    }
 }

--- a/crates/kernel-ffi/src/qwen36_moe.rs
+++ b/crates/kernel-ffi/src/qwen36_moe.rs
@@ -275,6 +275,62 @@ extern "C" {
         barrier_counter: *mut c_uint,
         barrier_flag: *mut c_uint,
     ) -> c_int;
+
+    /// PR 4b3 staged single-layer linear-attention parity launcher. Same
+    /// staged-build-up discipline as `qwen36_moe_hip_attn_step_launch`,
+    /// but for the 3-of-4 hybrid layers that aren't full-attention.
+    /// `stage` selects how far to run; the matching staged intermediate
+    /// is published to `output` (BF16):
+    ///
+    /// | stage | output buffer contents (BF16)           |
+    /// |-------|------------------------------------------|
+    /// |   1   | `qkv_raw[qkv_dim]`                       |
+    /// |   2   | `silu_out[qkv_dim]`         (planned)    |
+    /// |   3   | `q_scaled || k_rep || v_heads` (planned) |
+    /// |   4   | `recurrent_out[V*v_dim]`    (planned)    |
+    /// |   5   | `output_hidden[hidden]`     (planned)    |
+    ///
+    /// PR 4b3 step 2 wires only `stage == 1`; the kernel ignores the conv
+    /// / dt / norm / out_proj / state pointers and the matching arguments
+    /// can be null. They're declared up front so subsequent staged commits
+    /// don't perturb the FFI ABI.
+    ///
+    /// `workspace` must be at least `qkv_dim + V*v_dim + 2*V` F32 entries
+    /// for stage 1 (later stages bump that up via the safe wrapper).
+    /// `output` must be at least `qkv_dim` BF16 entries on stage 1 (sized
+    /// for the largest staged intermediate by the safe wrapper). `sync_buf`
+    /// (counters/barrier_counter/barrier_flag) must be 32 zero bytes.
+    pub fn qwen36_moe_hip_linear_step_launch(
+        dtype: c_int,
+        device_ordinal: usize,
+        stage: c_int,
+        hidden: c_int,
+        num_k_heads: c_int,
+        num_v_heads: c_int,
+        head_k_dim: c_int,
+        head_v_dim: c_int,
+        conv_kernel_dim: c_int,
+        rms_norm_eps: f32,
+        input_hidden: *const c_void,
+        input_norm_w: *const c_void,
+        in_proj_qkv_w: *const c_void,
+        in_proj_z_w: *const c_void,
+        in_proj_a_w: *const c_void,
+        in_proj_b_w: *const c_void,
+        conv1d_w: *const c_void,
+        conv1d_bias: *const c_void,
+        dt_bias: *const c_void,
+        a_log: *const c_void,
+        norm_w: *const c_void,
+        out_proj_w: *const c_void,
+        conv_state: *mut c_void,
+        recurrent_state: *mut f32,
+        output: *mut c_void,
+        workspace: *mut f32,
+        counters: *mut c_uint,
+        barrier_counter: *mut c_uint,
+        barrier_flag: *mut c_uint,
+    ) -> c_int;
 }
 
 /// Safe wrapper over the stub launch. The engine pre-allocates `sync_buf`
@@ -463,6 +519,142 @@ pub fn attn_step_launch(
         return Err(GpuError::backend(
             backend,
             format!("qwen36_moe attn_step launch failed with status {status}"),
+        ));
+    }
+    Ok(())
+}
+
+/// Geometry for the staged linear-attention parity launcher. Mirrors
+/// `Qwen36MoeAttnStepParams`. Bundling these into a struct keeps the safe
+/// wrapper from sprouting a long scalar arglist.
+#[derive(Debug, Clone, Copy)]
+pub struct Qwen36MoeLinearStepParams {
+    pub stage: i32,
+    pub hidden: i32,
+    pub num_k_heads: i32,
+    pub num_v_heads: i32,
+    pub head_k_dim: i32,
+    pub head_v_dim: i32,
+    pub conv_kernel_dim: i32,
+    pub rms_norm_eps: f32,
+}
+
+/// Weight + state pointers for the staged linear-attention parity launcher.
+/// Pointers unused by the requested `stage` may be null; the kernel won't
+/// dereference them. See [`qwen36_moe_hip_linear_step_launch`] for the
+/// per-stage matrix.
+#[derive(Debug, Clone, Copy)]
+pub struct Qwen36MoeLinearStepWeights {
+    pub input_hidden: *const c_void,
+    pub input_norm_w: *const c_void,
+    pub in_proj_qkv_w: *const c_void,
+    pub in_proj_z_w: *const c_void,
+    pub in_proj_a_w: *const c_void,
+    pub in_proj_b_w: *const c_void,
+    pub conv1d_w: *const c_void,
+    pub conv1d_bias: *const c_void,
+    pub dt_bias: *const c_void,
+    pub a_log: *const c_void,
+    pub norm_w: *const c_void,
+    pub out_proj_w: *const c_void,
+    pub conv_state: *mut c_void,
+    pub recurrent_state: *mut f32,
+}
+
+/// Safe wrapper for the PR 4b3 staged linear-attention parity launcher.
+/// Same workspace / sync_buf layout as
+/// [`attn_step_launch`]: 32-byte zero scratch, F32 workspace sized for the
+/// stage's footprint, BF16 output sized for the largest staged intermediate.
+pub fn linear_step_launch(
+    ordinal: usize,
+    dtype: ScalarType,
+    params: Qwen36MoeLinearStepParams,
+    weights: &Qwen36MoeLinearStepWeights,
+    output: &mut GpuBuffer,
+    workspace: &mut GpuBuffer,
+    sync_buf: &mut GpuBuffer,
+) -> Result<(), GpuError> {
+    if dtype != ScalarType::BF16 {
+        return Err(GpuError::InvalidArg(format!(
+            "qwen36_moe::linear_step_launch: only BF16 is wired, got {dtype:?}"
+        )));
+    }
+    if !(1..=5).contains(&params.stage) {
+        return Err(GpuError::InvalidArg(format!(
+            "qwen36_moe::linear_step_launch: stage must be in 1..=5, got {}",
+            params.stage
+        )));
+    }
+    if params.stage > 1 {
+        return Err(GpuError::InvalidArg(format!(
+            "qwen36_moe::linear_step_launch: stage {} not yet implemented (PR 4b3 step 2 lands stage 1 only)",
+            params.stage
+        )));
+    }
+
+    let backend = output.backend();
+    let counters = sync_buf.as_mut_ptr() as *mut c_uint;
+    let barrier_counter = unsafe { (counters as *mut u8).add(16) as *mut c_uint };
+    let barrier_flag = unsafe { (counters as *mut u8).add(20) as *mut c_uint };
+
+    let status = match backend {
+        Backend::Hip => {
+            #[cfg(supersonic_backend_hip)]
+            unsafe {
+                qwen36_moe_hip_linear_step_launch(
+                    dtype.kernel_dtype_code(),
+                    ordinal,
+                    params.stage as c_int,
+                    params.hidden as c_int,
+                    params.num_k_heads as c_int,
+                    params.num_v_heads as c_int,
+                    params.head_k_dim as c_int,
+                    params.head_v_dim as c_int,
+                    params.conv_kernel_dim as c_int,
+                    params.rms_norm_eps,
+                    weights.input_hidden,
+                    weights.input_norm_w,
+                    weights.in_proj_qkv_w,
+                    weights.in_proj_z_w,
+                    weights.in_proj_a_w,
+                    weights.in_proj_b_w,
+                    weights.conv1d_w,
+                    weights.conv1d_bias,
+                    weights.dt_bias,
+                    weights.a_log,
+                    weights.norm_w,
+                    weights.out_proj_w,
+                    weights.conv_state,
+                    weights.recurrent_state,
+                    output.as_mut_ptr(),
+                    workspace.as_mut_ptr() as *mut f32,
+                    counters,
+                    barrier_counter,
+                    barrier_flag,
+                )
+            }
+            #[cfg(not(supersonic_backend_hip))]
+            {
+                return Err(GpuError::InvalidArg(
+                    "qwen36_moe::linear_step_launch: HIP backend not compiled".into(),
+                ));
+            }
+        }
+        Backend::Cuda => {
+            return Err(GpuError::InvalidArg(
+                "qwen36_moe::linear_step_launch: CUDA backend not yet wired".into(),
+            ));
+        }
+        Backend::Metal => {
+            return Err(GpuError::InvalidArg(
+                "qwen36_moe::linear_step_launch: Metal backend not yet wired".into(),
+            ));
+        }
+    };
+    if status != 0 {
+        return Err(GpuError::backend(
+            backend,
+            format!("qwen36_moe linear_step launch failed with status {status}"),
         ));
     }
     Ok(())
@@ -1372,6 +1564,185 @@ mod tests {
             got_bytes,
             &output_hidden_expected_bytes,
             0.05,
+            0.9999,
+        );
+    }
+
+    // ---- PR 4b3 step 2: linear-attn stage 1 parity vs the oracle ---------
+    //
+    // Same env-var pattern as the full-attn parity tests, but pointed at a
+    // JSON produced by `oracle/qwen36_moe_linear_oracle.py`:
+    //
+    //   python oracle/qwen36_moe_linear_oracle.py --mode synthetic \
+    //       --state fresh --out /tmp/qwen36_lin_fresh.json
+    //   SUPERSONIC_QWEN36_LINEAR_ORACLE_JSON=/tmp/qwen36_lin_fresh.json \
+    //       cargo test --release -p kernel-ffi qwen36_moe_linear_step
+    //
+    // Skipped with a clear message when the env var is unset so the FFI
+    // test stays runnable on Python-less hosts.
+
+    #[cfg(supersonic_backend_hip)]
+    struct LinearOracleGeom {
+        hidden: i32,
+        num_k_heads: i32,
+        num_v_heads: i32,
+        head_k_dim: i32,
+        head_v_dim: i32,
+        conv_kernel_dim: i32,
+        rms_norm_eps: f32,
+    }
+
+    #[cfg(supersonic_backend_hip)]
+    fn load_linear_oracle_json() -> Option<(serde_json::Value, LinearOracleGeom)> {
+        let json_path = std::env::var("SUPERSONIC_QWEN36_LINEAR_ORACLE_JSON").ok()?;
+        let raw = std::fs::read_to_string(&json_path)
+            .unwrap_or_else(|e| panic!("read linear oracle json {json_path}: {e}"));
+        let json: serde_json::Value =
+            serde_json::from_str(&raw).expect("linear oracle json parse");
+        assert_eq!(
+            json["dtype"].as_str().unwrap_or(""),
+            "bf16",
+            "linear-attn parity tests require the oracle to be in bf16 mode"
+        );
+        let cfg = &json["config"];
+        let geom = LinearOracleGeom {
+            hidden: cfg["hidden"].as_i64().unwrap() as i32,
+            num_k_heads: cfg["num_k_heads"].as_i64().unwrap() as i32,
+            num_v_heads: cfg["num_v_heads"].as_i64().unwrap() as i32,
+            head_k_dim: cfg["head_k_dim"].as_i64().unwrap() as i32,
+            head_v_dim: cfg["head_v_dim"].as_i64().unwrap() as i32,
+            conv_kernel_dim: cfg["conv_kernel_dim"].as_i64().unwrap() as i32,
+            rms_norm_eps: cfg["rms_norm_eps"].as_f64().unwrap() as f32,
+        };
+        Some((json, geom))
+    }
+
+    #[cfg(supersonic_backend_hip)]
+    #[test]
+    fn qwen36_moe_linear_step_1_qkv_raw_matches_oracle() {
+        use gpu_hal::{set_backend, Backend, GpuBuffer, ScalarType};
+
+        let Some((json, geom)) = load_linear_oracle_json() else {
+            eprintln!(
+                "skip: SUPERSONIC_QWEN36_LINEAR_ORACLE_JSON not set. \
+                 Generate a fixture with \
+                 `python oracle/qwen36_moe_linear_oracle.py --mode synthetic \
+                 --out /tmp/qwen36_lin.json` and re-run."
+            );
+            return;
+        };
+        let weights = &json["weights"];
+        let inters = &json["intermediates"];
+
+        let input_hidden_bytes = b64_decode(weights["input_hidden"].as_str().unwrap());
+        let input_norm_w_bytes = b64_decode(weights["input_norm_w"].as_str().unwrap());
+        let in_proj_qkv_w_bytes = b64_decode(weights["in_proj_qkv_w"].as_str().unwrap());
+        let in_proj_z_w_bytes = b64_decode(weights["in_proj_z_w"].as_str().unwrap());
+        let in_proj_a_w_bytes = b64_decode(weights["in_proj_a_w"].as_str().unwrap());
+        let in_proj_b_w_bytes = b64_decode(weights["in_proj_b_w"].as_str().unwrap());
+        let qkv_raw_expected_bytes = b64_decode(inters["qkv_raw"].as_str().unwrap());
+
+        let hidden_us = geom.hidden as usize;
+        let k_us = geom.num_k_heads as usize;
+        let v_us = geom.num_v_heads as usize;
+        let kd_us = geom.head_k_dim as usize;
+        let vd_us = geom.head_v_dim as usize;
+        let key_dim = k_us * kd_us;
+        let val_dim = v_us * vd_us;
+        let qkv_dim = 2 * key_dim + val_dim;
+
+        assert_eq!(input_hidden_bytes.len(), hidden_us * 2);
+        assert_eq!(input_norm_w_bytes.len(), hidden_us * 2);
+        assert_eq!(in_proj_qkv_w_bytes.len(), qkv_dim * hidden_us * 2);
+        assert_eq!(in_proj_z_w_bytes.len(), val_dim * hidden_us * 2);
+        assert_eq!(in_proj_a_w_bytes.len(), v_us * hidden_us * 2);
+        assert_eq!(in_proj_b_w_bytes.len(), v_us * hidden_us * 2);
+        assert_eq!(qkv_raw_expected_bytes.len(), qkv_dim * 2);
+
+        set_backend(Backend::Hip);
+        let ordinal = 0usize;
+
+        let input_hidden = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_us], &input_hidden_bytes,
+        ).expect("upload input_hidden");
+        let input_norm_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_us], &input_norm_w_bytes,
+        ).expect("upload input_norm_w");
+        let in_proj_qkv_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[qkv_dim, hidden_us], &in_proj_qkv_w_bytes,
+        ).expect("upload in_proj_qkv_w");
+        let in_proj_z_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[val_dim, hidden_us], &in_proj_z_w_bytes,
+        ).expect("upload in_proj_z_w");
+        let in_proj_a_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[v_us, hidden_us], &in_proj_a_w_bytes,
+        ).expect("upload in_proj_a_w");
+        let in_proj_b_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[v_us, hidden_us], &in_proj_b_w_bytes,
+        ).expect("upload in_proj_b_w");
+
+        // Output sized for the largest staged intermediate (qkv_dim BF16
+        // is the biggest until later stages bump this).
+        let mut output = GpuBuffer::zeros(
+            ordinal, ScalarType::BF16, &[qkv_dim],
+        ).expect("alloc output");
+        // Workspace sized for stage 1 (qkv_dim + V*v_dim + 2*V F32). Later
+        // stages will need more; keep this tight to fail loudly if a stage
+        // overruns.
+        let workspace_floats = qkv_dim + val_dim + 2 * v_us;
+        let mut workspace = GpuBuffer::zeros(
+            ordinal, ScalarType::F32, &[workspace_floats],
+        ).expect("alloc workspace");
+        let mut sync_buf = GpuBuffer::zeros(
+            ordinal, ScalarType::U8, &[32],
+        ).expect("alloc sync buf");
+
+        let params = Qwen36MoeLinearStepParams {
+            stage: 1,
+            hidden: geom.hidden,
+            num_k_heads: geom.num_k_heads,
+            num_v_heads: geom.num_v_heads,
+            head_k_dim: geom.head_k_dim,
+            head_v_dim: geom.head_v_dim,
+            conv_kernel_dim: geom.conv_kernel_dim,
+            rms_norm_eps: geom.rms_norm_eps,
+        };
+        let weight_ptrs = Qwen36MoeLinearStepWeights {
+            input_hidden: input_hidden.as_ptr(),
+            input_norm_w: input_norm_w.as_ptr(),
+            in_proj_qkv_w: in_proj_qkv_w.as_ptr(),
+            in_proj_z_w: in_proj_z_w.as_ptr(),
+            in_proj_a_w: in_proj_a_w.as_ptr(),
+            in_proj_b_w: in_proj_b_w.as_ptr(),
+            conv1d_w: std::ptr::null(),
+            conv1d_bias: std::ptr::null(),
+            dt_bias: std::ptr::null(),
+            a_log: std::ptr::null(),
+            norm_w: std::ptr::null(),
+            out_proj_w: std::ptr::null(),
+            conv_state: std::ptr::null_mut(),
+            recurrent_state: std::ptr::null_mut(),
+        };
+
+        linear_step_launch(
+            ordinal,
+            ScalarType::BF16,
+            params,
+            &weight_ptrs,
+            &mut output,
+            &mut workspace,
+            &mut sync_buf,
+        )
+        .expect("linear_step_launch stage 1");
+
+        // Stage 1 publishes qkv_raw as the full output buffer.
+        let got_bytes = output.to_host_bytes().expect("download output");
+        // 2048-wide F32 reduction; same envelope as PR 4b2 step 1's q_proj.
+        assert_parity(
+            "linear step1 qkv_raw",
+            &got_bytes,
+            &qkv_raw_expected_bytes,
+            0.04,
             0.9999,
         );
     }

--- a/crates/kernel-ffi/src/qwen36_moe.rs
+++ b/crates/kernel-ffi/src/qwen36_moe.rs
@@ -225,6 +225,56 @@ extern "C" {
         barrier_counter: *mut c_uint,
         barrier_flag: *mut c_uint,
     ) -> c_int;
+
+    /// PR 4b2 staged single-layer attention parity launcher. Runs the
+    /// full-attention path through `stage` (1..=5) and writes the matching
+    /// intermediate to `output`:
+    ///
+    /// | stage | output buffer contents (BF16)                      |
+    /// |-------|----------------------------------------------------|
+    /// |   1   | `q_normed[H*d]`                                    |
+    /// |   2   | `k_normed[Hkv*d]`         (`q_normed` recomputed)  |
+    /// |   3   | `q_rot[H*d] || k_rot[Hkv*d]` (planned)             |
+    /// |   4   | `attn[H*d]`                                        |
+    /// |   5   | `output_hidden[hidden]`                            |
+    ///
+    /// At PR 4b2 step 1 only `stage == 1` is wired; the kernel returns the
+    /// q-path intermediate and ignores the k_*/v_*/o_proj/RoPE/position
+    /// arguments. They're declared up front so the FFI ABI doesn't change
+    /// between staged commits.
+    ///
+    /// `workspace` must be at least `2 * num_heads * head_dim` F32 entries
+    /// (used to hold the BF16-rounded F32 view of `q_raw` between phases).
+    /// `output` must be at least `num_heads * head_dim` BF16 entries on
+    /// stage 1 — sized for the largest staged intermediate, BF16.
+    /// `sync_buf` (counters/barrier_counter/barrier_flag) must be 32 zero
+    /// bytes — see [`stub_launch`] for the layout convention.
+    pub fn qwen36_moe_hip_attn_step_launch(
+        dtype: c_int,
+        device_ordinal: usize,
+        stage: c_int,
+        hidden: c_int,
+        num_heads: c_int,
+        num_kv_heads: c_int,
+        head_dim: c_int,
+        rotary_dim: c_int,
+        rope_theta: f32,
+        rms_norm_eps: f32,
+        position: c_int,
+        input_hidden: *const c_void,
+        input_norm_w: *const c_void,
+        q_proj_w: *const c_void,
+        k_proj_w: *const c_void,
+        v_proj_w: *const c_void,
+        q_norm_w: *const c_void,
+        k_norm_w: *const c_void,
+        o_proj_w: *const c_void,
+        output: *mut c_void,
+        workspace: *mut f32,
+        counters: *mut c_uint,
+        barrier_counter: *mut c_uint,
+        barrier_flag: *mut c_uint,
+    ) -> c_int;
 }
 
 /// Safe wrapper over the stub launch. The engine pre-allocates `sync_buf`
@@ -290,6 +340,134 @@ pub fn stub_launch(
         return Err(GpuError::backend(
             backend,
             format!("qwen36_moe stub launch failed with status {status}"),
+        ));
+    }
+    Ok(())
+}
+
+/// Geometry + position state for the staged-attention parity launcher.
+/// These are constants of the layer being tested; bundling them into a
+/// struct keeps the safe wrapper below from sprouting eight scalar args.
+#[derive(Debug, Clone, Copy)]
+pub struct Qwen36MoeAttnStepParams {
+    pub stage: i32,
+    pub hidden: i32,
+    pub num_heads: i32,
+    pub num_kv_heads: i32,
+    pub head_dim: i32,
+    pub rotary_dim: i32,
+    pub rope_theta: f32,
+    pub rms_norm_eps: f32,
+    pub position: i32,
+}
+
+/// Weight pointers for the staged-attention parity launcher. Pointers
+/// unused by the requested `stage` may be null; the kernel won't dereference
+/// them. See [`qwen36_moe_hip_attn_step_launch`] for the per-stage matrix.
+#[derive(Debug, Clone, Copy)]
+pub struct Qwen36MoeAttnStepWeights {
+    pub input_hidden: *const c_void,
+    pub input_norm_w: *const c_void,
+    pub q_proj_w: *const c_void,
+    pub k_proj_w: *const c_void,
+    pub v_proj_w: *const c_void,
+    pub q_norm_w: *const c_void,
+    pub k_norm_w: *const c_void,
+    pub o_proj_w: *const c_void,
+}
+
+/// Safe wrapper for the PR 4b2 staged-attention parity launcher.
+///
+/// `output` must be a BF16 buffer with at least `num_heads * head_dim`
+/// elements (the size of the largest staged intermediate). `workspace` must
+/// be an F32 buffer with at least `2 * num_heads * head_dim` elements.
+/// `sync_buf` must be a 32-byte zero buffer (counter @ +0, barrier counter
+/// @ +16, barrier flag @ +20).
+pub fn attn_step_launch(
+    ordinal: usize,
+    dtype: ScalarType,
+    params: Qwen36MoeAttnStepParams,
+    weights: &Qwen36MoeAttnStepWeights,
+    output: &mut GpuBuffer,
+    workspace: &mut GpuBuffer,
+    sync_buf: &mut GpuBuffer,
+) -> Result<(), GpuError> {
+    if dtype != ScalarType::BF16 {
+        return Err(GpuError::InvalidArg(format!(
+            "qwen36_moe::attn_step_launch: only BF16 is wired, got {dtype:?}"
+        )));
+    }
+    if !(1..=5).contains(&params.stage) {
+        return Err(GpuError::InvalidArg(format!(
+            "qwen36_moe::attn_step_launch: stage must be in 1..=5, got {}",
+            params.stage
+        )));
+    }
+    if params.stage > 1 {
+        return Err(GpuError::InvalidArg(format!(
+            "qwen36_moe::attn_step_launch: stage {} not yet implemented (PR 4b2 step 1 only)",
+            params.stage
+        )));
+    }
+
+    let backend = output.backend();
+    let counters = sync_buf.as_mut_ptr() as *mut c_uint;
+    let barrier_counter = unsafe { (counters as *mut u8).add(16) as *mut c_uint };
+    let barrier_flag = unsafe { (counters as *mut u8).add(20) as *mut c_uint };
+
+    let status = match backend {
+        Backend::Hip => {
+            #[cfg(supersonic_backend_hip)]
+            unsafe {
+                qwen36_moe_hip_attn_step_launch(
+                    dtype.kernel_dtype_code(),
+                    ordinal,
+                    params.stage as c_int,
+                    params.hidden as c_int,
+                    params.num_heads as c_int,
+                    params.num_kv_heads as c_int,
+                    params.head_dim as c_int,
+                    params.rotary_dim as c_int,
+                    params.rope_theta,
+                    params.rms_norm_eps,
+                    params.position as c_int,
+                    weights.input_hidden,
+                    weights.input_norm_w,
+                    weights.q_proj_w,
+                    weights.k_proj_w,
+                    weights.v_proj_w,
+                    weights.q_norm_w,
+                    weights.k_norm_w,
+                    weights.o_proj_w,
+                    output.as_mut_ptr(),
+                    workspace.as_mut_ptr() as *mut f32,
+                    counters,
+                    barrier_counter,
+                    barrier_flag,
+                )
+            }
+            #[cfg(not(supersonic_backend_hip))]
+            {
+                return Err(GpuError::InvalidArg(
+                    "qwen36_moe::attn_step_launch: HIP backend not compiled".into(),
+                ));
+            }
+        }
+        Backend::Cuda => {
+            return Err(GpuError::InvalidArg(
+                "qwen36_moe::attn_step_launch: CUDA backend not yet wired".into(),
+            ));
+        }
+        Backend::Metal => {
+            return Err(GpuError::InvalidArg(
+                "qwen36_moe::attn_step_launch: Metal backend not yet wired".into(),
+            ));
+        }
+    };
+    if status != 0 {
+        return Err(GpuError::backend(
+            backend,
+            format!("qwen36_moe attn_step launch failed with status {status}"),
         ));
     }
     Ok(())
@@ -432,6 +610,236 @@ mod tests {
         assert_eq!(
             workspace_f32[4], 1.0,
             "[4] attn_output_gate consistency on full layers"
+        );
+    }
+
+    // ---- PR 4b2 step 1: q-path parity vs the PyTorch oracle --------------
+    //
+    // The test reads a JSON produced by `oracle/qwen36_moe_oracle.py`
+    // (synthetic or checkpoint mode), uploads the four input tensors needed
+    // for stage 1 (input_hidden, input_norm_w, q_proj_w, q_norm_w), runs
+    // the staged kernel, downloads the BF16 q_normed output, and compares
+    // against `intermediates.q_normed` from the oracle.
+    //
+    // To run: produce a JSON, then point the test at it via env var:
+    //
+    //   python oracle/qwen36_moe_oracle.py --mode synthetic \
+    //       --hidden 2048 --num-attention-heads 16 --num-kv-heads 2 \
+    //       --head-dim 256 --out /tmp/qwen36_syn.json
+    //   SUPERSONIC_QWEN36_ORACLE_JSON=/tmp/qwen36_syn.json \
+    //       cargo test --release -p kernel-ffi qwen36_moe_attn_step_1
+    //
+    // Without the env var the test prints a clear skip message and exits.
+    // We don't fail-on-missing because the FFI test must remain runnable
+    // on hosts without Python/PyTorch (CI without GPU, header-only checks).
+
+    /// Decode a base64 string to bytes. Inline so the test stays
+    /// dependency-free aside from serde_json. RFC 4648 alphabet, no padding
+    /// tolerance shortcuts (we know the oracle always emits valid BF16
+    /// payloads ≡ even-length byte streams ≡ 4n base64 chars after padding).
+    #[cfg(supersonic_backend_hip)]
+    fn b64_decode(input: &str) -> Vec<u8> {
+        const TABLE: &[u8; 256] = &{
+            let mut t = [255u8; 256];
+            let mut i = 0;
+            let charset = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+            while i < charset.len() {
+                t[charset[i] as usize] = i as u8;
+                i += 1;
+            }
+            t
+        };
+        let mut out = Vec::with_capacity(input.len() * 3 / 4);
+        let mut buf = 0u32;
+        let mut bits = 0;
+        for &b in input.as_bytes() {
+            if b == b'=' || b == b'\n' || b == b'\r' || b == b' ' {
+                continue;
+            }
+            let v = TABLE[b as usize];
+            assert!(v != 255, "qwen36_moe parity: invalid base64 byte {b:#x}");
+            buf = (buf << 6) | v as u32;
+            bits += 6;
+            if bits >= 8 {
+                bits -= 8;
+                out.push(((buf >> bits) & 0xFF) as u8);
+            }
+        }
+        out
+    }
+
+    /// Convert a stream of BF16 little-endian bytes to F32. The oracle
+    /// stores BF16 as raw int16 → bytes, matching the kernel's ABI.
+    #[cfg(supersonic_backend_hip)]
+    fn bf16_bytes_to_f32(bytes: &[u8]) -> Vec<f32> {
+        assert!(bytes.len() % 2 == 0, "qwen36_moe parity: BF16 bytes must be even");
+        bytes
+            .chunks_exact(2)
+            .map(|c| {
+                // BF16 = top 16 bits of an F32. Reconstruct by zero-extending.
+                let bits = u32::from(c[0]) | (u32::from(c[1]) << 8);
+                f32::from_bits(bits << 16)
+            })
+            .collect()
+    }
+
+    #[cfg(supersonic_backend_hip)]
+    #[test]
+    fn qwen36_moe_attn_step_1_q_normed_matches_oracle() {
+        use gpu_hal::{set_backend, Backend, GpuBuffer, ScalarType};
+
+        let json_path = match std::env::var("SUPERSONIC_QWEN36_ORACLE_JSON") {
+            Ok(v) => v,
+            Err(_) => {
+                eprintln!(
+                    "skip: SUPERSONIC_QWEN36_ORACLE_JSON not set. \
+                     Generate a fixture with \
+                     `python oracle/qwen36_moe_oracle.py --mode synthetic --out /tmp/syn.json` \
+                     and re-run."
+                );
+                return;
+            }
+        };
+
+        let raw = std::fs::read_to_string(&json_path)
+            .unwrap_or_else(|e| panic!("read oracle json {json_path}: {e}"));
+        let json: serde_json::Value = serde_json::from_str(&raw)
+            .expect("oracle json parse");
+        let cfg = &json["config"];
+        let weights = &json["weights"];
+        let inters = &json["intermediates"];
+        assert_eq!(json["dtype"].as_str().unwrap_or(""), "bf16",
+                   "PR 4b2 step 1 requires the oracle to be in bf16 mode");
+
+        let hidden = cfg["hidden"].as_i64().unwrap() as i32;
+        let num_heads = cfg["num_attention_heads"].as_i64().unwrap() as i32;
+        let num_kv_heads = cfg["num_kv_heads"].as_i64().unwrap() as i32;
+        let head_dim = cfg["head_dim"].as_i64().unwrap() as i32;
+        let rms_norm_eps = cfg["rms_norm_eps"].as_f64().unwrap() as f32;
+
+        // Decode the four BF16 inputs we need for stage 1.
+        let input_hidden_bytes = b64_decode(weights["input_hidden"].as_str().unwrap());
+        let input_norm_w_bytes = b64_decode(weights["input_norm_w"].as_str().unwrap());
+        let q_proj_w_bytes = b64_decode(weights["q_proj_w"].as_str().unwrap());
+        let q_norm_w_bytes = b64_decode(weights["q_norm_w"].as_str().unwrap());
+        let q_normed_expected_bytes = b64_decode(inters["q_normed"].as_str().unwrap());
+
+        // Sanity-check sizes against config-derived shapes.
+        let hidden_us = hidden as usize;
+        let h_us = num_heads as usize;
+        let d_us = head_dim as usize;
+        assert_eq!(input_hidden_bytes.len(), hidden_us * 2);
+        assert_eq!(input_norm_w_bytes.len(), hidden_us * 2);
+        assert_eq!(q_proj_w_bytes.len(), 2 * h_us * d_us * hidden_us * 2);
+        assert_eq!(q_norm_w_bytes.len(), d_us * 2);
+        assert_eq!(q_normed_expected_bytes.len(), h_us * d_us * 2);
+
+        set_backend(Backend::Hip);
+        let ordinal = 0usize;
+
+        // Upload all four inputs as BF16 buffers. The kernel reads them
+        // through `*const c_void` so the gpu-hal shape just needs to match
+        // element count.
+        let input_hidden = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_us], &input_hidden_bytes,
+        ).expect("upload input_hidden");
+        let input_norm_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_us], &input_norm_w_bytes,
+        ).expect("upload input_norm_w");
+        let q_proj_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[2 * h_us * d_us, hidden_us], &q_proj_w_bytes,
+        ).expect("upload q_proj_w");
+        let q_norm_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[d_us], &q_norm_w_bytes,
+        ).expect("upload q_norm_w");
+
+        let mut output = GpuBuffer::zeros(
+            ordinal, ScalarType::BF16, &[h_us * d_us],
+        ).expect("alloc output");
+        let mut workspace = GpuBuffer::zeros(
+            ordinal, ScalarType::F32, &[2 * h_us * d_us],
+        ).expect("alloc workspace");
+        let mut sync_buf = GpuBuffer::zeros(
+            ordinal, ScalarType::U8, &[32],
+        ).expect("alloc sync buf");
+
+        let params = Qwen36MoeAttnStepParams {
+            stage: 1,
+            hidden,
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            rotary_dim: 0,
+            rope_theta: 0.0,
+            rms_norm_eps,
+            position: 0,
+        };
+        let weight_ptrs = Qwen36MoeAttnStepWeights {
+            input_hidden: input_hidden.as_ptr(),
+            input_norm_w: input_norm_w.as_ptr(),
+            q_proj_w: q_proj_w.as_ptr(),
+            k_proj_w: std::ptr::null(),
+            v_proj_w: std::ptr::null(),
+            q_norm_w: q_norm_w.as_ptr(),
+            k_norm_w: std::ptr::null(),
+            o_proj_w: std::ptr::null(),
+        };
+
+        attn_step_launch(
+            ordinal,
+            ScalarType::BF16,
+            params,
+            &weight_ptrs,
+            &mut output,
+            &mut workspace,
+            &mut sync_buf,
+        )
+        .expect("attn_step_launch stage 1");
+
+        let got_bytes = output.to_host_bytes().expect("download output");
+        assert_eq!(got_bytes.len(), q_normed_expected_bytes.len());
+
+        let got = bf16_bytes_to_f32(&got_bytes);
+        let want = bf16_bytes_to_f32(&q_normed_expected_bytes);
+
+        // BF16 q_normed parity: kernel and oracle both round to BF16 at
+        // every store boundary, so most elements should be exact. The
+        // F32-accumulation order in the matmul can cause rare 1-ULP
+        // BF16 disagreements in the lower bits; tolerate that with a tight
+        // absolute threshold and require cosine similarity ≥ 0.9999.
+        let n = got.len();
+        let mut max_abs_diff = 0.0f32;
+        let mut sum_abs_diff = 0.0f32;
+        let mut dot = 0.0f64;
+        let mut got_sq = 0.0f64;
+        let mut want_sq = 0.0f64;
+        let mut exact = 0usize;
+        for i in 0..n {
+            let d = (got[i] - want[i]).abs();
+            if d == 0.0 { exact += 1; }
+            max_abs_diff = max_abs_diff.max(d);
+            sum_abs_diff += d;
+            dot += got[i] as f64 * want[i] as f64;
+            got_sq += (got[i] as f64).powi(2);
+            want_sq += (want[i] as f64).powi(2);
+        }
+        let cos_sim = dot / (got_sq.sqrt() * want_sq.sqrt() + 1e-30);
+        let mean_abs_diff = sum_abs_diff / n as f32;
+        eprintln!(
+            "[parity step1] n={n} exact={exact} max_abs={max_abs_diff:.5e} \
+             mean_abs={mean_abs_diff:.5e} cos_sim={cos_sim:.7}"
+        );
+
+        // Tolerances: synth-mode q_normed values land in roughly [-2, 2].
+        // BF16 ULP at magnitude 1 is ~7.8e-3; allow 4× that for matmul
+        // accumulation order drift.
+        assert!(
+            max_abs_diff <= 0.04,
+            "kernel q_normed diverges from oracle: max_abs={max_abs_diff} (>0.04)"
+        );
+        assert!(
+            cos_sim >= 0.9999,
+            "kernel q_normed cosine similarity {cos_sim:.7} below 0.9999"
         );
     }
 }

--- a/crates/model-store/src/store.rs
+++ b/crates/model-store/src/store.rs
@@ -108,3 +108,118 @@ impl BakedStore {
         Ok(buf)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// End-to-end loadability test against a real Qwen3.6-MoE bake.
+    /// Skipped when `SUPERSONIC_QWEN36_MOE_BAKE_DIR` is unset so CI / non-bake
+    /// machines stay green. Exercises mmap, manifest parse, and per-tensor
+    /// shape/layout/byte-range invariants the runtime relies on.
+    #[test]
+    fn qwen36_moe_bake_loadable() {
+        let Ok(bake_dir_str) = std::env::var("SUPERSONIC_QWEN36_MOE_BAKE_DIR") else {
+            eprintln!(
+                "skip: SUPERSONIC_QWEN36_MOE_BAKE_DIR not set. Point it at a bake \
+                 directory like .supersonic/v2-int4-gptq to validate end-to-end \
+                 loadability of a real Qwen3.6-MoE INT4 GPTQ bake."
+            );
+            return;
+        };
+        let bake_dir = Path::new(&bake_dir_str);
+        let store = BakedStore::open(bake_dir).expect("open bake");
+
+        // 1. Vocab/output sanity. lm_head is INT4-packed so its column count
+        //    is hidden/2 (2 nibbles per byte). Companion scale + zero must
+        //    both be present in the index.
+        let lm = store
+            .meta("lm_head.weight")
+            .expect("lm_head.weight missing");
+        assert_eq!(lm.layout, LayoutTag::Int4Quantized,
+                   "lm_head should be INT4 in this bake");
+        assert_eq!(lm.shape.len(), 2, "lm_head shape should be 2D");
+        assert_eq!(lm.shape[1], 2048 / 2,
+                   "lm_head INT4 column count = hidden/2 (2 nibbles per byte)");
+        assert!(store.contains("lm_head.weight_int4_scale"),
+                "lm_head.weight_int4_scale missing");
+        assert!(store.contains("lm_head.weight_int4_zero"),
+                "lm_head.weight_int4_zero missing");
+
+        // 2. Per-layer MoE expert presence. The bake must have all 40 layers
+        //    of fused expert weight, each with packed nibbles + scale + zero.
+        for li in 0..40 {
+            let lp = format!("model.language_model.layers.{li}.mlp.experts");
+            for kind in ["gate_up_proj", "down_proj"] {
+                let base = format!("{lp}.{kind}");
+                let scale = format!("{base}_int4_scale");
+                let zero = format!("{base}_int4_zero");
+                assert!(store.contains(&base),
+                        "missing fused expert tensor: {base}");
+                assert!(store.contains(&scale),
+                        "missing scale sidecar: {scale}");
+                assert!(store.contains(&zero),
+                        "missing zero sidecar: {zero}");
+                let m = store.meta(&base).unwrap();
+                assert_eq!(m.layout, LayoutTag::Int4Quantized,
+                           "{base} should be Int4Quantized");
+                assert_eq!(m.shape.len(), 3,
+                           "{base} should be 3D [E, rows, cols/2]");
+                assert_eq!(m.shape[0], 256,
+                           "{base} num_experts must be 256");
+            }
+        }
+
+        // 3. Norm + gate raw tensors per layer.
+        for li in 0..40 {
+            let lp = format!("model.language_model.layers.{li}");
+            for n in [
+                format!("{lp}.input_layernorm.weight"),
+                format!("{lp}.post_attention_layernorm.weight"),
+                format!("{lp}.mlp.gate.weight"),
+                format!("{lp}.mlp.shared_expert_gate.weight"),
+            ] {
+                let m = store.meta(&n)
+                    .unwrap_or_else(|| panic!("missing raw tensor: {n}"));
+                assert_eq!(m.layout, LayoutTag::Raw, "{n} should be Raw layout");
+                assert_eq!(m.dtype, "bf16", "{n} should be bf16");
+            }
+        }
+
+        // 4. Each tensor's [offset, offset+byte_len) must lie strictly
+        //    within weights.bin and never exceed it. Catches an
+        //    integer-overflow / off-by-one in the writer.
+        // 4a. Pull the file size via a normal stat to avoid relying on the
+        //     internal mmap accessor.
+        let weights_path = crate::weights_bin_path(bake_dir);
+        let weights_len = std::fs::metadata(&weights_path)
+            .expect("stat weights.bin").len();
+        for (name, _) in store.index.iter().take(20) {
+            let m = store.meta(name).unwrap();
+            let end = m.offset + m.byte_len;
+            assert!(end <= weights_len,
+                    "{name}: offset+len {end} > weights.bin len {weights_len}");
+            // raw_bytes() should succeed and have the right length.
+            let bytes = store.raw_bytes(name)
+                .unwrap_or_else(|| panic!("raw_bytes returned None for {name}"));
+            assert_eq!(bytes.len() as u64, m.byte_len,
+                       "{name}: raw_bytes length disagrees with manifest");
+        }
+
+        // 5. Quick bake-quality smoke: lm_head's INT4 scale must not be all
+        //    zero. A run that died mid-quant could leave us with a stub
+        //    scale tensor that would silently produce zero logits.
+        let scale_bytes = store.raw_bytes("lm_head.weight_int4_scale")
+            .expect("lm_head scale bytes");
+        let nonzero = scale_bytes.iter().filter(|&&b| b != 0).count();
+        assert!(nonzero > scale_bytes.len() / 4,
+                "lm_head scale looks suspicious: {nonzero}/{} bytes nonzero",
+                scale_bytes.len());
+
+        eprintln!(
+            "[bake-validate] OK — {} tensors, weights.bin {} MiB",
+            store.index.len(),
+            weights_len / (1024 * 1024),
+        );
+    }
+}

--- a/crates/qwen36_moe/Cargo.toml
+++ b/crates/qwen36_moe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "qwen36_moe"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+memmap2 = "0.9"
+safetensors = "0.5"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "2"

--- a/crates/qwen36_moe/src/config.rs
+++ b/crates/qwen36_moe/src/config.rs
@@ -1,0 +1,584 @@
+use serde::Deserialize;
+
+fn default_head_dim() -> usize {
+    256
+}
+fn default_full_attention_interval() -> usize {
+    4
+}
+fn default_linear_conv_kernel_dim() -> usize {
+    4
+}
+fn default_linear_key_head_dim() -> usize {
+    128
+}
+fn default_linear_value_head_dim() -> usize {
+    128
+}
+fn default_linear_num_key_heads() -> usize {
+    16
+}
+fn default_linear_num_value_heads() -> usize {
+    32
+}
+fn default_partial_rotary_factor() -> f64 {
+    0.25
+}
+fn default_rope_theta() -> f64 {
+    10_000_000.0
+}
+fn default_rope_type() -> String {
+    "default".to_string()
+}
+fn default_norm_topk_prob() -> bool {
+    true
+}
+fn default_router_aux_loss_coef() -> f64 {
+    0.001
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct RopeParameters {
+    #[serde(default = "default_rope_type")]
+    pub rope_type: String,
+    #[serde(default = "default_rope_theta")]
+    pub rope_theta: f64,
+    #[serde(default = "default_partial_rotary_factor")]
+    pub partial_rotary_factor: f64,
+    #[serde(default)]
+    pub mrope_interleaved: bool,
+    #[serde(default)]
+    pub mrope_section: Vec<usize>,
+}
+
+impl Default for RopeParameters {
+    fn default() -> Self {
+        Self {
+            rope_type: default_rope_type(),
+            rope_theta: default_rope_theta(),
+            partial_rotary_factor: default_partial_rotary_factor(),
+            mrope_interleaved: false,
+            mrope_section: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum Activation {
+    #[default]
+    Silu,
+    Gelu,
+    Swiglu,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct TextConfig {
+    pub vocab_size: usize,
+    pub hidden_size: usize,
+    pub num_hidden_layers: usize,
+    pub num_attention_heads: usize,
+    pub num_key_value_heads: usize,
+    pub max_position_embeddings: usize,
+    pub rms_norm_eps: f64,
+
+    #[serde(default)]
+    pub hidden_act: Activation,
+    #[serde(default)]
+    pub tie_word_embeddings: bool,
+    #[serde(default)]
+    pub eos_token_id: Option<serde_json::Value>,
+    #[serde(default)]
+    pub bos_token_id: Option<serde_json::Value>,
+
+    #[serde(default = "default_head_dim")]
+    pub head_dim: usize,
+    #[serde(default = "default_full_attention_interval")]
+    pub full_attention_interval: usize,
+    #[serde(default)]
+    pub attn_output_gate: bool,
+
+    #[serde(default = "default_linear_conv_kernel_dim")]
+    pub linear_conv_kernel_dim: usize,
+    #[serde(default = "default_linear_key_head_dim")]
+    pub linear_key_head_dim: usize,
+    #[serde(default = "default_linear_value_head_dim")]
+    pub linear_value_head_dim: usize,
+    #[serde(default = "default_linear_num_key_heads")]
+    pub linear_num_key_heads: usize,
+    #[serde(default = "default_linear_num_value_heads")]
+    pub linear_num_value_heads: usize,
+
+    #[serde(default)]
+    pub layer_types: Vec<String>,
+    #[serde(default)]
+    pub rope_parameters: Option<RopeParameters>,
+
+    pub num_experts: usize,
+    pub num_experts_per_tok: usize,
+    pub moe_intermediate_size: usize,
+    pub shared_expert_intermediate_size: usize,
+
+    #[serde(default = "default_norm_topk_prob")]
+    pub norm_topk_prob: bool,
+    #[serde(default = "default_router_aux_loss_coef")]
+    pub router_aux_loss_coef: f64,
+    #[serde(default)]
+    pub mlp_only_layers: Vec<usize>,
+    #[serde(default)]
+    pub decoder_sparse_step: Option<usize>,
+}
+
+impl TextConfig {
+    pub fn normalized(mut self) -> Self {
+        if self.layer_types.is_empty() {
+            let interval = self.full_attention_interval.max(1);
+            self.layer_types = (0..self.num_hidden_layers)
+                .map(|idx| {
+                    if (idx + 1) % interval == 0 {
+                        "full_attention".to_string()
+                    } else {
+                        "linear_attention".to_string()
+                    }
+                })
+                .collect();
+        }
+        self
+    }
+
+    pub fn rope_theta(&self) -> f64 {
+        self.rope_parameters
+            .as_ref()
+            .map(|p| p.rope_theta)
+            .unwrap_or_else(default_rope_theta)
+    }
+
+    pub fn partial_rotary_factor(&self) -> f64 {
+        self.rope_parameters
+            .as_ref()
+            .map(|p| p.partial_rotary_factor)
+            .unwrap_or_else(default_partial_rotary_factor)
+    }
+
+    pub fn rotary_dim(&self) -> usize {
+        (self.head_dim as f64 * self.partial_rotary_factor()) as usize
+    }
+
+    pub fn top_k(&self) -> usize {
+        self.num_experts_per_tok
+    }
+
+    pub fn is_full_attention(&self, layer_idx: usize) -> bool {
+        self.layer_types
+            .get(layer_idx)
+            .map(|t| t == "full_attention")
+            .unwrap_or(false)
+    }
+
+    pub fn is_dense_mlp_layer(&self, layer_idx: usize) -> bool {
+        self.mlp_only_layers.contains(&layer_idx)
+    }
+
+    pub fn linear_value_dim(&self) -> usize {
+        self.linear_num_value_heads * self.linear_value_head_dim
+    }
+
+    pub fn num_full_attention_layers(&self) -> usize {
+        (0..self.num_hidden_layers)
+            .filter(|&i| self.is_full_attention(i))
+            .count()
+    }
+
+    pub fn num_linear_attention_layers(&self) -> usize {
+        self.num_hidden_layers - self.num_full_attention_layers()
+    }
+
+    pub fn kv_bytes_per_token(&self, dtype_bytes: usize) -> u64 {
+        let per_layer = 2 * self.num_key_value_heads * self.head_dim * dtype_bytes;
+        (self.num_full_attention_layers() * per_layer) as u64
+    }
+
+    pub fn eos_token_ids(&self) -> Vec<u32> {
+        extract_token_ids(&self.eos_token_id)
+    }
+
+    pub fn bos_token_ids(&self) -> Vec<u32> {
+        extract_token_ids(&self.bos_token_id)
+    }
+}
+
+fn extract_token_ids(value: &Option<serde_json::Value>) -> Vec<u32> {
+    match value {
+        Some(serde_json::Value::Number(n)) => {
+            n.as_u64().map(|v| vec![v as u32]).unwrap_or_default()
+        }
+        Some(serde_json::Value::Array(arr)) => arr
+            .iter()
+            .filter_map(|v| v.as_u64().map(|n| n as u32))
+            .collect(),
+        _ => vec![],
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct Config {
+    pub text_config: TextConfig,
+    #[serde(default)]
+    pub architectures: Vec<String>,
+    #[serde(default)]
+    pub model_type: Option<String>,
+}
+
+impl Config {
+    pub fn normalized(mut self) -> Self {
+        self.text_config = self.text_config.normalized();
+        self
+    }
+}
+
+pub fn load_config(model_dir: &std::path::Path) -> Result<Config, String> {
+    let config_path = model_dir.join("config.json");
+    let text =
+        std::fs::read_to_string(&config_path).map_err(|e| format!("read config.json: {e}"))?;
+    let config: Config =
+        serde_json::from_str(&text).map_err(|e| format!("parse config.json: {e}"))?;
+    let normalized = config.normalized();
+    validate(&normalized)?;
+    Ok(normalized)
+}
+
+fn validate(config: &Config) -> Result<(), String> {
+    let t = &config.text_config;
+
+    if t.num_hidden_layers == 0 {
+        return Err("num_hidden_layers must be > 0".to_string());
+    }
+    if t.layer_types.len() != t.num_hidden_layers {
+        return Err(format!(
+            "layer_types length {} != num_hidden_layers {}",
+            t.layer_types.len(),
+            t.num_hidden_layers
+        ));
+    }
+    for (i, kind) in t.layer_types.iter().enumerate() {
+        if kind != "full_attention" && kind != "linear_attention" {
+            return Err(format!(
+                "layer_types[{i}] = {kind:?}, expected full_attention or linear_attention"
+            ));
+        }
+    }
+
+    let interval = t.full_attention_interval.max(1);
+    let expected_full: usize = (0..t.num_hidden_layers)
+        .filter(|&i| (i + 1) % interval == 0)
+        .count();
+    if t.num_full_attention_layers() != expected_full {
+        return Err(format!(
+            "hybrid pattern broken: got {} full-attention layers, expected {} (interval {}, layers {})",
+            t.num_full_attention_layers(),
+            expected_full,
+            interval,
+            t.num_hidden_layers,
+        ));
+    }
+
+    if t.num_attention_heads == 0 || t.num_key_value_heads == 0 {
+        return Err("attention head counts must be > 0".to_string());
+    }
+    if !t.num_attention_heads.is_multiple_of(t.num_key_value_heads) {
+        return Err(format!(
+            "num_attention_heads {} not divisible by num_key_value_heads {}",
+            t.num_attention_heads, t.num_key_value_heads
+        ));
+    }
+    let rot_dim = t.rotary_dim();
+    if rot_dim == 0 || !rot_dim.is_multiple_of(2) {
+        return Err(format!("rotary_dim {rot_dim} must be even and > 0"));
+    }
+    if t.rotary_dim() > t.head_dim {
+        return Err(format!(
+            "rotary_dim {} exceeds head_dim {}",
+            t.rotary_dim(),
+            t.head_dim
+        ));
+    }
+
+    if t.num_experts == 0 {
+        return Err("num_experts must be > 0 for MoE family".to_string());
+    }
+    if t.num_experts_per_tok == 0 || t.num_experts_per_tok > t.num_experts {
+        return Err(format!(
+            "num_experts_per_tok {} must be in 1..={}",
+            t.num_experts_per_tok, t.num_experts
+        ));
+    }
+    if t.moe_intermediate_size == 0 {
+        return Err("moe_intermediate_size must be > 0".to_string());
+    }
+    if t.shared_expert_intermediate_size == 0 {
+        return Err("shared_expert_intermediate_size must be > 0".to_string());
+    }
+    for &idx in &t.mlp_only_layers {
+        if idx >= t.num_hidden_layers {
+            return Err(format!(
+                "mlp_only_layers entry {idx} >= num_hidden_layers {}",
+                t.num_hidden_layers
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn real_qwen36_35b_a3b_config_json() -> String {
+        let mut layers = Vec::with_capacity(40);
+        for idx in 0..40 {
+            if (idx + 1) % 4 == 0 {
+                layers.push("\"full_attention\"");
+            } else {
+                layers.push("\"linear_attention\"");
+            }
+        }
+        let layer_types = layers.join(",");
+        format!(
+            r#"{{
+                "architectures": ["Qwen3_5MoeForConditionalGeneration"],
+                "model_type": "qwen3_5_moe",
+                "tie_word_embeddings": false,
+                "text_config": {{
+                    "attention_bias": false,
+                    "attention_dropout": 0.0,
+                    "attn_output_gate": true,
+                    "bos_token_id": 248044,
+                    "dtype": "bfloat16",
+                    "eos_token_id": 248044,
+                    "full_attention_interval": 4,
+                    "head_dim": 256,
+                    "hidden_act": "silu",
+                    "hidden_size": 2048,
+                    "initializer_range": 0.02,
+                    "layer_types": [{layer_types}],
+                    "linear_conv_kernel_dim": 4,
+                    "linear_key_head_dim": 128,
+                    "linear_num_key_heads": 16,
+                    "linear_num_value_heads": 32,
+                    "linear_value_head_dim": 128,
+                    "max_position_embeddings": 262144,
+                    "model_type": "qwen3_5_moe_text",
+                    "moe_intermediate_size": 512,
+                    "num_attention_heads": 16,
+                    "num_experts": 256,
+                    "num_experts_per_tok": 8,
+                    "num_hidden_layers": 40,
+                    "num_key_value_heads": 2,
+                    "output_router_logits": false,
+                    "partial_rotary_factor": 0.25,
+                    "rms_norm_eps": 1e-06,
+                    "rope_parameters": {{
+                        "mrope_interleaved": true,
+                        "mrope_section": [11, 11, 10],
+                        "partial_rotary_factor": 0.25,
+                        "rope_theta": 10000000,
+                        "rope_type": "default"
+                    }},
+                    "router_aux_loss_coef": 0.001,
+                    "shared_expert_intermediate_size": 512,
+                    "tie_word_embeddings": false,
+                    "use_cache": true,
+                    "vocab_size": 248320
+                }}
+            }}"#
+        )
+    }
+
+    #[test]
+    fn parses_real_qwen36_35b_a3b_config() {
+        let json = real_qwen36_35b_a3b_config_json();
+        let config: Config = serde_json::from_str(&json).expect("parse");
+        let config = config.normalized();
+        validate(&config).expect("validate");
+        let t = &config.text_config;
+
+        assert_eq!(config.architectures, vec!["Qwen3_5MoeForConditionalGeneration"]);
+        assert_eq!(config.model_type.as_deref(), Some("qwen3_5_moe"));
+
+        assert_eq!(t.vocab_size, 248320);
+        assert_eq!(t.hidden_size, 2048);
+        assert_eq!(t.num_hidden_layers, 40);
+        assert_eq!(t.num_attention_heads, 16);
+        assert_eq!(t.num_key_value_heads, 2);
+        assert_eq!(t.head_dim, 256);
+        assert_eq!(t.max_position_embeddings, 262144);
+        assert_eq!(t.full_attention_interval, 4);
+        assert!(t.attn_output_gate);
+
+        assert_eq!(t.linear_num_key_heads, 16);
+        assert_eq!(t.linear_num_value_heads, 32);
+        assert_eq!(t.linear_key_head_dim, 128);
+        assert_eq!(t.linear_value_head_dim, 128);
+        assert_eq!(t.linear_conv_kernel_dim, 4);
+        assert_eq!(t.linear_value_dim(), 32 * 128);
+
+        assert_eq!(t.rotary_dim(), 64);
+        assert_eq!(t.rope_theta(), 10_000_000.0);
+        let rp = t.rope_parameters.as_ref().expect("rope_parameters");
+        assert!(rp.mrope_interleaved);
+        assert_eq!(rp.mrope_section, vec![11, 11, 10]);
+
+        assert_eq!(t.num_experts, 256);
+        assert_eq!(t.num_experts_per_tok, 8);
+        assert_eq!(t.top_k(), 8);
+        assert_eq!(t.moe_intermediate_size, 512);
+        assert_eq!(t.shared_expert_intermediate_size, 512);
+        assert!(t.norm_topk_prob);
+        assert!((t.router_aux_loss_coef - 0.001).abs() < 1e-9);
+        assert!(t.mlp_only_layers.is_empty());
+        assert!(t.decoder_sparse_step.is_none());
+
+        assert_eq!(t.num_full_attention_layers(), 10);
+        assert_eq!(t.num_linear_attention_layers(), 30);
+        assert!(t.is_full_attention(3));
+        assert!(!t.is_full_attention(0));
+
+        assert_eq!(t.eos_token_ids(), vec![248044]);
+        assert_eq!(t.bos_token_ids(), vec![248044]);
+
+        assert_eq!(t.kv_bytes_per_token(2), (2 * 2 * 256 * 2 * 10) as u64);
+    }
+
+    #[test]
+    fn synthesizes_layer_types_when_missing() {
+        let json = r#"{
+            "text_config": {
+                "vocab_size": 1024,
+                "hidden_size": 256,
+                "num_hidden_layers": 8,
+                "num_attention_heads": 4,
+                "num_key_value_heads": 2,
+                "max_position_embeddings": 4096,
+                "rms_norm_eps": 1e-06,
+                "num_experts": 4,
+                "num_experts_per_tok": 2,
+                "moe_intermediate_size": 64,
+                "shared_expert_intermediate_size": 64
+            }
+        }"#;
+        let config: Config = serde_json::from_str(json).unwrap();
+        let config = config.normalized();
+        validate(&config).unwrap();
+        let t = &config.text_config;
+        assert_eq!(t.layer_types.len(), 8);
+        assert_eq!(t.num_full_attention_layers(), 2);
+        assert!(t.is_full_attention(3));
+        assert!(t.is_full_attention(7));
+    }
+
+    #[test]
+    fn rejects_layer_type_count_mismatch() {
+        let json = r#"{
+            "text_config": {
+                "vocab_size": 1024,
+                "hidden_size": 256,
+                "num_hidden_layers": 4,
+                "num_attention_heads": 4,
+                "num_key_value_heads": 2,
+                "max_position_embeddings": 4096,
+                "rms_norm_eps": 1e-06,
+                "layer_types": ["full_attention", "linear_attention"],
+                "num_experts": 4,
+                "num_experts_per_tok": 2,
+                "moe_intermediate_size": 64,
+                "shared_expert_intermediate_size": 64
+            }
+        }"#;
+        let config: Config = serde_json::from_str(json).unwrap();
+        let err = validate(&config.normalized()).unwrap_err();
+        assert!(err.contains("layer_types length"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_unknown_layer_type() {
+        let json = r#"{
+            "text_config": {
+                "vocab_size": 1024,
+                "hidden_size": 256,
+                "num_hidden_layers": 2,
+                "num_attention_heads": 4,
+                "num_key_value_heads": 2,
+                "max_position_embeddings": 4096,
+                "rms_norm_eps": 1e-06,
+                "layer_types": ["full_attention", "sliding_attention"],
+                "num_experts": 4,
+                "num_experts_per_tok": 2,
+                "moe_intermediate_size": 64,
+                "shared_expert_intermediate_size": 64
+            }
+        }"#;
+        let config: Config = serde_json::from_str(json).unwrap();
+        let err = validate(&config.normalized()).unwrap_err();
+        assert!(err.contains("sliding_attention"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_top_k_above_num_experts() {
+        let json = r#"{
+            "text_config": {
+                "vocab_size": 1024,
+                "hidden_size": 256,
+                "num_hidden_layers": 4,
+                "num_attention_heads": 4,
+                "num_key_value_heads": 2,
+                "max_position_embeddings": 4096,
+                "rms_norm_eps": 1e-06,
+                "num_experts": 4,
+                "num_experts_per_tok": 8,
+                "moe_intermediate_size": 64,
+                "shared_expert_intermediate_size": 64
+            }
+        }"#;
+        let config: Config = serde_json::from_str(json).unwrap();
+        let err = validate(&config.normalized()).unwrap_err();
+        assert!(err.contains("num_experts_per_tok"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_hybrid_pattern_break() {
+        let mut layers = (0..8)
+            .map(|idx| {
+                if (idx + 1) % 4 == 0 {
+                    "\"full_attention\""
+                } else {
+                    "\"linear_attention\""
+                }
+            })
+            .collect::<Vec<_>>();
+        layers[0] = "\"full_attention\"";
+        let layer_types = layers.join(",");
+        let json = format!(
+            r#"{{
+                "text_config": {{
+                    "vocab_size": 1024,
+                    "hidden_size": 256,
+                    "num_hidden_layers": 8,
+                    "num_attention_heads": 4,
+                    "num_key_value_heads": 2,
+                    "max_position_embeddings": 4096,
+                    "rms_norm_eps": 1e-06,
+                    "full_attention_interval": 4,
+                    "layer_types": [{layer_types}],
+                    "num_experts": 4,
+                    "num_experts_per_tok": 2,
+                    "moe_intermediate_size": 64,
+                    "shared_expert_intermediate_size": 64
+                }}
+            }}"#
+        );
+        let config: Config = serde_json::from_str(&json).unwrap();
+        let err = validate(&config.normalized()).unwrap_err();
+        assert!(err.contains("hybrid pattern broken"), "got: {err}");
+    }
+}

--- a/crates/qwen36_moe/src/lib.rs
+++ b/crates/qwen36_moe/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod config;
+pub mod loader;
+pub mod state;
+pub mod weights;

--- a/crates/qwen36_moe/src/loader.rs
+++ b/crates/qwen36_moe/src/loader.rs
@@ -1,0 +1,218 @@
+use std::collections::BTreeMap;
+use std::fs::File;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use memmap2::Mmap;
+use safetensors::{Dtype, SafeTensors};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum LoadError {
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("safetensors error: {0}")]
+    Safetensors(#[from] safetensors::SafeTensorError),
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("tensor not found: {0}")]
+    NotFound(String),
+    #[error("unsupported dtype: {0}")]
+    UnsupportedDtype(String),
+    #[error("malformed model dir: {0}")]
+    Malformed(String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScalarKind {
+    Bf16,
+    F16,
+    F32,
+    F64,
+    I64,
+    I32,
+    U8,
+    Bool,
+}
+
+impl ScalarKind {
+    pub fn size_bytes(self) -> usize {
+        match self {
+            Self::Bf16 | Self::F16 => 2,
+            Self::F32 | Self::I32 => 4,
+            Self::F64 | Self::I64 => 8,
+            Self::U8 | Self::Bool => 1,
+        }
+    }
+
+    pub fn from_safetensors(d: Dtype) -> Result<Self, LoadError> {
+        Ok(match d {
+            Dtype::BF16 => Self::Bf16,
+            Dtype::F16 => Self::F16,
+            Dtype::F32 => Self::F32,
+            Dtype::F64 => Self::F64,
+            Dtype::I64 => Self::I64,
+            Dtype::I32 => Self::I32,
+            Dtype::U8 => Self::U8,
+            Dtype::BOOL => Self::Bool,
+            other => return Err(LoadError::UnsupportedDtype(format!("{other:?}"))),
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TensorMeta {
+    pub shape: Vec<usize>,
+    pub dtype: ScalarKind,
+}
+
+impl TensorMeta {
+    pub fn elem_count(&self) -> u64 {
+        self.shape.iter().product::<usize>() as u64
+    }
+
+    pub fn byte_size(&self) -> u64 {
+        self.elem_count() * self.dtype.size_bytes() as u64
+    }
+}
+
+/// Read-only safetensors weight loader. Enumerates the BF16 HF download (or any
+/// safetensors-compatible model dir). Built for the dry-run and shape-validation
+/// path; the GPU-allocating path lands in PR 4 alongside the kernel work.
+pub struct WeightLoader {
+    shards: Vec<Arc<Mmap>>,
+    /// tensor name -> shard index
+    index: BTreeMap<String, usize>,
+}
+
+impl WeightLoader {
+    pub fn from_dir(dir: &Path) -> Result<Self, LoadError> {
+        let index_path = dir.join("model.safetensors.index.json");
+        if index_path.exists() {
+            Self::from_sharded(dir, &index_path)
+        } else {
+            let single = dir.join("model.safetensors");
+            if single.exists() {
+                Self::from_single(&single)
+            } else {
+                Err(LoadError::Malformed(format!(
+                    "no safetensors files found in {}",
+                    dir.display()
+                )))
+            }
+        }
+    }
+
+    fn from_single(path: &Path) -> Result<Self, LoadError> {
+        let file = File::open(path)?;
+        let mmap = Arc::new(unsafe { Mmap::map(&file)? });
+        let tensors = SafeTensors::deserialize(&mmap[..])?;
+        let mut index = BTreeMap::new();
+        for name in tensors.names() {
+            index.insert(name.to_string(), 0);
+        }
+        Ok(Self {
+            shards: vec![mmap],
+            index,
+        })
+    }
+
+    fn from_sharded(dir: &Path, index_path: &Path) -> Result<Self, LoadError> {
+        let raw: serde_json::Value = serde_json::from_str(&std::fs::read_to_string(index_path)?)?;
+        let weight_map = raw["weight_map"].as_object().ok_or_else(|| {
+            LoadError::Malformed("missing weight_map in safetensors index".into())
+        })?;
+        let mut shard_files: Vec<PathBuf> = Vec::new();
+        let mut shard_idx_map: BTreeMap<String, usize> = BTreeMap::new();
+        for filename in weight_map.values() {
+            let filename = filename.as_str().unwrap_or("").to_string();
+            if !shard_idx_map.contains_key(&filename) {
+                shard_idx_map.insert(filename.clone(), shard_files.len());
+                shard_files.push(dir.join(&filename));
+            }
+        }
+        let mut shards = Vec::with_capacity(shard_files.len());
+        for path in &shard_files {
+            let file = File::open(path)?;
+            shards.push(Arc::new(unsafe { Mmap::map(&file)? }));
+        }
+        let mut index = BTreeMap::new();
+        for (tensor_name, filename) in weight_map {
+            let filename = filename.as_str().unwrap_or("");
+            if let Some(&shard_idx) = shard_idx_map.get(filename) {
+                index.insert(tensor_name.clone(), shard_idx);
+            }
+        }
+        Ok(Self { shards, index })
+    }
+
+    pub fn contains(&self, name: &str) -> bool {
+        self.index.contains_key(name)
+    }
+
+    /// Total number of tensors across all shards.
+    pub fn tensor_count(&self) -> usize {
+        self.index.len()
+    }
+
+    /// All tensor names known to this loader, sorted lexicographically.
+    pub fn names(&self) -> impl Iterator<Item = &str> {
+        self.index.keys().map(String::as_str)
+    }
+
+    pub fn meta(&self, name: &str) -> Result<TensorMeta, LoadError> {
+        let &shard_idx = self
+            .index
+            .get(name)
+            .ok_or_else(|| LoadError::NotFound(name.to_string()))?;
+        let tensors = SafeTensors::deserialize(&self.shards[shard_idx][..])?;
+        let view = tensors.tensor(name)?;
+        Ok(TensorMeta {
+            shape: view.shape().to_vec(),
+            dtype: ScalarKind::from_safetensors(view.dtype())?,
+        })
+    }
+
+    /// Sum of byte sizes for the listed tensors. Reports any missing names so the
+    /// caller can flag schema drift before allocating.
+    pub fn accumulate_bytes<I, S>(&self, names: I) -> Result<u64, LoadError>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let mut total: u64 = 0;
+        for name in names {
+            let m = self.meta(name.as_ref())?;
+            total = total.saturating_add(m.byte_size());
+        }
+        Ok(total)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_dir_reports_malformed() {
+        let dir = std::env::temp_dir().join("supersonic-qwen36-moe-no-such-dir");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let err = WeightLoader::from_dir(&dir)
+            .err()
+            .expect("expected error from empty dir");
+        assert!(
+            matches!(err, LoadError::Malformed(_)),
+            "expected Malformed, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn scalar_kind_size_table() {
+        assert_eq!(ScalarKind::Bf16.size_bytes(), 2);
+        assert_eq!(ScalarKind::F16.size_bytes(), 2);
+        assert_eq!(ScalarKind::F32.size_bytes(), 4);
+        assert_eq!(ScalarKind::I64.size_bytes(), 8);
+        assert_eq!(ScalarKind::U8.size_bytes(), 1);
+    }
+}

--- a/crates/qwen36_moe/src/state.rs
+++ b/crates/qwen36_moe/src/state.rs
@@ -1,0 +1,161 @@
+use crate::config::TextConfig;
+
+/// VRAM accounting for the runtime-mutable state buffers (KV caches, linear
+/// attention conv/recurrent state, MoE scratch). PR 3 only computes sizes;
+/// the actual GPU allocation lands when the kernel is wired up.
+pub struct StateAccount {
+    pub full_kv_bytes: u64,
+    pub linear_conv_state_bytes: u64,
+    pub linear_recurrent_state_bytes: u64,
+    pub moe_scratch_bytes: u64,
+    pub activation_bytes: u64,
+    pub total_bytes: u64,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct StateLayout {
+    pub kv_dtype_bytes: u64,
+    pub context_tokens: u64,
+    pub batch_size: u64,
+}
+
+impl StateLayout {
+    pub fn new(context_tokens: usize, batch_size: usize, kv_fp8: bool) -> Self {
+        Self {
+            kv_dtype_bytes: if kv_fp8 { 1 } else { 2 },
+            context_tokens: context_tokens as u64,
+            batch_size: batch_size as u64,
+        }
+    }
+}
+
+impl StateAccount {
+    pub fn from_config(config: &TextConfig, layout: StateLayout) -> Self {
+        let hidden = config.hidden_size as u64;
+        let head_dim = config.head_dim as u64;
+        let kv_heads = config.num_key_value_heads as u64;
+        let n_full = config.num_full_attention_layers() as u64;
+        let n_linear = config.num_linear_attention_layers() as u64;
+
+        let kv_bytes_per_layer_per_token = 2 * kv_heads * head_dim * layout.kv_dtype_bytes;
+        let full_kv_bytes =
+            n_full * kv_bytes_per_layer_per_token * layout.context_tokens * layout.batch_size;
+
+        let lin_qkv_dim = (config.linear_num_key_heads * config.linear_key_head_dim
+            + config.linear_num_key_heads * config.linear_key_head_dim
+            + config.linear_num_value_heads * config.linear_value_head_dim) as u64;
+        let conv_state_bytes_per_layer =
+            2 * lin_qkv_dim * (config.linear_conv_kernel_dim as u64).saturating_sub(1);
+        let recurrent_state_bytes_per_layer = 4
+            * config.linear_num_value_heads as u64
+            * config.linear_value_head_dim as u64
+            * config.linear_key_head_dim as u64;
+        let linear_conv_state_bytes = n_linear * conv_state_bytes_per_layer * layout.batch_size;
+        let linear_recurrent_state_bytes =
+            n_linear * recurrent_state_bytes_per_layer * layout.batch_size;
+
+        let top_k = config.num_experts_per_tok as u64;
+        let num_experts = config.num_experts as u64;
+        let router_logits = 4 * num_experts * layout.batch_size;
+        let topk_indices = 4 * top_k * layout.batch_size;
+        let topk_weights = 4 * top_k * layout.batch_size;
+        let work_units = 16 * (top_k + 1) * layout.batch_size;
+        let expert_acc = 2 * hidden * layout.batch_size;
+        let moe_scratch_bytes =
+            router_logits + topk_indices + topk_weights + work_units + expert_acc;
+
+        let activation_bytes = 2 * hidden * layout.batch_size * 8;
+
+        let total_bytes = full_kv_bytes
+            + linear_conv_state_bytes
+            + linear_recurrent_state_bytes
+            + moe_scratch_bytes
+            + activation_bytes;
+        Self {
+            full_kv_bytes,
+            linear_conv_state_bytes,
+            linear_recurrent_state_bytes,
+            moe_scratch_bytes,
+            activation_bytes,
+            total_bytes,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config_35b_a3b() -> TextConfig {
+        let layer_types: Vec<String> = (0..40)
+            .map(|i| {
+                if (i + 1) % 4 == 0 {
+                    "full_attention".to_string()
+                } else {
+                    "linear_attention".to_string()
+                }
+            })
+            .collect();
+        TextConfig {
+            vocab_size: 248_320,
+            hidden_size: 2048,
+            num_hidden_layers: 40,
+            num_attention_heads: 16,
+            num_key_value_heads: 2,
+            max_position_embeddings: 262_144,
+            rms_norm_eps: 1e-6,
+            hidden_act: crate::config::Activation::Silu,
+            tie_word_embeddings: false,
+            eos_token_id: None,
+            bos_token_id: None,
+            head_dim: 256,
+            full_attention_interval: 4,
+            attn_output_gate: true,
+            linear_conv_kernel_dim: 4,
+            linear_key_head_dim: 128,
+            linear_value_head_dim: 128,
+            linear_num_key_heads: 16,
+            linear_num_value_heads: 32,
+            layer_types,
+            rope_parameters: None,
+            num_experts: 256,
+            num_experts_per_tok: 8,
+            moe_intermediate_size: 512,
+            shared_expert_intermediate_size: 512,
+            norm_topk_prob: true,
+            router_aux_loss_coef: 0.001,
+            mlp_only_layers: Vec::new(),
+            decoder_sparse_step: None,
+        }
+    }
+
+    #[test]
+    fn kv_cache_sizing_at_4k_context_under_5gib() {
+        let cfg = config_35b_a3b();
+        let layout = StateLayout::new(4096, 1, false);
+        let acct = StateAccount::from_config(&cfg, layout);
+        // 10 full layers × 2 KV heads × 256 head_dim × 4096 ctx × 2 BF16 × 2 (K+V)
+        let expected_kv = 10u64 * 2 * 256 * 4096 * 2 * 2;
+        assert_eq!(acct.full_kv_bytes, expected_kv);
+        let gib = 1024.0_f64.powi(3);
+        assert!(acct.full_kv_bytes as f64 / gib < 1.0);
+    }
+
+    #[test]
+    fn moe_scratch_is_well_under_a_megabyte() {
+        let cfg = config_35b_a3b();
+        let layout = StateLayout::new(4096, 1, false);
+        let acct = StateAccount::from_config(&cfg, layout);
+        // scratch is per-step, batch=1: ~router(1024) + topk(80) + work(144) +
+        // expert acc (4096) ≈ tiny.
+        assert!(acct.moe_scratch_bytes < 1 << 20);
+    }
+
+    #[test]
+    fn fp8_kv_halves_full_kv_bytes() {
+        let cfg = config_35b_a3b();
+        let bf16 = StateAccount::from_config(&cfg, StateLayout::new(4096, 1, false)).full_kv_bytes;
+        let fp8 = StateAccount::from_config(&cfg, StateLayout::new(4096, 1, true)).full_kv_bytes;
+        assert_eq!(bf16, 2 * fp8);
+    }
+}

--- a/crates/qwen36_moe/src/weights.rs
+++ b/crates/qwen36_moe/src/weights.rs
@@ -1,0 +1,666 @@
+use crate::config::TextConfig;
+
+pub const DEFAULT_PREFIX: &str = "model.language_model";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum LayerKind {
+    Linear,
+    Full,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TensorRole {
+    Embed,
+    Norm,
+    LmHead,
+    LayerInputNorm,
+    LayerPostAttnNorm,
+    /// `self_attn.q_proj.weight`. Real shape `[2 * num_heads * head_dim, hidden]`
+    /// when `attn_output_gate=true` (Qwen3-Next fuses Q with the output-gate
+    /// projection); otherwise `[num_heads * head_dim, hidden]`.
+    FullQProj,
+    FullKProj,
+    FullVProj,
+    FullOProj,
+    FullQNorm,
+    FullKNorm,
+    LinearInQkvProj,
+    LinearInZProj,
+    LinearInBProj,
+    LinearInAProj,
+    LinearOutProj,
+    LinearConv1d,
+    LinearDtBias,
+    LinearALog,
+    LinearNorm,
+    Router,
+    SharedExpertGate,
+    SharedExpertGateProj,
+    SharedExpertUpProj,
+    SharedExpertDownProj,
+    /// Fused `mlp.experts.gate_up_proj` (no `.weight` suffix) — single tensor
+    /// of shape `[num_experts, 2 * moe_intermediate_size, hidden]` carrying
+    /// gate and up projections for all experts in one slab.
+    ExpertGateUpProj,
+    /// `mlp.experts.down_proj` (no `.weight` suffix) — single tensor of shape
+    /// `[num_experts, hidden, moe_intermediate_size]`.
+    ExpertDownProj,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CheckpointDtype {
+    Bf16,
+    F32,
+}
+
+impl CheckpointDtype {
+    pub const fn size(self) -> u64 {
+        match self {
+            Self::Bf16 => 2,
+            Self::F32 => 4,
+        }
+    }
+}
+
+/// On-disk dtype for a tensor role in the published safetensors checkpoint.
+///
+/// Empirically: Qwen3.5-0.8B publishes `linear_attn.A_log` and
+/// `linear_attn.norm.weight` as F32. Qwen3.6-35B-A3B publishes the same
+/// tensors as BF16. Both load fine — runtime upcasts BF16 norms to F32 on
+/// demand (`crates/qwen35/src/weights.rs::ensure_f32_on_gpu`).
+///
+/// This function returns the **default-expected** dtype for accounting
+/// purposes — analytic byte totals use it, but a real checkpoint can store
+/// either F32 or BF16 for these two tensors and both are accepted by
+/// `dtype_compatible`. We default to BF16 here because that matches the
+/// MoE checkpoint we're targeting in v1; the 5 KiB drift on the analytic
+/// total when a checkpoint uses F32 instead is below the noise floor.
+pub fn checkpoint_dtype_for(role: TensorRole) -> CheckpointDtype {
+    let _ = role;
+    CheckpointDtype::Bf16
+}
+
+/// Whether `got` is an acceptable on-disk dtype for `role`. Lenient by design:
+/// norm-like and `A_log` tensors may be either F32 or BF16 depending on which
+/// Qwen3-Next variant published the checkpoint, and the runtime handles both.
+pub fn checkpoint_dtype_acceptable(role: TensorRole, got: CheckpointDtype) -> bool {
+    match role {
+        TensorRole::LinearNorm
+        | TensorRole::LinearALog
+        | TensorRole::Norm
+        | TensorRole::LayerInputNorm
+        | TensorRole::LayerPostAttnNorm
+        | TensorRole::FullQNorm
+        | TensorRole::FullKNorm => matches!(got, CheckpointDtype::F32 | CheckpointDtype::Bf16),
+        _ => got == CheckpointDtype::Bf16,
+    }
+}
+
+/// Computed elem count for a tensor role given the model config. Matches the
+/// shapes stored in the safetensors checkpoint, not what the runtime ships
+/// after bake-time transforms.
+pub fn checkpoint_elems_for(config: &TextConfig, role: TensorRole) -> u64 {
+    let hidden = config.hidden_size as u64;
+    let head_dim = config.head_dim as u64;
+    let q_dim_full = config.num_attention_heads as u64 * head_dim;
+    let kv_dim_full = config.num_key_value_heads as u64 * head_dim;
+
+    let lin_k_heads = config.linear_num_key_heads as u64;
+    let lin_v_heads = config.linear_num_value_heads as u64;
+    let lin_k_hd = config.linear_key_head_dim as u64;
+    let lin_v_hd = config.linear_value_head_dim as u64;
+    let lin_k_dim = lin_k_heads * lin_k_hd;
+    let lin_v_dim = lin_v_heads * lin_v_hd;
+    // Convention from a real Qwen3.5 0.8B checkpoint: `in_proj_qkv` packs
+    // Q, K, V channels with Q_heads == K_heads (no separate Qwen-Next field
+    // names them). For 0.8B: 16+16+16 heads × 128 = 6144. For 35B-A3B:
+    // 16+16+32 heads × 128 = 8192.
+    let lin_q_dim = lin_k_dim;
+    let lin_qkv_dim = lin_q_dim + lin_k_dim + lin_v_dim;
+    // conv1d packs the same Q+K+V channels along axis 0; shape is
+    // [lin_qkv_dim, 1, kernel].
+    let conv1d_elems = lin_qkv_dim * config.linear_conv_kernel_dim as u64;
+
+    let q_proj_out = if config.attn_output_gate {
+        2 * q_dim_full
+    } else {
+        q_dim_full
+    };
+
+    match role {
+        TensorRole::Embed | TensorRole::LmHead => hidden * config.vocab_size as u64,
+        TensorRole::Norm | TensorRole::LayerInputNorm | TensorRole::LayerPostAttnNorm => hidden,
+
+        TensorRole::FullQProj => q_proj_out * hidden,
+        TensorRole::FullKProj | TensorRole::FullVProj => kv_dim_full * hidden,
+        TensorRole::FullOProj => hidden * q_dim_full,
+        TensorRole::FullQNorm | TensorRole::FullKNorm => head_dim,
+
+        TensorRole::LinearInQkvProj => lin_qkv_dim * hidden,
+        TensorRole::LinearInZProj => lin_v_dim * hidden,
+        TensorRole::LinearInBProj | TensorRole::LinearInAProj => lin_v_heads * hidden,
+        TensorRole::LinearOutProj => hidden * lin_v_dim,
+        TensorRole::LinearConv1d => conv1d_elems,
+        TensorRole::LinearDtBias | TensorRole::LinearALog => lin_v_heads,
+        // linear_attn.norm.weight applies to per-head value stream; shape
+        // [head_dim]. Stored BF16 in 35B-A3B but F32 in some Qwen3.5 variants.
+        TensorRole::LinearNorm => lin_k_hd,
+
+        TensorRole::Router => config.num_experts as u64 * hidden,
+        // shared_expert_gate is shape [1, hidden] in the checkpoint.
+        TensorRole::SharedExpertGate => hidden,
+        TensorRole::SharedExpertGateProj | TensorRole::SharedExpertUpProj => {
+            config.shared_expert_intermediate_size as u64 * hidden
+        }
+        TensorRole::SharedExpertDownProj => hidden * config.shared_expert_intermediate_size as u64,
+
+        // Fused expert tensors carry weights for ALL experts in a single slab.
+        // `gate_up_proj`: [E, 2*moe_int, hidden] (gate concat'd with up).
+        // `down_proj`:    [E, hidden, moe_int].
+        TensorRole::ExpertGateUpProj => {
+            config.num_experts as u64 * 2 * config.moe_intermediate_size as u64 * hidden
+        }
+        TensorRole::ExpertDownProj => {
+            config.num_experts as u64 * hidden * config.moe_intermediate_size as u64
+        }
+    }
+}
+
+pub fn checkpoint_bytes_for(config: &TextConfig, role: TensorRole) -> u64 {
+    checkpoint_elems_for(config, role) * checkpoint_dtype_for(role).size()
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TensorSpec {
+    pub name: String,
+    pub role: TensorRole,
+    pub layer_idx: Option<usize>,
+    pub expert_idx: Option<usize>,
+}
+
+impl TensorSpec {
+    fn new(role: TensorRole, name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            role,
+            layer_idx: None,
+            expert_idx: None,
+        }
+    }
+
+    fn for_layer(role: TensorRole, name: impl Into<String>, layer: usize) -> Self {
+        Self {
+            name: name.into(),
+            role,
+            layer_idx: Some(layer),
+            expert_idx: None,
+        }
+    }
+
+    #[allow(dead_code)]
+    fn for_expert(role: TensorRole, name: impl Into<String>, layer: usize, expert: usize) -> Self {
+        // Reserved for future per-expert iteration paths if a checkpoint ever
+        // ships unfused expert tensors. The current Qwen3.6-MoE bake fuses
+        // them per-layer, so this helper is unused at the moment.
+        Self {
+            name: name.into(),
+            role,
+            layer_idx: Some(layer),
+            expert_idx: Some(expert),
+        }
+    }
+}
+
+/// Build the full list of tensor names this runtime expects in the loaded
+/// safetensors checkpoint. Used by the dry-run path to (a) fail fast if the
+/// checkpoint is missing tensors, (b) compute the BF16 footprint analytically,
+/// and (c) cross-check that footprint against the real on-disk total once the
+/// download is local.
+///
+/// The naming follows HuggingFace's `Qwen3_5MoeForConditionalGeneration` /
+/// `Qwen3_5MoeForCausalLM` convention. The text decoder lives under
+/// `model.language_model.*`; `lm_head.weight` is at the root (untied).
+pub fn expected_tensor_specs(config: &TextConfig, prefix: &str) -> Vec<TensorSpec> {
+    let mut out = Vec::new();
+    out.push(TensorSpec::new(
+        TensorRole::Embed,
+        format!("{prefix}.embed_tokens.weight"),
+    ));
+    out.push(TensorSpec::new(
+        TensorRole::Norm,
+        format!("{prefix}.norm.weight"),
+    ));
+    if !config.tie_word_embeddings {
+        out.push(TensorSpec::new(TensorRole::LmHead, "lm_head.weight"));
+    }
+
+    for idx in 0..config.num_hidden_layers {
+        let lp = format!("{prefix}.layers.{idx}");
+        out.push(TensorSpec::for_layer(
+            TensorRole::LayerInputNorm,
+            format!("{lp}.input_layernorm.weight"),
+            idx,
+        ));
+        out.push(TensorSpec::for_layer(
+            TensorRole::LayerPostAttnNorm,
+            format!("{lp}.post_attention_layernorm.weight"),
+            idx,
+        ));
+
+        if config.is_full_attention(idx) {
+            let fa = format!("{lp}.self_attn");
+            for (role, suffix) in [
+                (TensorRole::FullQProj, "q_proj.weight"),
+                (TensorRole::FullKProj, "k_proj.weight"),
+                (TensorRole::FullVProj, "v_proj.weight"),
+                (TensorRole::FullOProj, "o_proj.weight"),
+                (TensorRole::FullQNorm, "q_norm.weight"),
+                (TensorRole::FullKNorm, "k_norm.weight"),
+            ] {
+                out.push(TensorSpec::for_layer(role, format!("{fa}.{suffix}"), idx));
+            }
+        } else {
+            let la = format!("{lp}.linear_attn");
+            for (role, suffix) in [
+                (TensorRole::LinearInQkvProj, "in_proj_qkv.weight"),
+                (TensorRole::LinearInZProj, "in_proj_z.weight"),
+                (TensorRole::LinearInBProj, "in_proj_b.weight"),
+                (TensorRole::LinearInAProj, "in_proj_a.weight"),
+                (TensorRole::LinearOutProj, "out_proj.weight"),
+                (TensorRole::LinearConv1d, "conv1d.weight"),
+                (TensorRole::LinearDtBias, "dt_bias"),
+                (TensorRole::LinearALog, "A_log"),
+                (TensorRole::LinearNorm, "norm.weight"),
+            ] {
+                out.push(TensorSpec::for_layer(role, format!("{la}.{suffix}"), idx));
+            }
+        }
+
+        // MoE block. v1 assumes every layer uses MoE — `mlp_only_layers` is
+        // empty for 35B-A3B per the published config.
+        let mp = format!("{lp}.mlp");
+        out.push(TensorSpec::for_layer(
+            TensorRole::Router,
+            format!("{mp}.gate.weight"),
+            idx,
+        ));
+        out.push(TensorSpec::for_layer(
+            TensorRole::SharedExpertGate,
+            format!("{mp}.shared_expert_gate.weight"),
+            idx,
+        ));
+        out.push(TensorSpec::for_layer(
+            TensorRole::SharedExpertGateProj,
+            format!("{mp}.shared_expert.gate_proj.weight"),
+            idx,
+        ));
+        out.push(TensorSpec::for_layer(
+            TensorRole::SharedExpertUpProj,
+            format!("{mp}.shared_expert.up_proj.weight"),
+            idx,
+        ));
+        out.push(TensorSpec::for_layer(
+            TensorRole::SharedExpertDownProj,
+            format!("{mp}.shared_expert.down_proj.weight"),
+            idx,
+        ));
+        // Fused expert tensors: one gate_up_proj + one down_proj per layer,
+        // batched across all experts. Note: NO `.weight` suffix in the
+        // published Qwen3.6-MoE checkpoint.
+        out.push(TensorSpec::for_layer(
+            TensorRole::ExpertGateUpProj,
+            format!("{mp}.experts.gate_up_proj"),
+            idx,
+        ));
+        out.push(TensorSpec::for_layer(
+            TensorRole::ExpertDownProj,
+            format!("{mp}.experts.down_proj"),
+            idx,
+        ));
+    }
+    out
+}
+
+/// Theoretical checkpoint footprint computed analytically from the config —
+/// no checkpoint required. Useful to set the registry's `fixed_bytes` budget
+/// honestly and to compare against the on-disk total once the download is
+/// local. Mixed dtype across roles (F32 norms / A_log; BF16 everything else)
+/// matches what the published safetensors actually store.
+pub struct CheckpointAccount {
+    pub embed_bytes: u64,
+    pub final_norm_bytes: u64,
+    pub lm_head_bytes: u64,
+    pub per_layer_norm_bytes: u64,
+    pub full_attn_bytes_per_layer: u64,
+    pub linear_attn_bytes_per_layer: u64,
+    pub router_bytes_per_layer: u64,
+    pub shared_expert_bytes_per_layer: u64,
+    pub experts_bytes_per_layer: u64,
+    pub num_full_layers: u64,
+    pub num_linear_layers: u64,
+    pub total_bytes: u64,
+}
+
+impl CheckpointAccount {
+    pub fn from_config(config: &TextConfig) -> Self {
+        let cb = |role| checkpoint_bytes_for(config, role);
+
+        let embed_bytes = cb(TensorRole::Embed);
+        let final_norm_bytes = cb(TensorRole::Norm);
+        let lm_head_bytes = if config.tie_word_embeddings {
+            0
+        } else {
+            cb(TensorRole::LmHead)
+        };
+        let per_layer_norm_bytes = cb(TensorRole::LayerInputNorm)
+            + cb(TensorRole::LayerPostAttnNorm);
+
+        let full_attn_bytes_per_layer = cb(TensorRole::FullQProj)
+            + cb(TensorRole::FullKProj)
+            + cb(TensorRole::FullVProj)
+            + cb(TensorRole::FullOProj)
+            + cb(TensorRole::FullQNorm)
+            + cb(TensorRole::FullKNorm);
+
+        let linear_attn_bytes_per_layer = cb(TensorRole::LinearInQkvProj)
+            + cb(TensorRole::LinearInZProj)
+            + cb(TensorRole::LinearInBProj)
+            + cb(TensorRole::LinearInAProj)
+            + cb(TensorRole::LinearOutProj)
+            + cb(TensorRole::LinearConv1d)
+            + cb(TensorRole::LinearDtBias)
+            + cb(TensorRole::LinearALog)
+            + cb(TensorRole::LinearNorm);
+
+        let router_bytes_per_layer = cb(TensorRole::Router);
+        let shared_expert_bytes_per_layer = cb(TensorRole::SharedExpertGate)
+            + cb(TensorRole::SharedExpertGateProj)
+            + cb(TensorRole::SharedExpertUpProj)
+            + cb(TensorRole::SharedExpertDownProj);
+        // Fused-expert tensors already include the `* num_experts` factor in
+        // their elem count, so we don't multiply again here.
+        let experts_bytes_per_layer =
+            cb(TensorRole::ExpertGateUpProj) + cb(TensorRole::ExpertDownProj);
+
+        let num_full_layers = config.num_full_attention_layers() as u64;
+        let num_linear_layers = config.num_linear_attention_layers() as u64;
+        let num_hidden = config.num_hidden_layers as u64;
+
+        let total_bytes = embed_bytes
+            + final_norm_bytes
+            + lm_head_bytes
+            + num_hidden * per_layer_norm_bytes
+            + num_full_layers * full_attn_bytes_per_layer
+            + num_linear_layers * linear_attn_bytes_per_layer
+            + num_hidden
+                * (router_bytes_per_layer
+                    + shared_expert_bytes_per_layer
+                    + experts_bytes_per_layer);
+
+        Self {
+            embed_bytes,
+            final_norm_bytes,
+            lm_head_bytes,
+            per_layer_norm_bytes,
+            full_attn_bytes_per_layer,
+            linear_attn_bytes_per_layer,
+            router_bytes_per_layer,
+            shared_expert_bytes_per_layer,
+            experts_bytes_per_layer,
+            num_full_layers,
+            num_linear_layers,
+            total_bytes,
+        }
+    }
+
+    /// Same totals projected to an INT4-GPTQ packed footprint. Quantizable
+    /// projections (`_proj`, expert MLP, lm_head) shrink to ~4.5 bits/weight
+    /// once you fold in the BF16 scale+zero sidecar at group_size=128;
+    /// non-quantizable tensors (norms, routers, scalar gates, conv, dt_bias,
+    /// A_log) stay at their native size. Approximation, not bit-exact —
+    /// useful for VRAM budgeting before the bake exists.
+    pub fn project_int4_total_bytes(&self, config: &TextConfig, group_size: u64) -> u64 {
+        // Embed and lm_head: lm_head is INT4-quantized by the bake (Qwen3.5
+        // already uses this); embed stays BF16 because the runtime reads it
+        // for free in the kernel via lookup, not matmul.
+        let embed = self.embed_bytes;
+        let final_norm = self.final_norm_bytes;
+        // 4 bits / weight + 1 BF16 scale + 1 BF16 zero per [gs, gs] tile.
+        let lm_head = if config.tie_word_embeddings {
+            0
+        } else {
+            int4_bytes(
+                config.vocab_size as u64 * config.hidden_size as u64,
+                config.vocab_size as u64,
+                config.hidden_size as u64,
+                group_size,
+            )
+        };
+
+        let per_norm = self.per_layer_norm_bytes;
+        let mut total = embed + final_norm + lm_head + per_norm * config.num_hidden_layers as u64;
+
+        // Full attention projections (Q,K,V,O) quantize. q_norm/k_norm don't.
+        let q_dim = config.num_attention_heads as u64 * config.head_dim as u64;
+        let q_proj_out = if config.attn_output_gate { 2 * q_dim } else { q_dim };
+        let kv_dim = config.num_key_value_heads as u64 * config.head_dim as u64;
+        let hidden = config.hidden_size as u64;
+        let head_dim = config.head_dim as u64;
+        let full_int4 = int4_bytes(q_proj_out * hidden, q_proj_out, hidden, group_size)
+            + int4_bytes(kv_dim * hidden, kv_dim, hidden, group_size)
+            + int4_bytes(kv_dim * hidden, kv_dim, hidden, group_size)
+            + int4_bytes(hidden * q_dim, hidden, q_dim, group_size)
+            + 2 * 2 * head_dim;
+        total += self.num_full_layers * full_int4;
+
+        // Linear attention: in_proj_qkv/z/out_proj quantize; in_proj_a/b
+        // (per-head, [V_heads, hidden]) often won't align to gs=128 on the
+        // V_heads axis, so they stay BF16 — the bake predicate already
+        // rejects them on the shape gate. conv/dt_bias/A_log/norm stay too.
+        let lin_v_heads = config.linear_num_value_heads as u64;
+        let lin_v_hd = config.linear_value_head_dim as u64;
+        let lin_k_heads = config.linear_num_key_heads as u64;
+        let lin_k_hd = config.linear_key_head_dim as u64;
+        let lin_k_dim = lin_k_heads * lin_k_hd;
+        let lin_v_dim = lin_v_heads * lin_v_hd;
+        let lin_qkv_dim = lin_k_dim + lin_k_dim + lin_v_dim;
+        let lin_int4 = int4_bytes(lin_qkv_dim * hidden, lin_qkv_dim, hidden, group_size)
+            + int4_bytes(lin_v_dim * hidden, lin_v_dim, hidden, group_size)
+            + int4_bytes(hidden * lin_v_dim, hidden, lin_v_dim, group_size);
+        let lin_raw_bf16 = 2 * (lin_v_heads * hidden + lin_v_heads * hidden) // a, b
+            + 2 * lin_qkv_dim * config.linear_conv_kernel_dim as u64 // conv1d
+            + 2 * lin_v_heads // dt_bias
+            + 4 * lin_v_heads // A_log f32
+            + 4 * lin_k_hd; // norm f32
+        total += self.num_linear_layers * (lin_int4 + lin_raw_bf16);
+
+        // Router stays BF16; shared-expert + experts quantize their gate/up/down.
+        let router_raw = 2 * config.num_experts as u64 * hidden;
+        let scalar_gate_raw = 2 * hidden;
+        let moe_int = config.moe_intermediate_size as u64;
+        let shared_int = config.shared_expert_intermediate_size as u64;
+        let shared_int4 =
+            int4_bytes(shared_int * hidden, shared_int, hidden, group_size) * 2 // gate+up
+            + int4_bytes(hidden * shared_int, hidden, shared_int, group_size); // down
+        // Fused-expert tile dimensions: gate_up_proj is laid out as
+        // [E, 2*moe_int, hidden] which we treat as `E` parallel
+        // [2*moe_int, hidden] tiles for INT4 packing. Same for down_proj.
+        let expert_gate_up = int4_bytes(
+            2 * moe_int * hidden,
+            2 * moe_int,
+            hidden,
+            group_size,
+        );
+        let expert_down = int4_bytes(hidden * moe_int, hidden, moe_int, group_size);
+        let per_layer_expert_int4 =
+            config.num_experts as u64 * (expert_gate_up + expert_down);
+        total += config.num_hidden_layers as u64
+            * (router_raw + scalar_gate_raw + shared_int4 + per_layer_expert_int4);
+        total
+    }
+}
+
+fn int4_bytes(elems: u64, out_dim: u64, in_dim: u64, group_size: u64) -> u64 {
+    // 2 nibbles per byte
+    let packed = elems / 2;
+    // BF16 scale+zero per [out/gs, in/gs] tile, two tiles' worth (scale + zero)
+    let tiles = (out_dim / group_size).max(1) * (in_dim / group_size).max(1);
+    let sidecar = 2 * 2 * tiles;
+    packed + sidecar
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config_35b_a3b() -> TextConfig {
+        let layer_types: Vec<String> = (0..40)
+            .map(|i| {
+                if (i + 1) % 4 == 0 {
+                    "full_attention".to_string()
+                } else {
+                    "linear_attention".to_string()
+                }
+            })
+            .collect();
+        TextConfig {
+            vocab_size: 248_320,
+            hidden_size: 2048,
+            num_hidden_layers: 40,
+            num_attention_heads: 16,
+            num_key_value_heads: 2,
+            max_position_embeddings: 262_144,
+            rms_norm_eps: 1e-6,
+            hidden_act: crate::config::Activation::Silu,
+            tie_word_embeddings: false,
+            eos_token_id: None,
+            bos_token_id: None,
+            head_dim: 256,
+            full_attention_interval: 4,
+            attn_output_gate: true,
+            linear_conv_kernel_dim: 4,
+            linear_key_head_dim: 128,
+            linear_value_head_dim: 128,
+            linear_num_key_heads: 16,
+            linear_num_value_heads: 32,
+            layer_types,
+            rope_parameters: None,
+            num_experts: 256,
+            num_experts_per_tok: 8,
+            moe_intermediate_size: 512,
+            shared_expert_intermediate_size: 512,
+            norm_topk_prob: true,
+            router_aux_loss_coef: 0.001,
+            mlp_only_layers: Vec::new(),
+            decoder_sparse_step: None,
+        }
+    }
+
+    #[test]
+    fn enumeration_counts_match_35b_a3b_geometry() {
+        let cfg = config_35b_a3b();
+        let specs = expected_tensor_specs(&cfg, DEFAULT_PREFIX);
+
+        let mut count = std::collections::BTreeMap::<&'static str, usize>::new();
+        for s in &specs {
+            let bucket = match s.role {
+                TensorRole::Embed => "embed",
+                TensorRole::Norm => "norm",
+                TensorRole::LmHead => "lm_head",
+                TensorRole::LayerInputNorm | TensorRole::LayerPostAttnNorm => "layer_norm",
+                TensorRole::FullQProj
+                | TensorRole::FullKProj
+                | TensorRole::FullVProj
+                | TensorRole::FullOProj
+                | TensorRole::FullQNorm
+                | TensorRole::FullKNorm => "full",
+                TensorRole::LinearInQkvProj
+                | TensorRole::LinearInZProj
+                | TensorRole::LinearInBProj
+                | TensorRole::LinearInAProj
+                | TensorRole::LinearOutProj
+                | TensorRole::LinearConv1d
+                | TensorRole::LinearDtBias
+                | TensorRole::LinearALog
+                | TensorRole::LinearNorm => "linear",
+                TensorRole::Router => "router",
+                TensorRole::SharedExpertGate
+                | TensorRole::SharedExpertGateProj
+                | TensorRole::SharedExpertUpProj
+                | TensorRole::SharedExpertDownProj => "shared_expert",
+                TensorRole::ExpertGateUpProj | TensorRole::ExpertDownProj => "expert",
+            };
+            *count.entry(bucket).or_default() += 1;
+        }
+        assert_eq!(count["embed"], 1);
+        assert_eq!(count["norm"], 1);
+        assert_eq!(count["lm_head"], 1);
+        assert_eq!(count["layer_norm"], 2 * 40);
+        assert_eq!(count["full"], 6 * 10);
+        assert_eq!(count["linear"], 9 * 30);
+        assert_eq!(count["router"], 40);
+        assert_eq!(count["shared_expert"], 4 * 40);
+        // Fused-expert layout: 2 tensors per layer (gate_up_proj + down_proj)
+        // batched across all 256 experts in one slab each.
+        assert_eq!(count["expert"], 2 * 40);
+    }
+
+    #[test]
+    fn account_matches_summed_specs_for_35b_a3b() {
+        let cfg = config_35b_a3b();
+        let specs = expected_tensor_specs(&cfg, DEFAULT_PREFIX);
+        let total_from_specs: u64 = specs
+            .iter()
+            .map(|s| checkpoint_bytes_for(&cfg, s.role))
+            .sum();
+        let acct = CheckpointAccount::from_config(&cfg);
+        assert_eq!(
+            total_from_specs, acct.total_bytes,
+            "spec-sum vs analytic-account drift"
+        );
+        // 35B BF16 disk size sanity: ~65-70 GiB.
+        let gib = 1024.0_f64.powi(3);
+        let total_gib = acct.total_bytes as f64 / gib;
+        assert!(
+            (60.0..80.0).contains(&total_gib),
+            "expected ~60-80 GiB total, got {total_gib:.3}"
+        );
+    }
+
+    #[test]
+    fn linear_attn_qkv_matches_real_qwen35_0_8b_geometry() {
+        // Spot-check against the real 0.8B safetensors: in_proj_qkv = [6144, 1024]
+        // when hidden=1024, K=V=16 heads, head_dim=128. The key invariant here
+        // is that in_proj_qkv packs Q+K+V channels with Q_heads == K_heads.
+        let mut cfg_08b = config_35b_a3b();
+        cfg_08b.hidden_size = 1024;
+        cfg_08b.linear_num_value_heads = 16; // 0.8B uses 16 V heads
+        cfg_08b.num_experts = 1; // unused for this assert
+        cfg_08b.moe_intermediate_size = 64;
+        cfg_08b.shared_expert_intermediate_size = 64;
+        let qkv_elems = checkpoint_elems_for(&cfg_08b, TensorRole::LinearInQkvProj);
+        // 16K + 16K + 16V = 48 heads × 128 = 6144 channels × 1024 hidden
+        assert_eq!(qkv_elems, 6144 * 1024);
+    }
+
+    #[test]
+    fn int4_projection_fits_24gib_for_35b_a3b() {
+        let cfg = config_35b_a3b();
+        let acct = CheckpointAccount::from_config(&cfg);
+        let int4 = acct.project_int4_total_bytes(&cfg, 128);
+        let gib = 1024.0_f64.powi(3);
+        let int4_gib = int4 as f64 / gib;
+        // 35B INT4 projection: weights ~17.5 GiB + scales ~0.5 GiB + embed BF16 ~1 GiB.
+        // Plan §6 budgets 19 GiB for weights with overhead_factor 1.1.
+        assert!(
+            (16.0..22.0).contains(&int4_gib),
+            "expected ~17-21 GiB INT4 projection, got {int4_gib:.2}"
+        );
+        // BF16 baseline must be ~3.5x larger than INT4.
+        let ratio = acct.total_bytes as f64 / int4 as f64;
+        assert!(
+            (3.0..4.5).contains(&ratio),
+            "BF16/INT4 ratio out of band: {ratio:.2}"
+        );
+    }
+}

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -78,6 +78,7 @@ kernel-ffi = { path = "../kernel-ffi" }
 model-store = { path = "../model-store" }
 qwen35 = { path = "../qwen35" }
 qwen35_dflash = { path = "../qwen35_dflash" }
+qwen36_moe = { path = "../qwen36_moe" }
 gemma4 = { path = "../gemma4" }
 phi4 = { path = "../phi4" }
 anyhow = "1"

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -9,6 +9,7 @@ mod oracle;
 mod phi4_engine;
 mod prefill_engine;
 mod qwen35_dflash_engine;
+mod qwen36_moe_engine;
 mod registry;
 mod validate;
 
@@ -317,8 +318,8 @@ pub(crate) struct Cli {
     #[arg(long)]
     model_dir: PathBuf,
 
-    /// Text prompt (will be tokenized)
-    #[arg(long)]
+    /// Text prompt (will be tokenized). Required unless --dry-run is set.
+    #[arg(long, default_value = "")]
     prompt: String,
 
     /// Do not add tokenizer special tokens when encoding --prompt.
@@ -620,6 +621,12 @@ pub(crate) struct Cli {
     /// been explicitly tuned.
     #[arg(long)]
     allow_untested_gpu: Option<String>,
+
+    /// Enumerate the model checkpoint, compute analytic + on-disk VRAM
+    /// accounting, and exit. Currently only honored on `qwen3.6-35b-a3b`
+    /// (the runtime is still being built up; see PR 3 of the MoE plan).
+    #[arg(long)]
+    dry_run: bool,
 
     /// Disable downloading pre-baked weights from GitHub releases when the
     /// local bake is missing. Prints the manual bake guidance instead.
@@ -1064,12 +1071,11 @@ fn main() -> Result<()> {
     } else if cli.certified_kv_shadow_validate {
         anyhow::bail!("--certified-kv-shadow-validate requires --certified-kv");
     }
-    if model_variant.family() == ModelFamily::Qwen36Moe {
+    if model_variant.family() == ModelFamily::Qwen36Moe && !cli.dry_run {
         anyhow::bail!(
-            "qwen3.6-35b-a3b is recognized, but the MoE runtime is not implemented yet. \
-             Build a q4km bake with `python oracle/bake_q4km.py --model qwen3.6-35b-a3b --model-dir {}` first; \
-             runtime support needs the separate Qwen MoE engine/kernels.",
-            cli.model_dir.display(),
+            "qwen3.6-35b-a3b decode runtime is not yet implemented. \
+             Re-run with --dry-run to enumerate the checkpoint and report VRAM accounting; \
+             the kernel lands in PR 4 (CUDA) and PR 6 (HIP) of docs/qwen36-moe-plan.md."
         );
     }
 
@@ -1178,7 +1184,9 @@ fn main() -> Result<()> {
         ModelFamily::Llama31 => {
             return llama31_engine::run_llama31(&cli, &model_variant, entry, ordinal, total_vram);
         }
-        ModelFamily::Qwen36Moe => unreachable!("qwen3.6 MoE is rejected before registry lookup"),
+        ModelFamily::Qwen36Moe => {
+            return qwen36_moe_engine::run(&cli, entry, total_vram);
+        }
         ModelFamily::Qwen35 => {}
     }
 
@@ -1232,6 +1240,7 @@ fn main() -> Result<()> {
 
     let params = match &entry.params {
         FamilyParams::Qwen35(p) => p,
+        FamilyParams::Qwen36Moe(_) => unreachable!("qwen3.6-moe handled above"),
         FamilyParams::Gemma4(_) => unreachable!("gemma4 handled above"),
         FamilyParams::Phi4(_) => unreachable!("phi4 handled above"),
         FamilyParams::Llama31(_) => unreachable!("llama3.1 handled above"),
@@ -2686,6 +2695,7 @@ fn run_gemma4(
     let params = match &entry.params {
         FamilyParams::Gemma4(p) => p,
         FamilyParams::Qwen35(_) => unreachable!("dispatch filtered to Gemma4"),
+        FamilyParams::Qwen36Moe(_) => unreachable!("dispatch filtered to Gemma4"),
         FamilyParams::Phi4(_) => unreachable!("dispatch filtered to Gemma4"),
         FamilyParams::Llama31(_) => unreachable!("dispatch filtered to Gemma4"),
     };

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -319,7 +319,7 @@ pub(crate) struct Cli {
     model_dir: PathBuf,
 
     /// Text prompt (will be tokenized). Required unless --dry-run is set.
-    #[arg(long, default_value = "")]
+    #[arg(long, required_unless_present = "dry_run", default_value = "")]
     prompt: String,
 
     /// Do not add tokenizer special tokens when encoding --prompt.

--- a/crates/runner/src/phi4_engine.rs
+++ b/crates/runner/src/phi4_engine.rs
@@ -33,7 +33,10 @@ pub fn run_phi4(
 ) -> Result<()> {
     let params = match &entry.params {
         FamilyParams::Phi4(p) => p,
-        FamilyParams::Qwen35(_) | FamilyParams::Gemma4(_) | FamilyParams::Llama31(_) => {
+        FamilyParams::Qwen35(_)
+        | FamilyParams::Qwen36Moe(_)
+        | FamilyParams::Gemma4(_)
+        | FamilyParams::Llama31(_) => {
             unreachable!("run_phi4 dispatched for non-Phi4 variant {model_variant}")
         }
     };

--- a/crates/runner/src/qwen35_dflash_engine.rs
+++ b/crates/runner/src/qwen35_dflash_engine.rs
@@ -71,7 +71,10 @@ pub fn run_qwen35_dflash(
 
     let params = match &entry.params {
         FamilyParams::Qwen35(p) => *p,
-        FamilyParams::Gemma4(_) | FamilyParams::Phi4(_) | FamilyParams::Llama31(_) => {
+        FamilyParams::Qwen36Moe(_)
+        | FamilyParams::Gemma4(_)
+        | FamilyParams::Phi4(_)
+        | FamilyParams::Llama31(_) => {
             unreachable!("run_qwen35_dflash dispatched for non-qwen35 variant");
         }
     };

--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -47,6 +47,30 @@ pub struct DryRunReport {
     pub gpu_total_vram_bytes: u64,
     /// Populated when an INT4 baked package is present and loadable.
     pub bake: Option<BakeAccount>,
+    /// What the dry-run actually used for KV-cache sizing — and where it
+    /// came from. The string flavor (`Explicit`, `EstimatedFromPrompt`,
+    /// `MaxNewTokensOnly`) lets `print_report` flag the worst case so the
+    /// user knows the `fit:YES` answer covered their realistic prompt.
+    pub context_size_used: usize,
+    pub context_size_source: ContextSizeSource,
+}
+
+/// How `context_size_used` was derived. Anything other than `Explicit`
+/// means the dry-run is making an assumption the caller should verify.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContextSizeSource {
+    /// User passed `--context-size`; honoured verbatim.
+    Explicit,
+    /// User passed `--prompt` but no `--context-size`; estimated as
+    /// (prompt char count) + max_new_tokens. Char count is a conservative
+    /// upper bound on token count for English-ish text — true tokenisation
+    /// would need the model's tokenizer, which the dry-run path doesn't
+    /// load.
+    EstimatedFromPrompt,
+    /// Neither `--context-size` nor `--prompt` was given. Defaults to
+    /// max_new_tokens — almost certainly an undercount for any real
+    /// session. The report flags this as a worst-case caveat.
+    MaxNewTokensOnly,
 }
 
 /// Summary of a baked-package's contents — the runtime-ready view the
@@ -80,6 +104,7 @@ pub fn run_qwen36_moe_dry_run(
     entry: &RegistryEntry,
     total_vram: u64,
     context_size: usize,
+    context_size_source: ContextSizeSource,
     batch_size: usize,
     kv_fp8: bool,
     no_bake: bool,
@@ -191,6 +216,8 @@ pub fn run_qwen36_moe_dry_run(
         registry_budget_bytes,
         gpu_total_vram_bytes: total_vram,
         bake,
+        context_size_used: context_size,
+        context_size_source,
     })
 }
 
@@ -422,6 +449,18 @@ pub fn print_report(report: &DryRunReport) {
     );
     println!();
     println!("[state accounting]");
+    let max_pos = report.config.text_config.max_position_embeddings;
+    let ctx_label = match report.context_size_source {
+        ContextSizeSource::Explicit => "explicit --context-size".to_string(),
+        ContextSizeSource::EstimatedFromPrompt => {
+            format!("estimated from --prompt (chars + max_new_tokens)")
+        }
+        ContextSizeSource::MaxNewTokensOnly => "max_new_tokens only".to_string(),
+    };
+    println!(
+        "  context tokens:     {:>8}     (source: {ctx_label}; model max_pos={max_pos})",
+        report.context_size_used,
+    );
     println!(
         "  KV cache (full attn): {:>8.2} GiB",
         report.state.full_kv_bytes as f64 / GIB,
@@ -567,6 +606,28 @@ pub fn print_report(report: &DryRunReport) {
             report.checkpoint.total_bytes as f64 / GIB
         );
     }
+    if report.context_size_source == ContextSizeSource::MaxNewTokensOnly {
+        println!();
+        println!(
+            "  WARNING: context_size defaulted to max_new_tokens={}. KV cache for a real",
+            report.context_size_used,
+        );
+        println!(
+            "  decode session will be larger; pass --context-size <N> (or --prompt) for an",
+        );
+        println!(
+            "  honest fit number. Worst case at the model's max ({} tokens) needs",
+            max_pos,
+        );
+        // Quick worst-case KV estimate at model max — gives the user one
+        // concrete data point before they have to re-run with a flag.
+        let worst_kv = report.config.text_config.kv_bytes_per_token(2)
+            * max_pos as u64;
+        println!(
+            "  ~{:.2} GiB of KV cache alone (BF16).",
+            worst_kv as f64 / GIB,
+        );
+    }
 }
 
 pub fn run(
@@ -581,14 +642,28 @@ pub fn run(
              and exit. Full decode lands in PR 4 (CUDA) and PR 6 (HIP)."
         );
     }
-    let context_size = cli
-        .context_size
-        .unwrap_or_else(|| cli.max_new_tokens.max(1));
+    // Derive context_size + an honest source flag so the printed report can
+    // tell the user which of three answers they got: explicit, prompt-derived
+    // estimate, or worst-case defaults-only. The `--context-size` path is
+    // verbatim; otherwise we fall back to (prompt char count) + max_new_tokens
+    // when a prompt is given (chars are an upper bound on tokens for
+    // English-ish text), or just max_new_tokens when the user gave neither
+    // flag — that last case undercounts KV bytes for any realistic session,
+    // and the report flags it.
+    let max_new = cli.max_new_tokens.max(1);
+    let (context_size, context_size_source) = if let Some(ctx) = cli.context_size {
+        (ctx, ContextSizeSource::Explicit)
+    } else if !cli.prompt.is_empty() {
+        (cli.prompt.chars().count() + max_new, ContextSizeSource::EstimatedFromPrompt)
+    } else {
+        (max_new, ContextSizeSource::MaxNewTokensOnly)
+    };
     let report = run_qwen36_moe_dry_run(
         &cli.model_dir,
         entry,
         total_vram,
         context_size,
+        context_size_source,
         cli.batch_size.max(1),
         cli.kv_fp8,
         cli.no_bake,

--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -10,9 +10,12 @@
 //! the only meaningful runtime check is "did the safetensors index match
 //! what we expect from the config" plus a budget comparison.
 
-use std::path::Path;
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Result};
+use model_store::manifest::LayoutTag;
+use model_store::BakedStore;
 use qwen36_moe::config::{Config, TextConfig};
 use qwen36_moe::loader::{ScalarKind, WeightLoader};
 use qwen36_moe::state::{StateAccount, StateLayout};
@@ -42,6 +45,34 @@ pub struct DryRunReport {
     pub loader_warning: Option<String>,
     pub registry_budget_bytes: u64,
     pub gpu_total_vram_bytes: u64,
+    /// Populated when an INT4 baked package is present and loadable.
+    pub bake: Option<BakeAccount>,
+}
+
+/// Summary of a baked-package's contents — the runtime-ready view the
+/// kernel will see at decode time. Built by mmap'ing the bake at
+/// `model-store::bake_dir_int4()` and walking its manifest.
+#[derive(Debug, Clone)]
+pub struct BakeAccount {
+    pub bake_dir: PathBuf,
+    pub manifest_format_version: u32,
+    pub manifest_converter_version: u32,
+    pub tensor_count: usize,
+    pub weights_bin_bytes: u64,
+    /// Per-LayoutTag tensor counts. Sorted alphabetically by tag name for
+    /// deterministic output.
+    pub by_layout: BTreeMap<String, usize>,
+    /// Tensors expected per `expected_tensor_specs` that are absent from
+    /// the bake's index. A non-empty list means the bake is incomplete.
+    pub missing_specs: Vec<String>,
+    /// INT4 expert tensors per layer the runtime relies on. Each entry is
+    /// `(layer_idx, name)` for any of `gate_up_proj`, `down_proj` that's
+    /// missing or has a wrong layout.
+    pub bad_expert_tensors: Vec<(usize, String)>,
+    /// Cached aggregate byte sizes per category. Useful for comparing the
+    /// bake against the analytic INT4 projection.
+    pub int4_quantized_bytes: u64,
+    pub raw_bytes: u64,
 }
 
 pub fn run_qwen36_moe_dry_run(
@@ -70,6 +101,8 @@ pub fn run_qwen36_moe_dry_run(
 
     let layout = StateLayout::new(context_size, batch_size, kv_fp8);
     let state = StateAccount::from_config(&config.text_config, layout);
+
+    let bake = inspect_bake(model_dir, &config.text_config, weight_prefix);
 
     let mut on_disk_bytes = None;
     let mut on_disk_tensor_count = None;
@@ -157,6 +190,85 @@ pub fn run_qwen36_moe_dry_run(
         loader_warning,
         registry_budget_bytes,
         gpu_total_vram_bytes: total_vram,
+        bake,
+    })
+}
+
+/// Open the INT4 baked package (if present and valid) and summarise its
+/// contents. Returns None when no bake is on disk or its manifest can't be
+/// parsed; the dry-run continues either way.
+fn inspect_bake(
+    model_dir: &Path,
+    text_config: &TextConfig,
+    weight_prefix: &str,
+) -> Option<BakeAccount> {
+    let bake_dir = model_store::bake_dir_int4(model_dir);
+    if !bake_dir.exists() {
+        return None;
+    }
+    // Re-parse the manifest header even though BakedStore does too — we
+    // expose format/converter versions in the report so a stale bake is
+    // visible without having to dig into the file by hand.
+    let manifest_text =
+        std::fs::read_to_string(model_store::manifest_path(&bake_dir)).ok()?;
+    let manifest: model_store::manifest::Manifest =
+        serde_json::from_str(&manifest_text).ok()?;
+    let store = BakedStore::open(&bake_dir).ok()?;
+    let weights_bin_bytes = std::fs::metadata(model_store::weights_bin_path(&bake_dir))
+        .ok()?
+        .len();
+
+    // Aggregate per-layout tensor counts and per-category byte totals.
+    let mut by_layout: BTreeMap<String, usize> = BTreeMap::new();
+    let mut int4_quantized_bytes: u64 = 0;
+    let mut raw_bytes: u64 = 0;
+    for t in &manifest.tensors {
+        let key = format!("{:?}", t.layout);
+        *by_layout.entry(key).or_default() += 1;
+        match t.layout {
+            LayoutTag::Int4Quantized => int4_quantized_bytes += t.byte_len,
+            LayoutTag::Raw => raw_bytes += t.byte_len,
+            _ => {}
+        }
+    }
+
+    // Cross-check the bake against the runtime's expected tensor specs.
+    // A missing entry here would crash the loader at decode time; surface
+    // it during dry-run instead.
+    let specs = expected_tensor_specs(text_config, weight_prefix);
+    let mut missing_specs = Vec::new();
+    for spec in &specs {
+        if !store.contains(&spec.name) {
+            missing_specs.push(spec.name.clone());
+        }
+    }
+
+    // The fused MoE expert tensors are the bulk of the bake (~80% of the
+    // INT4 byte total on 35B-A3B). Spot-check every layer; absence here is
+    // fatal because the kernel can't run without a routed expert.
+    let mut bad_expert_tensors = Vec::new();
+    for li in 0..text_config.num_hidden_layers as usize {
+        for kind in ["gate_up_proj", "down_proj"] {
+            let name = format!("{weight_prefix}.layers.{li}.mlp.experts.{kind}");
+            match store.layout(&name) {
+                Some(LayoutTag::Int4Quantized) => {}
+                Some(other) => bad_expert_tensors.push((li, format!("{name} (layout={other:?})"))),
+                None => bad_expert_tensors.push((li, format!("{name} (missing)"))),
+            }
+        }
+    }
+
+    Some(BakeAccount {
+        bake_dir,
+        manifest_format_version: manifest.format_version,
+        manifest_converter_version: manifest.converter_version,
+        tensor_count: manifest.tensors.len(),
+        weights_bin_bytes,
+        by_layout,
+        missing_specs,
+        bad_expert_tensors,
+        int4_quantized_bytes,
+        raw_bytes,
     })
 }
 
@@ -369,6 +481,72 @@ pub fn print_report(report: &DryRunReport) {
         println!("  WARNING: {w}");
     }
     println!();
+    if let Some(bake) = &report.bake {
+        println!("[INT4 baked package]");
+        println!("  bake_dir:        {}", bake.bake_dir.display());
+        println!(
+            "  manifest:        format_version={} converter_version={}",
+            bake.manifest_format_version, bake.manifest_converter_version,
+        );
+        println!(
+            "  weights.bin:     {:.2} GiB    ({} tensors indexed)",
+            bake.weights_bin_bytes as f64 / GIB,
+            bake.tensor_count,
+        );
+        println!(
+            "  INT4 / Raw:      {:.2} GiB / {:.2} GiB",
+            bake.int4_quantized_bytes as f64 / GIB,
+            bake.raw_bytes as f64 / GIB,
+        );
+        let parts: Vec<String> = bake
+            .by_layout
+            .iter()
+            .map(|(l, n)| format!("{l}={n}"))
+            .collect();
+        println!("  layouts:         {}", parts.join(", "));
+        // Compare against the analytic INT4 projection — small drift is
+        // expected (the analytic model rounds shapes; the bake is exact).
+        let analytic_gib = report.int4_projected_bytes as f64 / GIB;
+        let bake_gib = bake.weights_bin_bytes as f64 / GIB;
+        println!(
+            "  vs analytic:     bake={:.2} GiB analytic_int4={:.2} GiB drift={:+.2} GiB",
+            bake_gib,
+            analytic_gib,
+            bake_gib - analytic_gib,
+        );
+        if !bake.missing_specs.is_empty() {
+            println!(
+                "  MISSING SPECS:   {} (showing first 10)",
+                bake.missing_specs.len()
+            );
+            for n in bake.missing_specs.iter().take(10) {
+                println!("    - {n}");
+            }
+        }
+        if !bake.bad_expert_tensors.is_empty() {
+            println!(
+                "  BAD EXPERT TENSORS: {} (showing first 10)",
+                bake.bad_expert_tensors.len()
+            );
+            for (li, n) in bake.bad_expert_tensors.iter().take(10) {
+                println!("    - layer {li}: {n}");
+            }
+        }
+        let bake_ok = bake.missing_specs.is_empty()
+            && bake.bad_expert_tensors.is_empty();
+        println!(
+            "  ready-for-decode: {}",
+            if bake_ok { "YES" } else { "NO" }
+        );
+        println!();
+    } else {
+        println!(
+            "[INT4 baked package] not present at .supersonic/v{}-int4-gptq/ \
+             (run `oracle/bake_int4.py` to produce one)",
+            model_store::manifest::FORMAT_VERSION
+        );
+        println!();
+    }
     println!("[VRAM budget]");
     println!(
         "  registry estimate (INT4 weights + KV @ ctx, ×overhead): {:.2} GiB",

--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -1,0 +1,420 @@
+//! Qwen3.6-MoE runtime engine.
+//!
+//! PR 3 stage: dry-run only. Loads `config.json`, enumerates the safetensors
+//! checkpoint, computes the analytic weight + state footprint, and reports
+//! it against the registry's VRAM budget. No GPU allocation, no kernel —
+//! that lands in PR 4 (CUDA) and PR 6 (HIP).
+//!
+//! The reason for the enumerate-only dry-run is the BF16 35B-A3B checkpoint
+//! is ~65 GiB and won't fit a 24 GiB GPU. Until the INT4/q4km bake exists,
+//! the only meaningful runtime check is "did the safetensors index match
+//! what we expect from the config" plus a budget comparison.
+
+use std::path::Path;
+
+use anyhow::{anyhow, Result};
+use qwen36_moe::config::{Config, TextConfig};
+use qwen36_moe::loader::{ScalarKind, WeightLoader};
+use qwen36_moe::state::{StateAccount, StateLayout};
+use qwen36_moe::weights::{
+    checkpoint_dtype_acceptable, expected_tensor_specs, CheckpointAccount, CheckpointDtype,
+    DEFAULT_PREFIX,
+};
+
+use crate::registry::{FamilyParams, Qwen36MoeKernelParams, RegistryEntry};
+
+const GIB: f64 = (1024 * 1024 * 1024) as f64;
+const MIB: f64 = (1024 * 1024) as f64;
+
+pub struct DryRunReport {
+    pub config: Config,
+    pub kernel_params: Qwen36MoeKernelParams,
+    pub checkpoint: CheckpointAccount,
+    pub int4_projected_bytes: u64,
+    pub state: StateAccount,
+    pub on_disk_bytes: Option<u64>,
+    pub on_disk_tensor_count: Option<usize>,
+    pub missing_tensors: Vec<String>,
+    pub dtype_mismatches: Vec<String>,
+    /// Set when safetensors files are partially present but the loader
+    /// couldn't open them (e.g. mid-download). The analytic accounting is
+    /// still emitted so the user gets useful output.
+    pub loader_warning: Option<String>,
+    pub registry_budget_bytes: u64,
+    pub gpu_total_vram_bytes: u64,
+}
+
+pub fn run_qwen36_moe_dry_run(
+    model_dir: &Path,
+    entry: &RegistryEntry,
+    total_vram: u64,
+    context_size: usize,
+    batch_size: usize,
+    kv_fp8: bool,
+    no_bake: bool,
+) -> Result<DryRunReport> {
+    let kernel_params = match entry.params {
+        FamilyParams::Qwen36Moe(p) => p,
+        _ => return Err(anyhow!("registry entry is not Qwen36Moe family")),
+    };
+
+    let config = qwen36_moe::config::load_config(model_dir)
+        .map_err(|e| anyhow!("parse config.json: {e}"))?;
+
+    sanity_check_kernel_params(&config.text_config, &kernel_params)?;
+
+    let weight_prefix = kernel_params.weight_prefix;
+    let specs = expected_tensor_specs(&config.text_config, weight_prefix);
+    let checkpoint = CheckpointAccount::from_config(&config.text_config);
+    let int4_projected_bytes = checkpoint.project_int4_total_bytes(&config.text_config, 128);
+
+    let layout = StateLayout::new(context_size, batch_size, kv_fp8);
+    let state = StateAccount::from_config(&config.text_config, layout);
+
+    let mut on_disk_bytes = None;
+    let mut on_disk_tensor_count = None;
+    let mut missing_tensors = Vec::new();
+    let mut dtype_mismatches = Vec::new();
+    let mut loader_warning = None;
+    if !no_bake_only_safetensors(model_dir, no_bake) {
+        // No safetensors expected — bake-only path. PR 3 doesn't yet open
+        // the baked store; revisit once PR 6 lands the INT4 reader.
+    } else if !has_safetensors(model_dir) {
+        // Safetensors missing AND no bake support yet — caller probably
+        // needs to download. Surface a helpful note rather than failing,
+        // because the analytic numbers are still useful.
+        loader_warning = Some(format!(
+            "no safetensors in {} — analytic accounting only",
+            model_dir.display()
+        ));
+    } else {
+        match WeightLoader::from_dir(model_dir) {
+            Ok(loader) => {
+                on_disk_tensor_count = Some(loader.tensor_count());
+                let mut total: u64 = 0;
+                let mut io_failures: usize = 0;
+                for spec in &specs {
+                    match loader.meta(&spec.name) {
+                        Ok(meta) => {
+                            total += meta.byte_size();
+                            let got_dtype = scalar_to_checkpoint_dtype(meta.dtype);
+                            if let Some(got) = got_dtype {
+                                if !checkpoint_dtype_acceptable(spec.role, got) {
+                                    dtype_mismatches.push(format!(
+                                        "{} got {:?} (not acceptable for {:?})",
+                                        spec.name, got, spec.role
+                                    ));
+                                }
+                            } else {
+                                dtype_mismatches.push(format!(
+                                    "{} got non-float dtype {:?}",
+                                    spec.name, meta.dtype
+                                ));
+                            }
+                        }
+                        Err(qwen36_moe::loader::LoadError::NotFound(_)) => {
+                            missing_tensors.push(spec.name.clone());
+                        }
+                        // Tensor is in the index but reading metadata failed
+                        // (e.g. shard file not yet present mid-download).
+                        // Don't kill the whole dry-run.
+                        Err(_) => io_failures += 1,
+                    }
+                }
+                on_disk_bytes = Some(total);
+                if io_failures > 0 {
+                    loader_warning = Some(format!(
+                        "{io_failures} tensors could not be read (likely partial download); \
+                         on-disk total is incomplete"
+                    ));
+                }
+            }
+            Err(e) => {
+                loader_warning = Some(format!(
+                    "could not open safetensors from {}: {e}",
+                    model_dir.display()
+                ));
+            }
+        }
+    }
+
+    let kv_bytes_per_token =
+        config.text_config.kv_bytes_per_token(if kv_fp8 { 1 } else { 2 });
+    let registry_budget_bytes = entry
+        .vram
+        .estimate_total(context_size, kv_bytes_per_token);
+
+    Ok(DryRunReport {
+        config,
+        kernel_params,
+        checkpoint,
+        int4_projected_bytes,
+        state,
+        on_disk_bytes,
+        on_disk_tensor_count,
+        missing_tensors,
+        dtype_mismatches,
+        loader_warning,
+        registry_budget_bytes,
+        gpu_total_vram_bytes: total_vram,
+    })
+}
+
+fn no_bake_only_safetensors(_model_dir: &Path, no_bake: bool) -> bool {
+    // PR 3 only supports safetensors. Future PRs will route to the baked
+    // store when `no_bake` is false and a bake is on disk.
+    let _ = no_bake;
+    true
+}
+
+fn has_safetensors(model_dir: &Path) -> bool {
+    model_dir.join("model.safetensors.index.json").exists()
+        || model_dir.join("model.safetensors").exists()
+}
+
+fn scalar_to_checkpoint_dtype(s: ScalarKind) -> Option<CheckpointDtype> {
+    match s {
+        ScalarKind::Bf16 => Some(CheckpointDtype::Bf16),
+        ScalarKind::F32 => Some(CheckpointDtype::F32),
+        _ => None,
+    }
+}
+
+fn sanity_check_kernel_params(
+    config: &TextConfig,
+    params: &Qwen36MoeKernelParams,
+) -> Result<()> {
+    if config.num_experts as u32 > params.num_experts {
+        return Err(anyhow!(
+            "config has num_experts={} but registry kernel scratch is sized for at most {}; \
+             update Qwen36MoeKernelParams or use a smaller checkpoint",
+            config.num_experts,
+            params.num_experts,
+        ));
+    }
+    if config.num_experts_per_tok as u32 > params.top_k {
+        return Err(anyhow!(
+            "config has num_experts_per_tok={} but registry kernel scratch is sized for top-{}; \
+             update Qwen36MoeKernelParams or use a smaller checkpoint",
+            config.num_experts_per_tok,
+            params.top_k,
+        ));
+    }
+    if config.moe_intermediate_size as u32 > params.moe_intermediate_size {
+        return Err(anyhow!(
+            "config moe_intermediate_size={} exceeds registry bound {}",
+            config.moe_intermediate_size,
+            params.moe_intermediate_size,
+        ));
+    }
+    if config.shared_expert_intermediate_size as u32 > params.shared_expert_intermediate_size {
+        return Err(anyhow!(
+            "config shared_expert_intermediate_size={} exceeds registry bound {}",
+            config.shared_expert_intermediate_size,
+            params.shared_expert_intermediate_size,
+        ));
+    }
+    Ok(())
+}
+
+pub fn print_report(report: &DryRunReport) {
+    let cfg = &report.config.text_config;
+    println!("[qwen3.6-moe] dry-run summary");
+    println!(
+        "  arch:           hidden={} layers={} (full={} linear={}) Q/KV heads={}/{} head_dim={}",
+        cfg.hidden_size,
+        cfg.num_hidden_layers,
+        cfg.num_full_attention_layers(),
+        cfg.num_linear_attention_layers(),
+        cfg.num_attention_heads,
+        cfg.num_key_value_heads,
+        cfg.head_dim,
+    );
+    println!(
+        "  moe:            num_experts={} top_k={} moe_int={} shared_int={} norm_topk={} attn_output_gate={}",
+        cfg.num_experts,
+        cfg.num_experts_per_tok,
+        cfg.moe_intermediate_size,
+        cfg.shared_expert_intermediate_size,
+        cfg.norm_topk_prob,
+        cfg.attn_output_gate,
+    );
+    println!(
+        "  vocab:          {}    rope_theta={}    max_pos={}    tie_embed={}",
+        cfg.vocab_size,
+        cfg.rope_theta(),
+        cfg.max_position_embeddings,
+        cfg.tie_word_embeddings,
+    );
+    let kp = &report.kernel_params;
+    println!(
+        "  kernel params:  prefix={} kv_chunk={} proj_buf_f={} attn_scratch_f={} moe_scratch_f={}",
+        kp.weight_prefix,
+        kp.kv_chunk_size,
+        kp.proj_buf_floats,
+        kp.attn_scratch_floats,
+        kp.moe_scratch_floats,
+    );
+    println!();
+    println!("[checkpoint accounting (analytic, BF16 + F32 mix)]");
+    println!(
+        "  embed:          {:>8.2} GiB",
+        report.checkpoint.embed_bytes as f64 / GIB
+    );
+    println!(
+        "  lm_head:        {:>8.2} GiB",
+        report.checkpoint.lm_head_bytes as f64 / GIB
+    );
+    println!(
+        "  full attn:      {:>8.2} GiB ({} layers × {:.1} MiB)",
+        (report.checkpoint.num_full_layers * report.checkpoint.full_attn_bytes_per_layer) as f64
+            / GIB,
+        report.checkpoint.num_full_layers,
+        report.checkpoint.full_attn_bytes_per_layer as f64 / MIB,
+    );
+    println!(
+        "  linear attn:    {:>8.2} GiB ({} layers × {:.1} MiB)",
+        (report.checkpoint.num_linear_layers * report.checkpoint.linear_attn_bytes_per_layer)
+            as f64
+            / GIB,
+        report.checkpoint.num_linear_layers,
+        report.checkpoint.linear_attn_bytes_per_layer as f64 / MIB,
+    );
+    let n_hidden = cfg.num_hidden_layers as u64;
+    println!(
+        "  routers:        {:>8.2} GiB ({} layers × {:.1} MiB)",
+        (n_hidden * report.checkpoint.router_bytes_per_layer) as f64 / GIB,
+        n_hidden,
+        report.checkpoint.router_bytes_per_layer as f64 / MIB,
+    );
+    println!(
+        "  shared experts: {:>8.2} GiB ({} layers × {:.1} MiB)",
+        (n_hidden * report.checkpoint.shared_expert_bytes_per_layer) as f64 / GIB,
+        n_hidden,
+        report.checkpoint.shared_expert_bytes_per_layer as f64 / MIB,
+    );
+    println!(
+        "  routed experts: {:>8.2} GiB ({} layers × {:.1} GiB / {} experts)",
+        (n_hidden * report.checkpoint.experts_bytes_per_layer) as f64 / GIB,
+        n_hidden,
+        report.checkpoint.experts_bytes_per_layer as f64 / GIB,
+        cfg.num_experts,
+    );
+    println!(
+        "  TOTAL (BF16):   {:>8.2} GiB",
+        report.checkpoint.total_bytes as f64 / GIB
+    );
+    println!(
+        "  TOTAL (INT4):   {:>8.2} GiB  (projected, gs=128)",
+        report.int4_projected_bytes as f64 / GIB
+    );
+    println!();
+    println!("[state accounting]");
+    println!(
+        "  KV cache (full attn): {:>8.2} GiB",
+        report.state.full_kv_bytes as f64 / GIB,
+    );
+    println!(
+        "  linear conv state:  {:>8.2} MiB",
+        report.state.linear_conv_state_bytes as f64 / MIB
+    );
+    println!(
+        "  linear recurrent:   {:>8.2} MiB",
+        report.state.linear_recurrent_state_bytes as f64 / MIB
+    );
+    println!(
+        "  moe scratch:        {:>8.2} KiB",
+        report.state.moe_scratch_bytes as f64 / 1024.0
+    );
+    println!(
+        "  activations:        {:>8.2} KiB",
+        report.state.activation_bytes as f64 / 1024.0
+    );
+    println!(
+        "  TOTAL state:        {:>8.2} GiB",
+        report.state.total_bytes as f64 / GIB
+    );
+    println!();
+    if let (Some(on_disk), Some(count)) = (report.on_disk_bytes, report.on_disk_tensor_count) {
+        println!("[on-disk safetensors]");
+        println!("  tensor count:    {count}");
+        println!(
+            "  total bytes:     {:.2} GiB  (analytic predicted {:.2} GiB; drift {:+.2} MiB)",
+            on_disk as f64 / GIB,
+            report.checkpoint.total_bytes as f64 / GIB,
+            (on_disk as f64 - report.checkpoint.total_bytes as f64) / MIB,
+        );
+        if !report.missing_tensors.is_empty() {
+            println!(
+                "  MISSING TENSORS: {} (showing first 10)",
+                report.missing_tensors.len()
+            );
+            for n in report.missing_tensors.iter().take(10) {
+                println!("    - {n}");
+            }
+        }
+        if !report.dtype_mismatches.is_empty() {
+            println!(
+                "  DTYPE MISMATCHES: {} (showing first 10)",
+                report.dtype_mismatches.len()
+            );
+            for n in report.dtype_mismatches.iter().take(10) {
+                println!("    - {n}");
+            }
+        }
+    } else {
+        println!("[on-disk safetensors] not present at model-dir; analytic numbers only");
+    }
+    if let Some(w) = &report.loader_warning {
+        println!("  WARNING: {w}");
+    }
+    println!();
+    println!("[VRAM budget]");
+    println!(
+        "  registry estimate (INT4 weights + KV @ ctx, ×overhead): {:.2} GiB",
+        report.registry_budget_bytes as f64 / GIB
+    );
+    println!(
+        "  detected GPU VRAM:                                       {:.2} GiB",
+        report.gpu_total_vram_bytes as f64 / GIB
+    );
+    let fits = report.registry_budget_bytes <= report.gpu_total_vram_bytes;
+    println!(
+        "  fit:                                                     {}",
+        if fits { "YES" } else { "NO" }
+    );
+    if !fits {
+        println!(
+            "  (BF16 weights alone need ~{:.1} GiB; an INT4/q4km bake is required.)",
+            report.checkpoint.total_bytes as f64 / GIB
+        );
+    }
+}
+
+pub fn run(
+    cli: &crate::Cli,
+    entry: &RegistryEntry,
+    total_vram: u64,
+) -> Result<()> {
+    if !cli.dry_run {
+        anyhow::bail!(
+            "qwen3.6-35b-a3b runtime: only --dry-run is implemented at this stage. \
+             Re-run with --dry-run to enumerate weights, compute the VRAM budget, \
+             and exit. Full decode lands in PR 4 (CUDA) and PR 6 (HIP)."
+        );
+    }
+    let context_size = cli
+        .context_size
+        .unwrap_or_else(|| cli.max_new_tokens.max(1));
+    let report = run_qwen36_moe_dry_run(
+        &cli.model_dir,
+        entry,
+        total_vram,
+        context_size,
+        cli.batch_size.max(1),
+        cli.kv_fp8,
+        cli.no_bake,
+    )?;
+    print_report(&report);
+    Ok(())
+}

--- a/crates/runner/src/registry.rs
+++ b/crates/runner/src/registry.rs
@@ -227,8 +227,33 @@ pub struct Llama31KernelParams {
     pub kv_chunk_size: usize,
 }
 
+/// Sanity bounds + scratch sizes for the Qwen3.6-MoE megakernel. The
+/// `num_experts` / `top_k` / `moe_intermediate_size` fields are NOT the
+/// source of truth — those come from the parsed `config.json`. They live
+/// here so we can refuse to launch a kernel against a checkpoint whose
+/// expert count blows past the megakernel's static scratch sizing.
+///
+/// Scratch fields are placeholder until PR 4 (CUDA kernel) lands. The values
+/// chosen here are conservative upper bounds drawn from the analytic state
+/// account in `qwen36_moe::state` — large enough for batch=1 decode at the
+/// 35B-A3B geometry without overpromising what the kernel will actually
+/// allocate.
+#[derive(Clone, Copy)]
+pub struct Qwen36MoeKernelParams {
+    pub weight_prefix: &'static str,
+    pub kv_chunk_size: usize,
+    pub proj_buf_floats: usize,
+    pub attn_scratch_floats: usize,
+    pub moe_scratch_floats: usize,
+    pub num_experts: u32,
+    pub top_k: u32,
+    pub moe_intermediate_size: u32,
+    pub shared_expert_intermediate_size: u32,
+}
+
 pub enum FamilyParams {
     Qwen35(Qwen35KernelParams),
+    Qwen36Moe(Qwen36MoeKernelParams),
     Gemma4(Gemma4KernelParams),
     Phi4(Phi4KernelParams),
     Llama31(Llama31KernelParams),
@@ -601,6 +626,51 @@ static REGISTRY: &[RegistryEntry] = &[
             kv_chunk_size: 256,
         }),
     },
+    // Qwen3.6-35B-A3B INT4 GPTQ on AMD gfx1100. Primary AMD v1 target.
+    // BF16 won't fit 24 GiB; this entry assumes the INT4 bake. PR 3
+    // wires it for the dry-run path; PR 6 lands the kernel.
+    RegistryEntry {
+        model: ModelVariant::Qwen3_6_35B_A3B,
+        backend: Backend::Hip,
+        arch: GpuArch::Gfx1100,
+        vram: VramBudget {
+            fixed_bytes: 19 * GIB,
+            overhead_factor: 1.1,
+        },
+        params: FamilyParams::Qwen36Moe(Qwen36MoeKernelParams {
+            weight_prefix: "model.language_model",
+            kv_chunk_size: 256,
+            proj_buf_floats: 16_480,
+            attn_scratch_floats: 24_576,
+            moe_scratch_floats: 4_096,
+            num_experts: 256,
+            top_k: 8,
+            moe_intermediate_size: 512,
+            shared_expert_intermediate_size: 512,
+        }),
+    },
+    // Qwen3.6-35B-A3B q4km on NVIDIA sm86. Primary CUDA v1 target. PR 4 lands
+    // the kernel.
+    RegistryEntry {
+        model: ModelVariant::Qwen3_6_35B_A3B,
+        backend: Backend::Cuda,
+        arch: GpuArch::Sm86,
+        vram: VramBudget {
+            fixed_bytes: 22 * GIB,
+            overhead_factor: 1.1,
+        },
+        params: FamilyParams::Qwen36Moe(Qwen36MoeKernelParams {
+            weight_prefix: "model.language_model",
+            kv_chunk_size: 256,
+            proj_buf_floats: 16_480,
+            attn_scratch_floats: 24_576,
+            moe_scratch_floats: 4_096,
+            num_experts: 256,
+            top_k: 8,
+            moe_intermediate_size: 512,
+            shared_expert_intermediate_size: 512,
+        }),
+    },
 ];
 
 pub fn lookup(
@@ -703,6 +773,30 @@ mod tests {
         );
         assert_eq!(ModelVariant::Qwen3_6_35B_A3B.to_string(), "qwen3.6-35b-a3b");
         assert!(supported_models_list().contains(&"qwen3.6-27b"));
+        assert!(supported_models_list().contains(&"qwen3.6-35b-a3b"));
+    }
+
+    #[test]
+    fn qwen36_moe_registry_entries_carry_real_geometry() {
+        for (backend, arch) in [
+            (Backend::Hip, GpuArch::Gfx1100),
+            (Backend::Cuda, GpuArch::Sm86),
+        ] {
+            let entry = lookup(&ModelVariant::Qwen3_6_35B_A3B, &backend, &arch)
+                .unwrap_or_else(|| panic!("qwen3.6-35b-a3b {backend} {arch} entry"));
+            match entry.params {
+                FamilyParams::Qwen36Moe(p) => {
+                    assert_eq!(p.weight_prefix, "model.language_model");
+                    assert_eq!(p.num_experts, 256);
+                    assert_eq!(p.top_k, 8);
+                    assert_eq!(p.moe_intermediate_size, 512);
+                    assert_eq!(p.shared_expert_intermediate_size, 512);
+                }
+                _ => panic!("qwen3.6-35b-a3b must use Qwen36Moe family params"),
+            }
+            // VRAM budget must leave headroom on a 24 GiB card.
+            assert!(entry.vram.fixed_bytes <= 24 * GIB);
+        }
     }
 
     #[test]

--- a/docs/qwen36-moe-plan.md
+++ b/docs/qwen36-moe-plan.md
@@ -1,0 +1,824 @@
+# Qwen3.6-35B-A3B MoE Runtime — Plan
+
+Status: **planning, no code yet** · drafted 2026-04-30
+
+This plan turns the existing `Qwen36Moe` registry placeholder into a working
+end-to-end decode path. The placeholder bails out at startup
+(`crates/runner/src/main.rs:1067`, also `crates/server/src/state.rs:159`); this
+document is the bridge from "recognised but unimplemented" to "decodes 8
+tokens that match a PyTorch oracle".
+
+The work is large enough that follow-up sessions should break it into
+PR-sized chunks before any code lands. Section 12 sketches that sequencing.
+
+---
+
+## 1. Background
+
+The model is a Qwen3-Next-class **hybrid linear/full-attention MoE**:
+
+- **Attention is the same family as Qwen3.5** — every fourth layer is full
+  attention, the others are linear (conv1d + recurrent state). This is
+  already in production in `crates/qwen35` and the decision in
+  `oracle/bake_q4km.py:805–812` ("`linear_attention` if `(i+1) % 4 != 0`")
+  applies unchanged. We do **not** need a new attention kernel.
+- **The FFN is replaced with MoE**: a routing gate plus N experts (each a
+  SwiGLU block) plus an always-on **shared expert**. Top-k routing (k≈8–10)
+  with `norm_topk_prob=true` and a small load-balancing aux loss
+  coefficient (irrelevant at inference).
+- **Total params ≈ 35B, active ≈ 3B per token.** All expert weights must
+  live in VRAM — there is no streaming path in SuperSonic today and adding
+  one is out of scope for v1.
+
+The Python bake side is **already MoE-aware**:
+
+- `oracle/bake_q4km.py:1064–1066` and `oracle/q4km_stream_gptq_bake.py:297`
+  emit `model_family: "qwen36-moe"` when the model name contains `35b-a3b`.
+- `oracle/bake_fp8.py:120–135` recognises the same family.
+- `oracle/upload_bake.py:78` maps `qwen3.6-35b-a3b → qwen36-moe`.
+- `is_q4km_target` (`oracle/bake_q4km.py:600–620`) already includes
+  `experts` in the include set and excludes `.gate.` / `router`, so router
+  weights stay BF16 and expert FFN matrices get INT4-packed.
+- `docs/bake-distribution.md:36` lists `qwen3.6-35b-a3b` as a supported
+  upload model.
+
+The **runtime side has nothing**. There is no engine, no kernel, no FFI
+module, no model crate. Both `main.rs:1067–1074` and
+`server/src/state.rs:159` bail before registry lookup. The
+`ModelFamily::Qwen36Moe` and `ModelVariant::Qwen3_6_35B_A3B` enum variants,
+plus the CLI alias parsing, are the only existing runtime hooks.
+
+---
+
+## 2. What we know about the architecture
+
+Confirmed from the Qwen3-Next config family (the same `Qwen3NextForCausalLM`
+class that 35B-A3B inherits) and from the existing Qwen3.5 implementation:
+
+| Aspect              | Value (proxy from 80B-A3B; verify for 35B) |
+|---------------------|---------------------------------------------|
+| Architecture class  | `Qwen3NextForCausalLM`                      |
+| Hidden size         | 2048                                        |
+| Attention layers    | hybrid: 1 full per 4 layers, 3 linear       |
+| Full-attn heads     | 16 Q heads, 2 KV heads (GQA), head_dim 256  |
+| Linear-attn heads   | 16 K-heads, 32 V-heads, head_dim 128        |
+| Linear conv kernel  | 4                                           |
+| Partial RoPE        | 0.25 of head_dim rotated, theta 1e7         |
+| Vocab               | 151,936                                     |
+| Tied embeddings     | false                                       |
+| Layer count         | 48 (verify for 35B)                         |
+| Experts             | 512 routed (verify for 35B; likely 128–256) |
+| Top-k               | 10 (verify; likely 6–8)                     |
+| Expert FFN intermediate | 512 (verify)                            |
+| Shared expert       | yes, intermediate 512                       |
+| Router norm         | `norm_topk_prob=true` (renormalise top-k)   |
+| Aux loss coef       | 0.001 (irrelevant at inference)             |
+| Dense FFN intermediate | 5120 (used only if `mlp_only_layers`     |
+|                     | non-empty; for 35B-A3B this should be empty) |
+
+**Critical open spike:** the 35B-A3B variant's exact (num_experts, top_k,
+moe_intermediate_size, num_hidden_layers) need to be read off the actual
+HF `config.json` once we have weights. A first PR should land a
+`crates/qwen36_moe/src/config.rs` that parses these fields and asserts the
+shape against the bake manifest, **before** any kernel work begins.
+
+### Tensor naming (Qwen3-Next / HF transformers convention)
+
+Confirmed by `oracle/q4km_bake_oracle.py:101` (`.mlp.gate_proj.weight`) and
+the standard HF Qwen3-MoE class naming. **Not Mixtral `w1/w2/w3`.**
+
+```
+model.language_model.embed_tokens.weight
+model.language_model.norm.weight
+lm_head.weight                                          # untied
+
+# Per layer L ∈ [0, num_hidden_layers):
+model.language_model.layers.{L}.input_layernorm.weight
+model.language_model.layers.{L}.post_attention_layernorm.weight
+
+# Full attention layers (every 4th):
+model.language_model.layers.{L}.self_attn.{q,k,v,o}_proj.weight
+model.language_model.layers.{L}.self_attn.{q,k}_norm.weight
+
+# Linear attention layers (the other 3 of 4):
+model.language_model.layers.{L}.linear_attn.in_proj_qkv.weight
+model.language_model.layers.{L}.linear_attn.in_proj_z.weight
+model.language_model.layers.{L}.linear_attn.in_proj_a.weight
+model.language_model.layers.{L}.linear_attn.in_proj_b.weight
+model.language_model.layers.{L}.linear_attn.out_proj.weight
+model.language_model.layers.{L}.linear_attn.conv1d.weight
+model.language_model.layers.{L}.linear_attn.dt_bias
+model.language_model.layers.{L}.linear_attn.A_log
+model.language_model.layers.{L}.linear_attn.norm.weight
+
+# MoE block (this is the new bit):
+model.language_model.layers.{L}.mlp.gate.weight                              # router
+model.language_model.layers.{L}.mlp.experts.{E}.{gate,up,down}_proj.weight   # E ∈ [0, num_experts)
+model.language_model.layers.{L}.mlp.shared_expert.{gate,up,down}_proj.weight
+model.language_model.layers.{L}.mlp.shared_expert_gate.weight                # scalar gate
+```
+
+**Bake interaction with `is_q4km_target`** (already correct, no Python
+changes needed):
+
+- `mlp.gate.weight`: excluded by the `.gate.` substring check → stays BF16.
+- `mlp.shared_expert_gate.weight`: also excluded by `.gate.` → stays BF16.
+- `mlp.experts.{E}.gate_proj.weight` and friends: included via `experts` →
+  packed INT4 + BF16 scale/zero sidecars.
+- `mlp.shared_expert.gate_proj.weight` etc: included via `_proj` → packed
+  INT4. Same as a dense FFN tensor.
+
+Verify after first bake: `grep mlp.gate.weight manifest.json` should show
+`"layout": "Raw"`, and `grep experts.0.gate_proj manifest.json` should show
+`"layout": "Int4Quantized"` plus a sibling `…_int4_scale` and `…_int4_zero`.
+
+---
+
+## 3. Crate & file layout
+
+We follow the **Phi4 template** — the smallest "added a new family" landed
+recently — strictly. The CLAUDE.md rule about isolated compilation units is
+non-negotiable on gfx11xx; merging kernels with Qwen3.5 has caused codegen
+regressions before. New files only, never extending Qwen3.5 sources.
+
+| New file                                         | Purpose                                          | Approx LoC |
+|--------------------------------------------------|--------------------------------------------------|------------|
+| `crates/qwen36_moe/Cargo.toml`                   | new crate                                        | ~25        |
+| `crates/qwen36_moe/src/lib.rs`                   | re-exports                                       | ~10        |
+| `crates/qwen36_moe/src/config.rs`                | parse `config.json`, MoE fields                  | ~250       |
+| `crates/qwen36_moe/src/loader.rs`                | bake-store reader, glue                          | ~200       |
+| `crates/qwen36_moe/src/weights.rs`               | per-layer expert/router weight slabs             | ~600       |
+| `crates/qwen36_moe/src/state.rs`                 | KV caches + linear-attn state + MoE scratch      | ~350       |
+| `crates/qwen36_moe/src/rotary.rs`                | partial-RoPE helpers                             | ~80        |
+| `crates/qwen36_moe/src/desc_builder.rs`          | builds the FFI layer-desc array                  | ~250       |
+| `crates/runner/src/qwen36_moe_engine.rs`         | top-level engine: prefill + decode loop          | ~1100      |
+| `crates/kernel-ffi/src/qwen36_moe.rs`            | FFI declarations + safe wrapper                  | ~500       |
+| `kernels/qwen36_moe.hip`                         | HIP megakernel                                   | ~6500      |
+| `kernels/qwen36_moe_bridge.cpp`                  | HIP launch glue                                  | ~250       |
+| `kernels/qwen36_moe_cuda.cuh`                    | CUDA megakernel (header-shared template)         | ~6500      |
+| `kernels/qwen36_moe_bridge_cuda.cu`              | CUDA launch glue                                 | ~250       |
+| `oracle/qwen36_moe_oracle.py`                    | HF reference forward, JSON state export          | ~600       |
+
+Edits to existing files (small, surgical):
+
+- `crates/kernel-ffi/build.rs` — add the four new kernel sources to the
+  HIP and CUDA source arrays, plus `cargo:rerun-if-changed` lines (~10 LoC).
+- `crates/kernel-ffi/src/lib.rs` — `pub mod qwen36_moe;` (~1 LoC).
+- `crates/runner/src/main.rs` — replace the bail at line 1067 with the
+  registry-lookup path; add `mod qwen36_moe_engine;`; add the new arm to
+  the family `match` at line 1173 (~5 LoC delta).
+- `crates/runner/src/registry.rs` — extend `FamilyParams` with a
+  `Qwen36Moe(Qwen36MoeKernelParams)` variant; add at least one
+  `RegistryEntry` (see §6); update test fixtures.
+- `crates/server/src/state.rs:159` — drop the bail, route to the new family.
+- `Cargo.toml` workspace members — add `crates/qwen36_moe`.
+
+**Total budget: roughly 17–18k LoC, dominated by the kernel.** This is in
+line with Gemma4 (~13k) and Qwen3.5 (~26k including dual kernels), and
+larger than Phi4 (~7k) because MoE adds expert-dispatch logic.
+
+### What `Qwen36MoeKernelParams` should carry
+
+```rust
+pub struct Qwen36MoeKernelParams {
+    pub weight_prefix: &'static str,        // "model.language_model"
+    pub kv_chunk_size: usize,               // 256 default, like Qwen3.5
+    pub proj_buf_floats: usize,             // attention scratch
+    pub attn_scratch_floats: usize,
+    pub moe_scratch_floats: usize,          // top-k softmax + expert outs
+    pub num_experts: u32,                   // pulled from config.json
+    pub top_k: u32,
+    pub moe_intermediate_size: u32,
+    pub shared_expert_intermediate_size: u32,
+}
+```
+
+The `num_experts` / `top_k` fields are **not** the source of truth — those
+come from the parsed `config.json`. They live in the registry only as
+sanity-check bounds (so we can refuse to launch a 35B-A3B kernel against a
+weights file with 1024 experts, etc.).
+
+---
+
+## 4. Kernel design strategy
+
+This is the design-critical section. The megakernel pattern means the
+**entire** decode step (norms, attention, MoE FFN, residuals) lives in one
+persistent kernel. The hard question is how to dispatch experts inside one
+kernel: top-k routing makes per-token expert work irregular.
+
+We outline three approaches, then pick.
+
+### Option A — Per-token expert loop (simplest)
+
+Each block strides over tokens. For each token it does:
+1. Compute router logits via mat-vec against `mlp.gate.weight`.
+2. Softmax over routes, pick top-k indices, renormalise (because
+   `norm_topk_prob=true`).
+3. Loop over the k selected experts in serial; each iteration is a
+   SwiGLU mat-vec against that expert's `gate_proj`/`up_proj`/`down_proj`.
+4. Add the shared expert (gated by `shared_expert_gate.weight` scalar).
+5. Add residual.
+
+**Pros:** trivial control flow, mirrors Qwen3.5's block-strided MLP exactly.
+LDS budget identical to Qwen3.5 because at any one moment only one expert's
+tile is loaded.
+
+**Cons:** for batch=1 this serialises k expert mat-vecs across the same set
+of blocks. With ~24 CUs on gfx1100 and `top_k≈8`, we leave most CUs idle
+during each expert step — the per-expert mat-vec is small (`hidden ×
+moe_intermediate ≈ 2048 × 512`) and a single mat-vec doesn't fill the GPU.
+
+### Option B — Expert-major, token-compacted
+
+Per layer:
+1. Compute routing for all batch tokens, build a compacted token list per
+   expert via in-kernel prefix-sum / atomics.
+2. For each expert that has ≥1 routed token, do one batched mat-vec across
+   those tokens.
+
+**Pros:** at batch>1 this amortises expert weight reads — multiple tokens
+sharing an expert pay one weight-traffic cost.
+
+**Cons:** at batch=1 it degenerates to Option A but with extra compaction
+overhead. The compaction itself is O(num_experts × batch) atomics + a
+barrier, which is non-trivial inside the megakernel. Adds ~500 LoC of
+in-kernel scratch management (per-expert offsets, atomic counters, sync).
+
+### Option C — Per-block (token, expert) work units (chosen)
+
+For each layer:
+1. Compute routing for all batch tokens, write a flat list of `(token,
+   expert, weight)` work units to scratch — total `batch × top_k` units
+   plus `batch` shared-expert units.
+2. Use the existing **work-stealing atomic-counter + grid barrier** pattern
+   (`sync_buf` / `g4_grid_barrier`) to dispatch work units across all
+   blocks. Each block fetches `next_unit = atomicAdd(counter, 1)` and
+   processes one (token, expert) mat-vec.
+3. Down-projection accumulates per-token outputs via atomics into a
+   scratch buffer indexed by token_id.
+4. After grid barrier, blocks add the residual and move to the next layer.
+
+**Pros:**
+- **Reuses an existing primitive.** The work-stealing matmul is already in
+  `kernels/full_attention_4b.hip` and well-debugged; we are not inventing
+  scheduling from scratch.
+- **For batch=1 with top_k=8 and a shared expert: 9 work units per layer,
+  spread across all 24+ CUs.** Each CU runs a different expert's
+  mat-vec concurrently — that's exactly the parallelism we need to hide
+  the small per-expert mat-vec size.
+- **Down-proj atomics are cheap** because per-token writes are
+  per-(token, hidden_dim) and conflicts are rare; on RDNA3 we can use
+  `atomicAdd(half2*)` on BF16 pairs.
+- **Trivially extends to batch>1** without a re-architecture.
+- **LDS budget stays Qwen3.5-like** — one expert tile per block at any
+  time.
+
+**Cons:**
+- The atomics-into-residual write needs a scratch-buffer cleanup pass.
+- The work-unit list itself takes scratch (`batch × (top_k + 1) × 8 bytes`,
+  trivial).
+
+**Pick: Option C.** It's the only one that exploits inter-expert
+parallelism at batch=1, which is the dominant decode case, and it leans on
+a primitive we already trust.
+
+### Routing precision
+
+Router logits and softmax run in **FP32**. `mlp.gate.weight` is BF16
+(excluded from INT4 by `is_q4km_target`). Top-k selection is a reduction
+over `num_experts`; for ≤512 experts a single-block bitonic sort or a
+selection-via-threshold-search works inside one block's LDS. Pick
+selection-by-radix or threshold-bisection in the implementation PR; both
+are O(num_experts × log num_experts) and fit in LDS for ≤512 experts.
+
+### gfx1100 occupancy & LDS budget
+
+Worst-case LDS use per block during MoE step:
+- `hidden_size = 2048` BF16 input row: 4 KiB
+- One expert tile (`block_n × group_size = 128 × 128` INT4 + scales):
+  ~8 KiB
+- Per-block `top_k` work-unit metadata: ~80 bytes
+- Total: ~12 KiB — well under gfx1100's 64 KiB LDS per WG cap; we should
+  comfortably hit ≥2 wavefronts/CU. Same envelope as Qwen3.5-9B which
+  already runs.
+
+Cross-check this against the actual config in the implementation PR — if
+`moe_intermediate_size` for 35B is larger than 512 the tile size must
+follow, and LDS pressure goes up.
+
+---
+
+## 5. Model state (mostly inherited from Qwen3.5)
+
+Qwen3.5's state (`crates/qwen35/src/state.rs`) already covers everything we
+need *except* the MoE-specific scratch:
+
+- KV caches per full-attention layer (chunked, default 256-token chunks).
+- Linear-attention conv state + recurrent state per linear layer.
+- RoPE tables.
+- Per-layer norms (kept in F32).
+
+What Qwen3.6-MoE adds:
+
+- **MoE scratch** (`moe_scratch_floats` in registry params): top-k
+  softmax buffer (`batch × top_k × 2` for index+weight), per-token
+  expert-output accumulator (`batch × hidden_size` BF16), router logits
+  scratch (`batch × num_experts` FP32), work-unit list (`batch × (top_k +
+  1) × 16` bytes).
+- **Shared expert output buffer**: same shape as a single expert's down
+  output; reused across layers.
+
+We do **not** copy the Qwen3.5 state struct into `qwen36_moe::state`. The
+crate gets its own struct so changes to one family can never silently
+ripple into the other. Code-level duplication is fine and explicitly
+encouraged by CLAUDE.md.
+
+---
+
+## 6. VRAM budgeting & the registry entry
+
+### Per-quant size (35B params, ignoring norms/embeddings)
+
+| Quant       | bits/weight | Weights only | + scales | + activations + KV (4K ctx) | Fits 24 GiB? |
+|-------------|-------------|--------------|----------|------------------------------|--------------|
+| BF16        | 16          | 70 GiB       | —        | ~71 GiB                      | no           |
+| FP8 native  | 8           | 35 GiB       | + ~0.5%  | ~36 GiB                      | no           |
+| INT4 GPTQ   | 4 + scales  | 17.5 GiB     | + ~0.6 GiB | ~19.5 GiB                  | yes          |
+| q4km (GGML) | ~4.5        | 19.7 GiB     | inline   | ~21 GiB                      | yes (tight)  |
+| q4km-gptq   | ~4.5        | ~19.7 GiB    | mixed    | ~21 GiB                      | yes (tight)  |
+
+### Initial registry entries to add
+
+For each entry, set `fixed_bytes` to weights-only (the runtime adds KV on
+top via `estimate_total`). The `overhead_factor` stays at 1.1 to match
+existing entries.
+
+```rust
+// HIP gfx1100, INT4 GPTQ — primary AMD target.
+RegistryEntry {
+    model: ModelVariant::Qwen3_6_35B_A3B,
+    backend: Backend::Hip,
+    arch: GpuArch::Gfx1100,
+    vram: VramBudget { fixed_bytes: 19 * GIB, overhead_factor: 1.1 },
+    params: FamilyParams::Qwen36Moe(Qwen36MoeKernelParams { /* … */ }),
+},
+
+// CUDA sm86, q4km — primary NVIDIA target.
+RegistryEntry {
+    model: ModelVariant::Qwen3_6_35B_A3B,
+    backend: Backend::Cuda,
+    arch: GpuArch::Sm86,
+    vram: VramBudget { fixed_bytes: 22 * GIB, overhead_factor: 1.1 },
+    params: FamilyParams::Qwen36Moe(Qwen36MoeKernelParams { /* … */ }),
+},
+```
+
+The numbers above must be **re-confirmed against an actual bake**. The
+plan PR should not freeze them; the implementation PR will measure and
+adjust.
+
+### What about gfx1150?
+
+gfx1150 is an APU with unified memory; its VRAM is system RAM minus what
+the OS holds. A 32 GiB APU could just about host a 19 GiB INT4 bake. We
+do **not** add a gfx1150 registry entry in v1 — it's a "see if it works
+opportunistically" scenario, not a committed combo. Users can pass
+`--allow-untested-gpu=gfx1100` to force-reuse the gfx1100 kernel.
+
+---
+
+## 7. Quant matrix for v1
+
+Given:
+
+- **q4km is currently CUDA-only** (`crates/runner/src/main.rs:1035–1037`
+  bails if `q4km_like && backend != Backend::Cuda`). Lifting that gate is
+  a separate project — not in scope here.
+- **INT4 GPTQ already works on HIP** for Qwen3.5; the existing
+  `oracle/bake_int4.py` calibration path will pick up MoE expert tensors
+  via `is_q4km_target`/`is_int4_target` matching `experts`/`_proj` with
+  no MoE-specific changes (Hessians are pooled per-layer across experts —
+  `oracle/bake_int4.py:72–82` confirms there is no per-expert logic, which
+  is acceptable because all experts in a layer see calibration traffic).
+- **FP8 bake is also already MoE-aware** (`oracle/bake_fp8.py`), but FP8
+  weights at 35B don't fit 24 GiB so it's not useful for the primary
+  targets.
+
+**v1 quant matrix:**
+
+| Backend | Arch    | Quant       | Bake script                    | Status  |
+|---------|---------|-------------|--------------------------------|---------|
+| HIP     | gfx1100 | INT4 GPTQ   | `oracle/bake_int4.py`          | **v1**  |
+| CUDA    | sm86    | q4km        | `oracle/bake_q4km.py` + GGUF   | **v1**  |
+| CUDA    | sm86    | q4km-gptq   | `oracle/bake_q4km.py --quantizer gptq` | **v1** |
+| HIP     | gfx1100 | q4km        | (needs HIP q4km kernel — out of scope) | v2 |
+| any     | any     | BF16 / FP8  | (won't fit 24 GiB)             | n/a     |
+
+Picking **two quants** for v1 is deliberate: q4km is a separate code path
+on the kernel side (GGML K-block dequant vs SuperSonic-native INT4
+dequant), and we want both validated end-to-end before declaring the
+runtime done. The CUDA megakernel must support both `Int4Quantized` and
+`GgmlQ4K` weight layouts; both already exist for Qwen3.5 in the CUDA
+build.
+
+---
+
+## 8. Backend matrix for v1
+
+- **HIP gfx1100** — primary AMD target. Single megakernel
+  (`kernels/qwen36_moe.hip`). INT4 GPTQ only.
+- **CUDA sm86** — primary NVIDIA target. Single megakernel
+  (`kernels/qwen36_moe_cuda.cuh` + `_bridge_cuda.cu`). q4km and INT4 GPTQ
+  both supported.
+
+**Out of v1 scope:** Metal (Apple M4), gfx1150 explicit support. Both can
+be added later by registry-only changes if the kernel ports cleanly; no
+new design work needed in this plan.
+
+---
+
+## 9. Bake distribution
+
+35B at q4km is ~22 GiB compressed; the existing tarball pipeline already
+handles >1.8 GiB by splitting into `.part01`, `.part02` etc. (see
+`docs/bake-distribution.md:32–40`).
+
+**Day-1 publish list** (each ≥10 GiB tar.zst, multi-part):
+
+- `qwen3.6-35b-a3b-int4-gptq-fmt2-cvt1.tar.zst.part{01..NN}` (HIP target).
+- `qwen3.6-35b-a3b-q4km-fmt2-cvt1.tar.zst.part{01..NN}` (CUDA target).
+- `qwen3.6-35b-a3b-q4km-gptq-fmt2-cvt1.tar.zst.part{01..NN}` (CUDA, better
+  perplexity).
+
+The producer flow is unchanged — `oracle/upload_bake.py` already accepts
+`qwen3.6-35b-a3b` (line 59). Bakes-index v1 schema covers it. **We do
+need release-hosted bakes from day 1** because:
+
+- 35B GPTQ calibration on a single 24 GiB GPU host takes hours and
+  requires ~64 GiB system RAM for the layer-by-layer Hessian pass.
+- The whole point of release-hosted bakes is to let small-VRAM users skip
+  calibration.
+- A user with a 24 GiB gfx1100 likely cannot calibrate locally; without a
+  release bake they have no path to running the model.
+
+The implementation PRs should ship a smoke-tested bake to `bakes-v2`
+**before** announcing the model as supported.
+
+---
+
+## 10. Verification
+
+### PyTorch oracle (`oracle/qwen36_moe_oracle.py`)
+
+Modeled exactly on `oracle/qwen35_oracle.py`. It:
+
+1. Loads the HF model in BF16 (or FP8 dequantised to BF16).
+2. Runs prefill over a tiny prompt ("Hello, world").
+3. Exports state per decode step: `hidden`, full-attention KV per layer,
+   linear-attn conv + recurrent state, **and** per-layer router logits,
+   chosen expert indices, expert outputs (sum over k), shared-expert
+   output. JSON + base64.
+4. Optionally records logits per step.
+
+The Rust runtime then either (a) loads HF state and decodes from there
+(parity check) or (b) runs prefill itself and compares logits at each step
+to the oracle.
+
+### Smoke test (CI-friendly when GPUs are available)
+
+```
+python oracle/bake_int4.py --model qwen3.6-35b-a3b --model-dir <hf-dir>
+cargo run --release --bin supersonic -- \
+  --model qwen3.6-35b-a3b \
+  --model-dir <hf-dir> \
+  --prompt "The quick brown fox" \
+  --max-new-tokens 8 \
+  --validate
+```
+
+Expected:
+
+- All 8 step logits match the oracle's BF16 forward to within INT4 GPTQ
+  tolerance (typically `cos_sim ≥ 0.999` per step on Qwen3.5; MoE may
+  show slightly looser numbers near the routing decision boundaries —
+  pick a per-step threshold of `cos_sim ≥ 0.997` and `top1 token-id
+  match` as the gate, refine after first measurement).
+- Decode time < 200 ms/token on gfx1100; < 80 ms/token on sm86. These
+  are coarse targets; final numbers go in `docs/performance.md`.
+
+### Pre-merge unit tests
+
+Inside `crates/qwen36_moe`:
+- `config.rs` parses the test-fixture `config.json` correctly.
+- `weights.rs` enumerates expert tensor names against a fake manifest
+  with N=4 experts and verifies shape consistency.
+- `desc_builder.rs` produces a layer-desc array whose pointers all fall
+  inside the bake's tensor offset table.
+
+Inside `crates/runner`:
+- A registry test like `qwen36_aliases_are_public_and_canonical`
+  (already exists at `registry.rs:690–706`) gets extended to assert a
+  `RegistryEntry` exists for `(Qwen3_6_35B_A3B, Hip, Gfx1100)` and
+  `(Qwen3_6_35B_A3B, Cuda, Sm86)`.
+
+---
+
+## 11. Risks & open spikes
+
+1. **Actual 35B-A3B config** — 80B-A3B's (512, top-10, moe_int=512) is a
+   proxy. First step in the implementation PR sequence is fetching and
+   recording the real numbers.
+2. **q4km-on-HIP gating** — if the user wants HIP gfx1100 + q4km in v1
+   instead of INT4 GPTQ, that is a separate kernel project (the CUDA q4km
+   path doesn't port to HIP without porting the GGML K-block dequant
+   inline-asm). Decision needed before kernel work starts.
+3. **Down-projection atomics on RDNA3** — Option C relies on
+   `atomicAdd` into BF16 pairs. RDNA3 supports `__hip_atomic_fetch_add` on
+   16-bit floats, but the codegen quality on hipcc 6.x is uneven. Build
+   a 50-line standalone test before committing to this path; if codegen
+   is bad, fall back to per-block scratch and a separate sum kernel.
+4. **Top-k selection at num_experts=512** — a sort over 512 values is
+   nontrivial inside the megakernel. Threshold-bisection is the safer
+   bet than bitonic sort; the bisection variant takes ~`ceil(log2(512))
+   = 9` reduction passes but uses no LDS. Worth a focused micro-bench
+   before deciding.
+5. **Shared-expert gating math** — Qwen3-Next applies the shared-expert
+   gate as `sigmoid(shared_expert_gate · x) · shared_expert(x)`. Confirm
+   against the HF source before implementing. Wrong math here is the
+   classic silent-divergence bug.
+6. **Hessian collection for 35B** — `oracle/bake_int4.py` accumulates
+   forward-hook Hessians on the **full** model. For 35B that's ~280 GiB
+   of FP32 Hessians if held in memory; the streaming GPTQ baker
+   (`oracle/q4km_stream_gptq_bake.py`) was built for exactly this case
+   for q4km but its INT4 equivalent may need work. Verify before
+   committing the producer side of bake distribution.
+7. **VRAM tightness on 24 GiB gfx1100** — at ~19.5 GiB weights + KV +
+   scratch we are within a few hundred MiB of the cap. Any growth in
+   `moe_scratch_floats` or in `kv_chunk_size` could push us over. The
+   implementation PR should track peak alloc against the budget and fail
+   the smoke test if it exceeds 22 GiB.
+
+---
+
+## 12. Suggested PR-sized chunks (for follow-up sessions)
+
+1. **PR 1 — Crate scaffolding + config parsing.** New `crates/qwen36_moe`
+   with `Cargo.toml`, `lib.rs`, `config.rs` (parses real 35B config.json,
+   asserts hybrid layer pattern, MoE field presence). Workspace
+   membership. No kernel work, no registry change. Closes the "what
+   does the config actually look like" spike.
+
+2. **PR 2 — Bake-side validation.** Run
+   `python oracle/bake_int4.py --model qwen3.6-35b-a3b --model-dir <hf>`
+   end-to-end on a tiny test fixture (artificially shrunk MoE: 4
+   experts, 2 layers). Add `oracle/test_bake_qwen36_moe.py` covering
+   manifest assertions: every expert weight is `Int4Quantized`, every
+   gate is `Raw`. No runtime work yet.
+
+3. **PR 3 — Runtime weight loader, no kernel.** `weights.rs`,
+   `loader.rs`, `state.rs`. Add a `--dry-run` CLI flag that loads
+   weights, builds state, prints VRAM accounting, and exits. Add the
+   registry entries with placeholder `Qwen36MoeKernelParams`. Replace
+   the bail at `main.rs:1067` with a route to the new dry-run path.
+
+4. **PR 4 — CUDA kernel + bridge + FFI, q4km only.** First working
+   decode path. Single arch (sm86). Skeleton `qwen36_moe_engine.rs`
+   that drives one step. Pass a single token through and record
+   logits to disk. No oracle comparison yet.
+
+5. **PR 5 — Oracle + parity gate.** `oracle/qwen36_moe_oracle.py`,
+   wire `--validate` through `qwen36_moe_engine`. Smoke test passes
+   on sm86 with `cos_sim ≥ 0.997`, top-1 match.
+
+6. **PR 6 — HIP kernel + bridge + FFI, INT4 GPTQ.** Port the CUDA
+   megakernel (most of `qwen36_moe_cuda.cuh` becomes
+   `qwen36_moe.hip`). Add gfx1100 registry entry. Smoke test passes
+   on gfx1100.
+
+7. **PR 7 — Bake distribution.** Run GPTQ calibration, upload to
+   `bakes-v2`. Update `docs/bake-distribution.md`. Add an integration
+   test that downloads the published bake, runs decode, compares
+   logits — runs in CI behind a `SUPERSONIC_INTEGRATION` env gate.
+
+8. **PR 8 — Performance pass.** Benchmark, write
+   `docs/qwen36-moe-performance.md`, tune `moe_scratch_floats` and
+   `kv_chunk_size` per arch, evaluate cooperative-launch preset like
+   the Qwen3.5 4B kernel uses.
+
+PR 1–3 are pure scaffolding and unblock parallel work on PR 4 and PR 6.
+PRs 4–6 are the design-critical path. PRs 7–8 are productionisation.
+
+---
+
+## 13. Out of scope (explicit non-goals)
+
+- **q4km on HIP.** Lifting the CUDA-only gate is a kernel project of its
+  own; defer.
+- **Streaming expert weights from CPU.** All experts must fit VRAM in
+  v1.
+- **Multi-GPU sharding.** Single-GPU only.
+- **Dynamic expert pruning / hot-expert caching.** v1 routes by raw
+  router logits without any caching layer.
+- **Continuous batching.** Decode-only single-sequence first;
+  many-sequence/batch is a follow-up after v1 ships.
+- **Metal / Apple M4 support.** Future addition; nothing in this plan
+  precludes it but no work is committed.
+
+---
+
+## 14. Approval gate before any code
+
+The two decisions a reviewer should confirm before PR 1 lands:
+
+1. **Quant choice for HIP gfx1100: INT4 GPTQ (this plan)** vs. blocking
+   on q4km-on-HIP. INT4 GPTQ is the recommendation because it works
+   today; q4km-on-HIP is months of extra work.
+2. **Kernel dispatch strategy: Option C (per-block work units, this
+   plan)** vs. Option A (per-token loop). Option C is the
+   recommendation because it parallelises across experts at batch=1.
+
+Once those are signed off, the work below is mechanical execution and
+can proceed PR by PR without further architectural debate.
+
+---
+
+## 15. Schema reality check (post-PR 3 addendum, 2026-04-30)
+
+Sections §1, §2, and §6 of this plan were drafted from the 80B-A3B proxy
+config. PR 1 landed config parsing against the real 35B-A3B
+`config.json`; PR 3 went further and enumerated the published
+`Qwen/Qwen3.6-35B-A3B` safetensors checkpoint end-to-end. Several plan
+assumptions did not survive contact with the real bake. **This section
+overrides the corresponding rows of §1 / §2 / §6 / §7 wherever they
+disagree.** Earlier sections are kept for historical context.
+
+### Geometry — what 35B-A3B actually ships
+
+| Aspect | Plan §1 (80B-A3B proxy) | **Real (35B-A3B)** |
+|---|---|---|
+| `num_hidden_layers` | 48 | **40** |
+| `hidden_size` | 2048 | 2048 ✓ |
+| Full-attn Q heads | 16 | 16 ✓ |
+| Full-attn KV heads | 2 | 2 ✓ |
+| `head_dim` | 256 | 256 ✓ |
+| `num_experts` | 512 | **256** |
+| `num_experts_per_tok` (top_k) | 10 | **8** |
+| `moe_intermediate_size` | 512 | 512 ✓ |
+| `shared_expert_intermediate_size` | 512 | 512 ✓ |
+| `vocab_size` | 151,936 | **248,320** |
+| `tie_word_embeddings` | false | false ✓ |
+| Architecture class | `Qwen3NextForCausalLM` | **`Qwen3_5MoeForConditionalGeneration`** (multimodal — vision + text + MTP) |
+| RoPE | partial 0.25, θ=1e7 | mRoPE, section [11,11,10], interleaved, partial 0.25, θ=1e7 |
+| `attn_output_gate` | not in plan | **true** — see "q_proj is doubled" below |
+
+Source of truth: `crates/qwen36_moe/src/config.rs` parses the live
+`config.json`; the `parses_real_qwen36_35b_a3b_config` test pins these
+values against a verbatim copy of the published config.
+
+### Tensor naming — overrides §2
+
+The §2 tensor list described an unfused, per-expert layout. **The real
+checkpoint stores experts as fused-batched tensors per layer, with no
+`.weight` suffix.** Cross-checked by directly enumerating
+`Qwen/Qwen3.6-35B-A3B`'s safetensors index in PR 3.
+
+```
+# What plan §2 said (every layer, every expert E ∈ [0, num_experts)):
+model.language_model.layers.{L}.mlp.experts.{E}.gate_proj.weight   # NOT real
+model.language_model.layers.{L}.mlp.experts.{E}.up_proj.weight     # NOT real
+model.language_model.layers.{L}.mlp.experts.{E}.down_proj.weight   # NOT real
+
+# What's actually in the checkpoint (note: no .weight suffix, 3D shapes):
+model.language_model.layers.{L}.mlp.experts.gate_up_proj   [E, 2*moe_int, hidden]  bf16
+model.language_model.layers.{L}.mlp.experts.down_proj      [E, hidden, moe_int]    bf16
+```
+
+Other MoE-block tensors are still per-projection and DO have `.weight`
+suffixes:
+
+```
+model.language_model.layers.{L}.mlp.gate.weight                    [E, hidden]      bf16
+model.language_model.layers.{L}.mlp.shared_expert_gate.weight      [1, hidden]      bf16
+model.language_model.layers.{L}.mlp.shared_expert.gate_proj.weight [moe_int, hidden] bf16
+model.language_model.layers.{L}.mlp.shared_expert.up_proj.weight   [moe_int, hidden] bf16
+model.language_model.layers.{L}.mlp.shared_expert.down_proj.weight [hidden, moe_int] bf16
+```
+
+### `attn_output_gate=true` — overrides §1
+
+Qwen3-Next MoE adds a sigmoid-gate on the attention output, fused into
+`q_proj`'s output dimension. Effects:
+
+```
+self_attn.q_proj.weight: [2 * num_heads * head_dim, hidden]    # 2× the plan's assumption
+self_attn.o_proj.weight: [hidden, num_heads * head_dim]        # unchanged
+```
+
+For 35B: `q_proj=[8192, 2048]` (not `[4096, 2048]`). The runtime must
+split q_proj's output into `[Q | output_gate]` lanes and apply
+`sigmoid(output_gate) * attn_output` before `o_proj`. Mechanically
+identical to how Phi4 splits a fused `gate_up_proj` — a stride trick at
+matmul time.
+
+### Linear-attn dtype — overrides §2
+
+Plan §2 (transcribed from a Qwen3.5-0.8B probe) implied
+`linear_attn.norm.weight` and `linear_attn.A_log` are F32. The published
+35B-A3B checkpoint stores **all** decoder weights — including these two —
+as **BF16**. The runtime must accept both dtypes; the existing
+`ensure_f32_on_gpu` helper in `crates/qwen35/src/weights.rs` handles BF16
+norms by upcasting on demand.
+
+### Things in the safetensors that v1 ignores
+
+- **Vision tower** (`model.visual.blocks.0..26.*`, `model.visual.merger.*`,
+  `model.visual.patch_embed.*`, `model.visual.pos_embed.weight`) —
+  multimodal weights for the conditional-generation class. Text-only
+  decode never references them.
+- **MTP head** (`mtp.layers.0.*`, `mtp.fc.weight`, `mtp.norm.weight`,
+  `mtp.pre_fc_norm_*`) — multi-token-prediction layer used during
+  training and optionally for speculative decoding. v1 single-sequence
+  decode does not consume it.
+
+The runtime should silently skip both groups during weight loading. The
+on-disk total of 67 GiB (1045 tensors) breaks down as: 64.56 GiB / 693
+tensors are language-decoder weights v1 actually uses, ~2.4 GiB / 352
+tensors are vision + MTP overhead.
+
+### The bake gap (the one that matters before PR 7)
+
+Both `is_int4_target` and `is_q4km_target` reject the fused expert
+tensors today: they require `name.endswith(".weight")`, and the q4km
+predicate additionally requires a 2D shape. The real names are
+`mlp.experts.gate_up_proj` (3D) and `mlp.experts.down_proj` (3D), with
+no `.weight` suffix. **A naive `python oracle/bake_int4.py --model
+qwen3.6-35b-a3b ...` run today would leave ~60 GiB of expert weight
+unquantized**, busting any 24 GiB GPU budget.
+
+There is also an upstream issue: `bake_int4.py` walks `nn.Linear`
+modules (`for mod in layer.modules() if isinstance(mod, nn.Linear)`).
+The HF `Qwen3_5Moe` implementation almost certainly stores experts as a
+single `nn.Parameter` under a custom MoE module, *not* as a list of
+`nn.Linear` per expert — so even if the predicates were updated, the
+GPTQ driver would still skip the experts entirely.
+
+**PR 7 (calibration) must close this gap before producing a usable
+INT4 bake.** Three options, in increasing order of effort:
+
+- (a) **Update predicates + extend the GPTQ driver to handle 3D fused
+  tensors.** Treat the `[E, out, in]` slab as `E` parallel `[out, in]`
+  matrices; share one Hessian per layer (since all experts see the same
+  pre-MoE activations). Pack each expert's nibbles as a contiguous
+  group_size tile, with one `[out/gs, in/gs]` BF16 scale+zero pair per
+  expert.
+
+- (b) **Unfuse before calibration, refuse after pack.** Add a state-dict
+  pre-hook that splits the fused params into per-expert `nn.Linear`,
+  run unmodified GPTQ, then re-pack the nibble layout into a fused INT4
+  slab on save. More code, no kernel-side change.
+
+- (c) **Skip Hessian-aware calibration on experts; min/max INT4 only.**
+  Quantize experts via plain min/max group-quant (still group_size=128
+  with BF16 scale+zero), keep GPTQ for dense projections only. Cheapest
+  path. Quality cost is unknown but probably tolerable since experts
+  only fire for ~3% of any given token's compute (top-8 of 256, at
+  `moe_int=512` vs the much larger Q/K/V/O+linear-attn matmuls).
+
+Recommendation: start with (c) for v1 to unblock the runtime quickly.
+Revisit (a) in a follow-up if quality is below the cos_sim ≥ 0.997
+gate.
+
+### Updated VRAM measurement (replaces §6 estimates)
+
+Numbers come from `--dry-run` against the live 67 GiB BF16 download:
+
+| Component | Bytes | Notes |
+|---|---|---|
+| `embed_tokens` | 0.95 GiB | BF16, vocab 248,320 × hidden 2048 |
+| `lm_head` | 0.95 GiB | untied, same shape |
+| Full-attn (10 layers) | 0.51 GiB | q_proj doubled by attn_output_gate |
+| Linear-attn (30 layers) | 1.88 GiB | qkv 8192×hidden, z 4096×hidden, conv 8192×4 |
+| Routers (40 layers) | 0.04 GiB | `mlp.gate.weight` BF16 stays Raw |
+| Shared experts (40 layers) | 0.23 GiB | per-projection BF16 |
+| Routed experts (40 layers) | 60.00 GiB | fused `[256, 1024, 2048]` + `[256, 2048, 512]` per layer |
+| **Total BF16 (decoder)** | **64.56 GiB** | byte-for-byte match between analytic + on-disk |
+| **Total INT4 GPTQ projection** | **16.89 GiB** | gs=128, weights packed + BF16 scale/zero sidecars |
+
+The plan's §6 19-GiB INT4 budget is correct with margin. After the
+runtime adds activations + KV + scratch (≤ 4 GiB at 4K context), the
+HIP gfx1100 entry projects 20.90 GiB total — fits a 24 GiB card.
+
+### Sections of the plan still valid
+
+- §3 crate layout and §4 kernel design (Option C work-stealing) are
+  unaffected.
+- §6 registry-entry layout is correct; only the per-quant byte numbers
+  in the table needed verification (done above).
+- §7 quant matrix is correct: INT4 GPTQ on HIP gfx1100, q4km on CUDA
+  sm86.
+- §10 verification + smoke-test approach is unchanged; the oracle just
+  needs to know the fused-expert tensor names.
+- §11 risks 4 (top-k at 256 is tighter than the plan's 512) and 5
+  (shared-expert gating math) still apply.
+- §12 PR sequencing is unchanged; this addendum lives inside PR 3.

--- a/kernels/qwen36_moe.hip
+++ b/kernels/qwen36_moe.hip
@@ -1451,4 +1451,299 @@ __global__ void qwen36_moe_linear_step_kernel(
     }
 }
 
+// =============================================================================
+// Single-block MoE FFN parity kernel (PR 4b4)
+//
+// Lives alongside the attn step kernel; together they cover the two halves
+// of one Qwen3.6-MoE layer (attn = pre-residual, FFN = post-residual).
+// Same staged build-up convention as PR 4b2/4b3 — each stage adds one slice
+// of compute and the host parity test reads the matching intermediate.
+//
+//   stage 1: post_attn rmsnorm + router gate + softmax + topk + renorm → write topk_weights, topk_idx
+//   stage 2: ... + shared expert (gate/up/silu/down + sigmoid_gate)    → write shared_out
+//   stage 3: ... + ONE expert FFN (top-1 dispatch via topk_idx[0])     → write expert_0_out
+//   stage 4: ... + topk-weighted sum across all k experts              → write moe_out
+//   stage 5: ... + residual add (input_hidden + moe_out + shared_out)  → write output_hidden
+//
+// PR 4b4 step 1 lands stage 1. Stages 2–5 add to this kernel; the launcher's
+// `stage` argument decides where to stop.
+//
+// Layout choices fixed up-front:
+//   block_size = 256  (4 waves on gfx1100; matches the attn kernel for symmetry)
+//   grid_size  = num_cus  (one block per CU, all guaranteed concurrent on RDNA3
+//                          → grid_barrier safe without coop launch — same as
+//                          the attn kernel and full_attention_4b.hip)
+//
+//   workspace[F32], staged-FFN scratch (offsets in F32 elements):
+//     H_NORM        = 0                                  [hidden]    rms-normed input
+//     ROUTER_LOGITS = hidden                             [E]
+//     ROUTER_PROBS  = hidden + E                         [E]
+//     TOPK_VAL      = hidden + 2*E                       [k]   renormed
+//     TOPK_IDX      = hidden + 2*E + k                   [k]   bit-cast u32 in float slot
+//     SHARED_MID    = hidden + 2*E + 2*k                 [Is]  shared-expert silu(g)*u
+//     SHARED_OUT    = hidden + 2*E + 2*k + Is            [hidden]
+//     EXPERT_STACK  = hidden + 2*E + 2*k + Is + hidden   [k * hidden] per-expert outs
+//     MOE_OUT       = ... + k*hidden                     [hidden]
+//     OUTPUT_HIDDEN = ... + hidden                       [hidden]
+//   For 35B-A3B (hidden=2048, E=256, k=8, Is=512) stage-5 footprint is
+//   ~23,568 F32 = ~92 KiB. Well within the persistent-decode budget.
+//
+// Parity output convention (BF16, sized for the largest staged intermediate):
+//   stage 1: output[0..k] = topk_weights  (BF16-rounded; renormed across k)
+//            output_idx[0..k] = topk_idx  (int32, separate buffer)
+//   stage 2..5: output written by the matching final phase (see comments
+//   on each stage in subsequent commits).
+
+template <typename T>
+__global__ void qwen36_moe_ffn_step_kernel(
+    int                            stage,
+    int                            hidden,
+    int                            num_experts,                  // E (256 on 35B-A3B)
+    int                            moe_intermediate,             // I (512 on 35B-A3B)
+    int                            shared_intermediate,          // Is (512 on 35B-A3B)
+    int                            top_k,                        // k (8 on 35B-A3B)
+    float                          rms_norm_eps,
+    const T* __restrict__          input_hidden,                 // [hidden] post-attn
+    const T* __restrict__          post_attn_norm_w,             // [hidden]
+    const T* __restrict__          gate_w,                       // [E, hidden]
+    const T* __restrict__          gate_up_proj_w,               // [E, 2*I, hidden]   (nullable for stage<3)
+    const T* __restrict__          down_proj_w,                  // [E, hidden, I]     (nullable for stage<3)
+    const T* __restrict__          shared_gate_proj_w,           // [Is, hidden]       (nullable for stage<2)
+    const T* __restrict__          shared_up_proj_w,             // [Is, hidden]       (nullable for stage<2)
+    const T* __restrict__          shared_down_proj_w,           // [hidden, Is]       (nullable for stage<2)
+    const T* __restrict__          shared_expert_gate_w,         // [1, hidden]        (nullable for stage<2)
+    T* __restrict__                output,                       // BF16, sized for the largest staged intermediate
+    int* __restrict__              output_idx,                   // [k] topk indices (stage 1+)
+    float* __restrict__            workspace,
+    unsigned int* __restrict__     counters,
+    unsigned int* __restrict__     barrier_counter,
+    unsigned int* __restrict__     barrier_flag) {
+    (void)gate_up_proj_w;
+    (void)down_proj_w;
+    (void)shared_gate_proj_w;
+    (void)shared_up_proj_w;
+    (void)shared_down_proj_w;
+    (void)shared_expert_gate_w;
+
+    const int num_blocks = static_cast<int>(gridDim.x);
+    const int tid        = threadIdx.x;
+    const int block_size = static_cast<int>(blockDim.x);
+
+    extern __shared__ float lds[];
+    float* h_norm_lds     = lds;             // [hidden]
+    float* shared_scratch = lds + hidden;    // [block_size]
+
+    const int OFF_H_NORM        = 0;
+    const int OFF_ROUTER_LOGITS = hidden;
+    const int OFF_ROUTER_PROBS  = hidden + num_experts;
+    const int OFF_TOPK_VAL      = hidden + 2 * num_experts;
+    const int OFF_TOPK_IDX      = hidden + 2 * num_experts + top_k;
+
+    // -- Phase A: load input + post_attn RMS norm --------------------------
+    // Same idiom as the attn kernel's Phase A. Every block computes h_norm
+    // into its own LDS (cheap reduction; cross-block sync would cost more).
+    for (int col = tid; col < hidden; col += block_size) {
+        h_norm_lds[col] = static_cast<float>(input_hidden[col]);
+    }
+    __syncthreads();
+
+    float partial_sq = 0.0f;
+    for (int col = tid; col < hidden; col += block_size) {
+        partial_sq += h_norm_lds[col] * h_norm_lds[col];
+    }
+    shared_scratch[tid] = partial_sq;
+    __syncthreads();
+    for (int s = block_size / 2; s > 0; s >>= 1) {
+        if (tid < s) shared_scratch[tid] += shared_scratch[tid + s];
+        __syncthreads();
+    }
+    __shared__ float inv_rms_input;
+    if (tid == 0) {
+        inv_rms_input = rsqrtf(shared_scratch[0] / static_cast<float>(hidden) + rms_norm_eps);
+    }
+    __syncthreads();
+
+    // BF16-round each h_norm element so the matmul reads what PyTorch reads.
+    // Block 0 is also responsible for staging the F32 of-BF16 view into
+    // workspace[OFF_H_NORM] for any later stages that prefer global memory.
+    for (int col = tid; col < hidden; col += block_size) {
+        const float w = static_cast<float>(post_attn_norm_w[col]);
+        const float v = bf16_round_rne_f32(h_norm_lds[col] * inv_rms_input * w);
+        h_norm_lds[col] = v;
+        if (blockIdx.x == 0) {
+            workspace[OFF_H_NORM + col] = v;
+        }
+    }
+    __syncthreads();
+
+    // -- Phase B: router_logits = gate_w @ h_norm  (work-stealing matvec) --
+    // 256 output rows on 35B-A3B; with hidden=2048 that's a small mat-vec.
+    // Each block claims rows from `counters[0]` and reduces across its
+    // threads. Same primitive as the attn kernel's q_proj phase.
+    for (;;) {
+        __shared__ unsigned int my_row_s;
+        if (tid == 0) {
+            my_row_s = atomicAdd(&counters[0], 1u);
+        }
+        __syncthreads();
+        const int my_row = static_cast<int>(my_row_s);
+        if (my_row >= num_experts) break;
+
+        const T* w_row = gate_w + static_cast<size_t>(my_row) * hidden;
+        float partial = 0.0f;
+        for (int col = tid; col < hidden; col += block_size) {
+            partial += static_cast<float>(w_row[col]) * h_norm_lds[col];
+        }
+        shared_scratch[tid] = partial;
+        __syncthreads();
+        for (int s = block_size / 2; s > 0; s >>= 1) {
+            if (tid < s) shared_scratch[tid] += shared_scratch[tid + s];
+            __syncthreads();
+        }
+        if (tid == 0) {
+            // Match the oracle's `(h_norm.f32 @ gate_w.f32.T).to(dtype)`:
+            // F32 internals, BF16-rounded on store.
+            workspace[OFF_ROUTER_LOGITS + my_row] = bf16_round_rne_f32(shared_scratch[0]);
+        }
+        __syncthreads();
+    }
+
+    // Cross-block barrier: all router logits finalised before block 0 reduces.
+    grid_barrier(barrier_counter, barrier_flag, num_blocks);
+
+    // -- Phase C: softmax + topk + renorm (block 0 only) -------------------
+    // 256 logits softmax fits in a single block trivially. We:
+    //   1. Find max for numerical stability.
+    //   2. exp(logit - max), sum.
+    //   3. Divide → router_probs[E] (F32, BF16-rounded for parity).
+    //   4. Top-k via k iterations of "find argmax, mark used".
+    //   5. Sum the top-k probs, divide each by the sum → renormed weights.
+    if (blockIdx.x == 0) {
+        const int E = num_experts;
+        const int K = top_k;
+
+        // Step 1: max reduction. Threads read logits and produce a per-thread
+        // max; tree-reduce in shared_scratch.
+        float local_max = -INFINITY;
+        for (int i = tid; i < E; i += block_size) {
+            const float v = workspace[OFF_ROUTER_LOGITS + i];
+            if (v > local_max) local_max = v;
+        }
+        shared_scratch[tid] = local_max;
+        __syncthreads();
+        for (int s = block_size / 2; s > 0; s >>= 1) {
+            if (tid < s) {
+                const float a = shared_scratch[tid];
+                const float b = shared_scratch[tid + s];
+                shared_scratch[tid] = (a > b) ? a : b;
+            }
+            __syncthreads();
+        }
+        __shared__ float row_max;
+        if (tid == 0) row_max = shared_scratch[0];
+        __syncthreads();
+
+        // Step 2: exp(logit - max), partial sum.
+        float local_sum = 0.0f;
+        for (int i = tid; i < E; i += block_size) {
+            const float e = expf(workspace[OFF_ROUTER_LOGITS + i] - row_max);
+            workspace[OFF_ROUTER_PROBS + i] = e;
+            local_sum += e;
+        }
+        shared_scratch[tid] = local_sum;
+        __syncthreads();
+        for (int s = block_size / 2; s > 0; s >>= 1) {
+            if (tid < s) shared_scratch[tid] += shared_scratch[tid + s];
+            __syncthreads();
+        }
+        __shared__ float row_sum;
+        if (tid == 0) row_sum = shared_scratch[0];
+        __syncthreads();
+
+        // Step 3: divide. Store BF16-rounded F32 (matches oracle's `.to(dtype)`).
+        const float inv_row_sum = 1.0f / row_sum;
+        for (int i = tid; i < E; i += block_size) {
+            const float p = bf16_round_rne_f32(workspace[OFF_ROUTER_PROBS + i] * inv_row_sum);
+            workspace[OFF_ROUTER_PROBS + i] = p;
+        }
+        __syncthreads();
+
+        // Step 4: top-k via k iterations. Each iter does a 256-wide argmax
+        // reduction on `router_probs`, then masks the winner. With K=8 this
+        // is 8 cycles → fine for a megakernel; a heap would beat it for
+        // larger k but k=8 is fixed in the model card.
+        //
+        // Tie-breaking: torch.topk returns the lowest index on ties; we
+        // match by carrying both (value, index) through the tree-reduce
+        // and preferring the lower index when values are equal.
+        //
+        // Static __shared__ buffers for the (val, idx) reduction. Sized to
+        // the fixed block_size=256; if block_size ever grows, increase
+        // these in lockstep. Allocated once at kernel entry to avoid the
+        // re-declare-inside-loop pitfall some compilers handle oddly.
+        __shared__ int   idx_buf[256];
+        __shared__ float val_buf[256];
+        for (int kk = 0; kk < K; kk++) {
+            // Per-thread argmax over the strided slice.
+            int   local_idx = -1;
+            float local_val = -INFINITY;
+            for (int i = tid; i < E; i += block_size) {
+                const float v = workspace[OFF_ROUTER_PROBS + i];
+                if (v > local_val ||
+                    (v == local_val && local_idx >= 0 && i < local_idx)) {
+                    local_val = v;
+                    local_idx = i;
+                }
+            }
+            idx_buf[tid] = local_idx;
+            val_buf[tid] = local_val;
+            __syncthreads();
+            for (int s = block_size / 2; s > 0; s >>= 1) {
+                if (tid < s) {
+                    const float a  = val_buf[tid];
+                    const float b  = val_buf[tid + s];
+                    const int   ia = idx_buf[tid];
+                    const int   ib = idx_buf[tid + s];
+                    bool take_b = false;
+                    if (b > a) take_b = true;
+                    else if (b == a && ib >= 0 &&
+                             (ia < 0 || ib < ia)) take_b = true;
+                    if (take_b) {
+                        val_buf[tid] = b;
+                        idx_buf[tid] = ib;
+                    }
+                }
+                __syncthreads();
+            }
+            if (tid == 0) {
+                const int   winner_idx = idx_buf[0];
+                const float winner_val = val_buf[0];
+                workspace[OFF_TOPK_IDX + kk] = __int_as_float(winner_idx);
+                workspace[OFF_TOPK_VAL + kk] = winner_val;
+                // Mask the winner so the next iter picks the next-largest.
+                workspace[OFF_ROUTER_PROBS + winner_idx] = -INFINITY;
+            }
+            __syncthreads();
+        }
+
+        // Step 5: renormalise the top-k probs to sum to 1.
+        // Sequential on tid==0 — k is tiny (8); a parallel reduction would
+        // be code-bulk for no measurable win.
+        if (tid == 0) {
+            float sum = 0.0f;
+            for (int i = 0; i < K; i++) sum += workspace[OFF_TOPK_VAL + i];
+            const float inv = 1.0f / sum;
+            for (int i = 0; i < K; i++) {
+                const float w = bf16_round_rne_f32(workspace[OFF_TOPK_VAL + i] * inv);
+                workspace[OFF_TOPK_VAL + i] = w;
+                if (stage == 1) {
+                    output[i]      = static_cast<T>(w);
+                    output_idx[i]  = __float_as_int(workspace[OFF_TOPK_IDX + i]);
+                }
+            }
+        }
+        __syncthreads();
+    }
+}
+
 } // namespace qwen36_moe

--- a/kernels/qwen36_moe.hip
+++ b/kernels/qwen36_moe.hip
@@ -782,4 +782,216 @@ __global__ void qwen36_moe_attn_step_kernel(
     }
 }
 
+// =============================================================================
+// Single-layer LINEAR-attention parity kernel (PR 4b3)
+//
+// Mirrors the staged build-up pattern from PR 4b2's full-attention kernel:
+// each stage adds one slice of compute, the host parity test downloads the
+// matching intermediate buffer and compares it to the linear-attn oracle
+// (oracle/qwen36_moe_linear_oracle.py).
+//
+//   stage 1: x_norm + in_proj_qkv + in_proj_z + in_proj_a + in_proj_b
+//            → publish qkv_raw [qkv_dim] BF16
+//   stage 2: ... + depthwise conv1d + silu
+//            → publish silu_out [qkv_dim] BF16  (planned)
+//   stage 3: ... + L2-norm Q/K + GQA repeat + Q scale
+//            → publish q_scaled || k_rep || v_heads (planned)
+//   stage 4: ... + delta-rule recurrent state update
+//            → publish recurrent_out [V*v_dim] BF16  (planned)
+//   stage 5: ... + per-head RMS norm + z-gate + out_proj + residual
+//            → publish output_hidden [hidden] BF16  (planned)
+//
+// PR 4b3 step 2 lands stage 1. Stages 2-5 follow in their own commits.
+//
+// Workspace layout (F32 elements, offsets) — pinned now even though only
+// the first four slots are written in stage 1, so later stages don't have
+// to reshuffle the layout:
+//
+//   QKV_RAW    = 0                                        [qkv_dim]
+//   Z_RAW      = qkv_dim                                  [V*v_dim]
+//   A_RAW      = qkv_dim + V*v_dim                        [V]
+//   B_RAW      = qkv_dim + V*v_dim + V                    [V]
+//   Q_NORMED   = qkv_dim + V*v_dim + 2*V                  [K*k_dim]
+//   K_NORMED   = ... + K*k_dim                            [K*k_dim]
+//   Q_REP      = ... + K*k_dim                            [V*k_dim]
+//   K_REP      = ... + V*k_dim                            [V*k_dim]
+//   BETA       = ... + V*k_dim                            [V]
+//   G          = ... + V                                  [V]
+//   REC_OUT    = ... + V                                  [V*v_dim]
+//   O_OUT      = ... + V*v_dim                            [hidden]
+//
+// For 35B-A3B (qkv_dim=8192, V=32, v_dim=128, K=16, k_dim=128, hidden=2048):
+//   stage-1 footprint = 8192 + 4096 + 32 + 32 = 12,352 F32 = 48 KiB
+//   stage-5 footprint = ~30,848 F32 = 120 KiB (still well under sane limits)
+//
+// Conv state and recurrent state live in dedicated state buffers (state
+// is up to 2 MiB per layer at F32) — those are NOT in `workspace`.
+
+template <typename T>
+__global__ void qwen36_moe_linear_step_kernel(
+    int                            stage,
+    int                            hidden,
+    int                            num_k_heads,         // K
+    int                            num_v_heads,         // V
+    int                            head_k_dim,          // k_dim
+    int                            head_v_dim,          // v_dim
+    int                            conv_kernel_dim,
+    float                          rms_norm_eps,
+    const T* __restrict__          input_hidden,        // [hidden]
+    const T* __restrict__          input_norm_w,        // [hidden]
+    const T* __restrict__          in_proj_qkv_w,       // [qkv_dim, hidden]
+    const T* __restrict__          in_proj_z_w,         // [V*v_dim, hidden]
+    const T* __restrict__          in_proj_a_w,         // [V, hidden]
+    const T* __restrict__          in_proj_b_w,         // [V, hidden]
+    const T* __restrict__          conv1d_w,            // unused at stage 1
+    const T* __restrict__          conv1d_bias,         // unused at stage 1
+    const T* __restrict__          dt_bias,             // unused at stage 1
+    const T* __restrict__          a_log,               // unused at stage 1
+    const T* __restrict__          norm_w,              // unused at stage 1
+    const T* __restrict__          out_proj_w,          // unused at stage 1
+    T* __restrict__                conv_state,          // unused at stage 1
+    float* __restrict__            recurrent_state,     // unused at stage 1
+    T* __restrict__                output,
+    float* __restrict__            workspace,
+    unsigned int* __restrict__     counters,
+    unsigned int* __restrict__     barrier_counter,
+    unsigned int* __restrict__     barrier_flag) {
+    (void)conv1d_w;
+    (void)conv1d_bias;
+    (void)dt_bias;
+    (void)a_log;
+    (void)norm_w;
+    (void)out_proj_w;
+    (void)conv_state;
+    (void)recurrent_state;
+
+    const int num_blocks = static_cast<int>(gridDim.x);
+    const int tid        = threadIdx.x;
+    const int block_size = static_cast<int>(blockDim.x);
+
+    extern __shared__ float lds[];
+    float* x_norm_lds    = lds;             // [hidden]
+    float* shared_scratch = lds + hidden;   // [block_size]
+
+    // Workspace offsets (computed once; same convention as the full-attn
+    // kernel's OFF_* locals).
+    const int K       = num_k_heads;
+    const int V       = num_v_heads;
+    const int k_dim   = head_k_dim;
+    const int v_dim   = head_v_dim;
+    const int key_dim = K * k_dim;
+    const int val_dim = V * v_dim;
+    const int qkv_dim = 2 * key_dim + val_dim;
+    const int OFF_QKV_RAW = 0;
+    const int OFF_Z_RAW   = qkv_dim;
+    const int OFF_A_RAW   = qkv_dim + val_dim;
+    const int OFF_B_RAW   = qkv_dim + val_dim + V;
+
+    // -- Phase A: load input_hidden + RMS norm into LDS --------------------
+    // Same idiom as the full-attn kernel's Phase A.
+    for (int col = tid; col < hidden; col += block_size) {
+        x_norm_lds[col] = static_cast<float>(input_hidden[col]);
+    }
+    __syncthreads();
+
+    float partial_sq = 0.0f;
+    for (int col = tid; col < hidden; col += block_size) {
+        partial_sq += x_norm_lds[col] * x_norm_lds[col];
+    }
+    shared_scratch[tid] = partial_sq;
+    __syncthreads();
+    for (int s = block_size / 2; s > 0; s >>= 1) {
+        if (tid < s) shared_scratch[tid] += shared_scratch[tid + s];
+        __syncthreads();
+    }
+    __shared__ float inv_rms_input;
+    if (tid == 0) {
+        inv_rms_input = rsqrtf(shared_scratch[0] / static_cast<float>(hidden) + rms_norm_eps);
+    }
+    __syncthreads();
+
+    for (int col = tid; col < hidden; col += block_size) {
+        const float w = static_cast<float>(input_norm_w[col]);
+        x_norm_lds[col] = bf16_round_rne_f32(x_norm_lds[col] * inv_rms_input * w);
+    }
+    __syncthreads();
+
+    // -- Phase B: four in-projections in one fused work pool ---------------
+    //
+    // qkv_raw, z_raw, a_raw, b_raw all read the same x_norm and have
+    // independent output rows, so we union them into one row-stealing pool
+    // of (qkv_dim + V*v_dim + 2*V) rows. Each block claims the next row,
+    // figures out which projection it belongs to, computes the dot
+    // product, and writes BF16-rounded F32 to the workspace at the right
+    // offset.
+    //
+    // Row-id range layout (in the order matching the workspace offsets):
+    //   [0,                       qkv_dim):                qkv (in_proj_qkv)
+    //   [qkv_dim,                 qkv_dim + V*v_dim):      z   (in_proj_z)
+    //   [qkv_dim + V*v_dim,       qkv_dim + V*v_dim + V):  a   (in_proj_a)
+    //   [qkv_dim + V*v_dim + V,   qkv_dim + V*v_dim + 2V): b   (in_proj_b)
+    const int total_rows = qkv_dim + val_dim + 2 * V;
+
+    for (;;) {
+        __shared__ unsigned int my_row_s;
+        if (tid == 0) {
+            my_row_s = atomicAdd(&counters[0], 1u);
+        }
+        __syncthreads();
+        const int my_row = static_cast<int>(my_row_s);
+        if (my_row >= total_rows) break;
+
+        // Pick projection + per-projection row-index + workspace dst.
+        const T* w_row;
+        int dst_off;
+        if (my_row < qkv_dim) {
+            w_row   = in_proj_qkv_w + static_cast<size_t>(my_row) * hidden;
+            dst_off = OFF_QKV_RAW + my_row;
+        } else if (my_row < qkv_dim + val_dim) {
+            const int r = my_row - qkv_dim;
+            w_row   = in_proj_z_w + static_cast<size_t>(r) * hidden;
+            dst_off = OFF_Z_RAW + r;
+        } else if (my_row < qkv_dim + val_dim + V) {
+            const int r = my_row - (qkv_dim + val_dim);
+            w_row   = in_proj_a_w + static_cast<size_t>(r) * hidden;
+            dst_off = OFF_A_RAW + r;
+        } else {
+            const int r = my_row - (qkv_dim + val_dim + V);
+            w_row   = in_proj_b_w + static_cast<size_t>(r) * hidden;
+            dst_off = OFF_B_RAW + r;
+        }
+
+        float partial = 0.0f;
+        for (int col = tid; col < hidden; col += block_size) {
+            partial += static_cast<float>(w_row[col]) * x_norm_lds[col];
+        }
+        shared_scratch[tid] = partial;
+        __syncthreads();
+        for (int s = block_size / 2; s > 0; s >>= 1) {
+            if (tid < s) shared_scratch[tid] += shared_scratch[tid + s];
+            __syncthreads();
+        }
+        if (tid == 0) {
+            workspace[dst_off] = bf16_round_rne_f32(shared_scratch[0]);
+        }
+        __syncthreads();
+    }
+
+    grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
+                               &counters[0]);
+
+    // Stage 1 publishes qkv_raw to the host-visible output buffer. Later
+    // stages publish their own intermediates and keep qkv_raw in workspace
+    // (where Phase C — depthwise conv1d — will read it).
+    if (stage == 1) {
+        for (int i = tid + blockIdx.x * block_size;
+             i < qkv_dim;
+             i += block_size * num_blocks) {
+            output[i] = static_cast<T>(workspace[OFF_QKV_RAW + i]);
+        }
+    }
+
+    // Stages 2..5 hook in here in follow-up commits.
+}
+
 } // namespace qwen36_moe

--- a/kernels/qwen36_moe.hip
+++ b/kernels/qwen36_moe.hip
@@ -1,0 +1,207 @@
+// Qwen3.6-MoE persistent decode megakernel — PR 4 infrastructure stub.
+//
+// Status: descriptor layout + stub launch only. The real megakernel
+// (~6500 LoC of attention + MoE compute) lands in follow-up PRs.
+//
+// What this file provides today:
+// 1. C++ struct definitions that mirror the Rust FFI types in
+//    `crates/kernel-ffi/src/qwen36_moe.rs`. A `static_assert` in the
+//    bridge pins the size on x86_64.
+// 2. A descriptor-validation kernel that walks the layer array, summarises
+//    integrity facts, and writes them to the workspace at known offsets.
+//    The host smoke test reads these back to confirm the Rust↔C++
+//    descriptor layout is in sync.
+// 3. The grid-barrier primitive ported verbatim from `full_attention_4b.hip`
+//    (proven correct under cooperative launch on gfx1100). Same primitive
+//    the real kernel will use for cross-layer synchronisation and for the
+//    Option-C work-stealing dispatch.
+//
+// CLAUDE.md is non-negotiable about isolation: hipcc on gfx11xx is
+// fragile, merging this with full_attention*.hip caused codegen
+// regressions in the past. Keep this file standalone.
+
+#include <hip/hip_bf16.h>
+#include <hip/hip_runtime.h>
+#include <stdint.h>
+
+namespace qwen36_moe {
+
+// -- Layer descriptor (mirror of Rust Qwen36MoeDecodeLayerDesc) ----------
+
+struct DecodeLayerDesc {
+    int  layer_idx;
+    int  is_full_attention;
+
+    // RMS norms
+    const void* input_norm_w;
+    float       input_norm_eps;
+    const void* post_attn_norm_w;
+    float       post_attn_norm_eps;
+
+    // Full-attention slots (read iff is_full_attention == 1)
+    const void* q_proj_w;
+    int         q_proj_out_dim;
+    int         attn_output_gate;
+    const void* k_proj_w;
+    const void* v_proj_w;
+    const void* o_proj_w;
+    const void* q_norm_w;
+    const void* k_norm_w;
+    int         attn_head_dim;
+    int         attn_num_heads;
+    int         attn_num_kv_heads;
+    void*       kv_cache_k;
+    void*       kv_cache_v;
+    int         kv_len;
+    int         kv_max_t;
+
+    // Linear-attention slots (read iff is_full_attention == 0)
+    const void* linear_in_proj_qkv_w;
+    const void* linear_in_proj_z_w;
+    const void* linear_in_proj_b_w;
+    const void* linear_in_proj_a_w;
+    const void* linear_out_proj_w;
+    const void* linear_conv1d_w;
+    const void* linear_dt_bias;
+    const void* linear_a_log_exp;
+    const void* linear_norm_w;
+    int         linear_qkv_dim;
+    int         linear_v_dim;
+    int         linear_v_heads;
+    int         linear_conv_kernel_dim;
+    void*       linear_conv_state;
+    void*       linear_recurrent_state;
+
+    // MoE block (always read)
+    const void* router_w;
+    const void* experts_gate_up_w;
+    const void* experts_down_w;
+    const void* shared_expert_gate_proj_w;
+    const void* shared_expert_up_proj_w;
+    const void* shared_expert_down_proj_w;
+    const void* shared_expert_gate_w;
+    int         num_experts;
+    int         top_k;
+    int         moe_intermediate_size;
+    int         shared_expert_intermediate_size;
+    int         norm_topk_prob;
+};
+
+// -- Grid barrier (verbatim from full_attention_4b.hip)
+//
+// Acquire/release ordering on `barrier_flag` makes this safe across CUs.
+// Block 0..N-1 each atomicAdd `barrier_counter`; the last arrival increments
+// the phase, others spin on a monotonic phase comparison. Coupled with
+// the launch using `multiProcessorCount` blocks (i.e. one block per CU,
+// all guaranteed concurrent on RDNA3), no cooperative-launch flag is
+// needed — same as the production qwen35-4b path.
+
+__device__ inline void grid_barrier(
+    unsigned int* barrier_counter,
+    unsigned int* barrier_flag,
+    int num_blocks
+) {
+    __syncthreads();
+    if (threadIdx.x == 0) {
+        unsigned int phase = __atomic_load_n(barrier_flag, __ATOMIC_RELAXED);
+        unsigned int old = atomicAdd(barrier_counter, 1u);
+        if (old == static_cast<unsigned int>(num_blocks) - 1) {
+            __atomic_store_n(barrier_counter, 0u, __ATOMIC_RELAXED);
+            __threadfence();
+            __atomic_store_n(barrier_flag, phase + 1, __ATOMIC_RELEASE);
+        } else {
+            while (__atomic_load_n(barrier_flag, __ATOMIC_ACQUIRE) == phase) {}
+        }
+    }
+    __syncthreads();
+}
+
+__device__ inline void grid_barrier_reset_counter(
+    unsigned int* barrier_counter,
+    unsigned int* barrier_flag,
+    int num_blocks,
+    unsigned int* counter_to_reset
+) {
+    __syncthreads();
+    if (threadIdx.x == 0) {
+        unsigned int phase = __atomic_load_n(barrier_flag, __ATOMIC_RELAXED);
+        unsigned int old = atomicAdd(barrier_counter, 1u);
+        if (old == static_cast<unsigned int>(num_blocks) - 1) {
+            __atomic_store_n(counter_to_reset, 0u, __ATOMIC_RELAXED);
+            __atomic_store_n(barrier_counter, 0u, __ATOMIC_RELAXED);
+            __threadfence();
+            __atomic_store_n(barrier_flag, phase + 1, __ATOMIC_RELEASE);
+        } else {
+            while (__atomic_load_n(barrier_flag, __ATOMIC_ACQUIRE) == phase) {}
+        }
+    }
+    __syncthreads();
+}
+
+// -- Descriptor-validation stub kernel
+//
+// Each block grabs the next layer index from `counters[0]` (work-stealing)
+// and contributes to global sentinel counters in `workspace`. Future kernel
+// work replaces the inner loop body with actual decode compute; the
+// outer iteration shape stays.
+
+__global__ void qwen36_moe_descriptor_walk_stub(
+    int                              num_layers,
+    const DecodeLayerDesc* __restrict__ layers,
+    float* __restrict__              workspace,
+    unsigned int* __restrict__       counters,
+    unsigned int* __restrict__       barrier_counter,
+    unsigned int* __restrict__       barrier_flag) {
+    const int num_blocks = static_cast<int>(gridDim.x);
+    const int bid        = blockIdx.x;
+
+    // Sentinel slots (only block 0 / thread 0 writes the initial values).
+    // Match `kernel-ffi/src/qwen36_moe.rs::stub_launch` doc.
+    if (bid == 0 && threadIdx.x == 0) {
+        workspace[0] = 0.0f; // num_layers seen
+        workspace[1] = 0.0f; // total experts
+        workspace[2] = 0.0f; // total top_k
+        workspace[3] = 1.0f; // hybrid pattern OK (zeroed by any failing block)
+        workspace[4] = 1.0f; // attn_output_gate consistent
+    }
+    grid_barrier(barrier_counter, barrier_flag, num_blocks);
+
+    // Cooperative work-stealing over layers. Each block grabs the next
+    // layer index from `counters[0]`. Same primitive the full kernel
+    // will use to dispatch (token, expert) work units later. Shared-memory
+    // broadcast of the claimed index is portable across any block_size.
+    __shared__ unsigned int s_layer_idx;
+    for (;;) {
+        if (threadIdx.x == 0) {
+            s_layer_idx = atomicAdd(&counters[0], 1u);
+        }
+        __syncthreads();
+        const unsigned int layer_idx = s_layer_idx;
+        if (layer_idx >= static_cast<unsigned int>(num_layers)) break;
+
+        const DecodeLayerDesc& d = layers[layer_idx];
+
+        if (threadIdx.x == 0) {
+            atomicAdd(&workspace[0], 1.0f);
+            atomicAdd(&workspace[1], static_cast<float>(d.num_experts));
+            atomicAdd(&workspace[2], static_cast<float>(d.top_k));
+
+            // Hybrid pattern check: layers (1..)%4==0 should be full.
+            const int expect_full = (((d.layer_idx + 1) % 4) == 0) ? 1 : 0;
+            if (d.is_full_attention != expect_full) {
+                workspace[3] = 0.0f;
+            }
+            // attn_output_gate consistency: only meaningful on full layers.
+            if (d.is_full_attention == 1 && d.attn_output_gate != 1) {
+                workspace[4] = 0.0f;
+            }
+        }
+        __syncthreads();
+    }
+
+    // Reset the work counter for any future barriers (idempotent here).
+    grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
+                               &counters[0]);
+}
+
+} // namespace qwen36_moe

--- a/kernels/qwen36_moe.hip
+++ b/kernels/qwen36_moe.hip
@@ -1485,15 +1485,22 @@ __global__ void qwen36_moe_linear_step_kernel(
 //     SUP           = hidden + 2*E + 2*k + 1 + Is                    [Is]  shared_up_proj output
 //     SHARED_MID    = hidden + 2*E + 2*k + 1 + 2*Is                  [Is]  silu(sgp) * sup (F32)
 //     SHARED_OUT    = hidden + 2*E + 2*k + 1 + 3*Is                  [hidden] shared expert path output (BF16-rounded F32)
-//     EXPERT_STACK  = hidden + 2*E + 2*k + 1 + 3*Is + hidden         [k * hidden] per-expert outs
-//     MOE_OUT       = ... + k*hidden                                 [hidden]
+//     EXPERT_GU     = ... + hidden                                   [2*I] gate_up_proj output for one expert (F32)
+//     EXPERT_MID    = ... + 2*I                                      [I]   silu(gu[:I]) * gu[I:]  (F32)
+//     EXPERT_STACK  = ... + I                                        [k * hidden] per-expert outs (F32, no BF16 round)
+//     MOE_OUT       = ... + k*hidden                                 [hidden] BF16-rounded F32
 //     OUTPUT_HIDDEN = ... + hidden                                   [hidden]
-//   For 35B-A3B (hidden=2048, E=256, k=8, Is=512) stage-5 footprint is
-//   ~26,641 F32 = ~104 KiB. Well within the persistent-decode budget.
+//   For 35B-A3B (hidden=2048, E=256, k=8, Is=512, I=512) stage-5 footprint
+//   is ~28,177 F32 = ~110 KiB. Well within the persistent-decode budget.
 //
-//   Note: SGP/SUP/SHARED_MID stay raw F32 (no BF16 round) to mirror the
-//   oracle's `silu(sgp) * sup` computed in F32 throughout. Only the final
-//   shared_out (= sg_scalar * (smid @ down_proj.T)) is BF16-rounded.
+//   Numerics: every per-expert intermediate (EXPERT_GU, EXPERT_MID,
+//   EXPERT_STACK) stays raw F32 to mirror the oracle's all-F32 chain
+//   (`mid @ down_proj.T` accumulates F32, then `topk_w * expert_stack`
+//   is summed in F32). The only BF16 rounds in the per-expert path are
+//   at (a) stage 3's test-output write where we expose one expert's
+//   output BF16-cast just like the oracle's `expert_stack.to(dtype)`,
+//   and (b) stage 4's moe_out where the topk-weighted sum is finally
+//   rounded — matching `moe_out.sum(0).to(dtype)` in the oracle.
 //
 // Parity output convention (BF16, sized for the largest staged intermediate):
 //   stage 1: output[0..k] = topk_weights  (BF16-rounded; renormed across k)
@@ -1525,8 +1532,7 @@ __global__ void qwen36_moe_ffn_step_kernel(
     unsigned int* __restrict__     counters,
     unsigned int* __restrict__     barrier_counter,
     unsigned int* __restrict__     barrier_flag) {
-    (void)gate_up_proj_w;
-    (void)down_proj_w;
+    // gate_up_proj_w, down_proj_w are used at stage>=3.
     // shared_*_w are used at stage>=2.
 
     const int num_blocks = static_cast<int>(gridDim.x);
@@ -1547,6 +1553,9 @@ __global__ void qwen36_moe_ffn_step_kernel(
     const int OFF_SUP           = OFF_SGP + shared_intermediate;
     const int OFF_SHARED_MID    = OFF_SUP + shared_intermediate;
     const int OFF_SHARED_OUT    = OFF_SHARED_MID + shared_intermediate;
+    const int OFF_EXPERT_GU     = OFF_SHARED_OUT + hidden;
+    const int OFF_EXPERT_MID    = OFF_EXPERT_GU + 2 * moe_intermediate;
+    const int OFF_EXPERT_STACK  = OFF_EXPERT_MID + moe_intermediate;
 
     // -- Phase A: load input + post_attn RMS norm --------------------------
     // Same idiom as the attn kernel's Phase A. Every block computes h_norm
@@ -1876,6 +1885,132 @@ __global__ void qwen36_moe_ffn_step_kernel(
                 workspace[OFF_SHARED_OUT + my_row] = val;
                 if (stage == 2) {
                     output[my_row] = static_cast<T>(val);
+                }
+            }
+            __syncthreads();
+        }
+    }
+
+    if (stage < 3) {
+        return;
+    }
+
+    // -- Phase G/H/I: per-expert FFN — top-1 dispatch (stage 3 only)  ------
+    // Stage 3 exercises the read pattern that stage 4 will sweep over k
+    // experts. We pick `e = topk_idx[0]` (the highest-scoring expert) and
+    // run its full FFN end-to-end:
+    //   gu      = gate_up_proj_w[e] @ h_norm                        [2*I]
+    //   mid     = silu(gu[:I]) * gu[I:]                             [I]
+    //   eo      = down_proj_w[e].T @ mid                            [hidden]
+    //
+    // All F32 internally; the only BF16 round in this path is when stage 3
+    // writes the test output (or, in stage 4, when the topk-weighted sum is
+    // finalised). EXPERT_STACK[0..hidden] keeps `eo` in F32 so stage 4 can
+    // multiply by topk_w without losing precision through a BF16 detour.
+    grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
+                               &counters[0]);
+
+    // Every block reads the chosen expert index from workspace once. The
+    // value was written by block 0 in Phase C and is visible after the
+    // grid barriers above.
+    __shared__ int s_expert_idx;
+    if (tid == 0) {
+        s_expert_idx = __float_as_int(workspace[OFF_TOPK_IDX + 0]);
+    }
+    __syncthreads();
+    const int e = s_expert_idx;
+
+    const int I_ = moe_intermediate;
+    const int two_I = 2 * I_;
+
+    // Phase G: matvec gate_up_proj_w[e] @ h_norm → EXPERT_GU[2*I].
+    // Layout: gate_up_proj_w[E, 2*I, hidden] — base for slab `e` is
+    // `e * 2*I * hidden`; row `r` within the slab is then `+ r * hidden`.
+    {
+        const T* gu_slab =
+            gate_up_proj_w + static_cast<size_t>(e) * two_I * hidden;
+        for (;;) {
+            __shared__ unsigned int my_row_g_s;
+            if (tid == 0) {
+                my_row_g_s = atomicAdd(&counters[0], 1u);
+            }
+            __syncthreads();
+            const int my_row = static_cast<int>(my_row_g_s);
+            if (my_row >= two_I) break;
+
+            const T* w_row = gu_slab + static_cast<size_t>(my_row) * hidden;
+            float partial = 0.0f;
+            for (int col = tid; col < hidden; col += block_size) {
+                partial += static_cast<float>(w_row[col]) * h_norm_lds[col];
+            }
+            shared_scratch[tid] = partial;
+            __syncthreads();
+            for (int s = block_size / 2; s > 0; s >>= 1) {
+                if (tid < s) shared_scratch[tid] += shared_scratch[tid + s];
+                __syncthreads();
+            }
+            if (tid == 0) {
+                // Raw F32 — oracle keeps the gate/up halves in F32 across
+                // the silu*mul step.
+                workspace[OFF_EXPERT_GU + my_row] = shared_scratch[0];
+            }
+            __syncthreads();
+        }
+    }
+
+    // Phase H: smid = silu(gu[:I]) * gu[I:] (block-0 only, F32 throughout).
+    grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
+                               &counters[0]);
+    if (blockIdx.x == 0) {
+        for (int i = tid; i < I_; i += block_size) {
+            const float gp = workspace[OFF_EXPERT_GU + i];
+            const float up = workspace[OFF_EXPERT_GU + I_ + i];
+            const float sigmoid_gp = 1.0f / (1.0f + expf(-gp));
+            const float silu_gp    = gp * sigmoid_gp;
+            workspace[OFF_EXPERT_MID + i] = silu_gp * up;
+        }
+        __syncthreads();
+    }
+
+    // Phase I: matvec down_proj_w[e].T @ mid → EXPERT_STACK[0..hidden].
+    // Layout: down_proj_w[E, hidden, I] — base for slab `e` is
+    // `e * hidden * I`; row `r` within the slab is `+ r * I`. The matmul
+    // contracts over I, producing one F32 element per output row.
+    grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
+                               &counters[0]);
+    {
+        const T* dp_slab =
+            down_proj_w + static_cast<size_t>(e) * hidden * I_;
+        for (;;) {
+            __shared__ unsigned int my_row_i_s;
+            if (tid == 0) {
+                my_row_i_s = atomicAdd(&counters[0], 1u);
+            }
+            __syncthreads();
+            const int my_row = static_cast<int>(my_row_i_s);
+            if (my_row >= hidden) break;
+
+            const T* w_row = dp_slab + static_cast<size_t>(my_row) * I_;
+            float partial = 0.0f;
+            for (int col = tid; col < I_; col += block_size) {
+                partial += static_cast<float>(w_row[col])
+                           * workspace[OFF_EXPERT_MID + col];
+            }
+            shared_scratch[tid] = partial;
+            __syncthreads();
+            for (int s = block_size / 2; s > 0; s >>= 1) {
+                if (tid < s) shared_scratch[tid] += shared_scratch[tid + s];
+                __syncthreads();
+            }
+            if (tid == 0) {
+                // Store raw F32 in EXPERT_STACK[0..hidden]. Stage 4 will
+                // weight-sum these (still F32) and BF16-round once at moe_out.
+                const float val = shared_scratch[0];
+                workspace[OFF_EXPERT_STACK + my_row] = val;
+                if (stage == 3) {
+                    // Oracle exposes `expert_stack` BF16-cast: match that
+                    // for the parity write.
+                    output[my_row] = static_cast<T>(bf16_round_rne_f32(val));
                 }
             }
             __syncthreads();

--- a/kernels/qwen36_moe.hip
+++ b/kernels/qwen36_moe.hip
@@ -253,9 +253,10 @@ __global__ void qwen36_moe_descriptor_walk_stub(
 //     Q_ROT    = 2*H*d + 2*Hkv*d + H*d + Hkv*d    [H*d]     stage-3 result
 //     K_ROT    = 3*H*d + 2*Hkv*d + H*d + Hkv*d    [Hkv*d]   stage-3 result
 //     ATTN     = 4*H*d + 4*Hkv*d                  [H*d]     stage-4 result
-//   …o_proj scratch (stage 5) goes in its own commit.
-//   Total stage-4 footprint: 5*H*d + 4*Hkv*d F32 elements.
-//   For 35B-A3B (H=16, Hkv=2, d=256, hidden=2048) that's 22,528 F32 = 88 KiB.
+//     GATED    = 5*H*d + 4*Hkv*d                  [H*d]     sigmoid(gate)*attn
+//     O_OUT    = 6*H*d + 4*Hkv*d                  [hidden]  o_proj output
+//   Total stage-5 footprint: 6*H*d + 4*Hkv*d + hidden F32 elements.
+//   For 35B-A3B (H=16, Hkv=2, d=256, hidden=2048) that's 28,672 F32 = 112 KiB.
 //
 //   counters[0]: work-stealing index, reused across phases. Reset by
 //                grid_barrier_reset_counter at every phase boundary.
@@ -392,6 +393,8 @@ __global__ void qwen36_moe_attn_step_kernel(
     const int OFF_Q_ROT    = 2 * H * d + 2 * Hkv * d + H * d + Hkv * d;
     const int OFF_K_ROT    = 3 * H * d + 2 * Hkv * d + H * d + Hkv * d;
     const int OFF_ATTN     = 4 * H * d + 4 * Hkv * d;
+    const int OFF_GATED    = 5 * H * d + 4 * Hkv * d;
+    const int OFF_O_OUT    = 6 * H * d + 4 * Hkv * d;
 
     // -- Phase C: per-head RMS norm of q_lanes = workspace[Q_RAW : Q_RAW+H*d]
     // Each block grabs a head index, reduces across head_dim, writes BF16
@@ -692,7 +695,91 @@ __global__ void qwen36_moe_attn_step_kernel(
         }
     }
 
-    // Stage 5 hooks in here in its own commit.
+    if (stage < 5) return;
+
+    grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
+                               &counters[0]);
+
+    // -- Phase H: gated_attn = bf16(sigmoid(out_gate)) * attn --------------
+    //
+    // out_gate is the upper half of q_raw stored at workspace[Q_RAW + H*d:].
+    // Each block grabs one Q head and produces gated_attn[h, :] in workspace.
+    // Oracle math (qwen36_moe_oracle.py line 215):
+    //   sigmoid_bf16 = bf16(sigmoid(f32(out_gate)))
+    //   gated_attn   = bf16(sigmoid_bf16 * attn)
+    {
+        for (;;) {
+            __shared__ unsigned int head_s;
+            if (tid == 0) {
+                head_s = atomicAdd(&counters[0], 1u);
+            }
+            __syncthreads();
+            const int h = static_cast<int>(head_s);
+            if (h >= H) break;
+
+            for (int i = tid; i < d; i += block_size) {
+                const float out_gate = workspace[OFF_Q_RAW + H * d + h * d + i];
+                const float attn_v   = workspace[OFF_ATTN + h * d + i];
+                const float sig      = 1.0f / (1.0f + expf(-out_gate));
+                const float sig_bf   = bf16_round_rne_f32(sig);
+                const float gated    = bf16_round_rne_f32(sig_bf * attn_v);
+                workspace[OFF_GATED + h * d + i] = gated;
+            }
+            __syncthreads();
+        }
+    }
+
+    grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
+                               &counters[0]);
+
+    // -- Phase I: o_proj matmul + residual ---------------------------------
+    //
+    // output_hidden[i] = bf16(input_hidden[i] +
+    //                        bf16(sum_j(o_proj_w[i, j] * gated_attn[j])))
+    //
+    // The o_proj output is BF16-rounded before adding the residual, then
+    // the sum itself is BF16-rounded. That's two RNE rounds — one at the
+    // matmul boundary (PyTorch's bf16 matmul), one at the add (bf16 + bf16).
+    // Skipping either drifts the test.
+    //
+    // Each block grabs one row of o_proj_w via work-stealing, reduces over
+    // qd = H*d in F32, and writes BF16 output_hidden to both workspace and
+    // (when stage == 5) the host-visible output buffer.
+    {
+        const int qd = H * d;
+
+        for (;;) {
+            __shared__ unsigned int my_row_s;
+            if (tid == 0) {
+                my_row_s = atomicAdd(&counters[0], 1u);
+            }
+            __syncthreads();
+            const int my_row = static_cast<int>(my_row_s);
+            if (my_row >= hidden) break;
+
+            const T* w_row = o_proj_w + static_cast<size_t>(my_row) * qd;
+            float partial = 0.0f;
+            for (int j = tid; j < qd; j += block_size) {
+                partial += load_as_float<T>(w_row, j) * workspace[OFF_GATED + j];
+            }
+            shared_scratch[tid] = partial;
+            __syncthreads();
+            for (int s = block_size / 2; s > 0; s >>= 1) {
+                if (tid < s) shared_scratch[tid] += shared_scratch[tid + s];
+                __syncthreads();
+            }
+            if (tid == 0) {
+                const float o_out  = bf16_round_rne_f32(shared_scratch[0]);
+                const float in_f   = load_as_float<T>(input_hidden, my_row);
+                const float result = bf16_round_rne_f32(in_f + o_out);
+                workspace[OFF_O_OUT + my_row] = result;
+                if (stage == 5) {
+                    output[my_row] = static_cast<T>(result);
+                }
+            }
+            __syncthreads();
+        }
+    }
 }
 
 } // namespace qwen36_moe

--- a/kernels/qwen36_moe.hip
+++ b/kernels/qwen36_moe.hip
@@ -252,9 +252,10 @@ __global__ void qwen36_moe_descriptor_walk_stub(
 //     K_NORMED = 2*H*d + 2*Hkv*d + H*d            [Hkv*d]   stage-2 result
 //     Q_ROT    = 2*H*d + 2*Hkv*d + H*d + Hkv*d    [H*d]     stage-3 result
 //     K_ROT    = 3*H*d + 2*Hkv*d + H*d + Hkv*d    [Hkv*d]   stage-3 result
-//   …attn slot (stage 4+) gets appended in its own commit.
-//   Total stage-3 footprint: 4*H*d + 4*Hkv*d F32 elements.
-//   For 35B-A3B (H=16, Hkv=2, d=256, hidden=2048) that's 18,432 F32 = 72 KiB.
+//     ATTN     = 4*H*d + 4*Hkv*d                  [H*d]     stage-4 result
+//   …o_proj scratch (stage 5) goes in its own commit.
+//   Total stage-4 footprint: 5*H*d + 4*Hkv*d F32 elements.
+//   For 35B-A3B (H=16, Hkv=2, d=256, hidden=2048) that's 22,528 F32 = 88 KiB.
 //
 //   counters[0]: work-stealing index, reused across phases. Reset by
 //                grid_barrier_reset_counter at every phase boundary.
@@ -390,6 +391,7 @@ __global__ void qwen36_moe_attn_step_kernel(
     const int OFF_K_NORMED = 2 * H * d + 2 * Hkv * d + H * d;
     const int OFF_Q_ROT    = 2 * H * d + 2 * Hkv * d + H * d + Hkv * d;
     const int OFF_K_ROT    = 3 * H * d + 2 * Hkv * d + H * d + Hkv * d;
+    const int OFF_ATTN     = 4 * H * d + 4 * Hkv * d;
 
     // -- Phase C: per-head RMS norm of q_lanes = workspace[Q_RAW : Q_RAW+H*d]
     // Each block grabs a head index, reduces across head_dim, writes BF16
@@ -619,7 +621,78 @@ __global__ void qwen36_moe_attn_step_kernel(
         }
     }
 
-    // Stages 4..5 hook in here in follow-up commits.
+    if (stage < 4) return;
+
+    grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
+                               &counters[0]);
+
+    // -- Phase G: GQA self-attention, kv_len = 1 ----------------------------
+    //
+    // The PR-4b2 oracle runs without a KV cache, so the only K/V token is
+    // the just-emitted one. With a single-token K, softmax over the score
+    // vector reduces to a single element ≡ 1.0 regardless of the score.
+    // The output therefore collapses to:
+    //
+    //   attn[h, :] = bf16(1.0) * v_full[h, :]
+    //              = v_raw[h // rep, :]      (already BF16-rounded F32)
+    //
+    // We still compute the QK score (skipped for the output) so the path
+    // exercises q_rot / k_rot loads — that's the slice of compute the
+    // future kv_len > 1 extension will reuse, with the softmax becoming
+    // non-trivial. For now the score is intentionally unused.
+    //
+    // Each block grabs one Q head, broadcasts the matching KV head's V row
+    // into workspace[ATTN + h*d : ...] and (when stage == 4) into output.
+    {
+        const int rep   = H / Hkv;
+        const float scale = rsqrtf(static_cast<float>(d));
+
+        for (;;) {
+            __shared__ unsigned int head_s;
+            if (tid == 0) {
+                head_s = atomicAdd(&counters[0], 1u);
+            }
+            __syncthreads();
+            const int hq = static_cast<int>(head_s);
+            if (hq >= H) break;
+
+            const int h_kv = hq / rep;
+
+            // Score (q · k) * scale — computed for path-coverage only at
+            // kv_len=1. Single-block reduction over head_dim=256.
+            float partial = 0.0f;
+            for (int i = tid; i < d; i += block_size) {
+                const float q = workspace[OFF_Q_ROT + hq   * d + i];
+                const float k = workspace[OFF_K_ROT + h_kv * d + i];
+                partial += q * k;
+            }
+            shared_scratch[tid] = partial;
+            __syncthreads();
+            for (int s = block_size / 2; s > 0; s >>= 1) {
+                if (tid < s) shared_scratch[tid] += shared_scratch[tid + s];
+                __syncthreads();
+            }
+            __shared__ float head_score;
+            if (tid == 0) {
+                head_score = shared_scratch[0] * scale;
+            }
+            __syncthreads();
+            (void)head_score;
+
+            // softmax([s]) = [1.0]; bf16(1.0 * v) = v. v_raw is already
+            // BF16-rounded F32 from Phase D so no extra rounding needed.
+            for (int i = tid; i < d; i += block_size) {
+                const float v = workspace[OFF_V_RAW + h_kv * d + i];
+                workspace[OFF_ATTN + hq * d + i] = v;
+                if (stage == 4) {
+                    output[hq * d + i] = static_cast<T>(v);
+                }
+            }
+            __syncthreads();
+        }
+    }
+
+    // Stage 5 hooks in here in its own commit.
 }
 
 } // namespace qwen36_moe

--- a/kernels/qwen36_moe.hip
+++ b/kernels/qwen36_moe.hip
@@ -1556,6 +1556,7 @@ __global__ void qwen36_moe_ffn_step_kernel(
     const int OFF_EXPERT_GU     = OFF_SHARED_OUT + hidden;
     const int OFF_EXPERT_MID    = OFF_EXPERT_GU + 2 * moe_intermediate;
     const int OFF_EXPERT_STACK  = OFF_EXPERT_MID + moe_intermediate;
+    const int OFF_MOE_OUT       = OFF_EXPERT_STACK + top_k * hidden;
 
     // -- Phase A: load input + post_attn RMS norm --------------------------
     // Same idiom as the attn kernel's Phase A. Every block computes h_norm
@@ -1895,122 +1896,169 @@ __global__ void qwen36_moe_ffn_step_kernel(
         return;
     }
 
-    // -- Phase G/H/I: per-expert FFN — top-1 dispatch (stage 3 only)  ------
-    // Stage 3 exercises the read pattern that stage 4 will sweep over k
-    // experts. We pick `e = topk_idx[0]` (the highest-scoring expert) and
-    // run its full FFN end-to-end:
-    //   gu      = gate_up_proj_w[e] @ h_norm                        [2*I]
-    //   mid     = silu(gu[:I]) * gu[I:]                             [I]
-    //   eo      = down_proj_w[e].T @ mid                            [hidden]
+    // -- Phase G/H/I: per-expert FFN — k-iteration loop  -------------------
+    // Stage 3 dispatches just topk_idx[0]; stage 4+ sweeps all k experts.
+    // The per-iteration body is the same; the difference is what we do
+    // after the loop:
+    //   stage 3 → expose EXPERT_STACK[0] BF16-cast as the parity output
+    //   stage 4 → sum topk_w[j] * EXPERT_STACK[j] across j, BF16-round once
     //
-    // All F32 internally; the only BF16 round in this path is when stage 3
-    // writes the test output (or, in stage 4, when the topk-weighted sum is
-    // finalised). EXPERT_STACK[0..hidden] keeps `eo` in F32 so stage 4 can
-    // multiply by topk_w without losing precision through a BF16 detour.
-    grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
-                               &counters[0]);
-
-    // Every block reads the chosen expert index from workspace once. The
-    // value was written by block 0 in Phase C and is visible after the
-    // grid barriers above.
-    __shared__ int s_expert_idx;
-    if (tid == 0) {
-        s_expert_idx = __float_as_int(workspace[OFF_TOPK_IDX + 0]);
-    }
-    __syncthreads();
-    const int e = s_expert_idx;
+    // Within each iteration:
+    //   gu  = gate_up_proj_w[e] @ h_norm                            [2*I]
+    //   mid = silu(gu[:I]) * gu[I:]                                 [I]
+    //   eo  = down_proj_w[e].T @ mid                                [hidden]
+    // EXPERT_STACK keeps `eo` raw F32 so stage 4 doesn't lose precision
+    // through a BF16 round-trip in the weighted sum.
 
     const int I_ = moe_intermediate;
     const int two_I = 2 * I_;
+    const int k_iters = (stage == 3) ? 1 : top_k;
 
-    // Phase G: matvec gate_up_proj_w[e] @ h_norm → EXPERT_GU[2*I].
-    // Layout: gate_up_proj_w[E, 2*I, hidden] — base for slab `e` is
-    // `e * 2*I * hidden`; row `r` within the slab is then `+ r * hidden`.
-    {
-        const T* gu_slab =
-            gate_up_proj_w + static_cast<size_t>(e) * two_I * hidden;
-        for (;;) {
-            __shared__ unsigned int my_row_g_s;
-            if (tid == 0) {
-                my_row_g_s = atomicAdd(&counters[0], 1u);
-            }
-            __syncthreads();
-            const int my_row = static_cast<int>(my_row_g_s);
-            if (my_row >= two_I) break;
+    for (int j = 0; j < k_iters; j++) {
+        // Per-iteration: every block reads the chosen expert index for
+        // this slot from workspace. Visible across blocks because the
+        // last grid barrier (Phase F's reset, plus any from the
+        // previous iteration's Phase I) ordered the writes.
+        grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
+                                   &counters[0]);
 
-            const T* w_row = gu_slab + static_cast<size_t>(my_row) * hidden;
-            float partial = 0.0f;
-            for (int col = tid; col < hidden; col += block_size) {
-                partial += static_cast<float>(w_row[col]) * h_norm_lds[col];
-            }
-            shared_scratch[tid] = partial;
-            __syncthreads();
-            for (int s = block_size / 2; s > 0; s >>= 1) {
-                if (tid < s) shared_scratch[tid] += shared_scratch[tid + s];
-                __syncthreads();
-            }
-            if (tid == 0) {
-                // Raw F32 — oracle keeps the gate/up halves in F32 across
-                // the silu*mul step.
-                workspace[OFF_EXPERT_GU + my_row] = shared_scratch[0];
-            }
-            __syncthreads();
-        }
-    }
-
-    // Phase H: smid = silu(gu[:I]) * gu[I:] (block-0 only, F32 throughout).
-    grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
-                               &counters[0]);
-    if (blockIdx.x == 0) {
-        for (int i = tid; i < I_; i += block_size) {
-            const float gp = workspace[OFF_EXPERT_GU + i];
-            const float up = workspace[OFF_EXPERT_GU + I_ + i];
-            const float sigmoid_gp = 1.0f / (1.0f + expf(-gp));
-            const float silu_gp    = gp * sigmoid_gp;
-            workspace[OFF_EXPERT_MID + i] = silu_gp * up;
+        __shared__ int s_expert_idx;
+        if (tid == 0) {
+            s_expert_idx = __float_as_int(workspace[OFF_TOPK_IDX + j]);
         }
         __syncthreads();
+        const int e = s_expert_idx;
+
+        // Phase G: matvec gate_up_proj_w[e] @ h_norm → EXPERT_GU[2*I].
+        // Layout: gate_up_proj_w[E, 2*I, hidden] — slab `e` base is
+        // `e * 2*I * hidden`; row `r` adds `r * hidden`.
+        {
+            const T* gu_slab =
+                gate_up_proj_w + static_cast<size_t>(e) * two_I * hidden;
+            for (;;) {
+                __shared__ unsigned int my_row_g_s;
+                if (tid == 0) {
+                    my_row_g_s = atomicAdd(&counters[0], 1u);
+                }
+                __syncthreads();
+                const int my_row = static_cast<int>(my_row_g_s);
+                if (my_row >= two_I) break;
+
+                const T* w_row = gu_slab + static_cast<size_t>(my_row) * hidden;
+                float partial = 0.0f;
+                for (int col = tid; col < hidden; col += block_size) {
+                    partial += static_cast<float>(w_row[col]) * h_norm_lds[col];
+                }
+                shared_scratch[tid] = partial;
+                __syncthreads();
+                for (int s = block_size / 2; s > 0; s >>= 1) {
+                    if (tid < s) shared_scratch[tid] += shared_scratch[tid + s];
+                    __syncthreads();
+                }
+                if (tid == 0) {
+                    workspace[OFF_EXPERT_GU + my_row] = shared_scratch[0];
+                }
+                __syncthreads();
+            }
+        }
+
+        // Phase H: smid = silu(gu[:I]) * gu[I:] (block-0 only, F32 throughout).
+        grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
+                                   &counters[0]);
+        if (blockIdx.x == 0) {
+            for (int i = tid; i < I_; i += block_size) {
+                const float gp = workspace[OFF_EXPERT_GU + i];
+                const float up = workspace[OFF_EXPERT_GU + I_ + i];
+                const float sigmoid_gp = 1.0f / (1.0f + expf(-gp));
+                const float silu_gp    = gp * sigmoid_gp;
+                workspace[OFF_EXPERT_MID + i] = silu_gp * up;
+            }
+            __syncthreads();
+        }
+
+        // Phase I: matvec down_proj_w[e].T @ mid → EXPERT_STACK[j*hidden..].
+        // Layout: down_proj_w[E, hidden, I]; slab `e` base is `e * hidden * I`,
+        // row `r` adds `r * I`. Contracts over I → one F32 per output row.
+        grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
+                                   &counters[0]);
+        {
+            const T* dp_slab =
+                down_proj_w + static_cast<size_t>(e) * hidden * I_;
+            const int slot_off = OFF_EXPERT_STACK + j * hidden;
+            for (;;) {
+                __shared__ unsigned int my_row_i_s;
+                if (tid == 0) {
+                    my_row_i_s = atomicAdd(&counters[0], 1u);
+                }
+                __syncthreads();
+                const int my_row = static_cast<int>(my_row_i_s);
+                if (my_row >= hidden) break;
+
+                const T* w_row = dp_slab + static_cast<size_t>(my_row) * I_;
+                float partial = 0.0f;
+                for (int col = tid; col < I_; col += block_size) {
+                    partial += static_cast<float>(w_row[col])
+                               * workspace[OFF_EXPERT_MID + col];
+                }
+                shared_scratch[tid] = partial;
+                __syncthreads();
+                for (int s = block_size / 2; s > 0; s >>= 1) {
+                    if (tid < s) shared_scratch[tid] += shared_scratch[tid + s];
+                    __syncthreads();
+                }
+                if (tid == 0) {
+                    const float val = shared_scratch[0];
+                    workspace[slot_off + my_row] = val;
+                    if (stage == 3 && j == 0) {
+                        // Match oracle's `expert_stack.to(dtype)` exposure.
+                        output[my_row] = static_cast<T>(bf16_round_rne_f32(val));
+                    }
+                }
+                __syncthreads();
+            }
+        }
     }
 
-    // Phase I: matvec down_proj_w[e].T @ mid → EXPERT_STACK[0..hidden].
-    // Layout: down_proj_w[E, hidden, I] — base for slab `e` is
-    // `e * hidden * I`; row `r` within the slab is `+ r * I`. The matmul
-    // contracts over I, producing one F32 element per output row.
+    if (stage < 4) {
+        return;
+    }
+
+    // -- Phase J: moe_out = sum_j (topk_w[j] * expert_stack[j])  -----------
+    // Single weighted reduction across `k` experts. Each output row `r` is
+    // independent → trivial work-stealing across hidden rows. The k loop
+    // inside the per-row work is short (k=8 on 35B-A3B); reading topk_w[j]
+    // and expert_stack[j*hidden + r] from workspace is cheap.
+    //
+    // Numerics: F32 accumulation, BF16-round once at the store. Matches
+    // `(topk_w_renorm.unsqueeze(-1) * expert_stack).sum(0).to(dtype)` in
+    // the oracle.
     grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
                                &counters[0]);
     {
-        const T* dp_slab =
-            down_proj_w + static_cast<size_t>(e) * hidden * I_;
+        const int K_ = top_k;
         for (;;) {
-            __shared__ unsigned int my_row_i_s;
+            __shared__ unsigned int my_row_j_s;
             if (tid == 0) {
-                my_row_i_s = atomicAdd(&counters[0], 1u);
+                my_row_j_s = atomicAdd(&counters[0], 1u);
             }
             __syncthreads();
-            const int my_row = static_cast<int>(my_row_i_s);
+            const int my_row = static_cast<int>(my_row_j_s);
             if (my_row >= hidden) break;
 
-            const T* w_row = dp_slab + static_cast<size_t>(my_row) * I_;
-            float partial = 0.0f;
-            for (int col = tid; col < I_; col += block_size) {
-                partial += static_cast<float>(w_row[col])
-                           * workspace[OFF_EXPERT_MID + col];
-            }
-            shared_scratch[tid] = partial;
-            __syncthreads();
-            for (int s = block_size / 2; s > 0; s >>= 1) {
-                if (tid < s) shared_scratch[tid] += shared_scratch[tid + s];
-                __syncthreads();
-            }
+            // Sequential per-row sum on a single thread (k=8). The row's
+            // 8 reads are coalesced across threads only if we parallelise
+            // by k — not worth the LDS shuffle for a tiny per-row sum.
             if (tid == 0) {
-                // Store raw F32 in EXPERT_STACK[0..hidden]. Stage 4 will
-                // weight-sum these (still F32) and BF16-round once at moe_out.
-                const float val = shared_scratch[0];
-                workspace[OFF_EXPERT_STACK + my_row] = val;
-                if (stage == 3) {
-                    // Oracle exposes `expert_stack` BF16-cast: match that
-                    // for the parity write.
-                    output[my_row] = static_cast<T>(bf16_round_rne_f32(val));
+                float acc = 0.0f;
+                for (int j = 0; j < K_; j++) {
+                    const float w = workspace[OFF_TOPK_VAL + j];
+                    const float v = workspace[OFF_EXPERT_STACK + j * hidden + my_row];
+                    acc += w * v;
+                }
+                const float val = bf16_round_rne_f32(acc);
+                workspace[OFF_MOE_OUT + my_row] = val;
+                if (stage == 4) {
+                    output[my_row] = static_cast<T>(val);
                 }
             }
             __syncthreads();

--- a/kernels/qwen36_moe.hip
+++ b/kernels/qwen36_moe.hip
@@ -1475,18 +1475,25 @@ __global__ void qwen36_moe_linear_step_kernel(
 //                          the attn kernel and full_attention_4b.hip)
 //
 //   workspace[F32], staged-FFN scratch (offsets in F32 elements):
-//     H_NORM        = 0                                  [hidden]    rms-normed input
-//     ROUTER_LOGITS = hidden                             [E]
-//     ROUTER_PROBS  = hidden + E                         [E]
-//     TOPK_VAL      = hidden + 2*E                       [k]   renormed
-//     TOPK_IDX      = hidden + 2*E + k                   [k]   bit-cast u32 in float slot
-//     SHARED_MID    = hidden + 2*E + 2*k                 [Is]  shared-expert silu(g)*u
-//     SHARED_OUT    = hidden + 2*E + 2*k + Is            [hidden]
-//     EXPERT_STACK  = hidden + 2*E + 2*k + Is + hidden   [k * hidden] per-expert outs
-//     MOE_OUT       = ... + k*hidden                     [hidden]
-//     OUTPUT_HIDDEN = ... + hidden                       [hidden]
+//     H_NORM        = 0                                              [hidden]    rms-normed input
+//     ROUTER_LOGITS = hidden                                         [E]
+//     ROUTER_PROBS  = hidden + E                                     [E]
+//     TOPK_VAL      = hidden + 2*E                                   [k]   renormed
+//     TOPK_IDX      = hidden + 2*E + k                               [k]   bit-cast u32 in float slot
+//     SG_SCALAR     = hidden + 2*E + 2*k                             [1]   sigmoid(shared_expert_gate @ h_norm)
+//     SGP           = hidden + 2*E + 2*k + 1                         [Is]  shared_gate_proj output (F32, no BF16 round)
+//     SUP           = hidden + 2*E + 2*k + 1 + Is                    [Is]  shared_up_proj output
+//     SHARED_MID    = hidden + 2*E + 2*k + 1 + 2*Is                  [Is]  silu(sgp) * sup (F32)
+//     SHARED_OUT    = hidden + 2*E + 2*k + 1 + 3*Is                  [hidden] shared expert path output (BF16-rounded F32)
+//     EXPERT_STACK  = hidden + 2*E + 2*k + 1 + 3*Is + hidden         [k * hidden] per-expert outs
+//     MOE_OUT       = ... + k*hidden                                 [hidden]
+//     OUTPUT_HIDDEN = ... + hidden                                   [hidden]
 //   For 35B-A3B (hidden=2048, E=256, k=8, Is=512) stage-5 footprint is
-//   ~23,568 F32 = ~92 KiB. Well within the persistent-decode budget.
+//   ~26,641 F32 = ~104 KiB. Well within the persistent-decode budget.
+//
+//   Note: SGP/SUP/SHARED_MID stay raw F32 (no BF16 round) to mirror the
+//   oracle's `silu(sgp) * sup` computed in F32 throughout. Only the final
+//   shared_out (= sg_scalar * (smid @ down_proj.T)) is BF16-rounded.
 //
 // Parity output convention (BF16, sized for the largest staged intermediate):
 //   stage 1: output[0..k] = topk_weights  (BF16-rounded; renormed across k)
@@ -1520,10 +1527,7 @@ __global__ void qwen36_moe_ffn_step_kernel(
     unsigned int* __restrict__     barrier_flag) {
     (void)gate_up_proj_w;
     (void)down_proj_w;
-    (void)shared_gate_proj_w;
-    (void)shared_up_proj_w;
-    (void)shared_down_proj_w;
-    (void)shared_expert_gate_w;
+    // shared_*_w are used at stage>=2.
 
     const int num_blocks = static_cast<int>(gridDim.x);
     const int tid        = threadIdx.x;
@@ -1538,6 +1542,11 @@ __global__ void qwen36_moe_ffn_step_kernel(
     const int OFF_ROUTER_PROBS  = hidden + num_experts;
     const int OFF_TOPK_VAL      = hidden + 2 * num_experts;
     const int OFF_TOPK_IDX      = hidden + 2 * num_experts + top_k;
+    const int OFF_SG_SCALAR     = hidden + 2 * num_experts + 2 * top_k;
+    const int OFF_SGP           = OFF_SG_SCALAR + 1;
+    const int OFF_SUP           = OFF_SGP + shared_intermediate;
+    const int OFF_SHARED_MID    = OFF_SUP + shared_intermediate;
+    const int OFF_SHARED_OUT    = OFF_SHARED_MID + shared_intermediate;
 
     // -- Phase A: load input + post_attn RMS norm --------------------------
     // Same idiom as the attn kernel's Phase A. Every block computes h_norm
@@ -1743,6 +1752,134 @@ __global__ void qwen36_moe_ffn_step_kernel(
             }
         }
         __syncthreads();
+    }
+
+    if (stage < 2) {
+        return;
+    }
+
+    // -- Phase D: shared-expert input projections (work-stealing matvec) ---
+    // Three matrices read out of one work-stealing loop. Row index space:
+    //   [0,             Is)            → sgp[r]    via shared_gate_proj_w
+    //   [Is,            2*Is)          → sup[r-Is] via shared_up_proj_w
+    //   [2*Is]                          → sg_scalar = sigmoid(shared_expert_gate_w @ h_norm)
+    // sgp and sup are stored as raw F32 (no BF16 round) so the silu*mul in
+    // Phase E matches the oracle's all-F32 path. sg_scalar likewise stays
+    // F32 — the only BF16 round in this stage is on the final shared_out.
+    //
+    // Block 0 finished topk; sync everyone before Phase D and reset the
+    // work-stealing counter (Phase B left it at >=E from the gate matmul).
+    grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
+                               &counters[0]);
+
+    const int Is_ = shared_intermediate;
+    const int total_rows_d = 2 * Is_ + 1;
+    for (;;) {
+        __shared__ unsigned int my_row_d_s;
+        if (tid == 0) {
+            my_row_d_s = atomicAdd(&counters[0], 1u);
+        }
+        __syncthreads();
+        const int my_row = static_cast<int>(my_row_d_s);
+        if (my_row >= total_rows_d) break;
+
+        const T* w_row;
+        int      write_offset;
+        bool     is_gate_row = false;
+        if (my_row < Is_) {
+            w_row        = shared_gate_proj_w + static_cast<size_t>(my_row) * hidden;
+            write_offset = OFF_SGP + my_row;
+        } else if (my_row < 2 * Is_) {
+            const int local = my_row - Is_;
+            w_row        = shared_up_proj_w + static_cast<size_t>(local) * hidden;
+            write_offset = OFF_SUP + local;
+        } else {
+            // Single-row "[1, hidden]" weight; dot it with h_norm and apply
+            // sigmoid() before storing into SG_SCALAR.
+            w_row        = shared_expert_gate_w;
+            write_offset = OFF_SG_SCALAR;
+            is_gate_row  = true;
+        }
+
+        float partial = 0.0f;
+        for (int col = tid; col < hidden; col += block_size) {
+            partial += static_cast<float>(w_row[col]) * h_norm_lds[col];
+        }
+        shared_scratch[tid] = partial;
+        __syncthreads();
+        for (int s = block_size / 2; s > 0; s >>= 1) {
+            if (tid < s) shared_scratch[tid] += shared_scratch[tid + s];
+            __syncthreads();
+        }
+        if (tid == 0) {
+            float val = shared_scratch[0];
+            if (is_gate_row) {
+                // sigmoid in F32 (matches oracle's `torch.sigmoid(sg_logit)`).
+                val = 1.0f / (1.0f + expf(-val));
+            }
+            workspace[write_offset] = val;
+        }
+        __syncthreads();
+    }
+
+    // -- Phase E: smid = silu(sgp) * sup  (block-0 only, F32 throughout) ---
+    // Block 0 owns the write so we don't have multiple blocks racing on
+    // `workspace[OFF_SHARED_MID..]`. The grid_barrier below makes the
+    // writes visible to every block before Phase F starts.
+    grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
+                               &counters[0]);
+    if (blockIdx.x == 0) {
+        for (int i = tid; i < Is_; i += block_size) {
+            const float gp     = workspace[OFF_SGP + i];
+            const float up     = workspace[OFF_SUP + i];
+            const float sigmoid_gp = 1.0f / (1.0f + expf(-gp));
+            const float silu_gp    = gp * sigmoid_gp;
+            // No BF16 round — oracle keeps this F32 until the final cast.
+            workspace[OFF_SHARED_MID + i] = silu_gp * up;
+        }
+        __syncthreads();
+    }
+
+    // -- Phase F: shared_out = sg_scalar * (smid @ down_proj.T) ------------
+    // Work-stealing matvec across `hidden` rows. The sg_scalar multiply is
+    // folded into the per-row write; BF16-round happens once at the end
+    // (matches `(sg_scalar * sdown).to(dtype)` in the oracle).
+    grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
+                               &counters[0]);
+    {
+        // Read sg_scalar once per block; stays in registers.
+        const float sg_scalar = workspace[OFF_SG_SCALAR];
+        for (;;) {
+            __shared__ unsigned int my_row_f_s;
+            if (tid == 0) {
+                my_row_f_s = atomicAdd(&counters[0], 1u);
+            }
+            __syncthreads();
+            const int my_row = static_cast<int>(my_row_f_s);
+            if (my_row >= hidden) break;
+
+            const T* w_row =
+                shared_down_proj_w + static_cast<size_t>(my_row) * Is_;
+            float partial = 0.0f;
+            for (int col = tid; col < Is_; col += block_size) {
+                partial += static_cast<float>(w_row[col])
+                           * workspace[OFF_SHARED_MID + col];
+            }
+            shared_scratch[tid] = partial;
+            __syncthreads();
+            for (int s = block_size / 2; s > 0; s >>= 1) {
+                if (tid < s) shared_scratch[tid] += shared_scratch[tid + s];
+                __syncthreads();
+            }
+            if (tid == 0) {
+                const float val = bf16_round_rne_f32(sg_scalar * shared_scratch[0]);
+                workspace[OFF_SHARED_OUT + my_row] = val;
+                if (stage == 2) {
+                    output[my_row] = static_cast<T>(val);
+                }
+            }
+            __syncthreads();
+        }
     }
 }
 

--- a/kernels/qwen36_moe.hip
+++ b/kernels/qwen36_moe.hip
@@ -21,10 +21,28 @@
 // regressions in the past. Keep this file standalone.
 
 #include <hip/hip_bf16.h>
+#include <hip/hip_bfloat16.h>
 #include <hip/hip_runtime.h>
+#include <math.h>
 #include <stdint.h>
 
 namespace qwen36_moe {
+
+// Round an F32 value to BF16 precision (round-to-nearest-even) and widen
+// back to F32. Used at every "BF16 store" point so that intermediate F32
+// computation matches the BF16-quantised values PyTorch produces. Finite
+// inputs only — qwen36_moe is downstream of upcasted-from-BF16 weights and
+// inputs, so NaN preservation is not needed here.
+__device__ __forceinline__ float bf16_round_rne_f32(float x) {
+    uint32_t bits;
+    __builtin_memcpy(&bits, &x, 4);
+    uint32_t rounding_bias = 0x7FFFu + ((bits >> 16) & 1u);
+    bits += rounding_bias;
+    bits &= 0xFFFF0000u;
+    float y;
+    __builtin_memcpy(&y, &bits, 4);
+    return y;
+}
 
 // -- Layer descriptor (mirror of Rust Qwen36MoeDecodeLayerDesc) ----------
 
@@ -202,6 +220,206 @@ __global__ void qwen36_moe_descriptor_walk_stub(
     // Reset the work counter for any future barriers (idempotent here).
     grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
                                &counters[0]);
+}
+
+// =============================================================================
+// Single-layer full-attention parity kernel (PR 4b2)
+//
+// This is the staged build-up of the real megakernel's attention path. Each
+// stage adds one slice of compute — the host parity test downloads the
+// matching intermediate buffer and compares it to the PyTorch oracle.
+//
+//   stage 1: x_norm + q_proj + q-gate split + per-head q_norm  → write q_normed
+//   stage 2: ... + k_proj + v_proj + per-head k_norm           → write k_normed
+//   stage 3: ... + partial-RoPE on q & k                       → write q_rot/k_rot
+//   stage 4: ... + GQA self-attention (kv_len=1)               → write attn
+//   stage 5: ... + sigmoid(out_gate)*attn + o_proj + residual  → write out
+//
+// PR 4b2 step 1 lands stage 1. Stages 2–5 ship in follow-up commits and add
+// to this same kernel; the launcher's `stage` argument decides where to stop.
+//
+// Layout choices fixed up-front so later stages don't reshuffle:
+//   block_size = 256  (4 waves on gfx1100; matches head_dim and divides
+//                     hidden=2048 evenly)
+//   grid_size  = num_cus  (one block per CU, all guaranteed concurrent on
+//                          RDNA3 → grid_barrier safe without coop launch)
+//
+//   workspace[F32], at least 2*H*d + 2*Hkv*d entries:
+//     [0,           2*H*d):           q_raw   (BF16-rounded F32 to mirror
+//                                              PyTorch's BF16 q_raw matmul)
+//     reserved for stage 2+:
+//     [2*H*d,       2*H*d + Hkv*d):   k_raw
+//     [2*H*d + Hkv*d, 2*H*d + 2*Hkv*d): v_raw
+//
+//   counters[0]: work-stealing index, reused across phases. Reset by
+//                grid_barrier_reset_counter at every phase boundary.
+//
+//   LDS layout (extern __shared__):
+//     lds[0,        hidden):           x_norm_lds (BF16-rounded F32 view)
+//     lds[hidden,   hidden+block_size): scratch (block reduction)
+//   Total: (hidden + block_size) * 4 bytes = (2048+256)*4 = 9 KiB on 35B-A3B.
+//   Comfortably under gfx1100's 64 KiB LDS/WG cap; ≥2 WGs/CU possible.
+
+template <typename T>
+__device__ inline float load_as_float(const T* p, int idx) {
+    return static_cast<float>(p[idx]);
+}
+
+template <typename T>
+__global__ void qwen36_moe_attn_step_kernel(
+    int                            stage,
+    int                            hidden,
+    int                            num_heads,
+    int                            num_kv_heads,
+    int                            head_dim,
+    int                            rotary_dim,    // unused at stage 1, parsed at stage 3+
+    float                          rope_theta,    // unused at stage 1
+    float                          rms_norm_eps,
+    int                            position,      // unused at stage 1
+    const T* __restrict__          input_hidden,  // [hidden]
+    const T* __restrict__          input_norm_w,  // [hidden]
+    const T* __restrict__          q_proj_w,      // [2*H*d, hidden]
+    const T* __restrict__          k_proj_w,      // [Hkv*d, hidden]   (nullable for stage<2)
+    const T* __restrict__          v_proj_w,      // [Hkv*d, hidden]   (nullable for stage<2)
+    const T* __restrict__          q_norm_w,      // [d]
+    const T* __restrict__          k_norm_w,      // [d]               (nullable for stage<2)
+    const T* __restrict__          o_proj_w,      // [hidden, H*d]     (nullable for stage<5)
+    T* __restrict__                output,        // BF16, sized for the largest staged intermediate
+    float* __restrict__             workspace,    // F32 scratch, see header comment
+    unsigned int* __restrict__     counters,
+    unsigned int* __restrict__     barrier_counter,
+    unsigned int* __restrict__     barrier_flag) {
+    (void)k_proj_w;
+    (void)v_proj_w;
+    (void)k_norm_w;
+    (void)o_proj_w;
+    (void)rotary_dim;
+    (void)rope_theta;
+    (void)position;
+
+    const int num_blocks = static_cast<int>(gridDim.x);
+    const int tid        = threadIdx.x;
+    const int block_size = static_cast<int>(blockDim.x);
+
+    extern __shared__ float lds[];
+    float* x_norm_lds    = lds;             // [hidden]
+    float* shared_scratch = lds + hidden;   // [block_size]
+
+    // -- Phase A: load input + RMS norm ------------------------------------
+    // Every block computes x_norm into its own LDS. Redundant compute, but
+    // avoids a pre-stage cross-block sync; the RMS reduction is cheap
+    // compared to the matmul that follows.
+    for (int col = tid; col < hidden; col += block_size) {
+        x_norm_lds[col] = load_as_float<T>(input_hidden, col);
+    }
+    __syncthreads();
+
+    float partial_sq = 0.0f;
+    for (int col = tid; col < hidden; col += block_size) {
+        partial_sq += x_norm_lds[col] * x_norm_lds[col];
+    }
+    shared_scratch[tid] = partial_sq;
+    __syncthreads();
+    for (int s = block_size / 2; s > 0; s >>= 1) {
+        if (tid < s) shared_scratch[tid] += shared_scratch[tid + s];
+        __syncthreads();
+    }
+    __shared__ float inv_rms_input;
+    if (tid == 0) {
+        inv_rms_input = rsqrtf(shared_scratch[0] / static_cast<float>(hidden) + rms_norm_eps);
+    }
+    __syncthreads();
+
+    // BF16-round each x_norm element so the matmul reads what PyTorch reads
+    // (its `out.to(in_dtype)` step in rms_norm).
+    for (int col = tid; col < hidden; col += block_size) {
+        const float w = load_as_float<T>(input_norm_w, col);
+        x_norm_lds[col] = bf16_round_rne_f32(x_norm_lds[col] * inv_rms_input * w);
+    }
+    __syncthreads();
+
+    // -- Phase B: q_raw = q_proj_w @ x_norm  (work-stealing matvec) --------
+    // Output rows of q_raw are written BF16-rounded into workspace[0..2*H*d]
+    // so that the per-head RMS norm in Phase C reads the same F32-of-BF16
+    // values PyTorch's BF16 q_raw represents.
+    const int q_out_dim = 2 * num_heads * head_dim;
+
+    for (;;) {
+        __shared__ unsigned int my_row_s;
+        if (tid == 0) {
+            my_row_s = atomicAdd(&counters[0], 1u);
+        }
+        __syncthreads();
+        const int my_row = static_cast<int>(my_row_s);
+        if (my_row >= q_out_dim) break;
+
+        const T* w_row = q_proj_w + static_cast<size_t>(my_row) * hidden;
+        float partial = 0.0f;
+        for (int col = tid; col < hidden; col += block_size) {
+            partial += load_as_float<T>(w_row, col) * x_norm_lds[col];
+        }
+        shared_scratch[tid] = partial;
+        __syncthreads();
+        for (int s = block_size / 2; s > 0; s >>= 1) {
+            if (tid < s) shared_scratch[tid] += shared_scratch[tid + s];
+            __syncthreads();
+        }
+        if (tid == 0) {
+            workspace[my_row] = bf16_round_rne_f32(shared_scratch[0]);
+        }
+        __syncthreads();
+    }
+
+    grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
+                               &counters[0]);
+
+    // -- Phase C: per-head RMS norm of q_lanes = workspace[0..H*d] ---------
+    // Each block grabs a head index and reduces across head_dim, writing
+    // BF16 q_normed[h*d : (h+1)*d] to `output`.
+    if (stage >= 1) {
+        const int H = num_heads;
+        const int d = head_dim;
+
+        for (;;) {
+            __shared__ unsigned int head_s;
+            if (tid == 0) {
+                head_s = atomicAdd(&counters[0], 1u);
+            }
+            __syncthreads();
+            const int h = static_cast<int>(head_s);
+            if (h >= H) break;
+
+            const int base = h * d;
+            float partial = 0.0f;
+            for (int i = tid; i < d; i += block_size) {
+                const float v = workspace[base + i];
+                partial += v * v;
+            }
+            shared_scratch[tid] = partial;
+            __syncthreads();
+            for (int s = block_size / 2; s > 0; s >>= 1) {
+                if (tid < s) shared_scratch[tid] += shared_scratch[tid + s];
+                __syncthreads();
+            }
+            __shared__ float head_inv_rms;
+            if (tid == 0) {
+                head_inv_rms = rsqrtf(shared_scratch[0] / static_cast<float>(d) + rms_norm_eps);
+            }
+            __syncthreads();
+
+            for (int i = tid; i < d; i += block_size) {
+                const float v = workspace[base + i];
+                const float wv = load_as_float<T>(q_norm_w, i);
+                const float normed = bf16_round_rne_f32(v * head_inv_rms * wv);
+                output[base + i] = static_cast<T>(normed);
+            }
+            __syncthreads();
+        }
+    }
+
+    // Stages 2..5 hook in here in follow-up commits. Each starts with a
+    // grid_barrier_reset_counter and reuses `counters[0]` for its own
+    // work-stealing.
 }
 
 } // namespace qwen36_moe

--- a/kernels/qwen36_moe.hip
+++ b/kernels/qwen36_moe.hip
@@ -1066,7 +1066,131 @@ __global__ void qwen36_moe_linear_step_kernel(
         }
     }
 
-    // Stages 3..5 hook in here in follow-up commits.
+    if (stage < 3) return;
+
+    grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
+                               &counters[0]);
+
+    // Workspace offsets reserved by the layout comment for stages 3+.
+    const int OFF_Q_NORMED = qkv_dim + val_dim + 2 * V;
+    const int OFF_K_NORMED = OFF_Q_NORMED + K * k_dim;
+    const int OFF_Q_REP    = OFF_K_NORMED + K * k_dim;
+    const int OFF_K_REP    = OFF_Q_REP + V * k_dim;
+
+    // -- Phase D: L2-normalize Q and K per K-head --------------------------
+    //
+    // q_raw lives at workspace[OFF_QKV_RAW : OFF_QKV_RAW + key_dim] (the
+    // first slice of silu_out from Phase C); k_raw is the next key_dim
+    // slice. Each block grabs one head out of a 2*K work pool — first K
+    // heads are Q, next K are K.
+    //
+    // L2 norm matches `F.normalize(p=2, dim=-1, eps=1e-6)`:
+    //   norm = sqrt(sum(x^2))                    in F32
+    //   denom = max(bf16(norm), eps)             clamped, BF16-rounded
+    //   y[i]  = bf16(x[i] / bf16(denom))         BF16-rounded division
+    {
+        const int total_heads = 2 * K;
+        for (;;) {
+            __shared__ unsigned int head_s;
+            if (tid == 0) {
+                head_s = atomicAdd(&counters[0], 1u);
+            }
+            __syncthreads();
+            const int head_idx = static_cast<int>(head_s);
+            if (head_idx >= total_heads) break;
+
+            const bool is_k = head_idx >= K;
+            const int  h    = is_k ? (head_idx - K) : head_idx;
+            const int  src_off = (is_k ? OFF_QKV_RAW + key_dim
+                                       : OFF_QKV_RAW) + h * k_dim;
+            const int  dst_off = (is_k ? OFF_K_NORMED : OFF_Q_NORMED) + h * k_dim;
+
+            // Sum of squares (F32 — the reduction is the precision-critical
+            // part; doing it in BF16 would drift visibly).
+            float partial_ss = 0.0f;
+            for (int i = tid; i < k_dim; i += block_size) {
+                const float v = workspace[src_off + i];
+                partial_ss += v * v;
+            }
+            shared_scratch[tid] = partial_ss;
+            __syncthreads();
+            for (int s = block_size / 2; s > 0; s >>= 1) {
+                if (tid < s) shared_scratch[tid] += shared_scratch[tid + s];
+                __syncthreads();
+            }
+            __shared__ float head_denom;
+            if (tid == 0) {
+                const float norm  = bf16_round_rne_f32(sqrtf(shared_scratch[0]));
+                head_denom        = bf16_round_rne_f32(fmaxf(norm, 1e-6f));
+            }
+            __syncthreads();
+
+            for (int i = tid; i < k_dim; i += block_size) {
+                const float v = workspace[src_off + i];
+                workspace[dst_off + i] = bf16_round_rne_f32(v / head_denom);
+            }
+            __syncthreads();
+        }
+    }
+
+    grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
+                               &counters[0]);
+
+    // -- Phase E: GQA fan-out + Q scale ------------------------------------
+    //
+    // For each V-head v in [0, V):
+    //   src_kh = v // rep
+    //   q_rep[v, :]   = bf16(q_normed[src_kh, :] * 1/sqrt(k_dim))
+    //   k_rep[v, :]   =      k_normed[src_kh, :]            (just broadcast)
+    //
+    // Stage 3 publishes q_scaled || k_rep || v_heads concatenated:
+    //   output[0..V*k_dim)                            = q_scaled
+    //   output[V*k_dim..2*V*k_dim)                    = k_rep
+    //   output[2*V*k_dim..2*V*k_dim + V*v_dim)        = v_heads
+    {
+        const int rep = V / K;
+        const float q_scale = rsqrtf(static_cast<float>(k_dim));
+
+        for (;;) {
+            __shared__ unsigned int vhead_s;
+            if (tid == 0) {
+                vhead_s = atomicAdd(&counters[0], 1u);
+            }
+            __syncthreads();
+            const int vhead = static_cast<int>(vhead_s);
+            if (vhead >= V) break;
+
+            const int src_kh = vhead / rep;
+            const int q_src  = OFF_Q_NORMED + src_kh * k_dim;
+            const int k_src  = OFF_K_NORMED + src_kh * k_dim;
+            const int q_dst  = OFF_Q_REP    + vhead  * k_dim;
+            const int k_dst  = OFF_K_REP    + vhead  * k_dim;
+
+            for (int i = tid; i < k_dim; i += block_size) {
+                const float qn = workspace[q_src + i];
+                const float kn = workspace[k_src + i];
+                const float qs = bf16_round_rne_f32(qn * q_scale);
+                workspace[q_dst + i] = qs;
+                workspace[k_dst + i] = kn;
+                if (stage == 3) {
+                    output[vhead * k_dim + i]               = static_cast<T>(qs);
+                    output[V * k_dim + vhead * k_dim + i]   = static_cast<T>(kn);
+                }
+            }
+            // V is reshape-only of v_raw (silu_out's third partition); no
+            // arithmetic, just publish for stage 3 verification.
+            if (stage == 3) {
+                const int v_src = OFF_QKV_RAW + 2 * key_dim + vhead * v_dim;
+                for (int i = tid; i < v_dim; i += block_size) {
+                    const float vv = workspace[v_src + i];
+                    output[2 * V * k_dim + vhead * v_dim + i] = static_cast<T>(vv);
+                }
+            }
+            __syncthreads();
+        }
+    }
+
+    // Stages 4..5 hook in here in follow-up commits.
 }
 
 } // namespace qwen36_moe

--- a/kernels/qwen36_moe.hip
+++ b/kernels/qwen36_moe.hip
@@ -989,9 +989,84 @@ __global__ void qwen36_moe_linear_step_kernel(
              i += block_size * num_blocks) {
             output[i] = static_cast<T>(workspace[OFF_QKV_RAW + i]);
         }
+        return;
     }
 
-    // Stages 2..5 hook in here in follow-up commits.
+    grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
+                               &counters[0]);
+
+    // -- Phase C: depthwise conv1d + silu + state update -------------------
+    //
+    // For each output channel ch in [0, qkv_dim):
+    //   conv_in[t] = conv_state_before[ch, t]   for t in [0, kernel-1)
+    //   conv_in[kernel-1] = bf16-rounded qkv_raw[ch]   (already in workspace)
+    //   conv_out_bf = bf16(sum_t(conv_in[t] * conv1d_w[ch, t]) + bias[ch])
+    //   silu_out    = bf16(conv_out_bf * sigmoid(conv_out_bf))
+    //   conv_state_after[ch, 0..kernel-2] = conv_in[1..kernel-1]
+    //
+    // Output channels are independent and the per-channel arithmetic is
+    // small (kernel multiplies + one sigmoid), so we use a strided
+    // thread-per-channel loop instead of block-per-channel work-stealing —
+    // ~256 channels processed per block per stride, much less overhead.
+    //
+    // KERNEL_MAX bounds the local conv_in array; 8 fits 35B-A3B's
+    // conv_kernel_dim=4 with margin and avoids dynamic LDS for the tiny
+    // per-thread scratch. Bigger kernels would just need a bump here.
+    constexpr int KERNEL_MAX = 8;
+    const int kernel = conv_kernel_dim;
+    const int kstate = kernel - 1;
+    const int total_threads = num_blocks * block_size;
+    for (int ch = blockIdx.x * block_size + tid;
+         ch < qkv_dim;
+         ch += total_threads) {
+        // Load conv_state_before (BF16) into a per-thread F32 register window.
+        float conv_in[KERNEL_MAX];
+        for (int t = 0; t < kstate; ++t) {
+            conv_in[t] = static_cast<float>(conv_state[ch * kstate + t]);
+        }
+        // Tail slot is the freshly-projected qkv_raw[ch] (already
+        // BF16-rounded in workspace by Phase B).
+        const float new_qkv = workspace[OFF_QKV_RAW + ch];
+        conv_in[kstate] = new_qkv;
+
+        // Depthwise conv1d: per-channel dot product over the kernel window.
+        float sum = 0.0f;
+        for (int t = 0; t < kernel; ++t) {
+            sum += conv_in[t] * static_cast<float>(conv1d_w[ch * kernel + t]);
+        }
+        // Bias is optional (None on 35B-A3B; the oracle handles both).
+        if (conv1d_bias != nullptr) {
+            sum += static_cast<float>(conv1d_bias[ch]);
+        }
+        // Match PyTorch BF16 conv: the matmul-then-bias result lands in BF16
+        // before silu reads it.
+        const float conv_out_bf = bf16_round_rne_f32(sum);
+
+        // SiLU: x * sigmoid(x) in F32, then BF16-round at the dtype
+        // boundary, exactly as `silu()` in oracle/qwen36_moe_linear_oracle.py.
+        const float sig = 1.0f / (1.0f + expf(-conv_out_bf));
+        const float silu_out = bf16_round_rne_f32(conv_out_bf * sig);
+
+        // Overwrite QKV_RAW slot with SILU_OUT — qkv_raw is no longer
+        // needed after this phase, and the channel layout is identical.
+        workspace[OFF_QKV_RAW + ch] = silu_out;
+
+        // Shift conv_state_before left by one and append the new qkv_raw
+        // at position kstate-1, store back as BF16. Each thread owns its
+        // channel's row — no cross-thread races.
+        for (int t = 0; t < kstate - 1; ++t) {
+            conv_state[ch * kstate + t] =
+                static_cast<T>(conv_in[t + 1]);
+        }
+        conv_state[ch * kstate + (kstate - 1)] = static_cast<T>(new_qkv);
+
+        // Stage 2 publishes silu_out to the host-visible output buffer.
+        if (stage == 2) {
+            output[ch] = static_cast<T>(silu_out);
+        }
+    }
+
+    // Stages 3..5 hook in here in follow-up commits.
 }
 
 } // namespace qwen36_moe

--- a/kernels/qwen36_moe.hip
+++ b/kernels/qwen36_moe.hip
@@ -2064,6 +2064,39 @@ __global__ void qwen36_moe_ffn_step_kernel(
             __syncthreads();
         }
     }
+
+    if (stage < 5) {
+        return;
+    }
+
+    // -- Phase K: residual add — output_hidden = input + moe + shared  -----
+    // The trivial closing slice. Each output row is independent; F32 sum
+    // with one BF16 round at the store, matching the oracle's
+    // `(input_hidden.f32 + moe_out.f32 + shared_out.f32).to(dtype)`.
+    //
+    // moe_out is already in workspace at OFF_MOE_OUT (BF16-rounded F32);
+    // shared_out is at OFF_SHARED_OUT (BF16-rounded F32). We add the
+    // input_hidden (BF16 → F32 promotion) on top.
+    grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
+                               &counters[0]);
+    for (;;) {
+        __shared__ unsigned int my_row_k_s;
+        if (tid == 0) {
+            my_row_k_s = atomicAdd(&counters[0], 1u);
+        }
+        __syncthreads();
+        const int my_row = static_cast<int>(my_row_k_s);
+        if (my_row >= hidden) break;
+
+        if (tid == 0) {
+            const float in_f   = static_cast<float>(input_hidden[my_row]);
+            const float moe_f  = workspace[OFF_MOE_OUT + my_row];
+            const float shr_f  = workspace[OFF_SHARED_OUT + my_row];
+            const float val    = bf16_round_rne_f32(in_f + moe_f + shr_f);
+            output[my_row] = static_cast<T>(val);
+        }
+        __syncthreads();
+    }
 }
 
 } // namespace qwen36_moe

--- a/kernels/qwen36_moe.hip
+++ b/kernels/qwen36_moe.hip
@@ -245,14 +245,16 @@ __global__ void qwen36_moe_descriptor_walk_stub(
 //                          RDNA3 → grid_barrier safe without coop launch)
 //
 //   workspace[F32], staged-attention scratch (offsets in F32 elements):
-//     Q_RAW    = 0                             [2*H*d]   q_proj output
-//     K_RAW    = 2*H*d                         [Hkv*d]   k_proj output
-//     V_RAW    = 2*H*d + Hkv*d                 [Hkv*d]   v_proj output
-//     Q_NORMED = 2*H*d + 2*Hkv*d               [H*d]     stage-1 result
-//     K_NORMED = 2*H*d + 2*Hkv*d + H*d         [Hkv*d]   stage-2 result
-//   …RoPE / attn slots (stages 3+) get appended in their own commits.
-//   Total stage-2 footprint: 2*H*d + 2*Hkv*d + H*d + Hkv*d F32 elements.
-//   For 35B-A3B (H=16, Hkv=2, d=256, hidden=2048) that's 13,824 F32 = 54 KiB.
+//     Q_RAW    = 0                                [2*H*d]   q_proj output
+//     K_RAW    = 2*H*d                            [Hkv*d]   k_proj output
+//     V_RAW    = 2*H*d + Hkv*d                    [Hkv*d]   v_proj output
+//     Q_NORMED = 2*H*d + 2*Hkv*d                  [H*d]     stage-1 result
+//     K_NORMED = 2*H*d + 2*Hkv*d + H*d            [Hkv*d]   stage-2 result
+//     Q_ROT    = 2*H*d + 2*Hkv*d + H*d + Hkv*d    [H*d]     stage-3 result
+//     K_ROT    = 3*H*d + 2*Hkv*d + H*d + Hkv*d    [Hkv*d]   stage-3 result
+//   …attn slot (stage 4+) gets appended in its own commit.
+//   Total stage-3 footprint: 4*H*d + 4*Hkv*d F32 elements.
+//   For 35B-A3B (H=16, Hkv=2, d=256, hidden=2048) that's 18,432 F32 = 72 KiB.
 //
 //   counters[0]: work-stealing index, reused across phases. Reset by
 //                grid_barrier_reset_counter at every phase boundary.
@@ -386,6 +388,8 @@ __global__ void qwen36_moe_attn_step_kernel(
     const int OFF_V_RAW    = 2 * H * d + Hkv * d;
     const int OFF_Q_NORMED = 2 * H * d + 2 * Hkv * d;
     const int OFF_K_NORMED = 2 * H * d + 2 * Hkv * d + H * d;
+    const int OFF_Q_ROT    = 2 * H * d + 2 * Hkv * d + H * d + Hkv * d;
+    const int OFF_K_ROT    = 3 * H * d + 2 * Hkv * d + H * d + Hkv * d;
 
     // -- Phase C: per-head RMS norm of q_lanes = workspace[Q_RAW : Q_RAW+H*d]
     // Each block grabs a head index, reduces across head_dim, writes BF16
@@ -531,9 +535,91 @@ __global__ void qwen36_moe_attn_step_kernel(
         }
     }
 
-    // Stages 3..5 hook in here in follow-up commits. Each starts with a
-    // grid_barrier_reset_counter and reuses `counters[0]` for its own
-    // work-stealing.
+    if (stage < 3) return;
+
+    grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
+                               &counters[0]);
+
+    // -- Phase F: partial RoPE on Q and K ----------------------------------
+    //
+    // For each head, rotate the first `rotary_dim` channels using the
+    // half-pair convention from oracle/qwen36_moe_oracle.py:
+    //
+    //   for i in [0, half):
+    //     a, b = x[i], x[half + i]
+    //     freq = position * theta^(-i/half)
+    //     c = bf16(cos(freq))      s = bf16(sin(freq))
+    //     out[i]        = bf16(bf16(a*c) - bf16(b*s))
+    //     out[half + i] = bf16(bf16(b*c) + bf16(a*s))
+    //   for i in [rotary_dim, d): out[i] = x[i]    (pass-through)
+    //
+    // Each "BF16-round" mirrors the BF16 dtype boundary in PyTorch — the
+    // multiplication, the subtraction, and the cos/sin cast all happen in
+    // BF16 in the oracle. Skipping any of these RNE rounds drifts the test.
+    //
+    // Work units = H + Hkv (one per attention head, Q and K combined).
+    // Stage 3 publishes q_rot || k_rot to the host-visible output buffer:
+    //   output[0..H*d)         = q_rot (BF16)
+    //   output[H*d..H*d+Hkv*d) = k_rot (BF16)
+    {
+        const int half = rotary_dim / 2;
+        const float theta_log = logf(rope_theta);
+        const int total_heads = H + Hkv;
+
+        for (;;) {
+            __shared__ unsigned int head_s;
+            if (tid == 0) {
+                head_s = atomicAdd(&counters[0], 1u);
+            }
+            __syncthreads();
+            const int head_idx = static_cast<int>(head_s);
+            if (head_idx >= total_heads) break;
+
+            const bool is_k = head_idx >= H;
+            const int  h    = is_k ? (head_idx - H) : head_idx;
+            const int  src_off = is_k ? OFF_K_NORMED : OFF_Q_NORMED;
+            const int  dst_off = is_k ? OFF_K_ROT    : OFF_Q_ROT;
+            // q_rot lives at output[0..H*d), k_rot at output[H*d..H*d+Hkv*d).
+            const int  pub_off = head_idx * d;
+
+            // Rotated half-pairs.
+            for (int i = tid; i < half; i += block_size) {
+                const float a = workspace[src_off + h * d + i];
+                const float b = workspace[src_off + h * d + half + i];
+                // freq = position * theta^(-i/half) = position / theta^(i/half).
+                // Match PyTorch's `theta ** (i/half)` ≡ exp((i/half) * log(theta)).
+                const float exponent = (static_cast<float>(i) / static_cast<float>(half)) * theta_log;
+                const float inv_freq = expf(-exponent);
+                const float freq = static_cast<float>(position) * inv_freq;
+                const float c = bf16_round_rne_f32(cosf(freq));
+                const float s = bf16_round_rne_f32(sinf(freq));
+                const float ac = bf16_round_rne_f32(a * c);
+                const float bs = bf16_round_rne_f32(b * s);
+                const float bc = bf16_round_rne_f32(b * c);
+                const float as_ = bf16_round_rne_f32(a * s);
+                const float rot_a = bf16_round_rne_f32(ac - bs);
+                const float rot_b = bf16_round_rne_f32(bc + as_);
+                workspace[dst_off + h * d + i]        = rot_a;
+                workspace[dst_off + h * d + half + i] = rot_b;
+                if (stage == 3) {
+                    output[pub_off + i]        = static_cast<T>(rot_a);
+                    output[pub_off + half + i] = static_cast<T>(rot_b);
+                }
+            }
+
+            // Pass-through tail [rotary_dim, head_dim).
+            for (int i = rotary_dim + tid; i < d; i += block_size) {
+                const float x = workspace[src_off + h * d + i];
+                workspace[dst_off + h * d + i] = x;
+                if (stage == 3) {
+                    output[pub_off + i] = static_cast<T>(x);
+                }
+            }
+            __syncthreads();
+        }
+    }
+
+    // Stages 4..5 hook in here in follow-up commits.
 }
 
 } // namespace qwen36_moe

--- a/kernels/qwen36_moe.hip
+++ b/kernels/qwen36_moe.hip
@@ -1190,7 +1190,265 @@ __global__ void qwen36_moe_linear_step_kernel(
         }
     }
 
-    // Stages 4..5 hook in here in follow-up commits.
+    if (stage < 4) return;
+
+    grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
+                               &counters[0]);
+
+    const int OFF_BETA    = OFF_K_REP + V * k_dim;
+    const int OFF_G       = OFF_BETA + V;
+    const int OFF_REC_OUT = OFF_G + V;
+
+    // -- Phase F: beta + g per V-head ---------------------------------------
+    // beta[h] = sigmoid(b_raw[h])                                  (F32)
+    // g[h]    = -softplus(a_raw[h] + dt_bias[h]) * exp(A_log[h])   (F32)
+    //
+    // V is small (32 on 35B-A3B) so we do this on block 0 only — every
+    // other block parks at the next grid barrier.
+    if (blockIdx.x == 0) {
+        for (int h = tid; h < V; h += block_size) {
+            const float a_v       = workspace[OFF_A_RAW + h];
+            const float b_v       = workspace[OFF_B_RAW + h];
+            const float dt_b      = static_cast<float>(dt_bias[h]);
+            const float a_log_v   = static_cast<float>(a_log[h]);
+            const float a_log_exp = expf(a_log_v);
+            const float arg       = a_v + dt_b;
+            const float softplus  = log1pf(expf(arg));
+            workspace[OFF_BETA + h] = 1.0f / (1.0f + expf(-b_v));
+            workspace[OFF_G + h]    = -softplus * a_log_exp;
+        }
+    }
+    grid_barrier(barrier_counter, barrier_flag, num_blocks);
+
+    // -- Phase G: delta-rule recurrent update --------------------------------
+    //
+    // Per V-head (work-stolen):
+    //   1. state[h, :, :] *= exp(g[h])                          (decay)
+    //   2. kv_mem[j] = sum_i(state[h, i, j] * k_rep[h, i])     for j ∈ [0, v_dim)
+    //   3. delta[j]  = (v_heads[h, j] - kv_mem[j]) * beta[h]
+    //   4. state[h, i, j] += k_rep[h, i] * delta[j]            (outer product)
+    //   5. rec_out[h, j] = sum_i(state[h, i, j] * q_scaled[h, i])  (BF16-round on store)
+    //
+    // All math in F32; recurrent state stays F32 between decode steps so
+    // there's no precision loss across the sequence. rec_out is BF16-rounded
+    // when written to workspace because Phase H (per-head RMS norm) reads it
+    // as a BF16 input.
+    //
+    // LDS scratch (per block):
+    //   kv_mem_lds[v_dim]  - kv_mem reduction outputs (F32)
+    //   delta_lds[v_dim]   - delta values (F32)
+    //   v_dim is bounded by 256 (35B-A3B uses 128); a static LDS array
+    //   sized 256 fits all current configs and avoids dynamic LDS arithmetic.
+    constexpr int V_DIM_MAX = 256;
+    __shared__ float kv_mem_lds[V_DIM_MAX];
+    __shared__ float delta_lds[V_DIM_MAX];
+    __shared__ float head_beta;
+    __shared__ float head_gstep;
+
+    {
+        for (;;) {
+            __shared__ unsigned int vh_s;
+            if (tid == 0) {
+                vh_s = atomicAdd(&counters[0], 1u);
+            }
+            __syncthreads();
+            const int h = static_cast<int>(vh_s);
+            if (h >= V) break;
+
+            if (tid == 0) {
+                head_beta  = workspace[OFF_BETA + h];
+                head_gstep = expf(workspace[OFF_G + h]);
+            }
+            __syncthreads();
+
+            const int state_off = h * k_dim * v_dim;
+            const int kv_off    = OFF_K_REP + h * k_dim;
+            const int qv_off    = OFF_Q_REP + h * k_dim;
+            const int v_off     = OFF_QKV_RAW + 2 * key_dim + h * v_dim;
+            const int total_state = k_dim * v_dim;
+
+            // Step 1: decay.
+            for (int e = tid; e < total_state; e += block_size) {
+                recurrent_state[state_off + e] *= head_gstep;
+            }
+            __syncthreads();
+
+            // Step 2: kv_mem[j] = sum_i(state[h, i, j] * k_rep[h, i]).
+            // Loop over j; for each j do a block-wide reduction over i.
+            for (int j = 0; j < v_dim; ++j) {
+                float partial = 0.0f;
+                for (int i = tid; i < k_dim; i += block_size) {
+                    partial += recurrent_state[state_off + i * v_dim + j] *
+                               workspace[kv_off + i];
+                }
+                shared_scratch[tid] = partial;
+                __syncthreads();
+                for (int s = block_size / 2; s > 0; s >>= 1) {
+                    if (tid < s) shared_scratch[tid] += shared_scratch[tid + s];
+                    __syncthreads();
+                }
+                if (tid == 0) {
+                    kv_mem_lds[j] = shared_scratch[0];
+                }
+                __syncthreads();
+            }
+
+            // Step 3: delta[j] = (v_heads[h, j] - kv_mem[j]) * beta[h].
+            for (int j = tid; j < v_dim; j += block_size) {
+                const float v_val = workspace[v_off + j];
+                delta_lds[j] = (v_val - kv_mem_lds[j]) * head_beta;
+            }
+            __syncthreads();
+
+            // Step 4: state[h, i, j] += k_rep[h, i] * delta[j].
+            for (int e = tid; e < total_state; e += block_size) {
+                const int i = e / v_dim;
+                const int j = e - i * v_dim;
+                recurrent_state[state_off + e] +=
+                    workspace[kv_off + i] * delta_lds[j];
+            }
+            __syncthreads();
+
+            // Step 5: recurrent_out[h, j] = sum_i(state[h, i, j] * q_scaled[h, i]).
+            for (int j = 0; j < v_dim; ++j) {
+                float partial = 0.0f;
+                for (int i = tid; i < k_dim; i += block_size) {
+                    partial += recurrent_state[state_off + i * v_dim + j] *
+                               workspace[qv_off + i];
+                }
+                shared_scratch[tid] = partial;
+                __syncthreads();
+                for (int s = block_size / 2; s > 0; s >>= 1) {
+                    if (tid < s) shared_scratch[tid] += shared_scratch[tid + s];
+                    __syncthreads();
+                }
+                if (tid == 0) {
+                    // Match oracle's `recurrent_out.to(dtype)` — F32 → BF16
+                    // cast happens here so Phase H reads BF16-precision
+                    // values regardless of stage.
+                    const float r = bf16_round_rne_f32(shared_scratch[0]);
+                    workspace[OFF_REC_OUT + h * v_dim + j] = r;
+                    if (stage == 4) {
+                        output[h * v_dim + j] = static_cast<T>(r);
+                    }
+                }
+                __syncthreads();
+            }
+        }
+    }
+
+    if (stage < 5) return;
+
+    grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
+                               &counters[0]);
+
+    // -- Phase H: per-V-head RMS norm + z-gate + multiply --------------------
+    //
+    // For each V-head h:
+    //   out_normed[h, :] = rms_norm(rec_out[h, :], norm_w, eps)        (per head)
+    //   z_silu[h, j]     = bf16(z_raw[h, j] * sigmoid(z_raw[h, j]))    (silu)
+    //   out_gated[h, j]  = bf16(out_normed[h, j] * z_silu[h, j])
+    //
+    // Fuse the three into one per-(h, j) computation, writing out_gated
+    // back into the OFF_REC_OUT slot — rec_out is no longer needed after
+    // this point. Block-per-head; V=32 work units fit comfortably across
+    // num_cus on gfx1100.
+    {
+        for (;;) {
+            __shared__ unsigned int vh_s;
+            if (tid == 0) {
+                vh_s = atomicAdd(&counters[0], 1u);
+            }
+            __syncthreads();
+            const int h = static_cast<int>(vh_s);
+            if (h >= V) break;
+
+            const int rec_off = OFF_REC_OUT + h * v_dim;
+            const int z_off   = OFF_Z_RAW   + h * v_dim;
+
+            // RMS norm reduction over v_dim — F32 partial then block-reduce.
+            float partial_sq = 0.0f;
+            for (int j = tid; j < v_dim; j += block_size) {
+                const float v = workspace[rec_off + j];
+                partial_sq += v * v;
+            }
+            shared_scratch[tid] = partial_sq;
+            __syncthreads();
+            for (int s = block_size / 2; s > 0; s >>= 1) {
+                if (tid < s) shared_scratch[tid] += shared_scratch[tid + s];
+                __syncthreads();
+            }
+            __shared__ float head_inv_rms_norm;
+            if (tid == 0) {
+                head_inv_rms_norm =
+                    rsqrtf(shared_scratch[0] / static_cast<float>(v_dim) + rms_norm_eps);
+            }
+            __syncthreads();
+
+            // Per-element fused: out_normed * z_silu, BF16-rounded at every
+            // dtype boundary so the path matches the oracle byte-for-byte.
+            for (int j = tid; j < v_dim; j += block_size) {
+                const float r       = workspace[rec_off + j];
+                const float n_w     = static_cast<float>(norm_w[j]);
+                const float on      = bf16_round_rne_f32(r * head_inv_rms_norm * n_w);
+                const float z_val   = workspace[z_off + j];
+                const float z_sig   = 1.0f / (1.0f + expf(-z_val));
+                const float z_silu_val = bf16_round_rne_f32(z_val * z_sig);
+                const float gated   = bf16_round_rne_f32(on * z_silu_val);
+                workspace[rec_off + j] = gated;   // overwrites rec_out in-place
+            }
+            __syncthreads();
+        }
+    }
+
+    grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
+                               &counters[0]);
+
+    // -- Phase I: out_proj matmul + residual --------------------------------
+    //
+    // out_gated lives at workspace[OFF_REC_OUT : OFF_REC_OUT + V*v_dim].
+    // out_proj_w shape: [hidden, V*v_dim].
+    //
+    //   o_out[i]          = bf16(sum_j(out_proj_w[i, j] * out_gated[j]))
+    //   output_hidden[i]  = bf16(input_hidden[i] + o_out[i])
+    //
+    // Two BF16 RNE rounds — one at the matmul boundary, one at the
+    // residual add — exactly mirroring `o_out = out_flat @ out_proj.T`
+    // and `output_hidden = input_hidden + o_out` in the oracle.
+    {
+        const int qd = V * v_dim;
+
+        for (;;) {
+            __shared__ unsigned int my_row_s;
+            if (tid == 0) {
+                my_row_s = atomicAdd(&counters[0], 1u);
+            }
+            __syncthreads();
+            const int my_row = static_cast<int>(my_row_s);
+            if (my_row >= hidden) break;
+
+            const T* w_row = out_proj_w + static_cast<size_t>(my_row) * qd;
+            float partial = 0.0f;
+            for (int j = tid; j < qd; j += block_size) {
+                partial += static_cast<float>(w_row[j]) * workspace[OFF_REC_OUT + j];
+            }
+            shared_scratch[tid] = partial;
+            __syncthreads();
+            for (int s = block_size / 2; s > 0; s >>= 1) {
+                if (tid < s) shared_scratch[tid] += shared_scratch[tid + s];
+                __syncthreads();
+            }
+            if (tid == 0) {
+                const float o_out  = bf16_round_rne_f32(shared_scratch[0]);
+                const float in_f   = static_cast<float>(input_hidden[my_row]);
+                const float result = bf16_round_rne_f32(in_f + o_out);
+                if (stage == 5) {
+                    output[my_row] = static_cast<T>(result);
+                }
+            }
+            __syncthreads();
+        }
+    }
 }
 
 } // namespace qwen36_moe

--- a/kernels/qwen36_moe.hip
+++ b/kernels/qwen36_moe.hip
@@ -244,12 +244,15 @@ __global__ void qwen36_moe_descriptor_walk_stub(
 //   grid_size  = num_cus  (one block per CU, all guaranteed concurrent on
 //                          RDNA3 → grid_barrier safe without coop launch)
 //
-//   workspace[F32], at least 2*H*d + 2*Hkv*d entries:
-//     [0,           2*H*d):           q_raw   (BF16-rounded F32 to mirror
-//                                              PyTorch's BF16 q_raw matmul)
-//     reserved for stage 2+:
-//     [2*H*d,       2*H*d + Hkv*d):   k_raw
-//     [2*H*d + Hkv*d, 2*H*d + 2*Hkv*d): v_raw
+//   workspace[F32], staged-attention scratch (offsets in F32 elements):
+//     Q_RAW    = 0                             [2*H*d]   q_proj output
+//     K_RAW    = 2*H*d                         [Hkv*d]   k_proj output
+//     V_RAW    = 2*H*d + Hkv*d                 [Hkv*d]   v_proj output
+//     Q_NORMED = 2*H*d + 2*Hkv*d               [H*d]     stage-1 result
+//     K_NORMED = 2*H*d + 2*Hkv*d + H*d         [Hkv*d]   stage-2 result
+//   …RoPE / attn slots (stages 3+) get appended in their own commits.
+//   Total stage-2 footprint: 2*H*d + 2*Hkv*d + H*d + Hkv*d F32 elements.
+//   For 35B-A3B (H=16, Hkv=2, d=256, hidden=2048) that's 13,824 F32 = 54 KiB.
 //
 //   counters[0]: work-stealing index, reused across phases. Reset by
 //                grid_barrier_reset_counter at every phase boundary.
@@ -373,13 +376,23 @@ __global__ void qwen36_moe_attn_step_kernel(
     grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
                                &counters[0]);
 
-    // -- Phase C: per-head RMS norm of q_lanes = workspace[0..H*d] ---------
-    // Each block grabs a head index and reduces across head_dim, writing
-    // BF16 q_normed[h*d : (h+1)*d] to `output`.
-    if (stage >= 1) {
-        const int H = num_heads;
-        const int d = head_dim;
+    // Workspace offsets (F32 elements). Kept in locals so the layout is
+    // documented next to the code that uses it.
+    const int H        = num_heads;
+    const int Hkv      = num_kv_heads;
+    const int d        = head_dim;
+    const int OFF_Q_RAW    = 0;
+    const int OFF_K_RAW    = 2 * H * d;
+    const int OFF_V_RAW    = 2 * H * d + Hkv * d;
+    const int OFF_Q_NORMED = 2 * H * d + 2 * Hkv * d;
+    const int OFF_K_NORMED = 2 * H * d + 2 * Hkv * d + H * d;
 
+    // -- Phase C: per-head RMS norm of q_lanes = workspace[Q_RAW : Q_RAW+H*d]
+    // Each block grabs a head index, reduces across head_dim, writes BF16
+    // q_normed to workspace[Q_NORMED..]. If stage == 1 we also publish
+    // q_normed to the host-visible `output` buffer; later stages keep
+    // q_normed in workspace as RoPE input.
+    {
         for (;;) {
             __shared__ unsigned int head_s;
             if (tid == 0) {
@@ -392,7 +405,7 @@ __global__ void qwen36_moe_attn_step_kernel(
             const int base = h * d;
             float partial = 0.0f;
             for (int i = tid; i < d; i += block_size) {
-                const float v = workspace[base + i];
+                const float v = workspace[OFF_Q_RAW + base + i];
                 partial += v * v;
             }
             shared_scratch[tid] = partial;
@@ -408,16 +421,117 @@ __global__ void qwen36_moe_attn_step_kernel(
             __syncthreads();
 
             for (int i = tid; i < d; i += block_size) {
-                const float v = workspace[base + i];
+                const float v = workspace[OFF_Q_RAW + base + i];
                 const float wv = load_as_float<T>(q_norm_w, i);
                 const float normed = bf16_round_rne_f32(v * head_inv_rms * wv);
-                output[base + i] = static_cast<T>(normed);
+                // Round-trip through BF16 representation: store BF16 in
+                // workspace as F32 so the next-stage RoPE reader sees the
+                // exact dtype-cast values PyTorch's `.to(bf16)` produces.
+                workspace[OFF_Q_NORMED + base + i] = normed;
+                if (stage == 1) {
+                    output[base + i] = static_cast<T>(normed);
+                }
             }
             __syncthreads();
         }
     }
 
-    // Stages 2..5 hook in here in follow-up commits. Each starts with a
+    if (stage < 2) {
+        // Stage 1 stops here. The reset_counter call below would still be
+        // safe but is unnecessary work for the parity test.
+        return;
+    }
+
+    grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
+                               &counters[0]);
+
+    // -- Phase D: k_raw, v_raw via fused work-stealing matvec --------------
+    // Combine k_proj_w and v_proj_w into a single 2*Hkv*d-row work pool so
+    // every block stays busy regardless of which projection it claims. Both
+    // projections share the same x_norm input, so this is purely a row
+    // dispatch fold — same pattern PyTorch uses internally for fused QKV.
+    const int kv_total_rows = 2 * Hkv * d;
+    for (;;) {
+        __shared__ unsigned int my_row_s;
+        if (tid == 0) {
+            my_row_s = atomicAdd(&counters[0], 1u);
+        }
+        __syncthreads();
+        const int my_row = static_cast<int>(my_row_s);
+        if (my_row >= kv_total_rows) break;
+
+        // First Hkv*d rows belong to k_proj, next Hkv*d to v_proj.
+        const bool is_v = my_row >= Hkv * d;
+        const int proj_row = is_v ? (my_row - Hkv * d) : my_row;
+        const T* w_row = (is_v ? v_proj_w : k_proj_w)
+            + static_cast<size_t>(proj_row) * hidden;
+        const int dst_off = (is_v ? OFF_V_RAW : OFF_K_RAW) + proj_row;
+
+        float partial = 0.0f;
+        for (int col = tid; col < hidden; col += block_size) {
+            partial += load_as_float<T>(w_row, col) * x_norm_lds[col];
+        }
+        shared_scratch[tid] = partial;
+        __syncthreads();
+        for (int s = block_size / 2; s > 0; s >>= 1) {
+            if (tid < s) shared_scratch[tid] += shared_scratch[tid + s];
+            __syncthreads();
+        }
+        if (tid == 0) {
+            workspace[dst_off] = bf16_round_rne_f32(shared_scratch[0]);
+        }
+        __syncthreads();
+    }
+
+    grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
+                               &counters[0]);
+
+    // -- Phase E: per-head RMS norm of K (Hkv heads) -----------------------
+    // Same shape as Phase C but reduces over Hkv heads, sourcing from
+    // workspace[K_RAW] and writing workspace[K_NORMED]. If stage == 2
+    // we also publish k_normed to the host-visible `output` buffer.
+    {
+        for (;;) {
+            __shared__ unsigned int head_s;
+            if (tid == 0) {
+                head_s = atomicAdd(&counters[0], 1u);
+            }
+            __syncthreads();
+            const int h = static_cast<int>(head_s);
+            if (h >= Hkv) break;
+
+            const int base = h * d;
+            float partial = 0.0f;
+            for (int i = tid; i < d; i += block_size) {
+                const float v = workspace[OFF_K_RAW + base + i];
+                partial += v * v;
+            }
+            shared_scratch[tid] = partial;
+            __syncthreads();
+            for (int s = block_size / 2; s > 0; s >>= 1) {
+                if (tid < s) shared_scratch[tid] += shared_scratch[tid + s];
+                __syncthreads();
+            }
+            __shared__ float head_inv_rms;
+            if (tid == 0) {
+                head_inv_rms = rsqrtf(shared_scratch[0] / static_cast<float>(d) + rms_norm_eps);
+            }
+            __syncthreads();
+
+            for (int i = tid; i < d; i += block_size) {
+                const float v = workspace[OFF_K_RAW + base + i];
+                const float wv = load_as_float<T>(k_norm_w, i);
+                const float normed = bf16_round_rne_f32(v * head_inv_rms * wv);
+                workspace[OFF_K_NORMED + base + i] = normed;
+                if (stage == 2) {
+                    output[base + i] = static_cast<T>(normed);
+                }
+            }
+            __syncthreads();
+        }
+    }
+
+    // Stages 3..5 hook in here in follow-up commits. Each starts with a
     // grid_barrier_reset_counter and reuses `counters[0]` for its own
     // work-stealing.
 }

--- a/kernels/qwen36_moe_bridge.cpp
+++ b/kernels/qwen36_moe_bridge.cpp
@@ -93,3 +93,98 @@ extern "C" int qwen36_moe_hip_stub_launch(
     if (sync_err != hipSuccess) return 255;
     return 0;
 }
+
+// PR 4b2 staged-attention parity launcher.
+// `dtype` follows the project convention: 2 = bf16. Other values are
+// rejected so the matching kernel template is unambiguous.
+extern "C" int qwen36_moe_hip_attn_step_launch(
+    int           dtype,
+    size_t        device_ordinal,
+    int           stage,
+    int           hidden,
+    int           num_heads,
+    int           num_kv_heads,
+    int           head_dim,
+    int           rotary_dim,
+    float         rope_theta,
+    float         rms_norm_eps,
+    int           position,
+    const void*   input_hidden,
+    const void*   input_norm_w,
+    const void*   q_proj_w,
+    const void*   k_proj_w,
+    const void*   v_proj_w,
+    const void*   q_norm_w,
+    const void*   k_norm_w,
+    const void*   o_proj_w,
+    void*         output,
+    float*        workspace,
+    unsigned int* counters,
+    unsigned int* barrier_counter,
+    unsigned int* barrier_flag) {
+    if (dtype != 2) return 110;            // only bf16 supported on stage 1
+    if (stage < 1 || stage > 5) return 111;
+    if (hidden <= 0 || num_heads <= 0 || num_kv_heads <= 0 || head_dim <= 0) {
+        return 112;
+    }
+    if (input_hidden == nullptr || input_norm_w == nullptr ||
+        q_proj_w == nullptr || q_norm_w == nullptr ||
+        output == nullptr || workspace == nullptr ||
+        counters == nullptr || barrier_counter == nullptr ||
+        barrier_flag == nullptr) {
+        return 113;
+    }
+
+    ScopedHipDevice scoped(static_cast<int>(device_ordinal));
+
+    hipDeviceProp_t props;
+    if (hipGetDeviceProperties(&props, static_cast<int>(device_ordinal)) !=
+        hipSuccess) {
+        return 250;
+    }
+    const int num_blocks =
+        props.multiProcessorCount > 0 ? props.multiProcessorCount : 16;
+    constexpr int block_size = 256;
+
+    // Zero the cooperative counter + barrier state before launch. The kernel
+    // expects all three to start at 0; sync_buf is documented as 32 zero
+    // bytes by the Rust-side wrapper but a defence-in-depth memset here
+    // keeps a misuse from corrupting the launch.
+    if (hipMemsetAsync(counters, 0, sizeof(unsigned int)) != hipSuccess) {
+        return 200;
+    }
+
+    const size_t lds_bytes = static_cast<size_t>(hidden + block_size) * sizeof(float);
+
+    hipLaunchKernelGGL(qwen36_moe::qwen36_moe_attn_step_kernel<hip_bfloat16>,
+                       dim3(static_cast<unsigned int>(num_blocks)),
+                       dim3(block_size),
+                       lds_bytes, 0,
+                       stage,
+                       hidden,
+                       num_heads,
+                       num_kv_heads,
+                       head_dim,
+                       rotary_dim,
+                       rope_theta,
+                       rms_norm_eps,
+                       position,
+                       static_cast<const hip_bfloat16*>(input_hidden),
+                       static_cast<const hip_bfloat16*>(input_norm_w),
+                       static_cast<const hip_bfloat16*>(q_proj_w),
+                       static_cast<const hip_bfloat16*>(k_proj_w),
+                       static_cast<const hip_bfloat16*>(v_proj_w),
+                       static_cast<const hip_bfloat16*>(q_norm_w),
+                       static_cast<const hip_bfloat16*>(k_norm_w),
+                       static_cast<const hip_bfloat16*>(o_proj_w),
+                       static_cast<hip_bfloat16*>(output),
+                       workspace,
+                       counters,
+                       barrier_counter,
+                       barrier_flag);
+    hipError_t launch_err = hipGetLastError();
+    hipError_t sync_err   = hipDeviceSynchronize();
+    if (launch_err != hipSuccess) return 254;
+    if (sync_err != hipSuccess) return 255;
+    return 0;
+}

--- a/kernels/qwen36_moe_bridge.cpp
+++ b/kernels/qwen36_moe_bridge.cpp
@@ -291,3 +291,94 @@ extern "C" int qwen36_moe_hip_linear_step_launch(
     if (sync_err_lin != hipSuccess) return 255;
     return 0;
 }
+
+// PR 4b4 staged MoE FFN parity launcher.
+// `dtype` follows the project convention: 2 = bf16. Other values are
+// rejected so the matching kernel template is unambiguous.
+extern "C" int qwen36_moe_hip_ffn_step_launch(
+    int           dtype,
+    size_t        device_ordinal,
+    int           stage,
+    int           hidden,
+    int           num_experts,
+    int           moe_intermediate,
+    int           shared_intermediate,
+    int           top_k,
+    float         rms_norm_eps,
+    const void*   input_hidden,
+    const void*   post_attn_norm_w,
+    const void*   gate_w,
+    const void*   gate_up_proj_w,
+    const void*   down_proj_w,
+    const void*   shared_gate_proj_w,
+    const void*   shared_up_proj_w,
+    const void*   shared_down_proj_w,
+    const void*   shared_expert_gate_w,
+    void*         output,
+    int*          output_idx,
+    float*        workspace,
+    unsigned int* counters,
+    unsigned int* barrier_counter,
+    unsigned int* barrier_flag) {
+    if (dtype != 2) return 130;            // only bf16 supported
+    if (stage < 1 || stage > 5) return 131;
+    if (hidden <= 0 || num_experts <= 0 || moe_intermediate <= 0 ||
+        shared_intermediate <= 0 || top_k <= 0 || top_k > num_experts) {
+        return 132;
+    }
+    if (input_hidden == nullptr || post_attn_norm_w == nullptr ||
+        gate_w == nullptr || output == nullptr || output_idx == nullptr ||
+        workspace == nullptr || counters == nullptr ||
+        barrier_counter == nullptr || barrier_flag == nullptr) {
+        return 133;
+    }
+
+    ScopedHipDevice scoped(static_cast<int>(device_ordinal));
+
+    hipDeviceProp_t props;
+    if (hipGetDeviceProperties(&props, static_cast<int>(device_ordinal)) !=
+        hipSuccess) {
+        return 250;
+    }
+    const int num_blocks =
+        props.multiProcessorCount > 0 ? props.multiProcessorCount : 16;
+    constexpr int block_size = 256;
+
+    if (hipMemsetAsync(counters, 0, sizeof(unsigned int)) != hipSuccess) {
+        return 200;
+    }
+
+    const size_t lds_bytes = static_cast<size_t>(hidden + block_size) * sizeof(float);
+
+    hipLaunchKernelGGL(qwen36_moe::qwen36_moe_ffn_step_kernel<hip_bfloat16>,
+                       dim3(static_cast<unsigned int>(num_blocks)),
+                       dim3(block_size),
+                       lds_bytes, 0,
+                       stage,
+                       hidden,
+                       num_experts,
+                       moe_intermediate,
+                       shared_intermediate,
+                       top_k,
+                       rms_norm_eps,
+                       static_cast<const hip_bfloat16*>(input_hidden),
+                       static_cast<const hip_bfloat16*>(post_attn_norm_w),
+                       static_cast<const hip_bfloat16*>(gate_w),
+                       static_cast<const hip_bfloat16*>(gate_up_proj_w),
+                       static_cast<const hip_bfloat16*>(down_proj_w),
+                       static_cast<const hip_bfloat16*>(shared_gate_proj_w),
+                       static_cast<const hip_bfloat16*>(shared_up_proj_w),
+                       static_cast<const hip_bfloat16*>(shared_down_proj_w),
+                       static_cast<const hip_bfloat16*>(shared_expert_gate_w),
+                       static_cast<hip_bfloat16*>(output),
+                       output_idx,
+                       workspace,
+                       counters,
+                       barrier_counter,
+                       barrier_flag);
+    hipError_t launch_err_ffn = hipGetLastError();
+    hipError_t sync_err_ffn   = hipDeviceSynchronize();
+    if (launch_err_ffn != hipSuccess) return 254;
+    if (sync_err_ffn != hipSuccess) return 255;
+    return 0;
+}

--- a/kernels/qwen36_moe_bridge.cpp
+++ b/kernels/qwen36_moe_bridge.cpp
@@ -1,0 +1,95 @@
+// Qwen3.6-MoE HIP launch bridge — PR 4 stub.
+//
+// Calls into the descriptor-walk stub kernel in qwen36_moe.hip. The
+// `qwen36_moe_hip_stub_launch` extern is the only symbol exposed today;
+// once the real megakernel lands, this file gains a
+// `qwen36_moe_hip_persistent_decode` entry alongside the stub (kept for
+// the smoke test).
+
+#include "qwen36_moe.hip"
+
+#include <cstdlib>
+#include <hip/hip_runtime.h>
+#include <stdint.h>
+
+namespace {
+
+struct ScopedHipDevice {
+    int  previous = -1;
+    bool changed  = false;
+
+    explicit ScopedHipDevice(int target) {
+        hipGetDevice(&previous);
+        if (previous != target) {
+            hipSetDevice(target);
+            changed = true;
+        }
+    }
+    ~ScopedHipDevice() {
+        if (changed && previous >= 0) hipSetDevice(previous);
+    }
+};
+
+// Pin Rust↔C++ struct layout. If this fails at compile time, someone
+// reordered fields on one side without the other. Update both sides
+// together.
+static_assert(sizeof(qwen36_moe::DecodeLayerDesc) >= 256,
+              "Qwen36MoeDecodeLayerDesc shrunk unexpectedly");
+static_assert(sizeof(qwen36_moe::DecodeLayerDesc) <= 512,
+              "Qwen36MoeDecodeLayerDesc grew unexpectedly");
+
+} // namespace
+
+// `dtype` encoding follows the Qwen/Gemma/Phi bridges: 0 = half, 2 = bf16.
+// The stub ignores dtype because it does no math; the real kernel will
+// branch on it.
+extern "C" int qwen36_moe_hip_stub_launch(
+    int                                  dtype,
+    size_t                               device_ordinal,
+    size_t                               num_layers,
+    const qwen36_moe::DecodeLayerDesc*   layers,
+    float*                               workspace,
+    unsigned int*                        counters,
+    unsigned int*                        barrier_counter,
+    unsigned int*                        barrier_flag) {
+    (void)dtype;
+    if (num_layers == 0 || num_layers > 1024) return 100;
+    if (layers == nullptr || workspace == nullptr) return 101;
+    if (counters == nullptr || barrier_counter == nullptr ||
+        barrier_flag == nullptr) {
+        return 102;
+    }
+
+    ScopedHipDevice scoped(static_cast<int>(device_ordinal));
+
+    hipDeviceProp_t props;
+    if (hipGetDeviceProperties(&props, static_cast<int>(device_ordinal)) !=
+        hipSuccess) {
+        return 250;
+    }
+    const int num_blocks =
+        props.multiProcessorCount > 0 ? props.multiProcessorCount : 16;
+    constexpr int block_size = 64; // wave-sized; descriptor walk is light
+
+    // Zero the cooperative counter before launch. The kernel uses
+    // `atomicAdd` to claim layer indices.
+    if (hipMemsetAsync(counters, 0, sizeof(unsigned int)) != hipSuccess) {
+        return 200;
+    }
+
+    hipLaunchKernelGGL(qwen36_moe::qwen36_moe_descriptor_walk_stub,
+                       dim3(static_cast<unsigned int>(num_blocks)),
+                       dim3(block_size),
+                       0, 0,
+                       static_cast<int>(num_layers),
+                       layers,
+                       workspace,
+                       counters,
+                       barrier_counter,
+                       barrier_flag);
+    hipError_t launch_err = hipGetLastError();
+    hipError_t sync_err   = hipDeviceSynchronize();
+    if (launch_err != hipSuccess) return 254;
+    if (sync_err != hipSuccess) return 255;
+    return 0;
+}

--- a/kernels/qwen36_moe_bridge.cpp
+++ b/kernels/qwen36_moe_bridge.cpp
@@ -188,3 +188,106 @@ extern "C" int qwen36_moe_hip_attn_step_launch(
     if (sync_err != hipSuccess) return 255;
     return 0;
 }
+
+// PR 4b3 staged linear-attention parity launcher.
+// `dtype` follows the project convention: 2 = bf16. Other values are
+// rejected so the matching kernel template is unambiguous.
+extern "C" int qwen36_moe_hip_linear_step_launch(
+    int           dtype,
+    size_t        device_ordinal,
+    int           stage,
+    int           hidden,
+    int           num_k_heads,
+    int           num_v_heads,
+    int           head_k_dim,
+    int           head_v_dim,
+    int           conv_kernel_dim,
+    float         rms_norm_eps,
+    const void*   input_hidden,
+    const void*   input_norm_w,
+    const void*   in_proj_qkv_w,
+    const void*   in_proj_z_w,
+    const void*   in_proj_a_w,
+    const void*   in_proj_b_w,
+    const void*   conv1d_w,
+    const void*   conv1d_bias,
+    const void*   dt_bias,
+    const void*   a_log,
+    const void*   norm_w,
+    const void*   out_proj_w,
+    void*         conv_state,
+    float*        recurrent_state,
+    void*         output,
+    float*        workspace,
+    unsigned int* counters,
+    unsigned int* barrier_counter,
+    unsigned int* barrier_flag) {
+    if (dtype != 2) return 120;
+    if (stage < 1 || stage > 5) return 121;
+    if (hidden <= 0 || num_k_heads <= 0 || num_v_heads <= 0 ||
+        head_k_dim <= 0 || head_v_dim <= 0 || conv_kernel_dim <= 0) {
+        return 122;
+    }
+    if (input_hidden == nullptr || input_norm_w == nullptr ||
+        in_proj_qkv_w == nullptr || in_proj_z_w == nullptr ||
+        in_proj_a_w == nullptr || in_proj_b_w == nullptr ||
+        output == nullptr || workspace == nullptr ||
+        counters == nullptr || barrier_counter == nullptr ||
+        barrier_flag == nullptr) {
+        return 123;
+    }
+
+    ScopedHipDevice scoped(static_cast<int>(device_ordinal));
+
+    hipDeviceProp_t props;
+    if (hipGetDeviceProperties(&props, static_cast<int>(device_ordinal)) !=
+        hipSuccess) {
+        return 250;
+    }
+    const int num_blocks =
+        props.multiProcessorCount > 0 ? props.multiProcessorCount : 16;
+    constexpr int block_size = 256;
+
+    if (hipMemsetAsync(counters, 0, sizeof(unsigned int)) != hipSuccess) {
+        return 200;
+    }
+
+    const size_t lds_bytes = static_cast<size_t>(hidden + block_size) * sizeof(float);
+
+    hipLaunchKernelGGL(qwen36_moe::qwen36_moe_linear_step_kernel<hip_bfloat16>,
+                       dim3(static_cast<unsigned int>(num_blocks)),
+                       dim3(block_size),
+                       lds_bytes, 0,
+                       stage,
+                       hidden,
+                       num_k_heads,
+                       num_v_heads,
+                       head_k_dim,
+                       head_v_dim,
+                       conv_kernel_dim,
+                       rms_norm_eps,
+                       static_cast<const hip_bfloat16*>(input_hidden),
+                       static_cast<const hip_bfloat16*>(input_norm_w),
+                       static_cast<const hip_bfloat16*>(in_proj_qkv_w),
+                       static_cast<const hip_bfloat16*>(in_proj_z_w),
+                       static_cast<const hip_bfloat16*>(in_proj_a_w),
+                       static_cast<const hip_bfloat16*>(in_proj_b_w),
+                       static_cast<const hip_bfloat16*>(conv1d_w),
+                       static_cast<const hip_bfloat16*>(conv1d_bias),
+                       static_cast<const hip_bfloat16*>(dt_bias),
+                       static_cast<const hip_bfloat16*>(a_log),
+                       static_cast<const hip_bfloat16*>(norm_w),
+                       static_cast<const hip_bfloat16*>(out_proj_w),
+                       static_cast<hip_bfloat16*>(conv_state),
+                       recurrent_state,
+                       static_cast<hip_bfloat16*>(output),
+                       workspace,
+                       counters,
+                       barrier_counter,
+                       barrier_flag);
+    hipError_t launch_err_lin = hipGetLastError();
+    hipError_t sync_err_lin   = hipDeviceSynchronize();
+    if (launch_err_lin != hipSuccess) return 254;
+    if (sync_err_lin != hipSuccess) return 255;
+    return 0;
+}

--- a/oracle/bake_int4.py
+++ b/oracle/bake_int4.py
@@ -69,7 +69,26 @@ def copy_weight_in_row_chunks(dst: torch.Tensor, src: torch.Tensor, rows_per_chu
 # ---------------------------------------------------------------------------
 # Target-tensor selection (mirrors crates/model-store/src/baker.rs::is_int4_target)
 # ---------------------------------------------------------------------------
+# Fused 3D MoE expert tensors in Qwen3.6-MoE store all experts in one slab and
+# do NOT use the `.weight` suffix:
+#     mlp.experts.gate_up_proj    [E, 2*moe_int, hidden]
+#     mlp.experts.down_proj       [E, hidden,    moe_int]
+# They quantize via a separate fused-MoE driver (see fused_expert_minmax_int4),
+# but `is_int4_target` still classifies them as INT4 targets so the planner /
+# manifest accounting line up.
+FUSED_EXPERT_SUFFIXES = (
+    ".mlp.experts.gate_up_proj",
+    ".mlp.experts.down_proj",
+)
+
+
+def is_fused_expert_target(name: str) -> bool:
+    return any(name.endswith(s) for s in FUSED_EXPERT_SUFFIXES)
+
+
 def is_int4_target(name: str) -> bool:
+    if is_fused_expert_target(name):
+        return True
     if not name.endswith(".weight"):
         return False
     if ("layernorm" in name
@@ -303,12 +322,163 @@ def gptq_quantize(
 
 
 def pack_nibbles(nibbles: torch.Tensor) -> torch.Tensor:
-    """[rows, cols] uint8 0..15 -> [rows, cols/2] uint8 packed 2/byte."""
-    rows, cols = nibbles.shape
+    """Pack 4-bit nibbles 2/byte along the last axis.
+
+    Accepts 2D `[rows, cols]` (dense projections) or 3D `[E, rows, cols]`
+    (fused MoE experts). Output keeps all leading axes and halves the last:
+    `[..., cols]` -> `[..., cols/2]`.
+    """
+    if nibbles.dim() < 2:
+        raise ValueError(f"expected >=2D nibble tensor, got shape {tuple(nibbles.shape)}")
+    cols = nibbles.shape[-1]
     if cols % 2 != 0:
-        raise ValueError(f"cols must be even, got {cols}")
-    r = nibbles.reshape(rows, cols // 2, 2).to(torch.uint8)
+        raise ValueError(f"last dim must be even, got {cols}")
+    leading = nibbles.shape[:-1]
+    r = nibbles.reshape(*leading, cols // 2, 2).to(torch.uint8)
     return (r[..., 0] | (r[..., 1] << 4)).contiguous()
+
+
+# ---------------------------------------------------------------------------
+# Fused MoE expert quantization (no GPTQ — min/max group-quant per expert).
+#
+# Qwen3.6-MoE stores each layer's experts as fused 3D tensors:
+#     mlp.experts.gate_up_proj    [E, 2*moe_int, hidden]   bf16
+#     mlp.experts.down_proj       [E, hidden,    moe_int]  bf16
+# These are nn.Parameters under a custom MoE module, NOT a list of nn.Linear,
+# so the GPTQ driver above (which walks nn.Linear) skips them. Running them
+# through full Hessian-aware GPTQ on the producer host is also impractical for
+# 256 experts × 40 layers × 2 projections.
+#
+# Plan §15 option (c): keep GPTQ for the dense projections, give the experts a
+# straight min/max INT4 group-quant per expert. Each expert gets its own
+# `[out/gs, in/gs]` BF16 scale+zero tile, fused along axis 0 with the other
+# experts in the layer. The runtime accounting in
+# `crates/qwen36_moe/src/weights.rs` (search `int4_bytes`) already sizes for
+# this layout.
+# ---------------------------------------------------------------------------
+@torch.no_grad()
+def fused_expert_minmax_int4(
+    W: torch.Tensor,
+    group_size: int,
+    work_device: torch.device | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Per-expert min/max INT4 group-quant for a fused MoE weight slab.
+
+    Parameters
+    ----------
+    W : [E, out, in] tensor (any float dtype). Treated as `E` parallel
+        `[out, in]` matrices; each is independently quantized.
+    group_size : tile dim (must divide both `out` and `in`; `in` must be even).
+    work_device : optional device for the per-expert reductions; defaults to
+        `W.device` (avoids an unnecessary copy when the model is already on GPU).
+
+    Returns
+    -------
+    nibbles : [E, out, in]            uint8, values 0..15  (CPU)
+    scales  : [E, out/gs, in/gs]      float32 (BF16-rounded, CPU)
+    zeros   : [E, out/gs, in/gs]      float32 (BF16-rounded, CPU)
+    """
+    if W.dim() != 3:
+        raise ValueError(f"fused expert tensor must be 3D, got shape {tuple(W.shape)}")
+    E, out_f, in_f = W.shape
+    gs = group_size
+    if in_f % gs != 0 or in_f % 2 != 0:
+        raise ValueError(
+            f"in_features {in_f} must be divisible by group_size={gs} and even"
+        )
+    if out_f % gs != 0:
+        raise ValueError(f"out_features {out_f} must be divisible by group_size={gs}")
+    scale_rows = out_f // gs
+    scale_cols = in_f // gs
+    nibbles_out = torch.empty((E, out_f, in_f), dtype=torch.uint8)
+    scale_out = torch.empty((E, scale_rows, scale_cols), dtype=torch.float32)
+    zero_out = torch.empty((E, scale_rows, scale_cols), dtype=torch.float32)
+    dev = work_device if work_device is not None else W.device
+
+    for e in range(E):
+        slab = W[e].to(device=dev, dtype=torch.float32)
+        # Reduce per-tile min/max in one reshape — vectorised inside the slab.
+        tiles = slab.reshape(scale_rows, gs, scale_cols, gs)
+        tmax = tiles.amax(dim=(1, 3))
+        tmin = tiles.amin(dim=(1, 3))
+        rng = tmax - tmin
+        sc = torch.where(rng > 0, rng / 15.0, torch.ones_like(rng))
+        zf = torch.where(rng > 0, -tmin / sc, torch.zeros_like(rng))
+        # Round through BF16 so reconstruction matches what the runtime kernel
+        # will read from the BF16 sidecar tensors.
+        sc = sc.to(torch.bfloat16).to(torch.float32)
+        zf = zf.to(torch.bfloat16).to(torch.float32)
+        sc_full = sc.repeat_interleave(gs, dim=0).repeat_interleave(gs, dim=1)
+        zf_full = zf.repeat_interleave(gs, dim=0).repeat_interleave(gs, dim=1)
+        q = torch.clamp(torch.round(slab / sc_full + zf_full), 0.0, 15.0).to(torch.uint8)
+        nibbles_out[e] = q.cpu()
+        scale_out[e] = sc.cpu()
+        zero_out[e] = zf.cpu()
+        del slab, tiles, sc_full, zf_full, q
+
+    return nibbles_out, scale_out, zero_out
+
+
+@torch.no_grad()
+def fused_expert_minmax_int4_packed(
+    W: torch.Tensor,
+    group_size: int,
+    work_device: torch.device | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """As `fused_expert_minmax_int4`, but pack nibbles per-expert as we go.
+
+    The 35B-A3B fused-expert nibble buffer is ~32 GiB unpacked vs ~16 GiB
+    packed. Packing each expert's slab into the output buffer immediately
+    (rather than calling the unpacked variant and packing afterward) keeps
+    peak host RAM at the packed size — the unpacked builder allocates the
+    full `[E, out, in]` uint8 tensor, which on 35B-A3B alone is ~32 GiB and
+    won't co-exist with an Accelerate-offloaded BF16 model on a 64 GiB host.
+
+    Returns
+    -------
+    packed_nibbles : [E, out, in/2]      uint8 (CPU)
+    scales         : [E, out/gs, in/gs]  float32 (BF16-rounded, CPU)
+    zeros          : [E, out/gs, in/gs]  float32 (BF16-rounded, CPU)
+    """
+    if W.dim() != 3:
+        raise ValueError(f"fused expert tensor must be 3D, got shape {tuple(W.shape)}")
+    E, out_f, in_f = W.shape
+    gs = group_size
+    if in_f % gs != 0 or in_f % 2 != 0:
+        raise ValueError(
+            f"in_features {in_f} must be divisible by group_size={gs} and even"
+        )
+    if out_f % gs != 0:
+        raise ValueError(f"out_features {out_f} must be divisible by group_size={gs}")
+    scale_rows = out_f // gs
+    scale_cols = in_f // gs
+    packed_out = torch.empty((E, out_f, in_f // 2), dtype=torch.uint8)
+    scale_out = torch.empty((E, scale_rows, scale_cols), dtype=torch.float32)
+    zero_out = torch.empty((E, scale_rows, scale_cols), dtype=torch.float32)
+    dev = work_device if work_device is not None else W.device
+
+    for e in range(E):
+        slab = W[e].to(device=dev, dtype=torch.float32)
+        tiles = slab.reshape(scale_rows, gs, scale_cols, gs)
+        tmax = tiles.amax(dim=(1, 3))
+        tmin = tiles.amin(dim=(1, 3))
+        rng = tmax - tmin
+        sc = torch.where(rng > 0, rng / 15.0, torch.ones_like(rng))
+        zf = torch.where(rng > 0, -tmin / sc, torch.zeros_like(rng))
+        sc = sc.to(torch.bfloat16).to(torch.float32)
+        zf = zf.to(torch.bfloat16).to(torch.float32)
+        sc_full = sc.repeat_interleave(gs, dim=0).repeat_interleave(gs, dim=1)
+        zf_full = zf.repeat_interleave(gs, dim=0).repeat_interleave(gs, dim=1)
+        q = torch.clamp(torch.round(slab / sc_full + zf_full), 0.0, 15.0).to(torch.uint8)
+        # Pack 2 nibbles/byte before leaving the device — this is the inner-most
+        # cost on the host RAM budget.
+        packed = (q[:, 0::2] | (q[:, 1::2] << 4)).contiguous().cpu()
+        packed_out[e] = packed
+        scale_out[e] = sc.cpu()
+        zero_out[e] = zf.cpu()
+        del slab, tiles, sc_full, zf_full, q, packed
+
+    return packed_out, scale_out, zero_out
 
 
 # ---------------------------------------------------------------------------
@@ -419,20 +589,189 @@ def move_kwargs_to(kwargs: dict[str, Any], device: torch.device) -> dict[str, An
 # ---------------------------------------------------------------------------
 # Sequential per-layer GPTQ driver
 # ---------------------------------------------------------------------------
+def _materialize_param(
+    param: torch.Tensor,
+    hf_name: str,
+    safetensors_loader: Callable[[str], torch.Tensor | None] | None,
+) -> torch.Tensor:
+    """Return the parameter's actual data, even if Accelerate offloaded it.
+
+    Under `device_map="auto"`, offloaded parameters appear as `meta`-device
+    placeholders after a forward pass — `param.data` then yields a meta
+    tensor and any subsequent op on it crashes mid-GPTQ with a device
+    mismatch. When that happens, fall back to reading the raw bytes
+    straight from the source safetensors files (the loader callback knows
+    the prefix-mapping logic that resolves HF flattened names to raw
+    safetensors keys).
+    """
+    if param.device.type != "meta":
+        return param.detach()
+    if safetensors_loader is None:
+        raise RuntimeError(
+            f"{hf_name} is on meta device and no safetensors fallback was given"
+        )
+    t = safetensors_loader(hf_name)
+    if t is None:
+        raise RuntimeError(
+            f"{hf_name} is on meta device and could not be loaded from safetensors"
+        )
+    return t.detach()
+
+
+def _writeback_param(
+    mod: nn.Module,
+    Q_dq: torch.Tensor,
+) -> bool:
+    """Try to copy the dequantised quantised weight back into `mod.weight`.
+
+    Returns True when the write succeeded. Under Accelerate offloading the
+    parameter's `.data` may be on `meta`, in which case `.copy_()` would
+    silently no-op into a non-existent tensor; rather than masking that
+    failure, return False so the caller can adjust expectations (the
+    per-layer re-run will then see the BF16 original instead of Q_dq —
+    weakens GPTQ error propagation but does not corrupt anything).
+    """
+    p = mod.weight
+    if p.device.type == "meta":
+        return False
+    p.data.copy_(Q_dq.to(p.dtype))
+    return True
+
+
+def _stream_quantized_tensor(
+    writer: "StreamingPackageWriter",
+    raw_name: str,
+    nibbles: torch.Tensor,           # [out, in] u8 (unpacked) or [E, out, in/2] u8 (already packed)
+    scale_t: torch.Tensor,           # f32, BF16-rounded
+    zero_t: torch.Tensor,            # f32, BF16-rounded
+) -> None:
+    """Pack (if needed) and stream a quantized tensor + sidecars to `writer`.
+    Mirrors the per-tensor block from the old in-RAM `tensors_out`-building
+    loop in `main`, kept in one place so dense GPTQ / lm_head / fused
+    experts all share the same on-disk layout."""
+    if nibbles.dim() == 3:
+        # Fused MoE experts arrive already packed.
+        packed = nibbles
+    else:
+        packed = pack_nibbles(nibbles)
+    writer.write_tensor(
+        raw_name, packed.numpy().tobytes(),
+        list(packed.shape), "u8", LAYOUT_INT4,
+    )
+    writer.write_tensor(
+        f"{raw_name}_int4_scale", bf16_to_bytes(scale_t),
+        list(scale_t.shape), "bf16", LAYOUT_RAW,
+    )
+    writer.write_tensor(
+        f"{raw_name}_int4_zero", bf16_to_bytes(zero_t),
+        list(zero_t.shape), "bf16", LAYOUT_RAW,
+    )
+
+
+def _selfcheck_dense(
+    nibbles: torch.Tensor,
+    scale_t: torch.Tensor,
+    zero_t: torch.Tensor,
+    live: torch.Tensor,
+    group_size: int,
+) -> tuple[bool, float]:
+    """Reconstruct a dense GPTQ tensor from (nibbles, scale, zero) and
+    compare against the live `mod.weight.data`. Returns (matched, linf).
+    A mismatch indicates a bake-vs-runtime format bug (not quantization
+    quality), so we want this loud and immediate."""
+    rows, cols = nibbles.shape
+    row_gr = torch.arange(rows) // group_size
+    col_gc = torch.arange(cols) // group_size
+    sc_full = scale_t[row_gr][:, col_gc]
+    zf_full = zero_t[row_gr][:, col_gc]
+    recon = nibbles.float() * sc_full - zf_full * sc_full
+    recon = recon.to(torch.bfloat16).to(torch.float32)
+    matched = torch.equal(recon, live)
+    linf = (recon - live).abs().max().item() if not matched else 0.0
+    return matched, linf
+
+
+def _selfcheck_fused(
+    packed: torch.Tensor,             # [E, out, in/2] u8
+    scale_t: torch.Tensor,            # [E, out/gs, in/gs] f32
+    zero_t: torch.Tensor,
+    orig_bf16: torch.Tensor | None,   # [E, out, in] BF16 (may be None if unavailable)
+    group_size: int,
+) -> tuple[bool, float]:
+    """Reconstruct a fused MoE expert tensor from packed nibbles + sidecars
+    and compare against the BF16 original. Returns (nibble_range_ok, linf).
+    Linf is reported as a quality signal — fused experts use min/max
+    quant, so non-zero Linf is expected; we only fail loudly on the
+    nibble-range invariant."""
+    E, rows, packed_cols = packed.shape
+    cols = packed_cols * 2
+    lo = (packed & 0x0F).to(torch.uint8)
+    hi = (packed >> 4).to(torch.uint8)
+    unpacked = torch.empty((E, rows, cols), dtype=torch.uint8)
+    unpacked[:, :, 0::2] = lo
+    unpacked[:, :, 1::2] = hi
+    nibble_range_ok = int(unpacked.max().item()) <= 15
+    linf = 0.0
+    if orig_bf16 is not None:
+        row_gr = torch.arange(rows) // group_size
+        col_gc = torch.arange(cols) // group_size
+        sc_full = scale_t.index_select(1, row_gr).index_select(2, col_gc)
+        zf_full = zero_t.index_select(1, row_gr).index_select(2, col_gc)
+        recon = unpacked.float() * sc_full - zf_full * sc_full
+        recon = recon.to(torch.bfloat16).to(torch.float32)
+        orig_f32 = orig_bf16.detach().to(device="cpu", dtype=torch.float32)
+        linf = (recon - orig_f32).abs().max().item()
+        del recon, sc_full, zf_full, orig_f32
+    del lo, hi, unpacked
+    return nibble_range_ok, linf
+
+
 def quantize_model(
     model: nn.Module,
     calib_ids: torch.Tensor,
     device: torch.device,
     group_size: int,
     damp: float,
-) -> dict[str, tuple[torch.Tensor, torch.Tensor, torch.Tensor]]:
+    writer: "StreamingPackageWriter",
+    hf_to_raw: dict[str, str],
+    safetensors_loader: Callable[[str], torch.Tensor | None] | None = None,
+) -> dict[str, Any]:
     """
-    Run sequential GPTQ. Returns {tensor_name: (nibbles, scale_f32, zero_f32)}
-    where nibbles is [out, in] uint8 and scale/zero are [out/gs, in/gs] f32.
+    Run sequential GPTQ, **streaming** each quantized tensor to `writer` as
+    it's produced (rather than accumulating in a host-RAM dict). Returns a
+    self-check stats dict:
+
+        {
+          "quantized_names": set[str],         # HF state-dict names that were quantized
+          "dense_total":     int,
+          "dense_mismatch":  int,
+          "dense_worst":     (name, linf),
+          "fused_total":     int,
+          "fused_worst":     (name, linf),
+          "nibble_range_ok": bool,
+        }
+
+    `hf_to_raw` maps HF state-dict names to safetensors keys so the writer
+    can use raw names (the runtime-visible layout). `safetensors_loader(hf_name)`
+    is consulted only when a parameter is on the `meta` device (Accelerate
+    offloading); the dense paths still prefer the live `mod.weight` when
+    it's on a real device.
     """
     model.eval()
+    # Locate the transformer-decoder block list. Qwen3.5 (non-MM) stores it at
+    # `model.model.layers`; Qwen3.6-MoE uses the multimodal class
+    # `Qwen3_5MoeForConditionalGeneration` and nests under
+    # `model.model.language_model.layers` alongside `.visual.*`.
     inner = model.model
-    layers = inner.layers
+    if hasattr(inner, "layers"):
+        text_root = inner
+    elif hasattr(inner, "language_model") and hasattr(inner.language_model, "layers"):
+        text_root = inner.language_model
+    else:
+        raise SystemExit(
+            "could not locate transformer layers under model.model[.language_model]"
+        )
+    layers = text_root.layers
     num_layers = len(layers)
 
     # Map nn.Linear -> state-dict weight name (for naming output tensors)
@@ -445,7 +784,15 @@ def quantize_model(
     hidden_cpu, layer_kwargs = capture_layer0_inputs(model, layers, calib_ids, device)
     layer_kwargs_dev = move_kwargs_to(layer_kwargs, device)
 
-    quantized: dict[str, tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = {}
+    stats: dict[str, Any] = {
+        "quantized_names": set(),     # HF state-dict names successfully streamed
+        "dense_total": 0,
+        "dense_mismatch": 0,
+        "dense_worst": ("", 0.0),
+        "fused_total": 0,
+        "fused_worst": ("", 0.0),
+        "nibble_range_ok": True,
+    }
     nsamples = len(hidden_cpu)
 
     for layer_idx in range(num_layers):
@@ -480,16 +827,44 @@ def quantize_model(
                 log(f"[gptq]   {name}: WARNING no activations captured, skipping")
                 continue
             t0 = time.perf_counter()
-            W = mod.weight.data.to(torch.float32)
+            # Bypass Accelerate's `meta`-device placeholder by reading from
+            # safetensors when needed. The fallback is silent on layers whose
+            # weights happen to be on a real device after forward.
+            raw = _materialize_param(mod.weight, name, safetensors_loader)
+            W = raw.to(device=device, dtype=torch.float32)
             Q_dq, nibbles, scale_t, zero_t = gptq_quantize(W, H, group_size, damp)
             elapsed = time.perf_counter() - t0
+            wrote = _writeback_param(mod, Q_dq)
+
+            raw_name = hf_to_raw.get(name)
+            if raw_name is None:
+                log(f"[gptq]   {name}: WARN no safetensors raw name; skipping write")
+            else:
+                nibbles_cpu = nibbles.cpu()
+                scale_cpu   = scale_t.cpu()
+                zero_cpu    = zero_t.cpu()
+                _stream_quantized_tensor(writer, raw_name, nibbles_cpu, scale_cpu, zero_cpu)
+                stats["quantized_names"].add(name)
+                # Inline self-check: recon should byte-match `mod.weight.data`
+                # after the writeback above. Only meaningful when the writeback
+                # actually landed (meta-device params skip writeback).
+                if wrote:
+                    stats["dense_total"] += 1
+                    live = mod.weight.data.to(torch.float32).cpu()
+                    matched, linf = _selfcheck_dense(
+                        nibbles_cpu, scale_cpu, zero_cpu, live, group_size,
+                    )
+                    if not matched:
+                        stats["dense_mismatch"] += 1
+                        if linf > stats["dense_worst"][1]:
+                            stats["dense_worst"] = (name, linf)
+                    del live
+                del nibbles_cpu, scale_cpu, zero_cpu
+
             log(f"[gptq]   {name}: shape={tuple(W.shape)} "
-                f"H_N={hook.N} took {elapsed:.1f}s")
-            # Swap in dequantized weights so subsequent forwards see the quantized
-            # version of this module.
-            mod.weight.data.copy_(Q_dq.to(mod.weight.dtype))
-            quantized[name] = (nibbles.cpu(), scale_t.cpu(), zero_t.cpu())
-            del W, Q_dq, nibbles, scale_t, zero_t, H
+                f"H_N={hook.N} took {elapsed:.1f}s"
+                + ("" if wrote else " [meta param: re-run will use BF16]"))
+            del raw, W, Q_dq, nibbles, scale_t, zero_t, H
 
         # Re-run the (now partially-quantized) layer so the next layer sees
         # post-quantization activations.
@@ -505,11 +880,14 @@ def quantize_model(
                 torch.cuda.empty_cache()
 
     # --- lm_head GPTQ pass ---
-    # The transformer layer loop above hooks every nn.Linear inside `inner.layers`,
-    # but lm_head sits outside. Capture its Hessian here (post-final-norm hidden
-    # state) and run the same column-wise GPTQ. This lets the runtime skip the
-    # 250k×hidden BF16 read on the dominant decode-side matmul.
-    final_norm = getattr(inner, "norm", None)
+    # The transformer layer loop above hooks every nn.Linear inside the text
+    # decoder, but lm_head sits outside. Capture its Hessian here (post-final-
+    # norm hidden state) and run the same column-wise GPTQ. This lets the
+    # runtime skip the 250k×hidden BF16 read on the dominant decode-side
+    # matmul. `final_norm` lives on the same submodule as the layer list
+    # (text_root), which is `model.model` for Qwen3.5 and
+    # `model.model.language_model` for Qwen3.6-MoE.
+    final_norm = getattr(text_root, "norm", None)
     lm_head = getattr(model, "lm_head", None)
     if (
         isinstance(lm_head, nn.Linear)
@@ -534,18 +912,96 @@ def quantize_model(
             t0 = time.perf_counter()
             # The output head is huge on 9B-class checkpoints. Quantize it on
             # CPU to avoid requiring an extra multi-GiB clone on an already-full
-            # producer GPU after the layer sweep.
-            W = lm_head.weight.data.detach().to(device="cpu", dtype=torch.float32)
+            # producer GPU after the layer sweep. Fall back to safetensors if
+            # Accelerate has the lm_head weight on `meta`.
+            raw = _materialize_param(lm_head.weight, "lm_head.weight", safetensors_loader)
+            W = raw.to(device="cpu", dtype=torch.float32)
             H = H.detach().to(device="cpu", dtype=torch.float32)
             Q_dq, nibbles, scale_t, zero_t = gptq_quantize(W, H, group_size, damp)
             elapsed = time.perf_counter() - t0
-            log(f"[gptq]   lm_head: shape={tuple(W.shape)} "
-                f"H_N={hook.N} took {elapsed:.1f}s")
-            copy_weight_in_row_chunks(lm_head.weight.data, Q_dq)
-            quantized["lm_head.weight"] = (nibbles.cpu(), scale_t.cpu(), zero_t.cpu())
-            del W, Q_dq, nibbles, scale_t, zero_t, H
+            wrote = lm_head.weight.device.type != "meta"
+            if wrote:
+                copy_weight_in_row_chunks(lm_head.weight.data, Q_dq)
 
-    return quantized
+            # lm_head.weight is always `lm_head.weight` raw — outside the
+            # `model.language_model.*` prefix so `hf_to_raw` may not have it.
+            raw_name = hf_to_raw.get("lm_head.weight", "lm_head.weight")
+            nibbles_cpu = nibbles.cpu()
+            scale_cpu   = scale_t.cpu()
+            zero_cpu    = zero_t.cpu()
+            _stream_quantized_tensor(writer, raw_name, nibbles_cpu, scale_cpu, zero_cpu)
+            stats["quantized_names"].add("lm_head.weight")
+            if wrote:
+                stats["dense_total"] += 1
+                live = lm_head.weight.data.to(torch.float32).cpu()
+                matched, linf = _selfcheck_dense(
+                    nibbles_cpu, scale_cpu, zero_cpu, live, group_size,
+                )
+                if not matched:
+                    stats["dense_mismatch"] += 1
+                    if linf > stats["dense_worst"][1]:
+                        stats["dense_worst"] = ("lm_head.weight", linf)
+                del live
+            del nibbles_cpu, scale_cpu, zero_cpu
+
+            log(f"[gptq]   lm_head: shape={tuple(W.shape)} "
+                f"H_N={hook.N} took {elapsed:.1f}s"
+                + ("" if wrote else " [meta param: write-back skipped]"))
+            del raw, W, Q_dq, nibbles, scale_t, zero_t, H
+
+    # --- Fused MoE expert pass ---
+    # Qwen3.6-MoE stores all experts in two 3D nn.Parameters per layer rather
+    # than as a list of nn.Linear, so the per-layer GPTQ loop above never sees
+    # them. Also: a Hessian-aware GPTQ over the fused layout doesn't really fit
+    # (see docs/qwen36-moe-plan.md §15). Plan §15 option (c) — plain min/max
+    # INT4 group-quant per expert, gs=128, BF16 scale/zero — covers the runtime
+    # VRAM gap (~60 GiB BF16 → ~15 GiB INT4 at 35B) cheaply.
+    #
+    # Memory model: under `device_map="auto"` the fused experts are mostly on
+    # CPU (or partially disk-offloaded). We iterate `named_parameters()` to
+    # avoid materialising a whole state_dict, materialise one fused tensor at
+    # a time on `device`, pack nibbles immediately to halve RAM use vs the
+    # unpacked layout, then free the BF16 source. Writing path detects packed
+    # 3D shapes via `dim() == 3` (dense GPTQ stays 2D + unpacked).
+    fused_param_names = sorted(
+        n for n, _ in model.named_parameters() if is_fused_expert_target(n)
+    )
+    if fused_param_names:
+        log(f"[gptq] fused MoE experts: quantizing {len(fused_param_names)} "
+            f"3D tensors (min/max group-quant, streaming packed nibbles to disk)")
+        named_params = dict(model.named_parameters())
+        for name in fused_param_names:
+            t0 = time.perf_counter()
+            param = named_params[name]
+            # Same Accelerate `meta` problem: fall back to safetensors when
+            # the fused tensor is offloaded.
+            raw = _materialize_param(param, name, safetensors_loader)
+            W = raw.to(device="cpu", dtype=torch.bfloat16)
+            packed, scale_t, zero_t = fused_expert_minmax_int4_packed(
+                W, group_size=group_size, work_device=device,
+            )
+            elapsed = time.perf_counter() - t0
+            log(f"[gptq]   {name}: shape={tuple(W.shape)} -> "
+                f"packed={tuple(packed.shape)} took {elapsed:.1f}s")
+
+            raw_name = hf_to_raw.get(name, name)
+            _stream_quantized_tensor(writer, raw_name, packed, scale_t, zero_t)
+            stats["quantized_names"].add(name)
+            stats["fused_total"] += 1
+            # Inline self-check while `W` is still on CPU. Linf is purely a
+            # quality signal (min/max quant always shows non-zero error);
+            # the nibble-range invariant is the structural pin.
+            range_ok, linf = _selfcheck_fused(packed, scale_t, zero_t, W, group_size)
+            if not range_ok:
+                stats["nibble_range_ok"] = False
+            if linf > stats["fused_worst"][1]:
+                stats["fused_worst"] = (name, linf)
+
+            del raw, W, packed, scale_t, zero_t
+            if device.type == "cuda":
+                torch.cuda.empty_cache()
+
+    return stats
 
 
 # ---------------------------------------------------------------------------
@@ -649,40 +1105,102 @@ def _build_name_map(hf_keys: list[str], raw_keys: set[str]) -> dict[str, str]:
     return out
 
 
+class StreamingPackageWriter:
+    """Streaming sink for the bake's `weights.bin` + `manifest.json`.
+
+    The original in-RAM `tensors_out` list held every quantized tensor's
+    bytes (~17 GiB on 35B-A3B: ~15 GiB packed expert nibbles + ~1 GiB BF16
+    embeds + ~1 GiB scale/zero sidecars) until the final `write_package`
+    flushed them out. On a 64 GiB host, that list plus the still-loaded
+    BF16 model plus the GPTQ working set blew through host RAM and OOM'd
+    near the end of the run.
+    Mirrors `BakePackageWriter` in `bake_q4km.py`. The on-disk format
+    (4096-byte alignment, `manifest.json` schema) is identical to the old
+    `write_package`; only the producer side becomes streaming.
+    """
+
+    def __init__(self, out_dir: Path, model_family: str = "qwen35"):
+        self.out_dir = out_dir
+        self.model_family = model_family
+        out_dir.mkdir(parents=True, exist_ok=True)
+        self.weights_path = out_dir / "weights.bin"
+        self._fh = open(self.weights_path, "wb")
+        self._cursor = 0
+        self._entries: list[dict[str, Any]] = []
+        self._names: set[str] = set()
+
+    def write_tensor(
+        self,
+        name: str,
+        data: bytes,
+        shape: list[int],
+        dtype_str: str,
+        layout: str,
+    ) -> int:
+        """Append a tensor; return its 4096-aligned byte offset."""
+        if name in self._names:
+            raise ValueError(f"duplicate tensor name {name!r} written to bake")
+        offset = align_up(self._cursor, 4096)
+        if offset > self._cursor:
+            self._fh.write(b"\x00" * (offset - self._cursor))
+        self._fh.write(data)
+        byte_len = len(data)
+        self._entries.append({
+            "name": name,
+            "shape": list(shape),
+            "dtype": dtype_str,
+            "layout": layout,
+            "offset": offset,
+            "byte_len": byte_len,
+        })
+        self._names.add(name)
+        self._cursor = offset + byte_len
+        return offset
+
+    def has(self, name: str) -> bool:
+        return name in self._names
+
+    def finalize(self) -> None:
+        """Flush weights.bin and emit manifest.json. Sorts manifest entries
+        alphabetically for stable diffs — runtime keys by name into a
+        HashMap so on-disk ordering doesn't matter, but a sorted manifest
+        makes diffing two bake outputs sane."""
+        self._fh.flush()
+        self._fh.close()
+        sorted_entries = sorted(self._entries, key=lambda e: e["name"])
+        manifest = {
+            "format_version": FORMAT_VERSION,
+            "converter_version": CONVERTER_VERSION,
+            "model_family": self.model_family,
+            "tensors": sorted_entries,
+        }
+        with open(self.out_dir / "manifest.json", "w") as f:
+            json.dump(manifest, f, indent=2)
+        log(f"[bake-int4] wrote {self._cursor / (1024 * 1024):.1f} MiB to {self.weights_path}")
+        log(f"[bake-int4] manifest: {self.out_dir / 'manifest.json'}")
+
+    def __enter__(self) -> "StreamingPackageWriter":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        if exc_type is None:
+            self.finalize()
+        else:
+            # On error: close the file handle but skip manifest emission so
+            # downstream code can't accidentally consume a partial bake.
+            self._fh.close()
+
+
 def write_package(
     out_dir: Path,
     tensors: list[tuple[str, bytes, list[int], str, str]],
 ) -> None:
-    out_dir.mkdir(parents=True, exist_ok=True)
-    entries: list[dict[str, Any]] = []
-    cursor = 0
-    weights_path = out_dir / "weights.bin"
-    with open(weights_path, "wb") as f:
+    """Compat wrapper for callers that still want the in-RAM list API.
+    All new code should construct a `StreamingPackageWriter` directly so
+    peak host RAM stays bounded by the largest single tensor."""
+    with StreamingPackageWriter(out_dir) as writer:
         for (name, data, shape, dtype_str, layout) in tensors:
-            offset = align_up(cursor, 4096)
-            if offset > cursor:
-                f.write(b"\x00" * (offset - cursor))
-            f.write(data)
-            byte_len = len(data)
-            entries.append({
-                "name": name,
-                "shape": shape,
-                "dtype": dtype_str,
-                "layout": layout,
-                "offset": offset,
-                "byte_len": byte_len,
-            })
-            cursor = offset + byte_len
-    manifest = {
-        "format_version": FORMAT_VERSION,
-        "converter_version": CONVERTER_VERSION,
-        "model_family": "qwen35",
-        "tensors": entries,
-    }
-    with open(out_dir / "manifest.json", "w") as f:
-        json.dump(manifest, f, indent=2)
-    log(f"[bake-int4] wrote {cursor / (1024 * 1024):.1f} MiB to {weights_path}")
-    log(f"[bake-int4] manifest: {out_dir / 'manifest.json'}")
+            writer.write_tensor(name, data, shape, dtype_str, layout)
 
 
 # ---------------------------------------------------------------------------
@@ -710,6 +1228,20 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--out-dir", default=None, type=Path,
                    help="Override output directory (default: "
                         "{model-dir}/.supersonic/v{FORMAT_VERSION}-int4-gptq)")
+    # Streaming offload — needed when BF16 weights don't fit a single GPU
+    # (35B-A3B is ~67 GiB, never fits 24 GiB VRAM). Same pattern as
+    # oracle/q4km_stream_gptq_bake.py: pass through to from_pretrained and
+    # skip the unconditional .to(device) so HF Accelerate manages placement.
+    p.add_argument("--device-map", default=None,
+                   help="Optional Transformers device_map, e.g. 'auto'. When set, "
+                        "the model is NOT explicitly moved with .to(device); "
+                        "HF Accelerate spreads layers across GPU/CPU/disk.")
+    p.add_argument("--max-memory", default=None,
+                   help="Optional JSON max_memory for HF Accelerate, e.g. "
+                        "'{\"0\":\"20GiB\",\"cpu\":\"50GiB\"}' (24 GiB GPU + 64 GiB host).")
+    p.add_argument("--offload-folder", default=None, type=Path,
+                   help="Disk-offload folder for params that don't fit GPU+CPU "
+                        "(needed for ~3 GiB shortfall on 35B-A3B with 24+50 GiB).")
     return p.parse_args()
 
 
@@ -734,11 +1266,30 @@ def main() -> None:
     log(f"[bake-int4] loading tokenizer from {model_dir}")
     tokenizer = AutoTokenizer.from_pretrained(str(model_dir), trust_remote_code=True)
     log(f"[bake-int4] loading model (bf16) from {model_dir}")
-    model = AutoModelForCausalLM.from_pretrained(
-        str(model_dir),
-        torch_dtype=torch.bfloat16,
-        trust_remote_code=True,
-    ).to(device)
+
+    load_kwargs: dict[str, Any] = {
+        "torch_dtype": torch.bfloat16,
+        "trust_remote_code": True,
+    }
+    if args.device_map:
+        load_kwargs["device_map"] = args.device_map
+        log(f"[bake-int4] device_map={args.device_map!r}")
+    if args.max_memory:
+        raw_max_memory = json.loads(args.max_memory)
+        # Accelerate accepts ints (GPU index) or "cpu"/"disk" string keys.
+        load_kwargs["max_memory"] = {
+            (int(k) if isinstance(k, str) and k.isdigit() else k): v
+            for k, v in raw_max_memory.items()
+        }
+        log(f"[bake-int4] max_memory={load_kwargs['max_memory']}")
+    if args.offload_folder:
+        args.offload_folder.mkdir(parents=True, exist_ok=True)
+        load_kwargs["offload_folder"] = str(args.offload_folder)
+        log(f"[bake-int4] offload_folder={args.offload_folder}")
+
+    model = AutoModelForCausalLM.from_pretrained(str(model_dir), **load_kwargs)
+    if args.device_map is None:
+        model = model.to(device)
     model.eval()
 
     # --- Determine the canonical tensor-name prefix by reading the raw
@@ -764,7 +1315,17 @@ def main() -> None:
         raise SystemExit("could not infer weight prefix from safetensors keys")
     log(f"[bake-int4] canonical weight prefix (from safetensors): {weight_prefix!r}")
 
-    sd_keys = list(model.state_dict().keys())
+    # Avoid `model.state_dict()` here — under `device_map="auto"` it gathers
+    # every offloaded param onto CPU at once, which on a 35B model easily
+    # exceeds host RAM. `named_parameters()` + `named_buffers()` give the same
+    # name set without materialising data; we materialise per-tensor on demand
+    # in the writing loop below.
+    named_lookup: dict[str, torch.Tensor] = {}
+    for n, p in model.named_parameters():
+        named_lookup[n] = p
+    for n, b in model.named_buffers():
+        named_lookup.setdefault(n, b)
+    sd_keys = list(named_lookup.keys())
     hf_to_raw = _build_name_map(sd_keys, raw_keys)
     missing_in_raw = [k for k in sd_keys if k not in hf_to_raw]
     if missing_in_raw:
@@ -782,6 +1343,31 @@ def main() -> None:
         ]
     log(f"[bake-int4] num_layers={num_layers} "
         f"full_layers={sum(1 for t in layer_types if t == 'full_attention')}")
+
+    # `safetensors_loader` is the meta-device escape hatch for `quantize_model`.
+    # When Accelerate offloads a parameter, its `.data` becomes a meta tensor
+    # after the per-layer forward and any subsequent op crashes with a
+    # device-mismatch. The loader resolves the HF flattened name to a raw
+    # safetensors key (using `hf_to_raw`) and reads the bytes directly.
+    def safetensors_loader(hf_name: str) -> torch.Tensor | None:
+        raw_name = hf_to_raw.get(hf_name)
+        if raw_name is None:
+            # Try the live mapping candidates as a last resort — covers
+            # parameters that aren't in the state-dict-derived sd_keys (e.g.
+            # untied lm_head when the safetensors prefix differs).
+            for cand in (
+                hf_name,
+                hf_name.replace("model.", "model.language_model.", 1)
+                if hf_name.startswith("model.")
+                and not hf_name.startswith("model.language_model.")
+                else hf_name,
+            ):
+                if cand in raw_keys:
+                    raw_name = cand
+                    break
+        if raw_name is None:
+            return None
+        return load_raw_tensor(model_dir, raw_name)
 
     # --- Load calibration data ---
     log("[bake-int4] loading WikiText-2 train split via `datasets`...")
@@ -803,124 +1389,125 @@ def main() -> None:
     calib = torch.stack([ids[s:s + args.seqlen] for s in starts])
     log(f"[bake-int4] calibration batch: {tuple(calib.shape)}")
 
-    # --- GPTQ ---
-    t0 = time.perf_counter()
-    quantized = quantize_model(
-        model, calib, device,
-        group_size=args.group_size,
-        damp=args.damp,
+    # --- Open the streaming writer up front so quantized tensors flow to
+    # disk as soon as they're produced. The producer side never holds more
+    # than one (nibbles, scale, zero) triple in RAM at a time; on 35B-A3B
+    # that's ~1 GiB peak (largest fused expert slab) instead of the ~17 GiB
+    # the in-RAM `tensors_out` list reached before this refactor.
+    out_dir = args.out_dir or (
+        model_dir / ".supersonic" / f"v{FORMAT_VERSION}-int4-gptq"
     )
-    gptq_elapsed = time.perf_counter() - t0
-    log(f"[bake-int4] GPTQ done in {gptq_elapsed / 60.0:.1f} min "
-        f"({len(quantized)} tensors quantized)")
-
-    # --- Sample generation sanity check (quantized weights live in the model) ---
-    try:
-        sample_ids = tokenizer("The quick brown fox", return_tensors="pt"
-                               ).input_ids.to(device)
-        with torch.no_grad():
-            gen = model.generate(sample_ids, max_new_tokens=12,
-                                 do_sample=False, use_cache=True)
-        log(f"[bake-int4] sample gen (post-quant, python-side): "
-            f"{tokenizer.decode(gen[0], skip_special_tokens=True)!r}")
-    except Exception as ex:
-        log(f"[bake-int4] sample gen failed: {ex}")
-
-    # --- Self-consistency check: reconstruct EVERY INT4 tensor from the
-    # just-computed (nibbles, scale, zero) and verify it matches the value
-    # copied into the live model's Linear weight. Any mismatch indicates a
-    # bake-vs-runtime format bug (not a quantization quality issue).
-    try:
-        gs = args.group_size
-        hf_modules = dict(model.named_modules())
-        mismatch = 0
-        worst: tuple[str, float] = ("", 0.0)
-        for hf_name, (nibbles_s, scale_s, zero_s) in quantized.items():
-            rows, cols = nibbles_s.shape
-            row_gr = torch.arange(rows) // gs
-            col_gc = torch.arange(cols) // gs
-            sc_full = scale_s[row_gr][:, col_gc]
-            zf_full = zero_s[row_gr][:, col_gc]
-            recon = nibbles_s.float() * sc_full - zf_full * sc_full
-            recon = recon.to(torch.bfloat16).to(torch.float32)
-            mod = hf_modules.get(hf_name[: -len(".weight")])
-            if mod is None:
-                continue
-            live = mod.weight.data.to(torch.float32).cpu()
-            if not torch.equal(recon, live):
-                mismatch += 1
-                linf = (recon - live).abs().max().item()
-                if linf > worst[1]:
-                    worst = (hf_name, linf)
-        log(f"[self-check] INT4 tensors: {mismatch}/{len(quantized)} mismatch"
-            + (f" (worst: {worst[0]} Linf={worst[1]:.2e})" if mismatch else ""))
-    except Exception as ex:
-        log(f"[self-check] failed: {ex}")
-
-    # --- Perplexity sanity check (with quantized weights live in the model) ---
-    if not args.skip_ppl:
-        log("[bake-int4] running perplexity sanity check on WikiText-2 test...")
-        try:
-            ppl = compute_ppl(model, tokenizer, device,
-                              seqlen=args.seqlen, n_chunks=args.ppl_chunks)
-            log(f"[bake-int4] PPL (WikiText-2 test, {args.ppl_chunks} chunks): "
-                f"{ppl:.2f}")
-        except Exception as ex:
-            log(f"[bake-int4] PPL check failed: {ex}")
-
-    # --- Assemble tensors for writing ---
-    log("[bake-int4] serialising tensors...")
-    # Walk the HF state dict but emit under raw-safetensors names so the Rust
-    # loader (which expects the raw layout, e.g. "model.language_model.X")
-    # finds every tensor.
-    eligible = [
-        hf_name for hf_name in sd_keys
-        if hf_name in hf_to_raw
-        and not hf_to_raw[hf_name].endswith("_scale_inv")
-        and (
-            hf_to_raw[hf_name].startswith(f"{weight_prefix}.")
-            or hf_to_raw[hf_name] == "lm_head.weight"
+    # Context-manager form: on a partial run (exception propagating out),
+    # `__exit__` closes the file handle but skips manifest emission so a
+    # downstream bake-consumer can't accidentally read a half-written package
+    # as if it were complete.
+    with StreamingPackageWriter(out_dir, model_family="qwen35") as writer:
+        # --- GPTQ ---
+        t0 = time.perf_counter()
+        stats = quantize_model(
+            model, calib, device,
+            group_size=args.group_size,
+            damp=args.damp,
+            writer=writer,
+            hf_to_raw=hf_to_raw,
+            safetensors_loader=safetensors_loader,
         )
-    ]
-    eligible.sort()
+        gptq_elapsed = time.perf_counter() - t0
+        log(f"[bake-int4] GPTQ done in {gptq_elapsed / 60.0:.1f} min "
+            f"({len(stats['quantized_names'])} tensors quantized + streamed)")
 
-    sd = model.state_dict()
-    # When `lm_head.weight` is tied to `embed_tokens.weight`, the HF state dict
-    # entry usually has no safetensors counterpart and the eligible loop above
-    # skips it. But if we just ran GPTQ on `model.lm_head` and produced a
-    # quantized tensor for it, force-include `lm_head.weight` so the runtime
-    # loads the INT4 version instead of falling back to the BF16 embed alias.
-    if "lm_head.weight" in quantized and "lm_head.weight" not in eligible:
-        eligible.append("lm_head.weight")
-        if "lm_head.weight" not in hf_to_raw:
-            hf_to_raw["lm_head.weight"] = "lm_head.weight"
-        if "lm_head.weight" not in sd and hasattr(model, "lm_head"):
-            sd["lm_head.weight"] = model.lm_head.weight.data
-    tensors_out: list[tuple[str, bytes, list[int], str, str]] = []
-    for hf_name in eligible:
-        raw_name = hf_to_raw[hf_name]
-        t = sd[hf_name]
-        shape = list(t.shape)
-        if hf_name in quantized:
-            nibbles, scale_t, zero_t = quantized[hf_name]
-            packed = pack_nibbles(nibbles)
-            packed_bytes = packed.numpy().tobytes()
-            tensors_out.append((
-                raw_name, packed_bytes,
-                [packed.shape[0], packed.shape[1]],
-                "u8", LAYOUT_INT4,
-            ))
-            tensors_out.append((
-                f"{raw_name}_int4_scale",
-                bf16_to_bytes(scale_t),
-                list(scale_t.shape), "bf16", LAYOUT_RAW,
-            ))
-            tensors_out.append((
-                f"{raw_name}_int4_zero",
-                bf16_to_bytes(zero_t),
-                list(zero_t.shape), "bf16", LAYOUT_RAW,
-            ))
-        else:
+        # --- Sample generation sanity check (quantized weights live in the model) ---
+        try:
+            sample_ids = tokenizer("The quick brown fox", return_tensors="pt"
+                                   ).input_ids.to(device)
+            with torch.no_grad():
+                gen = model.generate(sample_ids, max_new_tokens=12,
+                                     do_sample=False, use_cache=True)
+            log(f"[bake-int4] sample gen (post-quant, python-side): "
+                f"{tokenizer.decode(gen[0], skip_special_tokens=True)!r}")
+        except Exception as ex:
+            log(f"[bake-int4] sample gen failed: {ex}")
+
+        # Self-check stats — already collected inline during quantize_model
+        # so no second pass is needed (the old standalone pass had to
+        # re-walk the entire `quantized` dict and held every tensor's bytes
+        # in RAM until it finished).
+        log(f"[self-check] dense INT4: "
+            f"{stats['dense_mismatch']}/{stats['dense_total']} mismatch"
+            + (f" (worst: {stats['dense_worst'][0]} "
+               f"Linf={stats['dense_worst'][1]:.2e})"
+               if stats['dense_mismatch'] else ""))
+        if stats['fused_total']:
+            log(f"[self-check] fused MoE INT4: {stats['fused_total']} tensors, "
+                f"nibble_range_ok={stats['nibble_range_ok']}, "
+                f"worst-Linf-vs-bf16={stats['fused_worst'][0]} "
+                f"({stats['fused_worst'][1]:.2e})")
+
+        # --- Perplexity sanity check (with quantized weights live in the model) ---
+        if not args.skip_ppl:
+            log("[bake-int4] running perplexity sanity check on WikiText-2 test...")
+            try:
+                ppl = compute_ppl(model, tokenizer, device,
+                                  seqlen=args.seqlen, n_chunks=args.ppl_chunks)
+                log(f"[bake-int4] PPL (WikiText-2 test, {args.ppl_chunks} chunks): "
+                    f"{ppl:.2f}")
+            except Exception as ex:
+                log(f"[bake-int4] PPL check failed: {ex}")
+
+        # --- Stream non-quantized tensors ---
+        log("[bake-int4] streaming non-quantized tensors...")
+        # Walk the HF state dict but emit under raw-safetensors names so the
+        # Rust loader (which expects the raw layout, e.g.
+        # "model.language_model.X") finds every tensor.
+        eligible = [
+            hf_name for hf_name in sd_keys
+            if hf_name in hf_to_raw
+            and not hf_to_raw[hf_name].endswith("_scale_inv")
+            and (
+                hf_to_raw[hf_name].startswith(f"{weight_prefix}.")
+                or hf_to_raw[hf_name] == "lm_head.weight"
+            )
+        ]
+        eligible.sort()
+
+        # When `lm_head.weight` is tied to `embed_tokens.weight`, the HF state
+        # dict entry usually has no safetensors counterpart and the eligible
+        # loop above skips it. But if quantize_model just ran GPTQ on
+        # `model.lm_head` and streamed an INT4 tensor for it, that tensor is
+        # already in the writer — `writer.has(...)` skips it and the runtime
+        # loads the INT4 version instead of falling back to the BF16 embed alias.
+        if ("lm_head.weight" in stats["quantized_names"]
+                and "lm_head.weight" not in eligible):
+            eligible.append("lm_head.weight")
+            if "lm_head.weight" not in hf_to_raw:
+                hf_to_raw["lm_head.weight"] = "lm_head.weight"
+            if "lm_head.weight" not in named_lookup and hasattr(model, "lm_head"):
+                named_lookup["lm_head.weight"] = model.lm_head.weight
+
+        for hf_name in eligible:
+            raw_name = hf_to_raw[hf_name]
+            # Quantized tensors were streamed during quantize_model already;
+            # the writer's name set is the source of truth.
+            if writer.has(raw_name):
+                continue
+            # Materialise one tensor at a time onto host RAM — under
+            # device_map="auto" this is what triggers Accelerate to fetch the
+            # offloaded slice. If the param is on `meta` (post-forward
+            # placeholder), fall back to safetensors via the loader so we
+            # never write a meta tensor's bytes into the bake.
+            param_ref = named_lookup.get(hf_name)
+            if param_ref is None:
+                continue
+            if param_ref.device.type == "meta":
+                t = safetensors_loader(hf_name)
+                if t is None:
+                    log(f"[bake-int4] WARNING {hf_name}: meta param + no "
+                        f"safetensors fallback — skipping")
+                    continue
+                t = t.detach().to(device="cpu")
+            else:
+                t = param_ref.detach().to(device="cpu")
+            shape = list(t.shape)
             layout = classify_tensor(raw_name, shape, weight_prefix, layer_types)
             # For A_log (HeadExpReshaped): the HF model stores bf16(raw_A_log)
             # and computes exp() at runtime as exp(bf16(raw)). Keep that —
@@ -928,14 +1515,8 @@ def main() -> None:
             # live HF model uses, which breaks Python-vs-Rust equivalence.
             dtype_str = torch_dtype_to_str(t.dtype)
             b, final_shape, final_dtype = apply_layout(t, shape, layout, dtype_str)
-            tensors_out.append((raw_name, b, final_shape, final_dtype, layout))
-
-    tensors_out.sort(key=lambda x: x[0])
-
-    out_dir = args.out_dir or (
-        model_dir / ".supersonic" / f"v{FORMAT_VERSION}-int4-gptq"
-    )
-    write_package(out_dir, tensors_out)
+            writer.write_tensor(raw_name, b, final_shape, final_dtype, layout)
+            del t, b
     log(f"[bake-int4] done. Output: {out_dir}")
 
 

--- a/oracle/bake_int4.py
+++ b/oracle/bake_int4.py
@@ -26,6 +26,9 @@ GPTQ details:
 from __future__ import annotations
 
 import argparse
+import ctypes
+import ctypes.util
+import gc
 import json
 import math
 import os
@@ -37,6 +40,29 @@ from typing import Any, Callable
 import numpy as np
 import torch
 import torch.nn as nn
+
+
+def _malloc_trim() -> None:
+    """Return free()'d host pages to the OS — glibc's allocator otherwise
+    holds them in its arena cache, which made the per-layer GPTQ loop on
+    35B-A3B grow RSS by ~10 GiB across 40 layers and OOM at the lm_head
+    step. Best-effort: silently no-op on non-glibc platforms."""
+    try:
+        libc = ctypes.CDLL(ctypes.util.find_library("c") or "libc.so.6")
+        libc.malloc_trim(0)
+    except (OSError, AttributeError):
+        pass
+
+
+def _release_host_memory() -> None:
+    """Run between layers / heavy steps to reclaim host RAM. The pattern is:
+    drop unreferenced Python objects → empty CUDA caching pool → ask glibc
+    to release arena pages back to the OS. Without the malloc_trim call the
+    OS still sees the pages as resident even after PyTorch frees them."""
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+    _malloc_trim()
 
 # -- constants mirrored from crates/model-store/src/manifest.rs --
 FORMAT_VERSION = 2
@@ -879,6 +905,11 @@ def quantize_model(
             if device.type == "cuda":
                 torch.cuda.empty_cache()
 
+        # Hand free()d arena pages back to the OS. Without this the C
+        # runtime accumulates ~10 GiB of fragmentation across 40 layers
+        # of 35B-A3B and OOMs at the lm_head step.
+        _release_host_memory()
+
     # --- lm_head GPTQ pass ---
     # The transformer layer loop above hooks every nn.Linear inside the text
     # decoder, but lm_head sits outside. Capture its Hessian here (post-final-
@@ -895,17 +926,34 @@ def quantize_model(
         and is_int4_target("lm_head.weight")
     ):
         log(f"[gptq] lm_head: collecting Hessian over {nsamples} samples")
-        hook = HessianHook(lm_head)
+        # Compute the Hessian directly from `final_norm(hidden)` instead of
+        # invoking `lm_head(normed)` to fire a forward-pre hook. The hook
+        # version produced a [1, seqlen, vocab] BF16 output (~1 GiB at
+        # vocab=248320) per iteration; on a 40 GiB-cpu host that already
+        # holds 30+ GiB of offloaded weights, the transient pushed RSS over
+        # the OOM threshold near the end of the 128-sample loop.
+        H: torch.Tensor | None = None
+        H_N = 0
         with torch.no_grad():
             for s in range(nsamples):
                 hs = hidden_cpu[s].to(device)
                 normed = final_norm(hs)
-                _ = lm_head(normed)
-                del hs, normed
+                x = normed
+                if x.dim() > 2:
+                    x = x.reshape(-1, x.shape[-1])
+                x = x.to(torch.float32)
+                n = x.shape[0]
+                xx = (x.T @ x) * 2.0
+                if H is None:
+                    H = xx / n
+                    H_N = n
+                else:
+                    new_N = H_N + n
+                    H = H * (H_N / new_N) + xx / new_N
+                    H_N = new_N
+                del hs, normed, x, xx
             if device.type == "cuda":
                 torch.cuda.empty_cache()
-        H = hook.H
-        hook.close()
         if H is None:
             log("[gptq]   lm_head: WARNING no activations captured, skipping")
         else:
@@ -945,9 +993,10 @@ def quantize_model(
             del nibbles_cpu, scale_cpu, zero_cpu
 
             log(f"[gptq]   lm_head: shape={tuple(W.shape)} "
-                f"H_N={hook.N} took {elapsed:.1f}s"
+                f"H_N={H_N} took {elapsed:.1f}s"
                 + ("" if wrote else " [meta param: write-back skipped]"))
             del raw, W, Q_dq, nibbles, scale_t, zero_t, H
+            _release_host_memory()
 
     # --- Fused MoE expert pass ---
     # Qwen3.6-MoE stores all experts in two 3D nn.Parameters per layer rather
@@ -1000,6 +1049,11 @@ def quantize_model(
             del raw, W, packed, scale_t, zero_t
             if device.type == "cuda":
                 torch.cuda.empty_cache()
+            # Reclaim host pages between fused experts. Each tensor is a few
+            # hundred MiB on 35B-A3B (256 experts × MoE_intermediate); without
+            # malloc_trim, glibc keeps them in its arena cache and we drift
+            # ~10 GiB upward over the 80-tensor pass.
+            _release_host_memory()
 
     return stats
 

--- a/oracle/bake_q4km.py
+++ b/oracle/bake_q4km.py
@@ -597,7 +597,32 @@ def apply_layout(t: torch.Tensor, shape: list[int], layout: str, dtype_str: str)
     raise ValueError(f"unknown layout {layout}")
 
 
+# Fused 3D MoE expert tensors (Qwen3.6-MoE): names lack `.weight` and ship 3D.
+# Treated as `E` parallel `[out, in]` matrices for INT4 packing — see
+# `quantize_minmax_fused_experts` for the driver path.
+FUSED_EXPERT_SUFFIXES = (
+    ".mlp.experts.gate_up_proj",
+    ".mlp.experts.down_proj",
+)
+
+
+def is_fused_expert_target(name: str) -> bool:
+    return any(name.endswith(s) for s in FUSED_EXPERT_SUFFIXES)
+
+
 def is_q4km_target(name: str, shape: list[int], group_size: int) -> bool:
+    if is_fused_expert_target(name):
+        # Real shapes: gate_up_proj [E, 2*moe_int, hidden],
+        #              down_proj    [E, hidden, moe_int].
+        # Validate divisibility on the per-expert (out, in) axes and accept.
+        if len(shape) != 3:
+            return False
+        out_dim, in_dim = shape[1], shape[2]
+        if in_dim % group_size != 0 or in_dim % 2 != 0:
+            return False
+        if out_dim % group_size != 0:
+            return False
+        return True
     if not name.endswith(".weight") or len(shape) != 2:
         return False
     if shape[1] % group_size != 0 or shape[1] % 2 != 0:
@@ -618,6 +643,17 @@ def is_q4km_target(name: str, shape: list[int], group_size: int) -> bool:
         # on the dominant decode-side matmul.
         return True
     return "_proj" in name or "experts" in name or "ffn_" in name
+
+
+def pack_nibbles_3d(nibbles: torch.Tensor) -> torch.Tensor:
+    """Pack `[E, rows, cols]` uint8 nibbles into `[E, rows, cols/2]` u8 bytes."""
+    if nibbles.dim() != 3:
+        raise ValueError(f"expected 3D nibble tensor, got shape {tuple(nibbles.shape)}")
+    e, rows, cols = nibbles.shape
+    if cols % 2 != 0:
+        raise ValueError(f"cols must be even, got {cols}")
+    r = nibbles.reshape(e, rows, cols // 2, 2).to(torch.uint8)
+    return (r[..., 0] | (r[..., 1] << 4)).contiguous()
 
 
 def pack_nibbles(nibbles: torch.Tensor) -> torch.Tensor:
@@ -697,6 +733,56 @@ def quantize_minmax(W: torch.Tensor, group_size: int) -> tuple[torch.Tensor, tor
             scales[gr, gc] = sc
             zeros[gr, gc] = zf
     return pack_nibbles(nibbles), scales, zeros
+
+
+@torch.no_grad()
+def quantize_minmax_fused_experts(
+    W: torch.Tensor,
+    group_size: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Per-expert min/max INT4 group-quant for a 3D fused MoE weight slab.
+
+    Input shape: `[E, out, in]`. Each `[out, in]` expert is independently
+    quantized with `group_size`-tile BF16 scale + zero. Mirrors
+    `oracle/bake_int4.fused_expert_minmax_int4` so both bake paths produce the
+    same on-disk layout (packed nibbles `[E, out, in/2]`, scale/zero
+    `[E, out/gs, in/gs]`).
+    """
+    if W.dim() != 3:
+        raise SystemExit(f"fused expert tensor must be 3D, got shape {tuple(W.shape)}")
+    E, out_f, in_f = W.shape
+    gs = group_size
+    if in_f % gs != 0 or in_f % 2 != 0:
+        raise SystemExit(
+            f"fused expert in_features {in_f} must be divisible by "
+            f"group_size={gs} and even"
+        )
+    if out_f % gs != 0:
+        raise SystemExit(
+            f"fused expert out_features {out_f} must be divisible by group_size={gs}"
+        )
+    scale_rows = out_f // gs
+    scale_cols = in_f // gs
+    nibbles = torch.empty((E, out_f, in_f), dtype=torch.uint8)
+    scales = torch.empty((E, scale_rows, scale_cols), dtype=torch.float32)
+    zeros = torch.empty((E, scale_rows, scale_cols), dtype=torch.float32)
+    for e in range(E):
+        slab = W[e].to(torch.float32)
+        tiles = slab.reshape(scale_rows, gs, scale_cols, gs)
+        tmax = tiles.amax(dim=(1, 3))
+        tmin = tiles.amin(dim=(1, 3))
+        rng = tmax - tmin
+        sc = torch.where(rng > 0, rng / 15.0, torch.ones_like(rng))
+        zf = torch.where(rng > 0, -tmin / sc, torch.zeros_like(rng))
+        sc = sc.to(torch.bfloat16).to(torch.float32)
+        zf = zf.to(torch.bfloat16).to(torch.float32)
+        sc_full = sc.repeat_interleave(gs, dim=0).repeat_interleave(gs, dim=1)
+        zf_full = zf.repeat_interleave(gs, dim=0).repeat_interleave(gs, dim=1)
+        q = torch.clamp(torch.round(slab / sc_full + zf_full), 0, 15).to(torch.uint8)
+        nibbles[e] = q
+        scales[e] = sc
+        zeros[e] = zf
+    return pack_nibbles_3d(nibbles), scales, zeros
 
 
 @torch.no_grad()
@@ -859,7 +945,19 @@ def encode_tensor_entries(
     entries: list[tuple[str, bytes, list[int], str, str]] = []
     shape = list(t.shape)
     if is_q4km_target(name, shape, group_size):
-        if quantizer == QUANT_GPTQ:
+        if is_fused_expert_target(name):
+            # Fused MoE experts (Qwen3.6-MoE) — 3D `[E, out, in]`. Hessian-aware
+            # GPTQ doesn't apply cleanly to the fused layout (router decides
+            # which expert sees a token, so per-tensor Hessians are not
+            # well-defined). Always use min/max group-quant per expert; reject
+            # GPTQ requests loudly so the operator switches to --quantizer minmax.
+            if quantizer != QUANT_MINMAX:
+                raise SystemExit(
+                    f"{name}: fused MoE experts require --quantizer minmax "
+                    f"(got {quantizer!r}); see docs/qwen36-moe-plan.md §15."
+                )
+            packed, scales, zeros = quantize_minmax_fused_experts(t, group_size)
+        elif quantizer == QUANT_GPTQ:
             H = load_hessian(hessian_dir, name)
             if H is None:
                 raise SystemExit(

--- a/oracle/qwen36_moe_ffn_oracle.py
+++ b/oracle/qwen36_moe_ffn_oracle.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+"""
+PyTorch reference for one Qwen3.6-MoE FFN block's decode step.
+
+Companion to PR 4b4 of docs/qwen36-moe-plan.md. The attention oracle
+(`qwen36_moe_oracle.py`) covers the pre-FFN half of a layer; this oracle
+covers the post-attention half — RMS norm, top-k MoE expert dispatch,
+shared-expert path, and the final residual add. The HIP kernel's
+parity test reads the JSON this script emits and compares its own
+intermediates point for point.
+
+The MoE FFN block on Qwen3-Next (35B-A3B):
+
+  h_norm        = rms_norm(input_hidden, post_attn_norm_w, eps)
+
+  # router
+  router_logits = h_norm @ gate.T                         # [E=256]
+  router_probs  = softmax(router_logits, dim=-1)
+  topk_w, topk_idx = topk(router_probs, k=8)              # [k], [k]
+  topk_w        = topk_w / topk_w.sum()                   # renormalised
+
+  # per-expert FFN (gate_up_proj is fused: rows 0..512 = gate, 512..1024 = up)
+  for j in range(k):
+      e   = topk_idx[j]
+      gu  = gate_up_proj[e] @ h_norm                      # [2 * I]
+      gp, up = split(gu, [I, I])
+      mid = silu(gp) * up                                 # [I]
+      moe_out_j = down_proj[e] @ mid                      # [hidden]
+
+  moe_out = sum(topk_w[j] * moe_out_j)                    # [hidden]
+
+  # shared expert (always-on, smaller, gated by its own sigmoid)
+  shared_gate = sigmoid(shared_expert_gate @ h_norm)      # [1] scalar
+  shared_mid  = silu(shared_expert.gate_proj @ h_norm) \
+              * (shared_expert.up_proj  @ h_norm)         # [Is = 512]
+  shared_out  = shared_gate * (shared_expert.down_proj @ shared_mid)
+
+  output_hidden = input_hidden + moe_out + shared_out
+
+`input_hidden` here is the *post-attention residual* — i.e. the output
+of the attention oracle, NOT the original input to the layer. The
+kernel's MoE FFN entry takes the same buffer the attention kernel
+wrote to.
+
+Why hand-rolled rather than transformers: same reason as the attention
+oracle — the multimodal HF class for this checkpoint has vision + MTP
+heads we don't care about, and instantiating it costs ~70 GiB of host
+RAM. We load just the per-layer FFN tensors.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import sys
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+from safetensors import safe_open
+
+
+# ---------------------------------------------------------------------------
+# Tensor I/O helpers (same encoding the attention oracle uses)
+# ---------------------------------------------------------------------------
+def b64_bf16(t: torch.Tensor) -> str:
+    return base64.b64encode(
+        t.to(torch.bfloat16).contiguous().cpu().view(torch.int16).numpy().tobytes()
+    ).decode()
+
+
+def b64_f32(t: torch.Tensor) -> str:
+    return base64.b64encode(
+        t.to(torch.float32).contiguous().cpu().numpy().tobytes()
+    ).decode()
+
+
+def b64_i32(t: torch.Tensor) -> str:
+    return base64.b64encode(
+        t.to(torch.int32).contiguous().cpu().numpy().tobytes()
+    ).decode()
+
+
+def find_shard_for(model_dir: Path, name: str) -> Path:
+    idx_path = model_dir / "model.safetensors.index.json"
+    if idx_path.exists():
+        wm = json.loads(idx_path.read_text())["weight_map"]
+        if name not in wm:
+            raise SystemExit(f"tensor not in index: {name}")
+        return model_dir / wm[name]
+    single = model_dir / "model.safetensors"
+    if single.exists():
+        return single
+    raise SystemExit(f"no safetensors at {model_dir}")
+
+
+def load_tensor(model_dir: Path, name: str, device: str = "cpu") -> torch.Tensor:
+    path = find_shard_for(model_dir, name)
+    with safe_open(str(path), framework="pt", device=device) as f:
+        return f.get_tensor(name)
+
+
+# ---------------------------------------------------------------------------
+# Math primitives — kept structurally identical to what the kernel will do
+# ---------------------------------------------------------------------------
+def rms_norm(x: torch.Tensor, weight: torch.Tensor, eps: float) -> torch.Tensor:
+    """RMS norm without add-unit-offset. F32 internals, output in input dtype.
+    Matches the attention oracle's `rms_norm` byte-for-byte so the kernel can
+    reuse the same implementation across the attn + FFN halves of a layer."""
+    in_dtype = x.dtype
+    xf = x.to(torch.float32)
+    var = xf.pow(2).mean(dim=-1, keepdim=True)
+    out = xf * torch.rsqrt(var + eps) * weight.to(torch.float32)
+    return out.to(in_dtype)
+
+
+def silu(x: torch.Tensor) -> torch.Tensor:
+    """SiLU computed in F32 then cast back. The HIP kernel does the same;
+    keeping this explicit matches the BF16 round-tripping behaviour
+    (cast-up, op, cast-down with RNE) the kernel implements."""
+    in_dtype = x.dtype
+    return (x.to(torch.float32) * torch.sigmoid(x.to(torch.float32))).to(in_dtype)
+
+
+# ---------------------------------------------------------------------------
+# Per-block reference forward
+# ---------------------------------------------------------------------------
+def reference_moe_ffn_block(
+    *,
+    input_hidden: torch.Tensor,             # [hidden] — post-attention residual
+    post_attn_norm_w: torch.Tensor,         # [hidden]
+    gate_w: torch.Tensor,                   # [E=256, hidden]
+    gate_up_proj_w: torch.Tensor,           # [E, 2*I=1024, hidden]   (gate || up)
+    down_proj_w: torch.Tensor,              # [E, hidden, I=512]
+    shared_gate_proj_w: torch.Tensor,       # [Is=512, hidden]
+    shared_up_proj_w: torch.Tensor,         # [Is, hidden]
+    shared_down_proj_w: torch.Tensor,       # [hidden, Is]
+    shared_expert_gate_w: torch.Tensor,     # [1, hidden]
+    num_experts: int,
+    moe_intermediate: int,                  # I = 512 (per-expert, half of fused dim)
+    shared_intermediate: int,               # Is = 512 (= moe_intermediate on 35B)
+    top_k: int,
+    rms_norm_eps: float,
+) -> dict:
+    """Apply one MoE FFN block for a single token.
+    Returns a dict of every intermediate, all in the input dtype."""
+    dtype = input_hidden.dtype
+    hidden = input_hidden.shape[-1]
+    E = num_experts
+    I = moe_intermediate
+    Is = shared_intermediate
+    K = top_k
+
+    # 1. Post-attention RMS norm.
+    h_norm = rms_norm(input_hidden, post_attn_norm_w, rms_norm_eps)
+
+    # 2. Router. Matmul + softmax + top-k. Score-renormalisation is the
+    #    Qwen3-Next convention (renormalise across just the top-k probs so
+    #    they sum to 1 within the dispatch); the kernel's stage 1 must
+    #    reproduce both indices AND weights exactly.
+    router_logits = (h_norm.to(torch.float32) @ gate_w.to(torch.float32).T)  # [E]
+    router_probs = F.softmax(router_logits, dim=-1)                          # [E]
+    topk_vals, topk_idx = torch.topk(router_probs, K, dim=-1)                # [K]
+    topk_w_renorm = topk_vals / topk_vals.sum(dim=-1, keepdim=True)          # [K]
+
+    # 3. Per-expert MLP. The fused weight stores `gate || up` along its row
+    #    axis: rows [0..I) are the gate projection, rows [I..2I) are the up
+    #    projection. The kernel reads the slice for each selected expert.
+    per_expert_outs = []
+    for j in range(K):
+        e = int(topk_idx[j].item())
+        gu = h_norm.to(torch.float32) @ gate_up_proj_w[e].to(torch.float32).T   # [2*I]
+        gp = gu[:I]
+        up = gu[I:]
+        mid = (gp * torch.sigmoid(gp)) * up                                     # [I]
+        eo = mid @ down_proj_w[e].to(torch.float32).T                           # [hidden]
+        per_expert_outs.append(eo)
+    expert_stack = torch.stack(per_expert_outs, dim=0)                          # [K, hidden]
+    moe_out = (topk_w_renorm.unsqueeze(-1) * expert_stack).sum(dim=0).to(dtype) # [hidden]
+
+    # 4. Shared expert. Always-on path that runs in parallel; its output is
+    #    sigmoid-gated by `shared_expert_gate` (a single 1×hidden lane).
+    sg_logit = (h_norm.to(torch.float32) @ shared_expert_gate_w.to(torch.float32).T)  # [1]
+    sg_scalar = torch.sigmoid(sg_logit).squeeze(-1)                                   # scalar
+    sgp = h_norm.to(torch.float32) @ shared_gate_proj_w.to(torch.float32).T           # [Is]
+    sup = h_norm.to(torch.float32) @ shared_up_proj_w.to(torch.float32).T             # [Is]
+    smid = (sgp * torch.sigmoid(sgp)) * sup                                            # [Is]
+    sdown = smid @ shared_down_proj_w.to(torch.float32).T                              # [hidden]
+    shared_out = (sg_scalar * sdown).to(dtype)                                         # [hidden]
+
+    # 5. Residual sum. The MoE block's post-residual output replaces
+    #    `input_hidden` for the next layer's input.
+    output_hidden = (input_hidden.to(torch.float32) + moe_out.to(torch.float32)
+                     + shared_out.to(torch.float32)).to(dtype)
+
+    return {
+        "h_norm":          h_norm,
+        "router_logits":   router_logits.to(dtype),
+        "router_probs":    router_probs.to(dtype),
+        "topk_idx":        topk_idx.to(torch.int32),
+        "topk_weights":    topk_w_renorm.to(dtype),
+        "expert_stack":    expert_stack.to(dtype).reshape(K * hidden),
+        "moe_out":         moe_out,
+        "shared_gate":     sg_scalar.to(dtype),
+        "shared_mid":      smid.to(dtype),
+        "shared_out":      shared_out,
+        "output_hidden":   output_hidden,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Driver: synthetic + from-checkpoint modes
+# ---------------------------------------------------------------------------
+def synthesize_block(
+    *,
+    hidden: int,
+    num_experts: int,
+    moe_intermediate: int,
+    shared_intermediate: int,
+    seed: int,
+    dtype: torch.dtype,
+) -> dict:
+    g = torch.Generator().manual_seed(seed)
+
+    def randn(*shape: int) -> torch.Tensor:
+        # ~N(0, 1/sqrt(fan_in)) so projection outputs stay O(1) — same
+        # convention as the attention oracle.
+        fan_in = shape[-1] if len(shape) >= 2 else 1
+        scale = (1.0 / fan_in) ** 0.5
+        return (torch.randn(shape, generator=g, dtype=torch.float32) * scale).to(dtype)
+
+    def norm_w(n: int) -> torch.Tensor:
+        return (torch.ones(n, dtype=torch.float32)
+                + torch.randn(n, generator=g, dtype=torch.float32) * 0.02).to(dtype)
+
+    return dict(
+        input_hidden=randn(hidden),
+        post_attn_norm_w=norm_w(hidden),
+        gate_w=randn(num_experts, hidden),
+        gate_up_proj_w=randn(num_experts, 2 * moe_intermediate, hidden),
+        down_proj_w=randn(num_experts, hidden, moe_intermediate),
+        shared_gate_proj_w=randn(shared_intermediate, hidden),
+        shared_up_proj_w=randn(shared_intermediate, hidden),
+        shared_down_proj_w=randn(hidden, shared_intermediate),
+        # The shared-expert sigmoid gate is one row × hidden; small values
+        # keep sigmoid()<1 so the test catches a missing scalar multiply.
+        shared_expert_gate_w=randn(1, hidden),
+    )
+
+
+def load_block_from_checkpoint(
+    *, model_dir: Path, layer_idx: int, weight_prefix: str, device: str
+) -> dict:
+    lp = f"{weight_prefix}.layers.{layer_idx}"
+    mp = f"{lp}.mlp"
+    return dict(
+        post_attn_norm_w=load_tensor(model_dir, f"{lp}.post_attention_layernorm.weight", device),
+        gate_w=load_tensor(model_dir, f"{mp}.gate.weight", device),
+        gate_up_proj_w=load_tensor(model_dir, f"{mp}.experts.gate_up_proj", device),
+        down_proj_w=load_tensor(model_dir, f"{mp}.experts.down_proj", device),
+        shared_gate_proj_w=load_tensor(model_dir, f"{mp}.shared_expert.gate_proj.weight", device),
+        shared_up_proj_w=load_tensor(model_dir, f"{mp}.shared_expert.up_proj.weight", device),
+        shared_down_proj_w=load_tensor(model_dir, f"{mp}.shared_expert.down_proj.weight", device),
+        shared_expert_gate_w=load_tensor(model_dir, f"{mp}.shared_expert_gate.weight", device),
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Qwen3.6-MoE single-block FFN reference (PR 4b4 oracle)"
+    )
+    p.add_argument("--mode", choices=["synthetic", "checkpoint"], default="synthetic")
+    p.add_argument("--model-dir", type=Path,
+                   help="Path to the HuggingFace safetensors dir (checkpoint mode)")
+    p.add_argument("--layer-idx", type=int, default=0,
+                   help="Layer index. The MoE FFN is identical across full and "
+                        "linear attention layers, so layer 0 (linear) is fine.")
+    p.add_argument("--weight-prefix", default="model.language_model")
+    p.add_argument("--seed", type=int, default=0xC0FFEE,
+                   help="Synthesis seed (also seeds the synthetic input_hidden in "
+                        "checkpoint mode)")
+    p.add_argument("--dtype", choices=["bf16", "fp32"], default="bf16")
+    p.add_argument("--device", default="cpu",
+                   help="Run on this device (cpu, cuda:0). Defaults to cpu so the "
+                        "oracle is reproducible without a GPU. The 35B-A3B per-layer "
+                        "MoE weights total ~5.4 GiB BF16; a CPU run on 64 GiB "
+                        "host fits without trouble.")
+    p.add_argument("--out", type=Path, required=True,
+                   help="JSON output path")
+    p.add_argument("--hidden", type=int, default=2048)
+    p.add_argument("--num-experts", type=int, default=256)
+    p.add_argument("--moe-intermediate", type=int, default=512,
+                   help="Per-expert intermediate dim (I in the docstring; half of "
+                        "the fused gate_up_proj's row count)")
+    p.add_argument("--shared-intermediate", type=int, default=512,
+                   help="Shared-expert intermediate dim (= moe_intermediate on "
+                        "35B-A3B but kept separate in case future configs differ)")
+    p.add_argument("--top-k", type=int, default=8)
+    p.add_argument("--rms-norm-eps", type=float, default=1e-6)
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    dtype = torch.bfloat16 if args.dtype == "bf16" else torch.float32
+
+    if args.mode == "synthetic":
+        weights = synthesize_block(
+            hidden=args.hidden,
+            num_experts=args.num_experts,
+            moe_intermediate=args.moe_intermediate,
+            shared_intermediate=args.shared_intermediate,
+            seed=args.seed,
+            dtype=dtype,
+        )
+    else:
+        if args.model_dir is None:
+            raise SystemExit("--model-dir is required in checkpoint mode")
+        weights = load_block_from_checkpoint(
+            model_dir=args.model_dir,
+            layer_idx=args.layer_idx,
+            weight_prefix=args.weight_prefix,
+            device=args.device,
+        )
+        torch.manual_seed(args.seed)
+        weights["input_hidden"] = (
+            torch.randn(args.hidden, dtype=torch.float32) / args.hidden**0.5
+        ).to(dtype)
+        # Norm weights stored BF16 — cast to working dtype.
+        weights["post_attn_norm_w"] = weights["post_attn_norm_w"].to(dtype)
+
+    weights = {k: v.to(args.device) for k, v in weights.items()}
+
+    intermediates = reference_moe_ffn_block(
+        num_experts=args.num_experts,
+        moe_intermediate=args.moe_intermediate,
+        shared_intermediate=args.shared_intermediate,
+        top_k=args.top_k,
+        rms_norm_eps=args.rms_norm_eps,
+        **weights,
+    )
+
+    encode = b64_bf16 if args.dtype == "bf16" else b64_f32
+
+    # `topk_idx` is int32 regardless of the working dtype; everything else
+    # follows the working dtype.
+    enc_weights = {k: encode(v) for k, v in weights.items()}
+    enc_intermediates: dict[str, str] = {}
+    for k, v in intermediates.items():
+        if k == "topk_idx":
+            enc_intermediates[k] = b64_i32(v)
+        else:
+            enc_intermediates[k] = encode(v)
+
+    out = {
+        "schema": "qwen36-moe-oracle-ffn-v1",
+        "mode": args.mode,
+        "layer_idx": args.layer_idx,
+        "dtype": args.dtype,
+        "config": {
+            "hidden": args.hidden,
+            "num_experts": args.num_experts,
+            "moe_intermediate": args.moe_intermediate,
+            "shared_intermediate": args.shared_intermediate,
+            "top_k": args.top_k,
+            "rms_norm_eps": args.rms_norm_eps,
+        },
+        "weights": enc_weights,
+        "intermediates": enc_intermediates,
+    }
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(out))
+
+    out_norm = intermediates["output_hidden"].to(torch.float32).norm().item()
+    in_norm = weights["input_hidden"].to(torch.float32).norm().item()
+    delta = (intermediates["output_hidden"] - weights["input_hidden"]
+             ).to(torch.float32).norm().item()
+    selected = intermediates["topk_idx"].tolist()
+    sys.stderr.write(
+        f"[oracle-ffn] layer={args.layer_idx} mode={args.mode} "
+        f"|input|={in_norm:.4f} |output|={out_norm:.4f} |delta|={delta:.4f} "
+        f"top_k={selected}\n"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/oracle/qwen36_moe_linear_oracle.py
+++ b/oracle/qwen36_moe_linear_oracle.py
@@ -1,0 +1,525 @@
+#!/usr/bin/env python3
+"""
+PyTorch reference for one Qwen3.6-MoE linear-attention layer's decode step.
+
+Companion to PR 4b3 step 1. The 3-of-4 layers in the hybrid pattern that
+aren't full-attention are linear-attention (delta-rule recurrent state
++ depthwise conv pre-mix), and they need their own staged kernel.
+This oracle is the parity ground-truth for that kernel.
+
+As with `qwen36_moe_oracle.py`, the math is hand-rolled to avoid pulling
+in the multimodal `Qwen3_5MoeForConditionalGeneration` class — it would
+need ~70 GiB of RAM to instantiate and we only care about one layer's
+worth of tensors.
+
+Math implemented (single decode step, all per qwen35 production code):
+
+  x_norm     = rmsnorm(input_hidden, w_input_norm, eps)
+
+  qkv_raw    = x_norm @ in_proj_qkv.T              # [qkv_dim]
+  z_raw      = x_norm @ in_proj_z.T                # [V*v]
+  a_raw      = x_norm @ in_proj_a.T                # [V]
+  b_raw      = x_norm @ in_proj_b.T                # [V]
+
+  conv_input = concat(conv_state_before, qkv_raw)  # [qkv_dim, kernel]
+  conv_out   = depthwise_conv1d(conv_input, conv_w[, conv_b])  # [qkv_dim]
+  silu_out   = silu(conv_out)
+  conv_state_after = conv_input[:, 1:]             # shifted
+
+  q_raw, k_raw, v_raw = split(silu_out)            # along channel
+  q          = l2_normalize(q_raw.reshape(K, k))
+  k          = l2_normalize(k_raw.reshape(K, k))
+  v          =                v_raw.reshape(V, v)
+
+  rep        = V // K
+  q_rep      = q.repeat_interleave(rep, dim=0)     # [V, k]
+  k_rep      = k.repeat_interleave(rep, dim=0)
+  q_scaled   = q_rep * (1 / sqrt(k))
+
+  beta       = sigmoid(b_raw)                      # [V]
+  g          = -softplus(a_raw + dt_bias) * exp(A_log)   # [V]   (F32)
+
+  state      = recurrent_state_before * exp(g)[:, None, None]
+  kv_mem     = sum_k(state * k_rep[..., None])     # [V, v]
+  delta      = (v - kv_mem) * beta[..., None]
+  state_aft  = state + k_rep[..., None] * delta[:, None, :]
+  rec_out    = sum_k(state_aft * q_scaled[..., None])    # [V, v]
+
+  out_normed = rmsnorm_per_head(rec_out, norm_w, eps)
+  z_silu     = silu(z_raw.reshape(V, v))
+  out_gated  = out_normed * z_silu
+
+  o_out      = out_gated.reshape(V*v) @ out_proj.T
+  output_hidden = input_hidden + o_out
+
+Where K = num_k_heads, V = num_v_heads, k = head_k_dim, v = head_v_dim,
+qkv_dim = 2*K*k + V*v.
+
+The first decode step from a fresh prefill has conv_state_before and
+recurrent_state_before both zero. To exercise the recurrent update
+properly the oracle also supports a "warm" mode where prior state is
+seeded from the same RNG that produces the synthetic weights.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import sys
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+from safetensors import safe_open
+
+
+# ---------------------------------------------------------------------------
+# Tensor I/O helpers (identical to qwen36_moe_oracle.py)
+# ---------------------------------------------------------------------------
+def b64_bf16(t: torch.Tensor) -> str:
+    return base64.b64encode(
+        t.to(torch.bfloat16).contiguous().cpu().view(torch.int16).numpy().tobytes()
+    ).decode()
+
+
+def b64_f32(t: torch.Tensor) -> str:
+    return base64.b64encode(
+        t.to(torch.float32).contiguous().cpu().numpy().tobytes()
+    ).decode()
+
+
+def find_shard_for(model_dir: Path, name: str) -> Path:
+    idx_path = model_dir / "model.safetensors.index.json"
+    if idx_path.exists():
+        wm = json.loads(idx_path.read_text())["weight_map"]
+        if name not in wm:
+            raise SystemExit(f"tensor not in index: {name}")
+        return model_dir / wm[name]
+    single = model_dir / "model.safetensors"
+    if single.exists():
+        return single
+    raise SystemExit(f"no safetensors at {model_dir}")
+
+
+def load_tensor(model_dir: Path, name: str, device: str = "cpu") -> torch.Tensor:
+    path = find_shard_for(model_dir, name)
+    with safe_open(str(path), framework="pt", device=device) as f:
+        return f.get_tensor(name)
+
+
+# ---------------------------------------------------------------------------
+# Math primitives
+# ---------------------------------------------------------------------------
+def rms_norm(x: torch.Tensor, weight: torch.Tensor, eps: float) -> torch.Tensor:
+    """RMS norm without add-unit-offset. Computed in F32, output in input dtype."""
+    in_dtype = x.dtype
+    xf = x.to(torch.float32)
+    var = xf.pow(2).mean(dim=-1, keepdim=True)
+    out = xf * torch.rsqrt(var + eps) * weight.to(torch.float32)
+    return out.to(in_dtype)
+
+
+def silu(x: torch.Tensor) -> torch.Tensor:
+    """SiLU = x * sigmoid(x), computed in F32 then cast back."""
+    in_dtype = x.dtype
+    xf = x.to(torch.float32)
+    return (xf * torch.sigmoid(xf)).to(in_dtype)
+
+
+def l2_normalize_per_head(x: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
+    """F.normalize(p=2, dim=-1, eps=eps) — divides by max(norm, eps)."""
+    return F.normalize(x, p=2.0, dim=-1, eps=eps)
+
+
+# ---------------------------------------------------------------------------
+# Per-layer reference forward (single decode step)
+# ---------------------------------------------------------------------------
+def reference_linear_attn_layer(
+    *,
+    input_hidden: torch.Tensor,            # [hidden]
+    input_norm_w: torch.Tensor,            # [hidden]
+    in_proj_qkv_w: torch.Tensor,           # [qkv_dim, hidden]
+    in_proj_z_w: torch.Tensor,             # [V*v, hidden]
+    in_proj_a_w: torch.Tensor,             # [V, hidden]
+    in_proj_b_w: torch.Tensor,             # [V, hidden]
+    conv1d_w: torch.Tensor,                # [qkv_dim, 1, kernel]   (depthwise)
+    conv1d_bias: torch.Tensor | None,      # [qkv_dim] or None
+    dt_bias: torch.Tensor,                 # [V]
+    a_log: torch.Tensor,                   # [V]
+    norm_w: torch.Tensor,                  # [v]   per-head normalization weight
+    out_proj_w: torch.Tensor,              # [hidden, V*v]
+    conv_state_before: torch.Tensor,       # [qkv_dim, kernel - 1]
+    recurrent_state_before: torch.Tensor,  # [V, k, v]   F32
+    num_k_heads: int,                      # K
+    num_v_heads: int,                      # V
+    head_k_dim: int,                       # k
+    head_v_dim: int,                       # v
+    conv_kernel_dim: int,
+    rms_norm_eps: float,
+) -> dict:
+    dtype = input_hidden.dtype
+    K = num_k_heads
+    V = num_v_heads
+    k_dim = head_k_dim
+    v_dim = head_v_dim
+    key_dim = K * k_dim
+    value_dim = V * v_dim
+    qkv_dim = 2 * key_dim + value_dim
+    assert in_proj_qkv_w.shape[0] == qkv_dim, (
+        f"in_proj_qkv_w out_dim {in_proj_qkv_w.shape[0]} != expected {qkv_dim}"
+    )
+
+    # 1. Pre-attn RMS norm.
+    x_norm = rms_norm(input_hidden, input_norm_w, rms_norm_eps)
+
+    # 2. In-projections (qkv, z, a, b).
+    qkv_raw = x_norm @ in_proj_qkv_w.T                    # [qkv_dim]
+    z_raw = x_norm @ in_proj_z_w.T                        # [V*v]
+    a_raw = x_norm @ in_proj_a_w.T                        # [V]
+    b_raw = x_norm @ in_proj_b_w.T                        # [V]
+
+    # 3. Conv1d step.
+    # conv_state_before holds the prior `kernel-1` channels per
+    # qkv_dim. Append the new qkv_raw column to get a `[qkv_dim, kernel]`
+    # window, then sum element-wise against conv1d_w (depthwise: one
+    # filter per channel, no cross-channel mixing).
+    conv_input = torch.cat(
+        [conv_state_before.to(dtype), qkv_raw.unsqueeze(-1)], dim=-1
+    )                                                      # [qkv_dim, kernel]
+    conv_w_2d = conv1d_w.to(dtype).squeeze(1)              # [qkv_dim, kernel]
+    conv_out_f32 = (conv_input.to(torch.float32) * conv_w_2d.to(torch.float32)).sum(dim=-1)
+    if conv1d_bias is not None:
+        conv_out_f32 = conv_out_f32 + conv1d_bias.to(torch.float32)
+    conv_out = conv_out_f32.to(dtype)                      # [qkv_dim]
+    silu_out = silu(conv_out)                              # [qkv_dim]
+    conv_state_after = conv_input[:, 1:]                   # [qkv_dim, kernel-1]
+
+    # 4. Split q, k, v out of silu_out.
+    q_raw = silu_out[:key_dim]
+    k_raw = silu_out[key_dim:2 * key_dim]
+    v_raw = silu_out[2 * key_dim:2 * key_dim + value_dim]
+    q_heads = q_raw.reshape(K, k_dim)
+    k_heads = k_raw.reshape(K, k_dim)
+    v_heads = v_raw.reshape(V, v_dim)
+
+    # 5. L2-normalize Q and K per head.
+    q_normed = l2_normalize_per_head(q_heads, eps=1e-6)
+    k_normed = l2_normalize_per_head(k_heads, eps=1e-6)
+
+    # 6. GQA fan-out (linear attn replicates K-heads to match V-heads).
+    head_repeat = V // K
+    if head_repeat > 1:
+        q_rep = q_normed.repeat_interleave(head_repeat, dim=0)   # [V, k_dim]
+        k_rep = k_normed.repeat_interleave(head_repeat, dim=0)
+    else:
+        q_rep = q_normed
+        k_rep = k_normed
+
+    # 7. Scale Q.
+    q_scaled = q_rep * (1.0 / (k_dim ** 0.5))
+
+    # 8. Beta gate and decay g (F32 throughout — matches qwen35 oracle).
+    beta = torch.sigmoid(b_raw.to(torch.float32))                  # [V]
+    dt_bias_f = dt_bias.to(torch.float32)
+    a_log_exp = a_log.to(torch.float32).exp()
+    g = -torch.log1p(torch.exp(a_raw.to(torch.float32) + dt_bias_f)) * a_log_exp   # [V]
+
+    # 9. Delta-rule recurrent update (single step).
+    # state shape: [V, k_dim, v_dim]
+    state = recurrent_state_before.to(torch.float32).clone()
+    g_step = g.exp()                                                # [V]
+    state = state * g_step.unsqueeze(-1).unsqueeze(-1)              # decay
+    k_rep_f = k_rep.to(torch.float32)
+    q_scaled_f = q_scaled.to(torch.float32)
+    v_heads_f = v_heads.to(torch.float32)
+    kv_mem = (state * k_rep_f.unsqueeze(-1)).sum(dim=1)             # [V, v_dim]
+    delta = (v_heads_f - kv_mem) * beta.unsqueeze(-1)               # [V, v_dim]
+    state_after = state + k_rep_f.unsqueeze(-1) * delta.unsqueeze(1)
+    recurrent_out = (state_after * q_scaled_f.unsqueeze(-1)).sum(dim=1)   # [V, v_dim]
+
+    # 10. Per-head RMS norm of recurrent output.
+    rec_out_dtype = recurrent_out.to(dtype)
+    out_normed = rms_norm(rec_out_dtype, norm_w, rms_norm_eps)      # [V, v_dim]
+
+    # 11. Z gating (silu(z) elementwise multiply).
+    z_heads = z_raw.reshape(V, v_dim)
+    z_silu = silu(z_heads)
+    out_gated = out_normed * z_silu                                 # [V, v_dim]
+
+    # 12. Out projection + residual.
+    out_flat = out_gated.reshape(V * v_dim)
+    o_out = out_flat @ out_proj_w.T                                 # [hidden]
+    output_hidden = input_hidden + o_out
+
+    return {
+        "x_norm":                x_norm,
+        "qkv_raw":               qkv_raw,
+        "z_raw":                 z_raw,
+        "a_raw":                 a_raw,
+        "b_raw":                 b_raw,
+        "conv_input":            conv_input.reshape(-1),
+        "conv_out":              conv_out,
+        "silu_out":              silu_out,
+        "q_raw":                 q_raw,
+        "k_raw":                 k_raw,
+        "v_raw":                 v_raw,
+        "q_normed":              q_normed.reshape(-1),
+        "k_normed":              k_normed.reshape(-1),
+        "q_rep":                 q_rep.reshape(-1),
+        "k_rep":                 k_rep.reshape(-1),
+        "v_heads":               v_heads.reshape(-1),
+        "beta":                  beta,
+        "g":                     g,
+        "q_scaled":              q_scaled.reshape(-1),
+        "state_after":           state_after.reshape(-1),
+        "recurrent_out":         recurrent_out.reshape(-1),
+        "out_normed":            out_normed.reshape(-1),
+        "z_silu":                z_silu.reshape(-1),
+        "out_gated":             out_gated.reshape(-1),
+        "o_out":                 o_out,
+        "output_hidden":         output_hidden,
+        "conv_state_after":      conv_state_after.reshape(-1),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+def synthesize_layer(
+    *,
+    hidden: int,
+    K: int,
+    V: int,
+    k_dim: int,
+    v_dim: int,
+    kernel: int,
+    seed: int,
+    dtype: torch.dtype,
+    warm_state: bool,
+) -> dict:
+    g = torch.Generator().manual_seed(seed)
+
+    def randn(*shape: int) -> torch.Tensor:
+        fan_in = shape[-1] if len(shape) >= 2 else 1
+        scale = (1.0 / fan_in) ** 0.5
+        return (torch.randn(shape, generator=g, dtype=torch.float32) * scale).to(dtype)
+
+    def norm_w(n: int) -> torch.Tensor:
+        return (
+            torch.ones(n, dtype=torch.float32)
+            + torch.randn(n, generator=g, dtype=torch.float32) * 0.02
+        ).to(dtype)
+
+    key_dim = K * k_dim
+    value_dim = V * v_dim
+    qkv_dim = 2 * key_dim + value_dim
+
+    if warm_state:
+        # Seeded "post-prefill" state. Conv state stays BF16 (matches the
+        # production layout); recurrent state is F32 (production keeps it
+        # in F32 for stability).
+        conv_state = (torch.randn(qkv_dim, kernel - 1, generator=g, dtype=torch.float32) * 0.5).to(dtype)
+        recurrent_state = torch.randn(V, k_dim, v_dim, generator=g, dtype=torch.float32) * 0.1
+    else:
+        conv_state = torch.zeros(qkv_dim, kernel - 1, dtype=dtype)
+        recurrent_state = torch.zeros(V, k_dim, v_dim, dtype=torch.float32)
+
+    return dict(
+        input_hidden=randn(hidden),
+        input_norm_w=norm_w(hidden),
+        in_proj_qkv_w=randn(qkv_dim, hidden),
+        in_proj_z_w=randn(value_dim, hidden),
+        in_proj_a_w=randn(V, hidden),
+        in_proj_b_w=randn(V, hidden),
+        # depthwise conv: [out_channels, 1, kernel] with each channel having
+        # its own filter. Initialise small so the silu output stays tame.
+        conv1d_w=(torch.randn(qkv_dim, 1, kernel, generator=g, dtype=torch.float32) * 0.3).to(dtype),
+        conv1d_bias=None,
+        # dt_bias and A_log are per-V-head scalars; use small magnitudes so
+        # the softplus chain stays finite.
+        dt_bias=(torch.randn(V, generator=g, dtype=torch.float32) * 0.1).to(dtype),
+        a_log=(torch.randn(V, generator=g, dtype=torch.float32) * 0.5).to(dtype),
+        norm_w=norm_w(v_dim),
+        out_proj_w=randn(hidden, value_dim),
+        conv_state_before=conv_state,
+        recurrent_state_before=recurrent_state,
+    )
+
+
+def load_layer_from_checkpoint(
+    *, model_dir: Path, layer_idx: int, weight_prefix: str, device: str
+) -> dict:
+    lp = f"{weight_prefix}.layers.{layer_idx}"
+    la = f"{lp}.linear_attn"
+
+    def maybe_load(name: str) -> torch.Tensor | None:
+        try:
+            return load_tensor(model_dir, name, device)
+        except SystemExit:
+            return None
+
+    return dict(
+        input_norm_w=load_tensor(model_dir, f"{lp}.input_layernorm.weight", device),
+        in_proj_qkv_w=load_tensor(model_dir, f"{la}.in_proj_qkv.weight", device),
+        in_proj_z_w=load_tensor(model_dir, f"{la}.in_proj_z.weight", device),
+        in_proj_a_w=load_tensor(model_dir, f"{la}.in_proj_a.weight", device),
+        in_proj_b_w=load_tensor(model_dir, f"{la}.in_proj_b.weight", device),
+        conv1d_w=load_tensor(model_dir, f"{la}.conv1d.weight", device),
+        conv1d_bias=maybe_load(f"{la}.conv1d.bias"),
+        dt_bias=load_tensor(model_dir, f"{la}.dt_bias", device),
+        a_log=load_tensor(model_dir, f"{la}.A_log", device),
+        norm_w=load_tensor(model_dir, f"{la}.norm.weight", device),
+        out_proj_w=load_tensor(model_dir, f"{la}.out_proj.weight", device),
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Qwen3.6-MoE single-layer linear-attention reference forward"
+    )
+    p.add_argument("--mode", choices=["synthetic", "checkpoint"], default="synthetic")
+    p.add_argument("--model-dir", type=Path,
+                   help="Path to the HuggingFace safetensors dir (checkpoint mode)")
+    p.add_argument("--layer-idx", type=int, default=0,
+                   help="Linear-attention layer index (default 0)")
+    p.add_argument("--weight-prefix", default="model.language_model")
+    p.add_argument("--state", choices=["fresh", "warm"], default="fresh",
+                   help="Prior state: 'fresh' (zeros, first decode step) or "
+                        "'warm' (seeded random; exercises decay + delta update)")
+    p.add_argument("--seed", type=int, default=0xC0FFEE)
+    p.add_argument("--dtype", choices=["bf16", "fp32"], default="bf16")
+    p.add_argument("--device", default="cpu")
+    p.add_argument("--out", type=Path, required=True)
+    # Linear-attn geometry (35B-A3B defaults).
+    p.add_argument("--hidden", type=int, default=2048)
+    p.add_argument("--num-k-heads", type=int, default=16)
+    p.add_argument("--num-v-heads", type=int, default=32)
+    p.add_argument("--head-k-dim", type=int, default=128)
+    p.add_argument("--head-v-dim", type=int, default=128)
+    p.add_argument("--conv-kernel-dim", type=int, default=4)
+    p.add_argument("--rms-norm-eps", type=float, default=1e-6)
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    dtype = torch.bfloat16 if args.dtype == "bf16" else torch.float32
+
+    if args.mode == "synthetic":
+        weights = synthesize_layer(
+            hidden=args.hidden,
+            K=args.num_k_heads,
+            V=args.num_v_heads,
+            k_dim=args.head_k_dim,
+            v_dim=args.head_v_dim,
+            kernel=args.conv_kernel_dim,
+            seed=args.seed,
+            dtype=dtype,
+            warm_state=(args.state == "warm"),
+        )
+    else:
+        if args.model_dir is None:
+            raise SystemExit("--model-dir is required in checkpoint mode")
+        weights = load_layer_from_checkpoint(
+            model_dir=args.model_dir,
+            layer_idx=args.layer_idx,
+            weight_prefix=args.weight_prefix,
+            device=args.device,
+        )
+        # Reproducible synthetic input + state (same RNG style as
+        # qwen36_moe_oracle's checkpoint mode).
+        torch.manual_seed(args.seed)
+        weights["input_hidden"] = (
+            torch.randn(args.hidden, dtype=torch.float32) / args.hidden ** 0.5
+        ).to(dtype)
+        # Norm weights from 35B-A3B are stored BF16; cast to working dtype.
+        for k in ("input_norm_w", "norm_w"):
+            weights[k] = weights[k].to(dtype)
+
+        key_dim = args.num_k_heads * args.head_k_dim
+        value_dim = args.num_v_heads * args.head_v_dim
+        qkv_dim = 2 * key_dim + value_dim
+        if args.state == "warm":
+            weights["conv_state_before"] = (
+                torch.randn(qkv_dim, args.conv_kernel_dim - 1, dtype=torch.float32) * 0.5
+            ).to(dtype)
+            weights["recurrent_state_before"] = (
+                torch.randn(
+                    args.num_v_heads, args.head_k_dim, args.head_v_dim, dtype=torch.float32
+                ) * 0.1
+            )
+        else:
+            weights["conv_state_before"] = torch.zeros(
+                qkv_dim, args.conv_kernel_dim - 1, dtype=dtype
+            )
+            weights["recurrent_state_before"] = torch.zeros(
+                args.num_v_heads, args.head_k_dim, args.head_v_dim, dtype=torch.float32
+            )
+
+    weights = {k: (v.to(args.device) if isinstance(v, torch.Tensor) else v)
+               for k, v in weights.items()}
+
+    intermediates = reference_linear_attn_layer(
+        num_k_heads=args.num_k_heads,
+        num_v_heads=args.num_v_heads,
+        head_k_dim=args.head_k_dim,
+        head_v_dim=args.head_v_dim,
+        conv_kernel_dim=args.conv_kernel_dim,
+        rms_norm_eps=args.rms_norm_eps,
+        **weights,
+    )
+
+    encode = b64_bf16 if args.dtype == "bf16" else b64_f32
+    weight_payload = {}
+    for k, v in weights.items():
+        if v is None:
+            continue
+        # recurrent_state_before is F32 always; encode appropriately.
+        if k == "recurrent_state_before":
+            weight_payload[k] = b64_f32(v)
+        else:
+            weight_payload[k] = encode(v)
+
+    intermediate_payload = {}
+    for k, v in intermediates.items():
+        # state_after is F32 (production keeps recurrent state in F32);
+        # everything else follows the working dtype.
+        if k == "state_after":
+            intermediate_payload[k] = b64_f32(v)
+        else:
+            intermediate_payload[k] = encode(v)
+
+    out = {
+        "schema": "qwen36-moe-linear-oracle-layer-v1",
+        "mode": args.mode,
+        "state": args.state,
+        "layer_idx": args.layer_idx,
+        "dtype": args.dtype,
+        "config": {
+            "hidden": args.hidden,
+            "num_k_heads": args.num_k_heads,
+            "num_v_heads": args.num_v_heads,
+            "head_k_dim": args.head_k_dim,
+            "head_v_dim": args.head_v_dim,
+            "conv_kernel_dim": args.conv_kernel_dim,
+            "rms_norm_eps": args.rms_norm_eps,
+        },
+        "weights": weight_payload,
+        "intermediates": intermediate_payload,
+    }
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(out))
+
+    # Eyeball line.
+    out_norm = intermediates["output_hidden"].to(torch.float32).norm().item()
+    in_norm = weights["input_hidden"].to(torch.float32).norm().item()
+    delta = (intermediates["output_hidden"] - weights["input_hidden"]).to(torch.float32).norm().item()
+    sys.stderr.write(
+        f"[linear-oracle] layer={args.layer_idx} state={args.state} mode={args.mode} "
+        f"|input|={in_norm:.4f} |output|={out_norm:.4f} |delta|={delta:.4f}\n"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/oracle/qwen36_moe_oracle.py
+++ b/oracle/qwen36_moe_oracle.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+"""
+PyTorch reference for one Qwen3.6-MoE full-attention layer's decode step.
+
+Companion to PR 4b of docs/qwen36-moe-plan.md. Loads exactly the weights
+needed for one layer (no full-model instantiation — 35B doesn't fit
+24 GiB), runs the forward in PyTorch using primitives we control end
+to end, and emits every intermediate as JSON + base64. The HIP kernel's
+parity test reads this JSON and compares its own intermediates point
+for point.
+
+Why hand-rolled rather than transformers: the published checkpoint is
+a multimodal class (Qwen3_5MoeForConditionalGeneration) with vision +
+MTP heads we don't care about. Pulling it in via AutoModelForCausalLM
+would either flatten/strip silently or fail to dispatch, plus would
+need ~70 GiB of RAM to instantiate. Loading just the tensors we need
+keeps this script honest about what's being tested.
+
+Math implemented (per Qwen3-Next full-attention with attn_output_gate):
+
+  x_norm = rmsnorm(input, w_input_norm, eps)
+  q_raw  = x_norm @ q_proj.T                       # [2 * H * d]  H=16, d=256
+  q, gate = split(q_raw, axis=-1, [H*d, H*d])
+  k      = x_norm @ k_proj.T                       # [Hkv * d]    Hkv=2
+  v      = x_norm @ v_proj.T                       # [Hkv * d]
+  q      = rmsnorm_per_head(q, w_q_norm)           # over last dim per head
+  k      = rmsnorm_per_head(k, w_k_norm)
+  q, k   = rope(q, k, position, rotary_dim=64)     # partial RoPE
+  scores = q @ k.T / sqrt(d)                       # GQA: each Q head pairs
+                                                   #      with floor(h / (H/Hkv))
+  attn   = softmax(scores) @ v
+  attn   = sigmoid(gate) * attn                    # output gate
+  out    = attn @ o_proj.T
+  return input + out
+
+This is the prefill-position-zero variant: no prior KV cache, so the
+attention reduces to a single-token "self-attention" against itself.
+The kernel's first parity gate is on this exact path; KV-cache extension
+to non-zero positions follows the same shape, just with a longer K/V
+sequence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import sys
+from pathlib import Path
+
+import torch
+import torch.nn.functional as F
+from safetensors import safe_open
+
+
+# ---------------------------------------------------------------------------
+# Tensor I/O helpers
+# ---------------------------------------------------------------------------
+def b64_bf16(t: torch.Tensor) -> str:
+    return base64.b64encode(
+        t.to(torch.bfloat16).contiguous().cpu().view(torch.int16).numpy().tobytes()
+    ).decode()
+
+
+def b64_f32(t: torch.Tensor) -> str:
+    return base64.b64encode(
+        t.to(torch.float32).contiguous().cpu().numpy().tobytes()
+    ).decode()
+
+
+def find_shard_for(model_dir: Path, name: str) -> Path:
+    idx_path = model_dir / "model.safetensors.index.json"
+    if idx_path.exists():
+        wm = json.loads(idx_path.read_text())["weight_map"]
+        if name not in wm:
+            raise SystemExit(f"tensor not in index: {name}")
+        return model_dir / wm[name]
+    single = model_dir / "model.safetensors"
+    if single.exists():
+        return single
+    raise SystemExit(f"no safetensors at {model_dir}")
+
+
+def load_tensor(model_dir: Path, name: str, device: str = "cpu") -> torch.Tensor:
+    path = find_shard_for(model_dir, name)
+    with safe_open(str(path), framework="pt", device=device) as f:
+        return f.get_tensor(name)
+
+
+# ---------------------------------------------------------------------------
+# Math primitives — kept structurally identical to what the kernel will do
+# ---------------------------------------------------------------------------
+def rms_norm(x: torch.Tensor, weight: torch.Tensor, eps: float) -> torch.Tensor:
+    """RMS norm without add-unit-offset. Computed in F32, output in input dtype."""
+    in_dtype = x.dtype
+    xf = x.to(torch.float32)
+    var = xf.pow(2).mean(dim=-1, keepdim=True)
+    out = xf * torch.rsqrt(var + eps) * weight.to(torch.float32)
+    return out.to(in_dtype)
+
+
+def build_rope_tables(
+    rotary_dim: int, seq_len: int, theta: float, dtype: torch.dtype
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Cos/sin tables for partial RoPE. Returns `[seq_len, rotary_dim/2]` each
+    in the requested dtype. The kernel reads these at the position index."""
+    half = rotary_dim // 2
+    inv_freq = 1.0 / (theta ** (torch.arange(0, half, dtype=torch.float32) / half))
+    pos = torch.arange(seq_len, dtype=torch.float32)
+    freqs = torch.outer(pos, inv_freq)  # [seq_len, half]
+    return freqs.cos().to(dtype), freqs.sin().to(dtype)
+
+
+def apply_rope_partial(
+    x: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    rotary_dim: int,
+) -> torch.Tensor:
+    """Rotate the first `rotary_dim` channels of `x[..., d]` using the
+    half-pair convention: pair (i, i+half) for i in [0, half). Leaves
+    channels [rotary_dim:d] untouched."""
+    half = rotary_dim // 2
+    x_rot = x[..., :rotary_dim]
+    x_pass = x[..., rotary_dim:]
+    x_pair_a = x_rot[..., :half]
+    x_pair_b = x_rot[..., half:]
+    rot_a = x_pair_a * cos - x_pair_b * sin
+    rot_b = x_pair_b * cos + x_pair_a * sin
+    return torch.cat([rot_a, rot_b, x_pass], dim=-1)
+
+
+def gqa_attention(
+    q: torch.Tensor,  # [H, d]
+    k: torch.Tensor,  # [Hkv, d]
+    v: torch.Tensor,  # [Hkv, d]
+    head_dim: int,
+) -> torch.Tensor:
+    """Single-token self-attention with GQA broadcast. Returns [H, d]."""
+    H = q.shape[0]
+    Hkv = k.shape[0]
+    assert H % Hkv == 0, f"GQA requires H ({H}) % Hkv ({Hkv}) == 0"
+    rep = H // Hkv
+    k_full = k.repeat_interleave(rep, dim=0)  # [H, d]
+    v_full = v.repeat_interleave(rep, dim=0)  # [H, d]
+
+    # Query length 1 against key length 1: scores per head are scalar.
+    scale = 1.0 / (head_dim**0.5)
+    scores = (q * k_full).sum(dim=-1, keepdim=True) * scale  # [H, 1]
+    weights = F.softmax(scores.to(torch.float32), dim=-1).to(v_full.dtype)
+    return weights * v_full  # [H, d]
+
+
+# ---------------------------------------------------------------------------
+# Per-layer reference forward
+# ---------------------------------------------------------------------------
+def reference_full_attention_layer(
+    *,
+    input_hidden: torch.Tensor,        # [hidden]
+    input_norm_w: torch.Tensor,        # [hidden]
+    q_proj_w: torch.Tensor,            # [2*H*d, hidden]   (attn_output_gate=true)
+    k_proj_w: torch.Tensor,            # [Hkv*d, hidden]
+    v_proj_w: torch.Tensor,            # [Hkv*d, hidden]
+    q_norm_w: torch.Tensor,            # [d]
+    k_norm_w: torch.Tensor,            # [d]
+    o_proj_w: torch.Tensor,            # [hidden, H*d]
+    num_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    rotary_dim: int,
+    rope_theta: float,
+    rms_norm_eps: float,
+    position: int,
+) -> dict:
+    """Apply one full-attention layer for a single token at `position`.
+    Returns a dict of every intermediate, all in the input dtype."""
+    dtype = input_hidden.dtype
+    hidden = input_hidden.shape[-1]
+    H = num_heads
+    Hkv = num_kv_heads
+    d = head_dim
+
+    # 1. Pre-attention RMS norm.
+    x_norm = rms_norm(input_hidden, input_norm_w, rms_norm_eps)
+
+    # 2. Q/K/V projections. Q's output has 2*H*d channels (Q + output gate).
+    q_raw = x_norm @ q_proj_w.T  # [2*H*d]
+    k_raw = x_norm @ k_proj_w.T  # [Hkv*d]
+    v_raw = x_norm @ v_proj_w.T  # [Hkv*d]
+
+    # 3. Split Q's gate off and reshape per-head.
+    q_lanes = q_raw[: H * d]
+    out_gate_lanes = q_raw[H * d :]
+    q_heads = q_lanes.reshape(H, d)            # [H, d]
+    k_heads = k_raw.reshape(Hkv, d)            # [Hkv, d]
+    v_heads = v_raw.reshape(Hkv, d)            # [Hkv, d]
+    out_gate = out_gate_lanes.reshape(H, d)    # [H, d]
+
+    # 4. Per-head Q/K RMS norm.
+    q_normed = rms_norm(q_heads, q_norm_w, rms_norm_eps)
+    k_normed = rms_norm(k_heads, k_norm_w, rms_norm_eps)
+
+    # 5. Partial RoPE on Q and K.
+    seq_len = max(position + 1, 1)
+    cos_table, sin_table = build_rope_tables(rotary_dim, seq_len, rope_theta, dtype)
+    cos_pos = cos_table[position].to(dtype)  # [rotary_dim/2]
+    sin_pos = sin_table[position].to(dtype)
+    q_rot = apply_rope_partial(q_normed, cos_pos, sin_pos, rotary_dim)
+    k_rot = apply_rope_partial(k_normed, cos_pos, sin_pos, rotary_dim)
+
+    # 6. Self-attention against the just-emitted (k, v) (KV cache len = 1).
+    attn = gqa_attention(q_rot, k_rot, v_heads, d)  # [H, d]
+
+    # 7. Output gate (Qwen3-Next innovation).
+    gate = torch.sigmoid(out_gate.to(torch.float32)).to(dtype) * attn
+
+    # 8. O projection + residual.
+    gate_flat = gate.reshape(H * d)
+    o_out = gate_flat @ o_proj_w.T   # [hidden]
+    output_hidden = input_hidden + o_out
+
+    return {
+        "x_norm":         x_norm,
+        "q_raw":          q_raw,
+        "k_raw":          k_raw,
+        "v_raw":          v_raw,
+        "q_lanes":        q_lanes,
+        "out_gate_lanes": out_gate_lanes,
+        "q_normed":       q_normed.reshape(H * d),
+        "k_normed":       k_normed.reshape(Hkv * d),
+        "q_rot":          q_rot.reshape(H * d),
+        "k_rot":          k_rot.reshape(Hkv * d),
+        "attn":           attn.reshape(H * d),
+        "gated_attn":     gate_flat,
+        "o_out":          o_out,
+        "output_hidden":  output_hidden,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Driver: synthetic + from-checkpoint modes
+# ---------------------------------------------------------------------------
+def synthesize_layer(
+    *, hidden: int, H: int, Hkv: int, d: int, seed: int, dtype: torch.dtype
+) -> dict:
+    g = torch.Generator().manual_seed(seed)
+
+    def randn(*shape: int) -> torch.Tensor:
+        # ~N(0, 1/sqrt(fan_in)) so projection outputs stay O(1) — keeps
+        # the synthetic forward numerically tame for parity comparison.
+        fan_in = shape[-1] if len(shape) >= 2 else 1
+        scale = (1.0 / fan_in) ** 0.5
+        return (torch.randn(shape, generator=g, dtype=torch.float32) * scale).to(dtype)
+
+    # Norm weights at ~1.0 plus a small jitter so an off-by-one in the unit
+    # offset would be visible.
+    def norm_w(n: int) -> torch.Tensor:
+        return (torch.ones(n, dtype=torch.float32)
+                + torch.randn(n, generator=g, dtype=torch.float32) * 0.02).to(dtype)
+
+    return dict(
+        input_hidden=randn(hidden),
+        input_norm_w=norm_w(hidden),
+        q_proj_w=randn(2 * H * d, hidden),
+        k_proj_w=randn(Hkv * d, hidden),
+        v_proj_w=randn(Hkv * d, hidden),
+        q_norm_w=norm_w(d),
+        k_norm_w=norm_w(d),
+        o_proj_w=randn(hidden, H * d),
+    )
+
+
+def load_layer_from_checkpoint(
+    *, model_dir: Path, layer_idx: int, weight_prefix: str, device: str
+) -> dict:
+    lp = f"{weight_prefix}.layers.{layer_idx}"
+    fa = f"{lp}.self_attn"
+    return dict(
+        input_norm_w=load_tensor(model_dir, f"{lp}.input_layernorm.weight", device),
+        q_proj_w=load_tensor(model_dir, f"{fa}.q_proj.weight", device),
+        k_proj_w=load_tensor(model_dir, f"{fa}.k_proj.weight", device),
+        v_proj_w=load_tensor(model_dir, f"{fa}.v_proj.weight", device),
+        q_norm_w=load_tensor(model_dir, f"{fa}.q_norm.weight", device),
+        k_norm_w=load_tensor(model_dir, f"{fa}.k_norm.weight", device),
+        o_proj_w=load_tensor(model_dir, f"{fa}.o_proj.weight", device),
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Qwen3.6-MoE single-layer reference forward (PR 4b oracle)"
+    )
+    p.add_argument("--mode", choices=["synthetic", "checkpoint"], default="synthetic")
+    p.add_argument("--model-dir", type=Path,
+                   help="Path to the HuggingFace safetensors dir (checkpoint mode)")
+    p.add_argument("--layer-idx", type=int, default=3,
+                   help="Full-attention layer index (default 3 = first full layer)")
+    p.add_argument("--weight-prefix", default="model.language_model")
+    p.add_argument("--position", type=int, default=0)
+    p.add_argument("--seed", type=int, default=0xC0FFEE,
+                   help="Synthesis seed for `--mode synthetic`")
+    p.add_argument("--dtype", choices=["bf16", "fp32"], default="bf16")
+    p.add_argument("--device", default="cpu",
+                   help="Run on this device (cpu, cuda:0). Defaults to cpu so the "
+                        "oracle is reproducible without a GPU; `cuda:0` here = "
+                        "ROCm GPU on this machine via PyTorch's HIP wheel.")
+    p.add_argument("--out", type=Path, required=True,
+                   help="JSON output path")
+    p.add_argument("--num-attention-heads", type=int, default=16)
+    p.add_argument("--num-kv-heads", type=int, default=2)
+    p.add_argument("--head-dim", type=int, default=256)
+    p.add_argument("--hidden", type=int, default=2048)
+    p.add_argument("--rotary-dim", type=int, default=64)
+    p.add_argument("--rope-theta", type=float, default=1e7)
+    p.add_argument("--rms-norm-eps", type=float, default=1e-6)
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    dtype = torch.bfloat16 if args.dtype == "bf16" else torch.float32
+
+    if args.mode == "synthetic":
+        weights = synthesize_layer(
+            hidden=args.hidden,
+            H=args.num_attention_heads,
+            Hkv=args.num_kv_heads,
+            d=args.head_dim,
+            seed=args.seed,
+            dtype=dtype,
+        )
+    else:
+        if args.model_dir is None:
+            raise SystemExit("--model-dir is required in checkpoint mode")
+        weights = load_layer_from_checkpoint(
+            model_dir=args.model_dir,
+            layer_idx=args.layer_idx,
+            weight_prefix=args.weight_prefix,
+            device=args.device,
+        )
+        # Embed_tokens isn't needed; we synthesise the input_hidden the same
+        # way as synthetic mode so the parity test has a deterministic input
+        # without paying ~1 GiB to load the embedding table.
+        torch.manual_seed(args.seed)
+        weights["input_hidden"] = (
+            torch.randn(args.hidden, dtype=torch.float32) / args.hidden**0.5
+        ).to(dtype)
+        # Norm weights from 35B-A3B are stored BF16; cast to working dtype.
+        for k in ("input_norm_w", "q_norm_w", "k_norm_w"):
+            weights[k] = weights[k].to(dtype)
+
+    weights = {k: v.to(args.device) for k, v in weights.items()}
+
+    intermediates = reference_full_attention_layer(
+        num_heads=args.num_attention_heads,
+        num_kv_heads=args.num_kv_heads,
+        head_dim=args.head_dim,
+        rotary_dim=args.rotary_dim,
+        rope_theta=args.rope_theta,
+        rms_norm_eps=args.rms_norm_eps,
+        position=args.position,
+        **weights,
+    )
+
+    encode = b64_bf16 if args.dtype == "bf16" else b64_f32
+    out = {
+        "schema": "qwen36-moe-oracle-layer-v1",
+        "mode": args.mode,
+        "layer_idx": args.layer_idx,
+        "position": args.position,
+        "dtype": args.dtype,
+        "config": {
+            "hidden": args.hidden,
+            "num_attention_heads": args.num_attention_heads,
+            "num_kv_heads": args.num_kv_heads,
+            "head_dim": args.head_dim,
+            "rotary_dim": args.rotary_dim,
+            "rope_theta": args.rope_theta,
+            "rms_norm_eps": args.rms_norm_eps,
+            "attn_output_gate": True,
+        },
+        "weights": {k: encode(v) for k, v in weights.items()},
+        "intermediates": {k: encode(v) for k, v in intermediates.items()},
+    }
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(out))
+
+    # Quick eyeball at stderr — gives an at-a-glance "is this remotely sane".
+    out_norm = intermediates["output_hidden"].to(torch.float32).norm().item()
+    in_norm = weights["input_hidden"].to(torch.float32).norm().item()
+    sys.stderr.write(
+        f"[oracle] layer={args.layer_idx} pos={args.position} mode={args.mode} "
+        f"|input|={in_norm:.4f} |output|={out_norm:.4f} "
+        f"|delta|={(intermediates['output_hidden'] - weights['input_hidden']).to(torch.float32).norm().item():.4f}\n"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/oracle/test_bake_int4_streaming.py
+++ b/oracle/test_bake_int4_streaming.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""
+Unit tests for `StreamingPackageWriter` in `bake_int4.py`.
+
+The producer side of the bake (GPTQ driver + fused-expert pass) was
+accumulating every quantized tensor's bytes in a host-RAM list until a
+final flush, which OOM'd on 35B-A3B near the end of a run. The writer
+class replaces that with a streaming sink that opens `weights.bin` once,
+writes tensor bytes as they arrive, and emits `manifest.json` on
+`finalize`. These tests pin the on-disk format invariants the Rust loader
+(`crates/model-store/src/store.rs`) relies on:
+
+- 4096-byte alignment between successive tensors (`align_up` cursor)
+- byte-exact round-trip for every written tensor
+- duplicate tensor names rejected (catches a bake bug, not a runtime bug)
+- manifest entries sorted alphabetically (stable diffs across runs)
+- error path leaves no `manifest.json` (consumers can detect partial bakes)
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from bake_int4 import (
+    CONVERTER_VERSION,
+    FORMAT_VERSION,
+    StreamingPackageWriter,
+    align_up,
+)
+
+
+class StreamingPackageWriterTest(unittest.TestCase):
+    def _open(self, td: str) -> StreamingPackageWriter:
+        return StreamingPackageWriter(Path(td) / "bake", model_family="qwen35")
+
+    def test_alignment_and_offsets(self) -> None:
+        """Each tensor's byte offset is 4096-aligned, and successive tensors
+        are placed back-to-back with zero-padding between."""
+        with TemporaryDirectory() as td:
+            with self._open(td) as w:
+                w.write_tensor("a", b"\x01" * 100, [100], "u8", "Raw")
+                w.write_tensor("b", b"\x02" * 200, [200], "u8", "Raw")
+                w.write_tensor("c", b"\x03" * 5000, [5000], "u8", "Raw")
+            manifest = json.loads((Path(td) / "bake" / "manifest.json").read_text())
+            entries = {e["name"]: e for e in manifest["tensors"]}
+            self.assertEqual(entries["a"]["offset"], 0)
+            self.assertEqual(entries["a"]["byte_len"], 100)
+            self.assertEqual(entries["b"]["offset"], 4096)
+            self.assertEqual(entries["b"]["byte_len"], 200)
+            # 4096 + 200 = 4296 → rounded up to 8192.
+            self.assertEqual(entries["c"]["offset"], 8192)
+            self.assertEqual(entries["c"]["byte_len"], 5000)
+            # File length matches the last tensor's end.
+            file_len = (Path(td) / "bake" / "weights.bin").stat().st_size
+            self.assertEqual(file_len, 8192 + 5000)
+
+    def test_byte_exact_roundtrip(self) -> None:
+        """Reading bytes back from `weights.bin` at the manifest-recorded
+        offset yields exactly what was written. Catches the kind of
+        zero-padding-of-data-bytes bug that's invisible until the runtime
+        tries to use the tensor."""
+        payloads = {
+            "embed": bytes(range(256)) * 4,
+            "scale": b"\xab\xcd" * 100,
+            "tile":  b"\x12" * 1024,
+        }
+        with TemporaryDirectory() as td:
+            with self._open(td) as w:
+                for name, data in payloads.items():
+                    w.write_tensor(name, data, [len(data)], "u8", "Raw")
+            manifest = json.loads((Path(td) / "bake" / "manifest.json").read_text())
+            entries = {e["name"]: e for e in manifest["tensors"]}
+            wb = (Path(td) / "bake" / "weights.bin").read_bytes()
+            for name, data in payloads.items():
+                e = entries[name]
+                start = e["offset"]
+                end = start + e["byte_len"]
+                self.assertEqual(wb[start:end], data,
+                                 f"byte-roundtrip mismatch for {name!r}")
+
+    def test_duplicate_name_raises(self) -> None:
+        """Writing the same tensor name twice is a bake bug — silently
+        ignoring it would leave one of the two payloads orphaned in
+        `weights.bin` while the manifest pointed at the other."""
+        with TemporaryDirectory() as td:
+            w = StreamingPackageWriter(Path(td) / "bake", model_family="qwen35")
+            try:
+                w.write_tensor("dup", b"x" * 10, [10], "u8", "Raw")
+                with self.assertRaises(ValueError):
+                    w.write_tensor("dup", b"y" * 10, [10], "u8", "Raw")
+            finally:
+                # Don't call finalize — leaves no manifest, exactly the
+                # behaviour we want on error.
+                w._fh.close()  # noqa: SLF001 — test cleanup
+
+    def test_has_reflects_writes(self) -> None:
+        with TemporaryDirectory() as td:
+            with self._open(td) as w:
+                self.assertFalse(w.has("a"))
+                w.write_tensor("a", b"x" * 4, [4], "u8", "Raw")
+                self.assertTrue(w.has("a"))
+                self.assertFalse(w.has("b"))
+
+    def test_manifest_sorted_alphabetically(self) -> None:
+        """Manifest entries land alphabetically regardless of write order.
+        On-disk order in `weights.bin` follows write order (the runtime
+        keys by name into a HashMap so on-disk order is irrelevant); the
+        manifest sort is purely for stable diffs."""
+        with TemporaryDirectory() as td:
+            with self._open(td) as w:
+                for name in ["zeta", "alpha", "mu", "beta"]:
+                    w.write_tensor(name, b"x" * 8, [8], "u8", "Raw")
+            manifest = json.loads((Path(td) / "bake" / "manifest.json").read_text())
+            names = [e["name"] for e in manifest["tensors"]]
+            self.assertEqual(names, sorted(names))
+            self.assertEqual(names, ["alpha", "beta", "mu", "zeta"])
+
+    def test_manifest_header(self) -> None:
+        with TemporaryDirectory() as td:
+            with self._open(td) as w:
+                w.write_tensor("a", b"x", [1], "u8", "Raw")
+            manifest = json.loads((Path(td) / "bake" / "manifest.json").read_text())
+            self.assertEqual(manifest["format_version"], FORMAT_VERSION)
+            self.assertEqual(manifest["converter_version"], CONVERTER_VERSION)
+            self.assertEqual(manifest["model_family"], "qwen35")
+
+    def test_partial_bake_skips_manifest(self) -> None:
+        """If the producer raises mid-write, the manifest must not be
+        emitted — otherwise a downstream consumer might mmap weights.bin
+        and read truncated/missing tensors as if they were complete."""
+        bake = None
+        with TemporaryDirectory() as td:
+            bake = Path(td) / "bake"
+            try:
+                with StreamingPackageWriter(bake, model_family="qwen35") as w:
+                    w.write_tensor("a", b"x" * 16, [16], "u8", "Raw")
+                    raise RuntimeError("simulated GPTQ failure")
+            except RuntimeError:
+                pass
+            self.assertTrue((bake / "weights.bin").exists(),
+                            "weights.bin should be created even on partial run")
+            self.assertFalse((bake / "manifest.json").exists(),
+                             "manifest.json must NOT be written on partial run")
+
+    def test_align_up_helper(self) -> None:
+        # Sanity-check the helper the writer relies on; pads to next 4096.
+        self.assertEqual(align_up(0, 4096), 0)
+        self.assertEqual(align_up(1, 4096), 4096)
+        self.assertEqual(align_up(4095, 4096), 4096)
+        self.assertEqual(align_up(4096, 4096), 4096)
+        self.assertEqual(align_up(4097, 4096), 8192)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/oracle/test_bake_qwen36_moe.py
+++ b/oracle/test_bake_qwen36_moe.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""
+Bake-side classification tests for Qwen3.6-35B-A3B (qwen36-moe).
+
+PR 2 of docs/qwen36-moe-plan.md asks: "manifest assertions: every expert
+weight is `Int4Quantized`, every gate is `Raw`". The decision is made by
+`is_int4_target` (INT4 GPTQ — primary HIP path) and `is_q4km_target`
+(q4km — primary CUDA path). This file pins their behavior against the
+ACTUAL Qwen3.6-MoE tensor naming, as discovered post-PR 3 by enumerating
+the published Qwen/Qwen3.6-35B-A3B safetensors.
+
+Two surprises landed during PR 3 that shape this file:
+
+1. **Experts are fused, not per-expert.** The real checkpoint stores ONE
+   tensor per layer for gate+up across all 256 experts:
+       mlp.experts.gate_up_proj      [256, 1024, 2048]  bf16
+       mlp.experts.down_proj         [256, 2048, 512]   bf16
+   Note the *missing `.weight` suffix*. Plan §2 listed
+   `mlp.experts.{E}.{gate,up,down}_proj.weight` (768 tensors per layer);
+   that layout does not exist on disk for this model.
+
+2. **Current bake predicates do not pick up the fused tensors.** Both
+   `is_int4_target` and `is_q4km_target` require `name.endswith(".weight")`
+   and `is_q4km_target` additionally requires a 2D shape. The fused
+   tensors fail both gates, so under today's bake_int4.py / bake_q4km.py
+   they would be left BF16. This is a gap that PR 7 (calibration) must
+   fix — either by extending the predicates, by unfusing the slabs at
+   bake time, or by adding a separate fused-MoE pathway.
+
+This test file pins both points so a later refactor can't quietly drop
+the manifest contract.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from bake_int4 import is_int4_target
+from bake_q4km import is_q4km_target
+
+
+HIDDEN = 2048
+MOE_INTER = 512
+NUM_EXPERTS = 256
+VOCAB = 248320
+HEAD_DIM = 256
+KV_HEADS = 2
+Q_HEADS = 16
+GROUP_SIZE = 128
+
+
+def shape_for(name: str) -> list[int]:
+    """Return the on-disk shape for a real Qwen3.6-MoE tensor name."""
+    if name == "lm_head.weight":
+        return [VOCAB, HIDDEN]
+    if name.endswith(".embed_tokens.weight"):
+        return [VOCAB, HIDDEN]
+    if name.endswith(".norm.weight") or name.endswith("layernorm.weight"):
+        return [HIDDEN]
+    if name.endswith(".q_norm.weight") or name.endswith(".k_norm.weight"):
+        return [HEAD_DIM]
+    # `attn_output_gate=true` doubles q_proj's output dim (Q + output gate).
+    if name.endswith(".q_proj.weight"):
+        return [2 * Q_HEADS * HEAD_DIM, HIDDEN]
+    if name.endswith(".k_proj.weight") or name.endswith(".v_proj.weight"):
+        return [KV_HEADS * HEAD_DIM, HIDDEN]
+    if name.endswith(".o_proj.weight"):
+        return [HIDDEN, Q_HEADS * HEAD_DIM]
+    # 35B linear-attn: 16 K-heads × 128 + 16 K-heads × 128 + 32 V-heads × 128 = 8192.
+    if name.endswith(".linear_attn.in_proj_qkv.weight"):
+        return [8192, HIDDEN]
+    if name.endswith(".linear_attn.in_proj_z.weight"):
+        return [32 * 128, HIDDEN]
+    if name.endswith(".linear_attn.in_proj_a.weight"):
+        return [32, HIDDEN]
+    if name.endswith(".linear_attn.in_proj_b.weight"):
+        return [32, HIDDEN]
+    if name.endswith(".linear_attn.out_proj.weight"):
+        return [HIDDEN, 32 * 128]
+    if name.endswith(".linear_attn.conv1d.weight"):
+        return [8192, 1, 4]
+    if name.endswith(".linear_attn.dt_bias"):
+        return [32]
+    if name.endswith(".linear_attn.A_log"):
+        return [32]
+    if name.endswith(".mlp.gate.weight"):
+        return [NUM_EXPERTS, HIDDEN]
+    if name.endswith(".mlp.shared_expert_gate.weight"):
+        return [1, HIDDEN]
+    if name.endswith(".shared_expert.gate_proj.weight"):
+        return [MOE_INTER, HIDDEN]
+    if name.endswith(".shared_expert.up_proj.weight"):
+        return [MOE_INTER, HIDDEN]
+    if name.endswith(".shared_expert.down_proj.weight"):
+        return [HIDDEN, MOE_INTER]
+    if name.endswith(".mlp.experts.gate_up_proj"):
+        return [NUM_EXPERTS, 2 * MOE_INTER, HIDDEN]
+    if name.endswith(".mlp.experts.down_proj"):
+        return [NUM_EXPERTS, HIDDEN, MOE_INTER]
+    raise KeyError(f"no shape rule for {name}")
+
+
+# Fixed expectations: the tensors that DO ship in Qwen/Qwen3.6-35B-A3B.
+# (name, expected_int4_target, expected_q4km_target)
+EXPECTATIONS: list[tuple[str, bool, bool]] = [
+    # Embeddings / final norm / lm_head.
+    ("model.language_model.embed_tokens.weight", False, False),
+    ("model.language_model.norm.weight", False, False),
+    ("lm_head.weight", True, True),
+
+    # Per-layer norms.
+    ("model.language_model.layers.0.input_layernorm.weight", False, False),
+    ("model.language_model.layers.0.post_attention_layernorm.weight", False, False),
+    ("model.language_model.layers.3.input_layernorm.weight", False, False),
+    ("model.language_model.layers.3.post_attention_layernorm.weight", False, False),
+
+    # Full-attention layer (every 4th: indices 3, 7, 11, ...). Note q_proj
+    # is doubled by attn_output_gate=true.
+    ("model.language_model.layers.3.self_attn.q_proj.weight", True, True),
+    ("model.language_model.layers.3.self_attn.k_proj.weight", True, True),
+    ("model.language_model.layers.3.self_attn.v_proj.weight", True, True),
+    ("model.language_model.layers.3.self_attn.o_proj.weight", True, True),
+    ("model.language_model.layers.3.self_attn.q_norm.weight", False, False),
+    ("model.language_model.layers.3.self_attn.k_norm.weight", False, False),
+
+    # Linear-attention layer.
+    ("model.language_model.layers.0.linear_attn.in_proj_qkv.weight", True, True),
+    ("model.language_model.layers.0.linear_attn.in_proj_z.weight", True, True),
+    ("model.language_model.layers.0.linear_attn.in_proj_a.weight", False, False),
+    ("model.language_model.layers.0.linear_attn.in_proj_b.weight", False, False),
+    ("model.language_model.layers.0.linear_attn.out_proj.weight", True, True),
+    ("model.language_model.layers.0.linear_attn.conv1d.weight", False, False),
+    ("model.language_model.layers.0.linear_attn.norm.weight", False, False),
+    # Non-.weight tensors must not be targeted regardless of name.
+    ("model.language_model.layers.0.linear_attn.dt_bias", False, False),
+    ("model.language_model.layers.0.linear_attn.A_log", False, False),
+
+    # MoE block.
+    ("model.language_model.layers.0.mlp.gate.weight", False, False),                  # router stays BF16
+    ("model.language_model.layers.0.mlp.shared_expert_gate.weight", False, False),    # scalar gate stays BF16
+    ("model.language_model.layers.0.mlp.shared_expert.gate_proj.weight", True, True),
+    ("model.language_model.layers.0.mlp.shared_expert.up_proj.weight", True, True),
+    ("model.language_model.layers.0.mlp.shared_expert.down_proj.weight", True, True),
+]
+
+# The two real fused-expert tensor names. Expectations encode TODAY'S bake
+# behavior — both predicates currently return False (gap to fix in PR 7).
+FUSED_EXPERT_NAMES = (
+    "model.language_model.layers.0.mlp.experts.gate_up_proj",
+    "model.language_model.layers.0.mlp.experts.down_proj",
+)
+
+
+class Qwen36MoeBakeClassificationTest(unittest.TestCase):
+    def test_int4_target_split(self) -> None:
+        for name, want_int4, _ in EXPECTATIONS:
+            with self.subTest(name=name):
+                self.assertEqual(
+                    is_int4_target(name),
+                    want_int4,
+                    msg=f"is_int4_target({name!r}) classification changed",
+                )
+
+    def test_q4km_target_split(self) -> None:
+        for name, _, want_q4km in EXPECTATIONS:
+            with self.subTest(name=name):
+                shape = shape_for(name)
+                self.assertEqual(
+                    is_q4km_target(name, shape, GROUP_SIZE),
+                    want_q4km,
+                    msg=f"is_q4km_target({name!r}, shape={shape}) classification changed",
+                )
+
+    def test_router_and_shared_gate_stay_raw(self) -> None:
+        # Plan §2 is explicit: routers and the scalar shared-expert gate must
+        # not be quantized. Pin both axes for both bake paths.
+        for layer in (0, 3, 39):
+            router = f"model.language_model.layers.{layer}.mlp.gate.weight"
+            shared = f"model.language_model.layers.{layer}.mlp.shared_expert_gate.weight"
+            self.assertFalse(is_int4_target(router), router)
+            self.assertFalse(is_int4_target(shared), shared)
+            self.assertFalse(is_q4km_target(router, shape_for(router), GROUP_SIZE))
+            self.assertFalse(is_q4km_target(shared, shape_for(shared), GROUP_SIZE))
+
+    def test_shared_expert_projs_quantize(self) -> None:
+        for proj in ("gate_proj", "up_proj", "down_proj"):
+            name = f"model.language_model.layers.0.mlp.shared_expert.{proj}.weight"
+            shape = shape_for(name)
+            self.assertTrue(is_int4_target(name), name)
+            self.assertTrue(is_q4km_target(name, shape, GROUP_SIZE), name)
+
+    def test_fused_experts_are_not_yet_quantized(self) -> None:
+        """
+        Document — and pin — the gap that PR 7 (calibration) has to close.
+
+        The real Qwen3.6-MoE checkpoint stores experts as fused-batched
+        tensors with names that lack a `.weight` suffix and 3D shapes:
+
+            mlp.experts.gate_up_proj  [E, 2*moe_int, hidden]
+            mlp.experts.down_proj     [E, hidden, moe_int]
+
+        Both of `is_int4_target` (requires `.weight` suffix) and
+        `is_q4km_target` (also requires 2D shape) reject these. Therefore,
+        a naive `python oracle/bake_int4.py --model qwen3.6-35b-a3b ...`
+        run today would leave the experts BF16, producing a manifest with
+        ~60 GiB of unquantized expert weight — too big for any ROCm GPU
+        we target.
+
+        PR 7 must change one of:
+          (a) Update the predicates to recognise fused expert names AND
+              update bake_int4.py to handle 3D batched tensors.
+          (b) Add an unfuse-then-quantize-then-pack pass before GPTQ.
+          (c) Add a separate fused-MoE quantization driver.
+
+        If you're touching the bake code: make this test fail loudly,
+        update the assertions to assert `True` for the fused names, and
+        bump `FUSED_EXPERTS_QUANTIZED` below.
+        """
+        FUSED_EXPERTS_QUANTIZED = False  # flip to True when PR 7 lands
+        for name in FUSED_EXPERT_NAMES:
+            shape = shape_for(name)
+            i4 = is_int4_target(name)
+            q4 = is_q4km_target(name, shape, GROUP_SIZE)
+            self.assertEqual(
+                i4,
+                FUSED_EXPERTS_QUANTIZED,
+                f"is_int4_target({name!r}) = {i4}; "
+                f"flip FUSED_EXPERTS_QUANTIZED if PR 7 has landed",
+            )
+            self.assertEqual(
+                q4,
+                FUSED_EXPERTS_QUANTIZED,
+                f"is_q4km_target({name!r}, shape={shape}) = {q4}; "
+                f"flip FUSED_EXPERTS_QUANTIZED if PR 7 has landed",
+            )
+
+    def test_fused_expert_naming_invariants(self) -> None:
+        """
+        Sanity-pin the structural facts the rest of the runtime depends on:
+          - exactly two fused tensors per layer (gate_up_proj, down_proj)
+          - neither carries a `.weight` suffix
+          - both are 3D with `num_experts` on axis 0
+        """
+        for name in FUSED_EXPERT_NAMES:
+            self.assertFalse(name.endswith(".weight"), name)
+            shape = shape_for(name)
+            self.assertEqual(len(shape), 3, f"{name} shape={shape}")
+            self.assertEqual(shape[0], NUM_EXPERTS, f"{name} expert axis")
+        gate_up = shape_for(FUSED_EXPERT_NAMES[0])
+        down = shape_for(FUSED_EXPERT_NAMES[1])
+        # gate_up_proj fuses gate (moe_int) + up (moe_int) along axis 1.
+        self.assertEqual(gate_up[1], 2 * MOE_INTER)
+        self.assertEqual(gate_up[2], HIDDEN)
+        self.assertEqual(down[1], HIDDEN)
+        self.assertEqual(down[2], MOE_INTER)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/oracle/test_bake_qwen36_moe.py
+++ b/oracle/test_bake_qwen36_moe.py
@@ -9,7 +9,7 @@ weight is `Int4Quantized`, every gate is `Raw`". The decision is made by
 ACTUAL Qwen3.6-MoE tensor naming, as discovered post-PR 3 by enumerating
 the published Qwen/Qwen3.6-35B-A3B safetensors.
 
-Two surprises landed during PR 3 that shape this file:
+Two facts the published checkpoint forces on us:
 
 1. **Experts are fused, not per-expert.** The real checkpoint stores ONE
    tensor per layer for gate+up across all 256 experts:
@@ -19,16 +19,13 @@ Two surprises landed during PR 3 that shape this file:
    `mlp.experts.{E}.{gate,up,down}_proj.weight` (768 tensors per layer);
    that layout does not exist on disk for this model.
 
-2. **Current bake predicates do not pick up the fused tensors.** Both
-   `is_int4_target` and `is_q4km_target` require `name.endswith(".weight")`
-   and `is_q4km_target` additionally requires a 2D shape. The fused
-   tensors fail both gates, so under today's bake_int4.py / bake_q4km.py
-   they would be left BF16. This is a gap that PR 7 (calibration) must
-   fix — either by extending the predicates, by unfusing the slabs at
-   bake time, or by adding a separate fused-MoE pathway.
-
-This test file pins both points so a later refactor can't quietly drop
-the manifest contract.
+2. **Bake predicates pick up the fused tensors as INT4 targets** so the
+   experts get quantized into the runtime's expected layout. Plan §15
+   option (c) drove this: predicates accept the bare `mlp.experts.*` names
+   (no `.weight` suffix, 3D shape), and a separate fused-experts driver in
+   `bake_int4.py` / `bake_q4km.py` packs each expert's `[out, in]` slab
+   independently with `group_size=128` BF16 scale+zero — min/max group-quant,
+   no Hessian/GPTQ for the experts (GPTQ stays on the dense projections).
 """
 
 from __future__ import annotations
@@ -193,50 +190,50 @@ class Qwen36MoeBakeClassificationTest(unittest.TestCase):
             self.assertTrue(is_int4_target(name), name)
             self.assertTrue(is_q4km_target(name, shape, GROUP_SIZE), name)
 
-    def test_fused_experts_are_not_yet_quantized(self) -> None:
+    def test_fused_experts_are_quantized(self) -> None:
         """
-        Document — and pin — the gap that PR 7 (calibration) has to close.
+        Pin the post-PR 7-option-(c) reality: both bake paths classify the
+        fused MoE expert tensors as INT4 targets, so the runtime sees a
+        manifest with `Int4Quantized` packed nibbles + BF16 scale/zero
+        sidecars instead of ~60 GiB of BF16 expert weight.
 
-        The real Qwen3.6-MoE checkpoint stores experts as fused-batched
-        tensors with names that lack a `.weight` suffix and 3D shapes:
-
-            mlp.experts.gate_up_proj  [E, 2*moe_int, hidden]
-            mlp.experts.down_proj     [E, hidden, moe_int]
-
-        Both of `is_int4_target` (requires `.weight` suffix) and
-        `is_q4km_target` (also requires 2D shape) reject these. Therefore,
-        a naive `python oracle/bake_int4.py --model qwen3.6-35b-a3b ...`
-        run today would leave the experts BF16, producing a manifest with
-        ~60 GiB of unquantized expert weight — too big for any ROCm GPU
-        we target.
-
-        PR 7 must change one of:
-          (a) Update the predicates to recognise fused expert names AND
-              update bake_int4.py to handle 3D batched tensors.
-          (b) Add an unfuse-then-quantize-then-pack pass before GPTQ.
-          (c) Add a separate fused-MoE quantization driver.
-
-        If you're touching the bake code: make this test fail loudly,
-        update the assertions to assert `True` for the fused names, and
-        bump `FUSED_EXPERTS_QUANTIZED` below.
+        Predicates accept the bare names (no `.weight` suffix). For
+        `is_q4km_target` the 2D-only constraint is relaxed for fused names:
+        3D shapes `[E, out, in]` are accepted as long as the per-expert
+        `(out, in)` axes match the group_size / evenness rules. The actual
+        quantization runs through `fused_expert_minmax_int4` (bake_int4.py)
+        / `quantize_minmax_fused_experts` (bake_q4km.py) — plain min/max
+        group-quant per expert, no Hessian / GPTQ.
         """
-        FUSED_EXPERTS_QUANTIZED = False  # flip to True when PR 7 lands
         for name in FUSED_EXPERT_NAMES:
             shape = shape_for(name)
-            i4 = is_int4_target(name)
-            q4 = is_q4km_target(name, shape, GROUP_SIZE)
-            self.assertEqual(
-                i4,
-                FUSED_EXPERTS_QUANTIZED,
-                f"is_int4_target({name!r}) = {i4}; "
-                f"flip FUSED_EXPERTS_QUANTIZED if PR 7 has landed",
+            self.assertTrue(
+                is_int4_target(name),
+                f"is_int4_target({name!r}) must classify fused experts as INT4",
             )
-            self.assertEqual(
-                q4,
-                FUSED_EXPERTS_QUANTIZED,
-                f"is_q4km_target({name!r}, shape={shape}) = {q4}; "
-                f"flip FUSED_EXPERTS_QUANTIZED if PR 7 has landed",
+            self.assertTrue(
+                is_q4km_target(name, shape, GROUP_SIZE),
+                f"is_q4km_target({name!r}, shape={shape}) must accept "
+                f"3D fused expert tensors",
             )
+
+    def test_fused_expert_predicate_rejects_bad_shapes(self) -> None:
+        """
+        Sanity-pin the divisibility gates that `is_q4km_target` enforces on
+        fused experts. The runtime layout requires per-expert `(out, in)`
+        axes to be divisible by `group_size`, with `in` even (for nibble
+        packing). Catching mis-shaped fused tensors here prevents a silent
+        partial-tile bake that would diverge from the runtime kernel.
+        """
+        bad_in_dim = "model.language_model.layers.0.mlp.experts.gate_up_proj"
+        # `in` not divisible by group_size -> reject.
+        self.assertFalse(is_q4km_target(bad_in_dim, [4, 1024, 100], GROUP_SIZE))
+        # `out` not divisible by group_size -> reject.
+        self.assertFalse(is_q4km_target(bad_in_dim, [4, 100, 2048], GROUP_SIZE))
+        # 2D shape on a fused-expert name -> reject (must be 3D).
+        self.assertFalse(is_q4km_target(bad_in_dim, [1024, 2048], GROUP_SIZE))
+        # `is_int4_target` doesn't see shape, but it must still accept the name.
+        self.assertTrue(is_int4_target(bad_in_dim))
 
     def test_fused_expert_naming_invariants(self) -> None:
         """


### PR DESCRIPTION
## Summary

End-to-end Qwen3.6-MoE foundation. After this PR the runtime can:
- enumerate the 35B-A3B safetensors checkpoint and account VRAM
- bake the model to a 17 GiB INT4 GPTQ package (vs 65 GiB BF16)
- mmap the bake and confirm `ready-for-decode` per-layer
- run all three single-layer compute slices (full attn / linear attn / MoE FFN) under HIP and gate them against PyTorch oracles

The single missing piece for a first decoded token is **INT4 dequant inside the matmul phases of those three kernels** — that's the next PR.

## What lands

**Plan + scaffolding**
- `docs/qwen36-moe-plan.md` — design plan with post-PR-3 schema addendum (real 35B-A3B differs from the published 80B-A3B proxy in several places)
- `crates/qwen36_moe/` — config parsing, weight loader, state account, expected-tensor specs (PR 3)
- `crates/runner/src/qwen36_moe_engine.rs` — dry-run report (PR 3) + INT4 bake account section (this commit)
- `crates/runner/src/registry.rs` — registry entries

**Bake side (PR 7 step 1 + OOM fixes)**
- `oracle/bake_int4.py` — fused MoE expert support (option (c) min/max INT4 group-quant), Accelerate disk-offload args, `StreamingPackageWriter` so producer peak host-RAM stays ~1 GiB instead of ~17 GiB
- lm_head Hessian fix: skip the wasted lm_head forward (was producing a 1 GiB transient on CPU); compute Hessian directly on `final_norm(hidden)`
- `_release_host_memory()` between layers (gc + CUDA empty + libc malloc_trim) — got the 35B-A3B bake across the line on a 64 GiB host
- `oracle/test_bake_int4_streaming.py` (8 tests) + `oracle/test_bake_qwen36_moe.py` (7 tests)

**Kernel + FFI scaffolding**
- `kernels/qwen36_moe.hip` + `kernels/qwen36_moe_bridge.cpp` — per-CLAUDE.md isolation; descriptor-walk stub, grid barrier
- `crates/kernel-ffi/src/qwen36_moe.rs` — `Qwen36MoeDecodeLayerDesc`, `Qwen36MoeInt4ScaleDesc`, FFI externs + safe wrappers

**Three parity-gated single-layer kernels**

PR 4b1: oracle (`oracle/qwen36_moe_oracle.py`)

PR 4b2: full attention (5 stages, kv_len=1)
- stage 1: rmsnorm + q_proj + per-head q_norm
- stage 2: ... + k/v_proj + per-head k_norm
- stage 3: ... + partial RoPE on Q and K
- stage 4: ... + GQA self-attention
- stage 5: ... + sigmoid(gate)*attn + o_proj + residual

PR 4b3: linear attention (5 stages)
- stage 1: x_norm + 4 in_projs (qkv/z/a/b)
- stage 2: + depthwise conv1d + silu
- stage 3: + L2-norm + GQA fan-out + Q scale
- stages 4–5: delta-rule recurrent update + final stages

PR 4b4: MoE FFN (5 stages)
- stage 1: post_attn_norm + router gate + softmax + topk + renorm
- stage 2: shared expert (gate/up/silu/down + sigmoid_gate)
- stage 3: ONE expert FFN dispatch (top-1)
- stage 4: topk-weighted sum across all k experts
- stage 5: residual add

Stage parity envelopes on the synthetic oracle (cos_sim ≥ 0.999 floor):
| stage | result |
|-------|--------|
| FFN-1 | cos 0.9999993 (topk_weights) |
| FFN-2 | 63/64 exact (shared_out) |
| FFN-3 | **64/64 bit-exact** (one expert) |
| FFN-4 | cos 0.9999982 (moe_out) |
| FFN-5 | cos 0.9999982 (output_hidden) |

**Bake validation**
- `crates/model-store/src/store.rs` — `qwen36_moe_bake_loadable` test gated by `SUPERSONIC_QWEN36_MOE_BAKE_DIR`
- `crates/runner/src/qwen36_moe_engine.rs` — `BakeAccount` printed in dry-run

End-to-end against the freshly-baked Qwen3.6-35B-A3B INT4 GPTQ:
```
[INT4 baked package]
  weights.bin:     16.90 GiB    (1355 tensors indexed)
  INT4 / Raw:      15.89 GiB / 1.00 GiB
  layouts:         DepthwiseConvSqueezed=30, HeadBiasReshaped=30,
                   HeadExpReshaped=30, Int4Quantized=331, Raw=934
  vs analytic:     bake=16.90 GiB analytic_int4=16.89 GiB drift=+0.00 GiB
  ready-for-decode: YES

[VRAM budget]
  registry estimate: 20.90 GiB
  detected GPU VRAM:  23.98 GiB
  fit: YES
```

## What's NOT in this PR

- INT4 dequant inside the matmul phases of the 3 kernels — comes next, gated by an INT4 oracle
- Multi-layer driver / KV-cache extension to `kv_len > 1`
- Engine wiring beyond dry-run (descriptor population, sync_buf scratch, decode loop)

## Test plan

- [ ] `cargo build --release` (HIP toolchain)
- [ ] `cargo test -p kernel-ffi --release qwen36_moe_attn_step` (skips when no oracle JSON)
- [ ] `cargo test -p kernel-ffi --release qwen36_moe_linear_step` (same)
- [ ] `cargo test -p kernel-ffi --release qwen36_moe_ffn_step` (same)
- [ ] `cargo test -p model-store --release qwen36_moe_bake_loadable` (skips without `SUPERSONIC_QWEN36_MOE_BAKE_DIR`)
- [ ] `cargo test -p kernel-ffi --release hip_stub_launch_walks_descriptor_array`
- [ ] `python -m unittest oracle.test_bake_int4_streaming oracle.test_bake_qwen36_moe`
- [ ] Run the dry-run end-to-end:
  ```
  cargo run --release --bin supersonic -- --model qwen3.6-35b-a3b \
    --model-dir /path/to/Qwen3.6-35B-A3B --dry-run
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)