### PR TITLE
oracle: qwen36-moe bake cos_sim survey + audit doc refresh

### DIFF
--- a/docs/qwen36-moe-bake-quality-audit.md
+++ b/docs/qwen36-moe-bake-quality-audit.md
@@ -227,3 +227,69 @@ chain bug via a per-layer parity harness on real bake weights — load
 layer N's INT4 from the bake, run kernel + Python single-layer ref
 side-by-side, find which layer's output first diverges. That will
 isolate the kernel bug independent of the bake.
+
+## Update: HF parity bugs were the real blocker (PR #64)
+
+The "kernel chain produces near-random output" symptom traced to two
+HF-vs-SuperSonic decode-math discrepancies, NOT bake quality:
+
+  1. **`Qwen3_5MoeRMSNorm` `(1.0 + weight)` unit offset** (line 819 of
+     `transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py`). Our
+     oracles + kernel + host code were doing plain `output * weight`,
+     which scales norm output to ~zero against trained delta weights.
+  2. **`q_proj` per-head interleaved `[q | gate]` split.** HF reshapes
+     via `q_proj(x).view(..., H, head_dim*2).chunk(2, -1)`; we were
+     splitting flat `[:H*d]`/`[H*d:]`, which only happens to work for
+     head 0.
+
+After PR #64 lands, end-to-end on the SAME `v2-int4-gptq` bake — no
+rebake — produces:
+
+    "The quick brown fox" → "jumps over the lazy dog."
+    "The capital of France is" → "Paris. Paris is the most populous
+                                  city in the European Union, …"
+    "Q: List three primary colors. A:" → "Red, Yellow, and Blue.<EOS>"
+    Python Fibonacci prompt → 80 tokens of correct, indented code
+
+Per-tensor cos_sim survey on `v2-int4-gptq` post-scale-search,
+re-measured with **F64 reductions** (F32 reductions on tensors
+≥100M elements — e.g. lm_head — under-estimate norms enough to push
+cos_sim above 1.0; it came out at 1.20 before fixing the precision):
+
+| Class                                            | mean cos_sim | min    | tile count |
+|--------------------------------------------------|--------------|--------|------------|
+| `mlp.experts.gate_up_proj`  (fused, GPTQ)        | 0.987–0.993  | 0.957  | 128/expert |
+| `mlp.experts.down_proj`     (fused, GPTQ)        | 0.987–0.993  | 0.960  | 64/expert  |
+| `lm_head.weight`                                 | 0.987        | 0.987  | 31040      |
+| `linear_attn.in_proj_z`                          | 0.982        | 0.982  | 512        |
+| `self_attn.k_proj`                               | 0.984        | 0.984  | 64         |
+| `self_attn.q_proj`                               | 0.978        | 0.978  | 1024       |
+| `self_attn.v_proj`                               | 0.969        | 0.969  | 64         |
+| `self_attn.o_proj`                               | 0.936        | 0.936  | 512        |
+| `linear_attn.in_proj_qkv`                        | 0.961        | 0.961  | 1024       |
+| `linear_attn.out_proj`                           | 0.942        | 0.942  | 512        |
+| `mlp.shared_expert.gate_proj`                    | 0.928–0.967  | 0.928  | 64         |
+| `mlp.shared_expert.up_proj`                      | 0.973–0.978  | 0.973  | 64         |
+| `mlp.shared_expert.down_proj`                    | 0.949–0.957  | 0.949  | 64         |
+
+The audit's earlier "experts are min/max-only" finding is now stale —
+scale search (commit `91d7185`) was applied to BOTH the dense GPTQ
+path AND the fused-expert path, lifting MoE-expert cos_sim into the
+0.987–0.993 band. The remaining gap to ≥ 0.98 is concentrated in the
+**dense layer-OUTPUT projections** (`o_proj`, `out_proj`, `down_proj`,
+`shared_expert.gate_proj`) — they sit at the END of GPTQ's
+sequential-calibration order and inherit the most accumulated error
+from the projections quantized before them.
+
+End-to-end output suggests the existing bake is now **functionally
+adequate** for production use even though the formal ≥ 0.98 acceptance
+bar isn't met on every tensor. Closing the remaining 1–7% gap on the
+worst tensors is a separate, lower-priority quality push (Options 2,
+4 from this doc) — no longer blocking coherent decode.
+
+The survey is reproducible via:
+
+    ~/venvs/rocm/bin/python oracle/qwen36_moe_bake_cossim_survey.py \
+        --model-dir <snapshot> \
+        --bake-dir <snapshot>/.supersonic/v2-int4-gptq \
+        --layers 0,3 --out /tmp/qwen36_cossim_survey.tsv

--- a/oracle/qwen36_moe_bake_cossim_survey.py
+++ b/oracle/qwen36_moe_bake_cossim_survey.py
@@ -42,9 +42,18 @@ def find_shard_for(model_dir: Path, name: str) -> Path:
             raise TensorAbsent(f"tensor not in safetensors index: {name}")
         return model_dir / wm[name]
     single = model_dir / "model.safetensors"
-    if single.exists():
-        return single
-    raise SystemExit(f"no safetensors at {model_dir}")
+    if not single.exists():
+        raise SystemExit(f"no safetensors at {model_dir}")
+    # Single-file mode: there's no index to consult, so probe the file's
+    # tensor keys directly. Without this, `load_safetensors` would call
+    # `get_tensor(name)` for tensors that legitimately don't exist for
+    # this layer type (e.g. `self_attn.*` on a linear-attn layer) and
+    # safetensors would raise — which would now propagate past
+    # `TensorAbsent` and abort the survey. Header-only open is cheap.
+    with safe_open(str(single), framework="pt", device="cpu") as f:
+        if name not in f.keys():
+            raise TensorAbsent(f"tensor not in single-file safetensors: {name}")
+    return single
 
 
 def load_safetensors(model_dir: Path, name: str) -> torch.Tensor:

--- a/oracle/qwen36_moe_bake_cossim_survey.py
+++ b/oracle/qwen36_moe_bake_cossim_survey.py
@@ -16,7 +16,6 @@ import argparse
 import json
 import sys
 from pathlib import Path
-from typing import Callable
 
 import torch
 from safetensors import safe_open
@@ -27,12 +26,20 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _bake_loader import load_int4, load_int4_3d  # noqa: E402
 
 
+class TensorAbsent(Exception):
+    """Raised when a tensor name is legitimately absent for this layer
+    type (e.g. asking for `self_attn.q_proj` on a linear-attention
+    layer). Distinguishes legit-absent from real corruption (tensor is
+    expected but missing from one side, or shape mismatch) so the
+    caller can skip the former and surface the latter."""
+
+
 def find_shard_for(model_dir: Path, name: str) -> Path:
     idx_path = model_dir / "model.safetensors.index.json"
     if idx_path.exists():
         wm = json.loads(idx_path.read_text())["weight_map"]
         if name not in wm:
-            raise SystemExit(f"tensor not in safetensors index: {name}")
+            raise TensorAbsent(f"tensor not in safetensors index: {name}")
         return model_dir / wm[name]
     single = model_dir / "model.safetensors"
     if single.exists():
@@ -61,8 +68,19 @@ def cos_sim_2d(recon: torch.Tensor, ref: torch.Tensor) -> float:
 def survey_dense(
     bake_dir: str, model_dir: Path, name: str
 ) -> tuple[tuple[int, ...], int, float]:
+    """Returns (shape, tiles, cos_sim).
+
+    Raises `TensorAbsent` when the tensor is legitimately not present
+    for this layer type (caller should skip silently). Any other
+    failure — bake missing a tensor that safetensors has, shape
+    mismatch, dequant error — propagates to surface real corruption.
+    """
+    # Safetensors is the source of truth for "does this tensor exist
+    # for this layer type". Probe there first; if absent, it's a legit
+    # layer-type miss and the caller should skip. If present, anything
+    # below this point that fails is a real error.
+    ref = load_safetensors(model_dir, name)  # raises TensorAbsent
     recon, _packed, _s, _z = load_int4(bake_dir, name)
-    ref = load_safetensors(model_dir, name)
     if recon.shape != ref.shape:
         raise SystemExit(
             f"{name}: shape mismatch recon {tuple(recon.shape)} vs "
@@ -76,9 +94,13 @@ def survey_dense(
 def survey_fused(
     bake_dir: str, model_dir: Path, name: str
 ) -> tuple[tuple[int, ...], int, float, float, float]:
-    """Returns (shape, tiles_per_expert, mean cos_sim, min, max)."""
+    """Returns (shape, tiles_per_expert, mean cos_sim, min, max).
+
+    Same failure-mode contract as `survey_dense`: `TensorAbsent` for
+    legit layer-type miss; everything else propagates.
+    """
+    ref = load_safetensors(model_dir, name)  # raises TensorAbsent
     recon, _packed, _s, _z = load_int4_3d(bake_dir, name)
-    ref = load_safetensors(model_dir, name)
     if recon.shape != ref.shape:
         raise SystemExit(
             f"{name}: shape mismatch recon {tuple(recon.shape)} vs "
@@ -113,10 +135,14 @@ def main() -> None:
     rows: list[tuple[str, str, str, float, float, float]] = []  # (name, shape, tiles, mean, min, max)
 
     def add_dense(name: str) -> None:
+        # Only TensorAbsent is "expected miss for this layer type" — any
+        # other exception (KeyError from a bake manifest miss when the
+        # tensor IS in safetensors, SystemExit from a shape mismatch,
+        # dequant error) is real corruption and must surface.
         try:
             shape, tiles, cs = survey_dense(bake_dir, args.model_dir, name)
-        except (SystemExit, KeyError) as e:
-            return  # tensor doesn't exist for this layer type — quiet skip.
+        except TensorAbsent:
+            return
         rows.append((name, str(shape), str(tiles), cs, cs, cs))
 
     def add_fused(name: str) -> None:
@@ -124,7 +150,7 @@ def main() -> None:
             shape, tiles, cs_mean, cs_min, cs_max = survey_fused(
                 bake_dir, args.model_dir, name
             )
-        except (SystemExit, KeyError):
+        except TensorAbsent:
             return
         rows.append((name, str(shape), f"{tiles}/expert", cs_mean, cs_min, cs_max))
 

--- a/oracle/qwen36_moe_bake_cossim_survey.py
+++ b/oracle/qwen36_moe_bake_cossim_survey.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Per-tensor cos_sim survey of an INT4 GPTQ bake vs the safetensors
+ground truth. Prints a simple table so we can see which tensors are
+limiting bake quality after the latest baker changes (scale search on
+both dense + fused expert paths).
+
+Run:
+  ~/venvs/rocm/bin/python oracle/qwen36_moe_bake_cossim_survey.py \\
+      --model-dir <snapshot> --bake-dir <snapshot>/.supersonic/v2-int4-gptq \\
+      --layers 0,3 --out /tmp/qwen36_cossim_survey.tsv
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Callable
+
+import torch
+from safetensors import safe_open
+
+# Make sibling modules importable when run as a script.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _bake_loader import load_int4, load_int4_3d  # noqa: E402
+
+
+def find_shard_for(model_dir: Path, name: str) -> Path:
+    idx_path = model_dir / "model.safetensors.index.json"
+    if idx_path.exists():
+        wm = json.loads(idx_path.read_text())["weight_map"]
+        if name not in wm:
+            raise SystemExit(f"tensor not in safetensors index: {name}")
+        return model_dir / wm[name]
+    single = model_dir / "model.safetensors"
+    if single.exists():
+        return single
+    raise SystemExit(f"no safetensors at {model_dir}")
+
+
+def load_safetensors(model_dir: Path, name: str) -> torch.Tensor:
+    path = find_shard_for(model_dir, name)
+    with safe_open(str(path), framework="pt", device="cpu") as f:
+        return f.get_tensor(name)
+
+
+def cos_sim_2d(recon: torch.Tensor, ref: torch.Tensor) -> float:
+    # F64 reductions: F32 dot/norm on 100M+ element tensors loses enough
+    # precision to push cos_sim above 1.0 (lm_head.weight @ 508M elements
+    # comes out at 1.20 in F32 but the correct value is 0.987 in F64).
+    a = recon.to(torch.float64).reshape(-1)
+    b = ref.to(torch.float64).reshape(-1)
+    denom = (a.norm() * b.norm()).item()
+    if denom == 0.0:
+        return float("nan")
+    return float((a @ b).item() / denom)
+
+
+def survey_dense(
+    bake_dir: str, model_dir: Path, name: str
+) -> tuple[tuple[int, ...], int, float]:
+    recon, _packed, _s, _z = load_int4(bake_dir, name)
+    ref = load_safetensors(model_dir, name)
+    if recon.shape != ref.shape:
+        raise SystemExit(
+            f"{name}: shape mismatch recon {tuple(recon.shape)} vs "
+            f"safetensors {tuple(ref.shape)}"
+        )
+    out, in_ = ref.shape[-2], ref.shape[-1]
+    tiles = (out // 128) * (in_ // 128) if (out % 128 == 0 and in_ % 128 == 0) else 0
+    return tuple(ref.shape), tiles, cos_sim_2d(recon, ref)
+
+
+def survey_fused(
+    bake_dir: str, model_dir: Path, name: str
+) -> tuple[tuple[int, ...], int, float, float, float]:
+    """Returns (shape, tiles_per_expert, mean cos_sim, min, max)."""
+    recon, _packed, _s, _z = load_int4_3d(bake_dir, name)
+    ref = load_safetensors(model_dir, name)
+    if recon.shape != ref.shape:
+        raise SystemExit(
+            f"{name}: shape mismatch recon {tuple(recon.shape)} vs "
+            f"safetensors {tuple(ref.shape)}"
+        )
+    e, out, in_ = ref.shape
+    tiles = (out // 128) * (in_ // 128)
+    cs = []
+    for i in range(e):
+        cs.append(cos_sim_2d(recon[i], ref[i]))
+    cs_t = torch.tensor(cs)
+    return tuple(ref.shape), tiles, float(cs_t.mean()), float(cs_t.min()), float(cs_t.max())
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--model-dir", type=Path, required=True,
+                   help="Path to HuggingFace safetensors directory.")
+    p.add_argument("--bake-dir", type=Path, required=True,
+                   help="Path to SuperSonic INT4 GPTQ bake directory.")
+    p.add_argument("--weight-prefix", default="model.language_model")
+    p.add_argument("--layers", default="0,3",
+                   help="Comma-separated layer indices to survey "
+                        "(default: 0 = first linear-attn, 3 = first full-attn).")
+    p.add_argument("--out", type=Path, default=None,
+                   help="Optional TSV path; otherwise stdout only.")
+    args = p.parse_args()
+
+    layers = [int(x) for x in args.layers.split(",") if x]
+    bake_dir = str(args.bake_dir)
+
+    rows: list[tuple[str, str, str, float, float, float]] = []  # (name, shape, tiles, mean, min, max)
+
+    def add_dense(name: str) -> None:
+        try:
+            shape, tiles, cs = survey_dense(bake_dir, args.model_dir, name)
+        except (SystemExit, KeyError) as e:
+            return  # tensor doesn't exist for this layer type — quiet skip.
+        rows.append((name, str(shape), str(tiles), cs, cs, cs))
+
+    def add_fused(name: str) -> None:
+        try:
+            shape, tiles, cs_mean, cs_min, cs_max = survey_fused(
+                bake_dir, args.model_dir, name
+            )
+        except (SystemExit, KeyError):
+            return
+        rows.append((name, str(shape), f"{tiles}/expert", cs_mean, cs_min, cs_max))
+
+    for li in layers:
+        lp = f"{args.weight_prefix}.layers.{li}"
+        # Linear attn projections (only when this layer is linear).
+        for sub in ("linear_attn.in_proj_qkv", "linear_attn.in_proj_z",
+                    "linear_attn.out_proj"):
+            add_dense(f"{lp}.{sub}.weight")
+        # Full attn projections (only when this layer is full attn).
+        for sub in ("self_attn.q_proj", "self_attn.k_proj",
+                    "self_attn.v_proj", "self_attn.o_proj"):
+            add_dense(f"{lp}.{sub}.weight")
+        # MoE shared expert (always present).
+        for sub in ("shared_expert.gate_proj", "shared_expert.up_proj",
+                    "shared_expert.down_proj"):
+            add_dense(f"{lp}.mlp.{sub}.weight")
+        # MoE fused experts.
+        add_fused(f"{lp}.mlp.experts.gate_up_proj")
+        add_fused(f"{lp}.mlp.experts.down_proj")
+
+    # lm_head if quantized in the bake.
+    add_dense("lm_head.weight")
+
+    # Print table.
+    name_w = max(20, max(len(r[0]) for r in rows) if rows else 20)
+    shape_w = max(18, max(len(r[1]) for r in rows) if rows else 18)
+    print(f"{'tensor'.ljust(name_w)}  {'shape'.ljust(shape_w)}  "
+          f"{'tiles'.rjust(12)}  {'cos_sim'.rjust(8)}  "
+          f"{'min'.rjust(8)}  {'max'.rjust(8)}")
+    print("-" * (name_w + shape_w + 12 + 8 + 8 + 8 + 10))
+    for name, shape, tiles, mean, mn, mx in rows:
+        flag = "  <0.98" if mean < 0.98 else ""
+        print(f"{name.ljust(name_w)}  {shape.ljust(shape_w)}  "
+              f"{tiles.rjust(12)}  {mean:8.4f}  {mn:8.4f}  {mx:8.4f}{flag}")
+
+    if args.out is not None:
+        with args.out.open("w") as f:
+            f.write("name\tshape\ttiles\tcos_sim_mean\tcos_sim_min\tcos_sim_max\n")
+            for name, shape, tiles, mean, mn, mx in rows:
+                f.write(f"{name}\t{shape}\t{tiles}\t{mean:.6f}\t{mn:.6f}\t{mx:.6f}\n")
+        print(f"\nWrote {args.out}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `oracle/qwen36_moe_bake_cossim_survey.py` — per-tensor INT4-recon vs safetensors cos_sim across the bake, broken down by layer / projection / fused-expert.
- Refreshes `docs/qwen36-moe-bake-quality-audit.md` with the post-PR-#64 state. The audit's earlier framing ("kernel chain bug, NOT bake quality") was correct in spirit but the recommended-next-step had been overtaken by events: PR #64's HF-parity fixes (RMSNorm `(1+w)` offset + q_proj per-head split) closed the gap, not bake work.
- Documents an F64-precision pitfall that was masking the real lm_head cos_sim: F32 dot/norm on ≥100M element tensors loses enough precision to push cos_sim above 1.0 (lm_head came out at 1.20 in F32 vs 0.987 in F64).

## Findings

After re-running the survey on `v2-int4-gptq` with F64 reductions:

| Class                                         | mean cos_sim   | min    |
|-----------------------------------------------|----------------|--------|
| `mlp.experts.gate_up_proj` / `down_proj`      | 0.987–0.993    | 0.957  |
| `lm_head.weight`                              | 0.987          | 0.987  |
| `linear_attn.in_proj_z`, `self_attn.k_proj`   | 0.982–0.984    | —      |
| Layer-OUTPUT projections (`o_proj`, `out_proj`, `down_proj`, `shared_expert.gate_proj`) | 0.928–0.967 | 0.928  |
| Other dense projections                       | 0.961–0.978    | —      |

Scale search (commit `91d7185`) was applied to BOTH the dense GPTQ path AND the fused-expert path — the audit's earlier "experts are min/max-only" caveat is stale. Fused-expert cos_sim is now in the 0.987–0.993 band.

The remaining ≥0.98 gap is concentrated in dense layer-output projections (`o_proj`, `out_proj`, `down_proj`, `shared_expert.gate_proj`) — they sit at the end of GPTQ's sequential-calibration order and inherit the most accumulated error. End-to-end output (correct Python Fibonacci, factual Q&A, narrative continuation) suggests the existing bake is functionally adequate; closing the cos_sim gap is now a lower-priority quality push, not a coherent-decode blocker.

## Test plan

- [x] Survey runs end-to-end against the local 35B-A3B `v2-int4-gptq` bake; numbers match the table above.
- [x] F32 lm_head cos_sim (1.20) reproduces the precision bug; F64 (0.987) is in expected range.
- [ ] Reviewer can re-run the survey on any other Qwen3.6-MoE bake to verify reproducibility:
      ```
      ~/venvs/rocm/bin/python oracle/qwen36_moe_bake_cossim_survey.py \\
          --model-dir <snapshot> \\
          --bake-dir <snapshot>/.supersonic/v2-int4-gptq \\
          --layers 0,3 --out /tmp/qwen36_cossim_survey.tsv
      ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)