### PR TITLE
qwen36-moe: HF reference parity fixes (RMSNorm offset + q_proj split)

### DIFF
--- a/crates/runner/src/qwen36_moe_decode.rs
+++ b/crates/runner/src/qwen36_moe_decode.rs
@@ -744,9 +744,15 @@ pub fn f32_to_bf16_bytes(vals: &[f32]) -> Vec<u8> {
 
 /// Apply RMSnorm + lm_head GEMV on the host. Mirrors the multi-layer
 /// oracle's tail:
-///   final_normed = rms_norm(hidden, final_norm_w, eps)
+///   final_normed = rms_norm(hidden, final_norm_w, eps)   # (1+w) offset
 ///   logits       = final_normed.to(F32) @ lm_head_w.to(F32).T
 ///   logits       = logits.to(BF16)
+///
+/// The RMSnorm uses the HuggingFace `Qwen3_5MoeRMSNorm` convention with
+/// the `(1.0 + weight)` unit offset — `model.norm` in the HF text model
+/// (line 1354 of `transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py`)
+/// is an instance of `Qwen3_5MoeRMSNorm` whose forward computes
+/// `output * (1.0 + self.weight.float())`.
 ///
 /// All inputs are BF16 little-endian byte streams; output is BF16
 /// little-endian bytes for `vocab` logit channels.
@@ -794,14 +800,18 @@ pub fn host_final_norm_lm_head_f32(
 
     let h_f32 = bf16_bytes_to_f32(hidden_bytes);
 
-    // RMSnorm: F32 mean of squares -> rsqrt(var+eps) -> elementwise mul by w.
+    // RMSnorm with the HF `Qwen3_5MoeRMSNorm` convention: F32 mean of
+    // squares -> rsqrt(var+eps) -> elementwise mul by `(1.0 + w)`. The
+    // stored weight is a small delta around zero (initialized to zeros
+    // in HF — line 810 of modeling_qwen3_5_moe.py) and the effective
+    // scale factor is `1 + w`.
     let mean_sq: f32 =
         h_f32.iter().map(|&x| x * x).sum::<f32>() / hidden as f32;
     let rsqrt = 1.0 / (mean_sq + eps).sqrt();
     let normed: Vec<f32> = h_f32
         .iter()
         .zip(final_norm_w_f32.iter())
-        .map(|(&x, &w)| x * rsqrt * w)
+        .map(|(&x, &w)| x * rsqrt * (1.0 + w))
         .collect();
 
     // GEMV: lm_head [vocab, hidden] @ normed [hidden] -> logits [vocab].
@@ -1016,14 +1026,35 @@ mod tests {
 
     #[test]
     fn rms_norm_then_lm_head_matches_naive_computation() {
-        // Tiny hand-checked case. RMS-normalised (1, 2, 3) with norm_w=(1,1,1)
-        // and eps=0 has mean_sq=14/3 → rsqrt=sqrt(3/14). Times lm_head row
-        // [1, 0, 0] yields 1*sqrt(3/14) ≈ 0.4629. BF16 rounding is loose
-        // enough that we check within 1e-2.
+        // Tiny hand-checked case. RMS-normalised (1, 2, 3) has mean_sq=14/3
+        // → rsqrt=sqrt(3/14). With norm_w=(1,1,1) and the HF `(1+w)` unit
+        // offset, the effective scale per channel is 2. Times lm_head row
+        // [1, 0, 0] yields `1 * sqrt(3/14) * 2` ≈ 0.9258. BF16 rounding
+        // is loose enough that we check within 1e-2.
         let hidden = 3usize;
         let vocab = 1usize;
         let h_bytes = f32_to_bf16_bytes(&[1.0, 2.0, 3.0]);
         let w_bytes = f32_to_bf16_bytes(&[1.0, 1.0, 1.0]);
+        let lm_bytes = f32_to_bf16_bytes(&[1.0, 0.0, 0.0]);
+        let logits = host_final_norm_lm_head(&h_bytes, &w_bytes, &lm_bytes, hidden, vocab, 0.0);
+        let logit = bf16_bytes_to_f32(&logits)[0];
+        let expected = 2.0 * (3.0f32 / 14.0).sqrt();
+        assert!(
+            (logit - expected).abs() < 1e-2,
+            "logit {logit} far from expected {expected}"
+        );
+    }
+
+    #[test]
+    fn rms_norm_unit_offset_zero_weight_is_identity_scale() {
+        // With norm_w = zeros, the HF `(1+w)` convention degrades to
+        // a plain RMSnorm (effective scale = 1). Locks the offset in
+        // semantics — same input as the test above with weight=1 should
+        // give exactly half the logit when weight=0.
+        let hidden = 3usize;
+        let vocab = 1usize;
+        let h_bytes = f32_to_bf16_bytes(&[1.0, 2.0, 3.0]);
+        let w_bytes = f32_to_bf16_bytes(&[0.0, 0.0, 0.0]);
         let lm_bytes = f32_to_bf16_bytes(&[1.0, 0.0, 0.0]);
         let logits = host_final_norm_lm_head(&h_bytes, &w_bytes, &lm_bytes, hidden, vocab, 0.0);
         let logit = bf16_bytes_to_f32(&logits)[0];

--- a/kernels/qwen36_moe.hip
+++ b/kernels/qwen36_moe.hip
@@ -452,10 +452,12 @@ __global__ void qwen36_moe_attn_step_kernel(
     __syncthreads();
 
     // BF16-round each x_norm element so the matmul reads what PyTorch reads
-    // (its `out.to(in_dtype)` step in rms_norm).
+    // (its `out.to(in_dtype)` step in rms_norm). HF `Qwen3_5MoeRMSNorm`
+    // applies the `(1.0 + weight)` unit offset (line 819 of
+    // modeling_qwen3_5_moe.py); `input_layernorm` is one such instance.
     for (int col = tid; col < hidden; col += block_size) {
         const float w = load_as_float<T>(input_norm_w, col);
-        x_norm_lds[col] = bf16_round_rne_f32(x_norm_lds[col] * inv_rms_input * w);
+        x_norm_lds[col] = bf16_round_rne_f32(x_norm_lds[col] * inv_rms_input * (1.0f + w));
     }
     __syncthreads();
 
@@ -565,7 +567,8 @@ __global__ void qwen36_moe_attn_step_kernel(
             for (int i = tid; i < d; i += block_size) {
                 const float v = workspace[OFF_Q_RAW + base + i];
                 const float wv = load_as_float<T>(q_norm_w, i);
-                const float normed = bf16_round_rne_f32(v * head_inv_rms * wv);
+                // HF `Qwen3_5MoeRMSNorm` `(1.0 + weight)` unit offset.
+                const float normed = bf16_round_rne_f32(v * head_inv_rms * (1.0f + wv));
                 // Round-trip through BF16 representation: store BF16 in
                 // workspace as F32 so the next-stage RoPE reader sees the
                 // exact dtype-cast values PyTorch's `.to(bf16)` produces.
@@ -675,7 +678,8 @@ __global__ void qwen36_moe_attn_step_kernel(
             for (int i = tid; i < d; i += block_size) {
                 const float v = workspace[OFF_K_RAW + base + i];
                 const float wv = load_as_float<T>(k_norm_w, i);
-                const float normed = bf16_round_rne_f32(v * head_inv_rms * wv);
+                // HF `Qwen3_5MoeRMSNorm` `(1.0 + weight)` unit offset.
+                const float normed = bf16_round_rne_f32(v * head_inv_rms * (1.0f + wv));
                 workspace[OFF_K_NORMED + base + i] = normed;
                 if (stage == 2) {
                     output[base + i] = static_cast<T>(normed);
@@ -1165,9 +1169,11 @@ __global__ void qwen36_moe_linear_step_kernel(
     }
     __syncthreads();
 
+    // HF `Qwen3_5MoeRMSNorm` `(1.0 + weight)` unit offset for
+    // `input_layernorm` ahead of the linear-attn block.
     for (int col = tid; col < hidden; col += block_size) {
         const float w = static_cast<float>(input_norm_w[col]);
-        x_norm_lds[col] = bf16_round_rne_f32(x_norm_lds[col] * inv_rms_input * w);
+        x_norm_lds[col] = bf16_round_rne_f32(x_norm_lds[col] * inv_rms_input * (1.0f + w));
     }
     __syncthreads();
 
@@ -1903,11 +1909,13 @@ __global__ void qwen36_moe_ffn_step_kernel(
     __syncthreads();
 
     // BF16-round each h_norm element so the matmul reads what PyTorch reads.
-    // Block 0 is also responsible for staging the F32 of-BF16 view into
-    // workspace[OFF_H_NORM] for any later stages that prefer global memory.
+    // HF `Qwen3_5MoeRMSNorm` `(1.0 + weight)` unit offset for
+    // `post_attention_layernorm`. Block 0 also stages the F32 of-BF16 view
+    // into workspace[OFF_H_NORM] for any later stages that prefer global
+    // memory.
     for (int col = tid; col < hidden; col += block_size) {
         const float w = static_cast<float>(post_attn_norm_w[col]);
-        const float v = bf16_round_rne_f32(h_norm_lds[col] * inv_rms_input * w);
+        const float v = bf16_round_rne_f32(h_norm_lds[col] * inv_rms_input * (1.0f + w));
         h_norm_lds[col] = v;
         if (blockIdx.x == 0) {
             workspace[OFF_H_NORM + col] = v;

--- a/kernels/qwen36_moe.hip
+++ b/kernels/qwen36_moe.hip
@@ -531,11 +531,19 @@ __global__ void qwen36_moe_attn_step_kernel(
     // doesn't need to allocate space for it.
     const int OFF_SCORES   = 6 * H * d + 4 * Hkv * d + hidden;
 
-    // -- Phase C: per-head RMS norm of q_lanes = workspace[Q_RAW : Q_RAW+H*d]
+    // -- Phase C: per-head RMS norm of q lanes ----------------------------
+    //
+    // The q_proj output at `workspace[OFF_Q_RAW..OFF_Q_RAW+2*H*d]` carries
+    // BF16-rounded rows of `q_proj_w @ x_norm` in their natural HF layout:
+    // per-head interleaved `[q_h | gate_h]` because HF reshapes via
+    // `q_proj(x).view(..., H, head_dim*2).chunk(2, dim=-1)` (line 672 of
+    // modeling_qwen3_5_moe.py). For head h the q values live at offset
+    // `h*2*d + i` (i in [0, d)) and the output gate at `h*2*d + d + i`.
+    //
     // Each block grabs a head index, reduces across head_dim, writes BF16
-    // q_normed to workspace[Q_NORMED..]. If stage == 1 we also publish
-    // q_normed to the host-visible `output` buffer; later stages keep
-    // q_normed in workspace as RoPE input.
+    // q_normed to a *tightly packed* `OFF_Q_NORMED + h*d` so the RoPE +
+    // attention readers downstream see a `[H, d]` q array. If stage == 1
+    // we also publish q_normed to the host-visible `output` buffer.
     {
         for (;;) {
             __shared__ unsigned int head_s;
@@ -546,10 +554,11 @@ __global__ void qwen36_moe_attn_step_kernel(
             const int h = static_cast<int>(head_s);
             if (h >= H) break;
 
-            const int base = h * d;
+            const int q_in_base  = h * 2 * d;   // HF interleaved q half
+            const int q_out_base = h * d;       // tightly packed q_normed
             float partial = 0.0f;
             for (int i = tid; i < d; i += block_size) {
-                const float v = workspace[OFF_Q_RAW + base + i];
+                const float v = workspace[OFF_Q_RAW + q_in_base + i];
                 partial += v * v;
             }
             shared_scratch[tid] = partial;
@@ -565,16 +574,16 @@ __global__ void qwen36_moe_attn_step_kernel(
             __syncthreads();
 
             for (int i = tid; i < d; i += block_size) {
-                const float v = workspace[OFF_Q_RAW + base + i];
+                const float v = workspace[OFF_Q_RAW + q_in_base + i];
                 const float wv = load_as_float<T>(q_norm_w, i);
                 // HF `Qwen3_5MoeRMSNorm` `(1.0 + weight)` unit offset.
                 const float normed = bf16_round_rne_f32(v * head_inv_rms * (1.0f + wv));
                 // Round-trip through BF16 representation: store BF16 in
                 // workspace as F32 so the next-stage RoPE reader sees the
                 // exact dtype-cast values PyTorch's `.to(bf16)` produces.
-                workspace[OFF_Q_NORMED + base + i] = normed;
+                workspace[OFF_Q_NORMED + q_out_base + i] = normed;
                 if (stage == 1) {
-                    output[base + i] = static_cast<T>(normed);
+                    output[q_out_base + i] = static_cast<T>(normed);
                 }
             }
             __syncthreads();
@@ -939,9 +948,11 @@ __global__ void qwen36_moe_attn_step_kernel(
 
     // -- Phase H: gated_attn = bf16(sigmoid(out_gate)) * attn --------------
     //
-    // out_gate is the upper half of q_raw stored at workspace[Q_RAW + H*d:].
-    // Each block grabs one Q head and produces gated_attn[h, :] in workspace.
-    // Oracle math (qwen36_moe_oracle.py line 215):
+    // out_gate is the second-half lane of q_proj's per-head interleaved
+    // output: for head h it lives at workspace[OFF_Q_RAW + h*2*d + d + i]
+    // (HF `view(..., H, head_dim*2).chunk(2, -1)` convention). Each block
+    // grabs one Q head and produces gated_attn[h, :] in workspace.
+    // Oracle math (qwen36_moe_oracle.py `out_gate * attn`):
     //   sigmoid_bf16 = bf16(sigmoid(f32(out_gate)))
     //   gated_attn   = bf16(sigmoid_bf16 * attn)
     {
@@ -955,7 +966,7 @@ __global__ void qwen36_moe_attn_step_kernel(
             if (h >= H) break;
 
             for (int i = tid; i < d; i += block_size) {
-                const float out_gate = workspace[OFF_Q_RAW + H * d + h * d + i];
+                const float out_gate = workspace[OFF_Q_RAW + h * 2 * d + d + i];
                 const float attn_v   = workspace[OFF_ATTN + h * d + i];
                 const float sig      = 1.0f / (1.0f + expf(-out_gate));
                 const float sig_bf   = bf16_round_rne_f32(sig);

--- a/oracle/qwen36_moe_ffn_oracle.py
+++ b/oracle/qwen36_moe_ffn_oracle.py
@@ -281,14 +281,29 @@ def load_tensor(model_dir: Path, name: str, device: str = "cpu") -> torch.Tensor
 # ---------------------------------------------------------------------------
 # Math primitives — kept structurally identical to what the kernel will do
 # ---------------------------------------------------------------------------
-def rms_norm(x: torch.Tensor, weight: torch.Tensor, eps: float) -> torch.Tensor:
-    """RMS norm without add-unit-offset. F32 internals, output in input dtype.
-    Matches the attention oracle's `rms_norm` byte-for-byte so the kernel can
-    reuse the same implementation across the attn + FFN halves of a layer."""
+def rms_norm(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+    add_unit_offset: bool = True,
+) -> torch.Tensor:
+    """RMS norm with the HuggingFace `Qwen3_5MoeRMSNorm` convention.
+    F32 internals, output in input dtype. Matches the attention oracle's
+    `rms_norm` byte-for-byte so the kernel can reuse the same implementation
+    across the attn + FFN halves of a layer.
+
+    `add_unit_offset=True` (default) matches HuggingFace
+    `Qwen3_5MoeRMSNorm`: `output = x_normed * (1.0 + weight)`. Used for
+    `post_attention_layernorm`. The FFN block has no gated-norm site so
+    the parameter is passive here, kept for parity with the attn/linear
+    oracles.
+    """
     in_dtype = x.dtype
     xf = x.to(torch.float32)
     var = xf.pow(2).mean(dim=-1, keepdim=True)
-    out = xf * torch.rsqrt(var + eps) * weight.to(torch.float32)
+    w_f = weight.to(torch.float32)
+    scale = (1.0 + w_f) if add_unit_offset else w_f
+    out = xf * torch.rsqrt(var + eps) * scale
     return out.to(in_dtype)
 
 

--- a/oracle/qwen36_moe_linear_oracle.py
+++ b/oracle/qwen36_moe_linear_oracle.py
@@ -235,12 +235,28 @@ def load_tensor(model_dir: Path, name: str, device: str = "cpu") -> torch.Tensor
 # ---------------------------------------------------------------------------
 # Math primitives
 # ---------------------------------------------------------------------------
-def rms_norm(x: torch.Tensor, weight: torch.Tensor, eps: float) -> torch.Tensor:
-    """RMS norm without add-unit-offset. Computed in F32, output in input dtype."""
+def rms_norm(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+    add_unit_offset: bool = True,
+) -> torch.Tensor:
+    """RMS norm. Computed in F32, output in input dtype.
+
+    `add_unit_offset=True` matches HuggingFace `Qwen3_5MoeRMSNorm`:
+    `output = x_normed * (1.0 + weight)`. Default — used for
+    `input_layernorm` here.
+
+    `add_unit_offset=False` matches HuggingFace `Qwen3_5MoeRMSNormGated`
+    (no offset). Pass explicitly for `linear_attn.norm`, the only site
+    in this oracle that uses the gated convention.
+    """
     in_dtype = x.dtype
     xf = x.to(torch.float32)
     var = xf.pow(2).mean(dim=-1, keepdim=True)
-    out = xf * torch.rsqrt(var + eps) * weight.to(torch.float32)
+    w_f = weight.to(torch.float32)
+    scale = (1.0 + w_f) if add_unit_offset else w_f
+    out = xf * torch.rsqrt(var + eps) * scale
     return out.to(in_dtype)
 
 
@@ -362,9 +378,12 @@ def reference_linear_attn_layer(
     state_after = state + k_rep_f.unsqueeze(-1) * delta.unsqueeze(1)
     recurrent_out = (state_after * q_scaled_f.unsqueeze(-1)).sum(dim=1)   # [V, v_dim]
 
-    # 10. Per-head RMS norm of recurrent output.
+    # 10. Per-head RMS norm of recurrent output. The gated path uses
+    # `Qwen3_5MoeRMSNormGated` in HF — plain `weight`, no `(1+w)` offset.
     rec_out_dtype = recurrent_out.to(dtype)
-    out_normed = rms_norm(rec_out_dtype, norm_w, rms_norm_eps)      # [V, v_dim]
+    out_normed = rms_norm(
+        rec_out_dtype, norm_w, rms_norm_eps, add_unit_offset=False
+    )                                                                # [V, v_dim]
 
     # 11. Z gating (silu(z) elementwise multiply).
     z_heads = z_raw.reshape(V, v_dim)

--- a/oracle/qwen36_moe_oracle.py
+++ b/oracle/qwen36_moe_oracle.py
@@ -230,12 +230,30 @@ def load_tensor(model_dir: Path, name: str, device: str = "cpu") -> torch.Tensor
 # ---------------------------------------------------------------------------
 # Math primitives — kept structurally identical to what the kernel will do
 # ---------------------------------------------------------------------------
-def rms_norm(x: torch.Tensor, weight: torch.Tensor, eps: float) -> torch.Tensor:
-    """RMS norm without add-unit-offset. Computed in F32, output in input dtype."""
+def rms_norm(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+    add_unit_offset: bool = True,
+) -> torch.Tensor:
+    """RMS norm. Computed in F32, output in input dtype.
+
+    `add_unit_offset=True` matches HuggingFace `Qwen3_5MoeRMSNorm`:
+    `output = x_normed * (1.0 + weight)` — the stored weight is a small
+    delta around 0 and the effective scale is `1 + weight`. Used for
+    `input_layernorm`, `post_attention_layernorm`, `q_norm`, `k_norm`,
+    and the final `model.norm`.
+
+    `add_unit_offset=False` matches HuggingFace `Qwen3_5MoeRMSNormGated`
+    (no offset, plain `output = x_normed * weight`) — used for
+    `linear_attn.norm` only. Pass explicitly at that call site.
+    """
     in_dtype = x.dtype
     xf = x.to(torch.float32)
     var = xf.pow(2).mean(dim=-1, keepdim=True)
-    out = xf * torch.rsqrt(var + eps) * weight.to(torch.float32)
+    w_f = weight.to(torch.float32)
+    scale = (1.0 + w_f) if add_unit_offset else w_f
+    out = xf * torch.rsqrt(var + eps) * scale
     return out.to(in_dtype)
 
 

--- a/oracle/qwen36_moe_oracle.py
+++ b/oracle/qwen36_moe_oracle.py
@@ -347,12 +347,24 @@ def reference_full_attention_layer(
     v_raw = x_norm @ v_proj_w.T  # [Hkv*d]
 
     # 3. Split Q's gate off and reshape per-head.
-    q_lanes = q_raw[: H * d]
-    out_gate_lanes = q_raw[H * d :]
-    q_heads = q_lanes.reshape(H, d)            # [H, d]
+    #
+    # HF `Qwen3_5MoeAttention.forward` (line 672 of modeling_qwen3_5_moe.py)
+    # does:
+    #   query_states, gate = torch.chunk(
+    #       q_proj(x).view(*input_shape, -1, head_dim * 2), 2, dim=-1)
+    # i.e. reshape the flat `[H*2*d]` q_proj output to `[H, 2*d]` then
+    # chunk on the last dim. This makes the layout per-head interleaved
+    # `[q_h | gate_h]`: for head h, channels `[h*2d, h*2d+d)` are q, and
+    # `[h*2d+d, (h+1)*2d)` are the output gate. The trained q_proj weight
+    # rows are organized in this same order, so we MUST follow HF's
+    # convention — splitting flat `[:H*d]`/`[H*d:]` reads gate values
+    # into q (and vice versa) once h ≥ 1.
+    q_paired = q_raw.reshape(H, 2 * d)         # [H, 2*d]
+    q_heads, out_gate = torch.chunk(q_paired, 2, dim=-1)  # each [H, d]
+    q_lanes = q_heads.reshape(H * d)
+    out_gate_lanes = out_gate.reshape(H * d)
     k_heads = k_raw.reshape(Hkv, d)            # [Hkv, d]
     v_heads = v_raw.reshape(Hkv, d)            # [Hkv, d]
-    out_gate = out_gate_lanes.reshape(H, d)    # [H, d]
 
     # 4. Per-head Q/K RMS norm.
     q_normed = rms_norm(q_heads, q_norm_w, rms_norm_eps)


### PR DESCRIPTION
## Summary

Two HF-vs-SuperSonic decode-math discrepancies were causing gibberish
end-to-end output for Qwen3.6-MoE on the local INT4 GPTQ bake, even
though every per-block kernel was bit-exact against our hand-rolled
oracle and the multi-layer kernel chain matched the oracle through
traced layers. Both bugs come from the oracle implementing math that
self-consistently disagreed with HuggingFace's
`Qwen3_5MoeDecoderLayer`. Fix is to bring the oracle (and the kernel
that mirrors it) onto HF's exact convention.

### Bug 1: RMSNorm missing `(1.0 + weight)` unit offset
HF `Qwen3_5MoeRMSNorm.forward`
([modeling_qwen3_5_moe.py:819](https://github.com/huggingface/transformers))
computes `output * (1.0 + self.weight.float())` — stored weight is a
delta around zero, effective scale is `1 + w`. Our oracles + kernel +
host code did plain `output * weight`, scaling norm output to ~zero
against trained delta weights. Affects `input_layernorm`,
`post_attention_layernorm`, `q_norm`, `k_norm`, and the final
`model.norm`. The gated `linear_attn.norm` (HF
`Qwen3_5MoeRMSNormGated`) correctly stays without the offset.

### Bug 2: q_proj per-head interleaved [q | gate] split
HF `Qwen3_5MoeAttention.forward` does
`q_proj(x).view(..., H, head_dim*2).chunk(2, dim=-1)` — for head h,
output channels `[h*2d, h*2d+d)` are q and `[h*2d+d, (h+1)*2d)` are
the output gate. The trained weight rows are stored in this same
interleaved order. Our oracle + kernel were doing a flat split
(`[:H*d]` for all q heads, `[H*d:]` for all gates), which is correct
only for head 0 and reads gate values into q (and vice versa) for
heads ≥ 1.

### End-to-end result on the local v2-int4-gptq bake (no rebake)
Before: `> The quick brown fox storeparepareUDAUDAUDAUDAUDA` /
`::.::.::.::.::.::.::.::.`

After (RMSNorm fix only): `> The quick brown fox denun denun denun
denun denun denun denun denun` (responds to math change but still
degenerate).

After both fixes: `> The quick brown fox jumps over the lazy dog.`

## Test plan

- [ ] `cargo test --release -p runner --lib qwen36_moe` — passes (5/5
  including new `rms_norm_unit_offset_zero_weight_is_identity_scale`
  guard).
- [ ] Per-block parity tests under `kernel-ffi::qwen36_moe` (gated by
  `SUPERSONIC_QWEN36_ORACLE_JSON` env var) — regenerate JSON via the
  corresponding oracle script before running; both kernel and oracle
  use the new convention so intermediates remain bit-identical.
- [x] End-to-end smoke against the local 35B-A3B INT4 bake produces
  the canonical pangram completion: ` jumps`, ` over`, ` the`,
  ` lazy`, ` dog`, `.`, `\n\n`, ` ```` ` (token ids
  `[33075, 888, 279, 15217, 5388, 13, 271, 71093]`).
- [ ] Multi-layer parity test
  `qwen36_moe_multilayer_parity` — needs JSON regeneration via
  `oracle/qwen36_moe_multilayer_oracle.py` if previously cached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)