### PR TITLE
Bring Qwen3.5 CUDA sm86 low-bit paths to parity

### DIFF
--- a/crates/kernel-ffi/src/qwen36_moe.rs
+++ b/crates/kernel-ffi/src/qwen36_moe.rs
@@ -411,7 +411,7 @@ pub fn stub_launch(
     let barrier_counter = unsafe { (counters as *mut u8).add(16) as *mut c_uint };
     let barrier_flag = unsafe { (counters as *mut u8).add(20) as *mut c_uint };
 
-    let status = match backend {
+    let status: c_int = match backend {
         Backend::Hip => {
             #[cfg(supersonic_backend_hip)]
             unsafe {
@@ -518,7 +518,7 @@ pub fn attn_step_launch(
     let barrier_counter = unsafe { (counters as *mut u8).add(16) as *mut c_uint };
     let barrier_flag = unsafe { (counters as *mut u8).add(20) as *mut c_uint };
 
-    let status = match backend {
+    let status: c_int = match backend {
         Backend::Hip => {
             #[cfg(supersonic_backend_hip)]
             unsafe {
@@ -644,7 +644,7 @@ pub fn linear_step_launch(
     let barrier_counter = unsafe { (counters as *mut u8).add(16) as *mut c_uint };
     let barrier_flag = unsafe { (counters as *mut u8).add(20) as *mut c_uint };
 
-    let status = match backend {
+    let status: c_int = match backend {
         Backend::Hip => {
             #[cfg(supersonic_backend_hip)]
             unsafe {
@@ -780,7 +780,7 @@ pub fn ffn_step_launch(
     let barrier_counter = unsafe { (counters as *mut u8).add(16) as *mut c_uint };
     let barrier_flag = unsafe { (counters as *mut u8).add(20) as *mut c_uint };
 
-    let status = match backend {
+    let status: c_int = match backend {
         Backend::Hip => {
             #[cfg(supersonic_backend_hip)]
             unsafe {

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -1591,8 +1591,31 @@ fn main() -> Result<()> {
     }
     eprintln!("[weights] loaded in {:.0}ms", t0.elapsed().as_millis());
 
+    let gpu_validate_enabled = cli.gpu_validate && cli.batch_size == 1;
+    if cli.gpu_validate && cli.batch_size > 1 {
+        eprintln!("[gpu-validate] GPU oracle disabled for batch_size > 1");
+    }
+    let cuda_08b_hero_disabled = env::var_os("SUPERSONIC_DISABLE_CUDA_08B_HERO").is_some();
+    let cuda_08b_hero_candidate = backend == Backend::Cuda
+        && gpu_arch == GpuArch::Sm86
+        && model_variant == ModelVariant::Qwen3_5_0_8B
+        && cli.batch_size == 1
+        && !cli.validate
+        && !gpu_validate_enabled
+        && !cli.force_component_decode
+        && !cli.force_kernel_decode
+        && !cli.kv_fp8
+        && !weights.is_fp8
+        && !weights.is_int4
+        && !cuda_08b_hero_disabled;
+    // The sm86 registry entry advertises the 4B-capable path so low-bit and
+    // KV-FP8 descriptor plumbing is available. Plain 0.8B BF16 can still use
+    // the older dedicated CUDA hero path unless callers opt out or request a
+    // mode that needs the 4B descriptors.
+    let use_4b_kernel = params.use_4b_kernel && !cuda_08b_hero_candidate;
+
     // Validate batch_size
-    if cli.batch_size > 1 && !params.use_4b_kernel {
+    if cli.batch_size > 1 && !use_4b_kernel {
         anyhow::bail!("--batch-size > 1 requires 4B kernel (2B/4B/9B models)");
     }
     if cli.batch_size < 1 || cli.batch_size > kernel_ffi::MAX_BATCH_SIZE {
@@ -1622,7 +1645,7 @@ fn main() -> Result<()> {
         params.proj_buf_floats,
         attn_scratch_floats,
         params.kv_chunk_size,
-        params.use_4b_kernel,
+        use_4b_kernel,
         cli.prefill_chunk_size,
         cli.kv_fp8,
         cli.batch_size,
@@ -1990,17 +2013,11 @@ fn main() -> Result<()> {
         engine.replicate_state_to_batch()?;
     }
 
-    let gpu_validate_enabled = if cli.gpu_validate && cli.batch_size == 1 {
+    if gpu_validate_enabled {
         eprintln!(
             "[gpu-validate] replaying full token history through GPU prefill for reference..."
         );
-        true
-    } else {
-        if cli.gpu_validate && cli.batch_size > 1 {
-            eprintln!("[gpu-validate] GPU oracle disabled for batch_size > 1");
-        }
-        false
-    };
+    }
     // Replay-prefill path used to be the default for 4B single-seq decode
     // (safety net for numerical-parity work during the CUDA sm86 bring-up)
     // but it scales O(N) per step with context length and was ~7x slower
@@ -2011,7 +2028,7 @@ fn main() -> Result<()> {
     let cuda_qwen2b_replay_default = backend == Backend::Cuda
         && model_variant == ModelVariant::Qwen3_5_2B
         && cli.batch_size == 1
-        && params.use_4b_kernel
+        && use_4b_kernel
         && !cli.kv_fp8
         && !cli.force_kernel_decode
         && !cli.force_component_decode;
@@ -2023,39 +2040,25 @@ fn main() -> Result<()> {
         && !cli.force_kernel_decode
         && !cli.force_component_decode
         && !cli.kv_fp8
-        && params.use_4b_kernel
+        && use_4b_kernel
         && (cli.force_replay_decode || cuda_qwen2b_replay_default);
     let replay_kv_fp8_enabled =
-        params.use_4b_kernel && cli.kv_fp8 && cli.batch_size == 1 && !cli.force_kernel_decode;
+        use_4b_kernel && cli.kv_fp8 && cli.batch_size == 1 && !cli.force_kernel_decode;
     let component_single_decode_enabled =
-        cli.batch_size == 1 && params.use_4b_kernel && cli.force_component_decode;
+        cli.batch_size == 1 && use_4b_kernel && cli.force_component_decode;
     // Use the batched persistent megakernel path (decode_step_batch with b=1)
     // for 4B single-seq decode by default — measured ~300 ms/tok on gfx1150
     // vs ~500 ms/tok for decode_step() and ~2500 ms/tok for the legacy
     // replay path. Opt-out via --force-replay-decode (legacy parity) or
     // --force-component-decode (primitive-chain correctness).
     let kernel_single_decode_enabled = cli.batch_size == 1
-        && params.use_4b_kernel
+        && use_4b_kernel
         && !cli.force_replay_decode
         && !cli.force_component_decode;
-    let cuda_08b_hero_disabled = env::var_os("SUPERSONIC_DISABLE_CUDA_08B_HERO").is_some();
-    let cuda_08b_hero_enabled = backend == Backend::Cuda
-        && gpu_arch == GpuArch::Sm86
-        && model_variant == ModelVariant::Qwen3_5_0_8B
-        && !params.use_4b_kernel
-        && cli.batch_size == 1
-        && !cli.validate
-        && !gpu_validate_enabled
-        && !cli.force_component_decode
-        && !cli.force_kernel_decode
-        && !cli.kv_fp8
-        && oracle_output.is_none()
-        && !engine.weights().is_fp8
-        && !engine.weights().is_int4
-        && !cuda_08b_hero_disabled;
+    let cuda_08b_hero_enabled = cuda_08b_hero_candidate;
     let cuda_fast_greedy_disabled = env::var_os("SUPERSONIC_DISABLE_CUDA_FAST_GREEDY").is_some();
     let cuda_fast_greedy_enabled = backend == Backend::Cuda
-        && !params.use_4b_kernel
+        && !use_4b_kernel
         && cli.batch_size == 1
         && !cli.validate
         && !gpu_validate_enabled
@@ -2095,13 +2098,13 @@ fn main() -> Result<()> {
         }
     } else if replay_kv_fp8_enabled && cli.batch_size == 1 {
         eprintln!("[decode] single-sequence CUDA KV-FP8 uses replayed GPU prefill for correctness");
-    } else if cli.batch_size > 1 && params.use_4b_kernel && cli.kv_fp8 {
+    } else if cli.batch_size > 1 && use_4b_kernel && cli.kv_fp8 {
         eprintln!("[decode] batched CUDA KV-FP8 uses the persistent kernel path");
     } else if component_single_decode_enabled {
         eprintln!("[decode] WARNING: forcing single-sequence 4B onto the component decode path");
-    } else if cli.batch_size == 1 && params.use_4b_kernel && cli.force_kernel_decode {
+    } else if cli.batch_size == 1 && use_4b_kernel && cli.force_kernel_decode {
         eprintln!("[decode] WARNING: forcing single-sequence 4B onto the kernel decode path");
-    } else if cli.batch_size == 1 && params.use_4b_kernel && cli.kv_fp8 {
+    } else if cli.batch_size == 1 && use_4b_kernel && cli.kv_fp8 {
         eprintln!("[decode] WARNING: single-sequence CUDA KV-FP8 uses the b=1 kernel path");
     } else if cuda_08b_hero_enabled {
         eprintln!("[decode] CUDA 0.8B sm86 hero path enabled");
@@ -2152,7 +2155,7 @@ fn main() -> Result<()> {
                     ordinal,
                     params.kv_chunk_size,
                     cli.prefill_chunk_size,
-                    params.use_4b_kernel,
+                    use_4b_kernel,
                 )?;
                 engine.rebuild_prefill_state(&trace_token_ids, true)?;
             }
@@ -2178,7 +2181,7 @@ fn main() -> Result<()> {
                     ordinal,
                     params.kv_chunk_size,
                     cli.prefill_chunk_size,
-                    params.use_4b_kernel,
+                    use_4b_kernel,
                 )?;
                 engine.rebuild_prefill_state(&trace_token_ids, true)?;
             }
@@ -2199,7 +2202,7 @@ fn main() -> Result<()> {
                     ordinal,
                     params.kv_chunk_size,
                     cli.prefill_chunk_size,
-                    params.use_4b_kernel,
+                    use_4b_kernel,
                 )?;
                 engine.rebuild_prefill_state(&trace_token_ids, true)?;
             }
@@ -2220,7 +2223,7 @@ fn main() -> Result<()> {
                     ordinal,
                     params.kv_chunk_size,
                     cli.prefill_chunk_size,
-                    params.use_4b_kernel,
+                    use_4b_kernel,
                 )?;
                 engine.rebuild_prefill_state(&trace_token_ids, true)?;
             }
@@ -2289,7 +2292,7 @@ fn main() -> Result<()> {
                     ordinal,
                     params.kv_chunk_size,
                     cli.prefill_chunk_size,
-                    params.use_4b_kernel,
+                    use_4b_kernel,
                     cli.kv_fp8,
                     cli.batch_size,
                     step,
@@ -2332,7 +2335,7 @@ fn main() -> Result<()> {
                     ordinal,
                     params.kv_chunk_size,
                     cli.prefill_chunk_size,
-                    params.use_4b_kernel,
+                    use_4b_kernel,
                 )?
             } else if replay_kv_fp8_enabled {
                 let token_ids: Vec<u32> = prompt_ids
@@ -2356,7 +2359,7 @@ fn main() -> Result<()> {
                         ordinal,
                         params.kv_chunk_size,
                         cli.prefill_chunk_size,
-                        params.use_4b_kernel,
+                        use_4b_kernel,
                     )?;
                 }
                 if let Some(trace_layer) = cli.trace_component_input_layer {
@@ -2379,7 +2382,7 @@ fn main() -> Result<()> {
                         ordinal,
                         params.kv_chunk_size,
                         cli.prefill_chunk_size,
-                        params.use_4b_kernel,
+                        use_4b_kernel,
                     )?;
                     logits
                 } else if let Some(trace_layer) = cli.trace_component_layer {
@@ -2402,7 +2405,7 @@ fn main() -> Result<()> {
                         ordinal,
                         params.kv_chunk_size,
                         cli.prefill_chunk_size,
-                        params.use_4b_kernel,
+                        use_4b_kernel,
                     )?;
                     logits
                 } else if let Some(trace_layer) = cli.trace_component_linear_layer {
@@ -2426,7 +2429,7 @@ fn main() -> Result<()> {
                         ordinal,
                         params.kv_chunk_size,
                         cli.prefill_chunk_size,
-                        params.use_4b_kernel,
+                        use_4b_kernel,
                     )?;
                     logits
                 } else {
@@ -2453,7 +2456,7 @@ fn main() -> Result<()> {
                         ordinal,
                         params.kv_chunk_size,
                         cli.prefill_chunk_size,
-                        params.use_4b_kernel,
+                        use_4b_kernel,
                     )?;
                     engine.rebuild_prefill_state(&trace_token_ids, false)?;
                 }
@@ -2478,7 +2481,7 @@ fn main() -> Result<()> {
                         ordinal,
                         params.kv_chunk_size,
                         cli.prefill_chunk_size,
-                        params.use_4b_kernel,
+                        use_4b_kernel,
                     )?;
                     engine.rebuild_prefill_state(&trace_token_ids, false)?;
                 }
@@ -2498,7 +2501,7 @@ fn main() -> Result<()> {
                         ordinal,
                         params.kv_chunk_size,
                         cli.prefill_chunk_size,
-                        params.use_4b_kernel,
+                        use_4b_kernel,
                     )?;
                     engine.rebuild_prefill_state(&trace_token_ids, false)?;
                 }
@@ -2518,7 +2521,7 @@ fn main() -> Result<()> {
                         ordinal,
                         params.kv_chunk_size,
                         cli.prefill_chunk_size,
-                        params.use_4b_kernel,
+                        use_4b_kernel,
                     )?;
                     engine.rebuild_prefill_state(&trace_token_ids, false)?;
                 }
@@ -2590,7 +2593,7 @@ fn main() -> Result<()> {
                     ordinal,
                     params.kv_chunk_size,
                     cli.prefill_chunk_size,
-                    params.use_4b_kernel,
+                    use_4b_kernel,
                 )?;
                 let delta = validate::max_abs_delta(&logits, &gpu_logits);
                 let gpu_token = DecodeEngine::greedy_sample(&gpu_logits);
@@ -2622,7 +2625,7 @@ fn main() -> Result<()> {
                     ordinal,
                     params.kv_chunk_size,
                     cli.prefill_chunk_size,
-                    params.use_4b_kernel,
+                    use_4b_kernel,
                     cli.kv_fp8,
                     cli.batch_size,
                     step,

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -531,8 +531,8 @@ pub(crate) struct Cli {
     trace_oracle_prefill_layer: Option<usize>,
 
     /// Batch size for decode (number of sequences decoded in parallel).
-    /// Default 1. Supported on Qwen3.5 (requires 4B kernel: 2B/4B/9B models)
-    /// and Gemma 4 BF16 + INT4 via per-family batched megakernels.
+    /// Default 1. Supported on Qwen3.5 through the 4B-capable persistent
+    /// kernel and Gemma 4 BF16 + INT4 via per-family batched megakernels.
     #[arg(long, default_value = "1")]
     batch_size: usize,
 
@@ -1324,15 +1324,24 @@ fn main() -> Result<()> {
     }
 
     if backend == Backend::Cuda {
-        if cli.int4 {
-            anyhow::bail!("CUDA v1 does not support --int4 yet");
+        let qwen35_sm86 = matches!(
+            model_variant,
+            ModelVariant::Qwen3_5_0_8B
+                | ModelVariant::Qwen3_5_2B
+                | ModelVariant::Qwen3_5_4B
+                | ModelVariant::Qwen3_5_9B
+        ) && entry.arch == GpuArch::Sm86;
+        if cli.int4 && !qwen35_sm86 {
+            anyhow::bail!("CUDA --int4 currently supports only Qwen3.5 on sm86");
         }
-        if cli.fp8_runtime && model_variant != ModelVariant::Qwen3_6_27B {
-            anyhow::bail!("CUDA --fp8-runtime currently supports only qwen3.6-27b on sm86");
+        if cli.fp8_runtime && !(qwen35_sm86 || model_variant == ModelVariant::Qwen3_6_27B) {
+            anyhow::bail!(
+                "CUDA --fp8-runtime currently supports only Qwen3.5 and qwen3.6-27b on sm86"
+            );
         }
         if cli.kv_fp8 {
-            if model_variant != ModelVariant::Qwen3_5_4B || gpu_arch != GpuArch::Sm86 {
-                anyhow::bail!("CUDA --kv-fp8 currently supports only qwen3.5-4b on sm86");
+            if !qwen35_sm86 {
+                anyhow::bail!("CUDA --kv-fp8 currently supports only Qwen3.5 on sm86");
             }
             if env::var_os("SUPERSONIC_DEBUG_ENABLE_CUDA_KV_FP8_BF16_SIDECAR").is_none() {
                 env::set_var("SUPERSONIC_DEBUG_KV_FP8_BF16_SIDECAR_WINDOW", "128");

--- a/crates/runner/src/registry.rs
+++ b/crates/runner/src/registry.rs
@@ -454,7 +454,11 @@ static REGISTRY: &[RegistryEntry] = &[
             attn_scratch_floats: 16384,
             weight_prefix: "model.language_model",
             kv_chunk_size: 256,
-            use_4b_kernel: false,
+            // CUDA low-bit and KV-FP8 modes share the descriptor plumbing in
+            // the 4B-capable persistent kernel. The older dedicated 0.8B CUDA
+            // hero path remains available only as an opt-in fast BF16 route in
+            // main.rs when low-bit descriptors are absent.
+            use_4b_kernel: true,
         }),
     },
     RegistryEntry {

--- a/tests/sm86/run_negative.sh
+++ b/tests/sm86/run_negative.sh
@@ -73,27 +73,27 @@ COMMON_4B=(
     --max-new-tokens 1
 )
 
-run_fail "Test 1: CUDA rejects --int4" \
-    "CUDA v1 does not support --int4 yet" \
-    "${COMMON_0_8B[@]}" --int4
+COMMON_QWEN36_27B=(
+    --backend cuda
+    --model qwen3.6-27b
+    --model-dir "$MODEL_DIR_4B"
+    --prompt "Hello"
+    --max-new-tokens 1
+)
 
-run_fail "Test 2: CUDA rejects --fp8-runtime" \
-    "CUDA v1 does not support --fp8-runtime yet" \
-    "${COMMON_4B[@]}" --fp8-runtime
+run_fail "Test 1: CUDA rejects --int4 outside Qwen3.5" \
+    "CUDA --int4 currently supports only Qwen3.5 on sm86" \
+    "${COMMON_QWEN36_27B[@]}" --int4
 
-run_fail "Test 3: CUDA rejects --kv-fp8 on unsupported model" \
-    "CUDA --kv-fp8 currently supports only qwen3.5-4b on sm86" \
-    "${COMMON_0_8B[@]}" --kv-fp8
+run_fail "Test 2: CUDA rejects --kv-fp8 outside Qwen3.5" \
+    "CUDA --kv-fp8 currently supports only Qwen3.5 on sm86" \
+    "${COMMON_QWEN36_27B[@]}" --kv-fp8
 
-run_fail "Test 4: CUDA rejects batch on non-4B kernel" \
-    "--batch-size > 1 requires 4B kernel" \
-    "${COMMON_0_8B[@]}" --batch-size 2
-
-run_fail "Test 5: CUDA rejects out-of-range batch size" \
+run_fail "Test 3: CUDA rejects out-of-range batch size" \
     "--batch-size must be 1.." \
-    "${COMMON_4B[@]}" --batch-size 0
+    "${COMMON_4B[@]}" --int4 --batch-size 0
 
-run_fail "Test 6: unknown CUDA override stays explicit on unsupported model" \
+run_fail "Test 4: unknown CUDA override stays explicit on unsupported model" \
     "--allow-untested-gpu=sm999: no registry entry for model=gemma4-e2b backend=CUDA arch=sm999" \
     --backend cuda \
     --allow-untested-gpu sm999 \

--- a/tests/sm86/run_qwen35_matrix.sh
+++ b/tests/sm86/run_qwen35_matrix.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+#
+# CUDA sm86 supported-matrix smoke for Qwen3.5 low-bit modes.
+#
+# This is the CUDA counterpart to the Qwen rows in tests/gfx1100/run_matrix.sh.
+# It intentionally skips model dirs that are not available on the machine so a
+# single 3090 box can validate the subset it has downloaded.
+#
+# Usage:
+#   SUPERSONIC_MODEL_DIR_08B=/models/Qwen3.5-0.8B \
+#   SUPERSONIC_MODEL_DIR_2B=/models/Qwen3.5-2B \
+#   SUPERSONIC_MODEL_DIR_4B=/models/Qwen3.5-4B \
+#   SUPERSONIC_MODEL_DIR_9B=/models/Qwen3.5-9B \
+#     ./tests/sm86/run_qwen35_matrix.sh
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+if [ -f /root/.cargo/env ]; then
+    . /root/.cargo/env
+fi
+
+MODEL_DIR_08B="${MODEL_DIR_08B:-${SUPERSONIC_MODEL_DIR_08B:-${SUPERSONIC_MODEL_DIR:-}}}"
+MODEL_DIR_2B="${MODEL_DIR_2B:-${SUPERSONIC_MODEL_DIR_2B:-}}"
+MODEL_DIR_4B="${MODEL_DIR_4B:-${SUPERSONIC_MODEL_DIR_4B:-}}"
+MODEL_DIR_9B="${MODEL_DIR_9B:-${SUPERSONIC_MODEL_DIR_9B:-}}"
+
+PROMPT="${PROMPT:-Hello}"
+MAX_NEW_TOKENS="${MAX_NEW_TOKENS:-2}"
+TIMEOUT="${TIMEOUT:-900}"
+FETCH_TIMEOUT="${FETCH_TIMEOUT:-1800}"
+ORACLE_DEVICE="${ORACLE_DEVICE:-cpu}"
+MAX_DELTA_THRESHOLD="${MAX_DELTA_THRESHOLD:-2.0}"
+VALIDATE="${VALIDATE:-0}"
+
+TMPOUT=$(mktemp)
+trap "rm -f $TMPOUT" EXIT
+
+echo "=== SuperSonic sm86 Qwen3.5 CUDA matrix smoke ==="
+echo "Prompt:        $PROMPT"
+echo "Max new tokens: $MAX_NEW_TOKENS"
+echo "Oracle device: $ORACLE_DEVICE"
+echo "Validate:      $VALIDATE"
+echo ""
+
+echo "--- Building (release) ---"
+SUPERSONIC_BACKENDS="${SUPERSONIC_BACKENDS:-cuda}" \
+    cargo build --release --manifest-path "$REPO_ROOT/Cargo.toml" --bin supersonic
+echo ""
+
+SUPERSONIC="$REPO_ROOT/target/release/supersonic"
+
+PASSED=0
+FAILED=0
+SKIPPED=0
+
+run_case() {
+    local label="$1"; shift
+    local model="$1"; shift
+    local model_dir="$1"; shift
+    local effective_timeout="$1"; shift
+    local flags=("$@")
+
+    if [ -z "$model_dir" ]; then
+        printf "  %-36s SKIP (model dir missing)\n" "$label"
+        SKIPPED=$((SKIPPED + 1))
+        return
+    fi
+    mkdir -p "$model_dir"
+
+    local validate_flags=()
+    if [ "$VALIDATE" = "1" ]; then
+        validate_flags=(--validate --oracle-device "$ORACLE_DEVICE")
+    fi
+
+    if ! timeout "$effective_timeout" "$SUPERSONIC" \
+        --backend cuda \
+        --model "$model" \
+        --model-dir "$model_dir" \
+        --prompt "$PROMPT" \
+        --max-new-tokens "$MAX_NEW_TOKENS" \
+        "${validate_flags[@]}" \
+        "${flags[@]}" \
+        > "$TMPOUT" 2>&1 </dev/null; then
+        printf "  %-36s FAIL (process error / timeout)\n" "$label"
+        cat "$TMPOUT"
+        FAILED=$((FAILED + 1))
+        return
+    fi
+
+    if [ "$VALIDATE" != "1" ]; then
+        local tokens
+        tokens=$(grep '^\[tokens\]' "$TMPOUT" | sed 's/^\[tokens\] //' || true)
+        printf "  %-36s PASS tokens=%s\n" "$label" "${tokens:-<none>}"
+        PASSED=$((PASSED + 1))
+        return
+    fi
+
+    local delta
+    delta=$(grep -oP 'decode_max_delta=\K[0-9.]+' "$TMPOUT" || echo "MISSING")
+    if [ "$delta" = "MISSING" ]; then
+        printf "  %-36s FAIL (missing decode_max_delta)\n" "$label"
+        cat "$TMPOUT"
+        FAILED=$((FAILED + 1))
+        return
+    fi
+
+    local pass
+    pass=$(python3 -c "print('PASS' if float('$delta') <= float('$MAX_DELTA_THRESHOLD') else 'FAIL')")
+    if [ "$pass" = "PASS" ]; then
+        printf "  %-36s PASS delta=%s\n" "$label" "$delta"
+        PASSED=$((PASSED + 1))
+    else
+        printf "  %-36s FAIL delta=%s threshold=%s\n" "$label" "$delta" "$MAX_DELTA_THRESHOLD"
+        cat "$TMPOUT"
+        FAILED=$((FAILED + 1))
+    fi
+}
+
+run_qwen_model() {
+    local short="$1"
+    local model="$2"
+    local model_dir="$3"
+    local has_release_bf16="$4"
+    local has_release_fp8="$5"
+    local has_raw=0
+
+    if [ -n "$model_dir" ] && find "$model_dir" -maxdepth 1 -type f \( -name "*.safetensors" -o -name "*.safetensors.index.json" \) 2>/dev/null | grep -q .; then
+        has_raw=1
+    fi
+
+    echo "--- $model ---"
+    if [ -n "$model_dir" ] && { [ "$has_raw" -eq 1 ] || [ -f "$model_dir/.supersonic/v2/manifest.json" ] || [ "$has_release_bf16" -eq 1 ]; }; then
+        run_case "$short bf16" "$model" "$model_dir" "$FETCH_TIMEOUT"
+    else
+        printf "  %-36s SKIP (no BF16 release/raw checkpoint)\n" "$short bf16"
+        SKIPPED=$((SKIPPED + 1))
+    fi
+    run_case "$short --int4" "$model" "$model_dir" "$FETCH_TIMEOUT" --int4
+    if [ -n "$model_dir" ] && { [ "$has_raw" -eq 1 ] || [ -f "$model_dir/.supersonic/v2-fp8/manifest.json" ] || [ "$has_release_fp8" -eq 1 ]; }; then
+        run_case "$short --fp8-runtime" "$model" "$model_dir" "$FETCH_TIMEOUT" --fp8-runtime
+    else
+        printf "  %-36s SKIP (no FP8-native release/raw checkpoint)\n" "$short --fp8-runtime"
+        SKIPPED=$((SKIPPED + 1))
+    fi
+    if [ -n "$model_dir" ] && { [ "$has_raw" -eq 1 ] || [ -f "$model_dir/.supersonic/v2/manifest.json" ] || [ "$has_release_bf16" -eq 1 ]; }; then
+        run_case "$short --kv-fp8" "$model" "$model_dir" "$FETCH_TIMEOUT" --kv-fp8
+    else
+        printf "  %-36s SKIP (no BF16 release/raw checkpoint)\n" "$short --kv-fp8"
+        SKIPPED=$((SKIPPED + 1))
+    fi
+    echo ""
+}
+
+run_qwen_model "0.8B" "qwen3.5-0.8b" "$MODEL_DIR_08B" 1 1
+run_qwen_model "2B" "qwen3.5-2b" "$MODEL_DIR_2B" 1 1
+run_qwen_model "4B" "qwen3.5-4b" "$MODEL_DIR_4B" 1 1
+run_qwen_model "9B" "qwen3.5-9b" "$MODEL_DIR_9B" 0 1
+
+echo "Summary: $PASSED passed, $FAILED failed, $SKIPPED skipped"
+if [ "$FAILED" -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- enable CUDA sm86 Qwen3.5 `--int4`, `--fp8-runtime`, and `--kv-fp8` gates
- route CUDA `qwen3.5-0.8b` through the 4B-capable persistent kernel path used by low-bit/KV-FP8 descriptors
- fix CUDA-only Qwen3.6 MoE FFI status typing
- add `tests/sm86/run_qwen35_matrix.sh` for release-backed Qwen3.5 CUDA matrix smoke coverage
- update CUDA negative tests now that Qwen3.5 low-bit modes are supported

## Release bakes
Uploaded Qwen3.5 `bakes-v2` entries now cover:
- `0.8B`: BF16, FP8-native, INT4
- `2B`: BF16, FP8-native, INT4
- `4B`: BF16, FP8-native, INT4
- `9B`: FP8-native, INT4

`qwen3.5-9b` BF16 is still pending because this 16 GB workspace / 31 GB scratch container cannot hold the raw 9B BF16 shards and full BF16 bake simultaneously. That will be uploaded from a larger-storage machine.

## Validation
- `SUPERSONIC_BACKENDS=cuda cargo build --release --bin supersonic`
- fresh empty-dir release-backed sm86 matrix:
  - `qwen3.5-0.8b`: BF16, INT4, FP8-runtime, KV-FP8 passed
  - `qwen3.5-2b`: BF16, INT4, FP8-runtime, KV-FP8 passed
  - `qwen3.5-4b`: BF16, INT4, FP8-runtime, KV-FP8 passed
  - `qwen3.5-9b`: INT4 and FP8-runtime passed; BF16/KV-FP8 skipped pending 9B BF16 bake
- `SUPERSONIC_BACKENDS=cuda tests/sm86/run_negative.sh /workspace/models/Qwen3.5-9B /workspace/models/Qwen3.5-4B`
- `git diff --check`
