### PR TITLE
Match Phi4 CUDA argmax to BF16 logits

### DIFF
--- a/crates/runner/src/phi4_engine.rs
+++ b/crates/runner/src/phi4_engine.rs
@@ -403,6 +403,7 @@ pub fn run_phi4(
     let debug_dump_hidden = std::env::var("SUPERSONIC_PHI4_DUMP_HIDDEN").ok();
     let debug_dump_logits = std::env::var("SUPERSONIC_PHI4_DUMP_LOGITS").ok();
     let debug_dump_direct_argmax = std::env::var("SUPERSONIC_PHI4_DUMP_DIRECT_ARGMAX").ok();
+    let cuda_argmax_f32_accum = std::env::var_os("SUPERSONIC_PHI4_CUDA_ARGMAX_F32ACCUM").is_some();
     let mut debug_logit_samples: Vec<serde_json::Value> = Vec::new();
     let mut debug_direct_argmax_samples: Vec<serde_json::Value> = Vec::new();
     let head_dim = config.head_dim();
@@ -658,16 +659,30 @@ pub fn run_phi4(
                 && oracle_output.is_none()
                 && debug_dump_logits.is_none();
             let (next, logits_f32) = if use_direct_cuda_argmax {
-                kernel_ffi::cuda_lm_head_argmax_bf16_f32accum(
-                    ordinal,
-                    &normed_buf,
-                    &*weights.lm_head,
-                    &mut lm_argmax_vals,
-                    &mut lm_argmax_idxs,
-                    &mut lm_argmax_out,
-                    hidden_size,
-                    config.vocab_size,
-                )
+                if cuda_argmax_f32_accum {
+                    kernel_ffi::cuda_lm_head_argmax_bf16_f32accum(
+                        ordinal,
+                        &normed_buf,
+                        &*weights.lm_head,
+                        &mut lm_argmax_vals,
+                        &mut lm_argmax_idxs,
+                        &mut lm_argmax_out,
+                        hidden_size,
+                        config.vocab_size,
+                    )
+                } else {
+                    // Match the materialized/HIP path: logits are BF16 before greedy argmax.
+                    kernel_ffi::cuda_lm_head_argmax_bf16(
+                        ordinal,
+                        &normed_buf,
+                        &*weights.lm_head,
+                        &mut lm_argmax_vals,
+                        &mut lm_argmax_idxs,
+                        &mut lm_argmax_out,
+                        hidden_size,
+                        config.vocab_size,
+                    )
+                }
                 .map_err(|e| anyhow!("lm_head argmax at step {step}: {e}"))?;
                 let idx_bytes = lm_argmax_out
                     .to_host_bytes()


### PR DESCRIPTION
## Summary
- switch Phi4 direct CUDA LM-head argmax to the BF16-rounded logit path by default
- keep the previous FP32-accum argmax available with `SUPERSONIC_PHI4_CUDA_ARGMAX_F32ACCUM=1` for comparisons
- this makes direct CUDA argmax follow the materialized/HIP policy without forcing a full logits buffer

## Validation
- `SUPERSONIC_BACKENDS=cuda cargo build --release --bin supersonic`
- focused 5-prompt Phi4 INT4 sweep: 3/5 full matches, fixing the moon/sea/translate BF16 tie cases while leaving quick/water as known residual near-tie misses
- full 12-prompt Phi4 INT4 corpus: 10/12 full matches (`/tmp/phi4_bf16_direct_argmax_full_report.json`)

Notes: the previous FP32 direct path was 9/12 on the full corpus; the BF16-rounded path matches the prior materialized-logit behavior but stays on the fused direct argmax path.