### PR TITLE
Fix CUDA-only Qwen3.6 MoE build

### DIFF
--- a/crates/kernel-ffi/src/qwen36_moe.rs
+++ b/crates/kernel-ffi/src/qwen36_moe.rs
@@ -1130,7 +1130,7 @@ pub fn int4_dequant_smoke_launch(
     }
 
     let backend = packed_buf.backend();
-    let status = match backend {
+    let status: c_int = match backend {
         Backend::Hip => {
             #[cfg(supersonic_backend_hip)]
             unsafe {


### PR DESCRIPTION
## Summary
- add the missing `c_int` annotation on the Qwen3.6 MoE INT4 dequant smoke launch status so `SUPERSONIC_BACKENDS=cuda` builds compile when HIP is not enabled

## Phi4 CUDA parity notes from this branch
- full Phi4 INT4 corpus with diagnostics: 9/12 prompts matched; the 3 direct-CUDA divergences were all prefix-aligned near ties with 0.0 BF16 materialized gaps
- forcing BF16/materialized argmax fixed those 3 but regressed quick/water, ending at 10/12
- f32 epsilon sweeps also traded failures rather than solving them: `0.03125` kept the original 3 failures; `0.0625` failed all 5 focused prompts; `0.125` matched the exact-tie prompts but regressed quick/water
- cuBLAS F32 lm-head materialization matched the fused f32 behavior: quick/water OK, exact-tie prompts still diverged

Conclusion: no safe runtime argmax heuristic landed here. The remaining Phi4 CUDA mismatches are near-tie argmax policy/noise cases, not a broad logits parity failure.

## Validation
- `SUPERSONIC_BACKENDS=cuda cargo build --release --bin supersonic`
- `git diff --check`