### PR TITLE
Qwen3.6-MoE: end-to-end decode + bake quality + diagnosis

### DIFF
--- a/crates/kernel-ffi/src/qwen36_moe.rs
+++ b/crates/kernel-ffi/src/qwen36_moe.rs
@@ -334,6 +334,13 @@ extern "C" {
         out_proj_w: *const c_void,
         conv_state: *mut c_void,
         recurrent_state: *mut f32,
+        int4_group_size: c_int,
+        in_proj_qkv_scale: *const c_void,
+        in_proj_qkv_zero: *const c_void,
+        in_proj_z_scale: *const c_void,
+        in_proj_z_zero: *const c_void,
+        out_proj_scale: *const c_void,
+        out_proj_zero: *const c_void,
         output: *mut c_void,
         workspace: *mut f32,
         counters: *mut c_uint,
@@ -699,6 +706,11 @@ pub struct Qwen36MoeLinearStepParams {
 /// Pointers unused by the requested `stage` may be null; the kernel won't
 /// dereference them. See [`qwen36_moe_hip_linear_step_launch`] for the
 /// per-stage matrix.
+///
+/// `in_proj_qkv_w`, `in_proj_z_w`, and `out_proj_w` carry either BF16 weight
+/// slabs (when the matching field in [`Qwen36MoeLinearStepInt4`] is null) or
+/// INT4 packed-u8 slabs (when the matching `*_scale`/`*_zero` pair is set).
+/// `in_proj_a_w` / `in_proj_b_w` and the conv/state buffers always stay BF16.
 #[derive(Debug, Clone, Copy)]
 pub struct Qwen36MoeLinearStepWeights {
     pub input_hidden: *const c_void,
@@ -717,6 +729,37 @@ pub struct Qwen36MoeLinearStepWeights {
     pub recurrent_state: *mut f32,
 }
 
+/// Optional INT4 sidecar pointers + group size for the linear-attention
+/// parity launcher (PR 4b6). `group_size == 0` ⇒ INT4 disabled and every
+/// sidecar pointer must be null. Only the three projections the bake
+/// quantizes (`in_proj_qkv`, `in_proj_z`, `out_proj`) are switchable —
+/// `in_proj_a` / `in_proj_b` always stay BF16.
+#[derive(Debug, Clone, Copy)]
+pub struct Qwen36MoeLinearStepInt4 {
+    pub group_size: i32,
+    pub in_proj_qkv_scale: *const c_void,
+    pub in_proj_qkv_zero: *const c_void,
+    pub in_proj_z_scale: *const c_void,
+    pub in_proj_z_zero: *const c_void,
+    pub out_proj_scale: *const c_void,
+    pub out_proj_zero: *const c_void,
+}
+
+impl Qwen36MoeLinearStepInt4 {
+    /// All-null sidecars + group_size=0. BF16 path falls through.
+    pub const fn disabled() -> Self {
+        Self {
+            group_size: 0,
+            in_proj_qkv_scale: std::ptr::null(),
+            in_proj_qkv_zero: std::ptr::null(),
+            in_proj_z_scale: std::ptr::null(),
+            in_proj_z_zero: std::ptr::null(),
+            out_proj_scale: std::ptr::null(),
+            out_proj_zero: std::ptr::null(),
+        }
+    }
+}
+
 /// Safe wrapper for the PR 4b3 staged linear-attention parity launcher.
 /// Same workspace / sync_buf layout as
 /// [`attn_step_launch`]: 32-byte zero scratch, F32 workspace sized for the
@@ -726,6 +769,7 @@ pub fn linear_step_launch(
     dtype: ScalarType,
     params: Qwen36MoeLinearStepParams,
     weights: &Qwen36MoeLinearStepWeights,
+    int4: &Qwen36MoeLinearStepInt4,
     output: &mut GpuBuffer,
     workspace: &mut GpuBuffer,
     sync_buf: &mut GpuBuffer,
@@ -777,6 +821,13 @@ pub fn linear_step_launch(
                     weights.out_proj_w,
                     weights.conv_state,
                     weights.recurrent_state,
+                    int4.group_size as c_int,
+                    int4.in_proj_qkv_scale,
+                    int4.in_proj_qkv_zero,
+                    int4.in_proj_z_scale,
+                    int4.in_proj_z_zero,
+                    int4.out_proj_scale,
+                    int4.out_proj_zero,
                     output.as_mut_ptr(),
                     workspace.as_mut_ptr() as *mut f32,
                     counters,
@@ -2443,6 +2494,7 @@ mod tests {
             ScalarType::BF16,
             params,
             &weight_ptrs,
+            &Qwen36MoeLinearStepInt4::disabled(),
             &mut output,
             &mut workspace,
             &mut sync_buf,
@@ -2588,6 +2640,7 @@ mod tests {
             ScalarType::BF16,
             params,
             &weight_ptrs,
+            &Qwen36MoeLinearStepInt4::disabled(),
             &mut output,
             &mut workspace,
             &mut sync_buf,
@@ -2748,6 +2801,7 @@ mod tests {
             ScalarType::BF16,
             params,
             &weight_ptrs,
+            &Qwen36MoeLinearStepInt4::disabled(),
             &mut output,
             &mut workspace,
             &mut sync_buf,
@@ -2921,6 +2975,7 @@ mod tests {
             ScalarType::BF16,
             params,
             &weight_ptrs,
+            &Qwen36MoeLinearStepInt4::disabled(),
             &mut output,
             &mut workspace,
             &mut sync_buf,
@@ -3109,6 +3164,7 @@ mod tests {
             ScalarType::BF16,
             params,
             &weight_ptrs,
+            &Qwen36MoeLinearStepInt4::disabled(),
             &mut output,
             &mut workspace,
             &mut sync_buf,
@@ -3122,6 +3178,246 @@ mod tests {
         // PR 4b2 stage 5.
         assert_parity(
             "linear step5 output_hidden",
+            got_bytes,
+            &output_hidden_expected,
+            0.05,
+            0.9999,
+        );
+    }
+
+    // -------------------------------------------------------------------
+    // PR 4b6 step 4: linear-attn INT4 parity vs the INT4 oracle.
+    // -------------------------------------------------------------------
+
+    #[cfg(supersonic_backend_hip)]
+    fn linear_oracle_is_int4(json: &serde_json::Value) -> bool {
+        json["schema"].as_str() == Some("qwen36-moe-oracle-linear-int4-v1")
+    }
+
+    #[cfg(supersonic_backend_hip)]
+    fn decode_linear_int4_sidecar(
+        json: &serde_json::Value, name: &str,
+    ) -> (Vec<u8>, Vec<u8>, Vec<u8>) {
+        let blk = &json["int4_weights"][name];
+        let packed = b64_decode(blk["packed"].as_str()
+            .unwrap_or_else(|| panic!("missing int4_weights[{name}].packed")));
+        let scale = b64_decode(blk["scale"].as_str()
+            .unwrap_or_else(|| panic!("missing int4_weights[{name}].scale")));
+        let zero = b64_decode(blk["zero"].as_str()
+            .unwrap_or_else(|| panic!("missing int4_weights[{name}].zero")));
+        (packed, scale, zero)
+    }
+
+    #[cfg(supersonic_backend_hip)]
+    #[test]
+    fn qwen36_moe_linear_step_5_output_hidden_int4_matches_oracle() {
+        use gpu_hal::{set_backend, Backend, GpuBuffer, ScalarType};
+
+        let Some((json, geom)) = load_linear_oracle_json() else {
+            eprintln!(
+                "skip: SUPERSONIC_QWEN36_LINEAR_ORACLE_JSON not set. \
+                 Generate an INT4 fixture with \
+                 `python oracle/qwen36_moe_linear_oracle.py --mode synthetic \
+                 --int4 --out /tmp/qwen36_lin_int4.json`."
+            );
+            return;
+        };
+        if !linear_oracle_is_int4(&json) {
+            eprintln!(
+                "skip: oracle JSON is not INT4 (schema={}). Pass `--int4` to \
+                 the oracle to exercise this test.",
+                json["schema"].as_str().unwrap_or("?"),
+            );
+            return;
+        }
+        let cfg = &json["config"];
+        let group_size = cfg["int4_group_size"].as_i64().unwrap_or(0) as i32;
+        assert!(group_size > 0, "INT4 oracle missing config.int4_group_size");
+
+        let weights = &json["weights"];
+        let inters = &json["intermediates"];
+
+        // BF16 inputs that stay BF16 (norms + small scalars + conv + state).
+        let input_hidden_bytes = b64_decode(weights["input_hidden"].as_str().unwrap());
+        let input_norm_w_bytes = b64_decode(weights["input_norm_w"].as_str().unwrap());
+        let in_proj_a_w_bytes = b64_decode(weights["in_proj_a_w"].as_str().unwrap());
+        let in_proj_b_w_bytes = b64_decode(weights["in_proj_b_w"].as_str().unwrap());
+        let conv1d_w_bytes = b64_decode(weights["conv1d_w"].as_str().unwrap());
+        let conv1d_bias_bytes = weights.get("conv1d_bias")
+            .and_then(|v| v.as_str())
+            .map(b64_decode);
+        let conv_state_before_bytes = b64_decode(weights["conv_state_before"].as_str().unwrap());
+        let dt_bias_bytes = b64_decode(weights["dt_bias"].as_str().unwrap());
+        let a_log_bytes = b64_decode(weights["a_log"].as_str().unwrap());
+        let recurrent_state_before_bytes =
+            b64_decode(weights["recurrent_state_before"].as_str().unwrap());
+        let norm_w_bytes = b64_decode(weights["norm_w"].as_str().unwrap());
+
+        // INT4 sidecars for the three projections.
+        let (qkv_packed, qkv_scale, qkv_zero) =
+            decode_linear_int4_sidecar(&json, "in_proj_qkv_w");
+        let (z_packed, z_scale, z_zero) =
+            decode_linear_int4_sidecar(&json, "in_proj_z_w");
+        let (out_packed, out_scale, out_zero) =
+            decode_linear_int4_sidecar(&json, "out_proj_w");
+
+        let output_hidden_expected = b64_decode(inters["output_hidden"].as_str().unwrap());
+
+        let hidden_us = geom.hidden as usize;
+        let k_us = geom.num_k_heads as usize;
+        let v_us = geom.num_v_heads as usize;
+        let kd_us = geom.head_k_dim as usize;
+        let vd_us = geom.head_v_dim as usize;
+        let conv_kernel = geom.conv_kernel_dim as usize;
+        let qkv_dim = 2 * k_us * kd_us + v_us * vd_us;
+        let val_dim = v_us * vd_us;
+
+        // Sanity: shapes match the bake convention.
+        assert_eq!(qkv_packed.len(), qkv_dim * (hidden_us / 2),
+            "in_proj_qkv packed bytes mismatch");
+        assert_eq!(z_packed.len(), val_dim * (hidden_us / 2));
+        assert_eq!(out_packed.len(), hidden_us * (val_dim / 2));
+
+        set_backend(Backend::Hip);
+        let ordinal = 0usize;
+
+        let input_hidden = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_us], &input_hidden_bytes,
+        ).expect("upload input_hidden");
+        let input_norm_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_us], &input_norm_w_bytes,
+        ).expect("upload input_norm_w");
+        let in_proj_a_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[v_us, hidden_us], &in_proj_a_w_bytes,
+        ).expect("upload in_proj_a_w");
+        let in_proj_b_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[v_us, hidden_us], &in_proj_b_w_bytes,
+        ).expect("upload in_proj_b_w");
+        let conv1d_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[qkv_dim, conv_kernel], &conv1d_w_bytes,
+        ).expect("upload conv1d_w");
+        let conv1d_bias_buf = conv1d_bias_bytes.as_ref().map(|bytes| {
+            GpuBuffer::from_host_bytes(ordinal, ScalarType::BF16, &[qkv_dim], bytes)
+                .expect("upload conv1d_bias")
+        });
+        let mut conv_state = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[qkv_dim, conv_kernel - 1],
+            &conv_state_before_bytes,
+        ).expect("upload conv_state");
+        let dt_bias = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[v_us], &dt_bias_bytes,
+        ).expect("upload dt_bias");
+        let a_log = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[v_us], &a_log_bytes,
+        ).expect("upload a_log");
+        let mut recurrent_state = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::F32, &[v_us, kd_us, vd_us],
+            &recurrent_state_before_bytes,
+        ).expect("upload recurrent_state");
+        let norm_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[kd_us], &norm_w_bytes,
+        ).expect("upload norm_w");
+
+        // Projection weights uploaded as packed u8 + BF16 scale/zero.
+        let qkv_packed_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::U8, &[qkv_packed.len()], &qkv_packed,
+        ).expect("upload qkv packed");
+        let qkv_scale_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[qkv_scale.len() / 2], &qkv_scale,
+        ).expect("upload qkv scale");
+        let qkv_zero_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[qkv_zero.len() / 2], &qkv_zero,
+        ).expect("upload qkv zero");
+        let z_packed_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::U8, &[z_packed.len()], &z_packed,
+        ).expect("upload z packed");
+        let z_scale_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[z_scale.len() / 2], &z_scale,
+        ).expect("upload z scale");
+        let z_zero_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[z_zero.len() / 2], &z_zero,
+        ).expect("upload z zero");
+        let out_packed_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::U8, &[out_packed.len()], &out_packed,
+        ).expect("upload out packed");
+        let out_scale_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[out_scale.len() / 2], &out_scale,
+        ).expect("upload out scale");
+        let out_zero_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[out_zero.len() / 2], &out_zero,
+        ).expect("upload out zero");
+
+        let v_kdim = v_us * kd_us;
+        let stage_publish_max = 2 * v_kdim + val_dim;
+        let mut output = GpuBuffer::zeros(
+            ordinal, ScalarType::BF16, &[stage_publish_max],
+        ).expect("alloc output");
+        let workspace_floats =
+            qkv_dim + val_dim + 2 * v_us
+            + 2 * (k_us * kd_us)
+            + 2 * v_kdim
+            + v_us + v_us
+            + val_dim;
+        let mut workspace = GpuBuffer::zeros(
+            ordinal, ScalarType::F32, &[workspace_floats],
+        ).expect("alloc workspace");
+        let mut sync_buf = GpuBuffer::zeros(
+            ordinal, ScalarType::U8, &[32],
+        ).expect("alloc sync buf");
+
+        let params = Qwen36MoeLinearStepParams {
+            stage: 5,
+            hidden: geom.hidden,
+            num_k_heads: geom.num_k_heads,
+            num_v_heads: geom.num_v_heads,
+            head_k_dim: geom.head_k_dim,
+            head_v_dim: geom.head_v_dim,
+            conv_kernel_dim: geom.conv_kernel_dim,
+            rms_norm_eps: geom.rms_norm_eps,
+        };
+        let weight_ptrs = Qwen36MoeLinearStepWeights {
+            input_hidden: input_hidden.as_ptr(),
+            input_norm_w: input_norm_w.as_ptr(),
+            in_proj_qkv_w: qkv_packed_buf.as_ptr(),
+            in_proj_z_w: z_packed_buf.as_ptr(),
+            in_proj_a_w: in_proj_a_w.as_ptr(),
+            in_proj_b_w: in_proj_b_w.as_ptr(),
+            conv1d_w: conv1d_w.as_ptr(),
+            conv1d_bias: conv1d_bias_buf.as_ref().map(|b| b.as_ptr())
+                .unwrap_or(std::ptr::null()),
+            dt_bias: dt_bias.as_ptr(),
+            a_log: a_log.as_ptr(),
+            norm_w: norm_w.as_ptr(),
+            out_proj_w: out_packed_buf.as_ptr(),
+            conv_state: conv_state.as_mut_ptr(),
+            recurrent_state: recurrent_state.as_mut_ptr() as *mut f32,
+        };
+        let int4_ptrs = Qwen36MoeLinearStepInt4 {
+            group_size,
+            in_proj_qkv_scale: qkv_scale_buf.as_ptr(),
+            in_proj_qkv_zero: qkv_zero_buf.as_ptr(),
+            in_proj_z_scale: z_scale_buf.as_ptr(),
+            in_proj_z_zero: z_zero_buf.as_ptr(),
+            out_proj_scale: out_scale_buf.as_ptr(),
+            out_proj_zero: out_zero_buf.as_ptr(),
+        };
+
+        linear_step_launch(
+            ordinal,
+            ScalarType::BF16,
+            params,
+            &weight_ptrs,
+            &int4_ptrs,
+            &mut output,
+            &mut workspace,
+            &mut sync_buf,
+        )
+        .expect("linear_step_launch stage 5 (int4)");
+
+        let got_bytes_full = output.to_host_bytes().expect("download output");
+        let got_bytes = &got_bytes_full[..hidden_us * 2];
+        assert_parity(
+            "linear step5 int4 output_hidden",
             got_bytes,
             &output_hidden_expected,
             0.05,

--- a/crates/kernel-ffi/src/qwen36_moe.rs
+++ b/crates/kernel-ffi/src/qwen36_moe.rs
@@ -269,6 +269,15 @@ extern "C" {
         q_norm_w: *const c_void,
         k_norm_w: *const c_void,
         o_proj_w: *const c_void,
+        int4_group_size: c_int,
+        q_proj_scale: *const c_void,
+        q_proj_zero: *const c_void,
+        k_proj_scale: *const c_void,
+        k_proj_zero: *const c_void,
+        v_proj_scale: *const c_void,
+        v_proj_zero: *const c_void,
+        o_proj_scale: *const c_void,
+        o_proj_zero: *const c_void,
         output: *mut c_void,
         workspace: *mut f32,
         counters: *mut c_uint,
@@ -515,6 +524,10 @@ pub struct Qwen36MoeAttnStepParams {
 /// Weight pointers for the staged-attention parity launcher. Pointers
 /// unused by the requested `stage` may be null; the kernel won't dereference
 /// them. See [`qwen36_moe_hip_attn_step_launch`] for the per-stage matrix.
+///
+/// Each `*_proj_w` pointer carries either a BF16 weight slab (when the
+/// matching field in [`Qwen36MoeAttnStepInt4`] is null) or an INT4 packed-u8
+/// slab (when the matching `*_scale`/`*_zero` pair is set).
 #[derive(Debug, Clone, Copy)]
 pub struct Qwen36MoeAttnStepWeights {
     pub input_hidden: *const c_void,
@@ -525,6 +538,44 @@ pub struct Qwen36MoeAttnStepWeights {
     pub q_norm_w: *const c_void,
     pub k_norm_w: *const c_void,
     pub o_proj_w: *const c_void,
+}
+
+/// Optional INT4 sidecar pointers + group size for the full-attention
+/// parity launcher (PR 4b6). `group_size == 0` ⇒ INT4 disabled and every
+/// sidecar pointer must be null. When non-zero, each tensor is
+/// independently switchable: a non-null `*_scale`/`*_zero` pair routes
+/// that tensor's matvec through `int4_dequant_scalar`; a null pair keeps
+/// it on the BF16 path. Scales and zeros are BF16 with the bake's group
+/// layout — `[out/gs, in/gs]`.
+#[derive(Debug, Clone, Copy)]
+pub struct Qwen36MoeAttnStepInt4 {
+    pub group_size: i32,
+    pub q_proj_scale: *const c_void,
+    pub q_proj_zero: *const c_void,
+    pub k_proj_scale: *const c_void,
+    pub k_proj_zero: *const c_void,
+    pub v_proj_scale: *const c_void,
+    pub v_proj_zero: *const c_void,
+    pub o_proj_scale: *const c_void,
+    pub o_proj_zero: *const c_void,
+}
+
+impl Qwen36MoeAttnStepInt4 {
+    /// All-null sidecars + group_size=0. BF16 path falls through for every
+    /// tensor.
+    pub const fn disabled() -> Self {
+        Self {
+            group_size: 0,
+            q_proj_scale: std::ptr::null(),
+            q_proj_zero: std::ptr::null(),
+            k_proj_scale: std::ptr::null(),
+            k_proj_zero: std::ptr::null(),
+            v_proj_scale: std::ptr::null(),
+            v_proj_zero: std::ptr::null(),
+            o_proj_scale: std::ptr::null(),
+            o_proj_zero: std::ptr::null(),
+        }
+    }
 }
 
 /// Safe wrapper for the PR 4b2 staged-attention parity launcher.
@@ -539,6 +590,7 @@ pub fn attn_step_launch(
     dtype: ScalarType,
     params: Qwen36MoeAttnStepParams,
     weights: &Qwen36MoeAttnStepWeights,
+    int4: &Qwen36MoeAttnStepInt4,
     output: &mut GpuBuffer,
     workspace: &mut GpuBuffer,
     sync_buf: &mut GpuBuffer,
@@ -585,6 +637,15 @@ pub fn attn_step_launch(
                     weights.q_norm_w,
                     weights.k_norm_w,
                     weights.o_proj_w,
+                    int4.group_size as c_int,
+                    int4.q_proj_scale,
+                    int4.q_proj_zero,
+                    int4.k_proj_scale,
+                    int4.k_proj_zero,
+                    int4.v_proj_scale,
+                    int4.v_proj_zero,
+                    int4.o_proj_scale,
+                    int4.o_proj_zero,
                     output.as_mut_ptr(),
                     workspace.as_mut_ptr() as *mut f32,
                     counters,
@@ -1490,6 +1551,7 @@ mod tests {
             ScalarType::BF16,
             params,
             &weight_ptrs,
+            &Qwen36MoeAttnStepInt4::disabled(),
             &mut output,
             &mut workspace,
             &mut sync_buf,
@@ -1607,6 +1669,7 @@ mod tests {
             ScalarType::BF16,
             params,
             &weight_ptrs,
+            &Qwen36MoeAttnStepInt4::disabled(),
             &mut output,
             &mut workspace,
             &mut sync_buf,
@@ -1733,6 +1796,7 @@ mod tests {
             ScalarType::BF16,
             params,
             &weight_ptrs,
+            &Qwen36MoeAttnStepInt4::disabled(),
             &mut output,
             &mut workspace,
             &mut sync_buf,
@@ -1850,6 +1914,7 @@ mod tests {
             ScalarType::BF16,
             params,
             &weight_ptrs,
+            &Qwen36MoeAttnStepInt4::disabled(),
             &mut output,
             &mut workspace,
             &mut sync_buf,
@@ -1970,6 +2035,7 @@ mod tests {
             ScalarType::BF16,
             params,
             &weight_ptrs,
+            &Qwen36MoeAttnStepInt4::disabled(),
             &mut output,
             &mut workspace,
             &mut sync_buf,
@@ -1984,6 +2050,231 @@ mod tests {
         // Cosine similarity is the more meaningful metric for the residual.
         assert_parity(
             "step5 output_hidden",
+            got_bytes,
+            &output_hidden_expected_bytes,
+            0.05,
+            0.9999,
+        );
+    }
+
+    // -------------------------------------------------------------------
+    // PR 4b6 step 2: full-attention INT4 parity vs the INT4 oracle.
+    //
+    // Driven by the same env var as the BF16 attn tests; skipped silently
+    // when the JSON's schema is not `qwen36-moe-oracle-layer-int4-v1`.
+    // The INT4 oracle's `weights` block carries the BF16-reconstruction
+    // of each quantized tensor, so the BF16 reference computed against
+    // those weights is the exact intermediate the kernel must reproduce
+    // when it dequantizes (packed, scale, zero) on the fly.
+    //
+    // All four projection tensors (q_proj, k_proj, v_proj, o_proj) flow
+    // through the INT4 path. Norms stay BF16.
+    // -------------------------------------------------------------------
+
+    #[cfg(supersonic_backend_hip)]
+    fn attn_oracle_is_int4(json: &serde_json::Value) -> bool {
+        json["schema"].as_str() == Some("qwen36-moe-oracle-layer-int4-v1")
+    }
+
+    /// Pulls (packed, scale, zero) bytes for one INT4-quantized attn tensor.
+    #[cfg(supersonic_backend_hip)]
+    fn decode_attn_int4_sidecar(
+        json: &serde_json::Value, name: &str,
+    ) -> (Vec<u8>, Vec<u8>, Vec<u8>) {
+        let blk = &json["int4_weights"][name];
+        let packed = b64_decode(blk["packed"].as_str()
+            .unwrap_or_else(|| panic!("missing int4_weights[{name}].packed")));
+        let scale = b64_decode(blk["scale"].as_str()
+            .unwrap_or_else(|| panic!("missing int4_weights[{name}].scale")));
+        let zero = b64_decode(blk["zero"].as_str()
+            .unwrap_or_else(|| panic!("missing int4_weights[{name}].zero")));
+        (packed, scale, zero)
+    }
+
+    #[cfg(supersonic_backend_hip)]
+    #[test]
+    fn qwen36_moe_attn_step_5_output_hidden_int4_matches_oracle() {
+        use gpu_hal::{set_backend, Backend, GpuBuffer, ScalarType};
+
+        let Some((json, geom)) = load_oracle_json() else {
+            eprintln!(
+                "skip: SUPERSONIC_QWEN36_ORACLE_JSON not set. Generate \
+                 an INT4 fixture with \
+                 `python oracle/qwen36_moe_oracle.py --mode synthetic \
+                 --int4 --position 7 --out /tmp/qwen36_attn_int4.json`."
+            );
+            return;
+        };
+        if !attn_oracle_is_int4(&json) {
+            eprintln!(
+                "skip: oracle JSON is not INT4 (schema={}). Pass `--int4` \
+                 to the oracle to exercise this test.",
+                json["schema"].as_str().unwrap_or("?"),
+            );
+            return;
+        }
+        let cfg = &json["config"];
+        let group_size = cfg["int4_group_size"].as_i64().unwrap_or(0) as i32;
+        assert!(group_size > 0, "INT4 oracle missing config.int4_group_size");
+
+        let weights = &json["weights"];
+        let inters = &json["intermediates"];
+
+        let position = json["position"].as_i64().unwrap_or(0) as i32;
+        let rotary_dim = cfg["rotary_dim"].as_i64().unwrap() as i32;
+        let rope_theta = cfg["rope_theta"].as_f64().unwrap() as f32;
+
+        // BF16 inputs that stay BF16 (norms + input_hidden).
+        let input_hidden_bytes = b64_decode(weights["input_hidden"].as_str().unwrap());
+        let input_norm_w_bytes = b64_decode(weights["input_norm_w"].as_str().unwrap());
+        let q_norm_w_bytes = b64_decode(weights["q_norm_w"].as_str().unwrap());
+        let k_norm_w_bytes = b64_decode(weights["k_norm_w"].as_str().unwrap());
+
+        // INT4 sidecars for the four projections.
+        let (q_packed, q_scale, q_zero) = decode_attn_int4_sidecar(&json, "q_proj_w");
+        let (k_packed, k_scale, k_zero) = decode_attn_int4_sidecar(&json, "k_proj_w");
+        let (v_packed, v_scale, v_zero) = decode_attn_int4_sidecar(&json, "v_proj_w");
+        let (o_packed, o_scale, o_zero) = decode_attn_int4_sidecar(&json, "o_proj_w");
+
+        let output_hidden_expected_bytes =
+            b64_decode(inters["output_hidden"].as_str().unwrap());
+
+        let hidden_us = geom.hidden as usize;
+        let h_us = geom.num_heads as usize;
+        let hkv_us = geom.num_kv_heads as usize;
+        let d_us = geom.head_dim as usize;
+        let gsz_us = group_size as usize;
+
+        // Sanity: shapes match the bake convention.
+        assert_eq!(q_packed.len(), 2 * h_us * d_us * (hidden_us / 2),
+            "q_proj packed bytes mismatch");
+        assert_eq!(q_scale.len(),
+            (2 * h_us * d_us / gsz_us) * (hidden_us / gsz_us) * 2,
+            "q_proj scale bytes mismatch");
+        assert_eq!(k_packed.len(), hkv_us * d_us * (hidden_us / 2));
+        assert_eq!(v_packed.len(), hkv_us * d_us * (hidden_us / 2));
+        assert_eq!(o_packed.len(), hidden_us * (h_us * d_us / 2));
+
+        set_backend(Backend::Hip);
+        let ordinal = 0usize;
+
+        let input_hidden = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_us], &input_hidden_bytes,
+        ).expect("upload input_hidden");
+        let input_norm_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_us], &input_norm_w_bytes,
+        ).expect("upload input_norm_w");
+        let q_norm_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[d_us], &q_norm_w_bytes,
+        ).expect("upload q_norm_w");
+        let k_norm_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[d_us], &k_norm_w_bytes,
+        ).expect("upload k_norm_w");
+
+        // Projection weights uploaded as packed u8 + BF16 scale/zero.
+        let q_packed_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::U8, &[q_packed.len()], &q_packed,
+        ).expect("upload q packed");
+        let q_scale_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[q_scale.len() / 2], &q_scale,
+        ).expect("upload q scale");
+        let q_zero_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[q_zero.len() / 2], &q_zero,
+        ).expect("upload q zero");
+        let k_packed_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::U8, &[k_packed.len()], &k_packed,
+        ).expect("upload k packed");
+        let k_scale_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[k_scale.len() / 2], &k_scale,
+        ).expect("upload k scale");
+        let k_zero_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[k_zero.len() / 2], &k_zero,
+        ).expect("upload k zero");
+        let v_packed_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::U8, &[v_packed.len()], &v_packed,
+        ).expect("upload v packed");
+        let v_scale_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[v_scale.len() / 2], &v_scale,
+        ).expect("upload v scale");
+        let v_zero_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[v_zero.len() / 2], &v_zero,
+        ).expect("upload v zero");
+        let o_packed_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::U8, &[o_packed.len()], &o_packed,
+        ).expect("upload o packed");
+        let o_scale_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[o_scale.len() / 2], &o_scale,
+        ).expect("upload o scale");
+        let o_zero_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[o_zero.len() / 2], &o_zero,
+        ).expect("upload o zero");
+
+        let mut output = GpuBuffer::zeros(
+            ordinal, ScalarType::BF16,
+            &[parity_output_elems(geom.num_heads, geom.num_kv_heads, geom.head_dim)],
+        ).expect("alloc output");
+        let mut workspace = GpuBuffer::zeros(
+            ordinal, ScalarType::F32,
+            &[parity_workspace_floats(geom.num_heads, geom.num_kv_heads, geom.head_dim, geom.hidden)],
+        ).expect("alloc workspace");
+        let mut sync_buf = GpuBuffer::zeros(
+            ordinal, ScalarType::U8, &[32],
+        ).expect("alloc sync buf");
+
+        let params = Qwen36MoeAttnStepParams {
+            stage: 5,
+            hidden: geom.hidden,
+            num_heads: geom.num_heads,
+            num_kv_heads: geom.num_kv_heads,
+            head_dim: geom.head_dim,
+            rotary_dim,
+            rope_theta,
+            rms_norm_eps: geom.rms_norm_eps,
+            position,
+        };
+        // Projection weight pointers point at the packed u8 buffers.
+        let weight_ptrs = Qwen36MoeAttnStepWeights {
+            input_hidden: input_hidden.as_ptr(),
+            input_norm_w: input_norm_w.as_ptr(),
+            q_proj_w: q_packed_buf.as_ptr(),
+            k_proj_w: k_packed_buf.as_ptr(),
+            v_proj_w: v_packed_buf.as_ptr(),
+            q_norm_w: q_norm_w.as_ptr(),
+            k_norm_w: k_norm_w.as_ptr(),
+            o_proj_w: o_packed_buf.as_ptr(),
+        };
+        let int4_ptrs = Qwen36MoeAttnStepInt4 {
+            group_size,
+            q_proj_scale: q_scale_buf.as_ptr(),
+            q_proj_zero: q_zero_buf.as_ptr(),
+            k_proj_scale: k_scale_buf.as_ptr(),
+            k_proj_zero: k_zero_buf.as_ptr(),
+            v_proj_scale: v_scale_buf.as_ptr(),
+            v_proj_zero: v_zero_buf.as_ptr(),
+            o_proj_scale: o_scale_buf.as_ptr(),
+            o_proj_zero: o_zero_buf.as_ptr(),
+        };
+
+        attn_step_launch(
+            ordinal,
+            ScalarType::BF16,
+            params,
+            &weight_ptrs,
+            &int4_ptrs,
+            &mut output,
+            &mut workspace,
+            &mut sync_buf,
+        )
+        .expect("attn_step_launch stage 5 (int4)");
+
+        // Same envelope as the BF16 stage 5 test: cos_sim ≥ 0.9999, max
+        // |delta| ≤ 0.05. The reconstruction is bit-identical to what the
+        // oracle ran reference against, so any residual disagreement is
+        // F32 reduction-order drift through the matvec — same as BF16.
+        let got_bytes_full = output.to_host_bytes().expect("download output");
+        let got_bytes = &got_bytes_full[..hidden_us * 2];
+        assert_parity(
+            "step5 int4 output_hidden",
             got_bytes,
             &output_hidden_expected_bytes,
             0.05,

--- a/crates/kernel-ffi/src/qwen36_moe.rs
+++ b/crates/kernel-ffi/src/qwen36_moe.rs
@@ -3840,6 +3840,206 @@ mod tests {
         );
     }
 
+    #[cfg(supersonic_backend_hip)]
+    #[test]
+    fn qwen36_moe_ffn_step_3_expert0_int4_matches_oracle() {
+        use gpu_hal::{set_backend, Backend, GpuBuffer, ScalarType};
+
+        let Some((json, geom)) = load_ffn_oracle_json() else {
+            eprintln!(
+                "skip: SUPERSONIC_QWEN36_FFN_ORACLE_JSON not set. \
+                 See `qwen36_moe_ffn_step_2_shared_out_int4_matches_oracle` for setup."
+            );
+            return;
+        };
+        if !ffn_oracle_is_int4(&json) {
+            eprintln!(
+                "skip: oracle JSON is not INT4 (schema={}). Generate one with \
+                 `--int4` to exercise this test.",
+                json["schema"].as_str().unwrap_or("?"),
+            );
+            return;
+        }
+        let cfg = &json["config"];
+        let group_size = cfg["int4_group_size"].as_i64().unwrap_or(0) as i32;
+        assert!(group_size > 0, "INT4 oracle missing config.int4_group_size");
+
+        let weights = &json["weights"];
+        let inters = &json["intermediates"];
+
+        // Stage 3 needs everything stage 2 needed plus the fused gate_up_proj.
+        // gate_up_proj routes through INT4 (step 4 wires Phase G); down_proj
+        // stays BF16 in this test until step 5 lands. The oracle's BF16
+        // reconstruction for down_proj is in `weights.down_proj_w`.
+        let input_hidden_bytes = b64_decode(weights["input_hidden"].as_str().unwrap());
+        let post_attn_norm_w_bytes = b64_decode(weights["post_attn_norm_w"].as_str().unwrap());
+        let gate_w_bytes = b64_decode(weights["gate_w"].as_str().unwrap());
+        let down_proj_w_bytes = b64_decode(weights["down_proj_w"].as_str().unwrap());
+        let shared_expert_gate_w_bytes =
+            b64_decode(weights["shared_expert_gate_w"].as_str().unwrap());
+
+        let (gup_packed, gup_scale, gup_zero) =
+            decode_int4_sidecar(&json, "gate_up_proj_w");
+        let (sgp_packed, sgp_scale, sgp_zero) =
+            decode_int4_sidecar(&json, "shared_gate_proj_w");
+        let (sup_packed, sup_scale, sup_zero) =
+            decode_int4_sidecar(&json, "shared_up_proj_w");
+        let (sdp_packed, sdp_scale, sdp_zero) =
+            decode_int4_sidecar(&json, "shared_down_proj_w");
+
+        let expert_stack_expected = b64_decode(inters["expert_stack"].as_str().unwrap());
+
+        let hidden_us = geom.hidden as usize;
+        let e_us = geom.num_experts as usize;
+        let i_us = geom.moe_intermediate as usize;
+        let is_us = geom.shared_intermediate as usize;
+        let k_us = geom.top_k as usize;
+        let gsz_us = group_size as usize;
+        let two_i = 2 * i_us;
+
+        // Sanity: fused-expert packed shape is [E, 2*I, hidden/2].
+        assert_eq!(gup_packed.len(), e_us * two_i * (hidden_us / 2),
+            "gate_up_proj packed bytes mismatch");
+        assert_eq!(gup_scale.len(),
+            e_us * (two_i / gsz_us) * (hidden_us / gsz_us) * 2,
+            "gate_up_proj scale bytes mismatch");
+        assert_eq!(down_proj_w_bytes.len(), e_us * hidden_us * i_us * 2,
+            "down_proj BF16 bytes mismatch");
+
+        set_backend(Backend::Hip);
+        let ordinal = 0usize;
+
+        let input_hidden = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_us], &input_hidden_bytes,
+        ).expect("upload input_hidden");
+        let post_attn_norm_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_us], &post_attn_norm_w_bytes,
+        ).expect("upload post_attn_norm_w");
+        let gate_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[e_us, hidden_us], &gate_w_bytes,
+        ).expect("upload gate_w");
+        let down_proj_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16,
+            &[e_us, hidden_us, i_us], &down_proj_w_bytes,
+        ).expect("upload down_proj_w");
+        let shared_expert_gate_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[1, hidden_us], &shared_expert_gate_w_bytes,
+        ).expect("upload shared_expert_gate_w");
+
+        let gup_packed_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::U8, &[gup_packed.len()], &gup_packed,
+        ).expect("upload gup packed");
+        let gup_scale_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[gup_scale.len() / 2], &gup_scale,
+        ).expect("upload gup scale");
+        let gup_zero_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[gup_zero.len() / 2], &gup_zero,
+        ).expect("upload gup zero");
+
+        let sgp_packed_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::U8, &[sgp_packed.len()], &sgp_packed,
+        ).expect("upload sgp packed");
+        let sgp_scale_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[sgp_scale.len() / 2], &sgp_scale,
+        ).expect("upload sgp scale");
+        let sgp_zero_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[sgp_zero.len() / 2], &sgp_zero,
+        ).expect("upload sgp zero");
+        let sup_packed_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::U8, &[sup_packed.len()], &sup_packed,
+        ).expect("upload sup packed");
+        let sup_scale_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[sup_scale.len() / 2], &sup_scale,
+        ).expect("upload sup scale");
+        let sup_zero_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[sup_zero.len() / 2], &sup_zero,
+        ).expect("upload sup zero");
+        let sdp_packed_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::U8, &[sdp_packed.len()], &sdp_packed,
+        ).expect("upload sdp packed");
+        let sdp_scale_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[sdp_scale.len() / 2], &sdp_scale,
+        ).expect("upload sdp scale");
+        let sdp_zero_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[sdp_zero.len() / 2], &sdp_zero,
+        ).expect("upload sdp zero");
+
+        let mut output = GpuBuffer::zeros(
+            ordinal, ScalarType::BF16, &[ffn_parity_output_elems(&geom)],
+        ).expect("alloc output");
+        let mut output_idx = GpuBuffer::zeros(
+            ordinal, ScalarType::U32, &[k_us],
+        ).expect("alloc output_idx");
+        let mut workspace = GpuBuffer::zeros(
+            ordinal, ScalarType::F32, &[ffn_parity_workspace_floats(&geom)],
+        ).expect("alloc workspace");
+        let mut sync_buf = GpuBuffer::zeros(
+            ordinal, ScalarType::U8, &[32],
+        ).expect("alloc sync buf");
+
+        let params = Qwen36MoeFfnStepParams {
+            stage: 3,
+            hidden: geom.hidden,
+            num_experts: geom.num_experts,
+            moe_intermediate: geom.moe_intermediate,
+            shared_intermediate: geom.shared_intermediate,
+            top_k: geom.top_k,
+            rms_norm_eps: geom.rms_norm_eps,
+        };
+        let weight_ptrs = Qwen36MoeFfnStepWeights {
+            input_hidden: input_hidden.as_ptr(),
+            post_attn_norm_w: post_attn_norm_w.as_ptr(),
+            gate_w: gate_w.as_ptr(),
+            gate_up_proj_w: gup_packed_buf.as_ptr(),  // packed u8 — INT4 path
+            down_proj_w: down_proj_w.as_ptr(),         // BF16 reconstruction
+            shared_gate_proj_w: sgp_packed_buf.as_ptr(),
+            shared_up_proj_w: sup_packed_buf.as_ptr(),
+            shared_down_proj_w: sdp_packed_buf.as_ptr(),
+            shared_expert_gate_w: shared_expert_gate_w.as_ptr(),
+        };
+        let int4_ptrs = Qwen36MoeFfnStepInt4 {
+            group_size,
+            gate_up_proj_scale: gup_scale_buf.as_ptr(),
+            gate_up_proj_zero: gup_zero_buf.as_ptr(),
+            // down_proj stays BF16 until step 5 wires Phase I.
+            down_proj_scale: std::ptr::null(),
+            down_proj_zero: std::ptr::null(),
+            shared_gate_proj_scale: sgp_scale_buf.as_ptr(),
+            shared_gate_proj_zero: sgp_zero_buf.as_ptr(),
+            shared_up_proj_scale: sup_scale_buf.as_ptr(),
+            shared_up_proj_zero: sup_zero_buf.as_ptr(),
+            shared_down_proj_scale: sdp_scale_buf.as_ptr(),
+            shared_down_proj_zero: sdp_zero_buf.as_ptr(),
+        };
+
+        ffn_step_launch(
+            ordinal,
+            ScalarType::BF16,
+            params,
+            &weight_ptrs,
+            &int4_ptrs,
+            &mut output,
+            &mut output_idx,
+            &mut workspace,
+            &mut sync_buf,
+        )
+        .expect("ffn_step_launch stage 3 (int4)");
+
+        // Stage 3 publishes expert_0_out (BF16-cast view of the F32 stack)
+        // into output[0..hidden]. Compare against `intermediates.expert_stack`
+        // restricted to slot j=0.
+        let got_full = output.to_host_bytes().expect("download output");
+        let got_bytes = &got_full[..hidden_us * 2];
+        let expected_bytes = &expert_stack_expected[..hidden_us * 2];
+        assert_parity(
+            "ffn step3 int4 expert_0_out",
+            got_bytes,
+            expected_bytes,
+            0.05,
+            0.999,
+        );
+    }
+
     // -------------------------------------------------------------------
     // PR 4b5 step 2: INT4 dequant smoke test.
     //

--- a/crates/kernel-ffi/src/qwen36_moe.rs
+++ b/crates/kernel-ffi/src/qwen36_moe.rs
@@ -408,6 +408,17 @@ extern "C" {
         shared_up_proj_w: *const c_void,
         shared_down_proj_w: *const c_void,
         shared_expert_gate_w: *const c_void,
+        int4_group_size: c_int,
+        gate_up_proj_scale: *const c_void,
+        gate_up_proj_zero: *const c_void,
+        down_proj_scale: *const c_void,
+        down_proj_zero: *const c_void,
+        shared_gate_proj_scale: *const c_void,
+        shared_gate_proj_zero: *const c_void,
+        shared_up_proj_scale: *const c_void,
+        shared_up_proj_zero: *const c_void,
+        shared_down_proj_scale: *const c_void,
+        shared_down_proj_zero: *const c_void,
         output: *mut c_void,
         output_idx: *mut c_int,
         workspace: *mut f32,
@@ -756,6 +767,10 @@ pub struct Qwen36MoeFfnStepParams {
 /// Weight pointers for the staged MoE FFN parity launcher. Pointers unused
 /// by the requested `stage` may be null; the kernel won't dereference them.
 /// See [`qwen36_moe_hip_ffn_step_launch`] for the per-stage matrix.
+///
+/// Each `*_proj_w` pointer carries either a BF16 weight slab (when the
+/// matching field in [`Qwen36MoeFfnStepInt4`] is null) or an INT4 packed-u8
+/// slab (when the matching `*_scale`/`*_zero` pair is set).
 #[derive(Debug, Clone, Copy)]
 pub struct Qwen36MoeFfnStepWeights {
     pub input_hidden: *const c_void,
@@ -767,6 +782,48 @@ pub struct Qwen36MoeFfnStepWeights {
     pub shared_up_proj_w: *const c_void,
     pub shared_down_proj_w: *const c_void,
     pub shared_expert_gate_w: *const c_void,
+}
+
+/// Optional INT4 sidecar pointers + group size for the FFN parity launcher
+/// (PR 4b5). `group_size == 0` ⇒ INT4 disabled and every sidecar pointer
+/// must be null. When non-zero, each tensor is independently switchable:
+/// a non-null `*_scale`/`*_zero` pair routes that tensor's matvec through
+/// `int4_dequant_scalar`; a null pair keeps it on the BF16 path. Scales
+/// and zeros are BF16 with the bake's group layout — `[..., out/gs, in/gs]`.
+#[derive(Debug, Clone, Copy)]
+pub struct Qwen36MoeFfnStepInt4 {
+    pub group_size: i32,
+    pub gate_up_proj_scale: *const c_void,
+    pub gate_up_proj_zero: *const c_void,
+    pub down_proj_scale: *const c_void,
+    pub down_proj_zero: *const c_void,
+    pub shared_gate_proj_scale: *const c_void,
+    pub shared_gate_proj_zero: *const c_void,
+    pub shared_up_proj_scale: *const c_void,
+    pub shared_up_proj_zero: *const c_void,
+    pub shared_down_proj_scale: *const c_void,
+    pub shared_down_proj_zero: *const c_void,
+}
+
+impl Qwen36MoeFfnStepInt4 {
+    /// All-null sidecars + group_size=0. Use this when the BF16 path is
+    /// what you want — the kernel falls through to the existing matvecs
+    /// for every tensor.
+    pub const fn disabled() -> Self {
+        Self {
+            group_size: 0,
+            gate_up_proj_scale: std::ptr::null(),
+            gate_up_proj_zero: std::ptr::null(),
+            down_proj_scale: std::ptr::null(),
+            down_proj_zero: std::ptr::null(),
+            shared_gate_proj_scale: std::ptr::null(),
+            shared_gate_proj_zero: std::ptr::null(),
+            shared_up_proj_scale: std::ptr::null(),
+            shared_up_proj_zero: std::ptr::null(),
+            shared_down_proj_scale: std::ptr::null(),
+            shared_down_proj_zero: std::ptr::null(),
+        }
+    }
 }
 
 /// Safe wrapper for the PR 4b4 staged MoE FFN parity launcher.
@@ -782,6 +839,7 @@ pub fn ffn_step_launch(
     dtype: ScalarType,
     params: Qwen36MoeFfnStepParams,
     weights: &Qwen36MoeFfnStepWeights,
+    int4: &Qwen36MoeFfnStepInt4,
     output: &mut GpuBuffer,
     output_idx: &mut GpuBuffer,
     workspace: &mut GpuBuffer,
@@ -835,6 +893,17 @@ pub fn ffn_step_launch(
                     weights.shared_up_proj_w,
                     weights.shared_down_proj_w,
                     weights.shared_expert_gate_w,
+                    int4.group_size as c_int,
+                    int4.gate_up_proj_scale,
+                    int4.gate_up_proj_zero,
+                    int4.down_proj_scale,
+                    int4.down_proj_zero,
+                    int4.shared_gate_proj_scale,
+                    int4.shared_gate_proj_zero,
+                    int4.shared_up_proj_scale,
+                    int4.shared_up_proj_zero,
+                    int4.shared_down_proj_scale,
+                    int4.shared_down_proj_zero,
                     output.as_mut_ptr(),
                     output_idx.as_mut_ptr() as *mut c_int,
                     workspace.as_mut_ptr() as *mut f32,
@@ -2821,18 +2890,45 @@ mod tests {
     }
 
     /// Workspace floats sufficient for the largest staged FFN intermediate
-    /// (stage 5). Same convention as `parity_workspace_floats` for the attn
-    /// kernel — keep tight so a stage that overruns fails loudly.
+    /// (stage 5). Mirrors the kernel's per-stage offset layout in
+    /// `kernels/qwen36_moe.hip` (search `OFF_H_NORM`):
+    ///   H_NORM        [hidden]
+    ///   ROUTER_LOGITS [E]
+    ///   ROUTER_PROBS  [E]
+    ///   TOPK_VAL      [k]
+    ///   TOPK_IDX      [k]
+    ///   SG_SCALAR     [1]
+    ///   SGP           [Is]
+    ///   SUP           [Is]
+    ///   SHARED_MID    [Is]
+    ///   SHARED_OUT    [hidden]
+    ///   EXPERT_GU     [2*I]
+    ///   EXPERT_MID    [I]
+    ///   EXPERT_STACK  [k*hidden]
+    ///   MOE_OUT       [hidden]
+    ///
+    /// PR 4b4 step 4 (the original stage-3+ test wiring) silently undersized
+    /// this by 385 floats on the synthetic config — it omitted SG_SCALAR,
+    /// SGP, SUP, EXPERT_GU and EXPERT_MID. The HIP allocator's slack hid the
+    /// OOB on the BF16 path. The new INT4-sidecar kernel parameters PR 4b5
+    /// step 3 adds shift register/stack layout enough that the same OOB
+    /// starts overwriting live cooperative-launch state and stage>=4 hangs.
+    /// The right fix is to size the buffer for what the kernel actually uses.
     #[cfg(supersonic_backend_hip)]
     fn ffn_parity_workspace_floats(geom: &FfnOracleGeom) -> usize {
         let hidden = geom.hidden as usize;
         let e = geom.num_experts as usize;
         let k = geom.top_k as usize;
         let is_dim = geom.shared_intermediate as usize;
-        // hidden + 2*E + 2*k (router pieces)
-        // + is_dim (shared_mid) + hidden (shared_out)
-        // + k*hidden (expert_stack) + hidden (moe_out) + hidden (output)
-        hidden + 2 * e + 2 * k + is_dim + 3 * hidden + k * hidden
+        let i_dim = geom.moe_intermediate as usize;
+        // 3*hidden = H_NORM + SHARED_OUT + MOE_OUT
+        // 2*e      = ROUTER_LOGITS + ROUTER_PROBS
+        // 2*k      = TOPK_VAL + TOPK_IDX
+        // 1        = SG_SCALAR
+        // 3*is_dim = SGP + SUP + SHARED_MID
+        // 3*i_dim  = EXPERT_GU(2*I) + EXPERT_MID(I)
+        // k*hidden = EXPERT_STACK
+        3 * hidden + 2 * e + 2 * k + 1 + 3 * is_dim + 3 * i_dim + k * hidden
     }
 
     /// Output BF16 elements sufficient for the largest staged FFN
@@ -2936,6 +3032,7 @@ mod tests {
             ScalarType::BF16,
             params,
             &weight_ptrs,
+            &Qwen36MoeFfnStepInt4::disabled(),
             &mut output,
             &mut output_idx,
             &mut workspace,
@@ -3078,6 +3175,7 @@ mod tests {
             ScalarType::BF16,
             params,
             &weight_ptrs,
+            &Qwen36MoeFfnStepInt4::disabled(),
             &mut output,
             &mut output_idx,
             &mut workspace,
@@ -3222,6 +3320,7 @@ mod tests {
             ScalarType::BF16,
             params,
             &weight_ptrs,
+            &Qwen36MoeFfnStepInt4::disabled(),
             &mut output,
             &mut output_idx,
             &mut workspace,
@@ -3355,6 +3454,7 @@ mod tests {
             ScalarType::BF16,
             params,
             &weight_ptrs,
+            &Qwen36MoeFfnStepInt4::disabled(),
             &mut output,
             &mut output_idx,
             &mut workspace,
@@ -3489,6 +3589,7 @@ mod tests {
             ScalarType::BF16,
             params,
             &weight_ptrs,
+            &Qwen36MoeFfnStepInt4::disabled(),
             &mut output,
             &mut output_idx,
             &mut workspace,
@@ -3506,6 +3607,234 @@ mod tests {
             "ffn step5 output_hidden",
             got_bytes,
             &output_hidden_expected_bytes,
+            0.05,
+            0.999,
+        );
+    }
+
+    // -------------------------------------------------------------------
+    // PR 4b5 step 3: shared-expert INT4 parity vs the INT4 oracle.
+    //
+    // Driven by the same env var as the BF16 FFN tests; skipped silently
+    // when the JSON's schema is not `qwen36-moe-oracle-ffn-int4-v1`. The
+    // INT4 oracle's `weights` block carries the BF16-reconstruction of
+    // each quantized tensor, so the BF16 reference computed against those
+    // weights is the exact intermediate the kernel must reproduce when
+    // it dequantizes (packed, scale, zero) on the fly.
+    //
+    // Step 3 wires only the shared-expert tensors (gate_proj, up_proj,
+    // down_proj). Fused-expert weights stay BF16 in this test —
+    // `weights.gate_up_proj_w` and `weights.down_proj_w` are uploaded as
+    // BF16 and `Qwen36MoeFfnStepInt4`'s fused-expert sidecars stay null.
+    // Steps 4/5 will switch those over.
+    // -------------------------------------------------------------------
+
+    #[cfg(supersonic_backend_hip)]
+    fn ffn_oracle_is_int4(json: &serde_json::Value) -> bool {
+        json["schema"].as_str() == Some("qwen36-moe-oracle-ffn-int4-v1")
+    }
+
+    /// Pulls (packed, scale, zero) bytes for one INT4-quantized FFN tensor
+    /// from the oracle JSON. Returns owned `Vec<u8>` buffers in their
+    /// native byte representations (u8 for packed, BF16 LE for scale/zero).
+    #[cfg(supersonic_backend_hip)]
+    fn decode_int4_sidecar(
+        json: &serde_json::Value, name: &str,
+    ) -> (Vec<u8>, Vec<u8>, Vec<u8>) {
+        let blk = &json["int4_weights"][name];
+        let packed = b64_decode(blk["packed"].as_str()
+            .unwrap_or_else(|| panic!("missing int4_weights[{name}].packed")));
+        let scale = b64_decode(blk["scale"].as_str()
+            .unwrap_or_else(|| panic!("missing int4_weights[{name}].scale")));
+        let zero = b64_decode(blk["zero"].as_str()
+            .unwrap_or_else(|| panic!("missing int4_weights[{name}].zero")));
+        (packed, scale, zero)
+    }
+
+    #[cfg(supersonic_backend_hip)]
+    #[test]
+    fn qwen36_moe_ffn_step_2_shared_out_int4_matches_oracle() {
+        use gpu_hal::{set_backend, Backend, GpuBuffer, ScalarType};
+
+        let Some((json, geom)) = load_ffn_oracle_json() else {
+            eprintln!(
+                "skip: SUPERSONIC_QWEN36_FFN_ORACLE_JSON not set. \
+                 Generate an INT4 fixture with \
+                 `python oracle/qwen36_moe_ffn_oracle.py --mode synthetic \
+                 --int4 --out /tmp/qwen36_ffn_int4.json` and re-run."
+            );
+            return;
+        };
+        if !ffn_oracle_is_int4(&json) {
+            eprintln!(
+                "skip: oracle JSON is not INT4 (schema={}). Generate one with \
+                 the `--int4` flag if you want to exercise this test.",
+                json["schema"].as_str().unwrap_or("?"),
+            );
+            return;
+        }
+        let cfg = &json["config"];
+        let group_size = cfg["int4_group_size"].as_i64().unwrap_or(0) as i32;
+        assert!(group_size > 0, "INT4 oracle missing config.int4_group_size");
+
+        let weights = &json["weights"];
+        let inters = &json["intermediates"];
+
+        // Shared-expert weights become INT4 packed bytes; everything else
+        // stays as BF16 from `weights`. The BF16 reconstruction is *not*
+        // used at the kernel call site for INT4 tensors (the kernel reads
+        // packed bytes), but the oracle ran its reference computation
+        // against the same reconstruction so the intermediate target lines
+        // up byte-for-byte with the kernel's output.
+        let input_hidden_bytes = b64_decode(weights["input_hidden"].as_str().unwrap());
+        let post_attn_norm_w_bytes = b64_decode(weights["post_attn_norm_w"].as_str().unwrap());
+        let gate_w_bytes = b64_decode(weights["gate_w"].as_str().unwrap());
+        let shared_expert_gate_w_bytes =
+            b64_decode(weights["shared_expert_gate_w"].as_str().unwrap());
+
+        let (sgp_packed, sgp_scale, sgp_zero) =
+            decode_int4_sidecar(&json, "shared_gate_proj_w");
+        let (sup_packed, sup_scale, sup_zero) =
+            decode_int4_sidecar(&json, "shared_up_proj_w");
+        let (sdp_packed, sdp_scale, sdp_zero) =
+            decode_int4_sidecar(&json, "shared_down_proj_w");
+
+        let shared_out_expected_bytes =
+            b64_decode(inters["shared_out"].as_str().unwrap());
+
+        let hidden_us = geom.hidden as usize;
+        let e_us = geom.num_experts as usize;
+        let is_us = geom.shared_intermediate as usize;
+        let k_us = geom.top_k as usize;
+        let gsz_us = group_size as usize;
+
+        // Sanity: shapes match the bake convention.
+        assert_eq!(sgp_packed.len(), is_us * (hidden_us / 2),
+            "shared_gate_proj packed bytes mismatch");
+        assert_eq!(sgp_scale.len(), (is_us / gsz_us) * (hidden_us / gsz_us) * 2,
+            "shared_gate_proj scale bytes mismatch");
+        assert_eq!(sup_packed.len(), is_us * (hidden_us / 2));
+        assert_eq!(sdp_packed.len(), hidden_us * (is_us / 2));
+        assert_eq!(shared_out_expected_bytes.len(), hidden_us * 2);
+
+        set_backend(Backend::Hip);
+        let ordinal = 0usize;
+
+        let input_hidden = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_us], &input_hidden_bytes,
+        ).expect("upload input_hidden");
+        let post_attn_norm_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_us], &post_attn_norm_w_bytes,
+        ).expect("upload post_attn_norm_w");
+        let gate_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[e_us, hidden_us], &gate_w_bytes,
+        ).expect("upload gate_w");
+        let shared_expert_gate_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[1, hidden_us], &shared_expert_gate_w_bytes,
+        ).expect("upload shared_expert_gate_w");
+
+        // Packed INT4 buffers — uploaded as u8.
+        let sgp_packed_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::U8, &[sgp_packed.len()], &sgp_packed,
+        ).expect("upload sgp packed");
+        let sup_packed_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::U8, &[sup_packed.len()], &sup_packed,
+        ).expect("upload sup packed");
+        let sdp_packed_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::U8, &[sdp_packed.len()], &sdp_packed,
+        ).expect("upload sdp packed");
+        // BF16 scale/zero sidecars.
+        let sgp_scale_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[sgp_scale.len() / 2], &sgp_scale,
+        ).expect("upload sgp scale");
+        let sgp_zero_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[sgp_zero.len() / 2], &sgp_zero,
+        ).expect("upload sgp zero");
+        let sup_scale_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[sup_scale.len() / 2], &sup_scale,
+        ).expect("upload sup scale");
+        let sup_zero_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[sup_zero.len() / 2], &sup_zero,
+        ).expect("upload sup zero");
+        let sdp_scale_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[sdp_scale.len() / 2], &sdp_scale,
+        ).expect("upload sdp scale");
+        let sdp_zero_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[sdp_zero.len() / 2], &sdp_zero,
+        ).expect("upload sdp zero");
+
+        let mut output = GpuBuffer::zeros(
+            ordinal, ScalarType::BF16, &[ffn_parity_output_elems(&geom)],
+        ).expect("alloc output");
+        let mut output_idx = GpuBuffer::zeros(
+            ordinal, ScalarType::U32, &[k_us],
+        ).expect("alloc output_idx");
+        let mut workspace = GpuBuffer::zeros(
+            ordinal, ScalarType::F32, &[ffn_parity_workspace_floats(&geom)],
+        ).expect("alloc workspace");
+        let mut sync_buf = GpuBuffer::zeros(
+            ordinal, ScalarType::U8, &[32],
+        ).expect("alloc sync buf");
+
+        let params = Qwen36MoeFfnStepParams {
+            stage: 2,
+            hidden: geom.hidden,
+            num_experts: geom.num_experts,
+            moe_intermediate: geom.moe_intermediate,
+            shared_intermediate: geom.shared_intermediate,
+            top_k: geom.top_k,
+            rms_norm_eps: geom.rms_norm_eps,
+        };
+        // Shared-expert weight pointers point at the *packed* u8 buffers.
+        // Fused-expert pointers stay null (stage<3 doesn't read them).
+        let weight_ptrs = Qwen36MoeFfnStepWeights {
+            input_hidden: input_hidden.as_ptr(),
+            post_attn_norm_w: post_attn_norm_w.as_ptr(),
+            gate_w: gate_w.as_ptr(),
+            gate_up_proj_w: std::ptr::null(),
+            down_proj_w: std::ptr::null(),
+            shared_gate_proj_w: sgp_packed_buf.as_ptr(),
+            shared_up_proj_w: sup_packed_buf.as_ptr(),
+            shared_down_proj_w: sdp_packed_buf.as_ptr(),
+            shared_expert_gate_w: shared_expert_gate_w.as_ptr(),
+        };
+        let int4_ptrs = Qwen36MoeFfnStepInt4 {
+            group_size,
+            gate_up_proj_scale: std::ptr::null(),
+            gate_up_proj_zero: std::ptr::null(),
+            down_proj_scale: std::ptr::null(),
+            down_proj_zero: std::ptr::null(),
+            shared_gate_proj_scale: sgp_scale_buf.as_ptr(),
+            shared_gate_proj_zero: sgp_zero_buf.as_ptr(),
+            shared_up_proj_scale: sup_scale_buf.as_ptr(),
+            shared_up_proj_zero: sup_zero_buf.as_ptr(),
+            shared_down_proj_scale: sdp_scale_buf.as_ptr(),
+            shared_down_proj_zero: sdp_zero_buf.as_ptr(),
+        };
+
+        ffn_step_launch(
+            ordinal,
+            ScalarType::BF16,
+            params,
+            &weight_ptrs,
+            &int4_ptrs,
+            &mut output,
+            &mut output_idx,
+            &mut workspace,
+            &mut sync_buf,
+        )
+        .expect("ffn_step_launch stage 2 (int4)");
+
+        // Same envelope as the BF16 stage 2 test: cos_sim ≥ 0.999, max
+        // |delta| ≤ 0.05. The reconstruction is bit-identical to what the
+        // oracle ran reference against, so any residual disagreement is
+        // F32 reduction-order drift through the matvec — same as BF16.
+        let got_full = output.to_host_bytes().expect("download output");
+        let got_bytes = &got_full[..hidden_us * 2];
+        assert_parity(
+            "ffn step2 int4 shared_out",
+            got_bytes,
+            &shared_out_expected_bytes,
             0.05,
             0.999,
         );

--- a/crates/kernel-ffi/src/qwen36_moe.rs
+++ b/crates/kernel-ffi/src/qwen36_moe.rs
@@ -357,6 +357,38 @@ extern "C" {
     /// least `top_k` BF16 entries on stage 1 and `output_idx` must be at
     /// least `top_k` i32 entries. `sync_buf` (counters/barrier_counter/
     /// barrier_flag) must be 32 zero bytes.
+    ///
+    /// PR 4b5 step 2: INT4 dequant smoke launcher.
+    ///
+    /// Drives a tiny single-thread kernel that runs both `int4_dequant_8`
+    /// and `int4_dequant_scalar` over a `[out_rows, in_cols]` slab, writing
+    /// each helper's outputs into a separate buffer. The Rust-side test
+    /// validates byte-for-byte against a host reference computing the same
+    /// `bf16(q*s - z*s)` reconstruction. Catches porting bugs in the
+    /// helpers in isolation, before they're folded into the real FFN
+    /// matmuls in step 3+.
+    ///
+    /// `packed`: u8, shape `[out_rows, in_cols / 2]`, even col → low nibble.
+    /// `scale` / `zero`: BF16, shape `[out_rows / gsz, in_cols / gsz]`.
+    /// `dq_8_out`, `dq_scalar_out`: F32 device buffers, each
+    /// `out_rows * in_cols` long.
+    ///
+    /// Pre-conditions (the bridge validates them):
+    /// - `in_cols % 8 == 0`
+    /// - `in_cols % gsz == 0` and `gsz % 2 == 0`
+    /// - `out_rows % gsz == 0`
+    pub fn qwen36_moe_hip_int4_dequant_smoke_launch(
+        device_ordinal: usize,
+        packed: *const u8,
+        scale: *const c_void,
+        zero: *const c_void,
+        out_rows: c_int,
+        in_cols: c_int,
+        gsz: c_int,
+        dq_8_out: *mut f32,
+        dq_scalar_out: *mut f32,
+    ) -> c_int;
+
     pub fn qwen36_moe_hip_ffn_step_launch(
         dtype: c_int,
         device_ordinal: usize,
@@ -833,6 +865,95 @@ pub fn ffn_step_launch(
         return Err(GpuError::backend(
             backend,
             format!("qwen36_moe ffn_step launch failed with status {status}"),
+        ));
+    }
+    Ok(())
+}
+
+/// PR 4b5 step 2 safe wrapper for the INT4 dequant smoke launcher.
+///
+/// Drives the smoke kernel that exercises both `int4_dequant_8` and
+/// `int4_dequant_scalar` over the supplied `[out_rows, in_cols]` slab.
+/// `packed_buf` must be a u8 buffer with `out_rows * in_cols / 2` bytes.
+/// `scale_buf` and `zero_buf` must be BF16 buffers with `(out_rows / gsz)
+/// * (in_cols / gsz)` elements each. `dq_8_out` and `dq_scalar_out` must
+/// each be F32 buffers with at least `out_rows * in_cols` elements.
+#[allow(clippy::too_many_arguments)]
+pub fn int4_dequant_smoke_launch(
+    ordinal: usize,
+    packed_buf: &GpuBuffer,
+    scale_buf: &GpuBuffer,
+    zero_buf: &GpuBuffer,
+    out_rows: i32,
+    in_cols: i32,
+    gsz: i32,
+    dq_8_out: &mut GpuBuffer,
+    dq_scalar_out: &mut GpuBuffer,
+) -> Result<(), GpuError> {
+    if out_rows <= 0 || in_cols <= 0 || gsz <= 0 {
+        return Err(GpuError::InvalidArg(format!(
+            "qwen36_moe::int4_dequant_smoke_launch: positive dims required, \
+             got out_rows={out_rows} in_cols={in_cols} gsz={gsz}"
+        )));
+    }
+    if in_cols % 8 != 0 {
+        return Err(GpuError::InvalidArg(format!(
+            "qwen36_moe::int4_dequant_smoke_launch: in_cols ({in_cols}) must \
+             be divisible by 8 (the helpers' fast-path stride)"
+        )));
+    }
+    if in_cols % gsz != 0 || gsz % 2 != 0 {
+        return Err(GpuError::InvalidArg(format!(
+            "qwen36_moe::int4_dequant_smoke_launch: in_cols ({in_cols}) must \
+             be divisible by gsz ({gsz}) and gsz must be even"
+        )));
+    }
+    if out_rows % gsz != 0 {
+        return Err(GpuError::InvalidArg(format!(
+            "qwen36_moe::int4_dequant_smoke_launch: out_rows ({out_rows}) must \
+             be divisible by gsz ({gsz})"
+        )));
+    }
+
+    let backend = packed_buf.backend();
+    let status = match backend {
+        Backend::Hip => {
+            #[cfg(supersonic_backend_hip)]
+            unsafe {
+                qwen36_moe_hip_int4_dequant_smoke_launch(
+                    ordinal,
+                    packed_buf.as_ptr() as *const u8,
+                    scale_buf.as_ptr(),
+                    zero_buf.as_ptr(),
+                    out_rows as c_int,
+                    in_cols as c_int,
+                    gsz as c_int,
+                    dq_8_out.as_mut_ptr() as *mut f32,
+                    dq_scalar_out.as_mut_ptr() as *mut f32,
+                )
+            }
+            #[cfg(not(supersonic_backend_hip))]
+            {
+                return Err(GpuError::InvalidArg(
+                    "qwen36_moe::int4_dequant_smoke_launch: HIP backend not compiled".into(),
+                ));
+            }
+        }
+        Backend::Cuda => {
+            return Err(GpuError::InvalidArg(
+                "qwen36_moe::int4_dequant_smoke_launch: CUDA backend not yet wired".into(),
+            ));
+        }
+        Backend::Metal => {
+            return Err(GpuError::InvalidArg(
+                "qwen36_moe::int4_dequant_smoke_launch: Metal backend not yet wired".into(),
+            ));
+        }
+    };
+    if status != 0 {
+        return Err(GpuError::backend(
+            backend,
+            format!("qwen36_moe int4_dequant_smoke_launch failed with status {status}"),
         ));
     }
     Ok(())
@@ -3388,5 +3509,224 @@ mod tests {
             0.05,
             0.999,
         );
+    }
+
+    // -------------------------------------------------------------------
+    // PR 4b5 step 2: INT4 dequant smoke test.
+    //
+    // Builds a small `[out_rows, in_cols]` weight slab in F32 on host,
+    // runs min/max group-quant to (packed u8, BF16 scale, BF16 zero) with
+    // exactly the same math as `oracle/qwen36_moe_ffn_oracle.py`, uploads
+    // the sidecars, calls the smoke launcher, and verifies the GPU
+    // outputs of `int4_dequant_8` and `int4_dequant_scalar` both equal a
+    // host-computed reference byte-for-byte (these are F32 values rounded
+    // through BF16, so exact equality is the right bar).
+    //
+    // Two configs run in succession to cover both helper paths:
+    //   gsz=8, in_cols=16  → every 8-col span lies in one group     (fast)
+    //   gsz=4, in_cols=16  → every 8-col span crosses a boundary    (slow)
+    // -------------------------------------------------------------------
+
+    /// BF16 round-to-nearest-even of an F32 value, returning the 16-bit
+    /// big-end-of-F32 representation. Same math as the kernel's
+    /// `bf16_round_rne_f32`.
+    #[cfg(supersonic_backend_hip)]
+    fn bf16_round_bits(x: f32) -> u16 {
+        let bits = x.to_bits();
+        let rounding_bias = 0x7FFFu32 + ((bits >> 16) & 1);
+        let r = bits.wrapping_add(rounding_bias);
+        (r >> 16) as u16
+    }
+
+    /// Reverse: F32 from a BF16 bit pattern.
+    #[cfg(supersonic_backend_hip)]
+    fn f32_from_bf16(b: u16) -> f32 {
+        f32::from_bits((b as u32) << 16)
+    }
+
+    /// Min/max INT4 group-quant on a 2D `[out, in]` F32 slab — Rust mirror
+    /// of `minmax_int4_packed_and_recon` in the FFN oracle. Returns
+    /// `(packed [out, in/2] u8, scale [out/gs, in/gs] u16-as-BF16,
+    /// zero [out/gs, in/gs] u16-as-BF16)`.
+    #[cfg(supersonic_backend_hip)]
+    fn host_minmax_int4(
+        w: &[f32], out_rows: usize, in_cols: usize, gsz: usize,
+    ) -> (Vec<u8>, Vec<u16>, Vec<u16>) {
+        assert_eq!(w.len(), out_rows * in_cols);
+        assert_eq!(out_rows % gsz, 0);
+        assert_eq!(in_cols % gsz, 0);
+        assert_eq!(in_cols % 2, 0);
+        let sr = out_rows / gsz;
+        let sc = in_cols / gsz;
+
+        let mut packed = vec![0u8; out_rows * (in_cols / 2)];
+        let mut scale = vec![0u16; sr * sc];
+        let mut zero = vec![0u16; sr * sc];
+
+        for gr in 0..sr {
+            for gc in 0..sc {
+                let mut tmin = f32::INFINITY;
+                let mut tmax = f32::NEG_INFINITY;
+                for r in 0..gsz {
+                    for c in 0..gsz {
+                        let v = w[(gr * gsz + r) * in_cols + gc * gsz + c];
+                        tmin = tmin.min(v);
+                        tmax = tmax.max(v);
+                    }
+                }
+                let rng = tmax - tmin;
+                let s_f = if rng > 0.0 { rng / 15.0 } else { 1.0 };
+                let z_f = if rng > 0.0 { -tmin / s_f } else { 0.0 };
+                let s_bits = bf16_round_bits(s_f);
+                let z_bits = bf16_round_bits(z_f);
+                scale[gr * sc + gc] = s_bits;
+                zero[gr * sc + gc] = z_bits;
+                let s = f32_from_bf16(s_bits);
+                let z = f32_from_bf16(z_bits);
+                for r in 0..gsz {
+                    for c in 0..gsz {
+                        let row = gr * gsz + r;
+                        let col = gc * gsz + c;
+                        let v = w[row * in_cols + col];
+                        let q = (v / s + z).round().clamp(0.0, 15.0) as u8;
+                        // Pack: even col → low nibble, odd col → high nibble.
+                        let byte_idx = row * (in_cols / 2) + col / 2;
+                        if col & 1 == 0 {
+                            packed[byte_idx] = (packed[byte_idx] & 0xF0) | (q & 0x0F);
+                        } else {
+                            packed[byte_idx] = (packed[byte_idx] & 0x0F) | ((q & 0x0F) << 4);
+                        }
+                    }
+                }
+            }
+        }
+        (packed, scale, zero)
+    }
+
+    /// Reference reconstruction: `bf16(q*s - z*s)` per element. Returns
+    /// F32 values whose lower 16 bits are zero (i.e. exactly BF16-precision).
+    #[cfg(supersonic_backend_hip)]
+    fn host_dequant_recon(
+        packed: &[u8], scale: &[u16], zero: &[u16],
+        out_rows: usize, in_cols: usize, gsz: usize,
+    ) -> Vec<f32> {
+        let sc = in_cols / gsz;
+        let mut out = vec![0.0f32; out_rows * in_cols];
+        for row in 0..out_rows {
+            for col in 0..in_cols {
+                let gi = (row / gsz) * sc + col / gsz;
+                let s = f32_from_bf16(scale[gi]);
+                let z = f32_from_bf16(zero[gi]);
+                let byte = packed[row * (in_cols / 2) + col / 2];
+                let n = if col & 1 == 0 { byte & 0x0F } else { (byte >> 4) & 0x0F };
+                let v = (n as f32) * s - z * s;
+                out[row * in_cols + col] = f32::from_bits(
+                    (bf16_round_bits(v) as u32) << 16,
+                );
+            }
+        }
+        out
+    }
+
+    /// Encode a slice of BF16 16-bit values to LE bytes for `from_host_bytes`.
+    #[cfg(supersonic_backend_hip)]
+    fn bf16_bits_to_bytes(bits: &[u16]) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(bits.len() * 2);
+        for b in bits {
+            bytes.extend_from_slice(&b.to_le_bytes());
+        }
+        bytes
+    }
+
+    /// Drives one (out_rows, in_cols, gsz) configuration through the smoke
+    /// kernel and asserts both helper outputs match the host reference
+    /// exactly.
+    #[cfg(supersonic_backend_hip)]
+    fn run_int4_dequant_smoke(out_rows: usize, in_cols: usize, gsz: usize, label: &str) {
+        use gpu_hal::{set_backend, Backend, GpuBuffer, ScalarType};
+        set_backend(Backend::Hip);
+        let ordinal = 0usize;
+
+        // Deterministic synthetic weights: a 32-bit LCG seeded by config so
+        // each smoke variant uses different but reproducible values.
+        let n = out_rows * in_cols;
+        let mut rng_state: u32 = 0xC0FFEE
+            ^ ((out_rows as u32) << 16)
+            ^ ((in_cols as u32) << 8)
+            ^ (gsz as u32);
+        let mut w = vec![0.0f32; n];
+        for v in w.iter_mut() {
+            // LCG (Numerical Recipes constants) → uniform [-1, 1).
+            rng_state = rng_state.wrapping_mul(1664525).wrapping_add(1013904223);
+            let u = (rng_state >> 8) as f32 / ((1u32 << 24) as f32); // [0,1)
+            *v = u * 2.0 - 1.0;
+        }
+
+        let (packed, scale_bits, zero_bits) = host_minmax_int4(&w, out_rows, in_cols, gsz);
+        let recon_ref = host_dequant_recon(&packed, &scale_bits, &zero_bits,
+                                            out_rows, in_cols, gsz);
+
+        let packed_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::U8, &[packed.len()], &packed,
+        ).expect("upload packed");
+        let scale_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[scale_bits.len()],
+            &bf16_bits_to_bytes(&scale_bits),
+        ).expect("upload scale");
+        let zero_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[zero_bits.len()],
+            &bf16_bits_to_bytes(&zero_bits),
+        ).expect("upload zero");
+
+        let mut dq_8 = GpuBuffer::zeros(ordinal, ScalarType::F32, &[n])
+            .expect("alloc dq_8");
+        let mut dq_scalar = GpuBuffer::zeros(ordinal, ScalarType::F32, &[n])
+            .expect("alloc dq_scalar");
+
+        int4_dequant_smoke_launch(
+            ordinal,
+            &packed_buf, &scale_buf, &zero_buf,
+            out_rows as i32, in_cols as i32, gsz as i32,
+            &mut dq_8, &mut dq_scalar,
+        ).expect("smoke launch");
+
+        let dq_8_bytes = dq_8.to_host_bytes().expect("download dq_8");
+        let dq_scalar_bytes = dq_scalar.to_host_bytes().expect("download dq_scalar");
+        let dq_8_v: Vec<f32> = dq_8_bytes.chunks_exact(4)
+            .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]])).collect();
+        let dq_scalar_v: Vec<f32> = dq_scalar_bytes.chunks_exact(4)
+            .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]])).collect();
+
+        for i in 0..n {
+            assert_eq!(
+                dq_8_v[i].to_bits(), recon_ref[i].to_bits(),
+                "[{label}] int4_dequant_8 mismatch at i={i}: got {} ({:#010x}), want {} ({:#010x})",
+                dq_8_v[i], dq_8_v[i].to_bits(),
+                recon_ref[i], recon_ref[i].to_bits(),
+            );
+            assert_eq!(
+                dq_scalar_v[i].to_bits(), recon_ref[i].to_bits(),
+                "[{label}] int4_dequant_scalar mismatch at i={i}: got {} ({:#010x}), want {} ({:#010x})",
+                dq_scalar_v[i], dq_scalar_v[i].to_bits(),
+                recon_ref[i], recon_ref[i].to_bits(),
+            );
+        }
+    }
+
+    #[cfg(supersonic_backend_hip)]
+    #[test]
+    fn qwen36_moe_int4_dequant_smoke_fast_path() {
+        // gsz=8, in_cols=16 → every 8-col span lies in one group, so
+        // `int4_dequant_8` exercises its `g0 == g7` fast path on every span.
+        run_int4_dequant_smoke(8, 16, 8, "fast (gsz=8)");
+    }
+
+    #[cfg(supersonic_backend_hip)]
+    #[test]
+    fn qwen36_moe_int4_dequant_smoke_slow_path() {
+        // gsz=4, in_cols=16 → 8-col spans starting at col=0 cross from
+        // group 0 to group 1 (boundary at col=4); spans starting at col=8
+        // cross 2→3. Exercises the per-element `g0 != g7` slow path.
+        run_int4_dequant_smoke(8, 16, 4, "slow (gsz=4)");
     }
 }

--- a/crates/kernel-ffi/src/qwen36_moe.rs
+++ b/crates/kernel-ffi/src/qwen36_moe.rs
@@ -280,6 +280,9 @@ extern "C" {
         o_proj_zero: *const c_void,
         output: *mut c_void,
         workspace: *mut f32,
+        kv_cache_k: *mut c_void,
+        kv_cache_v: *mut c_void,
+        kv_max_t: c_int,
         counters: *mut c_uint,
         barrier_counter: *mut c_uint,
         barrier_flag: *mut c_uint,
@@ -545,6 +548,33 @@ pub struct Qwen36MoeAttnStepWeights {
     pub q_norm_w: *const c_void,
     pub k_norm_w: *const c_void,
     pub o_proj_w: *const c_void,
+    /// PR 4d KV cache. When both `kv_cache_k` and `kv_cache_v` are non-null
+    /// (and `kv_max_t > 0`), the kernel writes the current step's K/V at
+    /// slot `position` and attends over `kv_len = position + 1` past tokens.
+    /// When both are null, falls back to the kv_len=1 self-attention path
+    /// (back-compat for the per-block parity tests). Layout: BF16 tensors
+    /// of shape `[kv_max_t, num_kv_heads * head_dim]`.
+    pub kv_cache_k: *mut c_void,
+    pub kv_cache_v: *mut c_void,
+    pub kv_max_t: i32,
+}
+
+impl Default for Qwen36MoeAttnStepWeights {
+    fn default() -> Self {
+        Self {
+            input_hidden: std::ptr::null(),
+            input_norm_w: std::ptr::null(),
+            q_proj_w: std::ptr::null(),
+            k_proj_w: std::ptr::null(),
+            v_proj_w: std::ptr::null(),
+            q_norm_w: std::ptr::null(),
+            k_norm_w: std::ptr::null(),
+            o_proj_w: std::ptr::null(),
+            kv_cache_k: std::ptr::null_mut(),
+            kv_cache_v: std::ptr::null_mut(),
+            kv_max_t: 0,
+        }
+    }
 }
 
 /// Optional INT4 sidecar pointers + group size for the full-attention
@@ -655,6 +685,9 @@ pub fn attn_step_launch(
                     int4.o_proj_zero,
                     output.as_mut_ptr(),
                     workspace.as_mut_ptr() as *mut f32,
+                    weights.kv_cache_k,
+                    weights.kv_cache_v,
+                    weights.kv_max_t as c_int,
                     counters,
                     barrier_counter,
                     barrier_flag,
@@ -1595,6 +1628,9 @@ mod tests {
             q_norm_w: q_norm_w.as_ptr(),
             k_norm_w: std::ptr::null(),
             o_proj_w: std::ptr::null(),
+            kv_cache_k: std::ptr::null_mut(),
+            kv_cache_v: std::ptr::null_mut(),
+            kv_max_t: 0,
         };
 
         attn_step_launch(
@@ -1713,6 +1749,9 @@ mod tests {
             q_norm_w: q_norm_w.as_ptr(),
             k_norm_w: k_norm_w.as_ptr(),
             o_proj_w: std::ptr::null(),
+            kv_cache_k: std::ptr::null_mut(),
+            kv_cache_v: std::ptr::null_mut(),
+            kv_max_t: 0,
         };
 
         attn_step_launch(
@@ -1840,6 +1879,9 @@ mod tests {
             q_norm_w: q_norm_w.as_ptr(),
             k_norm_w: k_norm_w.as_ptr(),
             o_proj_w: std::ptr::null(),
+            kv_cache_k: std::ptr::null_mut(),
+            kv_cache_v: std::ptr::null_mut(),
+            kv_max_t: 0,
         };
 
         attn_step_launch(
@@ -1958,6 +2000,9 @@ mod tests {
             q_norm_w: q_norm_w.as_ptr(),
             k_norm_w: k_norm_w.as_ptr(),
             o_proj_w: std::ptr::null(),
+            kv_cache_k: std::ptr::null_mut(),
+            kv_cache_v: std::ptr::null_mut(),
+            kv_max_t: 0,
         };
 
         attn_step_launch(
@@ -2079,6 +2124,9 @@ mod tests {
             q_norm_w: q_norm_w.as_ptr(),
             k_norm_w: k_norm_w.as_ptr(),
             o_proj_w: o_proj_w.as_ptr(),
+            kv_cache_k: std::ptr::null_mut(),
+            kv_cache_v: std::ptr::null_mut(),
+            kv_max_t: 0,
         };
 
         attn_step_launch(
@@ -2293,6 +2341,9 @@ mod tests {
             q_norm_w: q_norm_w.as_ptr(),
             k_norm_w: k_norm_w.as_ptr(),
             o_proj_w: o_packed_buf.as_ptr(),
+            kv_cache_k: std::ptr::null_mut(),
+            kv_cache_v: std::ptr::null_mut(),
+            kv_max_t: 0,
         };
         let int4_ptrs = Qwen36MoeAttnStepInt4 {
             group_size,

--- a/crates/kernel-ffi/src/qwen36_moe.rs
+++ b/crates/kernel-ffi/src/qwen36_moe.rs
@@ -4040,6 +4040,205 @@ mod tests {
         );
     }
 
+    #[cfg(supersonic_backend_hip)]
+    #[test]
+    fn qwen36_moe_ffn_step_5_output_hidden_int4_matches_oracle() {
+        use gpu_hal::{set_backend, Backend, GpuBuffer, ScalarType};
+
+        let Some((json, geom)) = load_ffn_oracle_json() else {
+            eprintln!(
+                "skip: SUPERSONIC_QWEN36_FFN_ORACLE_JSON not set. \
+                 See `qwen36_moe_ffn_step_2_shared_out_int4_matches_oracle` for setup."
+            );
+            return;
+        };
+        if !ffn_oracle_is_int4(&json) {
+            eprintln!(
+                "skip: oracle JSON is not INT4 (schema={}). Generate one with \
+                 `--int4` to exercise this test.",
+                json["schema"].as_str().unwrap_or("?"),
+            );
+            return;
+        }
+        let cfg = &json["config"];
+        let group_size = cfg["int4_group_size"].as_i64().unwrap_or(0) as i32;
+        assert!(group_size > 0, "INT4 oracle missing config.int4_group_size");
+
+        let weights = &json["weights"];
+        let inters = &json["intermediates"];
+
+        // Stage 5 = the full FFN block. All five quantizable tensors flow
+        // through the INT4 path (Phase D: shared gate/up; Phase F: shared
+        // down; Phase G: gate_up_proj per expert; Phase I: down_proj per
+        // expert). The non-quantized tensors stay BF16.
+        let input_hidden_bytes = b64_decode(weights["input_hidden"].as_str().unwrap());
+        let post_attn_norm_w_bytes = b64_decode(weights["post_attn_norm_w"].as_str().unwrap());
+        let gate_w_bytes = b64_decode(weights["gate_w"].as_str().unwrap());
+        let shared_expert_gate_w_bytes =
+            b64_decode(weights["shared_expert_gate_w"].as_str().unwrap());
+
+        let (gup_packed, gup_scale, gup_zero) =
+            decode_int4_sidecar(&json, "gate_up_proj_w");
+        let (dp_packed, dp_scale, dp_zero) =
+            decode_int4_sidecar(&json, "down_proj_w");
+        let (sgp_packed, sgp_scale, sgp_zero) =
+            decode_int4_sidecar(&json, "shared_gate_proj_w");
+        let (sup_packed, sup_scale, sup_zero) =
+            decode_int4_sidecar(&json, "shared_up_proj_w");
+        let (sdp_packed, sdp_scale, sdp_zero) =
+            decode_int4_sidecar(&json, "shared_down_proj_w");
+
+        let output_hidden_expected = b64_decode(inters["output_hidden"].as_str().unwrap());
+
+        let hidden_us = geom.hidden as usize;
+        let e_us = geom.num_experts as usize;
+        let i_us = geom.moe_intermediate as usize;
+        let is_us = geom.shared_intermediate as usize;
+        let k_us = geom.top_k as usize;
+
+        // Sanity: down_proj packed shape is [E, hidden, I/2].
+        assert_eq!(dp_packed.len(), e_us * hidden_us * (i_us / 2),
+            "down_proj packed bytes mismatch");
+
+        set_backend(Backend::Hip);
+        let ordinal = 0usize;
+
+        let input_hidden = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_us], &input_hidden_bytes,
+        ).expect("upload input_hidden");
+        let post_attn_norm_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_us], &post_attn_norm_w_bytes,
+        ).expect("upload post_attn_norm_w");
+        let gate_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[e_us, hidden_us], &gate_w_bytes,
+        ).expect("upload gate_w");
+        let shared_expert_gate_w = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[1, hidden_us], &shared_expert_gate_w_bytes,
+        ).expect("upload shared_expert_gate_w");
+
+        // All five INT4 tensors uploaded as packed u8 + BF16 sidecars.
+        let gup_packed_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::U8, &[gup_packed.len()], &gup_packed,
+        ).expect("upload gup packed");
+        let gup_scale_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[gup_scale.len() / 2], &gup_scale,
+        ).expect("upload gup scale");
+        let gup_zero_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[gup_zero.len() / 2], &gup_zero,
+        ).expect("upload gup zero");
+        let dp_packed_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::U8, &[dp_packed.len()], &dp_packed,
+        ).expect("upload dp packed");
+        let dp_scale_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[dp_scale.len() / 2], &dp_scale,
+        ).expect("upload dp scale");
+        let dp_zero_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[dp_zero.len() / 2], &dp_zero,
+        ).expect("upload dp zero");
+        let sgp_packed_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::U8, &[sgp_packed.len()], &sgp_packed,
+        ).expect("upload sgp packed");
+        let sgp_scale_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[sgp_scale.len() / 2], &sgp_scale,
+        ).expect("upload sgp scale");
+        let sgp_zero_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[sgp_zero.len() / 2], &sgp_zero,
+        ).expect("upload sgp zero");
+        let sup_packed_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::U8, &[sup_packed.len()], &sup_packed,
+        ).expect("upload sup packed");
+        let sup_scale_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[sup_scale.len() / 2], &sup_scale,
+        ).expect("upload sup scale");
+        let sup_zero_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[sup_zero.len() / 2], &sup_zero,
+        ).expect("upload sup zero");
+        let sdp_packed_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::U8, &[sdp_packed.len()], &sdp_packed,
+        ).expect("upload sdp packed");
+        let sdp_scale_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[sdp_scale.len() / 2], &sdp_scale,
+        ).expect("upload sdp scale");
+        let sdp_zero_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[sdp_zero.len() / 2], &sdp_zero,
+        ).expect("upload sdp zero");
+
+        let mut output = GpuBuffer::zeros(
+            ordinal, ScalarType::BF16, &[ffn_parity_output_elems(&geom)],
+        ).expect("alloc output");
+        let mut output_idx = GpuBuffer::zeros(
+            ordinal, ScalarType::U32, &[k_us],
+        ).expect("alloc output_idx");
+        let mut workspace = GpuBuffer::zeros(
+            ordinal, ScalarType::F32, &[ffn_parity_workspace_floats(&geom)],
+        ).expect("alloc workspace");
+        let mut sync_buf = GpuBuffer::zeros(
+            ordinal, ScalarType::U8, &[32],
+        ).expect("alloc sync buf");
+
+        let _ = (i_us, is_us);  // kept for clarity above.
+
+        let params = Qwen36MoeFfnStepParams {
+            stage: 5,
+            hidden: geom.hidden,
+            num_experts: geom.num_experts,
+            moe_intermediate: geom.moe_intermediate,
+            shared_intermediate: geom.shared_intermediate,
+            top_k: geom.top_k,
+            rms_norm_eps: geom.rms_norm_eps,
+        };
+        let weight_ptrs = Qwen36MoeFfnStepWeights {
+            input_hidden: input_hidden.as_ptr(),
+            post_attn_norm_w: post_attn_norm_w.as_ptr(),
+            gate_w: gate_w.as_ptr(),
+            gate_up_proj_w: gup_packed_buf.as_ptr(),
+            down_proj_w: dp_packed_buf.as_ptr(),
+            shared_gate_proj_w: sgp_packed_buf.as_ptr(),
+            shared_up_proj_w: sup_packed_buf.as_ptr(),
+            shared_down_proj_w: sdp_packed_buf.as_ptr(),
+            shared_expert_gate_w: shared_expert_gate_w.as_ptr(),
+        };
+        let int4_ptrs = Qwen36MoeFfnStepInt4 {
+            group_size,
+            gate_up_proj_scale: gup_scale_buf.as_ptr(),
+            gate_up_proj_zero: gup_zero_buf.as_ptr(),
+            down_proj_scale: dp_scale_buf.as_ptr(),
+            down_proj_zero: dp_zero_buf.as_ptr(),
+            shared_gate_proj_scale: sgp_scale_buf.as_ptr(),
+            shared_gate_proj_zero: sgp_zero_buf.as_ptr(),
+            shared_up_proj_scale: sup_scale_buf.as_ptr(),
+            shared_up_proj_zero: sup_zero_buf.as_ptr(),
+            shared_down_proj_scale: sdp_scale_buf.as_ptr(),
+            shared_down_proj_zero: sdp_zero_buf.as_ptr(),
+        };
+
+        ffn_step_launch(
+            ordinal,
+            ScalarType::BF16,
+            params,
+            &weight_ptrs,
+            &int4_ptrs,
+            &mut output,
+            &mut output_idx,
+            &mut workspace,
+            &mut sync_buf,
+        )
+        .expect("ffn_step_launch stage 5 (int4)");
+
+        // Stage 5 publishes output_hidden = input + moe + shared. The
+        // residual add absorbs much of the matmul drift; same envelope
+        // as the BF16 stage 5 test (cos_sim ≥ 0.999).
+        let got_full = output.to_host_bytes().expect("download output");
+        let got_bytes = &got_full[..hidden_us * 2];
+        assert_parity(
+            "ffn step5 int4 output_hidden",
+            got_bytes,
+            &output_hidden_expected,
+            0.05,
+            0.999,
+        );
+    }
+
     // -------------------------------------------------------------------
     // PR 4b5 step 2: INT4 dequant smoke test.
     //

--- a/crates/runner/src/lib.rs
+++ b/crates/runner/src/lib.rs
@@ -16,5 +16,6 @@ pub mod gemma4_engine;
 pub mod gemma4_int4_engine;
 pub mod oracle;
 pub mod prefill_engine;
+pub mod qwen36_moe_decode;
 pub mod registry;
 pub mod validate;

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -331,6 +331,26 @@ pub(crate) struct Cli {
     #[arg(long, default_value = "8")]
     max_new_tokens: usize,
 
+    /// Sampling temperature. 0 = greedy argmax (default; reproducible).
+    /// Typical sampled values: 0.7–1.0.
+    #[arg(long, default_value = "0.0")]
+    temperature: f32,
+
+    /// Top-K filter: keep only the K highest-probability tokens before
+    /// sampling. 0 = no cap (full vocab considered).
+    #[arg(long, default_value = "0")]
+    top_k: usize,
+
+    /// Top-P (nucleus) filter: keep the smallest set of tokens whose
+    /// cumulative probability ≥ top_p. 1.0 = no truncation.
+    #[arg(long, default_value = "1.0")]
+    top_p: f32,
+
+    /// RNG seed for non-greedy sampling. Same seed + same prompt + same
+    /// model = bit-identical generation.
+    #[arg(long, default_value = "42")]
+    sampling_seed: u64,
+
     /// Maximum context size in tokens (prompt + generated). Used for VRAM estimation.
     /// Defaults to prompt length + max_new_tokens if not specified.
     #[arg(long)]

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -9,6 +9,7 @@ mod oracle;
 mod phi4_engine;
 mod prefill_engine;
 mod qwen35_dflash_engine;
+mod qwen36_moe_decode;
 mod qwen36_moe_engine;
 mod registry;
 mod validate;
@@ -1071,13 +1072,10 @@ fn main() -> Result<()> {
     } else if cli.certified_kv_shadow_validate {
         anyhow::bail!("--certified-kv-shadow-validate requires --certified-kv");
     }
-    if model_variant.family() == ModelFamily::Qwen36Moe && !cli.dry_run {
-        anyhow::bail!(
-            "qwen3.6-35b-a3b decode runtime is not yet implemented. \
-             Re-run with --dry-run to enumerate the checkpoint and report VRAM accounting; \
-             the kernel lands in PR 4 (CUDA) and PR 6 (HIP) of docs/qwen36-moe-plan.md."
-        );
-    }
+    // PR 4c step 2 wires the host-orchestrated chained-launch decode path
+    // for Qwen3.6-MoE — qwen36_moe_engine::run handles both --dry-run and
+    // the BF16 decode path (one token from the bake) so this early bail is
+    // no longer needed.
 
     // 2. Detect GPU
     let (arch_name, total_vram, warp_size) = match backend {

--- a/crates/runner/src/qwen36_moe_decode.rs
+++ b/crates/runner/src/qwen36_moe_decode.rs
@@ -76,7 +76,11 @@ pub struct MultiLayerGeom {
 
 /// Per-layer attention weight buffers. The two variants are mutually
 /// exclusive: a layer is full xor linear. Selection happens at populate time
-/// via [`is_full_attn_layer`].
+/// via [`is_full_attn_layer`]. When [`AttnLayerBuffers::Full::int4`] /
+/// [`AttnLayerBuffers::Linear::int4`] is `Some`, the matching weight buffer
+/// holds INT4 packed nibbles (`u8`, `[out, in/2]`) instead of BF16; the
+/// sidecar carries `(scale, zero)` BF16 tiles `[out/gs, in/gs]` and the
+/// active group_size.
 pub enum AttnLayerBuffers {
     Full {
         input_norm_w: GpuBuffer,
@@ -86,6 +90,7 @@ pub enum AttnLayerBuffers {
         q_norm_w: GpuBuffer,
         k_norm_w: GpuBuffer,
         o_proj_w: GpuBuffer,
+        int4: Option<FullAttnInt4Sidecars>,
     },
     Linear {
         input_norm_w: GpuBuffer,
@@ -103,11 +108,58 @@ pub enum AttnLayerBuffers {
         // ([V*K*Vd] F32), both mutated in place by the kernel.
         conv_state: GpuBuffer,
         recurrent_state: GpuBuffer,
+        int4: Option<LinearAttnInt4Sidecars>,
     },
 }
 
+/// INT4 sidecars for a full-attention layer. Mirrors the per-block FFI
+/// struct [`Qwen36MoeAttnStepInt4`]; only the four projection weights
+/// (q/k/v/o) are quantizable — norms stay BF16. Group size is pinned to
+/// 128 across the runtime + bake.
+pub struct FullAttnInt4Sidecars {
+    pub group_size: i32,
+    pub q_proj_scale: GpuBuffer,
+    pub q_proj_zero: GpuBuffer,
+    pub k_proj_scale: GpuBuffer,
+    pub k_proj_zero: GpuBuffer,
+    pub v_proj_scale: GpuBuffer,
+    pub v_proj_zero: GpuBuffer,
+    pub o_proj_scale: GpuBuffer,
+    pub o_proj_zero: GpuBuffer,
+}
+
+/// INT4 sidecars for a linear-attention layer. Mirrors
+/// [`Qwen36MoeLinearStepInt4`]; only `in_proj_qkv`, `in_proj_z`, `out_proj`
+/// are quantized — `in_proj_a/b`, conv1d, dt_bias, A_log, norms all stay BF16.
+pub struct LinearAttnInt4Sidecars {
+    pub group_size: i32,
+    pub in_proj_qkv_scale: GpuBuffer,
+    pub in_proj_qkv_zero: GpuBuffer,
+    pub in_proj_z_scale: GpuBuffer,
+    pub in_proj_z_zero: GpuBuffer,
+    pub out_proj_scale: GpuBuffer,
+    pub out_proj_zero: GpuBuffer,
+}
+
+/// INT4 sidecars for an MoE FFN block. Mirrors [`Qwen36MoeFfnStepInt4`];
+/// the router (`gate_w`) and the scalar `shared_expert_gate` stay BF16.
+pub struct FfnInt4Sidecars {
+    pub group_size: i32,
+    pub gate_up_proj_scale: GpuBuffer,
+    pub gate_up_proj_zero: GpuBuffer,
+    pub down_proj_scale: GpuBuffer,
+    pub down_proj_zero: GpuBuffer,
+    pub shared_gate_proj_scale: GpuBuffer,
+    pub shared_gate_proj_zero: GpuBuffer,
+    pub shared_up_proj_scale: GpuBuffer,
+    pub shared_up_proj_zero: GpuBuffer,
+    pub shared_down_proj_scale: GpuBuffer,
+    pub shared_down_proj_zero: GpuBuffer,
+}
+
 /// Per-layer MoE FFN weight buffers. Always present (every layer has an
-/// FFN block).
+/// FFN block). When `int4` is `Some`, every `*_proj_w` field carries
+/// packed nibbles instead of BF16 weights.
 pub struct FfnLayerBuffers {
     pub post_attn_norm_w: GpuBuffer,
     pub gate_w: GpuBuffer,
@@ -117,6 +169,7 @@ pub struct FfnLayerBuffers {
     pub shared_up_proj_w: GpuBuffer,
     pub shared_down_proj_w: GpuBuffer,
     pub shared_expert_gate_w: GpuBuffer,
+    pub int4: Option<FfnInt4Sidecars>,
 }
 
 /// One layer's worth of GPU-resident weight + state buffers.
@@ -351,6 +404,7 @@ pub fn run_chained_decode(
                 q_norm_w,
                 k_norm_w,
                 o_proj_w,
+                int4,
             } => {
                 let params = Qwen36MoeAttnStepParams {
                     stage: 5,
@@ -373,12 +427,26 @@ pub fn run_chained_decode(
                     k_norm_w: k_norm_w.as_ptr(),
                     o_proj_w: o_proj_w.as_ptr(),
                 };
+                let int4_ptrs = match int4 {
+                    Some(s) => Qwen36MoeAttnStepInt4 {
+                        group_size: s.group_size,
+                        q_proj_scale: s.q_proj_scale.as_ptr(),
+                        q_proj_zero: s.q_proj_zero.as_ptr(),
+                        k_proj_scale: s.k_proj_scale.as_ptr(),
+                        k_proj_zero: s.k_proj_zero.as_ptr(),
+                        v_proj_scale: s.v_proj_scale.as_ptr(),
+                        v_proj_zero: s.v_proj_zero.as_ptr(),
+                        o_proj_scale: s.o_proj_scale.as_ptr(),
+                        o_proj_zero: s.o_proj_zero.as_ptr(),
+                    },
+                    None => Qwen36MoeAttnStepInt4::disabled(),
+                };
                 attn_step_launch(
                     ordinal,
                     ScalarType::BF16,
                     params,
                     &weights,
-                    &Qwen36MoeAttnStepInt4::disabled(),
+                    &int4_ptrs,
                     &mut attn_output,
                     &mut attn_workspace,
                     &mut sync_buf,
@@ -399,6 +467,7 @@ pub fn run_chained_decode(
                 out_proj_w,
                 conv_state,
                 recurrent_state,
+                int4,
             } => {
                 let params = Qwen36MoeLinearStepParams {
                     stage: 5,
@@ -429,12 +498,24 @@ pub fn run_chained_decode(
                     conv_state: conv_state.as_mut_ptr(),
                     recurrent_state: recurrent_state.as_mut_ptr() as *mut f32,
                 };
+                let int4_ptrs = match int4 {
+                    Some(s) => Qwen36MoeLinearStepInt4 {
+                        group_size: s.group_size,
+                        in_proj_qkv_scale: s.in_proj_qkv_scale.as_ptr(),
+                        in_proj_qkv_zero: s.in_proj_qkv_zero.as_ptr(),
+                        in_proj_z_scale: s.in_proj_z_scale.as_ptr(),
+                        in_proj_z_zero: s.in_proj_z_zero.as_ptr(),
+                        out_proj_scale: s.out_proj_scale.as_ptr(),
+                        out_proj_zero: s.out_proj_zero.as_ptr(),
+                    },
+                    None => Qwen36MoeLinearStepInt4::disabled(),
+                };
                 linear_step_launch(
                     ordinal,
                     ScalarType::BF16,
                     params,
                     &weights,
-                    &Qwen36MoeLinearStepInt4::disabled(),
+                    &int4_ptrs,
                     &mut attn_output,
                     &mut attn_workspace,
                     &mut sync_buf,
@@ -490,12 +571,28 @@ pub fn run_chained_decode(
             shared_down_proj_w: ffn.shared_down_proj_w.as_ptr(),
             shared_expert_gate_w: ffn.shared_expert_gate_w.as_ptr(),
         };
+        let ffn_int4_ptrs = match &ffn.int4 {
+            Some(s) => Qwen36MoeFfnStepInt4 {
+                group_size: s.group_size,
+                gate_up_proj_scale: s.gate_up_proj_scale.as_ptr(),
+                gate_up_proj_zero: s.gate_up_proj_zero.as_ptr(),
+                down_proj_scale: s.down_proj_scale.as_ptr(),
+                down_proj_zero: s.down_proj_zero.as_ptr(),
+                shared_gate_proj_scale: s.shared_gate_proj_scale.as_ptr(),
+                shared_gate_proj_zero: s.shared_gate_proj_zero.as_ptr(),
+                shared_up_proj_scale: s.shared_up_proj_scale.as_ptr(),
+                shared_up_proj_zero: s.shared_up_proj_zero.as_ptr(),
+                shared_down_proj_scale: s.shared_down_proj_scale.as_ptr(),
+                shared_down_proj_zero: s.shared_down_proj_zero.as_ptr(),
+            },
+            None => Qwen36MoeFfnStepInt4::disabled(),
+        };
         ffn_step_launch(
             ordinal,
             ScalarType::BF16,
             params,
             &ffn_weights,
-            &Qwen36MoeFfnStepInt4::disabled(),
+            &ffn_int4_ptrs,
             &mut ffn_output,
             &mut ffn_output_idx,
             &mut ffn_workspace,
@@ -624,6 +721,56 @@ pub fn host_final_norm_lm_head(
     }
 
     f32_to_bf16_bytes(&logits)
+}
+
+/// Dequantize an INT4-packed weight slab back to BF16 bytes. Mirrors the
+/// kernel's `int4_dequant_scalar`: for each output row + input column the
+/// nibble is split off the byte (even col → low nibble, odd col → high),
+/// converted to F32, then `bf16(q*s - z*s)` written using the matching
+/// `[out/gs, in/gs]` BF16 scale/zero tile.
+///
+/// Used by the host-side lm_head path when the bake quantizes lm_head.
+/// `out_dim` × `in_dim` BF16 result = ~1 GiB for 35B-A3B (vocab 248K ×
+/// hidden 2048); fine for one-token smoke, kernel-side lm_head is PR 4d.
+pub fn dequant_int4_to_bf16_bytes(
+    packed: &[u8],
+    scale_bf16: &[u8],
+    zero_bf16: &[u8],
+    out_dim: usize,
+    in_dim: usize,
+    group_size: usize,
+) -> Vec<u8> {
+    assert_eq!(packed.len(), out_dim * in_dim / 2, "packed size mismatch");
+    assert_eq!(in_dim % group_size, 0, "in_dim must be divisible by group_size");
+    assert_eq!(out_dim % group_size, 0, "out_dim must be divisible by group_size");
+    let n_row_tiles = out_dim / group_size;
+    let n_col_tiles = in_dim / group_size;
+    assert_eq!(scale_bf16.len(), n_row_tiles * n_col_tiles * 2, "scale size mismatch");
+    assert_eq!(zero_bf16.len(), n_row_tiles * n_col_tiles * 2, "zero size mismatch");
+
+    let scale = bf16_bytes_to_f32(scale_bf16);
+    let zero = bf16_bytes_to_f32(zero_bf16);
+    let mut out = Vec::with_capacity(out_dim * in_dim * 2);
+    let half_in = in_dim / 2;
+    for o in 0..out_dim {
+        let row_tile = o / group_size;
+        let row_base = o * half_in;
+        for i in 0..in_dim {
+            let col_tile = i / group_size;
+            let tile_idx = row_tile * n_col_tiles + col_tile;
+            let s = scale[tile_idx];
+            let z = zero[tile_idx];
+            let byte = packed[row_base + (i / 2)];
+            let nib = if i % 2 == 0 { byte & 0x0F } else { (byte >> 4) & 0x0F };
+            let q = nib as f32;
+            // Single-rounding bf16(q*s - z*s) — matches the kernel's
+            // `bf16_round_rne_f32_finite(n*s - zs)`.
+            let bf = f32_to_bf16_bits(q * s - z * s);
+            out.push((bf & 0xFF) as u8);
+            out.push((bf >> 8) as u8);
+        }
+    }
+    out
 }
 
 /// Greedy argmax over a BF16 logits buffer. Returns the highest-scoring

--- a/crates/runner/src/qwen36_moe_decode.rs
+++ b/crates/runner/src/qwen36_moe_decode.rs
@@ -1,0 +1,690 @@
+//! Host-orchestrated multi-launch decode for Qwen3.6-MoE — PR 4c step 2.
+//!
+//! Walks the hybrid pattern (every 4th layer full-attn at indices 3/7/11/...,
+//! every other layer linear-attn) calling the per-block FFI launchers
+//! ([`kernel_ffi::qwen36_moe::attn_step_launch`] / `linear_step_launch` /
+//! `ffn_step_launch`) at stage 5 (full-layer output). One HIP launch per
+//! block per layer per token — high launch overhead, but correct,
+//! reviewable, and unblocks end-to-end testing. The persistent megakernel
+//! (PR 4c step 4) folds these N×3 launches down to 1.
+//!
+//! The decode core in [`run_chained_decode`] takes pre-allocated
+//! per-layer weight + state buffers and an initial hidden vector, runs the
+//! chain, and returns the final hidden plus per-layer post-attn / post-FFN
+//! intermediates (used by the parity test in
+//! `crates/runner/tests/qwen36_moe_multilayer_parity.rs` to gate
+//! correctness against the multi-layer Python oracle).
+//!
+//! [`host_final_norm_lm_head`] applies the final RMSnorm + lm_head GEMV on
+//! the host. The plan recommends host-side for PR 4c (~1ms slower per token
+//! vs a kernel; lifting it to GPU is PR 4d).
+//!
+//! Both the parity test (synthetic weights from oracle JSON) and the
+//! engine's real-decode path (weights from the bake) call into the same
+//! [`run_chained_decode`] core — the only difference is how the
+//! [`LayerBuffers`] vec gets populated.
+
+use std::ptr;
+
+use anyhow::{anyhow, Context, Result};
+use gpu_hal::{copy_d2h, memset_zeros, GpuBuffer, GpuError, ScalarType};
+use kernel_ffi::qwen36_moe::{
+    attn_step_launch, ffn_step_launch, linear_step_launch, Qwen36MoeAttnStepInt4,
+    Qwen36MoeAttnStepParams, Qwen36MoeAttnStepWeights, Qwen36MoeFfnStepInt4,
+    Qwen36MoeFfnStepParams, Qwen36MoeFfnStepWeights, Qwen36MoeLinearStepInt4,
+    Qwen36MoeLinearStepParams, Qwen36MoeLinearStepWeights,
+};
+
+/// Hybrid pattern: every 4th layer is full attention. Indices 3, 7, 11, ...
+/// are full; everything else is linear. Matches Qwen3.6-MoE 35B-A3B.
+pub const HYBRID_FULL_ATTN_STRIDE: i32 = 4;
+
+/// `true` when `layer_idx + 1` is a multiple of [`HYBRID_FULL_ATTN_STRIDE`].
+pub fn is_full_attn_layer(layer_idx: i32) -> bool {
+    (layer_idx + 1) % HYBRID_FULL_ATTN_STRIDE == 0
+}
+
+/// Geometry the chained decoder needs at every layer + the lm_head.
+/// Mirrors the synthetic + production cases.
+#[derive(Debug, Clone, Copy)]
+pub struct MultiLayerGeom {
+    pub hidden: i32,
+    pub vocab: i32,
+    pub num_layers: i32,
+    pub rms_norm_eps: f32,
+
+    // Full-attention (read iff a layer's `attn` is `Full`).
+    pub num_attention_heads: i32,
+    pub num_kv_heads: i32,
+    pub head_dim: i32,
+    pub rotary_dim: i32,
+    pub rope_theta: f32,
+
+    // Linear-attention (read iff a layer's `attn` is `Linear`).
+    pub num_k_heads: i32,
+    pub num_v_heads: i32,
+    pub head_k_dim: i32,
+    pub head_v_dim: i32,
+    pub conv_kernel_dim: i32,
+
+    // MoE FFN (every layer).
+    pub num_experts: i32,
+    pub moe_intermediate: i32,
+    pub shared_intermediate: i32,
+    pub top_k: i32,
+}
+
+/// Per-layer attention weight buffers. The two variants are mutually
+/// exclusive: a layer is full xor linear. Selection happens at populate time
+/// via [`is_full_attn_layer`].
+pub enum AttnLayerBuffers {
+    Full {
+        input_norm_w: GpuBuffer,
+        q_proj_w: GpuBuffer,
+        k_proj_w: GpuBuffer,
+        v_proj_w: GpuBuffer,
+        q_norm_w: GpuBuffer,
+        k_norm_w: GpuBuffer,
+        o_proj_w: GpuBuffer,
+    },
+    Linear {
+        input_norm_w: GpuBuffer,
+        in_proj_qkv_w: GpuBuffer,
+        in_proj_z_w: GpuBuffer,
+        in_proj_a_w: GpuBuffer,
+        in_proj_b_w: GpuBuffer,
+        conv1d_w: GpuBuffer,
+        conv1d_bias: Option<GpuBuffer>,
+        dt_bias: GpuBuffer,
+        a_log: GpuBuffer,
+        norm_w: GpuBuffer,
+        out_proj_w: GpuBuffer,
+        // Conv state ([qkv_dim, kernel-1] BF16) and recurrent state
+        // ([V*K*Vd] F32), both mutated in place by the kernel.
+        conv_state: GpuBuffer,
+        recurrent_state: GpuBuffer,
+    },
+}
+
+/// Per-layer MoE FFN weight buffers. Always present (every layer has an
+/// FFN block).
+pub struct FfnLayerBuffers {
+    pub post_attn_norm_w: GpuBuffer,
+    pub gate_w: GpuBuffer,
+    pub gate_up_proj_w: GpuBuffer,
+    pub down_proj_w: GpuBuffer,
+    pub shared_gate_proj_w: GpuBuffer,
+    pub shared_up_proj_w: GpuBuffer,
+    pub shared_down_proj_w: GpuBuffer,
+    pub shared_expert_gate_w: GpuBuffer,
+}
+
+/// One layer's worth of GPU-resident weight + state buffers.
+pub struct LayerBuffers {
+    pub attn: AttnLayerBuffers,
+    pub ffn: FfnLayerBuffers,
+}
+
+impl LayerBuffers {
+    pub fn is_full_attn(&self) -> bool {
+        matches!(self.attn, AttnLayerBuffers::Full { .. })
+    }
+}
+
+/// Captured intermediates from a chained decode pass. The per-layer hiddens
+/// are useful for granular parity diagnostics; `final_hidden_bytes` is what
+/// the host-side final RMSnorm + lm_head consumes.
+pub struct DecodeOutputs {
+    /// `[hidden]` BF16 little-endian — the residual after the last layer's
+    /// FFN, before the final RMSnorm.
+    pub final_hidden_bytes: Vec<u8>,
+    /// `[num_layers][hidden]` BF16. `output_after_attn[i]` is layer `i`'s
+    /// post-attention residual (input to that layer's FFN).
+    pub per_layer_attn_out: Vec<Vec<u8>>,
+    /// `[num_layers][hidden]` BF16. `output_after_ffn[i]` is layer `i`'s
+    /// post-FFN residual (input to layer `i+1`).
+    pub per_layer_ffn_out: Vec<Vec<u8>>,
+}
+
+/// Workspace floats sufficient for the full-attn parity launcher's stage 5
+/// (the largest stage). Mirrors `parity_workspace_floats` in the per-block
+/// test file: 6*H*d + 4*Hkv*d + hidden.
+fn full_attn_workspace_floats(geom: &MultiLayerGeom) -> usize {
+    let h = geom.num_attention_heads as usize;
+    let hkv = geom.num_kv_heads as usize;
+    let d = geom.head_dim as usize;
+    6 * h * d + 4 * hkv * d + geom.hidden as usize
+}
+
+/// BF16 elements sufficient for the full-attn parity launcher's largest
+/// stage (stage 3 publishes q_rot || k_rot, the widest output).
+fn full_attn_output_elems(geom: &MultiLayerGeom) -> usize {
+    let h = geom.num_attention_heads as usize;
+    let hkv = geom.num_kv_heads as usize;
+    let d = geom.head_dim as usize;
+    h * d + hkv * d
+}
+
+/// Workspace floats for the linear-attn parity launcher's stage 5. Mirrors
+/// the size used in the per-block test file. Only the linear-specific terms
+/// matter — the larger of the two attn workspaces drives the shared scratch
+/// allocation in `run_chained_decode`.
+fn linear_attn_workspace_floats(geom: &MultiLayerGeom) -> usize {
+    let k = geom.num_k_heads as usize;
+    let v = geom.num_v_heads as usize;
+    let kd = geom.head_k_dim as usize;
+    let vd = geom.head_v_dim as usize;
+    let key_dim = k * kd;
+    let val_dim = v * vd;
+    let qkv_dim = 2 * key_dim + val_dim;
+    let v_kdim = v * kd;
+    let v_vdim = v * vd;
+    qkv_dim + val_dim + 2 * v + 2 * key_dim + 2 * v_kdim + v + v + v_vdim
+}
+
+/// BF16 elements for the linear-attn parity launcher's widest stage.
+fn linear_attn_output_elems(geom: &MultiLayerGeom) -> usize {
+    let v = geom.num_v_heads as usize;
+    let kd = geom.head_k_dim as usize;
+    let vd = geom.head_v_dim as usize;
+    // Stage 5 publishes [hidden]; earlier stages publish wider intermediates.
+    // The per-block linear test uses `2 * V*Kd + V*Vd` as the upper bound.
+    2 * v * kd + v * vd
+}
+
+/// FFN parity launcher workspace floats — copied from the per-block test
+/// file's `ffn_parity_workspace_floats`. See its docstring for the
+/// per-stage layout (`OFF_H_NORM` in `kernels/qwen36_moe.hip`).
+fn ffn_workspace_floats(geom: &MultiLayerGeom) -> usize {
+    let hidden = geom.hidden as usize;
+    let e = geom.num_experts as usize;
+    let k = geom.top_k as usize;
+    let is_dim = geom.shared_intermediate as usize;
+    let i_dim = geom.moe_intermediate as usize;
+    3 * hidden + 2 * e + 2 * k + 1 + 3 * is_dim + 3 * i_dim + k * hidden
+}
+
+/// FFN output BF16 elements — stage 5 publishes `[hidden]`, which is also
+/// the upper bound (stages 2..=4 fit in a strict subset).
+fn ffn_output_elems(geom: &MultiLayerGeom) -> usize {
+    geom.hidden as usize
+}
+
+/// Reset the 32-byte cooperative-launch sync buffer between launches. The
+/// kernels use it for atomic counters + the grid barrier; failure to reset
+/// would cause the next launch's barrier to hang or skip work.
+fn reset_sync_buf(ordinal: usize, sync_buf: &mut GpuBuffer) -> Result<(), GpuError> {
+    memset_zeros(ordinal, sync_buf.as_mut_ptr(), 32)
+}
+
+/// Copy `[hidden]` BF16 elements out of a GPU buffer into a freshly
+/// allocated host vec. Convenience wrapper that respects the buffer's full
+/// size — kernels publish into the leading `hidden` elements but the
+/// allocation may be wider (stage-3 q_rot||k_rot etc).
+fn download_hidden_bf16(
+    ordinal: usize,
+    src: &GpuBuffer,
+    hidden: usize,
+) -> Result<Vec<u8>, GpuError> {
+    let bytes = hidden * 2;
+    let mut out = vec![0u8; bytes];
+    copy_d2h(
+        ordinal,
+        out.as_mut_ptr() as *mut std::ffi::c_void,
+        src.as_ptr(),
+        bytes,
+    )?;
+    Ok(out)
+}
+
+/// Run one full decode step across `layers.len()` layers, returning the
+/// per-layer hidden states + the final hidden (input to the lm_head).
+///
+/// Kernel state contract:
+///  - The full-attn launcher's stage 5 publishes `output_hidden = input +
+///    o_proj(...)` into the leading `hidden` elements of its output buffer.
+///  - The linear-attn launcher's stage 5 publishes the same residual; it
+///    also mutates the layer's `conv_state` / `recurrent_state` in place.
+///  - The FFN launcher's stage 5 publishes `output_hidden = input + moe_out
+///    + shared_out` into its output buffer's leading `hidden` elements.
+///
+/// Buffers reused across all layers within one step:
+///  - `hidden_a` / `hidden_b`: BF16 residual ping-pong. The current input
+///    lives in one, the just-published output in the other; we swap pointers
+///    by indexing rather than `mem::swap` so the fixed `as_ptr()` references
+///    we hand the kernel stay valid through the call.
+///  - `attn_workspace`: F32 scratch sized for `max(full, linear)` workspaces.
+///  - `attn_output`: BF16 scratch sized for the wider of the two attn
+///    output footprints.
+///  - `ffn_output`, `ffn_output_idx`, `ffn_workspace`: same idea per-FFN.
+///  - `sync_buf`: a single 32-byte cooperative-launch counter, zero-reset
+///    before each kernel call.
+///
+/// Per-layer state (lives in `LayerBuffers`, NOT shared):
+///  - Linear-attn `conv_state` + `recurrent_state` — mutated in place.
+///  - (Full-attn: no KV cache here. The single-block kernels treat each
+///    call as `kv_len=1` self-attention; KV-cache extension is a PR 4d
+///    follow-up.)
+pub fn run_chained_decode(
+    ordinal: usize,
+    geom: &MultiLayerGeom,
+    layers: &mut [LayerBuffers],
+    initial_hidden_bytes: &[u8],
+    position: i32,
+) -> Result<DecodeOutputs> {
+    let hidden = geom.hidden as usize;
+    if initial_hidden_bytes.len() != hidden * 2 {
+        return Err(anyhow!(
+            "initial_hidden_bytes len {} != expected {} (hidden*2 BF16 bytes)",
+            initial_hidden_bytes.len(),
+            hidden * 2,
+        ));
+    }
+    if layers.len() as i32 != geom.num_layers {
+        return Err(anyhow!(
+            "layers.len() {} != geom.num_layers {}",
+            layers.len(),
+            geom.num_layers,
+        ));
+    }
+
+    // Residual ping-pong. Two buffers, each sized [hidden] BF16. We index
+    // them by `front` so the buffer the kernel reads is well-defined for
+    // every launch; alternating `front = 1 - front` after each launch puts
+    // the just-written buffer into "input" position for the next call.
+    let mut hidden_a = GpuBuffer::from_host_bytes(
+        ordinal,
+        ScalarType::BF16,
+        &[hidden],
+        initial_hidden_bytes,
+    )
+    .context("alloc hidden_a")?;
+    let mut hidden_b =
+        GpuBuffer::zeros(ordinal, ScalarType::BF16, &[hidden]).context("alloc hidden_b")?;
+
+    // Shared attention scratch: sized for the larger of (full, linear).
+    let attn_ws_floats = full_attn_workspace_floats(geom).max(linear_attn_workspace_floats(geom));
+    let attn_out_elems = full_attn_output_elems(geom).max(linear_attn_output_elems(geom));
+    let mut attn_output = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[attn_out_elems])
+        .context("alloc attn_output")?;
+    let mut attn_workspace = GpuBuffer::zeros(ordinal, ScalarType::F32, &[attn_ws_floats])
+        .context("alloc attn_workspace")?;
+
+    // Shared FFN scratch.
+    let mut ffn_output = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[ffn_output_elems(geom)])
+        .context("alloc ffn_output")?;
+    let mut ffn_output_idx =
+        GpuBuffer::zeros(ordinal, ScalarType::U32, &[geom.top_k as usize])
+            .context("alloc ffn_output_idx")?;
+    let mut ffn_workspace = GpuBuffer::zeros(ordinal, ScalarType::F32, &[ffn_workspace_floats(geom)])
+        .context("alloc ffn_workspace")?;
+
+    let mut sync_buf =
+        GpuBuffer::zeros(ordinal, ScalarType::U8, &[32]).context("alloc sync_buf")?;
+
+    let mut per_layer_attn_out: Vec<Vec<u8>> = Vec::with_capacity(layers.len());
+    let mut per_layer_ffn_out: Vec<Vec<u8>> = Vec::with_capacity(layers.len());
+
+    // `front` indexes which of (hidden_a, hidden_b) holds the current
+    // "input to next launch". Starts at 0 (initial_hidden was uploaded
+    // into hidden_a). After each launch we swap.
+    let mut front: usize = 0;
+
+    for (layer_idx, layer) in layers.iter_mut().enumerate() {
+        // ---- Attention ----
+        reset_sync_buf(ordinal, &mut sync_buf).context("reset sync_buf (attn)")?;
+        // Capture the *const input pointer + *mut output pointer based on
+        // current `front`. Borrowing both `hidden_a` and `hidden_b`
+        // mutably at the same time isn't possible; pointer arithmetic is.
+        let (input_ptr, output_buf): (_, &mut GpuBuffer) = if front == 0 {
+            (hidden_a.as_ptr(), &mut hidden_b)
+        } else {
+            (hidden_b.as_ptr(), &mut hidden_a)
+        };
+
+        match &mut layer.attn {
+            AttnLayerBuffers::Full {
+                input_norm_w,
+                q_proj_w,
+                k_proj_w,
+                v_proj_w,
+                q_norm_w,
+                k_norm_w,
+                o_proj_w,
+            } => {
+                let params = Qwen36MoeAttnStepParams {
+                    stage: 5,
+                    hidden: geom.hidden,
+                    num_heads: geom.num_attention_heads,
+                    num_kv_heads: geom.num_kv_heads,
+                    head_dim: geom.head_dim,
+                    rotary_dim: geom.rotary_dim,
+                    rope_theta: geom.rope_theta,
+                    rms_norm_eps: geom.rms_norm_eps,
+                    position,
+                };
+                let weights = Qwen36MoeAttnStepWeights {
+                    input_hidden: input_ptr,
+                    input_norm_w: input_norm_w.as_ptr(),
+                    q_proj_w: q_proj_w.as_ptr(),
+                    k_proj_w: k_proj_w.as_ptr(),
+                    v_proj_w: v_proj_w.as_ptr(),
+                    q_norm_w: q_norm_w.as_ptr(),
+                    k_norm_w: k_norm_w.as_ptr(),
+                    o_proj_w: o_proj_w.as_ptr(),
+                };
+                attn_step_launch(
+                    ordinal,
+                    ScalarType::BF16,
+                    params,
+                    &weights,
+                    &Qwen36MoeAttnStepInt4::disabled(),
+                    &mut attn_output,
+                    &mut attn_workspace,
+                    &mut sync_buf,
+                )
+                .with_context(|| format!("attn_step_launch (layer {layer_idx}, full)"))?;
+            }
+            AttnLayerBuffers::Linear {
+                input_norm_w,
+                in_proj_qkv_w,
+                in_proj_z_w,
+                in_proj_a_w,
+                in_proj_b_w,
+                conv1d_w,
+                conv1d_bias,
+                dt_bias,
+                a_log,
+                norm_w,
+                out_proj_w,
+                conv_state,
+                recurrent_state,
+            } => {
+                let params = Qwen36MoeLinearStepParams {
+                    stage: 5,
+                    hidden: geom.hidden,
+                    num_k_heads: geom.num_k_heads,
+                    num_v_heads: geom.num_v_heads,
+                    head_k_dim: geom.head_k_dim,
+                    head_v_dim: geom.head_v_dim,
+                    conv_kernel_dim: geom.conv_kernel_dim,
+                    rms_norm_eps: geom.rms_norm_eps,
+                };
+                let weights = Qwen36MoeLinearStepWeights {
+                    input_hidden: input_ptr,
+                    input_norm_w: input_norm_w.as_ptr(),
+                    in_proj_qkv_w: in_proj_qkv_w.as_ptr(),
+                    in_proj_z_w: in_proj_z_w.as_ptr(),
+                    in_proj_a_w: in_proj_a_w.as_ptr(),
+                    in_proj_b_w: in_proj_b_w.as_ptr(),
+                    conv1d_w: conv1d_w.as_ptr(),
+                    conv1d_bias: conv1d_bias
+                        .as_ref()
+                        .map(|b| b.as_ptr())
+                        .unwrap_or(ptr::null()),
+                    dt_bias: dt_bias.as_ptr(),
+                    a_log: a_log.as_ptr(),
+                    norm_w: norm_w.as_ptr(),
+                    out_proj_w: out_proj_w.as_ptr(),
+                    conv_state: conv_state.as_mut_ptr(),
+                    recurrent_state: recurrent_state.as_mut_ptr() as *mut f32,
+                };
+                linear_step_launch(
+                    ordinal,
+                    ScalarType::BF16,
+                    params,
+                    &weights,
+                    &Qwen36MoeLinearStepInt4::disabled(),
+                    &mut attn_output,
+                    &mut attn_workspace,
+                    &mut sync_buf,
+                )
+                .with_context(|| format!("linear_step_launch (layer {layer_idx})"))?;
+            }
+        }
+
+        // attn_output[..hidden] now holds output_after_attn. Copy it into
+        // the front buffer so the FFN reads it as input. We use a D2D
+        // copy through the kernel for simplicity rather than juggling a
+        // third hidden buffer.
+        gpu_hal::copy_d2d(
+            ordinal,
+            output_buf.as_mut_ptr(),
+            attn_output.as_ptr(),
+            hidden * 2,
+        )
+        .context("d2d attn_output -> residual")?;
+
+        // Swap front: the just-published value is now the "current input".
+        front = 1 - front;
+
+        per_layer_attn_out.push(download_hidden_bf16(ordinal, output_buf, hidden)
+            .context("download per-layer attn output")?);
+
+        // ---- FFN ----
+        reset_sync_buf(ordinal, &mut sync_buf).context("reset sync_buf (ffn)")?;
+        let (input_ptr, output_buf): (_, &mut GpuBuffer) = if front == 0 {
+            (hidden_a.as_ptr(), &mut hidden_b)
+        } else {
+            (hidden_b.as_ptr(), &mut hidden_a)
+        };
+
+        let ffn = &layer.ffn;
+        let params = Qwen36MoeFfnStepParams {
+            stage: 5,
+            hidden: geom.hidden,
+            num_experts: geom.num_experts,
+            moe_intermediate: geom.moe_intermediate,
+            shared_intermediate: geom.shared_intermediate,
+            top_k: geom.top_k,
+            rms_norm_eps: geom.rms_norm_eps,
+        };
+        let ffn_weights = Qwen36MoeFfnStepWeights {
+            input_hidden: input_ptr,
+            post_attn_norm_w: ffn.post_attn_norm_w.as_ptr(),
+            gate_w: ffn.gate_w.as_ptr(),
+            gate_up_proj_w: ffn.gate_up_proj_w.as_ptr(),
+            down_proj_w: ffn.down_proj_w.as_ptr(),
+            shared_gate_proj_w: ffn.shared_gate_proj_w.as_ptr(),
+            shared_up_proj_w: ffn.shared_up_proj_w.as_ptr(),
+            shared_down_proj_w: ffn.shared_down_proj_w.as_ptr(),
+            shared_expert_gate_w: ffn.shared_expert_gate_w.as_ptr(),
+        };
+        ffn_step_launch(
+            ordinal,
+            ScalarType::BF16,
+            params,
+            &ffn_weights,
+            &Qwen36MoeFfnStepInt4::disabled(),
+            &mut ffn_output,
+            &mut ffn_output_idx,
+            &mut ffn_workspace,
+            &mut sync_buf,
+        )
+        .with_context(|| format!("ffn_step_launch (layer {layer_idx})"))?;
+
+        // Same D2D + swap as the attn step.
+        gpu_hal::copy_d2d(
+            ordinal,
+            output_buf.as_mut_ptr(),
+            ffn_output.as_ptr(),
+            hidden * 2,
+        )
+        .context("d2d ffn_output -> residual")?;
+        front = 1 - front;
+
+        per_layer_ffn_out.push(download_hidden_bf16(ordinal, output_buf, hidden)
+            .context("download per-layer ffn output")?);
+    }
+
+    let final_buf = if front == 0 { &hidden_a } else { &hidden_b };
+    let final_hidden_bytes =
+        download_hidden_bf16(ordinal, final_buf, hidden).context("download final hidden")?;
+
+    Ok(DecodeOutputs {
+        final_hidden_bytes,
+        per_layer_attn_out,
+        per_layer_ffn_out,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Host-side final RMSnorm + lm_head GEMV. The plan recommends host execution
+// for PR 4c; lifting to a dedicated kernel is PR 4d.
+// ---------------------------------------------------------------------------
+
+/// Decode a stream of BF16 little-endian bytes into F32. The oracle stores
+/// BF16 as raw int16 → bytes; this is the inverse.
+pub fn bf16_bytes_to_f32(bytes: &[u8]) -> Vec<f32> {
+    assert!(bytes.len() % 2 == 0, "BF16 bytes must be even");
+    bytes
+        .chunks_exact(2)
+        .map(|c| {
+            let bits = u32::from(c[0]) | (u32::from(c[1]) << 8);
+            f32::from_bits(bits << 16)
+        })
+        .collect()
+}
+
+/// Round an F32 to BF16 (RNE), returning the 16 raw bits. Matches PyTorch's
+/// `.to(torch.bfloat16)` rounding: nearest-even on the lopped-off mantissa
+/// bits, with the standard NaN-quieting convention.
+pub fn f32_to_bf16_bits(x: f32) -> u16 {
+    let bits = x.to_bits();
+    if (bits & 0x7FFF_FFFF) > 0x7F80_0000 {
+        // NaN: keep top 16 with quiet bit set.
+        return ((bits >> 16) | 0x0040) as u16;
+    }
+    let lsb = (bits >> 16) & 1;
+    let rounding_bias = 0x7FFFu32 + lsb;
+    let rounded = bits.wrapping_add(rounding_bias);
+    (rounded >> 16) as u16
+}
+
+/// Encode a slice of F32 values to BF16 little-endian bytes (RNE).
+pub fn f32_to_bf16_bytes(vals: &[f32]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(vals.len() * 2);
+    for &v in vals {
+        let bits = f32_to_bf16_bits(v);
+        out.push((bits & 0xFF) as u8);
+        out.push((bits >> 8) as u8);
+    }
+    out
+}
+
+/// Apply RMSnorm + lm_head GEMV on the host. Mirrors the multi-layer
+/// oracle's tail:
+///   final_normed = rms_norm(hidden, final_norm_w, eps)
+///   logits       = final_normed.to(F32) @ lm_head_w.to(F32).T
+///   logits       = logits.to(BF16)
+///
+/// All inputs are BF16 little-endian byte streams; output is BF16
+/// little-endian bytes for `vocab` logit channels.
+pub fn host_final_norm_lm_head(
+    hidden_bytes: &[u8],
+    final_norm_w_bytes: &[u8],
+    lm_head_w_bytes: &[u8],
+    hidden: usize,
+    vocab: usize,
+    eps: f32,
+) -> Vec<u8> {
+    assert_eq!(hidden_bytes.len(), hidden * 2, "hidden bytes mismatch");
+    assert_eq!(final_norm_w_bytes.len(), hidden * 2, "norm_w bytes mismatch");
+    assert_eq!(
+        lm_head_w_bytes.len(),
+        vocab * hidden * 2,
+        "lm_head bytes mismatch"
+    );
+
+    let h_f32 = bf16_bytes_to_f32(hidden_bytes);
+    let w_f32 = bf16_bytes_to_f32(final_norm_w_bytes);
+    let lm_f32 = bf16_bytes_to_f32(lm_head_w_bytes);
+
+    // RMSnorm: F32 mean of squares -> rsqrt(var+eps) -> elementwise mul by w.
+    let mean_sq: f32 =
+        h_f32.iter().map(|&x| x * x).sum::<f32>() / hidden as f32;
+    let rsqrt = 1.0 / (mean_sq + eps).sqrt();
+    let normed: Vec<f32> = h_f32
+        .iter()
+        .zip(w_f32.iter())
+        .map(|(&x, &w)| x * rsqrt * w)
+        .collect();
+
+    // GEMV: lm_head [vocab, hidden] @ normed [hidden] -> logits [vocab].
+    // F64 accumulator matches the oracle's torch.float32 reduction order
+    // closely enough for cos_sim parity at vocab+hidden ≤ a few thousand.
+    let mut logits = vec![0f32; vocab];
+    for v in 0..vocab {
+        let row_start = v * hidden;
+        let mut acc = 0f64;
+        for h in 0..hidden {
+            acc += lm_f32[row_start + h] as f64 * normed[h] as f64;
+        }
+        logits[v] = acc as f32;
+    }
+
+    f32_to_bf16_bytes(&logits)
+}
+
+/// Greedy argmax over a BF16 logits buffer. Returns the highest-scoring
+/// token id. Used by the runner's first-token smoke path.
+pub fn argmax_bf16_logits(logits_bytes: &[u8]) -> u32 {
+    let logits = bf16_bytes_to_f32(logits_bytes);
+    logits
+        .iter()
+        .enumerate()
+        .fold((0usize, f32::NEG_INFINITY), |(best_i, best_v), (i, &v)| {
+            if v > best_v {
+                (i, v)
+            } else {
+                (best_i, best_v)
+            }
+        })
+        .0 as u32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hybrid_pattern_marks_every_fourth_layer_full() {
+        for li in 0..40 {
+            let expect_full = (li + 1) % 4 == 0;
+            assert_eq!(is_full_attn_layer(li), expect_full, "layer {li}");
+        }
+    }
+
+    #[test]
+    fn bf16_roundtrip_preserves_normal_values() {
+        // PyTorch's BF16 rounding round-trips most "round" F32 values
+        // bit-exactly. Sample a few that have all-zero low mantissa bits
+        // so rounding is a no-op.
+        let bf16_clean = [0.0f32, 1.0, 2.0, 0.5, -3.25, 1024.0];
+        for &v in &bf16_clean {
+            let bytes = f32_to_bf16_bytes(&[v]);
+            let roundtrip = bf16_bytes_to_f32(&bytes);
+            assert_eq!(roundtrip[0], v, "bf16 roundtrip drift at {v}");
+        }
+    }
+
+    #[test]
+    fn rms_norm_then_lm_head_matches_naive_computation() {
+        // Tiny hand-checked case. RMS-normalised (1, 2, 3) with norm_w=(1,1,1)
+        // and eps=0 has mean_sq=14/3 → rsqrt=sqrt(3/14). Times lm_head row
+        // [1, 0, 0] yields 1*sqrt(3/14) ≈ 0.4629. BF16 rounding is loose
+        // enough that we check within 1e-2.
+        let hidden = 3usize;
+        let vocab = 1usize;
+        let h_bytes = f32_to_bf16_bytes(&[1.0, 2.0, 3.0]);
+        let w_bytes = f32_to_bf16_bytes(&[1.0, 1.0, 1.0]);
+        let lm_bytes = f32_to_bf16_bytes(&[1.0, 0.0, 0.0]);
+        let logits = host_final_norm_lm_head(&h_bytes, &w_bytes, &lm_bytes, hidden, vocab, 0.0);
+        let logit = bf16_bytes_to_f32(&logits)[0];
+        let expected = (3.0f32 / 14.0).sqrt();
+        assert!(
+            (logit - expected).abs() < 1e-2,
+            "logit {logit} far from expected {expected}"
+        );
+    }
+}

--- a/crates/runner/src/qwen36_moe_decode.rs
+++ b/crates/runner/src/qwen36_moe_decode.rs
@@ -413,6 +413,19 @@ pub fn run_chained_decode(
     let mut per_layer_attn_out: Vec<Vec<u8>> = Vec::with_capacity(layers.len());
     let mut per_layer_ffn_out: Vec<Vec<u8>> = Vec::with_capacity(layers.len());
 
+    // Optional per-layer L2-norm trace, gated by env var. Cheap (one D2H
+    // copy + a sum-of-squares per layer) and invaluable for spotting
+    // where the chain's signal blows up / collapses / NaNs at production
+    // scale where we have no oracle to gate against.
+    let trace_norms = std::env::var("SUPERSONIC_QWEN36_DEBUG_TRACE_NORMS")
+        .map(|v| !v.is_empty() && v != "0")
+        .unwrap_or(false);
+    if trace_norms {
+        let init_norm = bf16_bytes_to_f32(initial_hidden_bytes)
+            .iter().map(|x| x * x).sum::<f32>().sqrt();
+        eprintln!("[trace] step pos={position} init_hidden L2={init_norm:.4}");
+    }
+
     // `front` indexes which of (hidden_a, hidden_b) holds the current
     // "input to next launch". Starts at 0 (initial_hidden was uploaded
     // into hidden_a). After each launch we swap.
@@ -582,8 +595,17 @@ pub fn run_chained_decode(
         // Swap front: the just-published value is now the "current input".
         front = 1 - front;
 
-        per_layer_attn_out.push(download_hidden_bf16(ordinal, output_buf, hidden)
-            .context("download per-layer attn output")?);
+        let attn_out_bytes = download_hidden_bf16(ordinal, output_buf, hidden)
+            .context("download per-layer attn output")?;
+        if trace_norms {
+            let v = bf16_bytes_to_f32(&attn_out_bytes);
+            let l2 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+            let nan = v.iter().any(|x| !x.is_finite());
+            let kind = if matches!(layer.attn, AttnLayerBuffers::Full { .. }) { "full" } else { "lin " };
+            eprintln!("[trace]   layer {layer_idx:2} {kind} attn  L2={l2:.4}{}",
+                if nan { " NaN!" } else { "" });
+        }
+        per_layer_attn_out.push(attn_out_bytes);
 
         // ---- FFN ----
         reset_sync_buf(ordinal, &mut sync_buf).context("reset sync_buf (ffn)")?;
@@ -653,8 +675,16 @@ pub fn run_chained_decode(
         .context("d2d ffn_output -> residual")?;
         front = 1 - front;
 
-        per_layer_ffn_out.push(download_hidden_bf16(ordinal, output_buf, hidden)
-            .context("download per-layer ffn output")?);
+        let ffn_out_bytes = download_hidden_bf16(ordinal, output_buf, hidden)
+            .context("download per-layer ffn output")?;
+        if trace_norms {
+            let v = bf16_bytes_to_f32(&ffn_out_bytes);
+            let l2 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+            let nan = v.iter().any(|x| !x.is_finite());
+            eprintln!("[trace]   layer {layer_idx:2}      ffn   L2={l2:.4}{}",
+                if nan { " NaN!" } else { "" });
+        }
+        per_layer_ffn_out.push(ffn_out_bytes);
     }
 
     let final_buf = if front == 0 { &hidden_a } else { &hidden_b };

--- a/crates/runner/src/qwen36_moe_decode.rs
+++ b/crates/runner/src/qwen36_moe_decode.rs
@@ -91,6 +91,11 @@ pub enum AttnLayerBuffers {
         k_norm_w: GpuBuffer,
         o_proj_w: GpuBuffer,
         int4: Option<FullAttnInt4Sidecars>,
+        /// PR 4d KV cache for this full-attention layer. When `Some`, the
+        /// kernel writes the current step's K/V at slot `position` and
+        /// attends over `kv_len = position + 1` past tokens. When `None`
+        /// (parity tests, single-token decode), back-compat kv_len=1.
+        kv_cache: Option<FullAttnKvCache>,
     },
     Linear {
         input_norm_w: GpuBuffer,
@@ -110,6 +115,16 @@ pub enum AttnLayerBuffers {
         recurrent_state: GpuBuffer,
         int4: Option<LinearAttnInt4Sidecars>,
     },
+}
+
+/// PR 4d KV cache for a full-attention layer. `[kv_max_t, num_kv_heads *
+/// head_dim]` BF16 each, mutated by the kernel: at decode position `p` it
+/// writes the current step's K/V at slot `p` then attends over
+/// `kv_len = p + 1` past tokens. Lifetime tied to one decode session.
+pub struct FullAttnKvCache {
+    pub k: GpuBuffer,
+    pub v: GpuBuffer,
+    pub kv_max_t: i32,
 }
 
 /// INT4 sidecars for a full-attention layer. Mirrors the per-block FFI
@@ -355,8 +370,28 @@ pub fn run_chained_decode(
     let mut hidden_b =
         GpuBuffer::zeros(ordinal, ScalarType::BF16, &[hidden]).context("alloc hidden_b")?;
 
+    // PR 4d: when any full-attn layer carries a KV cache, the kernel uses
+    // an additional `[H, kv_max_t]` F32 region (OFF_SCORES) for per-head
+    // attention scores. Size workspace for the largest kv_max_t any layer
+    // declares.
+    let max_kv_t = layers
+        .iter()
+        .filter_map(|l| match &l.attn {
+            AttnLayerBuffers::Full {
+                kv_cache: Some(c), ..
+            } => Some(c.kv_max_t as usize),
+            _ => None,
+        })
+        .max()
+        .unwrap_or(0);
+    let attn_extra = if max_kv_t > 0 {
+        geom.num_attention_heads as usize * max_kv_t
+    } else {
+        0
+    };
+
     // Shared attention scratch: sized for the larger of (full, linear).
-    let attn_ws_floats = full_attn_workspace_floats(geom).max(linear_attn_workspace_floats(geom));
+    let attn_ws_floats = full_attn_workspace_floats(geom).max(linear_attn_workspace_floats(geom)) + attn_extra;
     let attn_out_elems = full_attn_output_elems(geom).max(linear_attn_output_elems(geom));
     let mut attn_output = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[attn_out_elems])
         .context("alloc attn_output")?;
@@ -405,6 +440,7 @@ pub fn run_chained_decode(
                 k_norm_w,
                 o_proj_w,
                 int4,
+                kv_cache,
             } => {
                 let params = Qwen36MoeAttnStepParams {
                     stage: 5,
@@ -417,6 +453,10 @@ pub fn run_chained_decode(
                     rms_norm_eps: geom.rms_norm_eps,
                     position,
                 };
+                let (kv_k_ptr, kv_v_ptr, kv_max_t) = match kv_cache {
+                    Some(c) => (c.k.as_mut_ptr(), c.v.as_mut_ptr(), c.kv_max_t),
+                    None => (ptr::null_mut(), ptr::null_mut(), 0),
+                };
                 let weights = Qwen36MoeAttnStepWeights {
                     input_hidden: input_ptr,
                     input_norm_w: input_norm_w.as_ptr(),
@@ -426,6 +466,9 @@ pub fn run_chained_decode(
                     q_norm_w: q_norm_w.as_ptr(),
                     k_norm_w: k_norm_w.as_ptr(),
                     o_proj_w: o_proj_w.as_ptr(),
+                    kv_cache_k: kv_k_ptr,
+                    kv_cache_v: kv_v_ptr,
+                    kv_max_t,
                 };
                 let int4_ptrs = match int4 {
                     Some(s) => Qwen36MoeAttnStepInt4 {

--- a/crates/runner/src/qwen36_moe_decode.rs
+++ b/crates/runner/src/qwen36_moe_decode.rs
@@ -816,6 +816,108 @@ pub fn dequant_int4_to_bf16_bytes(
     out
 }
 
+/// Tiny dependency-free xorshift64 RNG. Deterministic given the seed —
+/// the engine's `--sampling-seed` plus identical prompt + model + sampling
+/// params produces bit-identical generation.
+pub struct XorshiftRng(u64);
+
+impl XorshiftRng {
+    pub fn new(seed: u64) -> Self {
+        // Xorshift requires a non-zero state.
+        Self(if seed == 0 { 0x9E37_79B9_7F4A_7C15 } else { seed })
+    }
+    pub fn next_u64(&mut self) -> u64 {
+        self.0 ^= self.0 << 13;
+        self.0 ^= self.0 >> 7;
+        self.0 ^= self.0 << 17;
+        self.0
+    }
+    /// Uniform `f32` in `[0, 1)`. 24 random bits → IEEE single mantissa.
+    pub fn next_f32(&mut self) -> f32 {
+        (self.next_u64() >> 40) as f32 / ((1u64 << 24) as f32)
+    }
+}
+
+/// Sample one token from BF16 logits with optional temperature, top-K,
+/// and top-P (nucleus) filters. `temperature <= 0` falls through to
+/// greedy argmax (the deterministic, reproducible default — same as
+/// [`argmax_bf16_logits`]). `top_k == 0` means "no top-K cap" (full
+/// vocab); `top_p >= 1.0` means "no nucleus truncation".
+///
+/// Greedy is bit-identical to argmax_bf16_logits (same iteration order,
+/// no temperature scaling).
+pub fn sample_bf16_logits(
+    logits_bytes: &[u8],
+    temperature: f32,
+    top_k: usize,
+    top_p: f32,
+    rng: &mut XorshiftRng,
+) -> u32 {
+    if temperature <= 0.0 || top_k == 1 {
+        return argmax_bf16_logits(logits_bytes);
+    }
+    let logits = bf16_bytes_to_f32(logits_bytes);
+    let inv_t = 1.0 / temperature;
+
+    // Top-K: pick the K highest-logit indices, descending. For top_k==0
+    // sort the entire vocab (slow but only paid when sampling — vocab≈248K
+    // takes ~few ms per token, negligible vs the chained decode).
+    let mut indexed: Vec<(usize, f32)> =
+        logits.iter().enumerate().map(|(i, &v)| (i, v * inv_t)).collect();
+    let k = if top_k == 0 || top_k > indexed.len() {
+        indexed.len()
+    } else {
+        // Partial sort: select_nth_unstable + sort the head saves the tail.
+        let _ = indexed.select_nth_unstable_by(top_k - 1, |a, b| {
+            b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal)
+        });
+        top_k
+    };
+    indexed.truncate(k);
+    indexed.sort_unstable_by(|a, b| {
+        b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    // Softmax with max-stabilisation over the kept indices.
+    let max_logit = indexed[0].1;
+    let mut exps: Vec<f32> = indexed.iter().map(|(_, v)| (v - max_logit).exp()).collect();
+    let sum: f32 = exps.iter().sum();
+    if sum <= 0.0 || !sum.is_finite() {
+        return indexed[0].0 as u32;
+    }
+    for e in &mut exps {
+        *e /= sum;
+    }
+
+    // Top-P nucleus: smallest prefix whose cumulative prob ≥ top_p.
+    let nucleus_size = if top_p >= 1.0 {
+        exps.len()
+    } else {
+        let mut cum = 0.0f32;
+        let mut n = exps.len();
+        for (i, &p) in exps.iter().enumerate() {
+            cum += p;
+            if cum >= top_p {
+                n = i + 1;
+                break;
+            }
+        }
+        n.max(1)
+    };
+
+    // Sample from the (renormalised) nucleus.
+    let nucleus_sum: f32 = exps[..nucleus_size].iter().sum();
+    let r: f32 = rng.next_f32() * nucleus_sum;
+    let mut cum = 0.0f32;
+    for i in 0..nucleus_size {
+        cum += exps[i];
+        if cum >= r {
+            return indexed[i].0 as u32;
+        }
+    }
+    indexed[0].0 as u32
+}
+
 /// Greedy argmax over a BF16 logits buffer. Returns the highest-scoring
 /// token id. Used by the runner's first-token smoke path.
 pub fn argmax_bf16_logits(logits_bytes: &[u8]) -> u32 {

--- a/crates/runner/src/qwen36_moe_decode.rs
+++ b/crates/runner/src/qwen36_moe_decode.rs
@@ -766,9 +766,33 @@ pub fn host_final_norm_lm_head(
         "lm_head bytes mismatch"
     );
 
-    let h_f32 = bf16_bytes_to_f32(hidden_bytes);
+    // BF16-input convenience wrapper. For multi-token decode loops use
+    // `host_final_norm_lm_head_f32` directly with cached F32 lm_head + norm
+    // weight to avoid re-converting the (multi-GiB) lm_head matrix per step.
     let w_f32 = bf16_bytes_to_f32(final_norm_w_bytes);
     let lm_f32 = bf16_bytes_to_f32(lm_head_w_bytes);
+    host_final_norm_lm_head_f32(hidden_bytes, &w_f32, &lm_f32, hidden, vocab, eps)
+}
+
+/// Same math as [`host_final_norm_lm_head`] but with `final_norm_w` and
+/// `lm_head_w` already converted to F32 by the caller. Hot-loop variant —
+/// the BF16→F32 conversion of the lm_head matrix is by far the dominant
+/// cost on the 35B-A3B geometry (~1 GiB BF16 → ~2 GiB F32 per call), and
+/// it never changes across tokens, so the engine converts it once and
+/// passes the F32 view here per-step.
+pub fn host_final_norm_lm_head_f32(
+    hidden_bytes: &[u8],
+    final_norm_w_f32: &[f32],
+    lm_head_w_f32: &[f32],
+    hidden: usize,
+    vocab: usize,
+    eps: f32,
+) -> Vec<u8> {
+    assert_eq!(hidden_bytes.len(), hidden * 2, "hidden bytes mismatch");
+    assert_eq!(final_norm_w_f32.len(), hidden, "norm_w f32 len mismatch");
+    assert_eq!(lm_head_w_f32.len(), vocab * hidden, "lm_head f32 len mismatch");
+
+    let h_f32 = bf16_bytes_to_f32(hidden_bytes);
 
     // RMSnorm: F32 mean of squares -> rsqrt(var+eps) -> elementwise mul by w.
     let mean_sq: f32 =
@@ -776,7 +800,7 @@ pub fn host_final_norm_lm_head(
     let rsqrt = 1.0 / (mean_sq + eps).sqrt();
     let normed: Vec<f32> = h_f32
         .iter()
-        .zip(w_f32.iter())
+        .zip(final_norm_w_f32.iter())
         .map(|(&x, &w)| x * rsqrt * w)
         .collect();
 
@@ -788,7 +812,7 @@ pub fn host_final_norm_lm_head(
         let row_start = v * hidden;
         let mut acc = 0f64;
         for h in 0..hidden {
-            acc += lm_f32[row_start + h] as f64 * normed[h] as f64;
+            acc += lm_head_w_f32[row_start + h] as f64 * normed[h] as f64;
         }
         logits[v] = acc as f32;
     }

--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -27,8 +27,8 @@ use qwen36_moe::weights::{
 
 use crate::qwen36_moe_decode::{
     argmax_bf16_logits, dequant_int4_to_bf16_bytes, host_final_norm_lm_head, run_chained_decode,
-    AttnLayerBuffers, FfnInt4Sidecars, FfnLayerBuffers, FullAttnInt4Sidecars, LayerBuffers,
-    LinearAttnInt4Sidecars, MultiLayerGeom,
+    AttnLayerBuffers, FfnInt4Sidecars, FfnLayerBuffers, FullAttnInt4Sidecars, FullAttnKvCache,
+    LayerBuffers, LinearAttnInt4Sidecars, MultiLayerGeom,
 };
 use crate::registry::{FamilyParams, Qwen36MoeKernelParams, RegistryEntry};
 
@@ -767,6 +767,11 @@ fn load_layer_buffers(
     text_config: &TextConfig,
     weight_prefix: &str,
     int4_enabled: bool,
+    // When > 0, allocate a KV cache for full-attention layers sized for
+    // `kv_max_t` past tokens. Linear-attn layers use `conv_state` +
+    // `recurrent_state` instead (always allocated). 0 = no KV cache,
+    // kernel falls back to kv_len=1 (back-compat for the parity test).
+    kv_max_t: usize,
 ) -> Result<LayerBuffers> {
     let lp = format!("{weight_prefix}.layers.{layer_idx}");
 
@@ -787,6 +792,22 @@ fn load_layer_buffers(
         } else {
             None
         };
+        // KV cache: allocate per-layer when multi-token decode is requested.
+        // Layout: BF16 [kv_max_t, num_kv_heads * head_dim] for both K and V.
+        let kv_dim = (geom.num_kv_heads as usize) * (geom.head_dim as usize);
+        let kv_cache = if kv_max_t > 0 {
+            let k = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[kv_max_t, kv_dim])
+                .with_context(|| format!("alloc kv_cache_k (layer {layer_idx})"))?;
+            let v = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[kv_max_t, kv_dim])
+                .with_context(|| format!("alloc kv_cache_v (layer {layer_idx})"))?;
+            Some(FullAttnKvCache {
+                k,
+                v,
+                kv_max_t: kv_max_t as i32,
+            })
+        } else {
+            None
+        };
         AttnLayerBuffers::Full {
             input_norm_w: load_to_gpu(store, ordinal, &format!("{lp}.input_layernorm.weight"))?,
             q_proj_w: load_to_gpu(store, ordinal, &format!("{fa}.q_proj.weight"))?,
@@ -796,6 +817,7 @@ fn load_layer_buffers(
             k_norm_w: load_to_gpu(store, ordinal, &format!("{fa}.k_norm.weight"))?,
             o_proj_w: load_to_gpu(store, ordinal, &format!("{fa}.o_proj.weight"))?,
             int4,
+            kv_cache,
         }
     } else {
         let la = format!("{lp}.linear_attn");
@@ -925,19 +947,20 @@ fn host_load_bytes(store: &BakedStore, name: &str) -> Result<Vec<u8>> {
 }
 
 /// Tokenize the prompt and run the multi-token decode loop end-to-end:
-/// prefill the prompt one token at a time (linear-attn state accumulates
-/// in place; full-attn is currently `kv_len=1` per call — KV-cache
-/// extension is a follow-up), then generate `max_new` tokens via greedy
-/// argmax against the (cached) host-side lm_head GEMV. Streams decoded
-/// text to stdout as each token arrives.
+/// prefill the prompt one token at a time, then generate `max_new`
+/// tokens via greedy argmax against the (cached) host-side lm_head
+/// GEMV. Streams decoded text to stdout as each token arrives.
 ///
-/// **Quality caveat**: the per-block kernels are stage-5 single-block
-/// launchers — they don't expose KV cache pointers, so full-attention
-/// layers (10 of 40) attend only to the current token. Linear-attn
-/// layers (the other 30) accumulate state correctly across decode steps
-/// because the kernel mutates `conv_state`/`recurrent_state` in place.
-/// Real full-attn KV needs an FFI extension on `Qwen36MoeAttnStepWeights`
-/// + corresponding kernel work — separate piece.
+/// State persistence across decode steps:
+///  - Linear-attn `conv_state` + `recurrent_state` mutated in place by
+///    the kernel.
+///  - Full-attn KV cache (PR 4d): per-layer `[kv_max_t, Hkv*d]` BF16
+///    buffers; the kernel writes the current step's K/V at slot
+///    `position` and attends over `kv_len = position + 1` past tokens.
+///    `kv_max_t` sized for `prompt_len + max_new` here.
+///
+/// Greedy decoding only — sampling (temperature/top-p) and GPU-side
+/// lm_head GEMV (currently host F32) are next perf/quality steps.
 fn decode_text(
     model_dir: &Path,
     report: &DryRunReport,
@@ -1018,11 +1041,17 @@ fn decode_text(
     set_backend(Backend::Hip);
     let ordinal = 0usize;
 
+    // KV cache size: needs to fit prompt_len + max_new past tokens. Sized
+    // generously here since per-layer KV is small (10 full-attn layers ×
+    // [kv_max_t, Hkv*d=512] BF16 = 10 KiB per token of context).
+    let kv_max_t = prompt_ids.len() + max_new;
+
     let mut layers = Vec::with_capacity(geom.num_layers as usize);
     println!(
-        "  loading {} layers ({} INT4 sidecar sets)…",
+        "  loading {} layers ({} INT4 sidecar sets, KV cache cap = {} tokens)…",
         geom.num_layers,
         if int4_enabled { geom.num_layers } else { 0 },
+        kv_max_t,
     );
     for li in 0..geom.num_layers as usize {
         let layer = load_layer_buffers(
@@ -1033,6 +1062,7 @@ fn decode_text(
             &report.config.text_config,
             weight_prefix,
             int4_enabled,
+            kv_max_t,
         )
         .with_context(|| format!("load layer {li} weights"))?;
         layers.push(layer);
@@ -1139,8 +1169,8 @@ fn decode_text(
         },
     );
     println!(
-        "  (Note: full-attn KV cache is a follow-up — those layers see only \
-         the current token; quality is degraded but the pipeline is end-to-end.)"
+        "  (Note: greedy decoding only; sampling, temperature/top-p, and \
+         GPU-side lm_head are next.)"
     );
     if !generated_ids.is_empty() {
         println!("  Generated ids: {generated_ids:?}");
@@ -1247,6 +1277,7 @@ fn decode_first_token(model_dir: &Path, report: &DryRunReport) -> Result<u32> {
             &report.config.text_config,
             weight_prefix,
             int4_enabled,
+            0, // legacy single-token path: no KV cache, kv_len=1 fast path.
         )
         .with_context(|| format!("load layer {li} weights"))?;
         layers.push(layer);

--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -27,8 +27,8 @@ use qwen36_moe::weights::{
 
 use crate::qwen36_moe_decode::{
     argmax_bf16_logits, dequant_int4_to_bf16_bytes, host_final_norm_lm_head, run_chained_decode,
-    AttnLayerBuffers, FfnInt4Sidecars, FfnLayerBuffers, FullAttnInt4Sidecars, FullAttnKvCache,
-    LayerBuffers, LinearAttnInt4Sidecars, MultiLayerGeom,
+    sample_bf16_logits, AttnLayerBuffers, FfnInt4Sidecars, FfnLayerBuffers, FullAttnInt4Sidecars,
+    FullAttnKvCache, LayerBuffers, LinearAttnInt4Sidecars, MultiLayerGeom, XorshiftRng,
 };
 use crate::registry::{FamilyParams, Qwen36MoeKernelParams, RegistryEntry};
 
@@ -692,13 +692,32 @@ pub fn run(
     //    id so the "doesn't bail" criterion is verifiable end-to-end.
     println!();
     println!("=== Decode (PR 4c step 2: host-orchestrated chained launches) ===");
+    let sampling = SamplingParams {
+        temperature: cli.temperature,
+        top_k: cli.top_k,
+        top_p: cli.top_p,
+        seed: cli.sampling_seed,
+    };
     decode_text(
         &cli.model_dir,
         &report,
         &cli.prompt,
         cli.max_new_tokens.max(1),
+        sampling,
     )?;
     Ok(())
+}
+
+/// Bundles the sampling knobs for the multi-token decode loop. `temperature
+/// <= 0` ⇔ greedy argmax (the deterministic default — bit-identical with
+/// any seed). At temperature > 0, `top_k`/`top_p` filter the distribution
+/// before sampling, then `seed` drives the xorshift RNG.
+#[derive(Debug, Clone, Copy)]
+pub struct SamplingParams {
+    pub temperature: f32,
+    pub top_k: usize,
+    pub top_p: f32,
+    pub seed: u64,
 }
 
 /// Build the geometry the chained decoder needs from the parsed config +
@@ -966,6 +985,7 @@ fn decode_text(
     report: &DryRunReport,
     prompt: &str,
     max_new: usize,
+    sampling: SamplingParams,
 ) -> Result<()> {
     use std::io::Write as _;
 
@@ -1106,6 +1126,11 @@ fn decode_text(
     // forwards = (prompt_len - 1) prefill + max_new generation = prompt_len
     // + max_new - 1.
     let total_steps = prompt_ids.len() + max_new - 1;
+    let mut rng = XorshiftRng::new(sampling.seed);
+    println!(
+        "  sampling: temp={} top_k={} top_p={} seed={}",
+        sampling.temperature, sampling.top_k, sampling.top_p, sampling.seed,
+    );
 
     for step in 0..total_steps {
         // Embed lookup for the current token.
@@ -1128,7 +1153,7 @@ fn decode_text(
             continue;
         }
 
-        // Generation step: lm_head + argmax → next token.
+        // Generation step: lm_head + sample (greedy when temperature == 0).
         let logits = host_final_norm_lm_head(
             &outputs.final_hidden_bytes,
             &final_norm_bytes,
@@ -1137,7 +1162,13 @@ fn decode_text(
             geom.vocab as usize,
             geom.rms_norm_eps,
         );
-        let next_token = argmax_bf16_logits(&logits);
+        let next_token = sample_bf16_logits(
+            &logits,
+            sampling.temperature,
+            sampling.top_k,
+            sampling.top_p,
+            &mut rng,
+        );
         generated_ids.push(next_token);
 
         // Stream-decode and print.

--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -26,9 +26,10 @@ use qwen36_moe::weights::{
 };
 
 use crate::qwen36_moe_decode::{
-    argmax_bf16_logits, dequant_int4_to_bf16_bytes, host_final_norm_lm_head, run_chained_decode,
-    sample_bf16_logits, AttnLayerBuffers, FfnInt4Sidecars, FfnLayerBuffers, FullAttnInt4Sidecars,
-    FullAttnKvCache, LayerBuffers, LinearAttnInt4Sidecars, MultiLayerGeom, XorshiftRng,
+    argmax_bf16_logits, bf16_bytes_to_f32, dequant_int4_to_bf16_bytes, host_final_norm_lm_head,
+    host_final_norm_lm_head_f32, run_chained_decode, sample_bf16_logits, AttnLayerBuffers,
+    FfnInt4Sidecars, FfnLayerBuffers, FullAttnInt4Sidecars, FullAttnKvCache, LayerBuffers,
+    LinearAttnInt4Sidecars, MultiLayerGeom, XorshiftRng,
 };
 use crate::registry::{FamilyParams, Qwen36MoeKernelParams, RegistryEntry};
 
@@ -672,6 +673,23 @@ pub fn run(
         return Ok(());
     }
 
+    // The decode kernels (`kernels/qwen36_moe.hip`, the per-block step
+    // launchers in `kernel-ffi`) are HIP-only. The registry currently has
+    // both HIP and CUDA entries for `qwen3.6-35b-a3b` but the CUDA branches
+    // of `attn_step_launch` / `linear_step_launch` / `ffn_step_launch` all
+    // return `InvalidArg("CUDA backend not yet wired")`. Fail here with a
+    // clear message instead of letting the engine commit to HIP buffers
+    // (which would crash later inside the kernel-ffi wrappers when the
+    // registry-selected backend disagrees).
+    if entry.backend != Backend::Hip {
+        anyhow::bail!(
+            "qwen3.6-35b-a3b decode kernels are HIP-only at this stage; \
+             registry-selected backend was {:?}. Re-run with --backend hip, \
+             or use --dry-run for analytic accounting.",
+            entry.backend,
+        );
+    }
+
     // Real decode path (PR 4c step 2). Uses the host-orchestrated chained
     // launches in `crate::qwen36_moe_decode::run_chained_decode` against
     // per-layer weight buffers loaded from the baked package. INT4 GPTQ
@@ -1090,16 +1108,26 @@ fn decode_text(
 
     // Cache final_norm + dequantized lm_head once. Both are ≥1 GiB BF16
     // for 35B-A3B; reusing the cached buffers across decode steps avoids
-    // redoing the ~1 second INT4 dequant per token.
+    // redoing the ~1 second INT4 dequant per token. Convert to F32 once
+    // here too — the BF16→F32 fan-out of the lm_head matrix (~970 MiB →
+    // ~2 GiB) was previously dominating per-token latency in the host-
+    // side GEMV path; the F32 view is reused for every generated token.
     let final_norm_bytes = host_load_bytes(&store, &format!("{weight_prefix}.norm.weight"))
         .context("load final norm")?;
     let lm_head_bf16_bytes = load_lm_head_bf16(&store, &report.config.text_config, weight_prefix, &geom)
         .context("prepare host-side lm_head BF16 buffer")?;
+    let final_norm_f32 = bf16_bytes_to_f32(&final_norm_bytes);
+    let lm_head_f32 = bf16_bytes_to_f32(&lm_head_bf16_bytes);
     println!(
-        "  cached lm_head BF16 ({:.1} MiB) and final norm ({:.1} KiB).",
+        "  cached lm_head BF16 ({:.1} MiB → F32 {:.1} MiB) and final norm ({:.1} KiB).",
         lm_head_bf16_bytes.len() as f64 / MIB,
+        (lm_head_f32.len() * 4) as f64 / MIB,
         final_norm_bytes.len() as f64 / 1024.0,
     );
+    // Drop the BF16 buffer once the F32 view is built — engine doesn't
+    // need it after this point and the 970 MiB allocation is non-trivial.
+    drop(lm_head_bf16_bytes);
+    drop(final_norm_bytes);
 
     println!(
         "  decoding {} prompt token{} + generating ≤{} new token{}…",
@@ -1164,10 +1192,13 @@ fn decode_text(
         }
 
         // Generation step: lm_head + sample (greedy when temperature == 0).
-        let logits = host_final_norm_lm_head(
+        // Uses the F32-cached final_norm + lm_head so the per-token cost is
+        // just one BF16→F32 of the (small) hidden vector + GEMV; the
+        // expensive lm_head conversion happens once at decode_text start.
+        let logits = host_final_norm_lm_head_f32(
             &outputs.final_hidden_bytes,
-            &final_norm_bytes,
-            &lm_head_bf16_bytes,
+            &final_norm_f32,
+            &lm_head_f32,
             geom.hidden as usize,
             geom.vocab as usize,
             geom.rms_norm_eps,

--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -26,8 +26,9 @@ use qwen36_moe::weights::{
 };
 
 use crate::qwen36_moe_decode::{
-    argmax_bf16_logits, host_final_norm_lm_head, run_chained_decode, AttnLayerBuffers,
-    FfnLayerBuffers, LayerBuffers, MultiLayerGeom,
+    argmax_bf16_logits, dequant_int4_to_bf16_bytes, host_final_norm_lm_head, run_chained_decode,
+    AttnLayerBuffers, FfnInt4Sidecars, FfnLayerBuffers, FullAttnInt4Sidecars, LayerBuffers,
+    LinearAttnInt4Sidecars, MultiLayerGeom,
 };
 use crate::registry::{FamilyParams, Qwen36MoeKernelParams, RegistryEntry};
 
@@ -673,17 +674,20 @@ pub fn run(
 
     // Real decode path (PR 4c step 2). Uses the host-orchestrated chained
     // launches in `crate::qwen36_moe_decode::run_chained_decode` against
-    // per-layer weight buffers loaded from the BF16 baked package. The
-    // multi-layer parity test in `crates/runner/tests/qwen36_moe_multilayer_parity.rs`
-    // gates the decode core against the Python multi-layer oracle (cos_sim
-    // ≥ 0.999); this entry point is the same chain wired to the bake.
+    // per-layer weight buffers loaded from the baked package. INT4 GPTQ
+    // is the realistic path on 24 GiB VRAM; the BF16 fallback is wired
+    // for completeness but won't fit the 65 GiB 35B model. The multi-layer
+    // parity test in `crates/runner/tests/qwen36_moe_multilayer_parity.rs`
+    // gates the decode core against the Python multi-layer oracle for both
+    // BF16 (cos_sim 0.9999) and INT4 (cos_sim 0.9999) modes.
     //
     // Caveats for PR 4c step 2:
-    //  - BF16 only. INT4 chained decode + KV-cache extension are PR 4d.
     //  - One token, fresh state. Conv + recurrent state start zeroed; the
     //    full-attn KV cache isn't allocated (single-block kernels run with
     //    `kv_len=1`). Multi-token generation needs prefill + state
-    //    persistence which lands later.
+    //    persistence which land later.
+    //  - lm_head INT4 dequant runs host-side (~1 GiB BF16 buffer); the
+    //    lm_head GEMV likewise. Lifting both to the GPU is PR 4d.
     //  - Tokenizer not wired — the produced token is printed as a raw vocab
     //    id so the "doesn't bail" criterion is verifiable end-to-end.
     println!();
@@ -691,8 +695,8 @@ pub fn run(
     let token = decode_first_token(&cli.model_dir, &report)?;
     println!("First decoded token id: {token}");
     println!(
-        "(Note: BF16 only, fresh state, raw vocab id. INT4 chained decode + \
-         tokenizer + KV cache extension land in PR 4d.)"
+        "(Note: fresh state, single token, raw vocab id. KV-cache extension, \
+         tokenizer, and GPU-side lm_head land in PR 4d.)"
     );
     Ok(())
 }
@@ -740,9 +744,21 @@ fn load_to_gpu(store: &BakedStore, ordinal: usize, name: &str) -> Result<GpuBuff
         .with_context(|| format!("BakedStore::load_to_gpu({name})"))
 }
 
+/// Pinned by `oracle/bake_int4.py` and the kernel — every INT4 tensor in
+/// the bake quantizes at this group size. Detected per-tensor via a
+/// `*_int4_scale` sidecar; if any quantizable tensor is present and
+/// uses a different group_size we'd surface that as an error.
+const QWEN36_MOE_INT4_GROUP_SIZE: i32 = 128;
+
 /// Build one layer's worth of GPU-resident weight + state buffers from a
 /// BakedStore. Decides full-attn vs linear-attn by consulting the config's
 /// `layer_types` (every 4th layer is full per the standard hybrid pattern).
+/// `int4_enabled` controls whether the weight tensors are loaded as packed
+/// nibbles + sidecars or as BF16. The bake naming convention pairs
+/// `<name>.weight` (packed) with `<name>.weight_int4_scale`/`_int4_zero`
+/// for dense projections, and `<name>` (packed) with `<name>_int4_scale`/
+/// `_int4_zero` for fused-expert tensors (no `.weight` suffix in the
+/// HuggingFace checkpoint).
 fn load_layer_buffers(
     store: &BakedStore,
     ordinal: usize,
@@ -750,11 +766,27 @@ fn load_layer_buffers(
     geom: &MultiLayerGeom,
     text_config: &TextConfig,
     weight_prefix: &str,
+    int4_enabled: bool,
 ) -> Result<LayerBuffers> {
     let lp = format!("{weight_prefix}.layers.{layer_idx}");
 
     let attn = if text_config.is_full_attention(layer_idx) {
         let fa = format!("{lp}.self_attn");
+        let int4 = if int4_enabled {
+            Some(FullAttnInt4Sidecars {
+                group_size: QWEN36_MOE_INT4_GROUP_SIZE,
+                q_proj_scale: load_to_gpu(store, ordinal, &format!("{fa}.q_proj.weight_int4_scale"))?,
+                q_proj_zero:  load_to_gpu(store, ordinal, &format!("{fa}.q_proj.weight_int4_zero"))?,
+                k_proj_scale: load_to_gpu(store, ordinal, &format!("{fa}.k_proj.weight_int4_scale"))?,
+                k_proj_zero:  load_to_gpu(store, ordinal, &format!("{fa}.k_proj.weight_int4_zero"))?,
+                v_proj_scale: load_to_gpu(store, ordinal, &format!("{fa}.v_proj.weight_int4_scale"))?,
+                v_proj_zero:  load_to_gpu(store, ordinal, &format!("{fa}.v_proj.weight_int4_zero"))?,
+                o_proj_scale: load_to_gpu(store, ordinal, &format!("{fa}.o_proj.weight_int4_scale"))?,
+                o_proj_zero:  load_to_gpu(store, ordinal, &format!("{fa}.o_proj.weight_int4_zero"))?,
+            })
+        } else {
+            None
+        };
         AttnLayerBuffers::Full {
             input_norm_w: load_to_gpu(store, ordinal, &format!("{lp}.input_layernorm.weight"))?,
             q_proj_w: load_to_gpu(store, ordinal, &format!("{fa}.q_proj.weight"))?,
@@ -763,6 +795,7 @@ fn load_layer_buffers(
             q_norm_w: load_to_gpu(store, ordinal, &format!("{fa}.q_norm.weight"))?,
             k_norm_w: load_to_gpu(store, ordinal, &format!("{fa}.k_norm.weight"))?,
             o_proj_w: load_to_gpu(store, ordinal, &format!("{fa}.o_proj.weight"))?,
+            int4,
         }
     } else {
         let la = format!("{lp}.linear_attn");
@@ -779,6 +812,20 @@ fn load_layer_buffers(
             .with_context(|| format!("alloc conv_state (layer {layer_idx})"))?;
         let recurrent_state = GpuBuffer::zeros(ordinal, ScalarType::F32, &[state_elems])
             .with_context(|| format!("alloc recurrent_state (layer {layer_idx})"))?;
+
+        let int4 = if int4_enabled {
+            Some(LinearAttnInt4Sidecars {
+                group_size: QWEN36_MOE_INT4_GROUP_SIZE,
+                in_proj_qkv_scale: load_to_gpu(store, ordinal, &format!("{la}.in_proj_qkv.weight_int4_scale"))?,
+                in_proj_qkv_zero:  load_to_gpu(store, ordinal, &format!("{la}.in_proj_qkv.weight_int4_zero"))?,
+                in_proj_z_scale:   load_to_gpu(store, ordinal, &format!("{la}.in_proj_z.weight_int4_scale"))?,
+                in_proj_z_zero:    load_to_gpu(store, ordinal, &format!("{la}.in_proj_z.weight_int4_zero"))?,
+                out_proj_scale:    load_to_gpu(store, ordinal, &format!("{la}.out_proj.weight_int4_scale"))?,
+                out_proj_zero:     load_to_gpu(store, ordinal, &format!("{la}.out_proj.weight_int4_zero"))?,
+            })
+        } else {
+            None
+        };
 
         AttnLayerBuffers::Linear {
             input_norm_w: load_to_gpu(store, ordinal, &format!("{lp}.input_layernorm.weight"))?,
@@ -798,10 +845,30 @@ fn load_layer_buffers(
             out_proj_w: load_to_gpu(store, ordinal, &format!("{la}.out_proj.weight"))?,
             conv_state,
             recurrent_state,
+            int4,
         }
     };
 
     let mp = format!("{lp}.mlp");
+    // Fused-expert sidecars use `_int4_scale`/`_int4_zero` (no `.weight`).
+    // Shared-expert MLPs use the dense `<name>.weight_int4_scale` form.
+    let ffn_int4 = if int4_enabled {
+        Some(FfnInt4Sidecars {
+            group_size: QWEN36_MOE_INT4_GROUP_SIZE,
+            gate_up_proj_scale: load_to_gpu(store, ordinal, &format!("{mp}.experts.gate_up_proj_int4_scale"))?,
+            gate_up_proj_zero:  load_to_gpu(store, ordinal, &format!("{mp}.experts.gate_up_proj_int4_zero"))?,
+            down_proj_scale:    load_to_gpu(store, ordinal, &format!("{mp}.experts.down_proj_int4_scale"))?,
+            down_proj_zero:     load_to_gpu(store, ordinal, &format!("{mp}.experts.down_proj_int4_zero"))?,
+            shared_gate_proj_scale: load_to_gpu(store, ordinal, &format!("{mp}.shared_expert.gate_proj.weight_int4_scale"))?,
+            shared_gate_proj_zero:  load_to_gpu(store, ordinal, &format!("{mp}.shared_expert.gate_proj.weight_int4_zero"))?,
+            shared_up_proj_scale:   load_to_gpu(store, ordinal, &format!("{mp}.shared_expert.up_proj.weight_int4_scale"))?,
+            shared_up_proj_zero:    load_to_gpu(store, ordinal, &format!("{mp}.shared_expert.up_proj.weight_int4_zero"))?,
+            shared_down_proj_scale: load_to_gpu(store, ordinal, &format!("{mp}.shared_expert.down_proj.weight_int4_scale"))?,
+            shared_down_proj_zero:  load_to_gpu(store, ordinal, &format!("{mp}.shared_expert.down_proj.weight_int4_zero"))?,
+        })
+    } else {
+        None
+    };
     let ffn = FfnLayerBuffers {
         post_attn_norm_w: load_to_gpu(store, ordinal, &format!("{lp}.post_attention_layernorm.weight"))?,
         gate_w: load_to_gpu(store, ordinal, &format!("{mp}.gate.weight"))?,
@@ -813,6 +880,7 @@ fn load_layer_buffers(
         shared_up_proj_w: load_to_gpu(store, ordinal, &format!("{mp}.shared_expert.up_proj.weight"))?,
         shared_down_proj_w: load_to_gpu(store, ordinal, &format!("{mp}.shared_expert.down_proj.weight"))?,
         shared_expert_gate_w: load_to_gpu(store, ordinal, &format!("{mp}.shared_expert_gate.weight"))?,
+        int4: ffn_int4,
     };
 
     Ok(LayerBuffers { attn, ffn })
@@ -857,26 +925,35 @@ fn host_load_bytes(store: &BakedStore, name: &str) -> Result<Vec<u8>> {
 }
 
 /// Run one decode step against a real bake. Returns the argmax token id
-/// from the resulting logits.
-///
-/// **Untested on a real bake** — the 35B-A3B BF16 bake doesn't fit 24 GiB
-/// VRAM, and we don't have a smaller-geometry production bake to validate
-/// against. The decode core is parity-tested (cos_sim ≥ 0.999 vs Python
-/// oracle) via `crates/runner/tests/qwen36_moe_multilayer_parity.rs`; if a
-/// loadable bake materialises, this path uses the same chain wired to its
-/// per-layer pointers, so a crash here is more likely a tensor-name typo
-/// than an algorithmic bug.
+/// from the resulting logits. Prefers the INT4 GPTQ bake at
+/// `<model>/.supersonic/v{V}-int4-gptq/` (fits 24 GiB VRAM at ~17 GiB);
+/// falls back to the BF16 bake at `<model>/.supersonic/v{V}/` if INT4
+/// isn't present (BF16 is ~65 GiB and won't fit on a 7900 XTX, but the
+/// path stays for completeness).
 fn decode_first_token(model_dir: &Path, report: &DryRunReport) -> Result<u32> {
     let weight_prefix = report.kernel_params.weight_prefix;
-    let bake_dir = model_store::bake_dir(model_dir);
-    if !bake_dir.exists() {
+
+    // Pick the bake. INT4 is the realistic path on 24 GiB VRAM.
+    let int4_dir = model_store::bake_dir_int4(model_dir);
+    let bf16_dir = model_store::bake_dir(model_dir);
+    let (bake_dir, int4_enabled) = if int4_dir.exists() {
+        (int4_dir, true)
+    } else if bf16_dir.exists() {
+        (bf16_dir, false)
+    } else {
         return Err(anyhow!(
-            "decode requires a BF16 baked package at {}; create one with the \
-             standard bake pipeline or re-run with --dry-run for analytic accounting only. \
-             (PR 4c step 2 wires BF16 only — INT4 chained decode is PR 4d.)",
-            bake_dir.display()
+            "decode requires a baked package — neither INT4-GPTQ ({}) nor \
+             BF16 ({}) exists. Create one with the standard bake pipeline \
+             or re-run with --dry-run for analytic accounting only.",
+            int4_dir.display(),
+            bf16_dir.display()
         ));
-    }
+    };
+    println!(
+        "  loading from bake: {} ({})",
+        bake_dir.display(),
+        if int4_enabled { "INT4 GPTQ" } else { "BF16" }
+    );
     let store = BakedStore::open(&bake_dir)
         .with_context(|| format!("open BakedStore at {}", bake_dir.display()))?;
 
@@ -886,6 +963,13 @@ fn decode_first_token(model_dir: &Path, report: &DryRunReport) -> Result<u32> {
     let ordinal = 0usize;
 
     let mut layers = Vec::with_capacity(geom.num_layers as usize);
+    println!(
+        "  loading {} layer{} ({} INT4 sidecar set{})…",
+        geom.num_layers,
+        if geom.num_layers == 1 { "" } else { "s" },
+        if int4_enabled { geom.num_layers } else { 0 },
+        if geom.num_layers == 1 { "" } else { "s" },
+    );
     for li in 0..geom.num_layers as usize {
         let layer = load_layer_buffers(
             &store,
@@ -894,6 +978,7 @@ fn decode_first_token(model_dir: &Path, report: &DryRunReport) -> Result<u32> {
             &geom,
             &report.config.text_config,
             weight_prefix,
+            int4_enabled,
         )
         .with_context(|| format!("load layer {li} weights"))?;
         layers.push(layer);
@@ -911,25 +996,65 @@ fn decode_first_token(model_dir: &Path, report: &DryRunReport) -> Result<u32> {
         .unwrap_or(0) as usize;
     let initial_hidden = lookup_embed_row(&store, weight_prefix, bos, geom.hidden as usize)
         .with_context(|| format!("lookup embed row {bos}"))?;
+    println!("  embedding row {bos} loaded ({} BF16 bytes)", initial_hidden.len());
 
+    println!("  running chained decode…");
     let outputs =
         run_chained_decode(ordinal, &geom, &mut layers, &initial_hidden, 0).context("chained decode")?;
+    println!(
+        "  decode done; final hidden norm = {:.4}",
+        crate::qwen36_moe_decode::bf16_bytes_to_f32(&outputs.final_hidden_bytes)
+            .iter().map(|x| x * x).sum::<f32>().sqrt()
+    );
 
     let final_norm_bytes = host_load_bytes(&store, &format!("{weight_prefix}.norm.weight"))
         .context("load final norm")?;
-    // `tie_word_embeddings`: lm_head shares bytes with embed_tokens. Either
-    // way we read the [vocab, hidden] BF16 slab as a flat byte stream.
-    let lm_head_bytes = if report.config.text_config.tie_word_embeddings {
-        host_load_bytes(&store, &format!("{weight_prefix}.embed_tokens.weight"))
-            .context("load lm_head (tied)")?
+
+    // lm_head: may be tied to embed_tokens (BF16), standalone BF16, or
+    // INT4-quantized in the bake. Dequantize to BF16 host-side when needed
+    // (kernel-side INT4 lm_head is PR 4d).
+    let (lm_name, lm_packed) = if report.config.text_config.tie_word_embeddings {
+        // Tied: lm_head bytes == embed_tokens bytes (BF16 either way; the
+        // bake doesn't INT4 the embed table). Use the same blob.
+        let n = format!("{weight_prefix}.embed_tokens.weight");
+        let b = host_load_bytes(&store, &n).context("load tied lm_head from embed_tokens")?;
+        (n, b)
     } else {
-        host_load_bytes(&store, "lm_head.weight").context("load lm_head")?
+        let n = "lm_head.weight";
+        let b = host_load_bytes(&store, n).context("load lm_head")?;
+        (n.to_string(), b)
+    };
+    // INT4 detection: if a `*_int4_scale` sidecar exists for this name, the
+    // packed payload above is u8 nibbles (in_dim folded by 2).
+    let scale_name = format!("{lm_name}_int4_scale");
+    let lm_head_bf16_bytes = if store.contains(&scale_name) {
+        let zero_name = format!("{lm_name}_int4_zero");
+        let scale = host_load_bytes(&store, &scale_name).context("load lm_head INT4 scale")?;
+        let zero = host_load_bytes(&store, &zero_name).context("load lm_head INT4 zero")?;
+        let vocab = geom.vocab as usize;
+        let hidden = geom.hidden as usize;
+        println!(
+            "  dequantizing lm_head INT4 [{vocab}, {hidden}] (≈{:.1} MiB → {:.1} MiB BF16)…",
+            lm_packed.len() as f64 / MIB,
+            (vocab * hidden * 2) as f64 / MIB,
+        );
+        dequant_int4_to_bf16_bytes(
+            &lm_packed,
+            &scale,
+            &zero,
+            vocab,
+            hidden,
+            QWEN36_MOE_INT4_GROUP_SIZE as usize,
+        )
+    } else {
+        lm_packed
     };
 
+    println!("  computing host-side norm + lm_head GEMV…");
     let logits = host_final_norm_lm_head(
         &outputs.final_hidden_bytes,
         &final_norm_bytes,
-        &lm_head_bytes,
+        &lm_head_bf16_bytes,
         geom.hidden as usize,
         geom.vocab as usize,
         geom.rms_norm_eps,

--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -13,7 +13,8 @@
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
+use gpu_hal::{set_backend, Backend, GpuBuffer, ScalarType};
 use model_store::manifest::LayoutTag;
 use model_store::BakedStore;
 use qwen36_moe::config::{Config, TextConfig};
@@ -24,6 +25,10 @@ use qwen36_moe::weights::{
     DEFAULT_PREFIX,
 };
 
+use crate::qwen36_moe_decode::{
+    argmax_bf16_logits, host_final_norm_lm_head, run_chained_decode, AttnLayerBuffers,
+    FfnLayerBuffers, LayerBuffers, MultiLayerGeom,
+};
 use crate::registry::{FamilyParams, Qwen36MoeKernelParams, RegistryEntry};
 
 const GIB: f64 = (1024 * 1024 * 1024) as f64;
@@ -635,13 +640,6 @@ pub fn run(
     entry: &RegistryEntry,
     total_vram: u64,
 ) -> Result<()> {
-    if !cli.dry_run {
-        anyhow::bail!(
-            "qwen3.6-35b-a3b runtime: only --dry-run is implemented at this stage. \
-             Re-run with --dry-run to enumerate weights, compute the VRAM budget, \
-             and exit. Full decode lands in PR 4 (CUDA) and PR 6 (HIP)."
-        );
-    }
     // Derive context_size + an honest source flag so the printed report can
     // tell the user which of three answers they got: explicit, prompt-derived
     // estimate, or worst-case defaults-only. The `--context-size` path is
@@ -669,5 +667,272 @@ pub fn run(
         cli.no_bake,
     )?;
     print_report(&report);
+    if cli.dry_run {
+        return Ok(());
+    }
+
+    // Real decode path (PR 4c step 2). Uses the host-orchestrated chained
+    // launches in `crate::qwen36_moe_decode::run_chained_decode` against
+    // per-layer weight buffers loaded from the BF16 baked package. The
+    // multi-layer parity test in `crates/runner/tests/qwen36_moe_multilayer_parity.rs`
+    // gates the decode core against the Python multi-layer oracle (cos_sim
+    // ≥ 0.999); this entry point is the same chain wired to the bake.
+    //
+    // Caveats for PR 4c step 2:
+    //  - BF16 only. INT4 chained decode + KV-cache extension are PR 4d.
+    //  - One token, fresh state. Conv + recurrent state start zeroed; the
+    //    full-attn KV cache isn't allocated (single-block kernels run with
+    //    `kv_len=1`). Multi-token generation needs prefill + state
+    //    persistence which lands later.
+    //  - Tokenizer not wired — the produced token is printed as a raw vocab
+    //    id so the "doesn't bail" criterion is verifiable end-to-end.
+    println!();
+    println!("=== Decode (PR 4c step 2: host-orchestrated chained launches) ===");
+    let token = decode_first_token(&cli.model_dir, &report)?;
+    println!("First decoded token id: {token}");
+    println!(
+        "(Note: BF16 only, fresh state, raw vocab id. INT4 chained decode + \
+         tokenizer + KV cache extension land in PR 4d.)"
+    );
     Ok(())
+}
+
+/// Build the geometry the chained decoder needs from the parsed config +
+/// the registry's per-family params. Mirrors what
+/// `oracle/qwen36_moe_multilayer_oracle.py` puts in `config` and what
+/// `MultiLayerGeom` consumes.
+fn build_multi_layer_geom(
+    text_config: &TextConfig,
+    kernel_params: &Qwen36MoeKernelParams,
+) -> MultiLayerGeom {
+    MultiLayerGeom {
+        hidden: text_config.hidden_size as i32,
+        vocab: text_config.vocab_size as i32,
+        num_layers: text_config.num_hidden_layers as i32,
+        rms_norm_eps: text_config.rms_norm_eps as f32,
+
+        num_attention_heads: text_config.num_attention_heads as i32,
+        num_kv_heads: text_config.num_key_value_heads as i32,
+        head_dim: text_config.head_dim as i32,
+        rotary_dim: text_config.rotary_dim() as i32,
+        rope_theta: text_config.rope_theta() as f32,
+
+        num_k_heads: text_config.linear_num_key_heads as i32,
+        num_v_heads: text_config.linear_num_value_heads as i32,
+        head_k_dim: text_config.linear_key_head_dim as i32,
+        head_v_dim: text_config.linear_value_head_dim as i32,
+        conv_kernel_dim: text_config.linear_conv_kernel_dim as i32,
+
+        num_experts: kernel_params.num_experts as i32,
+        moe_intermediate: kernel_params.moe_intermediate_size as i32,
+        shared_intermediate: kernel_params.shared_expert_intermediate_size as i32,
+        top_k: kernel_params.top_k as i32,
+    }
+}
+
+/// Open a BakedStore from the bake dir, loading one tensor by name to a
+/// fresh GpuBuffer. The wrapper exists to attach a useful context message
+/// when a tensor is missing (the bake-validation in `inspect_bake` already
+/// runs as part of the dry-run, so a missing tensor here is a real bug).
+fn load_to_gpu(store: &BakedStore, ordinal: usize, name: &str) -> Result<GpuBuffer> {
+    store
+        .load_to_gpu(name, ordinal)
+        .with_context(|| format!("BakedStore::load_to_gpu({name})"))
+}
+
+/// Build one layer's worth of GPU-resident weight + state buffers from a
+/// BakedStore. Decides full-attn vs linear-attn by consulting the config's
+/// `layer_types` (every 4th layer is full per the standard hybrid pattern).
+fn load_layer_buffers(
+    store: &BakedStore,
+    ordinal: usize,
+    layer_idx: usize,
+    geom: &MultiLayerGeom,
+    text_config: &TextConfig,
+    weight_prefix: &str,
+) -> Result<LayerBuffers> {
+    let lp = format!("{weight_prefix}.layers.{layer_idx}");
+
+    let attn = if text_config.is_full_attention(layer_idx) {
+        let fa = format!("{lp}.self_attn");
+        AttnLayerBuffers::Full {
+            input_norm_w: load_to_gpu(store, ordinal, &format!("{lp}.input_layernorm.weight"))?,
+            q_proj_w: load_to_gpu(store, ordinal, &format!("{fa}.q_proj.weight"))?,
+            k_proj_w: load_to_gpu(store, ordinal, &format!("{fa}.k_proj.weight"))?,
+            v_proj_w: load_to_gpu(store, ordinal, &format!("{fa}.v_proj.weight"))?,
+            q_norm_w: load_to_gpu(store, ordinal, &format!("{fa}.q_norm.weight"))?,
+            k_norm_w: load_to_gpu(store, ordinal, &format!("{fa}.k_norm.weight"))?,
+            o_proj_w: load_to_gpu(store, ordinal, &format!("{fa}.o_proj.weight"))?,
+        }
+    } else {
+        let la = format!("{lp}.linear_attn");
+        let kernel = geom.conv_kernel_dim as usize;
+        let key_dim = (geom.num_k_heads as usize) * (geom.head_k_dim as usize);
+        let val_dim = (geom.num_v_heads as usize) * (geom.head_v_dim as usize);
+        let qkv_dim = 2 * key_dim + val_dim;
+        let state_elems =
+            (geom.num_v_heads as usize) * (geom.head_k_dim as usize) * (geom.head_v_dim as usize);
+
+        // First-decode-token state: conv + recurrent both zeros. The kernel
+        // mutates them in place; PR 4d will persist them across decode steps.
+        let conv_state = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[qkv_dim, kernel - 1])
+            .with_context(|| format!("alloc conv_state (layer {layer_idx})"))?;
+        let recurrent_state = GpuBuffer::zeros(ordinal, ScalarType::F32, &[state_elems])
+            .with_context(|| format!("alloc recurrent_state (layer {layer_idx})"))?;
+
+        AttnLayerBuffers::Linear {
+            input_norm_w: load_to_gpu(store, ordinal, &format!("{lp}.input_layernorm.weight"))?,
+            in_proj_qkv_w: load_to_gpu(store, ordinal, &format!("{la}.in_proj_qkv.weight"))?,
+            in_proj_z_w: load_to_gpu(store, ordinal, &format!("{la}.in_proj_z.weight"))?,
+            in_proj_a_w: load_to_gpu(store, ordinal, &format!("{la}.in_proj_a.weight"))?,
+            in_proj_b_w: load_to_gpu(store, ordinal, &format!("{la}.in_proj_b.weight"))?,
+            conv1d_w: load_to_gpu(store, ordinal, &format!("{la}.conv1d.weight"))?,
+            // conv1d.bias may be absent — match the loader's behaviour.
+            conv1d_bias: store
+                .contains(&format!("{la}.conv1d.bias"))
+                .then(|| load_to_gpu(store, ordinal, &format!("{la}.conv1d.bias")))
+                .transpose()?,
+            dt_bias: load_to_gpu(store, ordinal, &format!("{la}.dt_bias"))?,
+            a_log: load_to_gpu(store, ordinal, &format!("{la}.A_log"))?,
+            norm_w: load_to_gpu(store, ordinal, &format!("{la}.norm.weight"))?,
+            out_proj_w: load_to_gpu(store, ordinal, &format!("{la}.out_proj.weight"))?,
+            conv_state,
+            recurrent_state,
+        }
+    };
+
+    let mp = format!("{lp}.mlp");
+    let ffn = FfnLayerBuffers {
+        post_attn_norm_w: load_to_gpu(store, ordinal, &format!("{lp}.post_attention_layernorm.weight"))?,
+        gate_w: load_to_gpu(store, ordinal, &format!("{mp}.gate.weight"))?,
+        // Note: experts.gate_up_proj / experts.down_proj have NO `.weight`
+        // suffix in the published checkpoint — see expected_tensor_specs.
+        gate_up_proj_w: load_to_gpu(store, ordinal, &format!("{mp}.experts.gate_up_proj"))?,
+        down_proj_w: load_to_gpu(store, ordinal, &format!("{mp}.experts.down_proj"))?,
+        shared_gate_proj_w: load_to_gpu(store, ordinal, &format!("{mp}.shared_expert.gate_proj.weight"))?,
+        shared_up_proj_w: load_to_gpu(store, ordinal, &format!("{mp}.shared_expert.up_proj.weight"))?,
+        shared_down_proj_w: load_to_gpu(store, ordinal, &format!("{mp}.shared_expert.down_proj.weight"))?,
+        shared_expert_gate_w: load_to_gpu(store, ordinal, &format!("{mp}.shared_expert_gate.weight"))?,
+    };
+
+    Ok(LayerBuffers { attn, ffn })
+}
+
+/// Look up one row of the embedding table on the host. For the
+/// "first decode token" smoke path we use token 0 (or BOS if defined) so
+/// the path runs end-to-end without a tokenizer. The full embed_tokens
+/// tensor is BF16 `[vocab, hidden]`; we slice the first `hidden*2` bytes
+/// out of its mmap-backed raw payload to avoid a full GPU upload of the
+/// embedding table.
+fn lookup_embed_row(
+    store: &BakedStore,
+    weight_prefix: &str,
+    token_id: usize,
+    hidden: usize,
+) -> Result<Vec<u8>> {
+    let name = format!("{weight_prefix}.embed_tokens.weight");
+    let bytes = store
+        .raw_bytes(&name)
+        .ok_or_else(|| anyhow!("missing {name} in bake"))?;
+    let row_bytes = hidden * 2;
+    let start = token_id * row_bytes;
+    let end = start + row_bytes;
+    if end > bytes.len() {
+        return Err(anyhow!(
+            "embed_tokens row {token_id} out of bounds (need {end} bytes, have {})",
+            bytes.len()
+        ));
+    }
+    Ok(bytes[start..end].to_vec())
+}
+
+/// Pull the host-side bytes for a small tensor (final norm, lm_head). For
+/// lm_head with vocab=248K × hidden=2048 BF16 that's ~1 GiB — host RAM is
+/// fine but a future revision should run lm_head on the GPU (PR 4d).
+fn host_load_bytes(store: &BakedStore, name: &str) -> Result<Vec<u8>> {
+    let raw = store
+        .raw_bytes(name)
+        .ok_or_else(|| anyhow!("missing {name} in bake"))?;
+    Ok(raw.to_vec())
+}
+
+/// Run one decode step against a real bake. Returns the argmax token id
+/// from the resulting logits.
+///
+/// **Untested on a real bake** — the 35B-A3B BF16 bake doesn't fit 24 GiB
+/// VRAM, and we don't have a smaller-geometry production bake to validate
+/// against. The decode core is parity-tested (cos_sim ≥ 0.999 vs Python
+/// oracle) via `crates/runner/tests/qwen36_moe_multilayer_parity.rs`; if a
+/// loadable bake materialises, this path uses the same chain wired to its
+/// per-layer pointers, so a crash here is more likely a tensor-name typo
+/// than an algorithmic bug.
+fn decode_first_token(model_dir: &Path, report: &DryRunReport) -> Result<u32> {
+    let weight_prefix = report.kernel_params.weight_prefix;
+    let bake_dir = model_store::bake_dir(model_dir);
+    if !bake_dir.exists() {
+        return Err(anyhow!(
+            "decode requires a BF16 baked package at {}; create one with the \
+             standard bake pipeline or re-run with --dry-run for analytic accounting only. \
+             (PR 4c step 2 wires BF16 only — INT4 chained decode is PR 4d.)",
+            bake_dir.display()
+        ));
+    }
+    let store = BakedStore::open(&bake_dir)
+        .with_context(|| format!("open BakedStore at {}", bake_dir.display()))?;
+
+    let geom = build_multi_layer_geom(&report.config.text_config, &report.kernel_params);
+
+    set_backend(Backend::Hip);
+    let ordinal = 0usize;
+
+    let mut layers = Vec::with_capacity(geom.num_layers as usize);
+    for li in 0..geom.num_layers as usize {
+        let layer = load_layer_buffers(
+            &store,
+            ordinal,
+            li,
+            &geom,
+            &report.config.text_config,
+            weight_prefix,
+        )
+        .with_context(|| format!("load layer {li} weights"))?;
+        layers.push(layer);
+    }
+
+    // BOS token: if the config exposes one, prefer it; otherwise default to
+    // 0. Either way the parity criterion is "doesn't bail and emits a token",
+    // and the produced token id reflects whatever embedding row we picked.
+    let bos = report
+        .config
+        .text_config
+        .bos_token_id
+        .as_ref()
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as usize;
+    let initial_hidden = lookup_embed_row(&store, weight_prefix, bos, geom.hidden as usize)
+        .with_context(|| format!("lookup embed row {bos}"))?;
+
+    let outputs =
+        run_chained_decode(ordinal, &geom, &mut layers, &initial_hidden, 0).context("chained decode")?;
+
+    let final_norm_bytes = host_load_bytes(&store, &format!("{weight_prefix}.norm.weight"))
+        .context("load final norm")?;
+    // `tie_word_embeddings`: lm_head shares bytes with embed_tokens. Either
+    // way we read the [vocab, hidden] BF16 slab as a flat byte stream.
+    let lm_head_bytes = if report.config.text_config.tie_word_embeddings {
+        host_load_bytes(&store, &format!("{weight_prefix}.embed_tokens.weight"))
+            .context("load lm_head (tied)")?
+    } else {
+        host_load_bytes(&store, "lm_head.weight").context("load lm_head")?
+    };
+
+    let logits = host_final_norm_lm_head(
+        &outputs.final_hidden_bytes,
+        &final_norm_bytes,
+        &lm_head_bytes,
+        geom.hidden as usize,
+        geom.vocab as usize,
+        geom.rms_norm_eps,
+    );
+    Ok(argmax_bf16_logits(&logits))
 }

--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -693,10 +693,23 @@ pub fn run(
     println!();
     println!("=== Decode (PR 4c step 2: host-orchestrated chained launches) ===");
     let token = decode_first_token(&cli.model_dir, &report)?;
-    println!("First decoded token id: {token}");
+    let tokenizer_path = cli.model_dir.join("tokenizer.json");
+    match crate::load_tokenizer(&tokenizer_path) {
+        Ok(tok) => match tok.decode(&[token], false) {
+            Ok(text) => println!("First decoded token: id={token}  text={text:?}"),
+            Err(e) => {
+                println!("First decoded token id: {token}");
+                println!("  (tokenizer decode failed: {e})");
+            }
+        },
+        Err(e) => {
+            println!("First decoded token id: {token}");
+            println!("  (tokenizer not loadable from {}: {e})", tokenizer_path.display());
+        }
+    }
     println!(
-        "(Note: fresh state, single token, raw vocab id. KV-cache extension, \
-         tokenizer, and GPU-side lm_head land in PR 4d.)"
+        "(Note: fresh state, single token. Multi-token + prompt-driven \
+         generation + GPU-side lm_head land in PR 4d.)"
     );
     Ok(())
 }

--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -692,25 +692,12 @@ pub fn run(
     //    id so the "doesn't bail" criterion is verifiable end-to-end.
     println!();
     println!("=== Decode (PR 4c step 2: host-orchestrated chained launches) ===");
-    let token = decode_first_token(&cli.model_dir, &report)?;
-    let tokenizer_path = cli.model_dir.join("tokenizer.json");
-    match crate::load_tokenizer(&tokenizer_path) {
-        Ok(tok) => match tok.decode(&[token], false) {
-            Ok(text) => println!("First decoded token: id={token}  text={text:?}"),
-            Err(e) => {
-                println!("First decoded token id: {token}");
-                println!("  (tokenizer decode failed: {e})");
-            }
-        },
-        Err(e) => {
-            println!("First decoded token id: {token}");
-            println!("  (tokenizer not loadable from {}: {e})", tokenizer_path.display());
-        }
-    }
-    println!(
-        "(Note: fresh state, single token. Multi-token + prompt-driven \
-         generation + GPU-side lm_head land in PR 4d.)"
-    );
+    decode_text(
+        &cli.model_dir,
+        &report,
+        &cli.prompt,
+        cli.max_new_tokens.max(1),
+    )?;
     Ok(())
 }
 
@@ -937,12 +924,280 @@ fn host_load_bytes(store: &BakedStore, name: &str) -> Result<Vec<u8>> {
     Ok(raw.to_vec())
 }
 
-/// Run one decode step against a real bake. Returns the argmax token id
-/// from the resulting logits. Prefers the INT4 GPTQ bake at
-/// `<model>/.supersonic/v{V}-int4-gptq/` (fits 24 GiB VRAM at ~17 GiB);
-/// falls back to the BF16 bake at `<model>/.supersonic/v{V}/` if INT4
-/// isn't present (BF16 is ~65 GiB and won't fit on a 7900 XTX, but the
-/// path stays for completeness).
+/// Tokenize the prompt and run the multi-token decode loop end-to-end:
+/// prefill the prompt one token at a time (linear-attn state accumulates
+/// in place; full-attn is currently `kv_len=1` per call — KV-cache
+/// extension is a follow-up), then generate `max_new` tokens via greedy
+/// argmax against the (cached) host-side lm_head GEMV. Streams decoded
+/// text to stdout as each token arrives.
+///
+/// **Quality caveat**: the per-block kernels are stage-5 single-block
+/// launchers — they don't expose KV cache pointers, so full-attention
+/// layers (10 of 40) attend only to the current token. Linear-attn
+/// layers (the other 30) accumulate state correctly across decode steps
+/// because the kernel mutates `conv_state`/`recurrent_state` in place.
+/// Real full-attn KV needs an FFI extension on `Qwen36MoeAttnStepWeights`
+/// + corresponding kernel work — separate piece.
+fn decode_text(
+    model_dir: &Path,
+    report: &DryRunReport,
+    prompt: &str,
+    max_new: usize,
+) -> Result<()> {
+    use std::io::Write as _;
+
+    let weight_prefix = report.kernel_params.weight_prefix;
+
+    // Tokenizer first — without it we can't tokenize the prompt or stream
+    // decoded text. Falls back to BOS-only if the tokenizer can't load.
+    let tokenizer_path = model_dir.join("tokenizer.json");
+    let tokenizer = crate::load_tokenizer(&tokenizer_path).ok();
+
+    let bos_id = report
+        .config
+        .text_config
+        .bos_token_id
+        .as_ref()
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as u32;
+    let eos_id = report
+        .config
+        .text_config
+        .eos_token_id
+        .as_ref()
+        .and_then(|v| v.as_u64())
+        .map(|v| v as u32);
+
+    let prompt_ids: Vec<u32> = match (&tokenizer, prompt.is_empty()) {
+        (Some(tok), false) => {
+            let enc = tok.encode(prompt, true)
+                .map_err(|e| anyhow!("tokenize prompt: {e}"))?;
+            let ids: Vec<u32> = enc.get_ids().to_vec();
+            if ids.is_empty() {
+                vec![bos_id]
+            } else {
+                ids
+            }
+        }
+        _ => vec![bos_id],
+    };
+    println!(
+        "  prompt: {prompt:?} → {} token{} ({:?}{}…)",
+        prompt_ids.len(),
+        if prompt_ids.len() == 1 { "" } else { "s" },
+        &prompt_ids[..prompt_ids.len().min(8)],
+        if prompt_ids.len() > 8 { ", " } else { "" },
+    );
+
+    // Pick the bake. INT4 is the realistic path on 24 GiB VRAM.
+    let int4_dir = model_store::bake_dir_int4(model_dir);
+    let bf16_dir = model_store::bake_dir(model_dir);
+    let (bake_dir, int4_enabled) = if int4_dir.exists() {
+        (int4_dir, true)
+    } else if bf16_dir.exists() {
+        (bf16_dir, false)
+    } else {
+        return Err(anyhow!(
+            "decode requires a baked package — neither INT4-GPTQ ({}) nor \
+             BF16 ({}) exists. Create one with the standard bake pipeline \
+             or re-run with --dry-run for analytic accounting only.",
+            int4_dir.display(),
+            bf16_dir.display()
+        ));
+    };
+    println!(
+        "  loading from bake: {} ({})",
+        bake_dir.display(),
+        if int4_enabled { "INT4 GPTQ" } else { "BF16" }
+    );
+    let store = BakedStore::open(&bake_dir)
+        .with_context(|| format!("open BakedStore at {}", bake_dir.display()))?;
+
+    let geom = build_multi_layer_geom(&report.config.text_config, &report.kernel_params);
+
+    set_backend(Backend::Hip);
+    let ordinal = 0usize;
+
+    let mut layers = Vec::with_capacity(geom.num_layers as usize);
+    println!(
+        "  loading {} layers ({} INT4 sidecar sets)…",
+        geom.num_layers,
+        if int4_enabled { geom.num_layers } else { 0 },
+    );
+    for li in 0..geom.num_layers as usize {
+        let layer = load_layer_buffers(
+            &store,
+            ordinal,
+            li,
+            &geom,
+            &report.config.text_config,
+            weight_prefix,
+            int4_enabled,
+        )
+        .with_context(|| format!("load layer {li} weights"))?;
+        layers.push(layer);
+    }
+
+    // Cache final_norm + dequantized lm_head once. Both are ≥1 GiB BF16
+    // for 35B-A3B; reusing the cached buffers across decode steps avoids
+    // redoing the ~1 second INT4 dequant per token.
+    let final_norm_bytes = host_load_bytes(&store, &format!("{weight_prefix}.norm.weight"))
+        .context("load final norm")?;
+    let lm_head_bf16_bytes = load_lm_head_bf16(&store, &report.config.text_config, weight_prefix, &geom)
+        .context("prepare host-side lm_head BF16 buffer")?;
+    println!(
+        "  cached lm_head BF16 ({:.1} MiB) and final norm ({:.1} KiB).",
+        lm_head_bf16_bytes.len() as f64 / MIB,
+        final_norm_bytes.len() as f64 / 1024.0,
+    );
+
+    println!(
+        "  decoding {} prompt token{} + generating ≤{} new token{}…",
+        prompt_ids.len(),
+        if prompt_ids.len() == 1 { "" } else { "s" },
+        max_new,
+        if max_new == 1 { "" } else { "s" },
+    );
+    println!();
+    print!("> ");
+    if let Some(tok) = &tokenizer {
+        if let Ok(prompt_text) = tok.decode(&prompt_ids, false) {
+            print!("{prompt_text}");
+        }
+    }
+    std::io::stdout().flush().ok();
+
+    let mut generated_ids: Vec<u32> = Vec::with_capacity(max_new);
+    let mut current_token: u32 = prompt_ids[0];
+    let mut position: i32 = 0;
+    // Standard prefill+generate shape: feed prompt[0..N-1] as prefill (logits
+    // discarded), then prompt[N-1] is the first forward whose logits we
+    // sample. Subsequent gen steps feed the just-sampled token. Total
+    // forwards = (prompt_len - 1) prefill + max_new generation = prompt_len
+    // + max_new - 1.
+    let total_steps = prompt_ids.len() + max_new - 1;
+
+    for step in 0..total_steps {
+        // Embed lookup for the current token.
+        let initial_hidden = lookup_embed_row(
+            &store,
+            weight_prefix,
+            current_token as usize,
+            geom.hidden as usize,
+        )
+        .with_context(|| format!("embed lookup token {current_token} (step {step})"))?;
+
+        // Run the chain. Linear-attn state mutates in `layers` in place.
+        let outputs = run_chained_decode(ordinal, &geom, &mut layers, &initial_hidden, position)
+            .with_context(|| format!("chained decode (step {step}, position {position})"))?;
+        position += 1;
+
+        // Prefill steps: feed the next prompt token without computing logits.
+        if step + 1 < prompt_ids.len() {
+            current_token = prompt_ids[step + 1];
+            continue;
+        }
+
+        // Generation step: lm_head + argmax → next token.
+        let logits = host_final_norm_lm_head(
+            &outputs.final_hidden_bytes,
+            &final_norm_bytes,
+            &lm_head_bf16_bytes,
+            geom.hidden as usize,
+            geom.vocab as usize,
+            geom.rms_norm_eps,
+        );
+        let next_token = argmax_bf16_logits(&logits);
+        generated_ids.push(next_token);
+
+        // Stream-decode and print.
+        if let Some(tok) = &tokenizer {
+            if let Ok(text) = tok.decode(&[next_token], false) {
+                print!("{text}");
+                std::io::stdout().flush().ok();
+            }
+        }
+
+        if Some(next_token) == eos_id {
+            break;
+        }
+        current_token = next_token;
+    }
+
+    println!();
+    println!();
+    println!(
+        "Generated {} token{} ({} prompt + {} new). EOS: {}.",
+        generated_ids.len(),
+        if generated_ids.len() == 1 { "" } else { "s" },
+        prompt_ids.len(),
+        generated_ids.len(),
+        if eos_id.map(|e| generated_ids.last() == Some(&e)).unwrap_or(false) {
+            "yes"
+        } else {
+            "no (max_new_tokens hit)"
+        },
+    );
+    println!(
+        "  (Note: full-attn KV cache is a follow-up — those layers see only \
+         the current token; quality is degraded but the pipeline is end-to-end.)"
+    );
+    if !generated_ids.is_empty() {
+        println!("  Generated ids: {generated_ids:?}");
+    }
+
+    Ok(())
+}
+
+/// Load + dequantize lm_head into a BF16 byte buffer that the host-side
+/// GEMV in `host_final_norm_lm_head` consumes. Handles the three layouts:
+/// tied embeddings (BF16 from embed_tokens), standalone BF16, or INT4
+/// GPTQ (packed nibbles + scale/zero sidecars). The dequant runs once per
+/// process; the result is reused across all decode steps.
+fn load_lm_head_bf16(
+    store: &BakedStore,
+    text_config: &TextConfig,
+    weight_prefix: &str,
+    geom: &MultiLayerGeom,
+) -> Result<Vec<u8>> {
+    let (lm_name, lm_packed) = if text_config.tie_word_embeddings {
+        let n = format!("{weight_prefix}.embed_tokens.weight");
+        let b = host_load_bytes(store, &n).context("load tied lm_head from embed_tokens")?;
+        (n, b)
+    } else {
+        let n = "lm_head.weight";
+        let b = host_load_bytes(store, n).context("load lm_head")?;
+        (n.to_string(), b)
+    };
+    let scale_name = format!("{lm_name}_int4_scale");
+    if store.contains(&scale_name) {
+        let zero_name = format!("{lm_name}_int4_zero");
+        let scale = host_load_bytes(store, &scale_name).context("load lm_head INT4 scale")?;
+        let zero = host_load_bytes(store, &zero_name).context("load lm_head INT4 zero")?;
+        let vocab = geom.vocab as usize;
+        let hidden = geom.hidden as usize;
+        println!(
+            "  dequantizing lm_head INT4 [{vocab}, {hidden}] (≈{:.1} MiB → {:.1} MiB BF16)…",
+            lm_packed.len() as f64 / MIB,
+            (vocab * hidden * 2) as f64 / MIB,
+        );
+        Ok(dequant_int4_to_bf16_bytes(
+            &lm_packed,
+            &scale,
+            &zero,
+            vocab,
+            hidden,
+            QWEN36_MOE_INT4_GROUP_SIZE as usize,
+        ))
+    } else {
+        Ok(lm_packed)
+    }
+}
+
+/// Legacy single-token entry point — keeps the original `decode_first_token`
+/// callable so the path stays exercised. Currently unused but documents the
+/// minimal one-step decode shape.
+#[allow(dead_code)]
 fn decode_first_token(model_dir: &Path, report: &DryRunReport) -> Result<u32> {
     let weight_prefix = report.kernel_params.weight_prefix;
 

--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -1153,6 +1153,16 @@ fn decode_text(
             continue;
         }
 
+        // Optional dump for the host-side post-chain debug harness.
+        if let Ok(dump_path) = std::env::var("SUPERSONIC_QWEN36_DUMP_FINAL_HIDDEN") {
+            std::fs::write(&dump_path, &outputs.final_hidden_bytes)
+                .with_context(|| format!("write final_hidden dump to {dump_path}"))?;
+            eprintln!(
+                "[debug] dumped step={step} position={position} final_hidden ({} BF16 bytes) to {dump_path}",
+                outputs.final_hidden_bytes.len()
+            );
+        }
+
         // Generation step: lm_head + sample (greedy when temperature == 0).
         let logits = host_final_norm_lm_head(
             &outputs.final_hidden_bytes,
@@ -1162,6 +1172,14 @@ fn decode_text(
             geom.vocab as usize,
             geom.rms_norm_eps,
         );
+        if let Ok(dump_path) = std::env::var("SUPERSONIC_QWEN36_DUMP_LOGITS") {
+            std::fs::write(&dump_path, &logits)
+                .with_context(|| format!("write logits dump to {dump_path}"))?;
+            eprintln!(
+                "[debug] dumped step={step} logits ({} BF16 bytes) to {dump_path}",
+                logits.len()
+            );
+        }
         let next_token = sample_bf16_logits(
             &logits,
             sampling.temperature,

--- a/crates/runner/tests/qwen36_moe_multilayer_parity.rs
+++ b/crates/runner/tests/qwen36_moe_multilayer_parity.rs
@@ -1,0 +1,368 @@
+//! PR 4c step 2 multi-layer parity test for Qwen3.6-MoE.
+//!
+//! Loads the multi-layer Python oracle's JSON payload (produced by
+//! `oracle/qwen36_moe_multilayer_oracle.py`), uploads each layer's BF16
+//! weights + initial linear-attn state to the GPU, runs the chained decode
+//! via [`runner::qwen36_moe_decode::run_chained_decode`], applies the host-
+//! side final RMSnorm + lm_head, and compares against the oracle's
+//! `intermediates_per_layer` + `final_hidden` + `logits` (cos_sim ≥ 0.999
+//! per the PR 4c acceptance criteria; same ≤0.05 max-abs envelope as the
+//! per-block tests).
+//!
+//! Skipped silently when `SUPERSONIC_QWEN36_MULTILAYER_ORACLE_JSON` isn't
+//! set so CI / non-HIP machines stay green. To run locally:
+//!
+//! ```bash
+//! ~/venvs/rocm/bin/python oracle/qwen36_moe_multilayer_oracle.py \
+//!     --mode synthetic --num-layers 4 --out /tmp/qwen36_ml.json
+//! SUPERSONIC_QWEN36_MULTILAYER_ORACLE_JSON=/tmp/qwen36_ml.json \
+//!   cargo test --release -p runner --test qwen36_moe_multilayer_parity \
+//!     -- --nocapture
+//! ```
+//!
+//! Only runs when the HIP backend is compiled (PR 4c is HIP-only —
+//! `kernels/qwen36_moe.hip` is the only compiled implementation, per
+//! `~/.claude/.../memory/hardware_hip_only.md` and CLAUDE.md).
+//! The `supersonic_backend_hip` rustc cfg is set by `gpu-hal` and
+//! `kernel-ffi` build scripts but doesn't propagate to the `runner` crate's
+//! integration tests; we gate at runtime via [`gpu_hal::is_backend_compiled`]
+//! so this file always builds and skips cleanly when HIP isn't available.
+
+use base64::Engine;
+use gpu_hal::{is_backend_compiled, set_backend, Backend, GpuBuffer, ScalarType};
+use runner::qwen36_moe_decode::{
+    bf16_bytes_to_f32, host_final_norm_lm_head, is_full_attn_layer, run_chained_decode,
+    AttnLayerBuffers, FfnLayerBuffers, LayerBuffers, MultiLayerGeom,
+};
+use serde_json::Value;
+
+fn b64(input: &str) -> Vec<u8> {
+    base64::engine::general_purpose::STANDARD
+        .decode(input)
+        .expect("base64 decode")
+}
+
+fn b64_field(obj: &Value, name: &str) -> Vec<u8> {
+    let s = obj
+        .get(name)
+        .and_then(|v| v.as_str())
+        .unwrap_or_else(|| panic!("oracle JSON missing field {name}"));
+    b64(s)
+}
+
+fn parse_geom(json: &Value) -> MultiLayerGeom {
+    let cfg = &json["config"];
+    let attn = &cfg["attn"];
+    let lin = &cfg["lin"];
+    let ffn = &cfg["ffn"];
+    MultiLayerGeom {
+        hidden: cfg["hidden"].as_i64().unwrap() as i32,
+        vocab: cfg["vocab"].as_i64().unwrap() as i32,
+        num_layers: json["num_layers"].as_i64().unwrap() as i32,
+        rms_norm_eps: cfg["rms_norm_eps"].as_f64().unwrap() as f32,
+        num_attention_heads: attn["num_attention_heads"].as_i64().unwrap() as i32,
+        num_kv_heads: attn["num_kv_heads"].as_i64().unwrap() as i32,
+        head_dim: attn["head_dim"].as_i64().unwrap() as i32,
+        rotary_dim: attn["rotary_dim"].as_i64().unwrap() as i32,
+        rope_theta: attn["rope_theta"].as_f64().unwrap() as f32,
+        num_k_heads: lin["num_k_heads"].as_i64().unwrap() as i32,
+        num_v_heads: lin["num_v_heads"].as_i64().unwrap() as i32,
+        head_k_dim: lin["head_k_dim"].as_i64().unwrap() as i32,
+        head_v_dim: lin["head_v_dim"].as_i64().unwrap() as i32,
+        conv_kernel_dim: lin["conv_kernel_dim"].as_i64().unwrap() as i32,
+        num_experts: ffn["num_experts"].as_i64().unwrap() as i32,
+        moe_intermediate: ffn["moe_intermediate"].as_i64().unwrap() as i32,
+        shared_intermediate: ffn["shared_intermediate"].as_i64().unwrap() as i32,
+        top_k: ffn["top_k"].as_i64().unwrap() as i32,
+    }
+}
+
+fn upload_bf16(ordinal: usize, shape: &[usize], bytes: &[u8], label: &str) -> GpuBuffer {
+    GpuBuffer::from_host_bytes(ordinal, ScalarType::BF16, shape, bytes)
+        .unwrap_or_else(|e| panic!("upload {label}: {e}"))
+}
+
+fn upload_f32(ordinal: usize, shape: &[usize], bytes: &[u8], label: &str) -> GpuBuffer {
+    GpuBuffer::from_host_bytes(ordinal, ScalarType::F32, shape, bytes)
+        .unwrap_or_else(|e| panic!("upload {label}: {e}"))
+}
+
+fn build_full_attn_layer(
+    ordinal: usize,
+    geom: &MultiLayerGeom,
+    weights: &Value,
+) -> AttnLayerBuffers {
+    let hidden = geom.hidden as usize;
+    let h = geom.num_attention_heads as usize;
+    let hkv = geom.num_kv_heads as usize;
+    let d = geom.head_dim as usize;
+
+    AttnLayerBuffers::Full {
+        input_norm_w: upload_bf16(ordinal, &[hidden], &b64_field(weights, "input_norm_w"), "input_norm_w"),
+        q_proj_w: upload_bf16(ordinal, &[2 * h * d, hidden], &b64_field(weights, "q_proj_w"), "q_proj_w"),
+        k_proj_w: upload_bf16(ordinal, &[hkv * d, hidden], &b64_field(weights, "k_proj_w"), "k_proj_w"),
+        v_proj_w: upload_bf16(ordinal, &[hkv * d, hidden], &b64_field(weights, "v_proj_w"), "v_proj_w"),
+        q_norm_w: upload_bf16(ordinal, &[d], &b64_field(weights, "q_norm_w"), "q_norm_w"),
+        k_norm_w: upload_bf16(ordinal, &[d], &b64_field(weights, "k_norm_w"), "k_norm_w"),
+        o_proj_w: upload_bf16(ordinal, &[hidden, h * d], &b64_field(weights, "o_proj_w"), "o_proj_w"),
+    }
+}
+
+fn build_linear_attn_layer(
+    ordinal: usize,
+    geom: &MultiLayerGeom,
+    weights: &Value,
+) -> AttnLayerBuffers {
+    let hidden = geom.hidden as usize;
+    let k = geom.num_k_heads as usize;
+    let v = geom.num_v_heads as usize;
+    let kd = geom.head_k_dim as usize;
+    let vd = geom.head_v_dim as usize;
+    let kernel = geom.conv_kernel_dim as usize;
+    let key_dim = k * kd;
+    let val_dim = v * vd;
+    let qkv_dim = 2 * key_dim + val_dim;
+    let state_elems = v * kd * vd;
+
+    let conv1d_bias = weights
+        .get("conv1d_bias")
+        .and_then(|v| v.as_str())
+        .map(|s| upload_bf16(ordinal, &[qkv_dim], &b64(s), "conv1d_bias"));
+
+    AttnLayerBuffers::Linear {
+        input_norm_w: upload_bf16(ordinal, &[hidden], &b64_field(weights, "input_norm_w"), "input_norm_w"),
+        in_proj_qkv_w: upload_bf16(ordinal, &[qkv_dim, hidden], &b64_field(weights, "in_proj_qkv_w"), "in_proj_qkv_w"),
+        in_proj_z_w: upload_bf16(ordinal, &[val_dim, hidden], &b64_field(weights, "in_proj_z_w"), "in_proj_z_w"),
+        in_proj_a_w: upload_bf16(ordinal, &[v, hidden], &b64_field(weights, "in_proj_a_w"), "in_proj_a_w"),
+        in_proj_b_w: upload_bf16(ordinal, &[v, hidden], &b64_field(weights, "in_proj_b_w"), "in_proj_b_w"),
+        // The kernel's depthwise conv1d expects the channel-major layout the
+        // bake produces: `[qkv_dim, kernel]`. The oracle stores it in the
+        // squeezed shape; the BF16 byte stream is identical either way.
+        conv1d_w: upload_bf16(ordinal, &[qkv_dim, kernel], &b64_field(weights, "conv1d_w"), "conv1d_w"),
+        conv1d_bias,
+        dt_bias: upload_bf16(ordinal, &[v], &b64_field(weights, "dt_bias"), "dt_bias"),
+        a_log: upload_bf16(ordinal, &[v], &b64_field(weights, "a_log"), "a_log"),
+        norm_w: upload_bf16(ordinal, &[vd], &b64_field(weights, "norm_w"), "norm_w"),
+        out_proj_w: upload_bf16(ordinal, &[hidden, val_dim], &b64_field(weights, "out_proj_w"), "out_proj_w"),
+        conv_state: upload_bf16(
+            ordinal,
+            &[qkv_dim, kernel - 1],
+            &b64_field(weights, "conv_state_before"),
+            "conv_state_before",
+        ),
+        // Recurrent state is F32 (production keeps it F32 across decode steps).
+        recurrent_state: upload_f32(
+            ordinal,
+            &[state_elems],
+            &b64_field(weights, "recurrent_state_before"),
+            "recurrent_state_before",
+        ),
+    }
+}
+
+fn build_ffn_layer(ordinal: usize, geom: &MultiLayerGeom, weights: &Value) -> FfnLayerBuffers {
+    let hidden = geom.hidden as usize;
+    let e = geom.num_experts as usize;
+    let i_dim = geom.moe_intermediate as usize;
+    let is_dim = geom.shared_intermediate as usize;
+
+    FfnLayerBuffers {
+        post_attn_norm_w: upload_bf16(ordinal, &[hidden], &b64_field(weights, "post_attn_norm_w"), "post_attn_norm_w"),
+        gate_w: upload_bf16(ordinal, &[e, hidden], &b64_field(weights, "gate_w"), "gate_w"),
+        gate_up_proj_w: upload_bf16(
+            ordinal,
+            &[e, 2 * i_dim, hidden],
+            &b64_field(weights, "gate_up_proj_w"),
+            "gate_up_proj_w",
+        ),
+        down_proj_w: upload_bf16(
+            ordinal,
+            &[e, hidden, i_dim],
+            &b64_field(weights, "down_proj_w"),
+            "down_proj_w",
+        ),
+        shared_gate_proj_w: upload_bf16(ordinal, &[is_dim, hidden], &b64_field(weights, "shared_gate_proj_w"), "shared_gate_proj_w"),
+        shared_up_proj_w: upload_bf16(ordinal, &[is_dim, hidden], &b64_field(weights, "shared_up_proj_w"), "shared_up_proj_w"),
+        shared_down_proj_w: upload_bf16(ordinal, &[hidden, is_dim], &b64_field(weights, "shared_down_proj_w"), "shared_down_proj_w"),
+        shared_expert_gate_w: upload_bf16(
+            ordinal,
+            &[1, hidden],
+            &b64_field(weights, "shared_expert_gate_w"),
+            "shared_expert_gate_w",
+        ),
+    }
+}
+
+/// Identical envelope to the per-block parity tests: cos_sim against the
+/// oracle's BF16 buffer, plus a max |delta| tolerance. Per the plan, the
+/// final logits parity gate is `cos_sim ≥ 0.999`. Per-layer hiddens get a
+/// tighter `0.9999` floor since they're individual residuals (not a
+/// reduction over `vocab` lanes).
+fn assert_parity_bf16(label: &str, got: &[u8], want: &[u8], max_abs_tol: f32, cos_sim_floor: f64) {
+    assert_eq!(got.len(), want.len(), "{label}: byte length mismatch");
+    let g = bf16_bytes_to_f32(got);
+    let w = bf16_bytes_to_f32(want);
+    let n = g.len();
+    let mut max_abs = 0f32;
+    let mut sum_abs = 0f32;
+    let mut dot = 0f64;
+    let mut g_sq = 0f64;
+    let mut w_sq = 0f64;
+    let mut exact = 0usize;
+    for i in 0..n {
+        let d = (g[i] - w[i]).abs();
+        if d == 0.0 {
+            exact += 1;
+        }
+        max_abs = max_abs.max(d);
+        sum_abs += d;
+        dot += g[i] as f64 * w[i] as f64;
+        g_sq += (g[i] as f64).powi(2);
+        w_sq += (w[i] as f64).powi(2);
+    }
+    let cos_sim = dot / (g_sq.sqrt() * w_sq.sqrt() + 1e-30);
+    let mean_abs = sum_abs / n as f32;
+    eprintln!(
+        "[parity {label}] n={n} exact={exact} max_abs={max_abs:.5e} \
+         mean_abs={mean_abs:.5e} cos_sim={cos_sim:.7}"
+    );
+    assert!(
+        max_abs <= max_abs_tol,
+        "{label}: max_abs {max_abs} exceeds tolerance {max_abs_tol}"
+    );
+    assert!(
+        cos_sim >= cos_sim_floor,
+        "{label}: cos_sim {cos_sim:.7} below floor {cos_sim_floor}"
+    );
+}
+
+#[test]
+fn multilayer_chained_decode_matches_oracle() {
+    if !is_backend_compiled(Backend::Hip) {
+        eprintln!(
+            "skip: HIP backend not compiled — multi-layer parity test only \
+             exercises the HIP kernels (CUDA/Metal aren't wired)."
+        );
+        return;
+    }
+    let Ok(json_path) = std::env::var("SUPERSONIC_QWEN36_MULTILAYER_ORACLE_JSON") else {
+        eprintln!(
+            "skip: SUPERSONIC_QWEN36_MULTILAYER_ORACLE_JSON not set. Generate with \
+             `~/venvs/rocm/bin/python oracle/qwen36_moe_multilayer_oracle.py \
+             --mode synthetic --num-layers 4 --out /tmp/qwen36_ml.json`."
+        );
+        return;
+    };
+    let raw = std::fs::read_to_string(&json_path)
+        .unwrap_or_else(|e| panic!("read multi-layer oracle json {json_path}: {e}"));
+    let json: Value = serde_json::from_str(&raw).expect("parse multi-layer oracle json");
+    let schema = json["schema"].as_str().unwrap_or("");
+    assert_eq!(
+        schema, "qwen36-moe-oracle-multilayer-v1",
+        "PR 4c step 2 only handles BF16 multi-layer schema (got {schema}); INT4 multi-layer parity is a follow-up"
+    );
+    assert_eq!(
+        json["dtype"].as_str().unwrap_or(""),
+        "bf16",
+        "multi-layer parity requires bf16 dtype"
+    );
+
+    let geom = parse_geom(&json);
+    let position = json["position"].as_i64().unwrap_or(0) as i32;
+
+    set_backend(Backend::Hip);
+    let ordinal = 0usize;
+
+    // Per-layer weight + state buffers. One LayerBuffers per transformer
+    // layer; the order in `weights_per_layer` matches `layers[i].layer_idx`.
+    let weights_per_layer = json["weights_per_layer"]
+        .as_array()
+        .expect("oracle JSON missing weights_per_layer (regenerate without --no-emit-weights)");
+    assert_eq!(
+        weights_per_layer.len(),
+        geom.num_layers as usize,
+        "weights_per_layer length mismatch"
+    );
+
+    let mut layers: Vec<LayerBuffers> = Vec::with_capacity(geom.num_layers as usize);
+    for (li, layer_json) in weights_per_layer.iter().enumerate() {
+        let attn_w = &layer_json["attn"];
+        let ffn_w = &layer_json["ffn"];
+        let attn = if is_full_attn_layer(li as i32) {
+            build_full_attn_layer(ordinal, &geom, attn_w)
+        } else {
+            build_linear_attn_layer(ordinal, &geom, attn_w)
+        };
+        let ffn = build_ffn_layer(ordinal, &geom, ffn_w);
+        layers.push(LayerBuffers { attn, ffn });
+    }
+
+    let initial_hidden = b64_field(&json, "input_hidden");
+    let final_norm_w = b64_field(&json, "final_norm_w");
+    let lm_head_w = b64_field(&json, "lm_head_w");
+    let oracle_logits = b64_field(&json, "logits");
+
+    let outputs = run_chained_decode(ordinal, &geom, &mut layers, &initial_hidden, position)
+        .expect("chained decode");
+
+    // Per-layer parity. Tighter floor (0.9999) — no vocab-wide reduction
+    // to absorb noise.
+    // BF16 rounding noise compounds through residuals — every layer's matvec
+    // adds ~1 ULP per output channel, and N-layer chains see roughly N×
+    // the single-block max_abs and a few-times-N drop in cos_sim. The
+    // PR 4c acceptance criterion (cos_sim ≥ 0.999 on the final logits)
+    // is the real structural-correctness gate; per-layer envelopes are
+    // outlier sanity checks scaled with depth so the 4th residual being
+    // 4× noisier than the 1st doesn't false-positive.
+    let max_abs_envelope = |li: usize| -> f32 {
+        // Single-block stage-5 tests use 0.05; allow that much per layer
+        // of compounding (capped at 0.5 so a real divergence still trips).
+        (0.05 * (li as f32 + 1.0) * 1.5).min(0.5)
+    };
+    // Drop per-layer cos_sim floor by ~5e-5 per layer of depth — matches
+    // the observed drift on the synthetic 4-layer fixture (0.9999937 at
+    // layer 0 down to ~0.99988 at layer 3) with headroom. Still tight
+    // enough that any real bug (e.g. wrong layer kind, swapped weight
+    // pointer) trips it by orders of magnitude.
+    let cos_sim_floor = |li: usize| -> f64 {
+        (0.9999 - 5e-5 * li as f64).max(0.999)
+    };
+    let inters = json["intermediates_per_layer"].as_array().expect("intermediates_per_layer array");
+    assert_eq!(inters.len(), geom.num_layers as usize, "intermediates length mismatch");
+    for (li, item) in inters.iter().enumerate() {
+        let want_attn = b64_field(item, "output_after_attn");
+        let want_ffn = b64_field(item, "output_after_ffn");
+        let envelope = max_abs_envelope(li);
+        let floor = cos_sim_floor(li);
+        assert_parity_bf16(
+            &format!("layer {li} output_after_attn"),
+            &outputs.per_layer_attn_out[li],
+            &want_attn,
+            envelope,
+            floor,
+        );
+        assert_parity_bf16(
+            &format!("layer {li} output_after_ffn"),
+            &outputs.per_layer_ffn_out[li],
+            &want_ffn,
+            envelope,
+            floor,
+        );
+    }
+
+    // The kernel-side residual is covered by the per-layer last-FFN check
+    // above (oracle's `final_hidden` is POST-RMSnorm so it isn't directly
+    // comparable to `outputs.final_hidden_bytes`). Host-side final RMSnorm
+    // + lm_head against that residual produces logits to compare; the
+    // cos_sim floor is the PR 4c acceptance criterion (≥ 0.999 over the
+    // vocab logits).
+    let logits = host_final_norm_lm_head(
+        &outputs.final_hidden_bytes,
+        &final_norm_w,
+        &lm_head_w,
+        geom.hidden as usize,
+        geom.vocab as usize,
+        geom.rms_norm_eps,
+    );
+    assert_parity_bf16("logits", &logits, &oracle_logits, 0.5, 0.999);
+}

--- a/crates/runner/tests/qwen36_moe_multilayer_parity.rs
+++ b/crates/runner/tests/qwen36_moe_multilayer_parity.rs
@@ -161,6 +161,9 @@ fn build_full_attn_layer(
         k_norm_w: upload_bf16(ordinal, &[d], &b64_field(weights, "k_norm_w"), "k_norm_w"),
         o_proj_w,
         int4,
+        // Parity test runs at position=0; KV cache stays disabled so the
+        // kernel uses the back-compat kv_len=1 self-attention path.
+        kv_cache: None,
     }
 }
 

--- a/crates/runner/tests/qwen36_moe_multilayer_parity.rs
+++ b/crates/runner/tests/qwen36_moe_multilayer_parity.rs
@@ -32,7 +32,8 @@ use base64::Engine;
 use gpu_hal::{is_backend_compiled, set_backend, Backend, GpuBuffer, ScalarType};
 use runner::qwen36_moe_decode::{
     bf16_bytes_to_f32, host_final_norm_lm_head, is_full_attn_layer, run_chained_decode,
-    AttnLayerBuffers, FfnLayerBuffers, LayerBuffers, MultiLayerGeom,
+    AttnLayerBuffers, FfnInt4Sidecars, FfnLayerBuffers, FullAttnInt4Sidecars, LayerBuffers,
+    LinearAttnInt4Sidecars, MultiLayerGeom,
 };
 use serde_json::Value;
 
@@ -87,24 +88,79 @@ fn upload_f32(ordinal: usize, shape: &[usize], bytes: &[u8], label: &str) -> Gpu
         .unwrap_or_else(|e| panic!("upload {label}: {e}"))
 }
 
+fn upload_u8(ordinal: usize, shape: &[usize], bytes: &[u8], label: &str) -> GpuBuffer {
+    GpuBuffer::from_host_bytes(ordinal, ScalarType::U8, shape, bytes)
+        .unwrap_or_else(|e| panic!("upload {label}: {e}"))
+}
+
+/// Helper: pull (packed_u8, scale_bf16, zero_bf16) byte streams for one
+/// INT4-quantized tensor out of `int4_weights_per_layer[li].{attn|ffn}.<name>`.
+fn decode_int4_sidecar(block: &Value, name: &str) -> (Vec<u8>, Vec<u8>, Vec<u8>) {
+    let blk = &block[name];
+    let packed = b64(blk["packed"].as_str()
+        .unwrap_or_else(|| panic!("missing int4 {name}.packed")));
+    let scale = b64(blk["scale"].as_str()
+        .unwrap_or_else(|| panic!("missing int4 {name}.scale")));
+    let zero = b64(blk["zero"].as_str()
+        .unwrap_or_else(|| panic!("missing int4 {name}.zero")));
+    (packed, scale, zero)
+}
+
 fn build_full_attn_layer(
     ordinal: usize,
     geom: &MultiLayerGeom,
     weights: &Value,
+    int4_block: Option<&Value>,
+    group_size: i32,
 ) -> AttnLayerBuffers {
     let hidden = geom.hidden as usize;
     let h = geom.num_attention_heads as usize;
     let hkv = geom.num_kv_heads as usize;
     let d = geom.head_dim as usize;
 
+    // In INT4 mode the projection weight buffers carry packed nibbles
+    // ([out, in/2] u8) instead of BF16 reconstructions. Sidecars come from
+    // the parallel `int4_weights_per_layer[li].attn` block.
+    let (q_proj_w, k_proj_w, v_proj_w, o_proj_w, int4) = if let Some(blk) = int4_block {
+        let (qp, qs, qz) = decode_int4_sidecar(blk, "q_proj_w");
+        let (kp, ks, kz) = decode_int4_sidecar(blk, "k_proj_w");
+        let (vp, vs, vz) = decode_int4_sidecar(blk, "v_proj_w");
+        let (op, os, oz) = decode_int4_sidecar(blk, "o_proj_w");
+        let q_proj_w = upload_u8(ordinal, &[2 * h * d, hidden / 2], &qp, "q_proj packed");
+        let k_proj_w = upload_u8(ordinal, &[hkv * d, hidden / 2], &kp, "k_proj packed");
+        let v_proj_w = upload_u8(ordinal, &[hkv * d, hidden / 2], &vp, "v_proj packed");
+        let o_proj_w = upload_u8(ordinal, &[hidden, h * d / 2], &op, "o_proj packed");
+        let int4 = FullAttnInt4Sidecars {
+            group_size,
+            q_proj_scale: upload_bf16(ordinal, &[qs.len() / 2], &qs, "q scale"),
+            q_proj_zero:  upload_bf16(ordinal, &[qz.len() / 2], &qz, "q zero"),
+            k_proj_scale: upload_bf16(ordinal, &[ks.len() / 2], &ks, "k scale"),
+            k_proj_zero:  upload_bf16(ordinal, &[kz.len() / 2], &kz, "k zero"),
+            v_proj_scale: upload_bf16(ordinal, &[vs.len() / 2], &vs, "v scale"),
+            v_proj_zero:  upload_bf16(ordinal, &[vz.len() / 2], &vz, "v zero"),
+            o_proj_scale: upload_bf16(ordinal, &[os.len() / 2], &os, "o scale"),
+            o_proj_zero:  upload_bf16(ordinal, &[oz.len() / 2], &oz, "o zero"),
+        };
+        (q_proj_w, k_proj_w, v_proj_w, o_proj_w, Some(int4))
+    } else {
+        (
+            upload_bf16(ordinal, &[2 * h * d, hidden], &b64_field(weights, "q_proj_w"), "q_proj_w"),
+            upload_bf16(ordinal, &[hkv * d, hidden], &b64_field(weights, "k_proj_w"), "k_proj_w"),
+            upload_bf16(ordinal, &[hkv * d, hidden], &b64_field(weights, "v_proj_w"), "v_proj_w"),
+            upload_bf16(ordinal, &[hidden, h * d], &b64_field(weights, "o_proj_w"), "o_proj_w"),
+            None,
+        )
+    };
+
     AttnLayerBuffers::Full {
         input_norm_w: upload_bf16(ordinal, &[hidden], &b64_field(weights, "input_norm_w"), "input_norm_w"),
-        q_proj_w: upload_bf16(ordinal, &[2 * h * d, hidden], &b64_field(weights, "q_proj_w"), "q_proj_w"),
-        k_proj_w: upload_bf16(ordinal, &[hkv * d, hidden], &b64_field(weights, "k_proj_w"), "k_proj_w"),
-        v_proj_w: upload_bf16(ordinal, &[hkv * d, hidden], &b64_field(weights, "v_proj_w"), "v_proj_w"),
+        q_proj_w,
+        k_proj_w,
+        v_proj_w,
         q_norm_w: upload_bf16(ordinal, &[d], &b64_field(weights, "q_norm_w"), "q_norm_w"),
         k_norm_w: upload_bf16(ordinal, &[d], &b64_field(weights, "k_norm_w"), "k_norm_w"),
-        o_proj_w: upload_bf16(ordinal, &[hidden, h * d], &b64_field(weights, "o_proj_w"), "o_proj_w"),
+        o_proj_w,
+        int4,
     }
 }
 
@@ -112,6 +168,8 @@ fn build_linear_attn_layer(
     ordinal: usize,
     geom: &MultiLayerGeom,
     weights: &Value,
+    int4_block: Option<&Value>,
+    group_size: i32,
 ) -> AttnLayerBuffers {
     let hidden = geom.hidden as usize;
     let k = geom.num_k_heads as usize;
@@ -129,10 +187,36 @@ fn build_linear_attn_layer(
         .and_then(|v| v.as_str())
         .map(|s| upload_bf16(ordinal, &[qkv_dim], &b64(s), "conv1d_bias"));
 
+    let (in_proj_qkv_w, in_proj_z_w, out_proj_w, int4) = if let Some(blk) = int4_block {
+        let (qp, qs, qz) = decode_int4_sidecar(blk, "in_proj_qkv_w");
+        let (zp, zs, zz) = decode_int4_sidecar(blk, "in_proj_z_w");
+        let (op, os, oz) = decode_int4_sidecar(blk, "out_proj_w");
+        let in_proj_qkv_w = upload_u8(ordinal, &[qkv_dim, hidden / 2], &qp, "in_proj_qkv packed");
+        let in_proj_z_w = upload_u8(ordinal, &[val_dim, hidden / 2], &zp, "in_proj_z packed");
+        let out_proj_w = upload_u8(ordinal, &[hidden, val_dim / 2], &op, "out_proj packed");
+        let int4 = LinearAttnInt4Sidecars {
+            group_size,
+            in_proj_qkv_scale: upload_bf16(ordinal, &[qs.len() / 2], &qs, "in_proj_qkv scale"),
+            in_proj_qkv_zero:  upload_bf16(ordinal, &[qz.len() / 2], &qz, "in_proj_qkv zero"),
+            in_proj_z_scale:   upload_bf16(ordinal, &[zs.len() / 2], &zs, "in_proj_z scale"),
+            in_proj_z_zero:    upload_bf16(ordinal, &[zz.len() / 2], &zz, "in_proj_z zero"),
+            out_proj_scale:    upload_bf16(ordinal, &[os.len() / 2], &os, "out_proj scale"),
+            out_proj_zero:     upload_bf16(ordinal, &[oz.len() / 2], &oz, "out_proj zero"),
+        };
+        (in_proj_qkv_w, in_proj_z_w, out_proj_w, Some(int4))
+    } else {
+        (
+            upload_bf16(ordinal, &[qkv_dim, hidden], &b64_field(weights, "in_proj_qkv_w"), "in_proj_qkv_w"),
+            upload_bf16(ordinal, &[val_dim, hidden], &b64_field(weights, "in_proj_z_w"), "in_proj_z_w"),
+            upload_bf16(ordinal, &[hidden, val_dim], &b64_field(weights, "out_proj_w"), "out_proj_w"),
+            None,
+        )
+    };
+
     AttnLayerBuffers::Linear {
         input_norm_w: upload_bf16(ordinal, &[hidden], &b64_field(weights, "input_norm_w"), "input_norm_w"),
-        in_proj_qkv_w: upload_bf16(ordinal, &[qkv_dim, hidden], &b64_field(weights, "in_proj_qkv_w"), "in_proj_qkv_w"),
-        in_proj_z_w: upload_bf16(ordinal, &[val_dim, hidden], &b64_field(weights, "in_proj_z_w"), "in_proj_z_w"),
+        in_proj_qkv_w,
+        in_proj_z_w,
         in_proj_a_w: upload_bf16(ordinal, &[v, hidden], &b64_field(weights, "in_proj_a_w"), "in_proj_a_w"),
         in_proj_b_w: upload_bf16(ordinal, &[v, hidden], &b64_field(weights, "in_proj_b_w"), "in_proj_b_w"),
         // The kernel's depthwise conv1d expects the channel-major layout the
@@ -143,7 +227,7 @@ fn build_linear_attn_layer(
         dt_bias: upload_bf16(ordinal, &[v], &b64_field(weights, "dt_bias"), "dt_bias"),
         a_log: upload_bf16(ordinal, &[v], &b64_field(weights, "a_log"), "a_log"),
         norm_w: upload_bf16(ordinal, &[vd], &b64_field(weights, "norm_w"), "norm_w"),
-        out_proj_w: upload_bf16(ordinal, &[hidden, val_dim], &b64_field(weights, "out_proj_w"), "out_proj_w"),
+        out_proj_w,
         conv_state: upload_bf16(
             ordinal,
             &[qkv_dim, kernel - 1],
@@ -157,39 +241,76 @@ fn build_linear_attn_layer(
             &b64_field(weights, "recurrent_state_before"),
             "recurrent_state_before",
         ),
+        int4,
     }
 }
 
-fn build_ffn_layer(ordinal: usize, geom: &MultiLayerGeom, weights: &Value) -> FfnLayerBuffers {
+fn build_ffn_layer(
+    ordinal: usize,
+    geom: &MultiLayerGeom,
+    weights: &Value,
+    int4_block: Option<&Value>,
+    group_size: i32,
+) -> FfnLayerBuffers {
     let hidden = geom.hidden as usize;
     let e = geom.num_experts as usize;
     let i_dim = geom.moe_intermediate as usize;
     let is_dim = geom.shared_intermediate as usize;
 
+    let (gate_up_proj_w, down_proj_w, shared_gate_proj_w, shared_up_proj_w, shared_down_proj_w, int4) =
+        if let Some(blk) = int4_block {
+            let (gp, gs, gz) = decode_int4_sidecar(blk, "gate_up_proj_w");
+            let (dp, ds, dz) = decode_int4_sidecar(blk, "down_proj_w");
+            let (sgp, sgs, sgz) = decode_int4_sidecar(blk, "shared_gate_proj_w");
+            let (sup, sus, suz) = decode_int4_sidecar(blk, "shared_up_proj_w");
+            let (sdp, sds, sdz) = decode_int4_sidecar(blk, "shared_down_proj_w");
+            // Fused-expert tensors are 3D `[E, out, in]`; packed is
+            // `[E, out, in/2]` u8.
+            let gate_up_proj_w = upload_u8(ordinal, &[e, 2 * i_dim, hidden / 2], &gp, "gate_up packed");
+            let down_proj_w = upload_u8(ordinal, &[e, hidden, i_dim / 2], &dp, "down_proj packed");
+            let shared_gate_proj_w = upload_u8(ordinal, &[is_dim, hidden / 2], &sgp, "sgp packed");
+            let shared_up_proj_w = upload_u8(ordinal, &[is_dim, hidden / 2], &sup, "sup packed");
+            let shared_down_proj_w = upload_u8(ordinal, &[hidden, is_dim / 2], &sdp, "sdp packed");
+            let int4 = FfnInt4Sidecars {
+                group_size,
+                gate_up_proj_scale: upload_bf16(ordinal, &[gs.len() / 2], &gs, "gate_up scale"),
+                gate_up_proj_zero:  upload_bf16(ordinal, &[gz.len() / 2], &gz, "gate_up zero"),
+                down_proj_scale:    upload_bf16(ordinal, &[ds.len() / 2], &ds, "down_proj scale"),
+                down_proj_zero:     upload_bf16(ordinal, &[dz.len() / 2], &dz, "down_proj zero"),
+                shared_gate_proj_scale: upload_bf16(ordinal, &[sgs.len() / 2], &sgs, "sgp scale"),
+                shared_gate_proj_zero:  upload_bf16(ordinal, &[sgz.len() / 2], &sgz, "sgp zero"),
+                shared_up_proj_scale:   upload_bf16(ordinal, &[sus.len() / 2], &sus, "sup scale"),
+                shared_up_proj_zero:    upload_bf16(ordinal, &[suz.len() / 2], &suz, "sup zero"),
+                shared_down_proj_scale: upload_bf16(ordinal, &[sds.len() / 2], &sds, "sdp scale"),
+                shared_down_proj_zero:  upload_bf16(ordinal, &[sdz.len() / 2], &sdz, "sdp zero"),
+            };
+            (gate_up_proj_w, down_proj_w, shared_gate_proj_w, shared_up_proj_w, shared_down_proj_w, Some(int4))
+        } else {
+            (
+                upload_bf16(ordinal, &[e, 2 * i_dim, hidden], &b64_field(weights, "gate_up_proj_w"), "gate_up_proj_w"),
+                upload_bf16(ordinal, &[e, hidden, i_dim], &b64_field(weights, "down_proj_w"), "down_proj_w"),
+                upload_bf16(ordinal, &[is_dim, hidden], &b64_field(weights, "shared_gate_proj_w"), "shared_gate_proj_w"),
+                upload_bf16(ordinal, &[is_dim, hidden], &b64_field(weights, "shared_up_proj_w"), "shared_up_proj_w"),
+                upload_bf16(ordinal, &[hidden, is_dim], &b64_field(weights, "shared_down_proj_w"), "shared_down_proj_w"),
+                None,
+            )
+        };
+
     FfnLayerBuffers {
         post_attn_norm_w: upload_bf16(ordinal, &[hidden], &b64_field(weights, "post_attn_norm_w"), "post_attn_norm_w"),
         gate_w: upload_bf16(ordinal, &[e, hidden], &b64_field(weights, "gate_w"), "gate_w"),
-        gate_up_proj_w: upload_bf16(
-            ordinal,
-            &[e, 2 * i_dim, hidden],
-            &b64_field(weights, "gate_up_proj_w"),
-            "gate_up_proj_w",
-        ),
-        down_proj_w: upload_bf16(
-            ordinal,
-            &[e, hidden, i_dim],
-            &b64_field(weights, "down_proj_w"),
-            "down_proj_w",
-        ),
-        shared_gate_proj_w: upload_bf16(ordinal, &[is_dim, hidden], &b64_field(weights, "shared_gate_proj_w"), "shared_gate_proj_w"),
-        shared_up_proj_w: upload_bf16(ordinal, &[is_dim, hidden], &b64_field(weights, "shared_up_proj_w"), "shared_up_proj_w"),
-        shared_down_proj_w: upload_bf16(ordinal, &[hidden, is_dim], &b64_field(weights, "shared_down_proj_w"), "shared_down_proj_w"),
+        gate_up_proj_w,
+        down_proj_w,
+        shared_gate_proj_w,
+        shared_up_proj_w,
+        shared_down_proj_w,
         shared_expert_gate_w: upload_bf16(
             ordinal,
             &[1, hidden],
             &b64_field(weights, "shared_expert_gate_w"),
             "shared_expert_gate_w",
         ),
+        int4,
     }
 }
 
@@ -257,10 +378,11 @@ fn multilayer_chained_decode_matches_oracle() {
         .unwrap_or_else(|e| panic!("read multi-layer oracle json {json_path}: {e}"));
     let json: Value = serde_json::from_str(&raw).expect("parse multi-layer oracle json");
     let schema = json["schema"].as_str().unwrap_or("");
-    assert_eq!(
-        schema, "qwen36-moe-oracle-multilayer-v1",
-        "PR 4c step 2 only handles BF16 multi-layer schema (got {schema}); INT4 multi-layer parity is a follow-up"
-    );
+    let int4_mode = match schema {
+        "qwen36-moe-oracle-multilayer-v1" => false,
+        "qwen36-moe-oracle-multilayer-int4-v1" => true,
+        other => panic!("unsupported multi-layer schema: {other}"),
+    };
     assert_eq!(
         json["dtype"].as_str().unwrap_or(""),
         "bf16",
@@ -269,6 +391,11 @@ fn multilayer_chained_decode_matches_oracle() {
 
     let geom = parse_geom(&json);
     let position = json["position"].as_i64().unwrap_or(0) as i32;
+    let int4_group_size = if int4_mode {
+        json["config"]["int4_group_size"].as_i64().unwrap_or(128) as i32
+    } else {
+        0
+    };
 
     set_backend(Backend::Hip);
     let ordinal = 0usize;
@@ -284,16 +411,27 @@ fn multilayer_chained_decode_matches_oracle() {
         "weights_per_layer length mismatch"
     );
 
+    // INT4 sidecar block — present iff the oracle was run with --int4.
+    let int4_per_layer: Option<&Vec<Value>> = if int4_mode {
+        Some(json["int4_weights_per_layer"]
+            .as_array()
+            .expect("INT4 oracle missing int4_weights_per_layer (regenerate with --int4 and without --no-emit-weights)"))
+    } else {
+        None
+    };
+
     let mut layers: Vec<LayerBuffers> = Vec::with_capacity(geom.num_layers as usize);
     for (li, layer_json) in weights_per_layer.iter().enumerate() {
         let attn_w = &layer_json["attn"];
         let ffn_w = &layer_json["ffn"];
+        let attn_int4 = int4_per_layer.map(|v| &v[li]["attn"]);
+        let ffn_int4 = int4_per_layer.map(|v| &v[li]["ffn"]);
         let attn = if is_full_attn_layer(li as i32) {
-            build_full_attn_layer(ordinal, &geom, attn_w)
+            build_full_attn_layer(ordinal, &geom, attn_w, attn_int4, int4_group_size)
         } else {
-            build_linear_attn_layer(ordinal, &geom, attn_w)
+            build_linear_attn_layer(ordinal, &geom, attn_w, attn_int4, int4_group_size)
         };
-        let ffn = build_ffn_layer(ordinal, &geom, ffn_w);
+        let ffn = build_ffn_layer(ordinal, &geom, ffn_w, ffn_int4, int4_group_size);
         layers.push(LayerBuffers { attn, ffn });
     }
 

--- a/docs/qwen36-moe-bake-quality-audit.md
+++ b/docs/qwen36-moe-bake-quality-audit.md
@@ -1,0 +1,185 @@
+# Qwen3.6-MoE INT4 GPTQ bake quality audit
+
+**Status**: audit complete, no algorithmic bugs found. Quality issues are
+design limitations of the in-house GPTQ implementation.
+
+## Symptom
+
+Multi-token decode against the local INT4 GPTQ bake at
+`<model>/.supersonic/v2-int4-gptq/` produces near-random output:
+
+  $ supersonic --model qwen3.6-35b-a3b --model-dir <snap> \
+      --prompt "The quick brown fox" --max-new-tokens 8
+  > The quick brown foxstoreparepareUDAUDAUDAUDAUDA
+
+Per-prompt argmax IS responsive to input (different prompts → different
+first tokens), but the model immediately settles into a small set of
+tokens (UDA/store/pare/udas/lis). At T=0.8 + top_p=0.9 the entire vocab
+is sampled near-uniformly including foreign scripts ("OLOG internsieß
+第二段的统一 발표isk"), confirming the logit distribution is nearly flat.
+
+## What we ruled out
+
+### Engine + decode pipeline ✅
+  - Multi-layer parity test (synthetic 4-layer): cos_sim 0.9999 final
+    logits, BF16 + INT4 modes both pass.
+  - Per-block parity tests at *production* geometry against real
+    safetensors weights:
+      - Full-attn (layer 3, H=16, Hkv=2, d=256, hidden=2048):
+        n=2048 exact=2048 cos_sim=1.0  (bit-exact)
+      - Linear-attn (layer 0): passes
+      - FFN (layer 0, E=256, top_k=8, I=Is=512): passes
+  - KV cache reads/writes verified by the kv_len=1 fast-path being
+    bit-exact with the pre-cache PR 4b2 implementation.
+
+### Sampling ✅
+  - Greedy-vs-sampled output proves the issue isn't sampling — the
+    underlying logit distribution itself is too flat for either to
+    produce coherent text.
+
+### Bake ↔ kernel format ✅
+  - Python dequant `bf16(q*s - z*s)` matches the kernel's
+    `int4_dequant_scalar` formula exactly (same nibble-packing
+    convention, same tile indexing, same rounding).
+
+## What we found
+
+### Per-tensor INT4 reconstruction error from the bake
+
+Sampled tensors compared bake-INT4-reconstruction vs safetensors BF16
+(ground truth):
+
+  tensor                                         shape    tiles    cos_sim
+  layers.3.self_attn.q_proj                  (8192, 2048)  1024     0.961
+  layers.3.self_attn.o_proj                  (2048, 4096)   512     0.900
+  layers.0.linear_attn.in_proj_qkv           (8192, 2048)  1024     0.941
+  layers.0.linear_attn.in_proj_z             (4096, 2048)   512     0.971
+  layers.0.linear_attn.out_proj              (2048, 4096)   512     0.899
+  layers.0.mlp.shared_expert.gate_proj        (512, 2048)    64     0.880
+  layers.0.mlp.shared_expert.up_proj          (512, 2048)    64     0.952
+  layers.0.mlp.shared_expert.down_proj        (2048, 512)    64     0.925
+
+Per-tensor 3-12% directional error compounds across 40 layers ×
+multiple tensors per layer to effectively-random hidden states by the
+time the chain reaches the lm_head. Production AutoGPTQ INT4 typically
+delivers ≥ 0.99 per-tensor cos_sim; we are 0.05–0.12 below that bar.
+
+Notable: tensors that produce a `[..., out=2048 or 512]` (o_proj,
+out_proj, shared_expert.gate_proj) consistently land at the bottom of
+the cos_sim range. Those are the layer-output projections that GPTQ
+quantizes LAST in each layer's order; they inherit the most accumulated
+sequential-calibration error.
+
+### Algorithm audit (oracle/bake_int4.py)
+
+Walked the implementation against canonical GPTQ end to end. Every
+piece checks out:
+
+  - **Hessian** (`HessianHook`, line 513–536):
+    `H = 2/N * sum_t x_t x_t^T` accumulated via forward-pre hooks.
+    Recursive average update is correct; total `H` after all samples
+    matches the canonical formula.
+
+  - **Damping** (line 247–254): `H[i,i] += damp * mean(diag(H))`,
+    damp=0.01 default (matches AutoGPTQ).
+
+  - **Cholesky-of-inverse** (line 263–269): `L = chol(H)` (lower);
+    `Hinv = L^-T L^-1`; `U = chol(Hinv, upper=True)` upper-triangular
+    such that `U^T U = Hinv`. Stored back in `Hinv` (variable name is
+    misleading but math is correct).
+
+  - **Per-column error propagation** (line 307–340): standard GPTQ
+    update `err = (w - q_dq) / U[i,i]`; `W[:, i+1:] -= err * U[i, i+1:]`.
+
+  - **Block boundary error propagation** (line 343–344): standard
+    `Err1 @ Hinv[b:e, e:]` propagates accumulated block errors to all
+    columns past the block. With `blocksize == group_size == 128`, no
+    column-group spans a block boundary.
+
+  - **Scale derivation** (line 278–293): per-tile min/max,
+    `sc = rng/15`, `zf = -tmin/sc`, both rounded through BF16 to match
+    runtime kernel reads.
+
+  - **Quantization** (line 326–332): `q = clamp(round(w/sc + zf), 0, 15)`;
+    `q_dq = bf16(q*sc - zf*sc)` — matches kernel's `int4_dequant_scalar`
+    exactly so error feedback uses what the kernel will actually read.
+
+  - **Sequential calibration** (line 824–906): standard. Each layer's
+    quantized outputs feed the next layer's Hessian collection.
+
+  - **Calibration data** (line 1267–1280): defaults to 128 sequences ×
+    2048 tokens from WikiText-2 train. Standard.
+
+  - **lm_head GPTQ** (line 921–999): same algorithm applied to lm_head
+    using post-final-norm hidden as activation. Correct.
+
+### Identified design limitations (not bugs)
+
+1. **No scale search.** `set_tile_scales` (line 278) uses plain min/max
+   for every tile. AutoGPTQ tries multiple candidate scales per tile
+   (typically `rng * f / 15` for `f in [1.0, 0.95, 0.9, …]`) and picks
+   the one minimizing per-tile reconstruction MSE. Skipping scale
+   search costs noticeable per-tensor accuracy; this is the most likely
+   single contributor to our cos_sim gap vs AutoGPTQ-class output.
+
+2. **Min/max for fused experts (no GPTQ).** `fused_expert_minmax_int4`
+   (line 386) does plain min/max on each expert's `[out, in]` slab.
+   Justified in code comments by the fused 3D layout being awkward for
+   Hessian-aware quant on the producer host. ~half the model's
+   parameters take this path on Qwen3.6-MoE.
+
+3. **Coarse 128×128 tile granularity.** Each `(scale, zero)` pair
+   covers a 16384-weight tile with 16 quantization levels. Narrower
+   projections (e.g. shared_expert.gate_proj `[512, 2048]`, only 64
+   tiles total) get the most coarse quantization — visible in the
+   cos_sim survey.
+
+## What to do
+
+The audit confirms no bug to fix in the GPTQ algorithm. The realistic
+quality lever options, in order of expected impact vs effort:
+
+### Option 1: Add scale search (~1 day; modest gain per re-bake hour)
+Patch `set_tile_scales` (line 278 of `oracle/bake_int4.py`) to try
+~5 candidate scales per tile and pick the one minimizing per-tile MSE.
+~30 LoC. Re-baking 35B-A3B takes hours (whole calibration loop), so
+each iteration is expensive — but no infrastructure changes needed.
+
+### Option 2: Migrate to AutoGPTQ (~1 week; biggest gain)
+AutoGPTQ has been battle-tested on hundreds of production models and
+includes scale search, activation reordering, static-vs-dynamic group
+choices, and other tuning. Output format would need a small adapter
+(their `[in, out]` packing vs our `[out, in/2]`) but their per-tensor
+quality is well-documented at ≥ 0.99 cos_sim. Best long-term answer.
+
+### Option 3: Less aggressive quantization (~1 day; large gain at runtime cost)
+Switch from INT4 (4 bits + 16 levels) to INT8 (8 bits + 256 levels) for
+dense projections. Per-tensor cos_sim would jump to ~0.999. Doubles the
+weight VRAM (17 GiB → ~26 GiB), so no longer fits 24 GiB on this card —
+only useful when the goal is "verify the engine works end-to-end on
+*good* weights, even if not deployable on this card".
+
+### Option 4: Hessian-aware MoE expert quant (~2 days; modest gain)
+Replace `fused_expert_minmax_int4` with a router-aware GPTQ that only
+includes calibration tokens routed to each expert. Substantial code
+work; only worth it if dense projections (currently the worst tensors)
+are first improved by Option 1 or 2.
+
+## Recommendation
+
+Start with **Option 1 (add scale search)**. Smallest blast radius, no
+new infrastructure, directly addresses the worst-quality tensors in the
+audit. If post-scale-search per-tensor cos_sim still under 0.98 across
+the bake, escalate to Option 2.
+
+## Verification protocol for any future bake
+
+1. Run `oracle/bake_int4.py --model-dir <snap>` to produce
+   `.supersonic/v2-int4-gptq/`.
+2. Run the per-tensor cos_sim survey (see this doc's "What we found"
+   section — script captured in shell history at audit time).
+3. Acceptance: every quantized tensor cos_sim ≥ 0.98 vs safetensors.
+4. End-to-end smoke: `cargo run --release --bin supersonic --model
+   qwen3.6-35b-a3b --model-dir <snap> --prompt "The quick brown fox"
+   --max-new-tokens 16 --temperature 0.8 --top-p 0.9` — output should
+   be coherent English (not the current degenerate "UDAUDAUDA" pattern).

--- a/docs/qwen36-moe-bake-quality-audit.md
+++ b/docs/qwen36-moe-bake-quality-audit.md
@@ -183,3 +183,47 @@ the bake, escalate to Option 2.
    qwen3.6-35b-a3b --model-dir <snap> --prompt "The quick brown fox"
    --max-new-tokens 16 --temperature 0.8 --top-p 0.9` — output should
    be coherent English (not the current degenerate "UDAUDAUDA" pattern).
+
+## Update: Option 1 (scale search) landed and re-baked
+
+Scale search shipped in commit 91d7185. Re-bake completed in 32.8 min
+on the local 35B-A3B with --num-samples 32 + cpu=20GiB max_memory.
+Per-tensor cos_sim survey vs safetensors:
+
+  tensor                                              old      new    delta
+  layers.3.self_attn.q_proj                        0.9611   0.9787  +0.0176
+  layers.3.self_attn.k_proj                        0.9711   0.9838  +0.0126
+  layers.3.self_attn.o_proj                        0.9000   0.9357  +0.0357
+  layers.0.linear_attn.in_proj_qkv                 0.9410   0.9617  +0.0208
+  layers.0.linear_attn.in_proj_z                   0.9707   0.9823  +0.0116
+  layers.0.linear_attn.out_proj                    0.8991   0.9423  +0.0432
+  layers.0.mlp.shared_expert.gate_proj             0.8804   0.9278  +0.0474
+  layers.0.mlp.shared_expert.up_proj               0.9523   0.9732  +0.0209
+  layers.0.mlp.shared_expert.down_proj             0.9249   0.9569  +0.0319
+
+Worst tensors gained the most (+0.04 to +0.05). Average +0.025.
+Bake's own Python-side post-quant gen now produces a coherent first
+token: "The quick brown fox jumps面面…" — "jumps" follows the prompt
+correctly before degenerating into vocab gibberish.
+
+**However**: our SuperSonic kernel chain on the same weights still
+produces near-random output. Per-block parity tests at production
+geometry against safetensors are bit-exact (separately verified), but
+the 40-layer chain at production scale produces:
+
+  greedy  "The quick brown fox" → "::.::.::.::.::.::.::.::.ivadspot…"
+  T=0.8   "The quick brown fox" → "::. fundamentaisReviewer_color…"
+
+Different prompts produce different first tokens (kernel responds to
+input), but tokens aren't semantically appropriate. Since Python
+forward on the same weights produces "jumps" but our chain doesn't,
+the gap is in the kernel-side multi-layer chain at production scale —
+NOT bake quality, NOT sampling, NOT the per-block kernels.
+
+Acceptance criteria from this doc not met yet (worst tensor still
+0.928 vs ≥ 0.98 target; coherent generation through kernel chain not
+achieved). Next quality lever: localise the production-scale kernel
+chain bug via a per-layer parity harness on real bake weights — load
+layer N's INT4 from the bake, run kernel + Python single-layer ref
+side-by-side, find which layer's output first diverges. That will
+isolate the kernel bug independent of the bake.

--- a/docs/qwen36-moe-pr4c-plan.md
+++ b/docs/qwen36-moe-pr4c-plan.md
@@ -1,0 +1,259 @@
+# PR 4c — Qwen3.6-MoE Multi-Layer Driver
+
+Plan for stitching the parity-tested single-block kernels (full-attn,
+linear-attn, FFN — all with INT4 paths after PR 4b6) into a real decode
+that runs all `num_hidden_layers=40` layers and emits a token. This is
+the integration milestone.
+
+## Where we are after PR 4b6
+
+Every quantizable tensor in a Qwen3.6-MoE layer has a parity-tested
+INT4 dequant path against `oracle/bake_int4.py`'s reconstruction:
+
+- **Full-attention** (`kernels/qwen36_moe.hip` `qwen36_moe_attn_step_kernel`):
+  q_proj, k_proj, v_proj, o_proj.
+- **Linear-attention** (`qwen36_moe_linear_step_kernel`):
+  in_proj_qkv, in_proj_z, out_proj. (in_proj_a, in_proj_b stay BF16.)
+- **MoE FFN** (`qwen36_moe_ffn_step_kernel`):
+  gate_up_proj, down_proj (per-expert), shared gate_proj/up_proj/down_proj.
+
+Each kernel is a *single-block* parity-test driver: it processes one
+layer's worth of one decode step, with `kv_len=1` and a host-allocated
+workspace per call. They don't yet chain. PR 4c chains them.
+
+The Rust runner (`crates/runner/src/qwen36_moe_engine.rs`) is dry-run
+only — `run_qwen36_moe_dry_run` enumerates the bake and prints VRAM
+accounting. `run` bails on any non-`--dry-run` call. Replacing that
+bail with a real decode path is one of PR 4c's deliverables.
+
+## What PR 4c needs to deliver
+
+Three pieces. They can land in this order, each parity-gated:
+
+1. **Multi-layer Python oracle**. Chains `reference_full_attention_layer`
+   + `reference_linear_attn_layer` + `reference_moe_ffn_block` per the
+   hybrid pattern (3-of-4 linear, 1-of-4 full, every 4th layer full at
+   indices 3/7/11/...). Reference for parity. Synthetic mode + a
+   "minimum-real" mode that loads N layers from a checkpoint to keep
+   host RAM honest.
+
+2. **Host-orchestrated multi-launch driver**. Rust-side: per-layer
+   weight pointers, per-layer KV state for full-attn layers, per-layer
+   conv+recurrent state for linear-attn layers, dispatch loop that
+   calls the existing `attn_step_launch` / `linear_step_launch` /
+   `ffn_step_launch` in sequence. One HIP launch per kernel × N layers
+   per token. High launch overhead, but correct, reviewable, and
+   unblocks end-to-end testing.
+
+3. **Persistent-decode megakernel** (optional for PR 4c — could land
+   in a follow-up). A single `__global__` that walks the descriptor
+   array (PR 4 `qwen36_moe_descriptor_walk_stub` is the prototype)
+   and dispatches per-layer-type. Same compute, single launch. Goal
+   is to amortize the ~40 launches/token down to 1.
+
+The runner-side wiring (replace the bail at `qwen36_moe_engine.rs:639`
+with a real path) lands as part of (2).
+
+## Constraints
+
+- **VRAM**: 24 GiB on the RX 7900 XTX. INT4 bake is ~17 GiB; KV
+  caches + recurrent state are additional. The dry-run accountant
+  in `crates/qwen36_moe/src/weights.rs::project_int4_total_bytes`
+  already projects ~16-21 GiB for INT4 + sidecars + embed.
+- **Host RAM**: 64 GiB. Full BF16 35B model is ~65 GiB → won't fit.
+  Multi-layer oracle must avoid instantiating the full model. Either
+  load tensors per-layer on demand, or run with synthetic weights at
+  smaller geometry (e.g. 4 layers × small hidden) for parity work.
+- **hipcc on gfx11xx is fragile**. Per CLAUDE.md, the qwen36_moe and
+  full_attention_4b kernels are isolated compilation units. Adding
+  more `__global__`s to `qwen36_moe.hip` is fine; merging it with
+  `full_attention.hip` is not.
+- **HF reference for end-to-end check**: the Qwen3.5 multimodal class
+  needs ~70 GiB to instantiate. Skip it. Use the hand-rolled multi-
+  layer oracle as the parity reference. If a sanity check against HF
+  is wanted at the end, do it on a tiny model variant or via API.
+
+## Step plan
+
+### Step 1 — Multi-layer Python oracle
+
+`oracle/qwen36_moe_multilayer_oracle.py`. Imports the reference functions
+from the existing single-block oracles (move them to a shared module if
+that's cleaner — there's already enough copy-paste between the three).
+
+For one token at position `p`:
+```
+for layer_idx in 0..num_layers:
+    if (layer_idx + 1) % 4 == 0:
+        out = reference_full_attention_layer(input=h, ..., position=p)
+        h = out["output_hidden"]                # post-attn residual
+    else:
+        out = reference_linear_attn_layer(input=h, ...,
+              recurrent_state_before=rec_state[layer_idx],
+              conv_state_before=conv_state[layer_idx])
+        h = out["output_hidden"]
+        rec_state[layer_idx] = out["state_after"]
+        conv_state[layer_idx] = out["conv_state_after"]
+    out = reference_moe_ffn_block(input=h, ...)
+    h = out["output_hidden"]
+final_norm = rms_norm(h, w_norm)
+logits = final_norm @ lm_head.T
+```
+
+Output shape:
+```json
+{
+    "schema": "qwen36-moe-oracle-multilayer-v1",
+    "config": {...},
+    "weights_per_layer": [...],          // optional in synthetic mode
+    "intermediates_per_layer": [...],    // hidden after each layer's attn + FFN
+    "final_hidden": "<bf16 base64>",
+    "logits": "<bf16 base64>"
+}
+```
+
+Modes:
+- `--synthetic --num-layers 4`: 3 linear + 1 full at idx 3, small
+  geometry (hidden=256 etc.). Fits in seconds, fits in <1 GiB host RAM.
+  Primary parity gate.
+- `--checkpoint --num-layers 8`: load layers 0..7 from a real bake.
+  Sanity check at production geometry.
+- `--int4`: same INT4 quantization pattern as the single-block
+  oracles. Schema becomes `qwen36-moe-oracle-multilayer-int4-v1`.
+
+Self-check: chain `reference_full_attention_layer` and
+`reference_linear_attn_layer` + FFN from the existing references
+and verify output_hidden has finite norm. Don't add new math here —
+this oracle is pure orchestration.
+
+### Step 2 — Host-orchestrated Rust multi-launch driver
+
+New `crates/runner/src/qwen36_moe_decode.rs` (or extend
+`qwen36_moe_engine.rs` — the existing dry-run code is already 700 LoC,
+splitting into a separate module is probably cleaner).
+
+Responsibilities:
+1. **Build per-layer descriptor array.** One descriptor per layer, with
+   pointers into the bake's mmap'd weight regions. The descriptor type
+   already exists (`Qwen36MoeDecodeLayerDesc` in
+   `crates/kernel-ffi/src/qwen36_moe.rs`). PR 4c's job is to populate
+   it from the bake instead of from synthetic stubs.
+2. **Allocate per-layer state.**
+   - Full-attn layers (10 of 40): KV cache `[max_t, kv_dim]` × 2.
+   - Linear-attn layers (30 of 40): conv_state `[qkv_dim, kernel-1]`
+     + recurrent_state `[V, kd, vd]` (F32).
+3. **Allocate scratch.** Workspace + sync_buf for each kernel kind.
+   Reusable across layers within a step (workspaces are independent
+   per kernel call, all overwritten each step).
+4. **Decode loop.**
+   ```rust
+   for layer_idx in 0..num_layers {
+       if is_full(layer_idx) {
+           attn_step_launch(stage=5, ..., int4=&int4[layer_idx], ...)?;
+       } else {
+           linear_step_launch(stage=5, ..., int4=&int4[layer_idx], ...)?;
+       }
+       ffn_step_launch(stage=5, ..., int4=&int4[layer_idx], ...)?;
+   }
+   final_norm + lm_head_argmax → next token.
+   ```
+5. **Parity-test.** Compare final logits against the multi-layer
+   oracle (cos_sim ≥ 0.999). Same pattern as the per-block tests.
+6. **Replace the bail in `qwen36_moe_engine.rs::run`**. When `--dry-run`
+   isn't set, route to the new decode path.
+
+The key reuse here: every `*_step_launch` already runs a complete
+single-layer step at `stage=5`. We're just calling them in sequence
+with the right weight pointers and state buffers per layer.
+
+### Step 3 — End-to-end smoke + first decoded token
+
+Same idea as the existing `crates/runner/tests/qwen35_bughunt_smoke.rs`:
+small synthetic model, run the full decode pipeline, verify the chosen
+token matches what the multi-layer oracle picked. CI-friendly — no real
+bake required.
+
+Add a one-shot `--validate` path that runs the multi-layer oracle in
+Python and the kernel side in Rust against the same synthesised
+weights, compares logits.
+
+### Step 4 (optional) — Persistent-decode megakernel
+
+Single HIP launch that does what step 2 does in N launches. Walks
+descriptor array via the work-stealing primitive in
+`qwen36_moe_descriptor_walk_stub`. Each block claims a layer; per-layer
+the kernel does attn (full or linear) + FFN inline using the existing
+phase routines as `__device__` helpers. Significant refactor — the
+current single-block kernels have phases-as-inlined-code; persistent
+form needs them as functions.
+
+Defer to PR 4c.1 if PR 4c step 2 already gets us first token. The
+host-orchestrated path is good enough to ship; megakernel is perf
+work.
+
+## Open design decisions
+
+1. **Where does `lm_head` go?** Could land in a new kernel
+   (`qwen36_moe_lm_head_launch`) or run on the host (mmap'd weight,
+   F32 GEMV → argmax). Host is simpler, kernel is ~1 ms faster per
+   token. Recommend host for PR 4c, kernel for PR 4d.
+2. **KV cache layout.** Existing parity tests fix `kv_len=1`. PR 4c
+   step 2 still has `kv_len=1` for the *first* token after prefill;
+   PR 4d (KV extension) lifts that. So step 2 needs the buffers
+   pre-allocated at full size but only writes index 0.
+3. **Final norm**. Loaded as a regular BF16 weight; applied in the
+   host between the last layer's output and lm_head. Cheap.
+4. **State persistence across decode steps**. Conv state shifts by 1
+   each step; recurrent state is updated in place by the linear-attn
+   kernel. Both buffers are *mut* — the kernel reads and writes them.
+   Step 2 just needs to keep them alive across the decode loop.
+
+## Checkpoint files / pointers
+
+- **Kernel sources**: `kernels/qwen36_moe.hip`,
+  `kernels/qwen36_moe_bridge.cpp`. The single-block kernels are
+  `qwen36_moe_attn_step_kernel`, `qwen36_moe_linear_step_kernel`,
+  `qwen36_moe_ffn_step_kernel`. Stage 5 = full layer.
+- **Rust FFI**: `crates/kernel-ffi/src/qwen36_moe.rs` —
+  `attn_step_launch`, `linear_step_launch`, `ffn_step_launch` are the
+  safe wrappers. Each takes a `*StepWeights` + a `*StepInt4` struct.
+- **Descriptor type**: `Qwen36MoeDecodeLayerDesc` (same file). Already
+  has full-attn slots, linear-attn slots, and MoE block slots. Needs
+  parallel INT4 sidecar fields added in PR 4c (or pass them per-launch).
+- **Runner entry**: `crates/runner/src/qwen36_moe_engine.rs::run`.
+  Replace the `anyhow::bail!` at line 639 with a real decode path.
+- **Bake reader**: `crates/model-store::BakedStore` + the loader at
+  `crates/qwen36_moe/src/loader.rs`. Already mmaps weights and
+  exposes typed pointers.
+- **Existing per-layer oracles**: `oracle/qwen36_moe_oracle.py` (full
+  attn), `oracle/qwen36_moe_linear_oracle.py` (linear attn),
+  `oracle/qwen36_moe_ffn_oracle.py` (MoE FFN). All have BF16 + INT4
+  modes after PR 4b5/4b6.
+
+## Test fixtures available
+
+`SUPERSONIC_QWEN36_ORACLE_JSON` (full attn) and
+`SUPERSONIC_QWEN36_LINEAR_ORACLE_JSON` (linear attn) plus
+`SUPERSONIC_QWEN36_FFN_ORACLE_JSON` (FFN) drive the existing per-block
+parity tests. PR 4c step 1 adds
+`SUPERSONIC_QWEN36_MULTILAYER_ORACLE_JSON` for the multi-layer test.
+
+Generate them with:
+```bash
+~/venvs/rocm/bin/python oracle/qwen36_moe_oracle.py \
+    --mode synthetic --hidden 256 --num-attention-heads 4 \
+    --num-kv-heads 2 --head-dim 128 --position 7 --int4 \
+    --out /tmp/qwen36_attn_int4.json
+```
+
+## Acceptance criteria
+
+PR 4c is done when:
+- A synthesised 4-layer model decode in Rust produces logits matching
+  the Python multi-layer oracle (cos_sim ≥ 0.999).
+- `cargo run --release --bin supersonic --model qwen3.6-moe --model-dir
+  <bake> --prompt "..."` runs without `--dry-run` and emits at least
+  one token (no parity check on real model — just doesn't bail).
+- The host-orchestrated multi-launch driver lands as a single PR
+  (steps 1+2+3) without the persistent megakernel. Step 4 is a
+  follow-up.

--- a/kernels/qwen36_moe.hip
+++ b/kernels/qwen36_moe.hip
@@ -2171,13 +2171,35 @@ __global__ void qwen36_moe_ffn_step_kernel(
         }
 
         // Phase I: matvec down_proj_w[e].T @ mid → EXPERT_STACK[j*hidden..].
-        // Layout: down_proj_w[E, hidden, I]; slab `e` base is `e * hidden * I`,
-        // row `r` adds `r * I`. Contracts over I → one F32 per output row.
+        // BF16 layout: down_proj_w[E, hidden, I]; slab `e` base is
+        // `e * hidden * I`, row `r` adds `r * I`. Contracts over I → one
+        // F32 per output row.
+        // INT4 layout (when `down_proj_scale != nullptr`):
+        //   weights : [E, hidden, I/2] u8   — slab `e` base in bytes is
+        //                                      `e * hidden * (I/2)`.
+        //   scale   : [E, hidden/gsz, I/gsz] BF16 — slab `e` base in BF16
+        //                                      elems is
+        //                                      `e * (hidden/gsz) * (I/gsz)`.
         grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
                                    &counters[0]);
         {
-            const T* dp_slab =
+            const bool dp_int4 = (down_proj_scale != nullptr);
+            const T* dp_slab_bf16 =
                 down_proj_w + static_cast<size_t>(e) * hidden * I_;
+            const uint8_t*      dp_slab_packed = nullptr;
+            const hip_bfloat16* dp_slab_scale  = nullptr;
+            const hip_bfloat16* dp_slab_zero   = nullptr;
+            if (dp_int4) {
+                dp_slab_packed = reinterpret_cast<const uint8_t*>(down_proj_w)
+                               + static_cast<size_t>(e) * hidden
+                                 * (I_ / 2);
+                const int gsr = hidden / int4_group_size;
+                const int gsc = I_     / int4_group_size;
+                dp_slab_scale = down_proj_scale
+                              + static_cast<size_t>(e) * gsr * gsc;
+                dp_slab_zero  = down_proj_zero
+                              + static_cast<size_t>(e) * gsr * gsc;
+            }
             const int slot_off = OFF_EXPERT_STACK + j * hidden;
             for (;;) {
                 __shared__ unsigned int my_row_i_s;
@@ -2188,11 +2210,23 @@ __global__ void qwen36_moe_ffn_step_kernel(
                 const int my_row = static_cast<int>(my_row_i_s);
                 if (my_row >= hidden) break;
 
-                const T* w_row = dp_slab + static_cast<size_t>(my_row) * I_;
                 float partial = 0.0f;
-                for (int col = tid; col < I_; col += block_size) {
-                    partial += static_cast<float>(w_row[col])
-                               * workspace[OFF_EXPERT_MID + col];
+                if (dp_int4) {
+                    for (int col = tid; col < I_; col += block_size) {
+                        partial += int4_dequant_scalar(
+                                       dp_slab_packed,
+                                       dp_slab_scale,
+                                       dp_slab_zero,
+                                       my_row, col, I_, int4_group_size)
+                                   * workspace[OFF_EXPERT_MID + col];
+                    }
+                } else {
+                    const T* w_row =
+                        dp_slab_bf16 + static_cast<size_t>(my_row) * I_;
+                    for (int col = tid; col < I_; col += block_size) {
+                        partial += static_cast<float>(w_row[col])
+                                   * workspace[OFF_EXPERT_MID + col];
+                    }
                 }
                 shared_scratch[tid] = partial;
                 __syncthreads();

--- a/kernels/qwen36_moe.hip
+++ b/kernels/qwen36_moe.hip
@@ -1616,6 +1616,24 @@ __global__ void qwen36_moe_ffn_step_kernel(
     const T* __restrict__          shared_up_proj_w,             // [Is, hidden]       (nullable for stage<2)
     const T* __restrict__          shared_down_proj_w,           // [hidden, Is]       (nullable for stage<2)
     const T* __restrict__          shared_expert_gate_w,         // [1, hidden]        (nullable for stage<2)
+    // PR 4b5 INT4 sidecars. `int4_group_size == 0` ⇒ all weights are BF16
+    // and every sidecar pointer must be null. When non-zero, each sidecar
+    // pair (`*_scale`, `*_zero`) is consulted independently per tensor: a
+    // null `*_scale` for a given tensor keeps it on the BF16 path, a
+    // non-null pair switches that tensor to INT4. The kernel reinterprets
+    // the matching weight pointer as `const uint8_t*` packed bytes (low
+    // nibble = even col) and dequants per-element via `int4_dequant_scalar`.
+    int                                  int4_group_size,
+    const hip_bfloat16* __restrict__     gate_up_proj_scale,
+    const hip_bfloat16* __restrict__     gate_up_proj_zero,
+    const hip_bfloat16* __restrict__     down_proj_scale,
+    const hip_bfloat16* __restrict__     down_proj_zero,
+    const hip_bfloat16* __restrict__     shared_gate_proj_scale,
+    const hip_bfloat16* __restrict__     shared_gate_proj_zero,
+    const hip_bfloat16* __restrict__     shared_up_proj_scale,
+    const hip_bfloat16* __restrict__     shared_up_proj_zero,
+    const hip_bfloat16* __restrict__     shared_down_proj_scale,
+    const hip_bfloat16* __restrict__     shared_down_proj_zero,
     T* __restrict__                output,                       // BF16, sized for the largest staged intermediate
     int* __restrict__              output_idx,                   // [k] topk indices (stage 1+)
     float* __restrict__            workspace,
@@ -1624,6 +1642,10 @@ __global__ void qwen36_moe_ffn_step_kernel(
     unsigned int* __restrict__     barrier_flag) {
     // gate_up_proj_w, down_proj_w are used at stage>=3.
     // shared_*_w are used at stage>=2.
+    // INT4 sidecars (`*_scale`/`*_zero`) are read only for tensors whose
+    // `*_scale` pointer is non-null. The router (`gate_w`) and the scalar
+    // shared-expert gate (`shared_expert_gate_w`) are always BF16 — the
+    // INT4 bake excludes them, matching `crates/qwen36_moe/src/weights.rs`.
 
     const int num_blocks = static_cast<int>(gridDim.x);
     const int tid        = threadIdx.x;
@@ -1883,27 +1905,58 @@ __global__ void qwen36_moe_ffn_step_kernel(
         const int my_row = static_cast<int>(my_row_d_s);
         if (my_row >= total_rows_d) break;
 
-        const T* w_row;
+        const T* w_row = nullptr;                          // BF16 path
+        const void* i4_slab = nullptr;                     // INT4 path: full [out, hidden/2] u8
+        const hip_bfloat16* i4_scale = nullptr;
+        const hip_bfloat16* i4_zero  = nullptr;
+        int      i4_row = 0;                               // row index within the slab
         int      write_offset;
         bool     is_gate_row = false;
         if (my_row < Is_) {
-            w_row        = shared_gate_proj_w + static_cast<size_t>(my_row) * hidden;
+            if (shared_gate_proj_scale != nullptr) {
+                i4_slab  = reinterpret_cast<const void*>(shared_gate_proj_w);
+                i4_scale = shared_gate_proj_scale;
+                i4_zero  = shared_gate_proj_zero;
+                i4_row   = my_row;
+            } else {
+                w_row = shared_gate_proj_w + static_cast<size_t>(my_row) * hidden;
+            }
             write_offset = OFF_SGP + my_row;
         } else if (my_row < 2 * Is_) {
             const int local = my_row - Is_;
-            w_row        = shared_up_proj_w + static_cast<size_t>(local) * hidden;
+            if (shared_up_proj_scale != nullptr) {
+                i4_slab  = reinterpret_cast<const void*>(shared_up_proj_w);
+                i4_scale = shared_up_proj_scale;
+                i4_zero  = shared_up_proj_zero;
+                i4_row   = local;
+            } else {
+                w_row = shared_up_proj_w + static_cast<size_t>(local) * hidden;
+            }
             write_offset = OFF_SUP + local;
         } else {
             // Single-row "[1, hidden]" weight; dot it with h_norm and apply
-            // sigmoid() before storing into SG_SCALAR.
+            // sigmoid() before storing into SG_SCALAR. Always BF16 — the
+            // INT4 bake excludes `shared_expert_gate`.
             w_row        = shared_expert_gate_w;
             write_offset = OFF_SG_SCALAR;
             is_gate_row  = true;
         }
 
         float partial = 0.0f;
-        for (int col = tid; col < hidden; col += block_size) {
-            partial += static_cast<float>(w_row[col]) * h_norm_lds[col];
+        if (i4_scale != nullptr) {
+            // INT4 scalar dequant per element. Stride pattern matches the
+            // BF16 path (thread t reads cols t, t+block_size, …) so the
+            // reduction tree is unchanged.
+            for (int col = tid; col < hidden; col += block_size) {
+                partial += int4_dequant_scalar(
+                               i4_slab, i4_scale, i4_zero,
+                               i4_row, col, hidden, int4_group_size)
+                           * h_norm_lds[col];
+            }
+        } else {
+            for (int col = tid; col < hidden; col += block_size) {
+                partial += static_cast<float>(w_row[col]) * h_norm_lds[col];
+            }
         }
         shared_scratch[tid] = partial;
         __syncthreads();
@@ -1958,12 +2011,27 @@ __global__ void qwen36_moe_ffn_step_kernel(
             const int my_row = static_cast<int>(my_row_f_s);
             if (my_row >= hidden) break;
 
-            const T* w_row =
-                shared_down_proj_w + static_cast<size_t>(my_row) * Is_;
             float partial = 0.0f;
-            for (int col = tid; col < Is_; col += block_size) {
-                partial += static_cast<float>(w_row[col])
-                           * workspace[OFF_SHARED_MID + col];
+            if (shared_down_proj_scale != nullptr) {
+                // INT4 path: row `my_row` of `[hidden, Is]` packed as
+                // `[hidden, Is/2]` u8.
+                const void* i4_slab =
+                    reinterpret_cast<const void*>(shared_down_proj_w);
+                for (int col = tid; col < Is_; col += block_size) {
+                    partial += int4_dequant_scalar(
+                                   i4_slab,
+                                   shared_down_proj_scale,
+                                   shared_down_proj_zero,
+                                   my_row, col, Is_, int4_group_size)
+                               * workspace[OFF_SHARED_MID + col];
+                }
+            } else {
+                const T* w_row =
+                    shared_down_proj_w + static_cast<size_t>(my_row) * Is_;
+                for (int col = tid; col < Is_; col += block_size) {
+                    partial += static_cast<float>(w_row[col])
+                               * workspace[OFF_SHARED_MID + col];
+                }
             }
             shared_scratch[tid] = partial;
             __syncthreads();

--- a/kernels/qwen36_moe.hip
+++ b/kernels/qwen36_moe.hip
@@ -2088,11 +2088,34 @@ __global__ void qwen36_moe_ffn_step_kernel(
         const int e = s_expert_idx;
 
         // Phase G: matvec gate_up_proj_w[e] @ h_norm → EXPERT_GU[2*I].
-        // Layout: gate_up_proj_w[E, 2*I, hidden] — slab `e` base is
+        // BF16 layout: gate_up_proj_w[E, 2*I, hidden] — slab `e` base is
         // `e * 2*I * hidden`; row `r` adds `r * hidden`.
+        // INT4 layout (when `gate_up_proj_scale != nullptr`):
+        //   weights : [E, 2*I, hidden/2] u8   — slab `e` base in bytes is
+        //                                        `e * 2*I * (hidden/2)`.
+        //   scale   : [E, 2*I/gsz, hidden/gsz] BF16 — slab `e` base in
+        //                                        BF16 elems is
+        //                                        `e * (2*I/gsz) * (hidden/gsz)`.
+        // Same dequant + reduction discipline as the shared-expert INT4
+        // path (step 3); only the per-expert slab base offsets differ.
         {
-            const T* gu_slab =
+            const bool gu_int4 = (gate_up_proj_scale != nullptr);
+            const T* gu_slab_bf16 =
                 gate_up_proj_w + static_cast<size_t>(e) * two_I * hidden;
+            const uint8_t*      gu_slab_packed = nullptr;
+            const hip_bfloat16* gu_slab_scale  = nullptr;
+            const hip_bfloat16* gu_slab_zero   = nullptr;
+            if (gu_int4) {
+                gu_slab_packed = reinterpret_cast<const uint8_t*>(gate_up_proj_w)
+                               + static_cast<size_t>(e) * two_I
+                                 * (hidden / 2);
+                const int gsr = two_I  / int4_group_size;
+                const int gsc = hidden / int4_group_size;
+                gu_slab_scale = gate_up_proj_scale
+                              + static_cast<size_t>(e) * gsr * gsc;
+                gu_slab_zero  = gate_up_proj_zero
+                              + static_cast<size_t>(e) * gsr * gsc;
+            }
             for (;;) {
                 __shared__ unsigned int my_row_g_s;
                 if (tid == 0) {
@@ -2102,10 +2125,23 @@ __global__ void qwen36_moe_ffn_step_kernel(
                 const int my_row = static_cast<int>(my_row_g_s);
                 if (my_row >= two_I) break;
 
-                const T* w_row = gu_slab + static_cast<size_t>(my_row) * hidden;
                 float partial = 0.0f;
-                for (int col = tid; col < hidden; col += block_size) {
-                    partial += static_cast<float>(w_row[col]) * h_norm_lds[col];
+                if (gu_int4) {
+                    for (int col = tid; col < hidden; col += block_size) {
+                        partial += int4_dequant_scalar(
+                                       gu_slab_packed,
+                                       gu_slab_scale,
+                                       gu_slab_zero,
+                                       my_row, col, hidden, int4_group_size)
+                                   * h_norm_lds[col];
+                    }
+                } else {
+                    const T* w_row =
+                        gu_slab_bf16 + static_cast<size_t>(my_row) * hidden;
+                    for (int col = tid; col < hidden; col += block_size) {
+                        partial += static_cast<float>(w_row[col])
+                                   * h_norm_lds[col];
+                    }
                 }
                 shared_scratch[tid] = partial;
                 __syncthreads();

--- a/kernels/qwen36_moe.hip
+++ b/kernels/qwen36_moe.hip
@@ -381,6 +381,22 @@ __global__ void qwen36_moe_attn_step_kernel(
     const T* __restrict__          q_norm_w,      // [d]
     const T* __restrict__          k_norm_w,      // [d]               (nullable for stage<2)
     const T* __restrict__          o_proj_w,      // [hidden, H*d]     (nullable for stage<5)
+    // PR 4b6 INT4 sidecars. `int4_group_size == 0` ⇒ all weights are BF16
+    // and every sidecar pointer must be null. When non-zero, each sidecar
+    // pair (`*_scale`, `*_zero`) is consulted independently per tensor: a
+    // null `*_scale` for a given tensor keeps it on the BF16 path, a
+    // non-null pair switches that tensor to INT4. The kernel reinterprets
+    // the matching weight pointer as `const uint8_t*` packed bytes (low
+    // nibble = even col) and dequants per-element via `int4_dequant_scalar`.
+    int                                  int4_group_size,
+    const hip_bfloat16* __restrict__     q_proj_scale,
+    const hip_bfloat16* __restrict__     q_proj_zero,
+    const hip_bfloat16* __restrict__     k_proj_scale,
+    const hip_bfloat16* __restrict__     k_proj_zero,
+    const hip_bfloat16* __restrict__     v_proj_scale,
+    const hip_bfloat16* __restrict__     v_proj_zero,
+    const hip_bfloat16* __restrict__     o_proj_scale,
+    const hip_bfloat16* __restrict__     o_proj_zero,
     T* __restrict__                output,        // BF16, sized for the largest staged intermediate
     float* __restrict__             workspace,    // F32 scratch, see header comment
     unsigned int* __restrict__     counters,
@@ -439,7 +455,10 @@ __global__ void qwen36_moe_attn_step_kernel(
     // Output rows of q_raw are written BF16-rounded into workspace[0..2*H*d]
     // so that the per-head RMS norm in Phase C reads the same F32-of-BF16
     // values PyTorch's BF16 q_raw represents.
+    // INT4 (when `q_proj_scale != nullptr`): treat `q_proj_w` as
+    // `[2*H*d, hidden/2]` u8 and dequant per element. Same matvec stride.
     const int q_out_dim = 2 * num_heads * head_dim;
+    const bool q_int4 = (q_proj_scale != nullptr);
 
     for (;;) {
         __shared__ unsigned int my_row_s;
@@ -450,10 +469,20 @@ __global__ void qwen36_moe_attn_step_kernel(
         const int my_row = static_cast<int>(my_row_s);
         if (my_row >= q_out_dim) break;
 
-        const T* w_row = q_proj_w + static_cast<size_t>(my_row) * hidden;
         float partial = 0.0f;
-        for (int col = tid; col < hidden; col += block_size) {
-            partial += load_as_float<T>(w_row, col) * x_norm_lds[col];
+        if (q_int4) {
+            const void* q_packed = reinterpret_cast<const void*>(q_proj_w);
+            for (int col = tid; col < hidden; col += block_size) {
+                partial += int4_dequant_scalar(
+                               q_packed, q_proj_scale, q_proj_zero,
+                               my_row, col, hidden, int4_group_size)
+                           * x_norm_lds[col];
+            }
+        } else {
+            const T* w_row = q_proj_w + static_cast<size_t>(my_row) * hidden;
+            for (int col = tid; col < hidden; col += block_size) {
+                partial += load_as_float<T>(w_row, col) * x_norm_lds[col];
+            }
         }
         shared_scratch[tid] = partial;
         __syncthreads();
@@ -562,13 +591,25 @@ __global__ void qwen36_moe_attn_step_kernel(
         // First Hkv*d rows belong to k_proj, next Hkv*d to v_proj.
         const bool is_v = my_row >= Hkv * d;
         const int proj_row = is_v ? (my_row - Hkv * d) : my_row;
-        const T* w_row = (is_v ? v_proj_w : k_proj_w)
-            + static_cast<size_t>(proj_row) * hidden;
+        const T* w_slab = is_v ? v_proj_w : k_proj_w;
+        const hip_bfloat16* i4_scale = is_v ? v_proj_scale : k_proj_scale;
+        const hip_bfloat16* i4_zero  = is_v ? v_proj_zero  : k_proj_zero;
         const int dst_off = (is_v ? OFF_V_RAW : OFF_K_RAW) + proj_row;
 
         float partial = 0.0f;
-        for (int col = tid; col < hidden; col += block_size) {
-            partial += load_as_float<T>(w_row, col) * x_norm_lds[col];
+        if (i4_scale != nullptr) {
+            const void* w_packed = reinterpret_cast<const void*>(w_slab);
+            for (int col = tid; col < hidden; col += block_size) {
+                partial += int4_dequant_scalar(
+                               w_packed, i4_scale, i4_zero,
+                               proj_row, col, hidden, int4_group_size)
+                           * x_norm_lds[col];
+            }
+        } else {
+            const T* w_row = w_slab + static_cast<size_t>(proj_row) * hidden;
+            for (int col = tid; col < hidden; col += block_size) {
+                partial += load_as_float<T>(w_row, col) * x_norm_lds[col];
+            }
         }
         shared_scratch[tid] = partial;
         __syncthreads();
@@ -837,6 +878,7 @@ __global__ void qwen36_moe_attn_step_kernel(
     // (when stage == 5) the host-visible output buffer.
     {
         const int qd = H * d;
+        const bool o_int4 = (o_proj_scale != nullptr);
 
         for (;;) {
             __shared__ unsigned int my_row_s;
@@ -847,10 +889,20 @@ __global__ void qwen36_moe_attn_step_kernel(
             const int my_row = static_cast<int>(my_row_s);
             if (my_row >= hidden) break;
 
-            const T* w_row = o_proj_w + static_cast<size_t>(my_row) * qd;
             float partial = 0.0f;
-            for (int j = tid; j < qd; j += block_size) {
-                partial += load_as_float<T>(w_row, j) * workspace[OFF_GATED + j];
+            if (o_int4) {
+                const void* o_packed = reinterpret_cast<const void*>(o_proj_w);
+                for (int j = tid; j < qd; j += block_size) {
+                    partial += int4_dequant_scalar(
+                                   o_packed, o_proj_scale, o_proj_zero,
+                                   my_row, j, qd, int4_group_size)
+                               * workspace[OFF_GATED + j];
+                }
+            } else {
+                const T* w_row = o_proj_w + static_cast<size_t>(my_row) * qd;
+                for (int j = tid; j < qd; j += block_size) {
+                    partial += load_as_float<T>(w_row, j) * workspace[OFF_GATED + j];
+                }
             }
             shared_scratch[tid] = partial;
             __syncthreads();

--- a/kernels/qwen36_moe.hip
+++ b/kernels/qwen36_moe.hip
@@ -993,6 +993,17 @@ __global__ void qwen36_moe_linear_step_kernel(
     const T* __restrict__          out_proj_w,          // unused at stage 1
     T* __restrict__                conv_state,          // unused at stage 1
     float* __restrict__            recurrent_state,     // unused at stage 1
+    // PR 4b6 INT4 sidecars. Same null-pointer-as-mode discipline as the
+    // full-attn kernel. Only the three projections that the bake quantizes
+    // are wired (in_proj_qkv, in_proj_z, out_proj). in_proj_a/in_proj_b are
+    // tiny per-V-head scalars and stay BF16.
+    int                                  int4_group_size,
+    const hip_bfloat16* __restrict__     in_proj_qkv_scale,
+    const hip_bfloat16* __restrict__     in_proj_qkv_zero,
+    const hip_bfloat16* __restrict__     in_proj_z_scale,
+    const hip_bfloat16* __restrict__     in_proj_z_zero,
+    const hip_bfloat16* __restrict__     out_proj_scale,
+    const hip_bfloat16* __restrict__     out_proj_zero,
     T* __restrict__                output,
     float* __restrict__            workspace,
     unsigned int* __restrict__     counters,
@@ -1084,28 +1095,60 @@ __global__ void qwen36_moe_linear_step_kernel(
         if (my_row >= total_rows) break;
 
         // Pick projection + per-projection row-index + workspace dst.
-        const T* w_row;
+        // BF16 path tracks `w_row`; INT4 path tracks (slab base, scale, zero,
+        // local row index) so the helper indexes within the per-projection
+        // 2D weight regardless of which projection the row belongs to.
+        const T* w_row = nullptr;
+        const void* i4_slab = nullptr;
+        const hip_bfloat16* i4_scale = nullptr;
+        const hip_bfloat16* i4_zero  = nullptr;
+        int i4_row = 0;
         int dst_off;
         if (my_row < qkv_dim) {
-            w_row   = in_proj_qkv_w + static_cast<size_t>(my_row) * hidden;
+            if (in_proj_qkv_scale != nullptr) {
+                i4_slab  = reinterpret_cast<const void*>(in_proj_qkv_w);
+                i4_scale = in_proj_qkv_scale;
+                i4_zero  = in_proj_qkv_zero;
+                i4_row   = my_row;
+            } else {
+                w_row = in_proj_qkv_w + static_cast<size_t>(my_row) * hidden;
+            }
             dst_off = OFF_QKV_RAW + my_row;
         } else if (my_row < qkv_dim + val_dim) {
             const int r = my_row - qkv_dim;
-            w_row   = in_proj_z_w + static_cast<size_t>(r) * hidden;
+            if (in_proj_z_scale != nullptr) {
+                i4_slab  = reinterpret_cast<const void*>(in_proj_z_w);
+                i4_scale = in_proj_z_scale;
+                i4_zero  = in_proj_z_zero;
+                i4_row   = r;
+            } else {
+                w_row = in_proj_z_w + static_cast<size_t>(r) * hidden;
+            }
             dst_off = OFF_Z_RAW + r;
         } else if (my_row < qkv_dim + val_dim + V) {
+            // in_proj_a stays BF16 — bake excludes it.
             const int r = my_row - (qkv_dim + val_dim);
             w_row   = in_proj_a_w + static_cast<size_t>(r) * hidden;
             dst_off = OFF_A_RAW + r;
         } else {
+            // in_proj_b stays BF16 — bake excludes it.
             const int r = my_row - (qkv_dim + val_dim + V);
             w_row   = in_proj_b_w + static_cast<size_t>(r) * hidden;
             dst_off = OFF_B_RAW + r;
         }
 
         float partial = 0.0f;
-        for (int col = tid; col < hidden; col += block_size) {
-            partial += static_cast<float>(w_row[col]) * x_norm_lds[col];
+        if (i4_scale != nullptr) {
+            for (int col = tid; col < hidden; col += block_size) {
+                partial += int4_dequant_scalar(
+                               i4_slab, i4_scale, i4_zero,
+                               i4_row, col, hidden, int4_group_size)
+                           * x_norm_lds[col];
+            }
+        } else {
+            for (int col = tid; col < hidden; col += block_size) {
+                partial += static_cast<float>(w_row[col]) * x_norm_lds[col];
+            }
         }
         shared_scratch[tid] = partial;
         __syncthreads();
@@ -1559,6 +1602,7 @@ __global__ void qwen36_moe_linear_step_kernel(
     // and `output_hidden = input_hidden + o_out` in the oracle.
     {
         const int qd = V * v_dim;
+        const bool out_int4 = (out_proj_scale != nullptr);
 
         for (;;) {
             __shared__ unsigned int my_row_s;
@@ -1569,10 +1613,20 @@ __global__ void qwen36_moe_linear_step_kernel(
             const int my_row = static_cast<int>(my_row_s);
             if (my_row >= hidden) break;
 
-            const T* w_row = out_proj_w + static_cast<size_t>(my_row) * qd;
             float partial = 0.0f;
-            for (int j = tid; j < qd; j += block_size) {
-                partial += static_cast<float>(w_row[j]) * workspace[OFF_REC_OUT + j];
+            if (out_int4) {
+                const void* o_packed = reinterpret_cast<const void*>(out_proj_w);
+                for (int j = tid; j < qd; j += block_size) {
+                    partial += int4_dequant_scalar(
+                                   o_packed, out_proj_scale, out_proj_zero,
+                                   my_row, j, qd, int4_group_size)
+                               * workspace[OFF_REC_OUT + j];
+                }
+            } else {
+                const T* w_row = out_proj_w + static_cast<size_t>(my_row) * qd;
+                for (int j = tid; j < qd; j += block_size) {
+                    partial += static_cast<float>(w_row[j]) * workspace[OFF_REC_OUT + j];
+                }
             }
             shared_scratch[tid] = partial;
             __syncthreads();

--- a/kernels/qwen36_moe.hip
+++ b/kernels/qwen36_moe.hip
@@ -399,6 +399,14 @@ __global__ void qwen36_moe_attn_step_kernel(
     const hip_bfloat16* __restrict__     o_proj_zero,
     T* __restrict__                output,        // BF16, sized for the largest staged intermediate
     float* __restrict__             workspace,    // F32 scratch, see header comment
+    // PR 4d KV cache extension. When `kv_cache_k`/`kv_cache_v` are non-null
+    // and `kv_max_t > 0`, Phase G writes the current step's K/V at slot
+    // `position` and attends over `kv_len = position + 1` past tokens. When
+    // both pointers are null, falls back to the kv_len=1 self-attention
+    // path (PR 4b2 behavior — back-compat for the parity tests).
+    T* __restrict__                kv_cache_k,    // [kv_max_t, Hkv*d] BF16 (mut, nullable)
+    T* __restrict__                kv_cache_v,    // [kv_max_t, Hkv*d] BF16 (mut, nullable)
+    int                            kv_max_t,      // capacity bound; 0 ⇔ no cache
     unsigned int* __restrict__     counters,
     unsigned int* __restrict__     barrier_counter,
     unsigned int* __restrict__     barrier_flag) {
@@ -408,7 +416,7 @@ __global__ void qwen36_moe_attn_step_kernel(
     (void)o_proj_w;
     (void)rotary_dim;
     (void)rope_theta;
-    (void)position;
+    // `position` is now read in Phase G when KV cache is enabled.
 
     const int num_blocks = static_cast<int>(gridDim.x);
     const int tid        = threadIdx.x;
@@ -514,6 +522,12 @@ __global__ void qwen36_moe_attn_step_kernel(
     const int OFF_ATTN     = 4 * H * d + 4 * Hkv * d;
     const int OFF_GATED    = 5 * H * d + 4 * Hkv * d;
     const int OFF_O_OUT    = 6 * H * d + 4 * Hkv * d;
+    // Scores for the attention reduction when kv_len > 1. Per Q head we
+    // need [kv_len] F32 slots; allocate per-head slots [H, kv_max_t] so
+    // blocks processing different heads don't race. When kv_cache_k is
+    // null (back-compat kv_len=1 path) this region is unused — the engine
+    // doesn't need to allocate space for it.
+    const int OFF_SCORES   = 6 * H * d + 4 * Hkv * d + hidden;
 
     // -- Phase C: per-head RMS norm of q_lanes = workspace[Q_RAW : Q_RAW+H*d]
     // Each block grabs a head index, reduces across head_dim, writes BF16
@@ -760,27 +774,53 @@ __global__ void qwen36_moe_attn_step_kernel(
     grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
                                &counters[0]);
 
-    // -- Phase G: GQA self-attention, kv_len = 1 ----------------------------
+    // -- Phase G: GQA self-attention with optional KV cache -----------------
     //
-    // The PR-4b2 oracle runs without a KV cache, so the only K/V token is
-    // the just-emitted one. With a single-token K, softmax over the score
-    // vector reduces to a single element ≡ 1.0 regardless of the score.
-    // The output therefore collapses to:
+    // Two modes selected by whether kv_cache_k/v are non-null:
     //
-    //   attn[h, :] = bf16(1.0) * v_full[h, :]
-    //              = v_raw[h // rep, :]      (already BF16-rounded F32)
+    // 1) Back-compat (kv_cache == null): kv_len = 1 self-attention. Softmax
+    //    over a single score is 1.0; output[h] = V[h_kv]. Same path as the
+    //    PR 4b2 oracle, kept bit-exact so the per-block parity tests don't
+    //    regress.
     //
-    // We still compute the QK score (skipped for the output) so the path
-    // exercises q_rot / k_rot loads — that's the slice of compute the
-    // future kv_len > 1 extension will reuse, with the softmax becoming
-    // non-trivial. For now the score is intentionally unused.
-    //
-    // Each block grabs one Q head, broadcasts the matching KV head's V row
-    // into workspace[ATTN + h*d : ...] and (when stage == 4) into output.
+    // 2) KV cache enabled (kv_cache != null): write current (K_rot, V_raw)
+    //    at slot `position`, then attend over kv_len = position + 1 past
+    //    tokens with real softmax (max-stabilised, F32 exp). Per-Q-head
+    //    work-stealing; per-head scores live at workspace[OFF_SCORES +
+    //    hq * kv_max_t] so concurrent blocks computing different heads
+    //    don't race. Cap: kv_max_t must accommodate position + 1.
     {
         const int rep   = H / Hkv;
         const float scale = rsqrtf(static_cast<float>(d));
+        const bool use_kv_cache = (kv_cache_k != nullptr && kv_cache_v != nullptr);
+        const int kv_len = use_kv_cache ? (position + 1) : 1;
 
+        // Step 1: write current K/V into the cache (if enabled). All blocks
+        // cooperate via a flat work-stealing index since the writes are
+        // independent across (h_kv, i).
+        if (use_kv_cache) {
+            const int slot_base = position * Hkv * d;
+            const int total = Hkv * d;
+            for (int idx = blockIdx.x * block_size + tid;
+                 idx < total;
+                 idx += num_blocks * block_size) {
+                const int h_kv = idx / d;
+                const int i    = idx % d;
+                const float kv = workspace[OFF_K_ROT + h_kv * d + i];
+                const float vv = workspace[OFF_V_RAW + h_kv * d + i];
+                kv_cache_k[slot_base + h_kv * d + i] = static_cast<T>(kv);
+                kv_cache_v[slot_base + h_kv * d + i] = static_cast<T>(vv);
+            }
+            // Ensure all blocks' writes are visible before the read-side
+            // attention reduction reads cache[0..=position].
+            grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
+                                       &counters[0]);
+        }
+
+        // Step 2: per-Q-head attention reduction. Each block claims one head
+        // via atomicAdd on counters[0]; the write phase above already reset
+        // it (via grid_barrier_reset_counter when use_kv_cache, or by leaving
+        // it untouched when not).
         for (;;) {
             __shared__ unsigned int head_s;
             if (tid == 0) {
@@ -792,34 +832,96 @@ __global__ void qwen36_moe_attn_step_kernel(
 
             const int h_kv = hq / rep;
 
-            // Score (q · k) * scale — computed for path-coverage only at
-            // kv_len=1. Single-block reduction over head_dim=256.
-            float partial = 0.0f;
-            for (int i = tid; i < d; i += block_size) {
-                const float q = workspace[OFF_Q_ROT + hq   * d + i];
-                const float k = workspace[OFF_K_ROT + h_kv * d + i];
-                partial += q * k;
+            if (kv_len == 1) {
+                // Back-compat fast path — bit-exact match for PR 4b2 parity.
+                float partial = 0.0f;
+                for (int i = tid; i < d; i += block_size) {
+                    const float q = workspace[OFF_Q_ROT + hq   * d + i];
+                    const float k = workspace[OFF_K_ROT + h_kv * d + i];
+                    partial += q * k;
+                }
+                shared_scratch[tid] = partial;
+                __syncthreads();
+                for (int s = block_size / 2; s > 0; s >>= 1) {
+                    if (tid < s) shared_scratch[tid] += shared_scratch[tid + s];
+                    __syncthreads();
+                }
+                __shared__ float head_score;
+                if (tid == 0) {
+                    head_score = shared_scratch[0] * scale;
+                }
+                __syncthreads();
+                (void)head_score;
+                // softmax([s]) = [1.0]; output collapses to V at this position.
+                for (int i = tid; i < d; i += block_size) {
+                    const float v = workspace[OFF_V_RAW + h_kv * d + i];
+                    workspace[OFF_ATTN + hq * d + i] = v;
+                    if (stage == 4) {
+                        output[hq * d + i] = static_cast<T>(v);
+                    }
+                }
+                __syncthreads();
+                continue;
             }
-            shared_scratch[tid] = partial;
-            __syncthreads();
-            for (int s = block_size / 2; s > 0; s >>= 1) {
-                if (tid < s) shared_scratch[tid] += shared_scratch[tid + s];
+
+            // KV-cache path. Compute scores[t] = (q · K_cache[t]) * scale
+            // for t in 0..=position. Per-head scores live at
+            // workspace[OFF_SCORES + hq * kv_max_t + t].
+            const int score_base = OFF_SCORES + hq * kv_max_t;
+            for (int t = 0; t < kv_len; t++) {
+                float partial = 0.0f;
+                for (int i = tid; i < d; i += block_size) {
+                    const float q = workspace[OFF_Q_ROT + hq * d + i];
+                    const float k = static_cast<float>(
+                        kv_cache_k[t * Hkv * d + h_kv * d + i]);
+                    partial += q * k;
+                }
+                shared_scratch[tid] = partial;
+                __syncthreads();
+                for (int s = block_size / 2; s > 0; s >>= 1) {
+                    if (tid < s) shared_scratch[tid] += shared_scratch[tid + s];
+                    __syncthreads();
+                }
+                if (tid == 0) {
+                    workspace[score_base + t] = shared_scratch[0] * scale;
+                }
                 __syncthreads();
             }
-            __shared__ float head_score;
+
+            // Softmax with max-stabilisation. Done by tid==0 to keep the
+            // reduction simple — kv_len is small (≤ context window) and the
+            // remaining work (V-weighted reduction) is the bulk of the cost.
+            __shared__ float max_score;
+            __shared__ float exp_sum;
             if (tid == 0) {
-                head_score = shared_scratch[0] * scale;
+                float m = workspace[score_base];
+                for (int t = 1; t < kv_len; t++) {
+                    m = fmaxf(m, workspace[score_base + t]);
+                }
+                max_score = m;
+                float s = 0.0f;
+                for (int t = 0; t < kv_len; t++) {
+                    const float e = expf(workspace[score_base + t] - m);
+                    workspace[score_base + t] = e;
+                    s += e;
+                }
+                exp_sum = s;
             }
             __syncthreads();
-            (void)head_score;
 
-            // softmax([s]) = [1.0]; bf16(1.0 * v) = v. v_raw is already
-            // BF16-rounded F32 from Phase D so no extra rounding needed.
+            // Weighted sum of V over t. Each thread handles a slice of d.
+            const float inv_sum = 1.0f / exp_sum;
             for (int i = tid; i < d; i += block_size) {
-                const float v = workspace[OFF_V_RAW + h_kv * d + i];
-                workspace[OFF_ATTN + hq * d + i] = v;
+                float acc = 0.0f;
+                for (int t = 0; t < kv_len; t++) {
+                    const float w = workspace[score_base + t] * inv_sum;
+                    const float v = static_cast<float>(
+                        kv_cache_v[t * Hkv * d + h_kv * d + i]);
+                    acc += w * v;
+                }
+                workspace[OFF_ATTN + hq * d + i] = acc;
                 if (stage == 4) {
-                    output[hq * d + i] = static_cast<T>(v);
+                    output[hq * d + i] = static_cast<T>(acc);
                 }
             }
             __syncthreads();

--- a/kernels/qwen36_moe.hip
+++ b/kernels/qwen36_moe.hip
@@ -44,6 +44,96 @@ __device__ __forceinline__ float bf16_round_rne_f32(float x) {
     return y;
 }
 
+// ---------------------------------------------------------------------------
+// INT4 group-quant dequant — ported from kernels/full_attention_4b.hip
+// (PR 4b5). Per CLAUDE.md the qwen36_moe and full_attention_4b kernels are
+// isolated compilation units (hipcc on gfx11xx is fragile), so the helpers
+// live here as a copy rather than a shared header. The numerics match
+// `oracle/bake_int4.py`'s reconstruction exactly:
+//   recon = bf16_round_rne_f32(nibble * scale - zero * scale)
+// (single rounding through BF16 at the end).
+//
+// Layout (matches the bake + the full_attention_4b versions):
+//   weights : `[..., out, in/2]` u8   — 2 nibbles/byte, even col → low.
+//   scale   : `[..., out/gs, in/gs]` BF16
+//   zero    : `[..., out/gs, in/gs]` BF16
+
+// Dequantize 8 INT4 weights from 4 packed bytes.
+// `packed` carries 8 nibbles in the same nibble-order
+// `int4_dequant_8` in full_attention_4b uses (low nibble = even col).
+// `col` is the starting input column for the 8-element span (must be
+// 2-aligned). `scale_row = row / gsz`, `scale_cols = (cols + gsz - 1) / gsz`,
+// `sb = scale_row * scale_cols`. Fast path covers the common case where all
+// 8 columns share a group (gs=128 + 8-element step ⇒ true except at group
+// boundaries).
+__device__ inline void int4_dequant_8(
+    uint32_t packed,
+    const hip_bfloat16* __restrict__ scales,
+    const hip_bfloat16* __restrict__ zeros,
+    int scale_row, int col, int scale_cols, int gsz,
+    float out[8]
+) {
+    const int sb = scale_row * scale_cols;
+    int n0 = (packed >>  0) & 0xF;
+    int n1 = (packed >>  4) & 0xF;
+    int n2 = (packed >>  8) & 0xF;
+    int n3 = (packed >> 12) & 0xF;
+    int n4 = (packed >> 16) & 0xF;
+    int n5 = (packed >> 20) & 0xF;
+    int n6 = (packed >> 24) & 0xF;
+    int n7 = (packed >> 28) & 0xF;
+
+    const int g0 = col / gsz;
+    const int g7 = (col + 7) / gsz;
+    if (g0 == g7) {
+        float s = static_cast<float>(scales[sb + g0]);
+        float zs = static_cast<float>(zeros[sb + g0]) * s;
+        out[0] = bf16_round_rne_f32(static_cast<float>(n0) * s - zs);
+        out[1] = bf16_round_rne_f32(static_cast<float>(n1) * s - zs);
+        out[2] = bf16_round_rne_f32(static_cast<float>(n2) * s - zs);
+        out[3] = bf16_round_rne_f32(static_cast<float>(n3) * s - zs);
+        out[4] = bf16_round_rne_f32(static_cast<float>(n4) * s - zs);
+        out[5] = bf16_round_rne_f32(static_cast<float>(n5) * s - zs);
+        out[6] = bf16_round_rne_f32(static_cast<float>(n6) * s - zs);
+        out[7] = bf16_round_rne_f32(static_cast<float>(n7) * s - zs);
+    } else {
+        float s0 = static_cast<float>(scales[sb + g0]);
+        float zs0 = static_cast<float>(zeros[sb + g0]) * s0;
+        float s1 = static_cast<float>(scales[sb + g7]);
+        float zs1 = static_cast<float>(zeros[sb + g7]) * s1;
+        #define I4DQ(idx, ni) do { \
+            int gi = (col + idx) / gsz; \
+            float si = (gi == g0) ? s0 : s1; \
+            float zsi = (gi == g0) ? zs0 : zs1; \
+            out[idx] = bf16_round_rne_f32(static_cast<float>(ni) * si - zsi); \
+        } while(0)
+        I4DQ(0, n0); I4DQ(1, n1); I4DQ(2, n2); I4DQ(3, n3);
+        I4DQ(4, n4); I4DQ(5, n5); I4DQ(6, n6); I4DQ(7, n7);
+        #undef I4DQ
+    }
+}
+
+// Single-element dequant for non-8-aligned tails. `cols` is the unpacked
+// input dim of the 2D slab `(row, col)` indexes into. `scales`/`zeros`
+// are at `[(row/gs) * ((cols + gs - 1)/gs) + col/gs]` — same as the 2D
+// helpers in full_attention_4b.
+__device__ inline float int4_dequant_scalar(
+    const void* w_ptr, const void* scale_ptr, const void* zero_ptr,
+    int row, int col, int cols, int group_size
+) {
+    const uint8_t* data = static_cast<const uint8_t*>(w_ptr);
+    int byte_cols = cols / 2;
+    uint8_t packed_byte = data[static_cast<size_t>(row) * byte_cols + col / 2];
+    int nibble = (col & 1) ? ((packed_byte >> 4) & 0xF) : (packed_byte & 0xF);
+    const hip_bfloat16* scales = static_cast<const hip_bfloat16*>(scale_ptr);
+    const hip_bfloat16* zeros = static_cast<const hip_bfloat16*>(zero_ptr);
+    int si = (row / group_size) * ((cols + group_size - 1) / group_size)
+           + col / group_size;
+    float s = static_cast<float>(scales[si]);
+    return bf16_round_rne_f32(
+        static_cast<float>(nibble) * s - static_cast<float>(zeros[si]) * s);
+}
+
 // -- Layer descriptor (mirror of Rust Qwen36MoeDecodeLayerDesc) ----------
 
 struct DecodeLayerDesc {
@@ -2096,6 +2186,57 @@ __global__ void qwen36_moe_ffn_step_kernel(
             output[my_row] = static_cast<T>(val);
         }
         __syncthreads();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PR 4b5 step 2: INT4 dequant smoke kernel.
+//
+// Single-thread sweep over a small `[out_rows, in_cols]` slab that calls
+// both `int4_dequant_8` (fused 8-wide path) and `int4_dequant_scalar`
+// (single-element path) into separate output buffers. The host test
+// compares each output byte-for-byte against a Rust-side reference
+// implementing the same `bf16(q*s - z*s)` math. This catches porting
+// bugs in the helpers in isolation, before they're folded into the FFN
+// matmuls in step 3+.
+//
+// Pre-conditions (the bridge validates them):
+//   - in_cols % 8 == 0
+//   - in_cols % gsz == 0, gsz % 2 == 0 (single-byte index by `col / 2`)
+//   - out_rows % gsz == 0 (single-row scale tile per scale_row)
+__global__ void int4_dequant_smoke_kernel(
+    const uint8_t*      packed,        // [out_rows, in_cols / 2]
+    const hip_bfloat16* scale,         // [out_rows / gsz, in_cols / gsz]
+    const hip_bfloat16* zero,          // [out_rows / gsz, in_cols / gsz]
+    int                 out_rows,
+    int                 in_cols,
+    int                 gsz,
+    float*              dq_8_out,      // [out_rows * in_cols] from int4_dequant_8
+    float*              dq_scalar_out  // [out_rows * in_cols] from int4_dequant_scalar
+) {
+    if (blockIdx.x != 0 || threadIdx.x != 0) return;
+    const int byte_cols = in_cols / 2;
+    const int scale_cols = in_cols / gsz;
+    for (int row = 0; row < out_rows; ++row) {
+        // Path A: 8-wide fused dequant.
+        for (int col = 0; col < in_cols; col += 8) {
+            uint32_t pk = 0;
+            for (int b = 0; b < 4; ++b) {
+                pk |= static_cast<uint32_t>(
+                          packed[row * byte_cols + col / 2 + b]) << (8 * b);
+            }
+            float d[8];
+            int4_dequant_8(pk, scale, zero,
+                           row / gsz, col, scale_cols, gsz, d);
+            for (int i = 0; i < 8; ++i) {
+                dq_8_out[row * in_cols + col + i] = d[i];
+            }
+        }
+        // Path B: scalar dequant (one element at a time).
+        for (int col = 0; col < in_cols; ++col) {
+            dq_scalar_out[row * in_cols + col] = int4_dequant_scalar(
+                packed, scale, zero, row, col, in_cols, gsz);
+        }
     }
 }
 

--- a/kernels/qwen36_moe_bridge.cpp
+++ b/kernels/qwen36_moe_bridge.cpp
@@ -117,6 +117,15 @@ extern "C" int qwen36_moe_hip_attn_step_launch(
     const void*   q_norm_w,
     const void*   k_norm_w,
     const void*   o_proj_w,
+    int           int4_group_size,
+    const void*   q_proj_scale,
+    const void*   q_proj_zero,
+    const void*   k_proj_scale,
+    const void*   k_proj_zero,
+    const void*   v_proj_scale,
+    const void*   v_proj_zero,
+    const void*   o_proj_scale,
+    const void*   o_proj_zero,
     void*         output,
     float*        workspace,
     unsigned int* counters,
@@ -134,6 +143,23 @@ extern "C" int qwen36_moe_hip_attn_step_launch(
         barrier_flag == nullptr) {
         return 113;
     }
+    // INT4 sidecars: each scale must be paired with a zero. group_size==0
+    // disables INT4 entirely; otherwise it must be positive.
+    if (int4_group_size < 0) return 114;
+    auto pair_ok = [](const void* s, const void* z) -> bool {
+        return (s == nullptr) == (z == nullptr);
+    };
+    if (!pair_ok(q_proj_scale, q_proj_zero) ||
+        !pair_ok(k_proj_scale, k_proj_zero) ||
+        !pair_ok(v_proj_scale, v_proj_zero) ||
+        !pair_ok(o_proj_scale, o_proj_zero)) {
+        return 115;
+    }
+    const bool any_int4 =
+        (q_proj_scale != nullptr) || (k_proj_scale != nullptr) ||
+        (v_proj_scale != nullptr) || (o_proj_scale != nullptr);
+    if (any_int4 && int4_group_size <= 0) return 116;
+    if (!any_int4 && int4_group_size != 0) return 117;
 
     ScopedHipDevice scoped(static_cast<int>(device_ordinal));
 
@@ -177,6 +203,15 @@ extern "C" int qwen36_moe_hip_attn_step_launch(
                        static_cast<const hip_bfloat16*>(q_norm_w),
                        static_cast<const hip_bfloat16*>(k_norm_w),
                        static_cast<const hip_bfloat16*>(o_proj_w),
+                       int4_group_size,
+                       static_cast<const hip_bfloat16*>(q_proj_scale),
+                       static_cast<const hip_bfloat16*>(q_proj_zero),
+                       static_cast<const hip_bfloat16*>(k_proj_scale),
+                       static_cast<const hip_bfloat16*>(k_proj_zero),
+                       static_cast<const hip_bfloat16*>(v_proj_scale),
+                       static_cast<const hip_bfloat16*>(v_proj_zero),
+                       static_cast<const hip_bfloat16*>(o_proj_scale),
+                       static_cast<const hip_bfloat16*>(o_proj_zero),
                        static_cast<hip_bfloat16*>(output),
                        workspace,
                        counters,

--- a/kernels/qwen36_moe_bridge.cpp
+++ b/kernels/qwen36_moe_bridge.cpp
@@ -314,6 +314,17 @@ extern "C" int qwen36_moe_hip_ffn_step_launch(
     const void*   shared_up_proj_w,
     const void*   shared_down_proj_w,
     const void*   shared_expert_gate_w,
+    int           int4_group_size,
+    const void*   gate_up_proj_scale,
+    const void*   gate_up_proj_zero,
+    const void*   down_proj_scale,
+    const void*   down_proj_zero,
+    const void*   shared_gate_proj_scale,
+    const void*   shared_gate_proj_zero,
+    const void*   shared_up_proj_scale,
+    const void*   shared_up_proj_zero,
+    const void*   shared_down_proj_scale,
+    const void*   shared_down_proj_zero,
     void*         output,
     int*          output_idx,
     float*        workspace,
@@ -332,6 +343,26 @@ extern "C" int qwen36_moe_hip_ffn_step_launch(
         barrier_counter == nullptr || barrier_flag == nullptr) {
         return 133;
     }
+    // INT4 mode: group_size must divide the relevant dims and each scale
+    // must be paired with a zero. group_size==0 disables INT4 entirely.
+    if (int4_group_size < 0) return 134;
+    auto pair_ok = [](const void* s, const void* z) -> bool {
+        return (s == nullptr) == (z == nullptr);
+    };
+    if (!pair_ok(gate_up_proj_scale, gate_up_proj_zero) ||
+        !pair_ok(down_proj_scale, down_proj_zero) ||
+        !pair_ok(shared_gate_proj_scale, shared_gate_proj_zero) ||
+        !pair_ok(shared_up_proj_scale, shared_up_proj_zero) ||
+        !pair_ok(shared_down_proj_scale, shared_down_proj_zero)) {
+        return 135;
+    }
+    const bool any_int4 =
+        (gate_up_proj_scale != nullptr) || (down_proj_scale != nullptr) ||
+        (shared_gate_proj_scale != nullptr) ||
+        (shared_up_proj_scale != nullptr) ||
+        (shared_down_proj_scale != nullptr);
+    if (any_int4 && int4_group_size <= 0) return 136;
+    if (!any_int4 && int4_group_size != 0) return 137;
 
     ScopedHipDevice scoped(static_cast<int>(device_ordinal));
 
@@ -370,6 +401,17 @@ extern "C" int qwen36_moe_hip_ffn_step_launch(
                        static_cast<const hip_bfloat16*>(shared_up_proj_w),
                        static_cast<const hip_bfloat16*>(shared_down_proj_w),
                        static_cast<const hip_bfloat16*>(shared_expert_gate_w),
+                       int4_group_size,
+                       static_cast<const hip_bfloat16*>(gate_up_proj_scale),
+                       static_cast<const hip_bfloat16*>(gate_up_proj_zero),
+                       static_cast<const hip_bfloat16*>(down_proj_scale),
+                       static_cast<const hip_bfloat16*>(down_proj_zero),
+                       static_cast<const hip_bfloat16*>(shared_gate_proj_scale),
+                       static_cast<const hip_bfloat16*>(shared_gate_proj_zero),
+                       static_cast<const hip_bfloat16*>(shared_up_proj_scale),
+                       static_cast<const hip_bfloat16*>(shared_up_proj_zero),
+                       static_cast<const hip_bfloat16*>(shared_down_proj_scale),
+                       static_cast<const hip_bfloat16*>(shared_down_proj_zero),
                        static_cast<hip_bfloat16*>(output),
                        output_idx,
                        workspace,

--- a/kernels/qwen36_moe_bridge.cpp
+++ b/kernels/qwen36_moe_bridge.cpp
@@ -128,6 +128,9 @@ extern "C" int qwen36_moe_hip_attn_step_launch(
     const void*   o_proj_zero,
     void*         output,
     float*        workspace,
+    void*         kv_cache_k,
+    void*         kv_cache_v,
+    int           kv_max_t,
     unsigned int* counters,
     unsigned int* barrier_counter,
     unsigned int* barrier_flag) {
@@ -160,6 +163,16 @@ extern "C" int qwen36_moe_hip_attn_step_launch(
         (v_proj_scale != nullptr) || (o_proj_scale != nullptr);
     if (any_int4 && int4_group_size <= 0) return 116;
     if (!any_int4 && int4_group_size != 0) return 117;
+
+    // KV cache: pointers must be paired (both null or both non-null), and
+    // kv_max_t must be positive when enabled + ≥ position+1 to fit the
+    // current write.
+    const bool kv_enabled = (kv_cache_k != nullptr || kv_cache_v != nullptr);
+    if ((kv_cache_k == nullptr) != (kv_cache_v == nullptr)) return 118;
+    if (kv_enabled) {
+        if (kv_max_t <= 0) return 119;
+        if (position < 0 || position >= kv_max_t) return 120;
+    }
 
     ScopedHipDevice scoped(static_cast<int>(device_ordinal));
 
@@ -214,6 +227,9 @@ extern "C" int qwen36_moe_hip_attn_step_launch(
                        static_cast<const hip_bfloat16*>(o_proj_zero),
                        static_cast<hip_bfloat16*>(output),
                        workspace,
+                       static_cast<hip_bfloat16*>(kv_cache_k),
+                       static_cast<hip_bfloat16*>(kv_cache_v),
+                       kv_max_t,
                        counters,
                        barrier_counter,
                        barrier_flag);

--- a/kernels/qwen36_moe_bridge.cpp
+++ b/kernels/qwen36_moe_bridge.cpp
@@ -252,6 +252,13 @@ extern "C" int qwen36_moe_hip_linear_step_launch(
     const void*   out_proj_w,
     void*         conv_state,
     float*        recurrent_state,
+    int           int4_group_size,
+    const void*   in_proj_qkv_scale,
+    const void*   in_proj_qkv_zero,
+    const void*   in_proj_z_scale,
+    const void*   in_proj_z_zero,
+    const void*   out_proj_scale,
+    const void*   out_proj_zero,
     void*         output,
     float*        workspace,
     unsigned int* counters,
@@ -271,6 +278,23 @@ extern "C" int qwen36_moe_hip_linear_step_launch(
         barrier_flag == nullptr) {
         return 123;
     }
+    // INT4 sidecars: each scale must be paired with a zero. group_size==0
+    // disables INT4 entirely; otherwise it must be positive.
+    if (int4_group_size < 0) return 124;
+    auto pair_ok = [](const void* s, const void* z) -> bool {
+        return (s == nullptr) == (z == nullptr);
+    };
+    if (!pair_ok(in_proj_qkv_scale, in_proj_qkv_zero) ||
+        !pair_ok(in_proj_z_scale, in_proj_z_zero) ||
+        !pair_ok(out_proj_scale, out_proj_zero)) {
+        return 125;
+    }
+    const bool any_int4 =
+        (in_proj_qkv_scale != nullptr) ||
+        (in_proj_z_scale != nullptr) ||
+        (out_proj_scale != nullptr);
+    if (any_int4 && int4_group_size <= 0) return 126;
+    if (!any_int4 && int4_group_size != 0) return 127;
 
     ScopedHipDevice scoped(static_cast<int>(device_ordinal));
 
@@ -315,6 +339,13 @@ extern "C" int qwen36_moe_hip_linear_step_launch(
                        static_cast<const hip_bfloat16*>(out_proj_w),
                        static_cast<hip_bfloat16*>(conv_state),
                        recurrent_state,
+                       int4_group_size,
+                       static_cast<const hip_bfloat16*>(in_proj_qkv_scale),
+                       static_cast<const hip_bfloat16*>(in_proj_qkv_zero),
+                       static_cast<const hip_bfloat16*>(in_proj_z_scale),
+                       static_cast<const hip_bfloat16*>(in_proj_z_zero),
+                       static_cast<const hip_bfloat16*>(out_proj_scale),
+                       static_cast<const hip_bfloat16*>(out_proj_zero),
                        static_cast<hip_bfloat16*>(output),
                        workspace,
                        counters,

--- a/kernels/qwen36_moe_bridge.cpp
+++ b/kernels/qwen36_moe_bridge.cpp
@@ -382,3 +382,42 @@ extern "C" int qwen36_moe_hip_ffn_step_launch(
     if (sync_err_ffn != hipSuccess) return 255;
     return 0;
 }
+
+// PR 4b5 step 2: INT4 dequant smoke launcher.
+// Drives `qwen36_moe::int4_dequant_smoke_kernel` over a small `[out_rows,
+// in_cols]` slab and writes both helpers' outputs to separate buffers.
+// The Rust-side test validates byte-for-byte against a host reference.
+extern "C" int qwen36_moe_hip_int4_dequant_smoke_launch(
+    size_t         device_ordinal,
+    const uint8_t* packed,
+    const void*    scale,
+    const void*    zero,
+    int            out_rows,
+    int            in_cols,
+    int            gsz,
+    float*         dq_8_out,
+    float*         dq_scalar_out) {
+    if (packed == nullptr || scale == nullptr || zero == nullptr ||
+        dq_8_out == nullptr || dq_scalar_out == nullptr) {
+        return 140;
+    }
+    if (out_rows <= 0 || in_cols <= 0 || gsz <= 0) return 141;
+    if (in_cols % 8 != 0) return 142;
+    if (in_cols % gsz != 0 || gsz % 2 != 0) return 143;
+    if (out_rows % gsz != 0) return 144;
+
+    ScopedHipDevice scoped(static_cast<int>(device_ordinal));
+
+    hipLaunchKernelGGL(qwen36_moe::int4_dequant_smoke_kernel,
+                       dim3(1), dim3(1), 0, 0,
+                       packed,
+                       static_cast<const hip_bfloat16*>(scale),
+                       static_cast<const hip_bfloat16*>(zero),
+                       out_rows, in_cols, gsz,
+                       dq_8_out, dq_scalar_out);
+    hipError_t launch_err = hipGetLastError();
+    hipError_t sync_err   = hipDeviceSynchronize();
+    if (launch_err != hipSuccess) return 254;
+    if (sync_err != hipSuccess) return 255;
+    return 0;
+}

--- a/oracle/_bake_loader.py
+++ b/oracle/_bake_loader.py
@@ -1,0 +1,225 @@
+"""Shared helpers for loading SuperSonic INT4 GPTQ bakes from `weights.bin`
+into BF16-reconstructed tensors + parallel (packed, scale, zero) sidecars.
+
+The per-block oracles (`qwen36_moe_oracle.py`, `qwen36_moe_linear_oracle.py`,
+`qwen36_moe_ffn_oracle.py`) use this when their `--bake-dir` is set so the
+parity tests run against the *bake's actual quantized weights* — the
+canonical "does the kernel produce what Python expects on these specific
+INT4 reconstructions" check.
+
+Bake naming convention (matches `oracle/bake_int4.py`):
+  - Dense projections: `<name>.weight` (packed u8 [out, in/2]) +
+    `<name>.weight_int4_scale` + `<name>.weight_int4_zero` (BF16 tiles).
+  - Fused experts (no `.weight` suffix in HF state-dict): `<name>` packed +
+    `<name>_int4_scale` + `<name>_int4_zero`.
+  - Non-quantized: stored as their native dtype (BF16 for norms; F32 for A_log).
+
+Reconstruction matches the kernel's `int4_dequant_scalar` exactly:
+`bf16(q*s - z*s)` where (q, s, z) come from the bake's (packed, scale, zero).
+"""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+
+import numpy as np
+import torch
+
+
+GROUP_SIZE = 128  # pinned across the runtime + bake
+
+
+@lru_cache(maxsize=8)
+def _open_bake(bake_dir: str) -> tuple[dict, bytes]:
+    """Read manifest + mmap weights.bin once per bake-dir per process."""
+    bake_path = Path(bake_dir)
+    manifest = json.loads((bake_path / "manifest.json").read_text())
+    # Read weights.bin into memory. For 17 GiB on a 64 GiB host this is fine
+    # for a single-layer harness; the per-block oracles only touch a tiny
+    # slice. (mmap would be lighter but adds complexity and risks of
+    # unaligned-numpy-view bugs across torch versions — keep it simple.)
+    weights_data = (bake_path / "weights.bin").read_bytes()
+    return manifest, weights_data
+
+
+def _slab(manifest_idx: dict, data: bytes, name: str) -> tuple[bytes, list[int]]:
+    """Return raw bytes + shape for `name` from the bake's index."""
+    if name not in manifest_idx:
+        raise KeyError(f"tensor not in bake manifest: {name}")
+    t = manifest_idx[name]
+    return data[t["offset"]:t["offset"] + t["byte_len"]], t["shape"]
+
+
+def has_tensor(bake_dir: str, name: str) -> bool:
+    manifest, _ = _open_bake(bake_dir)
+    return any(t["name"] == name for t in manifest["tensors"])
+
+
+def load_bf16(bake_dir: str, name: str) -> torch.Tensor:
+    """Load a BF16 tensor from the bake. Used for norms, conv1d, dt_bias,
+    A_log — anything not INT4-quantized."""
+    manifest, data = _open_bake(bake_dir)
+    idx = {t["name"]: t for t in manifest["tensors"]}
+    raw, shape = _slab(idx, data, name)
+    arr = np.frombuffer(raw, dtype=np.int16).copy()
+    return torch.tensor(arr).view(torch.bfloat16).reshape(shape)
+
+
+def load_f32(bake_dir: str, name: str) -> torch.Tensor:
+    """Load an F32 tensor from the bake. A_log lives here in some
+    converters."""
+    manifest, data = _open_bake(bake_dir)
+    idx = {t["name"]: t for t in manifest["tensors"]}
+    raw, shape = _slab(idx, data, name)
+    arr = np.frombuffer(raw, dtype=np.float32).copy()
+    return torch.tensor(arr).reshape(shape)
+
+
+def load_native(bake_dir: str, name: str) -> torch.Tensor:
+    """Dtype-agnostic loader — picks BF16 or F32 based on the manifest's
+    declared dtype. Useful for tensors that vary between converters."""
+    manifest, data = _open_bake(bake_dir)
+    idx = {t["name"]: t for t in manifest["tensors"]}
+    if name not in idx:
+        raise KeyError(f"tensor not in bake manifest: {name}")
+    t = idx[name]
+    raw = data[t["offset"]:t["offset"] + t["byte_len"]]
+    shape = t["shape"]
+    dt = t["dtype"]
+    if dt == "bf16":
+        arr = np.frombuffer(raw, dtype=np.int16).copy()
+        return torch.tensor(arr).view(torch.bfloat16).reshape(shape)
+    if dt == "f32":
+        arr = np.frombuffer(raw, dtype=np.float32).copy()
+        return torch.tensor(arr).reshape(shape)
+    if dt == "u8":
+        arr = np.frombuffer(raw, dtype=np.uint8).copy()
+        return torch.tensor(arr).reshape(shape)
+    raise ValueError(f"unsupported dtype {dt} for {name}")
+
+
+def load_int4(
+    bake_dir: str,
+    name: str,
+    sidecar_suffix_style: str = "auto",
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Load a 2D INT4-quantized tensor from the bake and return
+    `(recon, packed, scale, zero)`:
+
+      recon  : BF16 [out, in]      — `bf16(q*s - z*s)` matching the kernel.
+      packed : u8   [out, in/2]    — raw nibble-packed bytes from the bake.
+      scale  : BF16 [out/gs, in/gs]
+      zero   : BF16 [out/gs, in/gs]
+
+    `sidecar_suffix_style`:
+      'dotweight'  → `<name>_int4_scale` (e.g. `q_proj.weight_int4_scale`)
+      'noweight'   → `<name>_int4_scale` (e.g. `experts.gate_up_proj_int4_scale`)
+      'auto'       → infer from `name`: if it ends in `.weight`, use
+                     `<name>_int4_scale` (which becomes
+                     `<base>.weight_int4_scale`); else
+                     `<name>_int4_scale` (raw experts).
+                     In both cases the literal sidecar name is
+                     `f"{name}_int4_scale"` — bake just glues the suffix on.
+    """
+    if sidecar_suffix_style not in ("auto", "dotweight", "noweight"):
+        raise ValueError(f"unknown sidecar_suffix_style: {sidecar_suffix_style}")
+
+    manifest, data = _open_bake(bake_dir)
+    idx = {t["name"]: t for t in manifest["tensors"]}
+
+    p_raw, ps = _slab(idx, data, name)
+    s_raw, ss = _slab(idx, data, f"{name}_int4_scale")
+    z_raw, _ = _slab(idx, data, f"{name}_int4_zero")
+
+    out_dim, in_half = ps[-2], ps[-1]
+    in_dim = in_half * 2
+    sr, sc = ss[-2], ss[-1]
+    if sr * GROUP_SIZE != out_dim:
+        raise ValueError(
+            f"{name}: scale rows {sr} × gs {GROUP_SIZE} != out_dim {out_dim}"
+        )
+    if sc * GROUP_SIZE != in_dim:
+        raise ValueError(
+            f"{name}: scale cols {sc} × gs {GROUP_SIZE} != in_dim {in_dim}"
+        )
+
+    packed = np.frombuffer(p_raw, dtype=np.uint8).copy().reshape(out_dim, in_half)
+    scale_bf = (
+        torch.tensor(np.frombuffer(s_raw, dtype=np.int16).copy())
+        .view(torch.bfloat16)
+        .reshape(sr, sc)
+    )
+    zero_bf = (
+        torch.tensor(np.frombuffer(z_raw, dtype=np.int16).copy())
+        .view(torch.bfloat16)
+        .reshape(sr, sc)
+    )
+
+    # Reconstruct BF16 weights via the kernel's bf16(q*s - z*s) formula.
+    s_f32 = scale_bf.to(torch.float32)
+    z_f32 = zero_bf.to(torch.float32)
+    q = np.empty((out_dim, in_dim), dtype=np.uint8)
+    q[:, 0::2] = packed & 0x0F
+    q[:, 1::2] = (packed >> 4) & 0x0F
+    s_full = s_f32.repeat_interleave(GROUP_SIZE, 0).repeat_interleave(GROUP_SIZE, 1)
+    z_full = z_f32.repeat_interleave(GROUP_SIZE, 0).repeat_interleave(GROUP_SIZE, 1)
+    recon = (
+        (torch.tensor(q, dtype=torch.float32) * s_full - z_full * s_full)
+        .to(torch.bfloat16)
+    )
+
+    return recon, torch.tensor(packed), scale_bf, zero_bf
+
+
+def load_int4_3d(
+    bake_dir: str,
+    name: str,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Like `load_int4` but for 3D fused-expert tensors (`[E, out, in/2]`
+    packed + `[E, out/gs, in/gs]` scale/zero). Returns recon `[E, out, in]`,
+    packed `[E, out, in/2]`, scale/zero `[E, out/gs, in/gs]`."""
+    manifest, data = _open_bake(bake_dir)
+    idx = {t["name"]: t for t in manifest["tensors"]}
+
+    p_raw, ps = _slab(idx, data, name)
+    s_raw, ss = _slab(idx, data, f"{name}_int4_scale")
+    z_raw, _ = _slab(idx, data, f"{name}_int4_zero")
+
+    e, out_dim, in_half = ps
+    in_dim = in_half * 2
+    e2, sr, sc = ss
+    if e != e2:
+        raise ValueError(f"{name}: expert axis mismatch {e} vs {e2}")
+    if sr * GROUP_SIZE != out_dim or sc * GROUP_SIZE != in_dim:
+        raise ValueError(f"{name}: scale shape doesn't match group_size")
+
+    packed = (
+        np.frombuffer(p_raw, dtype=np.uint8).copy().reshape(e, out_dim, in_half)
+    )
+    scale_bf = (
+        torch.tensor(np.frombuffer(s_raw, dtype=np.int16).copy())
+        .view(torch.bfloat16)
+        .reshape(e, sr, sc)
+    )
+    zero_bf = (
+        torch.tensor(np.frombuffer(z_raw, dtype=np.int16).copy())
+        .view(torch.bfloat16)
+        .reshape(e, sr, sc)
+    )
+
+    s_f32 = scale_bf.to(torch.float32)
+    z_f32 = zero_bf.to(torch.float32)
+    recon = torch.empty((e, out_dim, in_dim), dtype=torch.bfloat16)
+    for j in range(e):
+        q = np.empty((out_dim, in_dim), dtype=np.uint8)
+        q[:, 0::2] = packed[j] & 0x0F
+        q[:, 1::2] = (packed[j] >> 4) & 0x0F
+        s_full = s_f32[j].repeat_interleave(GROUP_SIZE, 0).repeat_interleave(GROUP_SIZE, 1)
+        z_full = z_f32[j].repeat_interleave(GROUP_SIZE, 0).repeat_interleave(GROUP_SIZE, 1)
+        recon[j] = (
+            (torch.tensor(q, dtype=torch.float32) * s_full - z_full * s_full)
+            .to(torch.bfloat16)
+        )
+    return recon, torch.tensor(packed), scale_bf, zero_bf

--- a/oracle/bake_int4.py
+++ b/oracle/bake_int4.py
@@ -278,19 +278,62 @@ def gptq_quantize(
     def set_tile_scales(gc: int, group_view: torch.Tensor) -> None:
         # group_view: [out_f, W] where W <= gs
         # Reshape to [scale_rows, gs, W] and compute per-row-tile min/max in one go.
+        # PR4d quality fix: AutoGPTQ-style scale search. Plain min/max gave
+        # per-tensor cos_sim 0.88-0.97 vs safetensors on the 35B-A3B bake;
+        # see docs/qwen36-moe-bake-quality-audit.md. Search over a small grid
+        # of "shrunk" scale factors (p < 1) and pick the per-row-tile setting
+        # that minimises post-BF16-round MSE on the dequantised tile. p < 1
+        # trades clipping at the distribution tails for tighter quantisation
+        # across the body — typically net positive for trained weights
+        # which concentrate near zero.
         width = group_view.shape[1]
         gv = group_view.reshape(scale_rows, gs, width)
-        tmax = gv.amax(dim=(1, 2))  # [scale_rows]
-        tmin = gv.amin(dim=(1, 2))
-        rng = tmax - tmin
-        sc = torch.where(rng > 0, rng / 15.0, torch.ones_like(rng))
-        zf = torch.where(rng > 0, -tmin / sc, torch.zeros_like(rng))
-        # Round through BF16 so the values we use to reconstruct weights match
-        # exactly what the runtime kernel reads (scale/zero are stored BF16).
-        sc = sc.to(torch.bfloat16).to(torch.float32)
-        zf = zf.to(torch.bfloat16).to(torch.float32)
-        scale_tile[:, gc] = sc
-        zero_tile[:, gc] = zf
+        tmax_orig = gv.amax(dim=(1, 2))  # [scale_rows]
+        tmin_orig = gv.amin(dim=(1, 2))
+
+        def derive(tmin_v: torch.Tensor, tmax_v: torch.Tensor):
+            rng_v = tmax_v - tmin_v
+            sc_v = torch.where(rng_v > 0, rng_v / 15.0, torch.ones_like(rng_v))
+            zf_v = torch.where(rng_v > 0, -tmin_v / sc_v, torch.zeros_like(rng_v))
+            # Round through BF16 so what we evaluate matches what the runtime
+            # kernel reads (scale/zero are BF16 sidecars).
+            return (sc_v.to(torch.bfloat16).to(torch.float32),
+                    zf_v.to(torch.bfloat16).to(torch.float32))
+
+        def tile_mse(sc_v: torch.Tensor, zf_v: torch.Tensor) -> torch.Tensor:
+            # Quantise + dequantise this column-group with the candidate
+            # (sc, zf) per row-tile, return per-row-tile MSE vs `gv`.
+            sc_b = sc_v.unsqueeze(1).unsqueeze(2)  # [scale_rows, 1, 1]
+            zf_b = zf_v.unsqueeze(1).unsqueeze(2)
+            # Guard against the rng==0 fallback yielding sc_b=1 → sc_b is
+            # always > 0 from `derive`; this is just defensive.
+            safe_sc = torch.where(sc_b == 0, torch.ones_like(sc_b), sc_b)
+            q = torch.clamp(torch.round(gv / safe_sc + zf_b), 0.0, 15.0)
+            recon = (q * sc_b - zf_b * sc_b).to(torch.bfloat16).to(torch.float32)
+            return ((gv - recon) ** 2).mean(dim=(1, 2))
+
+        # Baseline: full min/max (p=1.0). Always kept as the fallback so a
+        # numerically odd shrink can never regress us below the original.
+        best_sc, best_zf = derive(tmin_orig, tmax_orig)
+        best_mse = tile_mse(best_sc, best_zf)
+
+        # Shrunk-range candidates. p < 1 multiplies both tmin and tmax by p
+        # (symmetric shrink toward zero — same convention as AutoGPTQ's
+        # `Quantizer.find_params` mse=True path). Grid kept small (~7
+        # candidates) so the per-block scale-search cost stays under a
+        # millisecond per call; AutoGPTQ defaults to maxshrink=0.8 grid=100,
+        # but the marginal MSE gain after the first ~5 candidates is
+        # negligible for trained weights.
+        for p in (0.95, 0.90, 0.85, 0.80, 0.75, 0.70):
+            sc_p, zf_p = derive(p * tmin_orig, p * tmax_orig)
+            mse_p = tile_mse(sc_p, zf_p)
+            better = mse_p < best_mse
+            best_sc = torch.where(better, sc_p, best_sc)
+            best_zf = torch.where(better, zf_p, best_zf)
+            best_mse = torch.where(better, mse_p, best_mse)
+
+        scale_tile[:, gc] = best_sc
+        zero_tile[:, gc] = best_zf
 
     # Iterate columns in blocks; use blocksize == group_size so block boundaries
     # line up with column-group boundaries.
@@ -364,6 +407,54 @@ def pack_nibbles(nibbles: torch.Tensor) -> torch.Tensor:
     return (r[..., 0] | (r[..., 1] << 4)).contiguous()
 
 
+@torch.no_grad()
+def _minmax_int4_search_2d(
+    tiles: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """AutoGPTQ-style scale search for 2D-tiled INT4 quantisation.
+
+    `tiles` is a [scale_rows, gs, scale_cols, gs] float32 tensor — i.e. the
+    weights laid out so that axes (1, 3) span one quantisation tile. Returns
+    `(scale, zero)` of shape `[scale_rows, scale_cols]` (BF16-rounded F32),
+    chosen per-tile from a small grid of "shrink" factors that minimise
+    post-BF16-round MSE on the dequantised tile.
+
+    Used by `fused_expert_minmax_int4*`. The dense-projection scale search
+    in `gptq_quantize::set_tile_scales` runs the same algorithm specialised
+    for one column-group at a time (1D scale shape) so the two paths agree
+    on what "best scale" means.
+    """
+    tmax_orig = tiles.amax(dim=(1, 3))  # [scale_rows, scale_cols]
+    tmin_orig = tiles.amin(dim=(1, 3))
+
+    def derive(tmin_v: torch.Tensor, tmax_v: torch.Tensor):
+        rng_v = tmax_v - tmin_v
+        sc_v = torch.where(rng_v > 0, rng_v / 15.0, torch.ones_like(rng_v))
+        zf_v = torch.where(rng_v > 0, -tmin_v / sc_v, torch.zeros_like(rng_v))
+        # Round through BF16 — what the runtime kernel reads.
+        return (sc_v.to(torch.bfloat16).to(torch.float32),
+                zf_v.to(torch.bfloat16).to(torch.float32))
+
+    def tile_mse(sc_v: torch.Tensor, zf_v: torch.Tensor) -> torch.Tensor:
+        sc_b = sc_v.unsqueeze(1).unsqueeze(3)  # [sr, 1, sc, 1]
+        zf_b = zf_v.unsqueeze(1).unsqueeze(3)
+        safe_sc = torch.where(sc_b == 0, torch.ones_like(sc_b), sc_b)
+        q = torch.clamp(torch.round(tiles / safe_sc + zf_b), 0.0, 15.0)
+        recon = (q * sc_b - zf_b * sc_b).to(torch.bfloat16).to(torch.float32)
+        return ((tiles - recon) ** 2).mean(dim=(1, 3))  # [sr, sc]
+
+    best_sc, best_zf = derive(tmin_orig, tmax_orig)
+    best_mse = tile_mse(best_sc, best_zf)
+    for p in (0.95, 0.90, 0.85, 0.80, 0.75, 0.70):
+        sc_p, zf_p = derive(p * tmin_orig, p * tmax_orig)
+        mse_p = tile_mse(sc_p, zf_p)
+        better = mse_p < best_mse
+        best_sc = torch.where(better, sc_p, best_sc)
+        best_zf = torch.where(better, zf_p, best_zf)
+        best_mse = torch.where(better, mse_p, best_mse)
+    return best_sc, best_zf
+
+
 # ---------------------------------------------------------------------------
 # Fused MoE expert quantization (no GPTQ — min/max group-quant per expert).
 #
@@ -423,17 +514,10 @@ def fused_expert_minmax_int4(
 
     for e in range(E):
         slab = W[e].to(device=dev, dtype=torch.float32)
-        # Reduce per-tile min/max in one reshape — vectorised inside the slab.
+        # Tile shape [sr, gs, sc, gs] so axes (1, 3) span one tile.
         tiles = slab.reshape(scale_rows, gs, scale_cols, gs)
-        tmax = tiles.amax(dim=(1, 3))
-        tmin = tiles.amin(dim=(1, 3))
-        rng = tmax - tmin
-        sc = torch.where(rng > 0, rng / 15.0, torch.ones_like(rng))
-        zf = torch.where(rng > 0, -tmin / sc, torch.zeros_like(rng))
-        # Round through BF16 so reconstruction matches what the runtime kernel
-        # will read from the BF16 sidecar tensors.
-        sc = sc.to(torch.bfloat16).to(torch.float32)
-        zf = zf.to(torch.bfloat16).to(torch.float32)
+        # Per-tile scale search (same algorithm as gptq_quantize).
+        sc, zf = _minmax_int4_search_2d(tiles)
         sc_full = sc.repeat_interleave(gs, dim=0).repeat_interleave(gs, dim=1)
         zf_full = zf.repeat_interleave(gs, dim=0).repeat_interleave(gs, dim=1)
         q = torch.clamp(torch.round(slab / sc_full + zf_full), 0.0, 15.0).to(torch.uint8)
@@ -486,13 +570,8 @@ def fused_expert_minmax_int4_packed(
     for e in range(E):
         slab = W[e].to(device=dev, dtype=torch.float32)
         tiles = slab.reshape(scale_rows, gs, scale_cols, gs)
-        tmax = tiles.amax(dim=(1, 3))
-        tmin = tiles.amin(dim=(1, 3))
-        rng = tmax - tmin
-        sc = torch.where(rng > 0, rng / 15.0, torch.ones_like(rng))
-        zf = torch.where(rng > 0, -tmin / sc, torch.zeros_like(rng))
-        sc = sc.to(torch.bfloat16).to(torch.float32)
-        zf = zf.to(torch.bfloat16).to(torch.float32)
+        # Per-tile scale search (same algorithm as gptq_quantize).
+        sc, zf = _minmax_int4_search_2d(tiles)
         sc_full = sc.repeat_interleave(gs, dim=0).repeat_interleave(gs, dim=1)
         zf_full = zf.repeat_interleave(gs, dim=0).repeat_interleave(gs, dim=1)
         q = torch.clamp(torch.round(slab / sc_full + zf_full), 0.0, 15.0).to(torch.uint8)

--- a/oracle/qwen36_moe_ffn_oracle.py
+++ b/oracle/qwen36_moe_ffn_oracle.py
@@ -2,12 +2,25 @@
 """
 PyTorch reference for one Qwen3.6-MoE FFN block's decode step.
 
-Companion to PR 4b4 of docs/qwen36-moe-plan.md. The attention oracle
-(`qwen36_moe_oracle.py`) covers the pre-FFN half of a layer; this oracle
-covers the post-attention half — RMS norm, top-k MoE expert dispatch,
-shared-expert path, and the final residual add. The HIP kernel's
-parity test reads the JSON this script emits and compares its own
+Companion to PR 4b4 (BF16) and PR 4b5 (INT4) of docs/qwen36-moe-plan.md.
+The attention oracle (`qwen36_moe_oracle.py`) covers the pre-FFN half of a
+layer; this oracle covers the post-attention half — RMS norm, top-k MoE
+expert dispatch, shared-expert path, and the final residual add. The HIP
+kernel's parity test reads the JSON this script emits and compares its own
 intermediates point for point.
+
+`--int4` switches into INT4 mode: the five projection weights that the
+INT4 bake quantizes (`gate_up_proj`, `down_proj`, and the shared expert's
+`gate_proj`/`up_proj`/`down_proj`) are min/max group-quantized at gs=128
+with BF16 scale + zero. The `weights` block then carries the BF16-rounded
+*reconstruction* of those tensors (so the existing BF16 kernel path is
+still exercised) and a parallel `int4_weights` block carries the packed
+nibbles + scale + zero sidecars the INT4 kernel path will read. Schema
+becomes `qwen36-moe-oracle-ffn-int4-v1`.
+
+The INT4 quantization mirrors `oracle/bake_int4.py::fused_expert_minmax_int4_packed`
+exactly so reconstructions are byte-identical with what the runtime
+loader hands the kernel.
 
 The MoE FFN block on Qwen3-Next (35B-A3B):
 
@@ -80,6 +93,170 @@ def b64_i32(t: torch.Tensor) -> str:
     return base64.b64encode(
         t.to(torch.int32).contiguous().cpu().numpy().tobytes()
     ).decode()
+
+
+def b64_u8(t: torch.Tensor) -> str:
+    return base64.b64encode(
+        t.to(torch.uint8).contiguous().cpu().numpy().tobytes()
+    ).decode()
+
+
+# Tensors the INT4 bake quantizes for the FFN block. The router (`gate_w`)
+# and the scalar shared-expert gate (`shared_expert_gate_w`) stay BF16 — the
+# weight accountant in `crates/qwen36_moe/src/weights.rs` excludes them from
+# the INT4 budget for the same reason.
+INT4_FFN_TARGETS: tuple[str, ...] = (
+    "gate_up_proj_w",
+    "down_proj_w",
+    "shared_gate_proj_w",
+    "shared_up_proj_w",
+    "shared_down_proj_w",
+)
+
+
+@torch.no_grad()
+def minmax_int4_packed_and_recon(
+    W: torch.Tensor, group_size: int
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Min/max INT4 group-quant for a tensor whose last two axes are
+    `[out, in]`. Leading axes (e.g. the per-layer expert axis) are
+    preserved. Mirrors `bake_int4.py::fused_expert_minmax_int4_packed` for
+    3D fused-expert tensors and the equivalent 2D layout the bake produces
+    for dense projections (after collapsing GPTQ to plain min/max — group
+    size and storage layout are the same).
+
+    Returns (all on CPU except `recon`, which stays on `W.device` so it can
+    be reinjected as the BF16 weight value the BF16 kernel path reads):
+
+      packed   uint8  shape `[..., out, in/2]`     two nibbles per byte,
+                                                    even col → low nibble.
+      scale    f32    shape `[..., out/gs, in/gs]` BF16 values stored as f32.
+      zero     f32    shape `[..., out/gs, in/gs]` BF16 values stored as f32.
+      recon    bf16   shape `[..., out, in]`        single-rounding
+                                                    `bf16(q*s - z*s)` —
+                                                    matches the kernel's
+                                                    `bf16_round_rne_f32_finite(
+                                                       n*s - zs)` exactly.
+    """
+    if W.dim() < 2:
+        raise ValueError(f"expected 2+ dim, got shape {tuple(W.shape)}")
+    out_f, in_f = W.shape[-2], W.shape[-1]
+    gs = group_size
+    if in_f % gs != 0 or in_f % 2 != 0:
+        raise ValueError(
+            f"in_features {in_f} must be divisible by group_size={gs} and even"
+        )
+    if out_f % gs != 0:
+        raise ValueError(
+            f"out_features {out_f} must be divisible by group_size={gs}"
+        )
+    sr = out_f // gs
+    sc = in_f // gs
+    leading = tuple(W.shape[:-2])
+    Wf = W.reshape(-1, out_f, in_f).to(torch.float32)
+    n_slabs = Wf.shape[0]
+
+    packed_buf = torch.empty((n_slabs, out_f, in_f // 2), dtype=torch.uint8)
+    scale_buf = torch.empty((n_slabs, sr, sc), dtype=torch.float32)
+    zero_buf = torch.empty((n_slabs, sr, sc), dtype=torch.float32)
+    recon_buf = torch.empty((n_slabs, out_f, in_f),
+                            dtype=torch.bfloat16, device=W.device)
+
+    for i in range(n_slabs):
+        slab = Wf[i]
+        tiles = slab.reshape(sr, gs, sc, gs)
+        tmax = tiles.amax(dim=(1, 3))
+        tmin = tiles.amin(dim=(1, 3))
+        rng = tmax - tmin
+        s = torch.where(rng > 0, rng / 15.0, torch.ones_like(rng))
+        z = torch.where(rng > 0, -tmin / s, torch.zeros_like(rng))
+        # Round through BF16 — sidecars are stored BF16 in the bake and
+        # the kernel reads BF16 scale/zero.
+        s = s.to(torch.bfloat16).to(torch.float32)
+        z = z.to(torch.bfloat16).to(torch.float32)
+        s_full = s.repeat_interleave(gs, 0).repeat_interleave(gs, 1)
+        z_full = z.repeat_interleave(gs, 0).repeat_interleave(gs, 1)
+        q = torch.clamp(
+            torch.round(slab / s_full + z_full), 0.0, 15.0
+        ).to(torch.uint8)
+        # Single-rounding reconstruction: bf16(q*s - z*s). The kernel
+        # computes `bf16(n*s - zs)` with `zs = z*s` precomputed in F32, so
+        # the rounding boundary is identical.
+        recon = (q.to(torch.float32) * s_full - z_full * s_full).to(torch.bfloat16)
+        # Pack 2 nibbles/byte: even col → low, odd col → high. Same
+        # convention as the runtime loader and `int4_dequant_8`.
+        packed = (q[:, 0::2] | (q[:, 1::2] << 4)).contiguous()
+
+        packed_buf[i] = packed.cpu()
+        scale_buf[i] = s.cpu()
+        zero_buf[i] = z.cpu()
+        recon_buf[i] = recon
+
+    packed_buf = packed_buf.reshape(leading + (out_f, in_f // 2))
+    scale_buf = scale_buf.reshape(leading + (sr, sc))
+    zero_buf = zero_buf.reshape(leading + (sr, sc))
+    recon_buf = recon_buf.reshape(leading + (out_f, in_f))
+    return packed_buf, scale_buf, zero_buf, recon_buf
+
+
+@torch.no_grad()
+def dequant_int4_packed(
+    packed: torch.Tensor,
+    scale: torch.Tensor,
+    zero: torch.Tensor,
+    group_size: int,
+) -> torch.Tensor:
+    """Reference dequant — inverse of `minmax_int4_packed_and_recon`. Used
+    for the in-process self-check below. Returns BF16 values as F32."""
+    out_f = packed.shape[-2]
+    in_half = packed.shape[-1]
+    in_f = in_half * 2
+    gs = group_size
+    leading = tuple(packed.shape[:-2])
+    pf = packed.reshape(-1, out_f, in_half)
+    sf = scale.reshape(-1, out_f // gs, in_f // gs)
+    zf = zero.reshape(-1, out_f // gs, in_f // gs)
+    n = pf.shape[0]
+    out = torch.empty((n, out_f, in_f), dtype=torch.float32)
+    for i in range(n):
+        q = torch.empty((out_f, in_f), dtype=torch.uint8)
+        q[:, 0::2] = pf[i] & 0x0F
+        q[:, 1::2] = (pf[i] >> 4) & 0x0F
+        s_full = sf[i].repeat_interleave(gs, 0).repeat_interleave(gs, 1)
+        z_full = zf[i].repeat_interleave(gs, 0).repeat_interleave(gs, 1)
+        recon = (q.to(torch.float32) * s_full - z_full * s_full).to(torch.bfloat16)
+        out[i] = recon.to(torch.float32)
+    return out.reshape(leading + (out_f, in_f))
+
+
+def quantize_int4_ffn_weights(
+    weights: dict[str, torch.Tensor], group_size: int
+) -> dict[str, dict[str, torch.Tensor]]:
+    """Quantize the INT4-targeted FFN weights in-place: replace each entry
+    in `weights` with its BF16 reconstruction (cast to that weight's
+    original dtype + device). Return a parallel dict of
+    `{name: {"packed", "scale", "zero"}}` sidecars on CPU."""
+    int4_sidecars: dict[str, dict[str, torch.Tensor]] = {}
+    for name in INT4_FFN_TARGETS:
+        if name not in weights:
+            raise SystemExit(f"INT4 mode missing required weight: {name}")
+        W = weights[name]
+        packed, scale, zero, recon = minmax_int4_packed_and_recon(W, group_size)
+
+        # In-process self-check: verify (packed, scale, zero) round-trips
+        # to exactly `recon`. Catches packing bugs before the kernel ever
+        # sees the JSON.
+        recon_check = dequant_int4_packed(packed, scale, zero, group_size)
+        diff = (recon.to(torch.float32).cpu() - recon_check).abs().max().item()
+        if diff != 0.0:
+            raise RuntimeError(
+                f"INT4 self-check failed for {name}: "
+                f"max |recon - dequant(packed)| = {diff:.3e}"
+            )
+
+        int4_sidecars[name] = {"packed": packed, "scale": scale, "zero": zero}
+        weights[name] = recon.to(dtype=W.dtype, device=W.device)
+    return int4_sidecars
 
 
 def find_shard_for(model_dir: Path, name: str) -> Path:
@@ -298,6 +475,17 @@ def parse_args() -> argparse.Namespace:
                         "35B-A3B but kept separate in case future configs differ)")
     p.add_argument("--top-k", type=int, default=8)
     p.add_argument("--rms-norm-eps", type=float, default=1e-6)
+    p.add_argument("--int4", action="store_true",
+                   help="Quantize the fused-expert and shared-expert MLP "
+                        "weights to INT4 (min/max group-quant). The `weights` "
+                        "block carries the BF16 reconstruction; an additional "
+                        "`int4_weights` block carries (packed, scale, zero) "
+                        "sidecars for the kernel's INT4 path. Schema becomes "
+                        "`qwen36-moe-oracle-ffn-int4-v1`.")
+    p.add_argument("--int4-group-size", type=int, default=128,
+                   help="Group size for INT4 min/max quant. Must divide "
+                        "out_features and in_features of every quantized "
+                        "tensor. The runtime + bake both pin to 128.")
     return p.parse_args()
 
 
@@ -332,6 +520,13 @@ def main() -> None:
 
     weights = {k: v.to(args.device) for k, v in weights.items()}
 
+    int4_sidecars: dict[str, dict[str, torch.Tensor]] | None = None
+    if args.int4:
+        # Quantize before computing intermediates so the reference uses the
+        # same BF16-reconstructed weights the kernel will see — intermediates
+        # are then valid for both the BF16 and INT4 kernel paths.
+        int4_sidecars = quantize_int4_ffn_weights(weights, args.int4_group_size)
+
     intermediates = reference_moe_ffn_block(
         num_experts=args.num_experts,
         moe_intermediate=args.moe_intermediate,
@@ -353,22 +548,36 @@ def main() -> None:
         else:
             enc_intermediates[k] = encode(v)
 
+    config = {
+        "hidden": args.hidden,
+        "num_experts": args.num_experts,
+        "moe_intermediate": args.moe_intermediate,
+        "shared_intermediate": args.shared_intermediate,
+        "top_k": args.top_k,
+        "rms_norm_eps": args.rms_norm_eps,
+    }
+    if args.int4:
+        config["int4_group_size"] = args.int4_group_size
+
     out = {
-        "schema": "qwen36-moe-oracle-ffn-v1",
+        "schema": ("qwen36-moe-oracle-ffn-int4-v1"
+                   if args.int4 else "qwen36-moe-oracle-ffn-v1"),
         "mode": args.mode,
         "layer_idx": args.layer_idx,
         "dtype": args.dtype,
-        "config": {
-            "hidden": args.hidden,
-            "num_experts": args.num_experts,
-            "moe_intermediate": args.moe_intermediate,
-            "shared_intermediate": args.shared_intermediate,
-            "top_k": args.top_k,
-            "rms_norm_eps": args.rms_norm_eps,
-        },
+        "config": config,
         "weights": enc_weights,
         "intermediates": enc_intermediates,
     }
+    if int4_sidecars is not None:
+        out["int4_weights"] = {
+            name: {
+                "packed": b64_u8(t["packed"]),
+                "scale": b64_bf16(t["scale"]),
+                "zero": b64_bf16(t["zero"]),
+            }
+            for name, t in int4_sidecars.items()
+        }
     args.out.parent.mkdir(parents=True, exist_ok=True)
     args.out.write_text(json.dumps(out))
 
@@ -377,8 +586,9 @@ def main() -> None:
     delta = (intermediates["output_hidden"] - weights["input_hidden"]
              ).to(torch.float32).norm().item()
     selected = intermediates["topk_idx"].tolist()
+    int4_tag = "int4" if args.int4 else "bf16-w"
     sys.stderr.write(
-        f"[oracle-ffn] layer={args.layer_idx} mode={args.mode} "
+        f"[oracle-ffn] layer={args.layer_idx} mode={args.mode} weights={int4_tag} "
         f"|input|={in_norm:.4f} |output|={out_norm:.4f} |delta|={delta:.4f} "
         f"top_k={selected}\n"
     )

--- a/oracle/qwen36_moe_ffn_oracle.py
+++ b/oracle/qwen36_moe_ffn_oracle.py
@@ -447,9 +447,13 @@ def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(
         description="Qwen3.6-MoE single-block FFN reference (PR 4b4 oracle)"
     )
-    p.add_argument("--mode", choices=["synthetic", "checkpoint"], default="synthetic")
+    p.add_argument("--mode", choices=["synthetic", "checkpoint", "bake"], default="synthetic")
     p.add_argument("--model-dir", type=Path,
                    help="Path to the HuggingFace safetensors dir (checkpoint mode)")
+    p.add_argument("--bake-dir", type=Path,
+                   help="Path to a SuperSonic INT4 GPTQ bake directory "
+                        "(`bake` mode). Loads layer's INT4 weights directly "
+                        "from the bake; emits the bake's actual sidecars.")
     p.add_argument("--layer-idx", type=int, default=0,
                    help="Layer index. The MoE FFN is identical across full and "
                         "linear attention layers, so layer 0 (linear) is fine.")
@@ -493,6 +497,8 @@ def main() -> None:
     args = parse_args()
     dtype = torch.bfloat16 if args.dtype == "bf16" else torch.float32
 
+    int4_sidecars: dict[str, dict[str, torch.Tensor]] | None = None
+
     if args.mode == "synthetic":
         weights = synthesize_block(
             hidden=args.hidden,
@@ -502,6 +508,57 @@ def main() -> None:
             seed=args.seed,
             dtype=dtype,
         )
+    elif args.mode == "bake":
+        if args.bake_dir is None:
+            raise SystemExit("--bake-dir is required in bake mode")
+        from _bake_loader import load_bf16, load_int4, load_int4_3d
+
+        bake_dir = str(args.bake_dir)
+        lp = f"{args.weight_prefix}.layers.{args.layer_idx}"
+        mp = f"{lp}.mlp"
+
+        weights = {}
+        int4_sidecars = {}
+
+        # Fused-expert tensors: 3D INT4 (per-expert quantized).
+        for key, name in [
+            ("gate_up_proj_w", f"{mp}.experts.gate_up_proj"),
+            ("down_proj_w", f"{mp}.experts.down_proj"),
+        ]:
+            recon, packed, scale, zero = load_int4_3d(bake_dir, name)
+            weights[key] = recon
+            int4_sidecars[key] = {
+                "packed": packed,
+                "scale": scale.to(torch.float32),
+                "zero": zero.to(torch.float32),
+            }
+        # Shared-expert: dense 2D INT4.
+        for key, name in [
+            ("shared_gate_proj_w", f"{mp}.shared_expert.gate_proj.weight"),
+            ("shared_up_proj_w", f"{mp}.shared_expert.up_proj.weight"),
+            ("shared_down_proj_w", f"{mp}.shared_expert.down_proj.weight"),
+        ]:
+            recon, packed, scale, zero = load_int4(bake_dir, name)
+            weights[key] = recon
+            int4_sidecars[key] = {
+                "packed": packed,
+                "scale": scale.to(torch.float32),
+                "zero": zero.to(torch.float32),
+            }
+
+        # Non-quantized (BF16): router gate, scalar shared-gate, post-attn norm.
+        weights["gate_w"] = load_bf16(bake_dir, f"{mp}.gate.weight")
+        weights["shared_expert_gate_w"] = load_bf16(bake_dir, f"{mp}.shared_expert_gate.weight")
+        weights["post_attn_norm_w"] = load_bf16(bake_dir, f"{lp}.post_attention_layernorm.weight")
+
+        torch.manual_seed(args.seed)
+        weights["input_hidden"] = (
+            torch.randn(args.hidden, dtype=torch.float32) / args.hidden ** 0.5
+        ).to(dtype)
+        for k in ("gate_w", "shared_expert_gate_w", "post_attn_norm_w"):
+            weights[k] = weights[k].to(dtype)
+
+        args.int4 = True  # Force INT4 schema/JSON shape.
     else:
         if args.model_dir is None:
             raise SystemExit("--model-dir is required in checkpoint mode")
@@ -520,11 +577,11 @@ def main() -> None:
 
     weights = {k: v.to(args.device) for k, v in weights.items()}
 
-    int4_sidecars: dict[str, dict[str, torch.Tensor]] | None = None
-    if args.int4:
+    if args.int4 and int4_sidecars is None:
         # Quantize before computing intermediates so the reference uses the
         # same BF16-reconstructed weights the kernel will see — intermediates
         # are then valid for both the BF16 and INT4 kernel paths.
+        # (Skipped when bake mode already populated int4_sidecars from disk.)
         int4_sidecars = quantize_int4_ffn_weights(weights, args.int4_group_size)
 
     intermediates = reference_moe_ffn_block(

--- a/oracle/qwen36_moe_linear_oracle.py
+++ b/oracle/qwen36_moe_linear_oracle.py
@@ -502,9 +502,13 @@ def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(
         description="Qwen3.6-MoE single-layer linear-attention reference forward"
     )
-    p.add_argument("--mode", choices=["synthetic", "checkpoint"], default="synthetic")
+    p.add_argument("--mode", choices=["synthetic", "checkpoint", "bake"], default="synthetic")
     p.add_argument("--model-dir", type=Path,
                    help="Path to the HuggingFace safetensors dir (checkpoint mode)")
+    p.add_argument("--bake-dir", type=Path,
+                   help="Path to a SuperSonic INT4 GPTQ bake directory "
+                        "(`bake` mode). Loads layer's INT4 weights directly "
+                        "from the bake; emits the bake's actual sidecars.")
     p.add_argument("--layer-idx", type=int, default=0,
                    help="Linear-attention layer index (default 0)")
     p.add_argument("--weight-prefix", default="model.language_model")
@@ -539,6 +543,8 @@ def main() -> None:
     args = parse_args()
     dtype = torch.bfloat16 if args.dtype == "bf16" else torch.float32
 
+    int4_sidecars: dict[str, dict[str, torch.Tensor]] | None = None
+
     if args.mode == "synthetic":
         weights = synthesize_layer(
             hidden=args.hidden,
@@ -551,6 +557,80 @@ def main() -> None:
             dtype=dtype,
             warm_state=(args.state == "warm"),
         )
+    elif args.mode == "bake":
+        if args.bake_dir is None:
+            raise SystemExit("--bake-dir is required in bake mode")
+        from _bake_loader import has_tensor, load_bf16, load_int4, load_native
+
+        bake_dir = str(args.bake_dir)
+        lp = f"{args.weight_prefix}.layers.{args.layer_idx}"
+        la = f"{lp}.linear_attn"
+
+        weights = {}
+        int4_sidecars = {}
+        for key, name in [
+            ("in_proj_qkv_w", f"{la}.in_proj_qkv.weight"),
+            ("in_proj_z_w", f"{la}.in_proj_z.weight"),
+            ("out_proj_w", f"{la}.out_proj.weight"),
+        ]:
+            recon, packed, scale, zero = load_int4(bake_dir, name)
+            weights[key] = recon
+            int4_sidecars[key] = {
+                "packed": packed,
+                "scale": scale.to(torch.float32),
+                "zero": zero.to(torch.float32),
+            }
+
+        weights["input_norm_w"] = load_bf16(bake_dir, f"{lp}.input_layernorm.weight")
+        weights["norm_w"] = load_bf16(bake_dir, f"{la}.norm.weight")
+        weights["in_proj_a_w"] = load_bf16(bake_dir, f"{la}.in_proj_a.weight")
+        weights["in_proj_b_w"] = load_bf16(bake_dir, f"{la}.in_proj_b.weight")
+        weights["conv1d_w"] = load_bf16(bake_dir, f"{la}.conv1d.weight")
+        weights["conv1d_bias"] = (load_bf16(bake_dir, f"{la}.conv1d.bias")
+                                   if has_tensor(bake_dir, f"{la}.conv1d.bias") else None)
+        # Bake-side transforms (mirror Rust crates/model-store/src/transforms.rs):
+        #   dt_bias: stored reshaped (1, 1, V) — squeeze back to [V].
+        #   A_log: stored as PRE-EXPONENTIATED, reshaped (1, 1, V). The
+        #          reference computes a_log.exp() itself, so undo both: log
+        #          + squeeze to recover the [V] raw-log-domain value.
+        weights["dt_bias"] = load_native(bake_dir, f"{la}.dt_bias").squeeze()
+        a_log_exp_raw = load_native(bake_dir, f"{la}.A_log").squeeze().to(torch.float32)
+        weights["a_log"] = torch.log(a_log_exp_raw).to(torch.bfloat16)
+
+        # Reproducible synthetic input + state — same RNG style as
+        # checkpoint mode.
+        torch.manual_seed(args.seed)
+        weights["input_hidden"] = (
+            torch.randn(args.hidden, dtype=torch.float32) / args.hidden ** 0.5
+        ).to(dtype)
+        for k in ("input_norm_w", "norm_w", "in_proj_a_w", "in_proj_b_w",
+                  "conv1d_w", "dt_bias", "a_log"):
+            if weights.get(k) is not None and weights[k].dtype != dtype:
+                weights[k] = weights[k].to(dtype)
+        if weights["conv1d_bias"] is not None:
+            weights["conv1d_bias"] = weights["conv1d_bias"].to(dtype)
+        # Fresh state: the bake doesn't store decode-time state.
+        key_dim = args.num_k_heads * args.head_k_dim
+        value_dim = args.num_v_heads * args.head_v_dim
+        qkv_dim = 2 * key_dim + value_dim
+        if args.state == "warm":
+            weights["conv_state_before"] = (
+                torch.randn(qkv_dim, args.conv_kernel_dim - 1, dtype=torch.float32) * 0.5
+            ).to(dtype)
+            weights["recurrent_state_before"] = (
+                torch.randn(args.num_v_heads, args.head_k_dim, args.head_v_dim,
+                            dtype=torch.float32) * 0.1
+            )
+        else:
+            weights["conv_state_before"] = torch.zeros(
+                qkv_dim, args.conv_kernel_dim - 1, dtype=dtype
+            )
+            weights["recurrent_state_before"] = torch.zeros(
+                args.num_v_heads, args.head_k_dim, args.head_v_dim, dtype=torch.float32
+            )
+
+        # Force INT4 schema/JSON shape so kernel-ffi tests can consume it.
+        args.int4 = True
     else:
         if args.model_dir is None:
             raise SystemExit("--model-dir is required in checkpoint mode")
@@ -593,10 +673,10 @@ def main() -> None:
     weights = {k: (v.to(args.device) if isinstance(v, torch.Tensor) else v)
                for k, v in weights.items()}
 
-    int4_sidecars: dict[str, dict[str, torch.Tensor]] | None = None
-    if args.int4:
+    if args.int4 and int4_sidecars is None:
         # Quantize before computing intermediates so the reference uses the
         # same BF16-reconstructed weights the kernel will see.
+        # (Skipped when bake mode already populated int4_sidecars from disk.)
         int4_sidecars = quantize_int4_linear_weights(weights, args.int4_group_size)
 
     intermediates = reference_linear_attn_layer(

--- a/oracle/qwen36_moe_linear_oracle.py
+++ b/oracle/qwen36_moe_linear_oracle.py
@@ -2,10 +2,20 @@
 """
 PyTorch reference for one Qwen3.6-MoE linear-attention layer's decode step.
 
-Companion to PR 4b3 step 1. The 3-of-4 layers in the hybrid pattern that
-aren't full-attention are linear-attention (delta-rule recurrent state
-+ depthwise conv pre-mix), and they need their own staged kernel.
-This oracle is the parity ground-truth for that kernel.
+Companion to PR 4b3 step 1 (BF16) and PR 4b6 step 3 (INT4). The 3-of-4
+layers in the hybrid pattern that aren't full-attention are
+linear-attention (delta-rule recurrent state + depthwise conv pre-mix),
+and they need their own staged kernel. This oracle is the parity
+ground-truth for that kernel.
+
+`--int4` switches into INT4 mode: the three projection weights that the
+INT4 bake quantizes (`in_proj_qkv`, `in_proj_z`, `out_proj`) are
+min/max group-quantized at gs=128 with BF16 scale + zero. `in_proj_a`
+and `in_proj_b` (small per-V-head scalars) plus the conv1d, dt_bias,
+A_log, norms and state buffers all stay BF16 — the bake excludes them
+from the INT4 budget; see `crates/qwen36_moe/src/weights.rs::lin_int4`.
+
+Schema becomes `qwen36-moe-oracle-linear-int4-v1` when --int4 is set.
 
 As with `qwen36_moe_oracle.py`, the math is hand-rolled to avoid pulling
 in the multimodal `Qwen3_5MoeForConditionalGeneration` class — it would
@@ -87,6 +97,120 @@ def b64_f32(t: torch.Tensor) -> str:
     return base64.b64encode(
         t.to(torch.float32).contiguous().cpu().numpy().tobytes()
     ).decode()
+
+
+def b64_u8(t: torch.Tensor) -> str:
+    return base64.b64encode(
+        t.to(torch.uint8).contiguous().cpu().numpy().tobytes()
+    ).decode()
+
+
+# Tensors the INT4 bake quantizes for one linear-attention layer. The
+# small per-V-head scalars `in_proj_a` / `in_proj_b` plus all the
+# small/conv/state tensors stay BF16 — the bake excludes them. See
+# `crates/qwen36_moe/src/weights.rs::lin_int4` for the matching budget.
+INT4_LINEAR_TARGETS: tuple[str, ...] = (
+    "in_proj_qkv_w",
+    "in_proj_z_w",
+    "out_proj_w",
+)
+
+
+@torch.no_grad()
+def minmax_int4_packed_and_recon(
+    W: torch.Tensor, group_size: int
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Min/max INT4 group-quant for a 2D `[out, in]` weight. Mirrors the
+    helpers in `qwen36_moe_oracle.py` and `qwen36_moe_ffn_oracle.py`,
+    which in turn mirror `oracle/bake_int4.py`. Single-rounding
+    `bf16(q*s - z*s)` reconstruction matches the kernel's
+    `int4_dequant_scalar`.
+
+    Returns (packed/scale/zero on CPU; recon stays on `W.device`):
+      packed   uint8  shape `[out, in/2]`     two nibbles per byte,
+                                               even col → low nibble.
+      scale    f32    shape `[out/gs, in/gs]` BF16 values stored as f32.
+      zero     f32    shape `[out/gs, in/gs]` BF16 values stored as f32.
+      recon    bf16   shape `[out, in]`        kernel's reconstruction.
+    """
+    if W.dim() != 2:
+        raise ValueError(f"expected 2D, got shape {tuple(W.shape)}")
+    out_f, in_f = W.shape
+    gs = group_size
+    if in_f % gs != 0 or in_f % 2 != 0:
+        raise ValueError(
+            f"in_features {in_f} must be divisible by group_size={gs} and even"
+        )
+    if out_f % gs != 0:
+        raise ValueError(
+            f"out_features {out_f} must be divisible by group_size={gs}"
+        )
+    sr = out_f // gs
+    sc = in_f // gs
+
+    slab = W.to(torch.float32)
+    tiles = slab.reshape(sr, gs, sc, gs)
+    tmax = tiles.amax(dim=(1, 3))
+    tmin = tiles.amin(dim=(1, 3))
+    rng = tmax - tmin
+    s = torch.where(rng > 0, rng / 15.0, torch.ones_like(rng))
+    z = torch.where(rng > 0, -tmin / s, torch.zeros_like(rng))
+    s = s.to(torch.bfloat16).to(torch.float32)
+    z = z.to(torch.bfloat16).to(torch.float32)
+    s_full = s.repeat_interleave(gs, 0).repeat_interleave(gs, 1)
+    z_full = z.repeat_interleave(gs, 0).repeat_interleave(gs, 1)
+    q = torch.clamp(
+        torch.round(slab / s_full + z_full), 0.0, 15.0
+    ).to(torch.uint8)
+    recon = (q.to(torch.float32) * s_full - z_full * s_full).to(torch.bfloat16)
+    packed = (q[:, 0::2] | (q[:, 1::2] << 4)).contiguous()
+    return packed.cpu(), s.cpu(), z.cpu(), recon
+
+
+@torch.no_grad()
+def dequant_int4_packed(
+    packed: torch.Tensor, scale: torch.Tensor, zero: torch.Tensor,
+    group_size: int,
+) -> torch.Tensor:
+    """Reference dequant — inverse of `minmax_int4_packed_and_recon`."""
+    out_f = packed.shape[-2]
+    in_half = packed.shape[-1]
+    in_f = in_half * 2
+    gs = group_size
+    q = torch.empty((out_f, in_f), dtype=torch.uint8)
+    q[:, 0::2] = packed & 0x0F
+    q[:, 1::2] = (packed >> 4) & 0x0F
+    s_full = scale.repeat_interleave(gs, 0).repeat_interleave(gs, 1)
+    z_full = zero.repeat_interleave(gs, 0).repeat_interleave(gs, 1)
+    recon = (q.to(torch.float32) * s_full - z_full * s_full).to(torch.bfloat16)
+    return recon.to(torch.float32)
+
+
+def quantize_int4_linear_weights(
+    weights: dict[str, torch.Tensor], group_size: int
+) -> dict[str, dict[str, torch.Tensor]]:
+    """Quantize the INT4-targeted linear-attn weights in-place: replace
+    each entry in `weights` with its BF16 reconstruction (cast to the
+    weight's original dtype + device). Return a parallel dict of
+    `{name: {"packed", "scale", "zero"}}` sidecars on CPU."""
+    int4_sidecars: dict[str, dict[str, torch.Tensor]] = {}
+    for name in INT4_LINEAR_TARGETS:
+        if name not in weights:
+            raise SystemExit(f"INT4 mode missing required weight: {name}")
+        W = weights[name]
+        packed, scale, zero, recon = minmax_int4_packed_and_recon(W, group_size)
+
+        recon_check = dequant_int4_packed(packed, scale, zero, group_size)
+        diff = (recon.to(torch.float32).cpu() - recon_check).abs().max().item()
+        if diff != 0.0:
+            raise RuntimeError(
+                f"INT4 self-check failed for {name}: "
+                f"max |recon - dequant(packed)| = {diff:.3e}"
+            )
+
+        int4_sidecars[name] = {"packed": packed, "scale": scale, "zero": zero}
+        weights[name] = recon.to(dtype=W.dtype, device=W.device)
+    return int4_sidecars
 
 
 def find_shard_for(model_dir: Path, name: str) -> Path:
@@ -399,6 +523,15 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--head-v-dim", type=int, default=128)
     p.add_argument("--conv-kernel-dim", type=int, default=4)
     p.add_argument("--rms-norm-eps", type=float, default=1e-6)
+    p.add_argument("--int4", action="store_true",
+                   help="Quantize the three projection weights "
+                        "(in_proj_qkv, in_proj_z, out_proj) to INT4 "
+                        "(min/max group-quant). Schema becomes "
+                        "`qwen36-moe-oracle-linear-int4-v1`.")
+    p.add_argument("--int4-group-size", type=int, default=128,
+                   help="Group size for INT4 min/max quant. Must divide "
+                        "out_features and in_features of every quantized "
+                        "tensor. The runtime + bake both pin to 128.")
     return p.parse_args()
 
 
@@ -460,6 +593,12 @@ def main() -> None:
     weights = {k: (v.to(args.device) if isinstance(v, torch.Tensor) else v)
                for k, v in weights.items()}
 
+    int4_sidecars: dict[str, dict[str, torch.Tensor]] | None = None
+    if args.int4:
+        # Quantize before computing intermediates so the reference uses the
+        # same BF16-reconstructed weights the kernel will see.
+        int4_sidecars = quantize_int4_linear_weights(weights, args.int4_group_size)
+
     intermediates = reference_linear_attn_layer(
         num_k_heads=args.num_k_heads,
         num_v_heads=args.num_v_heads,
@@ -490,24 +629,38 @@ def main() -> None:
         else:
             intermediate_payload[k] = encode(v)
 
+    config = {
+        "hidden": args.hidden,
+        "num_k_heads": args.num_k_heads,
+        "num_v_heads": args.num_v_heads,
+        "head_k_dim": args.head_k_dim,
+        "head_v_dim": args.head_v_dim,
+        "conv_kernel_dim": args.conv_kernel_dim,
+        "rms_norm_eps": args.rms_norm_eps,
+    }
+    if args.int4:
+        config["int4_group_size"] = args.int4_group_size
+
     out = {
-        "schema": "qwen36-moe-linear-oracle-layer-v1",
+        "schema": ("qwen36-moe-oracle-linear-int4-v1"
+                   if args.int4 else "qwen36-moe-linear-oracle-layer-v1"),
         "mode": args.mode,
         "state": args.state,
         "layer_idx": args.layer_idx,
         "dtype": args.dtype,
-        "config": {
-            "hidden": args.hidden,
-            "num_k_heads": args.num_k_heads,
-            "num_v_heads": args.num_v_heads,
-            "head_k_dim": args.head_k_dim,
-            "head_v_dim": args.head_v_dim,
-            "conv_kernel_dim": args.conv_kernel_dim,
-            "rms_norm_eps": args.rms_norm_eps,
-        },
+        "config": config,
         "weights": weight_payload,
         "intermediates": intermediate_payload,
     }
+    if int4_sidecars is not None:
+        out["int4_weights"] = {
+            name: {
+                "packed": b64_u8(t["packed"]),
+                "scale": b64_bf16(t["scale"]),
+                "zero": b64_bf16(t["zero"]),
+            }
+            for name, t in int4_sidecars.items()
+        }
     args.out.parent.mkdir(parents=True, exist_ok=True)
     args.out.write_text(json.dumps(out))
 

--- a/oracle/qwen36_moe_multilayer_oracle.py
+++ b/oracle/qwen36_moe_multilayer_oracle.py
@@ -1,0 +1,659 @@
+#!/usr/bin/env python3
+"""
+Multi-layer reference forward for Qwen3.6-MoE — PR 4c step 1.
+
+Chains the parity-tested per-block references — `reference_full_attention_layer`
+(`qwen36_moe_oracle.py`), `reference_linear_attn_layer`
+(`qwen36_moe_linear_oracle.py`), `reference_moe_ffn_block`
+(`qwen36_moe_ffn_oracle.py`) — into one decode step across N transformer
+layers. Walks the hybrid pattern (every 4th layer is full attention, indices
+3/7/11/...; the other three are linear attention), applies the final RMSnorm,
+and projects through `lm_head` to logits. This oracle is the parity ground
+truth for PR 4c step 2's host-orchestrated multi-launch driver.
+
+This script is pure orchestration: every per-layer math primitive — RMSnorm,
+RoPE, GQA, conv1d, delta-rule recurrent update, top-k MoE dispatch, shared
+expert, INT4 min/max group-quant — is imported from the per-block oracles
+unchanged. The INT4 sidecar self-checks fire transitively per layer when
+`--int4` is set; this script adds no new math.
+
+Modes:
+  --synthetic --num-layers 4
+      4 layers (3 linear + 1 full at idx 3) at small synthetic geometry
+      (default `hidden=256`). Primary parity gate: fits in <1 GiB host RAM
+      and runs in seconds. INT4 mode pinned to `group_size=128`.
+  --checkpoint --num-layers 8 --model-dir /path/to/Qwen3.6-MoE
+      Loads per-layer tensors on demand from a real checkpoint to keep host
+      RAM honest (35B BF16 is ~65 GiB — won't fit 64 GiB host). Production-
+      geometry sanity check; not a CI gate. The final RMSnorm + `lm_head`
+      stay synthesized in checkpoint mode too — loading the lm_head tensor
+      from a multimodal Qwen3.5MoE checkpoint requires care around tied
+      embeddings and tokenizer vocab, which is out of scope for step 1.
+
+Schema:
+  qwen36-moe-oracle-multilayer-v1            (BF16 weights)
+  qwen36-moe-oracle-multilayer-int4-v1       (--int4)
+
+Output JSON shape:
+  {
+    "schema": "...",
+    "mode":   "synthetic" | "checkpoint",
+    "position": int,
+    "num_layers": int,
+    "config": { hidden, vocab, attn{...}, lin{...}, ffn{...}, rms_norm_eps,
+                int4_group_size? },
+    "layers": [{ "layer_idx": int, "kind": "full" | "linear" }, ...],
+    "input_hidden":  bf16_b64,
+    "final_norm_w":  bf16_b64,
+    "lm_head_w":     bf16_b64,
+    "weights_per_layer":  [{ "attn": {...}, "ffn": {...} }, ...],
+    "intermediates_per_layer": [{ layer_idx, kind,
+                                  output_after_attn: bf16_b64,
+                                  output_after_ffn:  bf16_b64 }, ...],
+    "final_hidden": bf16_b64,
+    "logits":       bf16_b64,
+    "int4_weights_per_layer": [{ "attn": {name: {packed,scale,zero}},
+                                 "ffn": {...} }, ...]    # only with --int4
+  }
+
+Step 2 will read this JSON, upload the per-layer weights + initial input
+to the GPU, run the kernel chain, and compare against `intermediates_per_layer`
++ `final_hidden` + `logits`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64  # noqa: F401  -- re-exported via per-block helpers; left explicit for grep.
+import json
+import sys
+from pathlib import Path
+
+# Per-block oracles live alongside this file; make them importable when this
+# script is run directly (`python oracle/qwen36_moe_multilayer_oracle.py`).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import torch
+
+from qwen36_moe_oracle import (
+    INT4_ATTN_TARGETS,                                                  # noqa: F401
+    b64_bf16,
+    b64_f32,
+    b64_u8,
+    load_layer_from_checkpoint as load_full_attn_from_checkpoint,
+    quantize_int4_attn_weights,
+    reference_full_attention_layer,
+    rms_norm,
+    synthesize_layer as synthesize_full_attn_layer,
+)
+from qwen36_moe_linear_oracle import (
+    INT4_LINEAR_TARGETS,                                                # noqa: F401
+    load_layer_from_checkpoint as load_linear_attn_from_checkpoint,
+    quantize_int4_linear_weights,
+    reference_linear_attn_layer,
+    synthesize_layer as synthesize_linear_attn_layer,
+)
+from qwen36_moe_ffn_oracle import (
+    INT4_FFN_TARGETS,                                                   # noqa: F401
+    load_block_from_checkpoint as load_ffn_block_from_checkpoint,
+    quantize_int4_ffn_weights,
+    reference_moe_ffn_block,
+    synthesize_block as synthesize_ffn_block,
+)
+
+
+# Hybrid pattern: every 4th layer is full attention. Indices 3, 7, 11, ...
+# are full; everything else is linear. Matches Qwen3.6-MoE 35B-A3B layout.
+HYBRID_FULL_ATTN_STRIDE = 4
+
+
+def is_full_attn_layer(layer_idx: int) -> bool:
+    return (layer_idx + 1) % HYBRID_FULL_ATTN_STRIDE == 0
+
+
+# ---------------------------------------------------------------------------
+# Per-layer weight synthesis. Each layer needs distinct synthetic weights or
+# the chained forward becomes degenerate (every layer applies the same
+# transform). `layer_seed` is derived from the base seed below.
+# ---------------------------------------------------------------------------
+def derive_layer_seed(base_seed: int, layer_idx: int, kind: str) -> int:
+    """Distinct seed per (layer, kind) pair so attn and ffn weights aren't
+    aliased and layer N differs from layer N+1. Two large coprimes mixed
+    with the kind so attn/ffn within one layer also differ — without this
+    they share the leading `randn(hidden)` draw and `input_hidden` would
+    alias `post_attn_norm_w`."""
+    kind_offset = 0 if kind == "attn" else 0x9E37_79B1
+    return (base_seed + layer_idx * 1009 + kind_offset) & 0x7FFF_FFFF
+
+
+def synthesize_layer_weights(
+    *,
+    layer_idx: int,
+    hidden: int,
+    attn_cfg: dict,
+    lin_cfg: dict,
+    ffn_cfg: dict,
+    base_seed: int,
+    dtype: torch.dtype,
+    warm_state: bool,
+) -> dict:
+    attn_seed = derive_layer_seed(base_seed, layer_idx, "attn")
+    ffn_seed = derive_layer_seed(base_seed, layer_idx, "ffn")
+
+    if is_full_attn_layer(layer_idx):
+        attn_w = synthesize_full_attn_layer(
+            hidden=hidden,
+            H=attn_cfg["num_attention_heads"],
+            Hkv=attn_cfg["num_kv_heads"],
+            d=attn_cfg["head_dim"],
+            seed=attn_seed,
+            dtype=dtype,
+        )
+    else:
+        attn_w = synthesize_linear_attn_layer(
+            hidden=hidden,
+            K=lin_cfg["num_k_heads"],
+            V=lin_cfg["num_v_heads"],
+            k_dim=lin_cfg["head_k_dim"],
+            v_dim=lin_cfg["head_v_dim"],
+            kernel=lin_cfg["conv_kernel_dim"],
+            seed=attn_seed,
+            dtype=dtype,
+            warm_state=warm_state,
+        )
+    # Chained forward: each layer's input comes from the previous layer's
+    # output, not from a freshly synthesised vector. Drop the per-layer
+    # `input_hidden` the per-block synth routines include.
+    attn_w.pop("input_hidden", None)
+
+    ffn_w = synthesize_ffn_block(
+        hidden=hidden,
+        num_experts=ffn_cfg["num_experts"],
+        moe_intermediate=ffn_cfg["moe_intermediate"],
+        shared_intermediate=ffn_cfg["shared_intermediate"],
+        seed=ffn_seed,
+        dtype=dtype,
+    )
+    ffn_w.pop("input_hidden", None)
+
+    return {"attn": attn_w, "ffn": ffn_w}
+
+
+def load_layer_weights_from_checkpoint(
+    *,
+    layer_idx: int,
+    model_dir: Path,
+    weight_prefix: str,
+    device: str,
+    dtype: torch.dtype,
+    hidden: int,
+    lin_cfg: dict,
+    state_kind: str,
+    base_seed: int,
+) -> dict:
+    """Per-block checkpoint load wrappers fetch the trained projection
+    weights for one layer. Linear-attn layers also need conv + recurrent
+    state, which the per-block loader doesn't supply (the kernel-side caller
+    owns state lifetime), so we synthesise them here using the same warm/fresh
+    convention as the per-block linear oracle."""
+    if is_full_attn_layer(layer_idx):
+        attn_w = load_full_attn_from_checkpoint(
+            model_dir=model_dir,
+            layer_idx=layer_idx,
+            weight_prefix=weight_prefix,
+            device=device,
+        )
+        # Norm weights stored BF16 in the checkpoint; cast to working dtype
+        # so the matmuls don't silently mix dtypes.
+        for k in ("input_norm_w", "q_norm_w", "k_norm_w"):
+            attn_w[k] = attn_w[k].to(dtype)
+    else:
+        attn_w = load_linear_attn_from_checkpoint(
+            model_dir=model_dir,
+            layer_idx=layer_idx,
+            weight_prefix=weight_prefix,
+            device=device,
+        )
+        for k in ("input_norm_w", "norm_w"):
+            attn_w[k] = attn_w[k].to(dtype)
+
+        K = lin_cfg["num_k_heads"]
+        V = lin_cfg["num_v_heads"]
+        k_dim = lin_cfg["head_k_dim"]
+        v_dim = lin_cfg["head_v_dim"]
+        kernel = lin_cfg["conv_kernel_dim"]
+        qkv_dim = 2 * K * k_dim + V * v_dim
+
+        # Reproducible per-layer state — same RNG style as the per-block
+        # linear oracle's checkpoint mode, with a layer-specific seed so
+        # different layers see different state.
+        g = torch.Generator().manual_seed(
+            derive_layer_seed(base_seed, layer_idx, "state")
+        )
+        if state_kind == "warm":
+            attn_w["conv_state_before"] = (
+                torch.randn(qkv_dim, kernel - 1, generator=g, dtype=torch.float32) * 0.5
+            ).to(dtype)
+            attn_w["recurrent_state_before"] = (
+                torch.randn(V, k_dim, v_dim, generator=g, dtype=torch.float32) * 0.1
+            )
+        else:
+            attn_w["conv_state_before"] = torch.zeros(qkv_dim, kernel - 1, dtype=dtype)
+            attn_w["recurrent_state_before"] = torch.zeros(
+                V, k_dim, v_dim, dtype=torch.float32
+            )
+
+    ffn_w = load_ffn_block_from_checkpoint(
+        model_dir=model_dir,
+        layer_idx=layer_idx,
+        weight_prefix=weight_prefix,
+        device=device,
+    )
+    ffn_w["post_attn_norm_w"] = ffn_w["post_attn_norm_w"].to(dtype)
+
+    return {"attn": attn_w, "ffn": ffn_w}
+
+
+# ---------------------------------------------------------------------------
+# Decode loop. Walks the hybrid pattern, residuals chained, returns per-layer
+# intermediates + final_hidden + logits.
+# ---------------------------------------------------------------------------
+def run_multilayer_decode(
+    *,
+    layers: list[dict],
+    initial_hidden: torch.Tensor,
+    final_norm_w: torch.Tensor,
+    lm_head_w: torch.Tensor,
+    attn_cfg: dict,
+    lin_cfg: dict,
+    ffn_cfg: dict,
+    rms_norm_eps: float,
+    position: int,
+) -> tuple[list[dict], torch.Tensor, torch.Tensor]:
+    h = initial_hidden
+    intermediates: list[dict] = []
+
+    for layer_idx, layer in enumerate(layers):
+        if is_full_attn_layer(layer_idx):
+            attn_out = reference_full_attention_layer(
+                input_hidden=h,
+                position=position,
+                num_heads=attn_cfg["num_attention_heads"],
+                num_kv_heads=attn_cfg["num_kv_heads"],
+                head_dim=attn_cfg["head_dim"],
+                rotary_dim=attn_cfg["rotary_dim"],
+                rope_theta=attn_cfg["rope_theta"],
+                rms_norm_eps=rms_norm_eps,
+                **layer["attn"],
+            )
+            kind = "full"
+        else:
+            attn_out = reference_linear_attn_layer(
+                input_hidden=h,
+                num_k_heads=lin_cfg["num_k_heads"],
+                num_v_heads=lin_cfg["num_v_heads"],
+                head_k_dim=lin_cfg["head_k_dim"],
+                head_v_dim=lin_cfg["head_v_dim"],
+                conv_kernel_dim=lin_cfg["conv_kernel_dim"],
+                rms_norm_eps=rms_norm_eps,
+                **layer["attn"],
+            )
+            kind = "linear"
+
+        h_after_attn = attn_out["output_hidden"]
+        ffn_out = reference_moe_ffn_block(
+            input_hidden=h_after_attn,
+            num_experts=ffn_cfg["num_experts"],
+            moe_intermediate=ffn_cfg["moe_intermediate"],
+            shared_intermediate=ffn_cfg["shared_intermediate"],
+            top_k=ffn_cfg["top_k"],
+            rms_norm_eps=rms_norm_eps,
+            **layer["ffn"],
+        )
+        h_after_ffn = ffn_out["output_hidden"]
+
+        intermediates.append({
+            "layer_idx": layer_idx,
+            "kind": kind,
+            "output_after_attn": h_after_attn,
+            "output_after_ffn": h_after_ffn,
+        })
+        h = h_after_ffn
+
+    final_hidden = rms_norm(h, final_norm_w, rms_norm_eps)
+    # F32 GEMV → cast to working dtype for the parity gate. Production
+    # decode samples in F32 too; matching that here keeps the kernel-side
+    # comparison apples-to-apples once step 2 lands.
+    logits = (
+        final_hidden.to(torch.float32) @ lm_head_w.to(torch.float32).T
+    ).to(initial_hidden.dtype)
+
+    return intermediates, final_hidden, logits
+
+
+# ---------------------------------------------------------------------------
+# Encoding helpers for the JSON payload.
+# ---------------------------------------------------------------------------
+def encode_attn_weights(
+    layer_idx: int, attn_w: dict, encode
+) -> dict[str, str]:
+    """Encode the projection + norm + state tensors for one layer's attention
+    block. Linear-attn `recurrent_state_before` is F32 in production so it's
+    encoded as F32 even when the working dtype is BF16; everything else
+    follows the working dtype."""
+    out: dict[str, str] = {}
+    for name, tensor in attn_w.items():
+        if tensor is None:
+            continue
+        if not is_full_attn_layer(layer_idx) and name == "recurrent_state_before":
+            out[name] = b64_f32(tensor)
+        else:
+            out[name] = encode(tensor)
+    return out
+
+
+def encode_ffn_weights(ffn_w: dict, encode) -> dict[str, str]:
+    return {name: encode(tensor) for name, tensor in ffn_w.items() if tensor is not None}
+
+
+# ---------------------------------------------------------------------------
+# Argparse + main
+# ---------------------------------------------------------------------------
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Multi-layer Qwen3.6-MoE reference forward (PR 4c step 1)"
+    )
+    p.add_argument("--mode", choices=["synthetic", "checkpoint"], default="synthetic")
+    p.add_argument("--model-dir", type=Path,
+                   help="HuggingFace safetensors dir (checkpoint mode)")
+    p.add_argument("--weight-prefix", default="model.language_model")
+    p.add_argument("--num-layers", type=int, default=4,
+                   help="Number of transformer layers to chain. Default 4 = "
+                        "3 linear + 1 full (smallest hybrid window).")
+    p.add_argument("--position", type=int, default=0,
+                   help="Decode position (only affects full-attn layers' RoPE).")
+    p.add_argument("--state", choices=["fresh", "warm"], default="warm",
+                   help="Initial state for linear-attn layers. Warm exercises "
+                        "decay + delta update; fresh starts from zeros.")
+    p.add_argument("--seed", type=int, default=0xC0FFEE,
+                   help="Base seed for synthesis (per-layer + per-kind seeds "
+                        "derived from this).")
+    p.add_argument("--dtype", choices=["bf16", "fp32"], default="bf16")
+    p.add_argument("--device", default="cpu")
+    p.add_argument("--out", type=Path, required=True,
+                   help="JSON output path")
+
+    # Geometry — synthetic defaults are tuned to satisfy INT4 group_size=128
+    # divisibility on every quantized projection at the smallest size.
+    p.add_argument("--hidden", type=int, default=256)
+    p.add_argument("--vocab", type=int, default=1024,
+                   help="lm_head output dim. Stays BF16 (no INT4 path).")
+
+    # Full-attn geometry (small synthetic; production is H=16, Hkv=2, d=256).
+    p.add_argument("--num-attention-heads", type=int, default=4)
+    p.add_argument("--num-kv-heads", type=int, default=2)
+    p.add_argument("--head-dim", type=int, default=64)
+    p.add_argument("--rotary-dim", type=int, default=32)
+    p.add_argument("--rope-theta", type=float, default=1e7)
+
+    # Linear-attn geometry (small synthetic; production is K=16, V=32, k=v=128).
+    p.add_argument("--num-k-heads", type=int, default=4)
+    p.add_argument("--num-v-heads", type=int, default=8)
+    p.add_argument("--head-k-dim", type=int, default=32)
+    p.add_argument("--head-v-dim", type=int, default=32)
+    p.add_argument("--conv-kernel-dim", type=int, default=4)
+
+    # FFN geometry (small synthetic; production is E=256, I=Is=512, top_k=8).
+    p.add_argument("--num-experts", type=int, default=8)
+    p.add_argument("--moe-intermediate", type=int, default=128,
+                   help="Per-expert intermediate dim. Must be ≥ INT4 "
+                        "group_size (128) so down_proj's in_features fits.")
+    p.add_argument("--shared-intermediate", type=int, default=128)
+    p.add_argument("--top-k", type=int, default=2)
+
+    p.add_argument("--rms-norm-eps", type=float, default=1e-6)
+
+    p.add_argument("--int4", action="store_true",
+                   help="Quantize each layer's projection weights via the "
+                        "per-block oracles' INT4 helpers (min/max group-quant). "
+                        "Schema becomes `qwen36-moe-oracle-multilayer-int4-v1`.")
+    p.add_argument("--int4-group-size", type=int, default=128,
+                   help="Group size for INT4 min/max quant. Pinned to 128 "
+                        "across the runtime + bake.")
+
+    p.add_argument("--no-emit-weights", action="store_true",
+                   help="Skip per-layer weight emission. Use for cheap shape/"
+                        "schema checks; step 2 (kernel parity) needs them.")
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    dtype = torch.bfloat16 if args.dtype == "bf16" else torch.float32
+
+    attn_cfg = {
+        "num_attention_heads": args.num_attention_heads,
+        "num_kv_heads": args.num_kv_heads,
+        "head_dim": args.head_dim,
+        "rotary_dim": args.rotary_dim,
+        "rope_theta": args.rope_theta,
+    }
+    lin_cfg = {
+        "num_k_heads": args.num_k_heads,
+        "num_v_heads": args.num_v_heads,
+        "head_k_dim": args.head_k_dim,
+        "head_v_dim": args.head_v_dim,
+        "conv_kernel_dim": args.conv_kernel_dim,
+    }
+    ffn_cfg = {
+        "num_experts": args.num_experts,
+        "moe_intermediate": args.moe_intermediate,
+        "shared_intermediate": args.shared_intermediate,
+        "top_k": args.top_k,
+    }
+
+    # Synthesise initial input + final RMSnorm + lm_head with the base seed.
+    # Both modes synthesise these — loading lm_head from a multimodal Qwen3.5MoE
+    # checkpoint requires care around tied embeddings + tokenizer vocab and is
+    # out of scope for step 1 (the per-layer parity is what we're after).
+    g = torch.Generator().manual_seed(args.seed)
+    initial_hidden = (
+        torch.randn(args.hidden, generator=g, dtype=torch.float32) / args.hidden ** 0.5
+    ).to(dtype)
+    final_norm_w = (
+        torch.ones(args.hidden, dtype=torch.float32)
+        + torch.randn(args.hidden, generator=g, dtype=torch.float32) * 0.02
+    ).to(dtype)
+    # lm_head: [vocab, hidden]. ~N(0, 1/sqrt(hidden)) keeps logits O(1).
+    lm_head_w = (
+        torch.randn(args.vocab, args.hidden, generator=g, dtype=torch.float32)
+        / args.hidden ** 0.5
+    ).to(dtype)
+
+    initial_hidden = initial_hidden.to(args.device)
+    final_norm_w = final_norm_w.to(args.device)
+    lm_head_w = lm_head_w.to(args.device)
+
+    # Per-layer weights.
+    layers: list[dict] = []
+    for layer_idx in range(args.num_layers):
+        if args.mode == "synthetic":
+            layer = synthesize_layer_weights(
+                layer_idx=layer_idx,
+                hidden=args.hidden,
+                attn_cfg=attn_cfg,
+                lin_cfg=lin_cfg,
+                ffn_cfg=ffn_cfg,
+                base_seed=args.seed,
+                dtype=dtype,
+                warm_state=(args.state == "warm"),
+            )
+        else:
+            if args.model_dir is None:
+                raise SystemExit("--model-dir is required in checkpoint mode")
+            layer = load_layer_weights_from_checkpoint(
+                layer_idx=layer_idx,
+                model_dir=args.model_dir,
+                weight_prefix=args.weight_prefix,
+                device=args.device,
+                dtype=dtype,
+                hidden=args.hidden,
+                lin_cfg=lin_cfg,
+                state_kind=args.state,
+                base_seed=args.seed,
+            )
+        # Move to device. recurrent_state_before stays F32 (production
+        # convention); everything else follows working dtype.
+        layer["attn"] = {
+            k: (v.to(args.device) if isinstance(v, torch.Tensor) else v)
+            for k, v in layer["attn"].items()
+        }
+        layer["ffn"] = {
+            k: (v.to(args.device) if isinstance(v, torch.Tensor) else v)
+            for k, v in layer["ffn"].items()
+        }
+        layers.append(layer)
+
+    # INT4 quantize-in-place. The per-block helpers self-check that
+    # (packed, scale, zero) round-trips byte-for-byte to the BF16
+    # reconstruction they write back into `layer["attn"|"ffn"]`. So this
+    # loop transitively gives us the per-layer INT4 self-check the
+    # acceptance criteria require.
+    int4_per_layer: list[dict] | None = None
+    if args.int4:
+        int4_per_layer = []
+        for layer_idx, layer in enumerate(layers):
+            entry: dict = {}
+            if is_full_attn_layer(layer_idx):
+                entry["attn"] = quantize_int4_attn_weights(
+                    layer["attn"], args.int4_group_size
+                )
+            else:
+                entry["attn"] = quantize_int4_linear_weights(
+                    layer["attn"], args.int4_group_size
+                )
+            entry["ffn"] = quantize_int4_ffn_weights(
+                layer["ffn"], args.int4_group_size
+            )
+            int4_per_layer.append(entry)
+
+    # Run the chained decode.
+    intermediates, final_hidden, logits = run_multilayer_decode(
+        layers=layers,
+        initial_hidden=initial_hidden,
+        final_norm_w=final_norm_w,
+        lm_head_w=lm_head_w,
+        attn_cfg=attn_cfg,
+        lin_cfg=lin_cfg,
+        ffn_cfg=ffn_cfg,
+        rms_norm_eps=args.rms_norm_eps,
+        position=args.position,
+    )
+
+    # Build JSON.
+    encode = b64_bf16 if args.dtype == "bf16" else b64_f32
+
+    config = {
+        "hidden": args.hidden,
+        "vocab": args.vocab,
+        "rms_norm_eps": args.rms_norm_eps,
+        "attn": {
+            **attn_cfg,
+            "rms_norm_eps": args.rms_norm_eps,
+            "attn_output_gate": True,
+        },
+        "lin": {**lin_cfg, "rms_norm_eps": args.rms_norm_eps},
+        "ffn": {**ffn_cfg, "rms_norm_eps": args.rms_norm_eps},
+    }
+    if args.int4:
+        config["int4_group_size"] = args.int4_group_size
+
+    layer_meta = [
+        {"layer_idx": i, "kind": "full" if is_full_attn_layer(i) else "linear"}
+        for i in range(args.num_layers)
+    ]
+
+    intermediate_payload = [
+        {
+            "layer_idx": item["layer_idx"],
+            "kind": item["kind"],
+            "output_after_attn": encode(item["output_after_attn"]),
+            "output_after_ffn": encode(item["output_after_ffn"]),
+        }
+        for item in intermediates
+    ]
+
+    out = {
+        "schema": (
+            "qwen36-moe-oracle-multilayer-int4-v1"
+            if args.int4
+            else "qwen36-moe-oracle-multilayer-v1"
+        ),
+        "mode": args.mode,
+        "state": args.state,
+        "position": args.position,
+        "num_layers": args.num_layers,
+        "dtype": args.dtype,
+        "config": config,
+        "layers": layer_meta,
+        "input_hidden": encode(initial_hidden),
+        "final_norm_w": encode(final_norm_w),
+        "lm_head_w": encode(lm_head_w),
+        "intermediates_per_layer": intermediate_payload,
+        "final_hidden": encode(final_hidden),
+        "logits": encode(logits),
+    }
+
+    if not args.no_emit_weights:
+        out["weights_per_layer"] = [
+            {
+                "attn": encode_attn_weights(i, layer["attn"], encode),
+                "ffn": encode_ffn_weights(layer["ffn"], encode),
+            }
+            for i, layer in enumerate(layers)
+        ]
+
+    if int4_per_layer is not None and not args.no_emit_weights:
+        out["int4_weights_per_layer"] = [
+            {
+                "attn": {
+                    name: {
+                        "packed": b64_u8(t["packed"]),
+                        "scale": b64_bf16(t["scale"]),
+                        "zero": b64_bf16(t["zero"]),
+                    }
+                    for name, t in entry["attn"].items()
+                },
+                "ffn": {
+                    name: {
+                        "packed": b64_u8(t["packed"]),
+                        "scale": b64_bf16(t["scale"]),
+                        "zero": b64_bf16(t["zero"]),
+                    }
+                    for name, t in entry["ffn"].items()
+                },
+            }
+            for entry in int4_per_layer
+        ]
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(out))
+
+    # Eyeball line — drift across layers is what step 2's parity gate compares.
+    in_norm = initial_hidden.to(torch.float32).norm().item()
+    final_norm = final_hidden.to(torch.float32).norm().item()
+    logits_norm = logits.to(torch.float32).norm().item()
+    full_count = sum(1 for i in range(args.num_layers) if is_full_attn_layer(i))
+    lin_count = args.num_layers - full_count
+    int4_tag = "int4" if args.int4 else "bf16-w"
+    sys.stderr.write(
+        f"[multilayer-oracle] mode={args.mode} layers={args.num_layers} "
+        f"({lin_count} linear + {full_count} full) "
+        f"weights={int4_tag} state={args.state} pos={args.position} "
+        f"|input|={in_norm:.4f} |final|={final_norm:.4f} "
+        f"|logits|={logits_norm:.4f}\n"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/oracle/qwen36_moe_oracle.py
+++ b/oracle/qwen36_moe_oracle.py
@@ -430,9 +430,18 @@ def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(
         description="Qwen3.6-MoE single-layer reference forward (PR 4b oracle)"
     )
-    p.add_argument("--mode", choices=["synthetic", "checkpoint"], default="synthetic")
+    p.add_argument("--mode", choices=["synthetic", "checkpoint", "bake"], default="synthetic")
     p.add_argument("--model-dir", type=Path,
                    help="Path to the HuggingFace safetensors dir (checkpoint mode)")
+    p.add_argument("--bake-dir", type=Path,
+                   help="Path to a SuperSonic INT4 GPTQ bake directory "
+                        "(`bake` mode). Loads layer's INT4 weights directly + "
+                        "reconstructs to BF16 via the kernel's exact "
+                        "`bf16(q*s - z*s)` formula. Schema becomes "
+                        "`qwen36-moe-oracle-layer-int4-v1` with `int4_weights` "
+                        "carrying the bake's *actual* packed/scale/zero — the "
+                        "harness for verifying the kernel produces the right "
+                        "output on the bake's specific INT4 patterns.")
     p.add_argument("--layer-idx", type=int, default=3,
                    help="Full-attention layer index (default 3 = first full layer)")
     p.add_argument("--weight-prefix", default="model.language_model")
@@ -471,6 +480,8 @@ def main() -> None:
     args = parse_args()
     dtype = torch.bfloat16 if args.dtype == "bf16" else torch.float32
 
+    int4_sidecars: dict[str, dict[str, torch.Tensor]] | None = None
+
     if args.mode == "synthetic":
         weights = synthesize_layer(
             hidden=args.hidden,
@@ -480,6 +491,51 @@ def main() -> None:
             seed=args.seed,
             dtype=dtype,
         )
+    elif args.mode == "bake":
+        if args.bake_dir is None:
+            raise SystemExit("--bake-dir is required in bake mode")
+        # Bake mode: load INT4 weights from the SuperSonic bake directly, use
+        # the bake's BF16 reconstructions as the "weights" for the reference
+        # forward, and emit the bake's actual (packed, scale, zero) sidecars
+        # so the kernel-ffi parity test verifies the kernel reproduces what
+        # Python computes on these specific INT4 patterns.
+        from _bake_loader import load_bf16, load_int4
+
+        bake_dir = str(args.bake_dir)
+        lp = f"{args.weight_prefix}.layers.{args.layer_idx}"
+        fa = f"{lp}.self_attn"
+
+        weights = {}
+        int4_sidecars = {}
+        for key, name in [
+            ("q_proj_w", f"{fa}.q_proj.weight"),
+            ("k_proj_w", f"{fa}.k_proj.weight"),
+            ("v_proj_w", f"{fa}.v_proj.weight"),
+            ("o_proj_w", f"{fa}.o_proj.weight"),
+        ]:
+            recon, packed, scale, zero = load_int4(bake_dir, name)
+            weights[key] = recon
+            int4_sidecars[key] = {
+                "packed": packed,
+                "scale": scale.to(torch.float32),
+                "zero": zero.to(torch.float32),
+            }
+        weights["input_norm_w"] = load_bf16(bake_dir, f"{lp}.input_layernorm.weight")
+        weights["q_norm_w"] = load_bf16(bake_dir, f"{fa}.q_norm.weight")
+        weights["k_norm_w"] = load_bf16(bake_dir, f"{fa}.k_norm.weight")
+
+        # Synthesise input_hidden the same way checkpoint mode does so the
+        # parity test has a deterministic input without loading embed_tokens.
+        torch.manual_seed(args.seed)
+        weights["input_hidden"] = (
+            torch.randn(args.hidden, dtype=torch.float32) / args.hidden**0.5
+        ).to(dtype)
+        for k in ("input_norm_w", "q_norm_w", "k_norm_w"):
+            weights[k] = weights[k].to(dtype)
+
+        # Force the INT4 path so the schema/JSON shape matches what the
+        # kernel-ffi INT4 parity tests expect.
+        args.int4 = True
     else:
         if args.model_dir is None:
             raise SystemExit("--model-dir is required in checkpoint mode")
@@ -502,11 +558,11 @@ def main() -> None:
 
     weights = {k: v.to(args.device) for k, v in weights.items()}
 
-    int4_sidecars: dict[str, dict[str, torch.Tensor]] | None = None
-    if args.int4:
+    if args.int4 and int4_sidecars is None:
         # Quantize before computing intermediates so the reference uses the
         # same BF16-reconstructed weights the kernel will see — intermediates
         # are then valid for both the BF16 and INT4 kernel paths.
+        # (Skipped when bake mode already populated int4_sidecars from disk.)
         int4_sidecars = quantize_int4_attn_weights(weights, args.int4_group_size)
 
     intermediates = reference_full_attention_layer(

--- a/oracle/qwen36_moe_oracle.py
+++ b/oracle/qwen36_moe_oracle.py
@@ -2,12 +2,22 @@
 """
 PyTorch reference for one Qwen3.6-MoE full-attention layer's decode step.
 
-Companion to PR 4b of docs/qwen36-moe-plan.md. Loads exactly the weights
-needed for one layer (no full-model instantiation — 35B doesn't fit
-24 GiB), runs the forward in PyTorch using primitives we control end
-to end, and emits every intermediate as JSON + base64. The HIP kernel's
-parity test reads this JSON and compares its own intermediates point
-for point.
+Companion to PR 4b (BF16) and PR 4b6 (INT4) of docs/qwen36-moe-plan.md.
+Loads exactly the weights needed for one layer (no full-model
+instantiation — 35B doesn't fit 24 GiB), runs the forward in PyTorch
+using primitives we control end to end, and emits every intermediate
+as JSON + base64. The HIP kernel's parity test reads this JSON and
+compares its own intermediates point for point.
+
+`--int4` switches into INT4 mode: the four projection weights that the
+INT4 bake quantizes (`q_proj`, `k_proj`, `v_proj`, `o_proj`) are
+min/max group-quantized at gs=128 with BF16 scale + zero. The `weights`
+block then carries the BF16-rounded *reconstruction* of those tensors
+(so the existing BF16 kernel path is still exercised) and a parallel
+`int4_weights` block carries the packed nibbles + scale + zero sidecars
+the INT4 kernel path will read. Schema becomes
+`qwen36-moe-oracle-layer-int4-v1`. Norms (input/q/k) stay BF16 — the
+bake excludes them.
 
 Why hand-rolled rather than transformers: the published checkpoint is
 a multimodal class (Qwen3_5MoeForConditionalGeneration) with vision +
@@ -66,6 +76,136 @@ def b64_f32(t: torch.Tensor) -> str:
     return base64.b64encode(
         t.to(torch.float32).contiguous().cpu().numpy().tobytes()
     ).decode()
+
+
+def b64_u8(t: torch.Tensor) -> str:
+    return base64.b64encode(
+        t.to(torch.uint8).contiguous().cpu().numpy().tobytes()
+    ).decode()
+
+
+# Tensors the INT4 bake quantizes for one full-attention layer. The norm
+# weights (input_norm, q_norm, k_norm) stay BF16 — the bake excludes them
+# from the INT4 budget for the same reason `crates/qwen36_moe/src/weights.rs`
+# does.
+INT4_ATTN_TARGETS: tuple[str, ...] = (
+    "q_proj_w",
+    "k_proj_w",
+    "v_proj_w",
+    "o_proj_w",
+)
+
+
+@torch.no_grad()
+def minmax_int4_packed_and_recon(
+    W: torch.Tensor, group_size: int
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Min/max INT4 group-quant for a 2D `[out, in]` weight. Mirrors the
+    `minmax_int4_packed_and_recon` in `qwen36_moe_ffn_oracle.py` exactly,
+    which in turn mirrors `oracle/bake_int4.py`.
+
+    Returns (packed/scale/zero on CPU; recon stays on `W.device`):
+
+      packed   uint8  shape `[out, in/2]`     two nibbles per byte,
+                                               even col → low nibble.
+      scale    f32    shape `[out/gs, in/gs]` BF16 values stored as f32.
+      zero     f32    shape `[out/gs, in/gs]` BF16 values stored as f32.
+      recon    bf16   shape `[out, in]`        single-rounding
+                                               `bf16(q*s - z*s)` —
+                                               matches the kernel's
+                                               `bf16_round_rne_f32_finite(
+                                                  n*s - zs)` exactly.
+    """
+    if W.dim() != 2:
+        raise ValueError(f"expected 2D, got shape {tuple(W.shape)}")
+    out_f, in_f = W.shape
+    gs = group_size
+    if in_f % gs != 0 or in_f % 2 != 0:
+        raise ValueError(
+            f"in_features {in_f} must be divisible by group_size={gs} and even"
+        )
+    if out_f % gs != 0:
+        raise ValueError(
+            f"out_features {out_f} must be divisible by group_size={gs}"
+        )
+    sr = out_f // gs
+    sc = in_f // gs
+
+    slab = W.to(torch.float32)
+    tiles = slab.reshape(sr, gs, sc, gs)
+    tmax = tiles.amax(dim=(1, 3))
+    tmin = tiles.amin(dim=(1, 3))
+    rng = tmax - tmin
+    s = torch.where(rng > 0, rng / 15.0, torch.ones_like(rng))
+    z = torch.where(rng > 0, -tmin / s, torch.zeros_like(rng))
+    # Round through BF16 — sidecars are stored BF16 in the bake and the
+    # kernel reads BF16 scale/zero.
+    s = s.to(torch.bfloat16).to(torch.float32)
+    z = z.to(torch.bfloat16).to(torch.float32)
+    s_full = s.repeat_interleave(gs, 0).repeat_interleave(gs, 1)
+    z_full = z.repeat_interleave(gs, 0).repeat_interleave(gs, 1)
+    q = torch.clamp(
+        torch.round(slab / s_full + z_full), 0.0, 15.0
+    ).to(torch.uint8)
+    # Single-rounding reconstruction: bf16(q*s - z*s). The kernel computes
+    # `bf16(n*s - zs)` with `zs = z*s` precomputed in F32, so the rounding
+    # boundary is identical.
+    recon = (q.to(torch.float32) * s_full - z_full * s_full).to(torch.bfloat16)
+    # Pack 2 nibbles/byte: even col → low, odd col → high.
+    packed = (q[:, 0::2] | (q[:, 1::2] << 4)).contiguous()
+    return packed.cpu(), s.cpu(), z.cpu(), recon
+
+
+@torch.no_grad()
+def dequant_int4_packed(
+    packed: torch.Tensor,
+    scale: torch.Tensor,
+    zero: torch.Tensor,
+    group_size: int,
+) -> torch.Tensor:
+    """Reference dequant — inverse of `minmax_int4_packed_and_recon`. Used
+    for the in-process self-check below."""
+    out_f = packed.shape[-2]
+    in_half = packed.shape[-1]
+    in_f = in_half * 2
+    gs = group_size
+    q = torch.empty((out_f, in_f), dtype=torch.uint8)
+    q[:, 0::2] = packed & 0x0F
+    q[:, 1::2] = (packed >> 4) & 0x0F
+    s_full = scale.repeat_interleave(gs, 0).repeat_interleave(gs, 1)
+    z_full = zero.repeat_interleave(gs, 0).repeat_interleave(gs, 1)
+    recon = (q.to(torch.float32) * s_full - z_full * s_full).to(torch.bfloat16)
+    return recon.to(torch.float32)
+
+
+def quantize_int4_attn_weights(
+    weights: dict[str, torch.Tensor], group_size: int
+) -> dict[str, dict[str, torch.Tensor]]:
+    """Quantize the INT4-targeted attn weights in-place: replace each entry
+    in `weights` with its BF16 reconstruction (cast to that weight's
+    original dtype + device). Return a parallel dict of
+    `{name: {"packed", "scale", "zero"}}` sidecars on CPU."""
+    int4_sidecars: dict[str, dict[str, torch.Tensor]] = {}
+    for name in INT4_ATTN_TARGETS:
+        if name not in weights:
+            raise SystemExit(f"INT4 mode missing required weight: {name}")
+        W = weights[name]
+        packed, scale, zero, recon = minmax_int4_packed_and_recon(W, group_size)
+
+        # In-process self-check: verify (packed, scale, zero) round-trips
+        # to exactly `recon`. Catches packing bugs before the kernel ever
+        # sees the JSON.
+        recon_check = dequant_int4_packed(packed, scale, zero, group_size)
+        diff = (recon.to(torch.float32).cpu() - recon_check).abs().max().item()
+        if diff != 0.0:
+            raise RuntimeError(
+                f"INT4 self-check failed for {name}: "
+                f"max |recon - dequant(packed)| = {diff:.3e}"
+            )
+
+        int4_sidecars[name] = {"packed": packed, "scale": scale, "zero": zero}
+        weights[name] = recon.to(dtype=W.dtype, device=W.device)
+    return int4_sidecars
 
 
 def find_shard_for(model_dir: Path, name: str) -> Path:
@@ -313,6 +453,17 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--rotary-dim", type=int, default=64)
     p.add_argument("--rope-theta", type=float, default=1e7)
     p.add_argument("--rms-norm-eps", type=float, default=1e-6)
+    p.add_argument("--int4", action="store_true",
+                   help="Quantize the four projection weights (q/k/v/o_proj) "
+                        "to INT4 (min/max group-quant). The `weights` block "
+                        "carries the BF16 reconstruction; an additional "
+                        "`int4_weights` block carries (packed, scale, zero) "
+                        "sidecars for the kernel's INT4 path. Schema becomes "
+                        "`qwen36-moe-oracle-layer-int4-v1`.")
+    p.add_argument("--int4-group-size", type=int, default=128,
+                   help="Group size for INT4 min/max quant. Must divide "
+                        "out_features and in_features of every quantized "
+                        "tensor. The runtime + bake both pin to 128.")
     return p.parse_args()
 
 
@@ -351,6 +502,13 @@ def main() -> None:
 
     weights = {k: v.to(args.device) for k, v in weights.items()}
 
+    int4_sidecars: dict[str, dict[str, torch.Tensor]] | None = None
+    if args.int4:
+        # Quantize before computing intermediates so the reference uses the
+        # same BF16-reconstructed weights the kernel will see — intermediates
+        # are then valid for both the BF16 and INT4 kernel paths.
+        int4_sidecars = quantize_int4_attn_weights(weights, args.int4_group_size)
+
     intermediates = reference_full_attention_layer(
         num_heads=args.num_attention_heads,
         num_kv_heads=args.num_kv_heads,
@@ -363,33 +521,49 @@ def main() -> None:
     )
 
     encode = b64_bf16 if args.dtype == "bf16" else b64_f32
+    config = {
+        "hidden": args.hidden,
+        "num_attention_heads": args.num_attention_heads,
+        "num_kv_heads": args.num_kv_heads,
+        "head_dim": args.head_dim,
+        "rotary_dim": args.rotary_dim,
+        "rope_theta": args.rope_theta,
+        "rms_norm_eps": args.rms_norm_eps,
+        "attn_output_gate": True,
+    }
+    if args.int4:
+        config["int4_group_size"] = args.int4_group_size
+
     out = {
-        "schema": "qwen36-moe-oracle-layer-v1",
+        "schema": ("qwen36-moe-oracle-layer-int4-v1"
+                   if args.int4 else "qwen36-moe-oracle-layer-v1"),
         "mode": args.mode,
         "layer_idx": args.layer_idx,
         "position": args.position,
         "dtype": args.dtype,
-        "config": {
-            "hidden": args.hidden,
-            "num_attention_heads": args.num_attention_heads,
-            "num_kv_heads": args.num_kv_heads,
-            "head_dim": args.head_dim,
-            "rotary_dim": args.rotary_dim,
-            "rope_theta": args.rope_theta,
-            "rms_norm_eps": args.rms_norm_eps,
-            "attn_output_gate": True,
-        },
+        "config": config,
         "weights": {k: encode(v) for k, v in weights.items()},
         "intermediates": {k: encode(v) for k, v in intermediates.items()},
     }
+    if int4_sidecars is not None:
+        out["int4_weights"] = {
+            name: {
+                "packed": b64_u8(t["packed"]),
+                "scale": b64_bf16(t["scale"]),
+                "zero": b64_bf16(t["zero"]),
+            }
+            for name, t in int4_sidecars.items()
+        }
     args.out.parent.mkdir(parents=True, exist_ok=True)
     args.out.write_text(json.dumps(out))
 
     # Quick eyeball at stderr — gives an at-a-glance "is this remotely sane".
     out_norm = intermediates["output_hidden"].to(torch.float32).norm().item()
     in_norm = weights["input_hidden"].to(torch.float32).norm().item()
+    int4_tag = "int4" if args.int4 else "bf16-w"
     sys.stderr.write(
         f"[oracle] layer={args.layer_idx} pos={args.position} mode={args.mode} "
+        f"weights={int4_tag} "
         f"|input|={in_norm:.4f} |output|={out_norm:.4f} "
         f"|delta|={(intermediates['output_hidden'] - weights['input_hidden']).to(torch.float32).norm().item():.4f}\n"
     )


### PR DESCRIPTION
## Summary

Lands the host-orchestrated multi-launch decode for Qwen3.6-MoE 35B-A3B
end-to-end against the local INT4 GPTQ bake, with all the supporting
infrastructure that took to get there. Engine no longer bails on
non-`--dry-run` calls; the kernel chain runs the full 40-layer hybrid
(linear-attn / full-attn / MoE-FFN) on real bake weights.

22 commits split into four conceptual chunks:

### PR 4c (host-orchestrated multi-launch decode)
- `oracle: PR 4c step 1 — Qwen3.6-MoE multi-layer reference`
- `runner: PR 4c step 2 — Qwen3.6-MoE host-orchestrated multi-launch decode`
- `runner: PR 4c step 2 INT4 — wire INT4 sidecars + decode 35B-A3B end-to-end`
- `runner: PR 4c step 2 — decode emitted token through tokenizer`

Multi-layer parity test passes at synthetic geometry: cos_sim 0.9999
final logits both BF16 and INT4 modes. Real-bake decode at production
scale runs end-to-end through 40 layers / 120 HIP launches per token.

### PR 4d (multi-token + KV cache + sampling)
- `runner: PR 4d step 1 — multi-token decode loop with prompt tokenization`
- `kernel+runner: PR 4d step 2 — full-attn KV cache extension`
- `runner: PR 4d step 3 — temperature/top-K/top-P sampling + RNG`

Per-block parity stays bit-exact in the kv_len=1 fast path; per-block
parity tests at production geometry against safetensors are bit-exact
(full-attn, linear-attn, FFN — verified separately during diagnosis).

### Bake quality work
- `docs: GPTQ baker audit — no algorithmic bugs, design limitations`
- `oracle: scale search in INT4 GPTQ baker (~half the per-tensor error)`
- `docs: scale-search re-bake results — quality lift confirmed, kernel gap remains`

Audit found no GPTQ bugs but identified missing AutoGPTQ-style
per-tile scale search. Implemented + re-baked the 35B-A3B model in
33 minutes. Per-tensor cos_sim improvements:

| tensor                                   | old    | new    | delta |
|------------------------------------------|--------|--------|-------|
| layers.3.self_attn.o_proj                | 0.9000 | 0.9357 | +0.036 |
| layers.0.linear_attn.out_proj            | 0.8991 | 0.9423 | +0.043 |
| layers.0.mlp.shared_expert.gate_proj     | 0.8804 | 0.9278 | +0.047 |
| layers.0.linear_attn.in_proj_qkv         | 0.9410 | 0.9617 | +0.021 |
| layers.3.self_attn.q_proj                | 0.9611 | 0.9787 | +0.018 |
| ... (all 9 sampled improved)             |        |        |       |

Worst tensors gained the most. Bake's own Python sample-gen now
produces \"The quick brown fox jumps...\" — the first generated token is
coherent (vs the baseline bake's degenerate \"...storeparepareUDA...\").

### Per-layer bake parity harness (diagnosis)
- `oracle+runner: per-layer bake parity harness — chain math is correct`
- `runner: env-gated final_hidden + logits dumps for post-chain diagnosis`

New \`oracle/_bake_loader.py\` reads the bake's INT4 weights + sidecar
transforms (HeadBiasReshaped, HeadExpReshaped) into the format the
per-block reference oracles consume. \`--mode bake --bake-dir <path>\`
added to all three per-block oracles. Verified per-block kernels at
production geometry on the actual bake's INT4 patterns:

  - layer 3 full-attn: n=2048 exact=2048 cos_sim=1.0 (BIT-EXACT)
  - layer 0 linear-attn: n=2048 exact=2048 cos_sim=1.0 (BIT-EXACT)
  - layer 0 FFN: passes both BF16 and INT4 stage-5 tests

Per-layer L2-norm trace (\`SUPERSONIC_QWEN36_DEBUG_TRACE_NORMS=1\`)
verified the multi-layer kernel chain matches the Python reference
through layers 0-3 bit-exactly; the L2 trajectory grows ~20x init→final
which is legitimate model behavior (Python reference produces the same
sequence).

## Caveats / known issue (deferred)

End-to-end greedy decode on the real bake still produces gibberish
(\`The quick brown fox::.::.::.::.ivadspot...\`) even though every
verifiable component (per-block kernels, multi-layer chain, host norm
+ lm_head GEMV + argmax) is bit-correct relative to our Python
reference oracles.

Diagnosis above proves the kernel and our reference math are
self-consistent, but they collectively diverge from HuggingFace's
actual Qwen3_5MoeDecoderLayer forward (HF's \`model.generate\` on the
same in-memory bake produces \"jumps\"). The bug is in our hand-rolled
per-block reference math, which the kernel faithfully reproduces.

Likely suspects in the per-block oracles: RoPE convention, RMSnorm
unit offset, output-gate placement, linear-attn delta-rule sign/order,
MoE routing renormalize-vs-not. Diff against
\`transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py\` is the next
investigation — separate, focused, ML-implementation work.

Until that lands, the kernel + chain is shippable for kernel
correctness + perf testing but won't generate coherent text.

## Test plan

- [x] Multi-layer parity test passes (`cargo test -p runner --test qwen36_moe_multilayer_parity`)
- [x] Per-block kernel parity tests pass at production geom against safetensors
- [x] Per-block kernel parity tests pass at production geom against the real INT4 bake (new harness)
- [x] Engine + decode runs end-to-end without bailing on `cargo run --release --bin supersonic --model qwen3.6-35b-a3b --model-dir <snap> --prompt "..."`
- [x] `--dry-run` path unchanged
- [x] Existing per-block parity tests at synthetic geometry still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)