### PR TITLE
qwen36-moe: stage timings + GPU lm_head + 8-wide INT4 + chain breakdown (~4.4× per-token)

### DIFF
--- a/crates/kernel-ffi/src/qwen36_moe.rs
+++ b/crates/kernel-ffi/src/qwen36_moe.rs
@@ -445,6 +445,35 @@ extern "C" {
         barrier_counter: *mut c_uint,
         barrier_flag: *mut c_uint,
     ) -> c_int;
+
+    /// Final RMSNorm + lm_head GEMV in a single kernel — replaces the
+    /// host-side `host_final_norm_lm_head_f32` for qwen3.6-MoE.
+    ///
+    /// All buffers are device pointers, all BF16 (`dtype = 2`):
+    ///   - `final_hidden`: [hidden] BF16, the output of `run_chained_decode`.
+    ///   - `final_norm_w`: [hidden] BF16 — `model.norm.weight`. Applies the
+    ///      HF `Qwen3_5MoeRMSNorm` `(1 + w)` unit offset.
+    ///   - `lm_head_w`: [vocab, hidden] BF16, dequantized once at startup.
+    ///   - `logits`: [vocab] BF16, output.
+    ///   - `counter`: [1] u32. Used as a work-stealing atomic across vocab
+    ///     rows; the launcher memsets it to 0 before each call so the
+    ///     caller doesn't need to.
+    ///
+    /// Returns 0 on success; non-zero on validation / launch failure (see
+    /// `qwen36_moe_hip_lm_head_launch` in `kernels/qwen36_moe_bridge.cpp`
+    /// for the error code matrix).
+    pub fn qwen36_moe_hip_lm_head_launch(
+        dtype: c_int,
+        device_ordinal: usize,
+        hidden: c_int,
+        vocab: c_int,
+        rms_norm_eps: f32,
+        final_hidden: *const c_void,
+        final_norm_w: *const c_void,
+        lm_head_w: *const c_void,
+        logits: *mut c_void,
+        counter: *mut c_uint,
+    ) -> c_int;
 }
 
 /// Safe wrapper over the stub launch. The engine pre-allocates `sync_buf`
@@ -1168,6 +1197,88 @@ pub fn int4_dequant_smoke_launch(
         return Err(GpuError::backend(
             backend,
             format!("qwen36_moe int4_dequant_smoke_launch failed with status {status}"),
+        ));
+    }
+    Ok(())
+}
+
+/// Safe wrapper for the GPU final RMSNorm + lm_head GEMV.
+///
+/// All buffers must already be on `ordinal` and BF16:
+///   - `final_hidden_buf`: shape `[hidden]`.
+///   - `final_norm_w_buf`: shape `[hidden]` — `model.norm.weight`.
+///   - `lm_head_w_buf`: shape `[vocab, hidden]`. Caller is responsible
+///     for dequantizing INT4 / BF16-casting it once at startup.
+///   - `logits_buf`: shape `[vocab]`, output. Overwritten on every call.
+///   - `counter_buf`: shape `[1]` U32. Used as the work-stealing counter
+///     across vocab rows; the launcher memsets it to 0 before each call.
+#[allow(clippy::too_many_arguments)]
+pub fn lm_head_launch(
+    ordinal: usize,
+    hidden: i32,
+    vocab: i32,
+    rms_norm_eps: f32,
+    final_hidden_buf: &GpuBuffer,
+    final_norm_w_buf: &GpuBuffer,
+    lm_head_w_buf: &GpuBuffer,
+    logits_buf: &mut GpuBuffer,
+    counter_buf: &mut GpuBuffer,
+) -> Result<(), GpuError> {
+    if hidden <= 0 || vocab <= 0 {
+        return Err(GpuError::InvalidArg(format!(
+            "qwen36_moe::lm_head_launch: positive dims required, \
+             got hidden={hidden} vocab={vocab}"
+        )));
+    }
+    let block_size: i32 = 256;
+    if hidden % block_size != 0 {
+        return Err(GpuError::InvalidArg(format!(
+            "qwen36_moe::lm_head_launch: hidden ({hidden}) must be a \
+             multiple of block_size ({block_size}) — the per-block \
+             reduction across hidden assumes that"
+        )));
+    }
+
+    let backend = lm_head_w_buf.backend();
+    let status = match backend {
+        Backend::Hip => {
+            #[cfg(supersonic_backend_hip)]
+            unsafe {
+                qwen36_moe_hip_lm_head_launch(
+                    /* dtype = bf16 */ 2,
+                    ordinal,
+                    hidden as c_int,
+                    vocab as c_int,
+                    rms_norm_eps,
+                    final_hidden_buf.as_ptr(),
+                    final_norm_w_buf.as_ptr(),
+                    lm_head_w_buf.as_ptr(),
+                    logits_buf.as_mut_ptr(),
+                    counter_buf.as_mut_ptr() as *mut c_uint,
+                )
+            }
+            #[cfg(not(supersonic_backend_hip))]
+            {
+                return Err(GpuError::InvalidArg(
+                    "qwen36_moe::lm_head_launch: HIP backend not compiled".into(),
+                ));
+            }
+        }
+        Backend::Cuda => {
+            return Err(GpuError::InvalidArg(
+                "qwen36_moe::lm_head_launch: CUDA backend not yet wired".into(),
+            ));
+        }
+        Backend::Metal => {
+            return Err(GpuError::InvalidArg(
+                "qwen36_moe::lm_head_launch: Metal backend not yet wired".into(),
+            ));
+        }
+    };
+    if status != 0 {
+        return Err(GpuError::backend(
+            backend,
+            format!("qwen36_moe lm_head_launch failed with status {status}"),
         ));
     }
     Ok(())
@@ -5094,5 +5205,168 @@ mod tests {
         // group 0 to group 1 (boundary at col=4); spans starting at col=8
         // cross 2→3. Exercises the per-element `g0 != g7` slow path.
         run_int4_dequant_smoke(8, 16, 4, "slow (gsz=4)");
+    }
+
+    /// HIP parity test for the GPU final-RMSNorm + lm_head GEMV kernel.
+    /// Builds a small synthetic vocab=512 / hidden=256 problem on the host,
+    /// runs both:
+    ///   - an F32 reference (the same math as
+    ///     `qwen36_moe_decode::host_final_norm_lm_head_f32`), and
+    ///   - the GPU kernel via `lm_head_launch`,
+    /// then asserts the BF16 logits agree by cosine similarity ≥ 0.999.
+    /// Bit-exactness isn't required: the GPU path multiplies BF16 values
+    /// with F32 accumulation and rounds the final logit to BF16, so it's
+    /// strictly less precise than the host F32-throughout reference. A
+    /// high cos_sim catches any systematic kernel bug while tolerating
+    /// the inherent BF16 rounding noise.
+    #[cfg(supersonic_backend_hip)]
+    #[test]
+    fn qwen36_moe_lm_head_matches_host_f32_reference() {
+        use gpu_hal::{copy_d2h, set_backend, Backend, GpuBuffer, ScalarType};
+
+        set_backend(Backend::Hip);
+        let ordinal = 0usize;
+        let hidden: i32 = 256;
+        let vocab: i32 = 512;
+        let eps: f32 = 1e-6;
+
+        // Deterministic seeded data — same convention the per-block oracles
+        // use (~N(0, 1/sqrt(fan_in)) so logits stay O(1)).
+        fn xorshift(state: &mut u32) -> f32 {
+            let mut x = *state;
+            x ^= x << 13;
+            x ^= x >> 17;
+            x ^= x << 5;
+            *state = x;
+            // Map u32 → roughly N(0, 1) via Box-Muller-light: fold to (-1, 1).
+            ((x & 0xFFFFFF) as f32 / 0xFFFFFF as f32) * 2.0 - 1.0
+        }
+        let mut rng = 0xC0FFEEu32;
+        let mut bf16_round = |v: f32| -> u16 {
+            let bits = v.to_bits();
+            let rounding_bias = 0x7FFFu32 + ((bits >> 16) & 1);
+            ((bits.wrapping_add(rounding_bias)) >> 16) as u16
+        };
+
+        let final_hidden_f32: Vec<f32> =
+            (0..hidden).map(|_| xorshift(&mut rng) * 0.5).collect();
+        let final_norm_w_f32: Vec<f32> =
+            (0..hidden).map(|_| xorshift(&mut rng) * 0.02).collect();
+        // lm_head: ~N(0, 1/sqrt(hidden)).
+        let scale = 1.0 / (hidden as f32).sqrt();
+        let lm_head_f32: Vec<f32> = (0..(vocab as usize) * (hidden as usize))
+            .map(|_| xorshift(&mut rng) * scale)
+            .collect();
+
+        // Pack to BF16 little-endian bytes for the GPU upload.
+        let to_bf16_bytes = |xs: &[f32]| -> Vec<u8> {
+            let mut out = Vec::with_capacity(xs.len() * 2);
+            for &v in xs {
+                let b = bf16_round(v);
+                out.push((b & 0xFF) as u8);
+                out.push((b >> 8) as u8);
+            }
+            out
+        };
+        let final_hidden_bytes = to_bf16_bytes(&final_hidden_f32);
+        let final_norm_w_bytes = to_bf16_bytes(&final_norm_w_f32);
+        let lm_head_bytes = to_bf16_bytes(&lm_head_f32);
+
+        // F32 reference (matches `host_final_norm_lm_head_f32`).
+        let bf16_to_f32 = |bytes: &[u8]| -> Vec<f32> {
+            bytes
+                .chunks_exact(2)
+                .map(|c| {
+                    let bits = ((c[1] as u32) << 24) | ((c[0] as u32) << 16);
+                    f32::from_bits(bits)
+                })
+                .collect()
+        };
+        let h_f32 = bf16_to_f32(&final_hidden_bytes);
+        let nw_f32 = bf16_to_f32(&final_norm_w_bytes);
+        let lm_f32 = bf16_to_f32(&lm_head_bytes);
+        let mean_sq = h_f32.iter().map(|&x| x * x).sum::<f32>() / hidden as f32;
+        let rsqrt = 1.0 / (mean_sq + eps).sqrt();
+        let normed: Vec<f32> = h_f32
+            .iter()
+            .zip(nw_f32.iter())
+            .map(|(&x, &w)| x * rsqrt * (1.0 + w))
+            .collect();
+        let mut want_logits_f32 = vec![0f32; vocab as usize];
+        for v in 0..vocab as usize {
+            let row = v * hidden as usize;
+            let mut acc = 0f64;
+            for h in 0..hidden as usize {
+                acc += lm_f32[row + h] as f64 * normed[h] as f64;
+            }
+            want_logits_f32[v] = acc as f32;
+        }
+
+        // GPU path.
+        let final_hidden_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden as usize], &final_hidden_bytes,
+        ).expect("upload final_hidden");
+        let final_norm_w_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden as usize], &final_norm_w_bytes,
+        ).expect("upload final_norm_w");
+        let lm_head_w_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[vocab as usize, hidden as usize], &lm_head_bytes,
+        ).expect("upload lm_head_w");
+        let mut logits_buf = GpuBuffer::zeros(
+            ordinal, ScalarType::BF16, &[vocab as usize],
+        ).expect("alloc logits");
+        let mut counter_buf = GpuBuffer::zeros(ordinal, ScalarType::U32, &[1])
+            .expect("alloc counter");
+
+        super::lm_head_launch(
+            ordinal,
+            hidden,
+            vocab,
+            eps,
+            &final_hidden_buf,
+            &final_norm_w_buf,
+            &lm_head_w_buf,
+            &mut logits_buf,
+            &mut counter_buf,
+        ).expect("lm_head launch");
+
+        let mut got_bytes = vec![0u8; vocab as usize * 2];
+        copy_d2h(
+            ordinal,
+            got_bytes.as_mut_ptr() as *mut _,
+            logits_buf.as_ptr(),
+            got_bytes.len(),
+        ).expect("d2h logits");
+        let got_logits = bf16_to_f32(&got_bytes);
+
+        // BF16 cos_sim: should be very high (≥ 0.999) because both paths
+        // converge on the same dot product modulo BF16 rounding noise on
+        // the GPU side. Use F64 reductions to avoid the same precision
+        // pitfall the bake survey hit on lm_head (PR #67).
+        let dot: f64 = got_logits.iter().zip(want_logits_f32.iter())
+            .map(|(&a, &b)| a as f64 * b as f64).sum();
+        let na: f64 = got_logits.iter().map(|&x| (x as f64).powi(2)).sum::<f64>().sqrt();
+        let nb: f64 = want_logits_f32.iter().map(|&x| (x as f64).powi(2)).sum::<f64>().sqrt();
+        let cos_sim = dot / (na * nb);
+        assert!(
+            cos_sim >= 0.999,
+            "GPU lm_head logits cos_sim {cos_sim:.6} below 0.999 threshold \
+             (na={na:.4} nb={nb:.4} dot={dot:.4}) — likely a kernel math bug, \
+             not BF16 rounding noise"
+        );
+
+        // Top-1 should agree on the F32 reference; if it disagrees, log it
+        // (could be a near-tie under BF16 rounding) but don't fail the test.
+        let argmax = |v: &[f32]| v.iter().enumerate()
+            .max_by(|a, b| a.1.partial_cmp(b.1).unwrap()).map(|(i, _)| i).unwrap();
+        let got_top = argmax(&got_logits);
+        let want_top = argmax(&want_logits_f32);
+        if got_top != want_top {
+            eprintln!(
+                "[lm_head parity] argmax differs (got={got_top} want={want_top}) — \
+                 expected at high enough cos_sim with near-tied logits, but logging \
+                 in case it's a real ordering bug"
+            );
+        }
     }
 }

--- a/crates/runner/src/qwen36_moe_decode.rs
+++ b/crates/runner/src/qwen36_moe_decode.rs
@@ -212,6 +212,13 @@ pub struct DecodeOutputs {
     /// `[num_layers][hidden]` BF16. `output_after_ffn[i]` is layer `i`'s
     /// post-FFN residual (input to layer `i+1`).
     pub per_layer_ffn_out: Vec<Vec<u8>>,
+    /// Wall-clock breakdown of the kernel launches inside this chain.
+    /// `*_us` are sums-across-layers in microseconds. The launches are
+    /// internally synchronous (`hipDeviceSynchronize` in the bridge), so
+    /// the host wall-clock here measures real GPU + sync time.
+    pub kernel_full_attn_us: u64,
+    pub kernel_linear_attn_us: u64,
+    pub kernel_ffn_us: u64,
 }
 
 /// Workspace floats sufficient for the full-attn parity launcher's stage 5
@@ -486,6 +493,14 @@ pub fn run_chained_decode_with_options(
     let mut per_layer_attn_out: Vec<Vec<u8>> = Vec::with_capacity(layers.len());
     let mut per_layer_ffn_out: Vec<Vec<u8>> = Vec::with_capacity(layers.len());
 
+    // Per-kernel-class wall-clock accumulators. Reported back via
+    // `DecodeOutputs.kernel_*_us`; the engine surfaces them under
+    // `--emit-stage-timings` so we can see whether attn / linear / ffn
+    // dominates the chain time.
+    let mut t_full_attn = std::time::Duration::ZERO;
+    let mut t_linear_attn = std::time::Duration::ZERO;
+    let mut t_ffn = std::time::Duration::ZERO;
+
     // `capture` ⇔ "I need the per-layer hidden bytes on the host".
     // True if the caller asked for them OR if `trace_norms` is on (norm
     // computation reads the BF16 bytes). Otherwise we skip the D2H
@@ -569,6 +584,7 @@ pub fn run_chained_decode_with_options(
                     },
                     None => Qwen36MoeAttnStepInt4::disabled(),
                 };
+                let t_k = std::time::Instant::now();
                 attn_step_launch(
                     ordinal,
                     ScalarType::BF16,
@@ -580,6 +596,7 @@ pub fn run_chained_decode_with_options(
                     &mut sync_buf,
                 )
                 .with_context(|| format!("attn_step_launch (layer {layer_idx}, full)"))?;
+                t_full_attn += t_k.elapsed();
             }
             AttnLayerBuffers::Linear {
                 input_norm_w,
@@ -638,6 +655,7 @@ pub fn run_chained_decode_with_options(
                     },
                     None => Qwen36MoeLinearStepInt4::disabled(),
                 };
+                let t_k = std::time::Instant::now();
                 linear_step_launch(
                     ordinal,
                     ScalarType::BF16,
@@ -649,6 +667,7 @@ pub fn run_chained_decode_with_options(
                     &mut sync_buf,
                 )
                 .with_context(|| format!("linear_step_launch (layer {layer_idx})"))?;
+                t_linear_attn += t_k.elapsed();
             }
         }
 
@@ -726,6 +745,7 @@ pub fn run_chained_decode_with_options(
             },
             None => Qwen36MoeFfnStepInt4::disabled(),
         };
+        let t_k = std::time::Instant::now();
         ffn_step_launch(
             ordinal,
             ScalarType::BF16,
@@ -738,6 +758,7 @@ pub fn run_chained_decode_with_options(
             &mut sync_buf,
         )
         .with_context(|| format!("ffn_step_launch (layer {layer_idx})"))?;
+        t_ffn += t_k.elapsed();
 
         // Same D2D + swap as the attn step.
         gpu_hal::copy_d2d(
@@ -771,6 +792,9 @@ pub fn run_chained_decode_with_options(
         final_hidden_bytes,
         per_layer_attn_out,
         per_layer_ffn_out,
+        kernel_full_attn_us: t_full_attn.as_micros() as u64,
+        kernel_linear_attn_us: t_linear_attn.as_micros() as u64,
+        kernel_ffn_us: t_ffn.as_micros() as u64,
     })
 }
 

--- a/crates/runner/src/qwen36_moe_decode.rs
+++ b/crates/runner/src/qwen36_moe_decode.rs
@@ -333,12 +333,85 @@ fn download_hidden_bf16(
 ///  - (Full-attn: no KV cache here. The single-block kernels treat each
 ///    call as `kv_len=1` self-attention; KV-cache extension is a PR 4d
 ///    follow-up.)
+/// Knobs for `run_chained_decode`'s per-layer diagnostics.
+///
+/// Two costly options that the production decode loop doesn't need:
+///
+///   - `capture_per_layer`: when true, D2H-downloads each layer's
+///     post-attn and post-ffn hidden into `DecodeOutputs.per_layer_*`.
+///     The multilayer parity test consumes these; the engine doesn't.
+///     Each download forces a full GPU sync, so on 35B-A3B (40 layers)
+///     the unconditional path is ~80 syncs/token of pure overhead. Off
+///     by default — turn on only for tests / parity diagnostics.
+///   - `trace_norms`: when true, prints per-layer L2 norms for spotting
+///     signal blow-up / collapse / NaN at production scale. Implies
+///     `capture_per_layer` (we need the data to compute the norm).
+///     Defaults from the `SUPERSONIC_QWEN36_DEBUG_TRACE_NORMS` env var
+///     — see `ChainedDecodeOptions::from_env`.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ChainedDecodeOptions {
+    pub capture_per_layer: bool,
+    pub trace_norms: bool,
+}
+
+impl ChainedDecodeOptions {
+    /// Default flags + the legacy `SUPERSONIC_QWEN36_DEBUG_TRACE_NORMS`
+    /// env var as the trace-norms enable. Production callers use this.
+    pub fn from_env() -> Self {
+        let trace_norms = std::env::var("SUPERSONIC_QWEN36_DEBUG_TRACE_NORMS")
+            .map(|v| !v.is_empty() && v != "0")
+            .unwrap_or(false);
+        Self {
+            capture_per_layer: false,
+            trace_norms,
+        }
+    }
+}
+
 pub fn run_chained_decode(
     ordinal: usize,
     geom: &MultiLayerGeom,
     layers: &mut [LayerBuffers],
     initial_hidden_bytes: &[u8],
     position: i32,
+) -> Result<DecodeOutputs> {
+    run_chained_decode_with_options(
+        ordinal, geom, layers, initial_hidden_bytes, position,
+        ChainedDecodeOptions {
+            // Existing behaviour: parity tests rely on `per_layer_*` —
+            // they call this entry point directly. The fast engine path
+            // routes through `run_chained_decode_fast` (defined below).
+            capture_per_layer: true,
+            trace_norms: ChainedDecodeOptions::from_env().trace_norms,
+        },
+    )
+}
+
+/// Production decode entry point: skips the per-layer D2H downloads
+/// (which force ~80 GPU syncs/token on 35B-A3B and which neither the
+/// engine nor sampling consume — only the multilayer parity test
+/// reads `per_layer_*`). Reuses `run_chained_decode_with_options`'s
+/// implementation so parity guarantees are unchanged.
+pub fn run_chained_decode_fast(
+    ordinal: usize,
+    geom: &MultiLayerGeom,
+    layers: &mut [LayerBuffers],
+    initial_hidden_bytes: &[u8],
+    position: i32,
+) -> Result<DecodeOutputs> {
+    run_chained_decode_with_options(
+        ordinal, geom, layers, initial_hidden_bytes, position,
+        ChainedDecodeOptions::from_env(),
+    )
+}
+
+pub fn run_chained_decode_with_options(
+    ordinal: usize,
+    geom: &MultiLayerGeom,
+    layers: &mut [LayerBuffers],
+    initial_hidden_bytes: &[u8],
+    position: i32,
+    options: ChainedDecodeOptions,
 ) -> Result<DecodeOutputs> {
     let hidden = geom.hidden as usize;
     if initial_hidden_bytes.len() != hidden * 2 {
@@ -413,13 +486,12 @@ pub fn run_chained_decode(
     let mut per_layer_attn_out: Vec<Vec<u8>> = Vec::with_capacity(layers.len());
     let mut per_layer_ffn_out: Vec<Vec<u8>> = Vec::with_capacity(layers.len());
 
-    // Optional per-layer L2-norm trace, gated by env var. Cheap (one D2H
-    // copy + a sum-of-squares per layer) and invaluable for spotting
-    // where the chain's signal blows up / collapses / NaNs at production
-    // scale where we have no oracle to gate against.
-    let trace_norms = std::env::var("SUPERSONIC_QWEN36_DEBUG_TRACE_NORMS")
-        .map(|v| !v.is_empty() && v != "0")
-        .unwrap_or(false);
+    // `capture` ⇔ "I need the per-layer hidden bytes on the host".
+    // True if the caller asked for them OR if `trace_norms` is on (norm
+    // computation reads the BF16 bytes). Otherwise we skip the D2H
+    // copies entirely, which on 35B-A3B drops 80 GPU syncs/token.
+    let trace_norms = options.trace_norms;
+    let capture = options.capture_per_layer || trace_norms;
     if trace_norms {
         let init_norm = bf16_bytes_to_f32(initial_hidden_bytes)
             .iter().map(|x| x * x).sum::<f32>().sqrt();
@@ -595,17 +667,19 @@ pub fn run_chained_decode(
         // Swap front: the just-published value is now the "current input".
         front = 1 - front;
 
-        let attn_out_bytes = download_hidden_bf16(ordinal, output_buf, hidden)
-            .context("download per-layer attn output")?;
-        if trace_norms {
-            let v = bf16_bytes_to_f32(&attn_out_bytes);
-            let l2 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
-            let nan = v.iter().any(|x| !x.is_finite());
-            let kind = if matches!(layer.attn, AttnLayerBuffers::Full { .. }) { "full" } else { "lin " };
-            eprintln!("[trace]   layer {layer_idx:2} {kind} attn  L2={l2:.4}{}",
-                if nan { " NaN!" } else { "" });
+        if capture {
+            let attn_out_bytes = download_hidden_bf16(ordinal, output_buf, hidden)
+                .context("download per-layer attn output")?;
+            if trace_norms {
+                let v = bf16_bytes_to_f32(&attn_out_bytes);
+                let l2 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+                let nan = v.iter().any(|x| !x.is_finite());
+                let kind = if matches!(layer.attn, AttnLayerBuffers::Full { .. }) { "full" } else { "lin " };
+                eprintln!("[trace]   layer {layer_idx:2} {kind} attn  L2={l2:.4}{}",
+                    if nan { " NaN!" } else { "" });
+            }
+            per_layer_attn_out.push(attn_out_bytes);
         }
-        per_layer_attn_out.push(attn_out_bytes);
 
         // ---- FFN ----
         reset_sync_buf(ordinal, &mut sync_buf).context("reset sync_buf (ffn)")?;
@@ -675,16 +749,18 @@ pub fn run_chained_decode(
         .context("d2d ffn_output -> residual")?;
         front = 1 - front;
 
-        let ffn_out_bytes = download_hidden_bf16(ordinal, output_buf, hidden)
-            .context("download per-layer ffn output")?;
-        if trace_norms {
-            let v = bf16_bytes_to_f32(&ffn_out_bytes);
-            let l2 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
-            let nan = v.iter().any(|x| !x.is_finite());
-            eprintln!("[trace]   layer {layer_idx:2}      ffn   L2={l2:.4}{}",
-                if nan { " NaN!" } else { "" });
+        if capture {
+            let ffn_out_bytes = download_hidden_bf16(ordinal, output_buf, hidden)
+                .context("download per-layer ffn output")?;
+            if trace_norms {
+                let v = bf16_bytes_to_f32(&ffn_out_bytes);
+                let l2 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+                let nan = v.iter().any(|x| !x.is_finite());
+                eprintln!("[trace]   layer {layer_idx:2}      ffn   L2={l2:.4}{}",
+                    if nan { " NaN!" } else { "" });
+            }
+            per_layer_ffn_out.push(ffn_out_bytes);
         }
-        per_layer_ffn_out.push(ffn_out_bytes);
     }
 
     let final_buf = if front == 0 { &hidden_a } else { &hidden_b };

--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -27,9 +27,10 @@ use qwen36_moe::weights::{
 
 use crate::qwen36_moe_decode::{
     argmax_bf16_logits, bf16_bytes_to_f32, dequant_int4_to_bf16_bytes, host_final_norm_lm_head,
-    host_final_norm_lm_head_f32, run_chained_decode, sample_bf16_logits, AttnLayerBuffers,
-    FfnInt4Sidecars, FfnLayerBuffers, FullAttnInt4Sidecars, FullAttnKvCache, LayerBuffers,
-    LinearAttnInt4Sidecars, MultiLayerGeom, XorshiftRng,
+    host_final_norm_lm_head_f32, run_chained_decode, run_chained_decode_fast,
+    sample_bf16_logits, AttnLayerBuffers, FfnInt4Sidecars, FfnLayerBuffers,
+    FullAttnInt4Sidecars, FullAttnKvCache, LayerBuffers, LinearAttnInt4Sidecars,
+    MultiLayerGeom, XorshiftRng,
 };
 use crate::registry::{FamilyParams, Qwen36MoeKernelParams, RegistryEntry};
 
@@ -1213,8 +1214,12 @@ fn decode_text(
         let t_embed_step = t0.elapsed();
 
         // Run the chain. Linear-attn state mutates in `layers` in place.
+        // `run_chained_decode_fast` skips the per-layer D2H sync chain
+        // (~80 GPU syncs/token on 35B-A3B) — `decode_text` only consumes
+        // `final_hidden_bytes`. The multilayer parity test still calls
+        // the legacy `run_chained_decode` which captures per-layer.
         let t1 = std::time::Instant::now();
-        let outputs = run_chained_decode(ordinal, &geom, &mut layers, &initial_hidden, position)
+        let outputs = run_chained_decode_fast(ordinal, &geom, &mut layers, &initial_hidden, position)
             .with_context(|| format!("chained decode (step {step}, position {position})"))?;
         let t_chain_step = t1.elapsed();
         position += 1;

--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -1108,26 +1108,50 @@ fn decode_text(
         layers.push(layer);
     }
 
-    // Cache final_norm + dequantized lm_head once. Both are ≥1 GiB BF16
-    // for 35B-A3B; reusing the cached buffers across decode steps avoids
-    // redoing the ~1 second INT4 dequant per token. Convert to F32 once
-    // here too — the BF16→F32 fan-out of the lm_head matrix (~970 MiB →
-    // ~2 GiB) was previously dominating per-token latency in the host-
-    // side GEMV path; the F32 view is reused for every generated token.
+    // Upload final_norm + dequantized lm_head to the GPU once. The
+    // GPU lm_head kernel (`qwen36_moe::lm_head_launch`) does
+    // RMSNorm + GEMV in BF16 in one shot, replacing the previous
+    // host-side F32 GEMV that dominated per-token wall-clock at
+    // ~233 ms / 360 ms total on 35B-A3B greedy decode (PR #68
+    // stage-timings).
+    //
+    // VRAM cost: ~970 MiB for lm_head BF16 + 4 KiB for final_norm +
+    // 500 KiB for the logits buffer. Comfortably within the 24 GiB
+    // budget alongside the 17 GiB INT4 weight bake.
     let final_norm_bytes = host_load_bytes(&store, &format!("{weight_prefix}.norm.weight"))
         .context("load final norm")?;
     let lm_head_bf16_bytes = load_lm_head_bf16(&store, &report.config.text_config, weight_prefix, &geom)
-        .context("prepare host-side lm_head BF16 buffer")?;
-    let final_norm_f32 = bf16_bytes_to_f32(&final_norm_bytes);
-    let lm_head_f32 = bf16_bytes_to_f32(&lm_head_bf16_bytes);
+        .context("prepare lm_head BF16 buffer")?;
     println!(
-        "  cached lm_head BF16 ({:.1} MiB → F32 {:.1} MiB) and final norm ({:.1} KiB).",
+        "  uploading lm_head BF16 ({:.1} MiB) and final norm ({:.1} KiB) to GPU…",
         lm_head_bf16_bytes.len() as f64 / MIB,
-        (lm_head_f32.len() * 4) as f64 / MIB,
         final_norm_bytes.len() as f64 / 1024.0,
     );
-    // Drop the BF16 buffer once the F32 view is built — engine doesn't
-    // need it after this point and the 970 MiB allocation is non-trivial.
+    let final_norm_w_buf = GpuBuffer::from_host_bytes(
+        ordinal,
+        ScalarType::BF16,
+        &[geom.hidden as usize],
+        &final_norm_bytes,
+    )
+    .context("upload final_norm_w to GPU")?;
+    let lm_head_w_buf = GpuBuffer::from_host_bytes(
+        ordinal,
+        ScalarType::BF16,
+        &[geom.vocab as usize, geom.hidden as usize],
+        &lm_head_bf16_bytes,
+    )
+    .context("upload lm_head BF16 to GPU")?;
+    let mut logits_buf = GpuBuffer::zeros(
+        ordinal,
+        ScalarType::BF16,
+        &[geom.vocab as usize],
+    )
+    .context("alloc logits_buf on GPU")?;
+    let mut counter_buf = GpuBuffer::zeros(ordinal, ScalarType::U32, &[1])
+        .context("alloc lm_head counter_buf on GPU")?;
+    let mut final_hidden_buf =
+        GpuBuffer::zeros(ordinal, ScalarType::BF16, &[geom.hidden as usize])
+            .context("alloc final_hidden_buf on GPU")?;
     drop(lm_head_bf16_bytes);
     drop(final_norm_bytes);
 
@@ -1211,16 +1235,35 @@ fn decode_text(
             );
         }
 
-        // Generation step: final_norm + lm_head GEMV (host F32, cached).
+        // Generation step: final_norm + lm_head GEMV on the GPU
+        // (`kernel_ffi::qwen36_moe::lm_head_launch`). H2D the freshly
+        // produced final_hidden into the persistent `final_hidden_buf`
+        // — `run_chained_decode` already D2H'd it for diagnostics; the
+        // re-upload is ~4 KB, microseconds at PCIe Gen4 speeds — then
+        // launch the kernel + D2H the BF16 logits.
         let t2 = std::time::Instant::now();
-        let logits = host_final_norm_lm_head_f32(
-            &outputs.final_hidden_bytes,
-            &final_norm_f32,
-            &lm_head_f32,
-            geom.hidden as usize,
-            geom.vocab as usize,
+        gpu_hal::copy_h2d(
+            ordinal,
+            final_hidden_buf.as_mut_ptr(),
+            outputs.final_hidden_bytes.as_ptr() as *const _,
+            outputs.final_hidden_bytes.len(),
+        )
+        .context("h2d final_hidden -> final_hidden_buf")?;
+        kernel_ffi::qwen36_moe::lm_head_launch(
+            ordinal,
+            geom.hidden,
+            geom.vocab,
             geom.rms_norm_eps,
-        );
+            &final_hidden_buf,
+            &final_norm_w_buf,
+            &lm_head_w_buf,
+            &mut logits_buf,
+            &mut counter_buf,
+        )
+        .context("gpu lm_head launch")?;
+        let logits = logits_buf
+            .to_host_bytes()
+            .context("d2h logits from GPU lm_head")?;
         let t_lm_head_step = t2.elapsed();
         if let Ok(dump_path) = std::env::var("SUPERSONIC_QWEN36_DUMP_LOGITS") {
             std::fs::write(&dump_path, &logits)

--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -1200,6 +1200,10 @@ fn decode_text(
     let mut t_lm_head = std::time::Duration::ZERO;
     let mut t_sample = std::time::Duration::ZERO;
     let mut t_detok = std::time::Duration::ZERO;
+    // Within-chain breakdown by kernel class (microseconds).
+    let mut t_chain_full_attn_us: u64 = 0;
+    let mut t_chain_linear_attn_us: u64 = 0;
+    let mut t_chain_ffn_us: u64 = 0;
 
     for step in 0..total_steps {
         // Embed lookup for the current token.
@@ -1305,6 +1309,9 @@ fn decode_text(
         t_lm_head += t_lm_head_step;
         t_sample += t_sample_step;
         t_detok += t_detok_step;
+        t_chain_full_attn_us += outputs.kernel_full_attn_us;
+        t_chain_linear_attn_us += outputs.kernel_linear_attn_us;
+        t_chain_ffn_us += outputs.kernel_ffn_us;
 
         if Some(next_token) == eos_id {
             break;
@@ -1338,6 +1345,9 @@ fn decode_text(
         let detok_ms = to_ms(t_detok);
         let total_ms = chain_ms + embed_ms + lm_head_ms + sample_ms + detok_ms;
         let n = gen_steps as f64;
+        let full_attn_ms = (t_chain_full_attn_us as f64) / 1000.0;
+        let linear_attn_ms = (t_chain_linear_attn_us as f64) / 1000.0;
+        let ffn_ms = (t_chain_ffn_us as f64) / 1000.0;
         eprintln!(
             "[qwen36-moe stage-timings] gen_steps={gen_steps} \
              embed_ms_avg={:.3} chain_ms_avg={:.3} lm_head_ms_avg={:.3} \
@@ -1351,6 +1361,17 @@ fn decode_text(
             total_ms / n,
             chain_ms,
             lm_head_ms,
+        );
+        eprintln!(
+            "[qwen36-moe chain-breakdown] gen_steps={gen_steps} \
+             full_attn_ms_avg={:.3} linear_attn_ms_avg={:.3} ffn_ms_avg={:.3} \
+             (full_attn_total_ms={:.1} linear_attn_total_ms={:.1} ffn_total_ms={:.1})",
+            full_attn_ms / n,
+            linear_attn_ms / n,
+            ffn_ms / n,
+            full_attn_ms,
+            linear_attn_ms,
+            ffn_ms,
         );
     }
 

--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -722,6 +722,7 @@ pub fn run(
         &cli.prompt,
         cli.max_new_tokens.max(1),
         sampling,
+        cli.emit_stage_timings,
     )?;
     Ok(())
 }
@@ -1004,6 +1005,7 @@ fn decode_text(
     prompt: &str,
     max_new: usize,
     sampling: SamplingParams,
+    emit_stage_timings: bool,
 ) -> Result<()> {
     use std::io::Write as _;
 
@@ -1160,8 +1162,23 @@ fn decode_text(
         sampling.temperature, sampling.top_k, sampling.top_p, sampling.seed,
     );
 
+    // Per-stage wall-clock accumulators. Aggregated across generation steps
+    // only (prefill steps run the chain but skip the lm_head/sample stages,
+    // so timing prefill mixed with gen would distort the per-token average).
+    // `chain_ms` includes the GPU work + the D2H copy of `final_hidden_bytes`
+    // — `run_chained_decode` syncs before returning, so the wall-clock here
+    // is a real GPU+sync measurement. CPU-side stages (embed lookup, lm_head
+    // GEMV, sampling, detokenize) are pure host work.
+    let mut gen_steps: usize = 0;
+    let mut t_embed = std::time::Duration::ZERO;
+    let mut t_chain = std::time::Duration::ZERO;
+    let mut t_lm_head = std::time::Duration::ZERO;
+    let mut t_sample = std::time::Duration::ZERO;
+    let mut t_detok = std::time::Duration::ZERO;
+
     for step in 0..total_steps {
         // Embed lookup for the current token.
+        let t0 = std::time::Instant::now();
         let initial_hidden = lookup_embed_row(
             &store,
             weight_prefix,
@@ -1169,10 +1186,13 @@ fn decode_text(
             geom.hidden as usize,
         )
         .with_context(|| format!("embed lookup token {current_token} (step {step})"))?;
+        let t_embed_step = t0.elapsed();
 
         // Run the chain. Linear-attn state mutates in `layers` in place.
+        let t1 = std::time::Instant::now();
         let outputs = run_chained_decode(ordinal, &geom, &mut layers, &initial_hidden, position)
             .with_context(|| format!("chained decode (step {step}, position {position})"))?;
+        let t_chain_step = t1.elapsed();
         position += 1;
 
         // Prefill steps: feed the next prompt token without computing logits.
@@ -1191,10 +1211,8 @@ fn decode_text(
             );
         }
 
-        // Generation step: lm_head + sample (greedy when temperature == 0).
-        // Uses the F32-cached final_norm + lm_head so the per-token cost is
-        // just one BF16→F32 of the (small) hidden vector + GEMV; the
-        // expensive lm_head conversion happens once at decode_text start.
+        // Generation step: final_norm + lm_head GEMV (host F32, cached).
+        let t2 = std::time::Instant::now();
         let logits = host_final_norm_lm_head_f32(
             &outputs.final_hidden_bytes,
             &final_norm_f32,
@@ -1203,6 +1221,7 @@ fn decode_text(
             geom.vocab as usize,
             geom.rms_norm_eps,
         );
+        let t_lm_head_step = t2.elapsed();
         if let Ok(dump_path) = std::env::var("SUPERSONIC_QWEN36_DUMP_LOGITS") {
             std::fs::write(&dump_path, &logits)
                 .with_context(|| format!("write logits dump to {dump_path}"))?;
@@ -1211,6 +1230,7 @@ fn decode_text(
                 logits.len()
             );
         }
+        let t3 = std::time::Instant::now();
         let next_token = sample_bf16_logits(
             &logits,
             sampling.temperature,
@@ -1218,15 +1238,25 @@ fn decode_text(
             sampling.top_p,
             &mut rng,
         );
+        let t_sample_step = t3.elapsed();
         generated_ids.push(next_token);
 
         // Stream-decode and print.
+        let t4 = std::time::Instant::now();
         if let Some(tok) = &tokenizer {
             if let Ok(text) = tok.decode(&[next_token], false) {
                 print!("{text}");
                 std::io::stdout().flush().ok();
             }
         }
+        let t_detok_step = t4.elapsed();
+
+        gen_steps += 1;
+        t_embed += t_embed_step;
+        t_chain += t_chain_step;
+        t_lm_head += t_lm_head_step;
+        t_sample += t_sample_step;
+        t_detok += t_detok_step;
 
         if Some(next_token) == eos_id {
             break;
@@ -1248,12 +1278,32 @@ fn decode_text(
             "no (max_new_tokens hit)"
         },
     );
-    println!(
-        "  (Note: greedy decoding only; sampling, temperature/top-p, and \
-         GPU-side lm_head are next.)"
-    );
     if !generated_ids.is_empty() {
         println!("  Generated ids: {generated_ids:?}");
+    }
+    if emit_stage_timings && gen_steps > 0 {
+        let to_ms = |d: std::time::Duration| d.as_secs_f64() * 1000.0;
+        let chain_ms = to_ms(t_chain);
+        let embed_ms = to_ms(t_embed);
+        let lm_head_ms = to_ms(t_lm_head);
+        let sample_ms = to_ms(t_sample);
+        let detok_ms = to_ms(t_detok);
+        let total_ms = chain_ms + embed_ms + lm_head_ms + sample_ms + detok_ms;
+        let n = gen_steps as f64;
+        eprintln!(
+            "[qwen36-moe stage-timings] gen_steps={gen_steps} \
+             embed_ms_avg={:.3} chain_ms_avg={:.3} lm_head_ms_avg={:.3} \
+             sample_ms_avg={:.3} detok_ms_avg={:.3} total_ms_avg={:.3} \
+             (chain_total_ms={:.1} lm_head_total_ms={:.1})",
+            embed_ms / n,
+            chain_ms / n,
+            lm_head_ms / n,
+            sample_ms / n,
+            detok_ms / n,
+            total_ms / n,
+            chain_ms,
+            lm_head_ms,
+        );
     }
 
     Ok(())

--- a/kernels/qwen36_moe.hip
+++ b/kernels/qwen36_moe.hip
@@ -113,6 +113,53 @@ __device__ inline void int4_dequant_8(
     }
 }
 
+// Work-stealing matvec inner loop for an INT4 slab `[out_rows, in_cols/2]`.
+//
+// Computes the partial dot product `sum_i (dequant(w[my_row, i]) * x[i])`
+// for the cols this thread is responsible for, using the 8-wide
+// `int4_dequant_8` helper instead of the scalar path.
+//
+// Caller pre-resolves the slab pointers (so the same helper drives both 2D
+// dense and 3D fused-expert matmuls — for 3D, just pass the per-expert
+// slab pointers). `cols` must be a multiple of 8 (the 8-element span unit)
+// AND of `gsz` (so `scale_cols = cols / gsz` is well-defined). Each thread
+// processes 8 cols per iteration starting at `tid * 8`, striding by
+// `block_size * 8`. Caller must ensure `block_size * 8` divides cleanly
+// (hidden=2048 with block_size=256 fits exactly with 1 iter/thread).
+//
+// 4-byte-aligned `pk` load is safe because:
+//   - byte_cols = cols / 2 is a multiple of 4 (cols is a multiple of 8)
+//   - col_start / 2 is a multiple of 4 (col_start is in steps of 8)
+//   so the resulting `&packed[my_row * byte_cols + col_start/2]` is always
+//   4-byte aligned.
+__device__ inline float int4_dq8_matvec_partial(
+    const uint8_t*      __restrict__ packed,
+    const hip_bfloat16* __restrict__ scales,
+    const hip_bfloat16* __restrict__ zeros,
+    const float*        __restrict__ x,
+    int my_row, int cols, int gsz,
+    int tid, int block_size
+) {
+    const int byte_cols  = cols / 2;
+    const int scale_cols = cols / gsz;
+    const int scale_row  = my_row / gsz;
+    const size_t row_byte_off = static_cast<size_t>(my_row) * byte_cols;
+
+    float partial = 0.0f;
+    for (int col_start = tid * 8; col_start < cols; col_start += block_size * 8) {
+        const uint32_t pk = *reinterpret_cast<const uint32_t*>(
+            &packed[row_byte_off + col_start / 2]);
+        float dq[8];
+        int4_dequant_8(pk, scales, zeros,
+                       scale_row, col_start, scale_cols, gsz, dq);
+        #pragma unroll
+        for (int i = 0; i < 8; ++i) {
+            partial += dq[i] * x[col_start + i];
+        }
+    }
+    return partial;
+}
+
 // Single-element dequant for non-8-aligned tails. `cols` is the unpacked
 // input dim of the 2D slab `(row, col)` indexes into. `scales`/`zeros`
 // are at `[(row/gs) * ((cols + gs - 1)/gs) + col/gs]` — same as the 2D
@@ -481,13 +528,17 @@ __global__ void qwen36_moe_attn_step_kernel(
 
         float partial = 0.0f;
         if (q_int4) {
-            const void* q_packed = reinterpret_cast<const void*>(q_proj_w);
-            for (int col = tid; col < hidden; col += block_size) {
-                partial += int4_dequant_scalar(
-                               q_packed, q_proj_scale, q_proj_zero,
-                               my_row, col, hidden, int4_group_size)
-                           * x_norm_lds[col];
-            }
+            // 8-wide INT4 dequant + dot accumulate. ~2-4× faster than the
+            // scalar path on RDNA3 because it amortizes scale/zero lookups
+            // across the 8-element span and folds 4 nibble-byte reads into
+            // a single 4-byte uint32 load.
+            partial = int4_dq8_matvec_partial(
+                reinterpret_cast<const uint8_t*>(q_proj_w),
+                static_cast<const hip_bfloat16*>(q_proj_scale),
+                static_cast<const hip_bfloat16*>(q_proj_zero),
+                x_norm_lds,
+                my_row, hidden, int4_group_size,
+                tid, block_size);
         } else {
             const T* w_row = q_proj_w + static_cast<size_t>(my_row) * hidden;
             for (int col = tid; col < hidden; col += block_size) {
@@ -624,13 +675,11 @@ __global__ void qwen36_moe_attn_step_kernel(
 
         float partial = 0.0f;
         if (i4_scale != nullptr) {
-            const void* w_packed = reinterpret_cast<const void*>(w_slab);
-            for (int col = tid; col < hidden; col += block_size) {
-                partial += int4_dequant_scalar(
-                               w_packed, i4_scale, i4_zero,
-                               proj_row, col, hidden, int4_group_size)
-                           * x_norm_lds[col];
-            }
+            partial = int4_dq8_matvec_partial(
+                reinterpret_cast<const uint8_t*>(w_slab),
+                i4_scale, i4_zero, x_norm_lds,
+                proj_row, hidden, int4_group_size,
+                tid, block_size);
         } else {
             const T* w_row = w_slab + static_cast<size_t>(proj_row) * hidden;
             for (int col = tid; col < hidden; col += block_size) {
@@ -1008,13 +1057,13 @@ __global__ void qwen36_moe_attn_step_kernel(
 
             float partial = 0.0f;
             if (o_int4) {
-                const void* o_packed = reinterpret_cast<const void*>(o_proj_w);
-                for (int j = tid; j < qd; j += block_size) {
-                    partial += int4_dequant_scalar(
-                                   o_packed, o_proj_scale, o_proj_zero,
-                                   my_row, j, qd, int4_group_size)
-                               * workspace[OFF_GATED + j];
-                }
+                partial = int4_dq8_matvec_partial(
+                    reinterpret_cast<const uint8_t*>(o_proj_w),
+                    static_cast<const hip_bfloat16*>(o_proj_scale),
+                    static_cast<const hip_bfloat16*>(o_proj_zero),
+                    workspace + OFF_GATED,
+                    my_row, qd, int4_group_size,
+                    tid, block_size);
             } else {
                 const T* w_row = o_proj_w + static_cast<size_t>(my_row) * qd;
                 for (int j = tid; j < qd; j += block_size) {
@@ -1258,12 +1307,11 @@ __global__ void qwen36_moe_linear_step_kernel(
 
         float partial = 0.0f;
         if (i4_scale != nullptr) {
-            for (int col = tid; col < hidden; col += block_size) {
-                partial += int4_dequant_scalar(
-                               i4_slab, i4_scale, i4_zero,
-                               i4_row, col, hidden, int4_group_size)
-                           * x_norm_lds[col];
-            }
+            partial = int4_dq8_matvec_partial(
+                static_cast<const uint8_t*>(i4_slab),
+                i4_scale, i4_zero, x_norm_lds,
+                i4_row, hidden, int4_group_size,
+                tid, block_size);
         } else {
             for (int col = tid; col < hidden; col += block_size) {
                 partial += static_cast<float>(w_row[col]) * x_norm_lds[col];
@@ -1734,13 +1782,13 @@ __global__ void qwen36_moe_linear_step_kernel(
 
             float partial = 0.0f;
             if (out_int4) {
-                const void* o_packed = reinterpret_cast<const void*>(out_proj_w);
-                for (int j = tid; j < qd; j += block_size) {
-                    partial += int4_dequant_scalar(
-                                   o_packed, out_proj_scale, out_proj_zero,
-                                   my_row, j, qd, int4_group_size)
-                               * workspace[OFF_REC_OUT + j];
-                }
+                partial = int4_dq8_matvec_partial(
+                    reinterpret_cast<const uint8_t*>(out_proj_w),
+                    static_cast<const hip_bfloat16*>(out_proj_scale),
+                    static_cast<const hip_bfloat16*>(out_proj_zero),
+                    workspace + OFF_REC_OUT,
+                    my_row, qd, int4_group_size,
+                    tid, block_size);
             } else {
                 const T* w_row = out_proj_w + static_cast<size_t>(my_row) * qd;
                 for (int j = tid; j < qd; j += block_size) {
@@ -2171,15 +2219,11 @@ __global__ void qwen36_moe_ffn_step_kernel(
 
         float partial = 0.0f;
         if (i4_scale != nullptr) {
-            // INT4 scalar dequant per element. Stride pattern matches the
-            // BF16 path (thread t reads cols t, t+block_size, …) so the
-            // reduction tree is unchanged.
-            for (int col = tid; col < hidden; col += block_size) {
-                partial += int4_dequant_scalar(
-                               i4_slab, i4_scale, i4_zero,
-                               i4_row, col, hidden, int4_group_size)
-                           * h_norm_lds[col];
-            }
+            partial = int4_dq8_matvec_partial(
+                static_cast<const uint8_t*>(i4_slab),
+                i4_scale, i4_zero, h_norm_lds,
+                i4_row, hidden, int4_group_size,
+                tid, block_size);
         } else {
             for (int col = tid; col < hidden; col += block_size) {
                 partial += static_cast<float>(w_row[col]) * h_norm_lds[col];
@@ -2242,16 +2286,13 @@ __global__ void qwen36_moe_ffn_step_kernel(
             if (shared_down_proj_scale != nullptr) {
                 // INT4 path: row `my_row` of `[hidden, Is]` packed as
                 // `[hidden, Is/2]` u8.
-                const void* i4_slab =
-                    reinterpret_cast<const void*>(shared_down_proj_w);
-                for (int col = tid; col < Is_; col += block_size) {
-                    partial += int4_dequant_scalar(
-                                   i4_slab,
-                                   shared_down_proj_scale,
-                                   shared_down_proj_zero,
-                                   my_row, col, Is_, int4_group_size)
-                               * workspace[OFF_SHARED_MID + col];
-                }
+                partial = int4_dq8_matvec_partial(
+                    reinterpret_cast<const uint8_t*>(shared_down_proj_w),
+                    static_cast<const hip_bfloat16*>(shared_down_proj_scale),
+                    static_cast<const hip_bfloat16*>(shared_down_proj_zero),
+                    workspace + OFF_SHARED_MID,
+                    my_row, Is_, int4_group_size,
+                    tid, block_size);
             } else {
                 const T* w_row =
                     shared_down_proj_w + static_cast<size_t>(my_row) * Is_;
@@ -2354,14 +2395,11 @@ __global__ void qwen36_moe_ffn_step_kernel(
 
                 float partial = 0.0f;
                 if (gu_int4) {
-                    for (int col = tid; col < hidden; col += block_size) {
-                        partial += int4_dequant_scalar(
-                                       gu_slab_packed,
-                                       gu_slab_scale,
-                                       gu_slab_zero,
-                                       my_row, col, hidden, int4_group_size)
-                                   * h_norm_lds[col];
-                    }
+                    partial = int4_dq8_matvec_partial(
+                        gu_slab_packed, gu_slab_scale, gu_slab_zero,
+                        h_norm_lds,
+                        my_row, hidden, int4_group_size,
+                        tid, block_size);
                 } else {
                     const T* w_row =
                         gu_slab_bf16 + static_cast<size_t>(my_row) * hidden;
@@ -2439,14 +2477,11 @@ __global__ void qwen36_moe_ffn_step_kernel(
 
                 float partial = 0.0f;
                 if (dp_int4) {
-                    for (int col = tid; col < I_; col += block_size) {
-                        partial += int4_dequant_scalar(
-                                       dp_slab_packed,
-                                       dp_slab_scale,
-                                       dp_slab_zero,
-                                       my_row, col, I_, int4_group_size)
-                                   * workspace[OFF_EXPERT_MID + col];
-                    }
+                    partial = int4_dq8_matvec_partial(
+                        dp_slab_packed, dp_slab_scale, dp_slab_zero,
+                        workspace + OFF_EXPERT_MID,
+                        my_row, I_, int4_group_size,
+                        tid, block_size);
                 } else {
                     const T* w_row =
                         dp_slab_bf16 + static_cast<size_t>(my_row) * I_;

--- a/kernels/qwen36_moe.hip
+++ b/kernels/qwen36_moe.hip
@@ -2605,4 +2605,107 @@ __global__ void int4_dequant_smoke_kernel(
     }
 }
 
+// ---------------------------------------------------------------------------
+// Final RMSNorm + lm_head GEMV in a single kernel — replaces the host-side
+// path in `qwen36_moe_decode::host_final_norm_lm_head_f32`.
+//
+// On 35B-A3B the host F32 GEMV at [vocab=248320, hidden=2048] dominated the
+// per-token wall-clock (233 ms of 360 ms in the local greedy benchmark; see
+// PR #68's stage-timings output). Lifting it to the GPU eliminates the F32
+// fan-out of the lm_head matrix (previously 970 MiB → 1.94 GiB at startup +
+// per-token streaming through the host LLC) and the per-token CPU work.
+//
+// Math (matches `host_final_norm_lm_head_f32` byte-for-byte through the
+// BF16 rounding boundary):
+//
+//   inv_rms     = rsqrt(mean(x_i^2) + eps)               # F32 reduction
+//   x_normed[i] = bf16(x_i * inv_rms * (1.0 + final_norm_w[i]))   # `(1+w)`
+//   logits[v]   = bf16(sum_i(lm_head_w[v, i] * x_normed[i]))
+//
+// LDS layout (matches the attn/linear/ffn step kernels):
+//   lds[0,                 block_size):  shared_scratch (block reduction)
+//   lds[block_size,        block_size + hidden):  x_norm_lds (F32 view of
+//                                                  BF16-rounded normed hidden)
+//   Total = (block_size + hidden) * 4 bytes = (256 + 2048) * 4 = 9 KiB on
+//   35B-A3B. Same budget as the attn kernel; ≥2 WGs/CU on gfx1100.
+//
+// Block strategy: each block computes the RMSNorm into its own LDS
+// (redundant across blocks — cheap, ~few µs for hidden=2048 — but lets the
+// matvec read x_norm from LDS instead of global memory). Then a
+// work-stealing loop assigns vocab rows to blocks via an atomic counter.
+// Each block fully reduces one row before grabbing the next.
+//
+// `counter` is a `[1] u32` device buffer; the host must memset it to 0
+// before each launch.
+template <typename T>
+__global__ void qwen36_moe_lm_head_kernel(
+    const T*               __restrict__ final_hidden,    // [hidden] BF16
+    const T*               __restrict__ final_norm_w,    // [hidden] BF16
+    const T*               __restrict__ lm_head_w,       // [vocab, hidden] BF16
+    T*                     __restrict__ logits,          // [vocab] BF16
+    unsigned int*          __restrict__ counter,         // [1] u32
+    int                                  hidden,
+    int                                  vocab,
+    float                                rms_norm_eps) {
+    const int tid = threadIdx.x;
+    const int block_size = blockDim.x;
+    extern __shared__ unsigned char lds_raw[];
+    float* shared_scratch = reinterpret_cast<float*>(lds_raw);
+    float* x_norm_lds     = shared_scratch + block_size;
+
+    // -- Phase A: per-block RMSNorm of final_hidden into LDS ---------------
+    float partial_sq = 0.0f;
+    for (int col = tid; col < hidden; col += block_size) {
+        const float v = load_as_float<T>(final_hidden, col);
+        x_norm_lds[col] = v;
+        partial_sq += v * v;
+    }
+    shared_scratch[tid] = partial_sq;
+    __syncthreads();
+    for (int s = block_size / 2; s > 0; s >>= 1) {
+        if (tid < s) shared_scratch[tid] += shared_scratch[tid + s];
+        __syncthreads();
+    }
+    __shared__ float inv_rms;
+    if (tid == 0) {
+        inv_rms = rsqrtf(shared_scratch[0] / static_cast<float>(hidden) + rms_norm_eps);
+    }
+    __syncthreads();
+
+    // Apply `(1.0 + w)` HF Qwen3_5MoeRMSNorm unit offset, BF16-round each
+    // x_normed element so the matmul reads what PyTorch reads.
+    for (int col = tid; col < hidden; col += block_size) {
+        const float w = load_as_float<T>(final_norm_w, col);
+        x_norm_lds[col] = bf16_round_rne_f32(x_norm_lds[col] * inv_rms * (1.0f + w));
+    }
+    __syncthreads();
+
+    // -- Phase B: work-stealing matvec across vocab rows -------------------
+    for (;;) {
+        __shared__ unsigned int my_row_s;
+        if (tid == 0) {
+            my_row_s = atomicAdd(counter, 1u);
+        }
+        __syncthreads();
+        const int my_row = static_cast<int>(my_row_s);
+        if (my_row >= vocab) break;
+
+        const T* w_row = lm_head_w + static_cast<size_t>(my_row) * hidden;
+        float partial = 0.0f;
+        for (int col = tid; col < hidden; col += block_size) {
+            partial += load_as_float<T>(w_row, col) * x_norm_lds[col];
+        }
+        shared_scratch[tid] = partial;
+        __syncthreads();
+        for (int s = block_size / 2; s > 0; s >>= 1) {
+            if (tid < s) shared_scratch[tid] += shared_scratch[tid + s];
+            __syncthreads();
+        }
+        if (tid == 0) {
+            logits[my_row] = static_cast<T>(bf16_round_rne_f32(shared_scratch[0]));
+        }
+        __syncthreads();
+    }
+}
+
 } // namespace qwen36_moe

--- a/kernels/qwen36_moe_bridge.cpp
+++ b/kernels/qwen36_moe_bridge.cpp
@@ -545,3 +545,73 @@ extern "C" int qwen36_moe_hip_int4_dequant_smoke_launch(
     if (sync_err != hipSuccess) return 255;
     return 0;
 }
+
+// PR follow-up to #68: GPU-side final RMSNorm + lm_head GEMV launcher.
+// Replaces the host-side path in `qwen36_moe_decode::host_final_norm_lm_head_f32`
+// which dominated per-token wall-clock at 233 ms / 360 ms total on
+// 35B-A3B greedy decode.
+//
+// Inputs are device pointers (BF16 throughout: final_hidden, final_norm_w,
+// lm_head_w; logits is BF16 output). `counter` is a `[1] u32` device buffer
+// the kernel uses for work-stealing across vocab rows; this launcher
+// memsets it to 0 before launch.
+//
+// Currently bf16-only (`dtype == 2`). Geometry assumptions:
+//   - `hidden % block_size == 0` (block reduction lane scheme assumes it).
+//   - `vocab > 0`; the work-stealing loop self-terminates when
+//     `my_row >= vocab`.
+extern "C" int qwen36_moe_hip_lm_head_launch(
+    int           dtype,
+    size_t        device_ordinal,
+    int           hidden,
+    int           vocab,
+    float         rms_norm_eps,
+    const void*   final_hidden,
+    const void*   final_norm_w,
+    const void*   lm_head_w,
+    void*         logits,
+    unsigned int* counter) {
+    if (dtype != 2) return 130;            // only bf16 supported
+    if (hidden <= 0 || vocab <= 0) return 132;
+    if (final_hidden == nullptr || final_norm_w == nullptr ||
+        lm_head_w == nullptr || logits == nullptr || counter == nullptr) {
+        return 133;
+    }
+
+    ScopedHipDevice scoped(static_cast<int>(device_ordinal));
+
+    hipDeviceProp_t props;
+    if (hipGetDeviceProperties(&props, static_cast<int>(device_ordinal)) !=
+        hipSuccess) {
+        return 250;
+    }
+    const int num_blocks =
+        props.multiProcessorCount > 0 ? props.multiProcessorCount : 16;
+    constexpr int block_size = 256;
+
+    if (hipMemsetAsync(counter, 0, sizeof(unsigned int)) != hipSuccess) {
+        return 200;
+    }
+
+    // shared_scratch [block_size] + x_norm_lds [hidden], both F32.
+    const size_t lds_bytes =
+        static_cast<size_t>(hidden + block_size) * sizeof(float);
+
+    hipLaunchKernelGGL(qwen36_moe::qwen36_moe_lm_head_kernel<hip_bfloat16>,
+                       dim3(static_cast<unsigned int>(num_blocks)),
+                       dim3(block_size),
+                       lds_bytes, 0,
+                       static_cast<const hip_bfloat16*>(final_hidden),
+                       static_cast<const hip_bfloat16*>(final_norm_w),
+                       static_cast<const hip_bfloat16*>(lm_head_w),
+                       static_cast<hip_bfloat16*>(logits),
+                       counter,
+                       hidden,
+                       vocab,
+                       rms_norm_eps);
+    hipError_t launch_err = hipGetLastError();
+    hipError_t sync_err   = hipDeviceSynchronize();
+    if (launch_err != hipSuccess) return 254;
+    if (sync_err != hipSuccess) return 255;
+    return 0;
+}


### PR DESCRIPTION
## Summary

Five commits on the qwen36-moe perf track. Cumulative speedup: **360 ms → 80 ms per token = 4.5×** on greedy decode against the local 35B-A3B v2-int4-gptq bake (~12.5 tokens/sec on a 7900 XTX). Generated ids on canonical prompts remain bit-identical to the original host path; diverse-prompt smoke (factual / narrative / 64-token Python / sampled) all stay coherent.

### Per-stage breakdown

| Stage          | original  | + GPU lm_head | + 8-wide INT4 | + diag-skip + breakdown | total change |
|----------------|-----------|---------------|---------------|-------------------------|--------------|
| embed          | 0.007 ms  | 0.005 ms      | 0.004 ms      | 0.004 ms                | ~same        |
| chain (GPU)    | 126.0 ms  | 120.1 ms      | 63.0 ms       | **61.1 ms**             | **−52%**     |
| lm_head        | 233.4 ms  | **18.6 ms**   | 18.5 ms       | 18.5 ms                 | **−92%**     |
| sample         | 0.27 ms   | 0.27 ms       | 0.27 ms       | 0.27 ms                 | ~same        |
| detok          | 0.006 ms  | 0.005 ms      | 0.005 ms      | 0.005 ms                | ~same        |
| **total/tok**  | 359.7 ms  | 138.9 ms      | 81.8 ms       | **80.0 ms**             | **−78% (4.5×)** |

### Chain breakdown (NEW, this PR)

\`--emit-stage-timings\` now emits a per-kernel-class line:

\`\`\`
[chain-breakdown] gen_steps=16
  full_attn_ms_avg=4.1   linear_attn_ms_avg=21.2   ffn_ms_avg=35.6
\`\`\`

| Kernel class | per-token | per-layer | layers | share of chain |
|--------------|-----------|-----------|--------|----------------|
| full_attn    | 4.1 ms    | 0.41 ms   | 10     | 7%             |
| linear_attn  | 21.2 ms   | 0.71 ms   | 30     | 35%            |
| **FFN (MoE)**| **35.6 ms** | 0.89 ms | 40     | **58%**        |

### Commits

1. **Stage timings + drop stale post-decode banner.** Wires \`--emit-stage-timings\` into qwen36-moe \`decode_text\` with five buckets averaged across generation steps. Drops the now-stale "(Note: greedy decoding only…)" banner.

2. **GPU-side final RMSNorm + lm_head GEMV.** New \`qwen36_moe_lm_head_kernel<T>\` doing RMSNorm + GEMV in BF16 with F32 accumulation — same path HF runs at inference. Replaces the host F32 GEMV (65% of per-token wall-clock). Engine swaps F32 host caches for persistent GPU BF16 buffers. Parity test \`qwen36_moe_lm_head_matches_host_f32_reference\` asserts cos_sim ≥ 0.999 against F32 host reference. **lm_head: 233 ms → 18.6 ms (12.5×).**

3. **All INT4 matmuls → 8-wide dequant.** Every INT4 matvec was on the scalar dequant path. Routed all hot sites — q/k/v/o_proj, fused linear in_proj, linear out_proj, per-expert gate_up + down_proj, shared down_proj — through a new \`int4_dq8_matvec_partial\` helper that uses \`int4_dequant_8\` (4-byte uint32 load, amortized scale/zero, eight F32 muladds). **Chain: 120 → 63 ms (1.9×).**

4. **Skip per-layer D2H syncs on production path.** \`run_chained_decode\` was unconditionally D2H'ing each layer's attn + ffn output for diagnostic data the engine never reads (only the multilayer parity test consumes them). Split into legacy / fast / explicit-options entry points; engine routes through fast.

5. **Per-kernel-class chain breakdown.** New \`[chain-breakdown]\` stage-timings line surfaces wall-clock per attn / linear / ffn launch class. Confirms FFN at 58% of chain time is the next big lever.

## Test plan

- [x] \`cargo test --release -p kernel-ffi qwen36_moe_lm_head_matches_host_f32_reference\` (cos_sim ≥ 0.999)
- [x] Full qwen36_moe parity sweep: 25/26 (only known issue #66 \`ffn_step_1_topk\` near-tie, pre-existing).
- [x] \`qwen36_moe_multilayer_parity\` test still passes via legacy entry point.
- [x] End-to-end "The quick brown fox" 16-token greedy: bit-identical generated ids \`[33075, 888, 279, 15217, 5388, 13, 271, 71093, 66, 198, 1032, 361, 10038, 834, 29, 198]\`.
- [x] Diverse prompts coherent (capital of France, Fibonacci function, sampled rainbow at seed=7).
- [x] Stage timings + chain breakdown empirically confirm the speedup numbers above on local 7900 XTX.

## Future work (next perf PR)

The chain breakdown points the way clearly:

1. **FFN expert parallelization** (highest ROI, ~58% of chain time). The K_top=8 experts currently run sequentially in the per-expert phase G/H/I loop with grid barriers between phases AND between iterations (~24 grid barriers per FFN call). Splitting blocks into K_top groups (12 blocks/group on gfx1100) so all 8 experts process G/H/I concurrently could shave ~25-30 ms off chain time. Workspace expansion required (~42 KiB) plus per-group atomic counters in \`sync_buf\` (currently sized for one global counter — needs to grow to 16+ slots).

2. **Linear-attn refactor** (35% of chain). Per-layer at 0.71 ms — modest absolute work but multiplied by 30 layers. Profile next.

3. **Persistent megakernel** (PR 4c step 4). 80 launches → 1; saves ~1-2 ms launch overhead, opens space for further inter-layer optimizations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)