### PR TITLE
qwen36-moe: concurrent K_top expert dispatch + linear-attn barrier cleanup

### DIFF
--- a/crates/kernel-ffi/src/qwen36_moe.rs
+++ b/crates/kernel-ffi/src/qwen36_moe.rs
@@ -1053,6 +1053,22 @@ pub fn ffn_step_launch(
             params.top_k, params.num_experts,
         )));
     }
+    // The concurrent-experts G/H/I dispatch uses counters[0..2*top_k] for
+    // per-group work-stealing (Phase G slots [0..top_k), Phase I slots
+    // [top_k..2*top_k)). The sync_buf carries 16 u32 counter slots before
+    // barrier_counter at +64; pushing past slot 15 corrupts barrier state
+    // and can hang the kernel, so cap top_k at the layout's hard limit. If
+    // a future model needs top_k > 8 we'll grow sync_buf in lockstep.
+    const MAX_TOP_K: i32 = 8;
+    if params.top_k > MAX_TOP_K {
+        return Err(GpuError::InvalidArg(format!(
+            "qwen36_moe::ffn_step_launch: top_k ({}) exceeds the FFN \
+             concurrent-experts dispatch limit ({MAX_TOP_K}); the 16-slot \
+             sync_buf reserves 2*top_k counter slots before barrier_counter \
+             at +64, so top_k > {MAX_TOP_K} would overrun into barrier state",
+            params.top_k,
+        )));
+    }
     // Only stage 1 is wired through PR 4b4 step 2; stage 2..=5 will land in
     // follow-up commits to this PR.
 

--- a/crates/kernel-ffi/src/qwen36_moe.rs
+++ b/crates/kernel-ffi/src/qwen36_moe.rs
@@ -247,7 +247,7 @@ extern "C" {
     /// (used to hold the BF16-rounded F32 view of `q_raw` between phases).
     /// `output` must be at least `num_heads * head_dim` BF16 entries on
     /// stage 1 — sized for the largest staged intermediate, BF16.
-    /// `sync_buf` (counters/barrier_counter/barrier_flag) must be 32 zero
+    /// `sync_buf` (counters/barrier_counter/barrier_flag) must be 96 zero
     /// bytes — see [`stub_launch`] for the layout convention.
     pub fn qwen36_moe_hip_attn_step_launch(
         dtype: c_int,
@@ -311,7 +311,7 @@ extern "C" {
     /// for stage 1 (later stages bump that up via the safe wrapper).
     /// `output` must be at least `qkv_dim` BF16 entries on stage 1 (sized
     /// for the largest staged intermediate by the safe wrapper). `sync_buf`
-    /// (counters/barrier_counter/barrier_flag) must be 32 zero bytes.
+    /// (counters/barrier_counter/barrier_flag) must be 96 zero bytes.
     pub fn qwen36_moe_hip_linear_step_launch(
         dtype: c_int,
         device_ordinal: usize,
@@ -375,7 +375,7 @@ extern "C" {
     /// entries for stage 1 (later stages bump that up). `output` must be at
     /// least `top_k` BF16 entries on stage 1 and `output_idx` must be at
     /// least `top_k` i32 entries. `sync_buf` (counters/barrier_counter/
-    /// barrier_flag) must be 32 zero bytes.
+    /// barrier_flag) must be 96 zero bytes.
     ///
     /// PR 4b5 step 2: INT4 dequant smoke launcher.
     ///
@@ -477,9 +477,12 @@ extern "C" {
 }
 
 /// Safe wrapper over the stub launch. The engine pre-allocates `sync_buf`
-/// as a 32-byte zeroed scratch (work-stealing counter at offset 0, grid
-/// barrier counter at +16, flag at +20 — same layout as
-/// `crate::persistent_decode_4b`).
+/// as a 96-byte zeroed scratch — 16 u32 work-stealing counter slots at
+/// +0..+63 (only counters[0] used here; the FFN concurrent-experts dispatch
+/// uses 2*K_top of them), grid barrier counter at +64, flag at +68. The
+/// 32-byte form used by `crate::persistent_decode_4b` is the older single-
+/// counter layout — qwen36_moe shares one widened sync_buf across all four
+/// step launchers (stub/attn/linear/ffn) so any can run with any.
 ///
 /// Returns when the kernel signals completion via `hipDeviceSynchronize`.
 /// The smoke-test path reads `workspace` back to verify descriptor
@@ -499,8 +502,12 @@ pub fn stub_launch(
     }
     let backend = layer_descs_device.backend();
     let counters = sync_buf.as_mut_ptr() as *mut c_uint;
-    let barrier_counter = unsafe { (counters as *mut u8).add(16) as *mut c_uint };
-    let barrier_flag = unsafe { (counters as *mut u8).add(20) as *mut c_uint };
+    // Layout: 16 u32 work-stealing counter slots at +0..+63 (the FFN
+    // concurrent-experts dispatch uses 2*K_top of these; attn/linear/stub
+    // only touch counters[0]). Barrier counter+flag follow at +64/+68.
+    // Sync_buf must be at least 96 bytes zeroed before launch.
+    let barrier_counter = unsafe { (counters as *mut u8).add(64) as *mut c_uint };
+    let barrier_flag = unsafe { (counters as *mut u8).add(68) as *mut c_uint };
 
     let status: c_int = match backend {
         Backend::Hip => {
@@ -649,8 +656,8 @@ impl Qwen36MoeAttnStepInt4 {
 /// `output` must be a BF16 buffer with at least `num_heads * head_dim`
 /// elements (the size of the largest staged intermediate). `workspace` must
 /// be an F32 buffer with at least `2 * num_heads * head_dim` elements.
-/// `sync_buf` must be a 32-byte zero buffer (counter @ +0, barrier counter
-/// @ +16, barrier flag @ +20).
+/// `sync_buf` must be a 96-byte zero buffer (counters @ +0..+63 — only
+/// counters[0] used here, barrier counter @ +64, barrier flag @ +68).
 pub fn attn_step_launch(
     ordinal: usize,
     dtype: ScalarType,
@@ -676,8 +683,12 @@ pub fn attn_step_launch(
 
     let backend = output.backend();
     let counters = sync_buf.as_mut_ptr() as *mut c_uint;
-    let barrier_counter = unsafe { (counters as *mut u8).add(16) as *mut c_uint };
-    let barrier_flag = unsafe { (counters as *mut u8).add(20) as *mut c_uint };
+    // Layout: 16 u32 work-stealing counter slots at +0..+63 (the FFN
+    // concurrent-experts dispatch uses 2*K_top of these; attn/linear/stub
+    // only touch counters[0]). Barrier counter+flag follow at +64/+68.
+    // Sync_buf must be at least 96 bytes zeroed before launch.
+    let barrier_counter = unsafe { (counters as *mut u8).add(64) as *mut c_uint };
+    let barrier_flag = unsafe { (counters as *mut u8).add(68) as *mut c_uint };
 
     let status: c_int = match backend {
         Backend::Hip => {
@@ -823,8 +834,8 @@ impl Qwen36MoeLinearStepInt4 {
 }
 
 /// Safe wrapper for the PR 4b3 staged linear-attention parity launcher.
-/// Same workspace / sync_buf layout as
-/// [`attn_step_launch`]: 32-byte zero scratch, F32 workspace sized for the
+/// Same workspace / sync_buf layout as [`attn_step_launch`]: 96-byte zero
+/// scratch (only counters[0] used here), F32 workspace sized for the
 /// stage's footprint, BF16 output sized for the largest staged intermediate.
 pub fn linear_step_launch(
     ordinal: usize,
@@ -851,8 +862,12 @@ pub fn linear_step_launch(
 
     let backend = output.backend();
     let counters = sync_buf.as_mut_ptr() as *mut c_uint;
-    let barrier_counter = unsafe { (counters as *mut u8).add(16) as *mut c_uint };
-    let barrier_flag = unsafe { (counters as *mut u8).add(20) as *mut c_uint };
+    // Layout: 16 u32 work-stealing counter slots at +0..+63 (the FFN
+    // concurrent-experts dispatch uses 2*K_top of these; attn/linear/stub
+    // only touch counters[0]). Barrier counter+flag follow at +64/+68.
+    // Sync_buf must be at least 96 bytes zeroed before launch.
+    let barrier_counter = unsafe { (counters as *mut u8).add(64) as *mut c_uint };
+    let barrier_flag = unsafe { (counters as *mut u8).add(68) as *mut c_uint };
 
     let status: c_int = match backend {
         Backend::Hip => {
@@ -1006,8 +1021,10 @@ impl Qwen36MoeFfnStepInt4 {
 /// (the size of the largest staged intermediate). `output_idx` must be an
 /// i32 buffer with at least `top_k` elements. `workspace` must be an F32
 /// buffer sized for the requested stage's footprint (see the layout comment
-/// in `kernels/qwen36_moe.hip`). `sync_buf` must be a 32-byte zero buffer
-/// (counter @ +0, barrier counter @ +16, barrier flag @ +20).
+/// in `kernels/qwen36_moe.hip`). `sync_buf` must be a 96-byte zero buffer:
+/// 16 u32 work-stealing counter slots at +0..+63 (the per-expert G/I phases
+/// use counters[0..2*top_k] for cyclic per-group dispatch), barrier counter
+/// at +64, barrier flag at +68.
 pub fn ffn_step_launch(
     ordinal: usize,
     dtype: ScalarType,
@@ -1041,8 +1058,12 @@ pub fn ffn_step_launch(
 
     let backend = output.backend();
     let counters = sync_buf.as_mut_ptr() as *mut c_uint;
-    let barrier_counter = unsafe { (counters as *mut u8).add(16) as *mut c_uint };
-    let barrier_flag = unsafe { (counters as *mut u8).add(20) as *mut c_uint };
+    // Layout: 16 u32 work-stealing counter slots at +0..+63 (the FFN
+    // concurrent-experts dispatch uses 2*K_top of these; attn/linear/stub
+    // only touch counters[0]). Barrier counter+flag follow at +64/+68.
+    // Sync_buf must be at least 96 bytes zeroed before launch.
+    let barrier_counter = unsafe { (counters as *mut u8).add(64) as *mut c_uint };
+    let barrier_flag = unsafe { (counters as *mut u8).add(68) as *mut c_uint };
 
     let status: c_int = match backend {
         Backend::Hip => {
@@ -1380,7 +1401,7 @@ mod tests {
         // ~MiB; keeping this tiny lets the smoke test stay fast.
         let mut workspace = GpuBuffer::zeros(ordinal, ScalarType::F32, &[16])
             .expect("alloc workspace");
-        let mut sync_buf = GpuBuffer::zeros(ordinal, ScalarType::U8, &[32])
+        let mut sync_buf = GpuBuffer::zeros(ordinal, ScalarType::U8, &[96])
             .expect("alloc sync buf");
 
         stub_launch(
@@ -1716,7 +1737,7 @@ mod tests {
             &[parity_workspace_floats(geom.num_heads, geom.num_kv_heads, geom.head_dim, geom.hidden)],
         ).expect("alloc workspace");
         let mut sync_buf = GpuBuffer::zeros(
-            ordinal, ScalarType::U8, &[32],
+            ordinal, ScalarType::U8, &[96],
         ).expect("alloc sync buf");
 
         let params = Qwen36MoeAttnStepParams {
@@ -1837,7 +1858,7 @@ mod tests {
             &[parity_workspace_floats(geom.num_heads, geom.num_kv_heads, geom.head_dim, geom.hidden)],
         ).expect("alloc workspace");
         let mut sync_buf = GpuBuffer::zeros(
-            ordinal, ScalarType::U8, &[32],
+            ordinal, ScalarType::U8, &[96],
         ).expect("alloc sync buf");
 
         let params = Qwen36MoeAttnStepParams {
@@ -1967,7 +1988,7 @@ mod tests {
             &[parity_workspace_floats(geom.num_heads, geom.num_kv_heads, geom.head_dim, geom.hidden)],
         ).expect("alloc workspace");
         let mut sync_buf = GpuBuffer::zeros(
-            ordinal, ScalarType::U8, &[32],
+            ordinal, ScalarType::U8, &[96],
         ).expect("alloc sync buf");
 
         let params = Qwen36MoeAttnStepParams {
@@ -2088,7 +2109,7 @@ mod tests {
             &[parity_workspace_floats(geom.num_heads, geom.num_kv_heads, geom.head_dim, geom.hidden)],
         ).expect("alloc workspace");
         let mut sync_buf = GpuBuffer::zeros(
-            ordinal, ScalarType::U8, &[32],
+            ordinal, ScalarType::U8, &[96],
         ).expect("alloc sync buf");
 
         let params = Qwen36MoeAttnStepParams {
@@ -2212,7 +2233,7 @@ mod tests {
             &[parity_workspace_floats(geom.num_heads, geom.num_kv_heads, geom.head_dim, geom.hidden)],
         ).expect("alloc workspace");
         let mut sync_buf = GpuBuffer::zeros(
-            ordinal, ScalarType::U8, &[32],
+            ordinal, ScalarType::U8, &[96],
         ).expect("alloc sync buf");
 
         let params = Qwen36MoeAttnStepParams {
@@ -2428,7 +2449,7 @@ mod tests {
             &[parity_workspace_floats(geom.num_heads, geom.num_kv_heads, geom.head_dim, geom.hidden)],
         ).expect("alloc workspace");
         let mut sync_buf = GpuBuffer::zeros(
-            ordinal, ScalarType::U8, &[32],
+            ordinal, ScalarType::U8, &[96],
         ).expect("alloc sync buf");
 
         let params = Qwen36MoeAttnStepParams {
@@ -2621,7 +2642,7 @@ mod tests {
             ordinal, ScalarType::F32, &[workspace_floats],
         ).expect("alloc workspace");
         let mut sync_buf = GpuBuffer::zeros(
-            ordinal, ScalarType::U8, &[32],
+            ordinal, ScalarType::U8, &[96],
         ).expect("alloc sync buf");
 
         let params = Qwen36MoeLinearStepParams {
@@ -2767,7 +2788,7 @@ mod tests {
             ordinal, ScalarType::F32, &[workspace_floats],
         ).expect("alloc workspace");
         let mut sync_buf = GpuBuffer::zeros(
-            ordinal, ScalarType::U8, &[32],
+            ordinal, ScalarType::U8, &[96],
         ).expect("alloc sync buf");
 
         let params = Qwen36MoeLinearStepParams {
@@ -2928,7 +2949,7 @@ mod tests {
             ordinal, ScalarType::F32, &[workspace_floats],
         ).expect("alloc workspace");
         let mut sync_buf = GpuBuffer::zeros(
-            ordinal, ScalarType::U8, &[32],
+            ordinal, ScalarType::U8, &[96],
         ).expect("alloc sync buf");
 
         let params = Qwen36MoeLinearStepParams {
@@ -3102,7 +3123,7 @@ mod tests {
             ordinal, ScalarType::F32, &[workspace_floats],
         ).expect("alloc workspace");
         let mut sync_buf = GpuBuffer::zeros(
-            ordinal, ScalarType::U8, &[32],
+            ordinal, ScalarType::U8, &[96],
         ).expect("alloc sync buf");
 
         let params = Qwen36MoeLinearStepParams {
@@ -3291,7 +3312,7 @@ mod tests {
             ordinal, ScalarType::F32, &[workspace_floats],
         ).expect("alloc workspace");
         let mut sync_buf = GpuBuffer::zeros(
-            ordinal, ScalarType::U8, &[32],
+            ordinal, ScalarType::U8, &[96],
         ).expect("alloc sync buf");
 
         let params = Qwen36MoeLinearStepParams {
@@ -3524,7 +3545,7 @@ mod tests {
             ordinal, ScalarType::F32, &[workspace_floats],
         ).expect("alloc workspace");
         let mut sync_buf = GpuBuffer::zeros(
-            ordinal, ScalarType::U8, &[32],
+            ordinal, ScalarType::U8, &[96],
         ).expect("alloc sync buf");
 
         let params = Qwen36MoeLinearStepParams {
@@ -3651,8 +3672,8 @@ mod tests {
     ///   SUP           [Is]
     ///   SHARED_MID    [Is]
     ///   SHARED_OUT    [hidden]
-    ///   EXPERT_GU     [2*I]
-    ///   EXPERT_MID    [I]
+    ///   EXPERT_GU     [k * 2*I]   one [2*I] slab per concurrent expert group
+    ///   EXPERT_MID    [k * I]     one [I]   slab per concurrent expert group
     ///   EXPERT_STACK  [k*hidden]
     ///   MOE_OUT       [hidden]
     ///
@@ -3670,14 +3691,16 @@ mod tests {
         let k = geom.top_k as usize;
         let is_dim = geom.shared_intermediate as usize;
         let i_dim = geom.moe_intermediate as usize;
-        // 3*hidden = H_NORM + SHARED_OUT + MOE_OUT
-        // 2*e      = ROUTER_LOGITS + ROUTER_PROBS
-        // 2*k      = TOPK_VAL + TOPK_IDX
-        // 1        = SG_SCALAR
-        // 3*is_dim = SGP + SUP + SHARED_MID
-        // 3*i_dim  = EXPERT_GU(2*I) + EXPERT_MID(I)
-        // k*hidden = EXPERT_STACK
-        3 * hidden + 2 * e + 2 * k + 1 + 3 * is_dim + 3 * i_dim + k * hidden
+        // 3*hidden     = H_NORM + SHARED_OUT + MOE_OUT
+        // 2*e          = ROUTER_LOGITS + ROUTER_PROBS
+        // 2*k          = TOPK_VAL + TOPK_IDX
+        // 1            = SG_SCALAR
+        // 3*is_dim     = SGP + SUP + SHARED_MID
+        // k*3*i_dim    = EXPERT_GU(k*2*I) + EXPERT_MID(k*I) — sized for the
+        //                concurrent-experts G/H/I dispatch (one slab per
+        //                expert group)
+        // k*hidden     = EXPERT_STACK
+        3 * hidden + 2 * e + 2 * k + 1 + 3 * is_dim + k * 3 * i_dim + k * hidden
     }
 
     /// Output BF16 elements sufficient for the largest staged FFN
@@ -3752,7 +3775,7 @@ mod tests {
             ordinal, ScalarType::F32, &[ffn_parity_workspace_floats(&geom)],
         ).expect("alloc workspace");
         let mut sync_buf = GpuBuffer::zeros(
-            ordinal, ScalarType::U8, &[32],
+            ordinal, ScalarType::U8, &[96],
         ).expect("alloc sync buf");
 
         let params = Qwen36MoeFfnStepParams {
@@ -3895,7 +3918,7 @@ mod tests {
             ordinal, ScalarType::F32, &[ffn_parity_workspace_floats(&geom)],
         ).expect("alloc workspace");
         let mut sync_buf = GpuBuffer::zeros(
-            ordinal, ScalarType::U8, &[32],
+            ordinal, ScalarType::U8, &[96],
         ).expect("alloc sync buf");
 
         let params = Qwen36MoeFfnStepParams {
@@ -4040,7 +4063,7 @@ mod tests {
             ordinal, ScalarType::F32, &[ffn_parity_workspace_floats(&geom)],
         ).expect("alloc workspace");
         let mut sync_buf = GpuBuffer::zeros(
-            ordinal, ScalarType::U8, &[32],
+            ordinal, ScalarType::U8, &[96],
         ).expect("alloc sync buf");
 
         let params = Qwen36MoeFfnStepParams {
@@ -4174,7 +4197,7 @@ mod tests {
             ordinal, ScalarType::F32, &[ffn_parity_workspace_floats(&geom)],
         ).expect("alloc workspace");
         let mut sync_buf = GpuBuffer::zeros(
-            ordinal, ScalarType::U8, &[32],
+            ordinal, ScalarType::U8, &[96],
         ).expect("alloc sync buf");
 
         let params = Qwen36MoeFfnStepParams {
@@ -4309,7 +4332,7 @@ mod tests {
             ordinal, ScalarType::F32, &[ffn_parity_workspace_floats(&geom)],
         ).expect("alloc workspace");
         let mut sync_buf = GpuBuffer::zeros(
-            ordinal, ScalarType::U8, &[32],
+            ordinal, ScalarType::U8, &[96],
         ).expect("alloc sync buf");
 
         let params = Qwen36MoeFfnStepParams {
@@ -4522,7 +4545,7 @@ mod tests {
             ordinal, ScalarType::F32, &[ffn_parity_workspace_floats(&geom)],
         ).expect("alloc workspace");
         let mut sync_buf = GpuBuffer::zeros(
-            ordinal, ScalarType::U8, &[32],
+            ordinal, ScalarType::U8, &[96],
         ).expect("alloc sync buf");
 
         let params = Qwen36MoeFfnStepParams {
@@ -4723,7 +4746,7 @@ mod tests {
             ordinal, ScalarType::F32, &[ffn_parity_workspace_floats(&geom)],
         ).expect("alloc workspace");
         let mut sync_buf = GpuBuffer::zeros(
-            ordinal, ScalarType::U8, &[32],
+            ordinal, ScalarType::U8, &[96],
         ).expect("alloc sync buf");
 
         let params = Qwen36MoeFfnStepParams {
@@ -4922,7 +4945,7 @@ mod tests {
             ordinal, ScalarType::F32, &[ffn_parity_workspace_floats(&geom)],
         ).expect("alloc workspace");
         let mut sync_buf = GpuBuffer::zeros(
-            ordinal, ScalarType::U8, &[32],
+            ordinal, ScalarType::U8, &[96],
         ).expect("alloc sync buf");
 
         let _ = (i_us, is_us);  // kept for clarity above.

--- a/crates/runner/src/qwen36_moe_decode.rs
+++ b/crates/runner/src/qwen36_moe_decode.rs
@@ -270,13 +270,17 @@ fn linear_attn_output_elems(geom: &MultiLayerGeom) -> usize {
 /// FFN parity launcher workspace floats — copied from the per-block test
 /// file's `ffn_parity_workspace_floats`. See its docstring for the
 /// per-stage layout (`OFF_H_NORM` in `kernels/qwen36_moe.hip`).
+///
+/// The per-expert scratch slabs (`EXPERT_GU`, `EXPERT_MID`) are sized
+/// `k * 2*I` and `k * I` respectively so all `top_k` experts can run
+/// G/H/I concurrently (one block-group per expert).
 fn ffn_workspace_floats(geom: &MultiLayerGeom) -> usize {
     let hidden = geom.hidden as usize;
     let e = geom.num_experts as usize;
     let k = geom.top_k as usize;
     let is_dim = geom.shared_intermediate as usize;
     let i_dim = geom.moe_intermediate as usize;
-    3 * hidden + 2 * e + 2 * k + 1 + 3 * is_dim + 3 * i_dim + k * hidden
+    3 * hidden + 2 * e + 2 * k + 1 + 3 * is_dim + k * 3 * i_dim + k * hidden
 }
 
 /// FFN output BF16 elements — stage 5 publishes `[hidden]`, which is also
@@ -285,11 +289,18 @@ fn ffn_output_elems(geom: &MultiLayerGeom) -> usize {
     geom.hidden as usize
 }
 
-/// Reset the 32-byte cooperative-launch sync buffer between launches. The
+/// Reset the 96-byte cooperative-launch sync buffer between launches. The
 /// kernels use it for atomic counters + the grid barrier; failure to reset
 /// would cause the next launch's barrier to hang or skip work.
+///
+/// Layout (matches the four qwen36_moe FFI wrappers):
+///   counters[0..16]      bytes  0..63  (16 work-stealing slots, used by the
+///                                       FFN concurrent-experts dispatch)
+///   barrier_counter      bytes 64..67
+///   barrier_flag         bytes 68..71
+///   (padding to 96 bytes for alignment headroom)
 fn reset_sync_buf(ordinal: usize, sync_buf: &mut GpuBuffer) -> Result<(), GpuError> {
-    memset_zeros(ordinal, sync_buf.as_mut_ptr(), 32)
+    memset_zeros(ordinal, sync_buf.as_mut_ptr(), 96)
 }
 
 /// Copy `[hidden]` BF16 elements out of a GPU buffer into a freshly
@@ -488,7 +499,7 @@ pub fn run_chained_decode_with_options(
         .context("alloc ffn_workspace")?;
 
     let mut sync_buf =
-        GpuBuffer::zeros(ordinal, ScalarType::U8, &[32]).context("alloc sync_buf")?;
+        GpuBuffer::zeros(ordinal, ScalarType::U8, &[96]).context("alloc sync_buf")?;
 
     let mut per_layer_attn_out: Vec<Vec<u8>> = Vec::with_capacity(layers.len());
     let mut per_layer_ffn_out: Vec<Vec<u8>> = Vec::with_capacity(layers.len());

--- a/kernels/qwen36_moe.hip
+++ b/kernels/qwen36_moe.hip
@@ -1848,13 +1848,18 @@ __global__ void qwen36_moe_linear_step_kernel(
 //     SUP           = hidden + 2*E + 2*k + 1 + Is                    [Is]  shared_up_proj output
 //     SHARED_MID    = hidden + 2*E + 2*k + 1 + 2*Is                  [Is]  silu(sgp) * sup (F32)
 //     SHARED_OUT    = hidden + 2*E + 2*k + 1 + 3*Is                  [hidden] shared expert path output (BF16-rounded F32)
-//     EXPERT_GU     = ... + hidden                                   [2*I] gate_up_proj output for one expert (F32)
-//     EXPERT_MID    = ... + 2*I                                      [I]   silu(gu[:I]) * gu[I:]  (F32)
-//     EXPERT_STACK  = ... + I                                        [k * hidden] per-expert outs (F32, no BF16 round)
+//     EXPERT_GU     = ... + hidden                                   [k * 2*I] per-expert gate_up_proj outputs (F32)
+//                                                                    one [2*I] slab per concurrent expert group
+//     EXPERT_MID    = ... + k*2*I                                    [k * I]   per-expert silu(gu[:I]) * gu[I:] (F32)
+//                                                                    one [I] slab per concurrent expert group
+//     EXPERT_STACK  = ... + k*I                                      [k * hidden] per-expert outs (F32, no BF16 round)
 //     MOE_OUT       = ... + k*hidden                                 [hidden] BF16-rounded F32
 //     OUTPUT_HIDDEN = ... + hidden                                   [hidden]
 //   For 35B-A3B (hidden=2048, E=256, k=8, Is=512, I=512) stage-5 footprint
-//   is ~28,177 F32 = ~110 KiB. Well within the persistent-decode budget.
+//   is ~38,929 F32 = ~152 KiB after EXPERT_GU/MID grew K_top-wide so all
+//   `top_k` experts can run G/H/I concurrently (one block-group per expert,
+//   `num_blocks / k` blocks per group on gfx1100 = 96/8 = 12). Still well
+//   within the persistent-decode budget.
 //
 //   Numerics: every per-expert intermediate (EXPERT_GU, EXPERT_MID,
 //   EXPERT_STACK) stays raw F32 to mirror the oracle's all-F32 chain
@@ -1939,8 +1944,8 @@ __global__ void qwen36_moe_ffn_step_kernel(
     const int OFF_SHARED_MID    = OFF_SUP + shared_intermediate;
     const int OFF_SHARED_OUT    = OFF_SHARED_MID + shared_intermediate;
     const int OFF_EXPERT_GU     = OFF_SHARED_OUT + hidden;
-    const int OFF_EXPERT_MID    = OFF_EXPERT_GU + 2 * moe_intermediate;
-    const int OFF_EXPERT_STACK  = OFF_EXPERT_MID + moe_intermediate;
+    const int OFF_EXPERT_MID    = OFF_EXPERT_GU + top_k * 2 * moe_intermediate;
+    const int OFF_EXPERT_STACK  = OFF_EXPERT_MID + top_k * moe_intermediate;
     const int OFF_MOE_OUT       = OFF_EXPERT_STACK + top_k * hidden;
 
     // -- Phase A: load input + post_attn RMS norm --------------------------
@@ -2322,14 +2327,50 @@ __global__ void qwen36_moe_ffn_step_kernel(
         return;
     }
 
-    // -- Phase G/H/I: per-expert FFN — k-iteration loop  -------------------
-    // Stage 3 dispatches just topk_idx[0]; stage 4+ sweeps all k experts.
-    // The per-iteration body is the same; the difference is what we do
-    // after the loop:
-    //   stage 3 → expose EXPERT_STACK[0] BF16-cast as the parity output
-    //   stage 4 → sum topk_w[j] * EXPERT_STACK[j] across j, BF16-round once
+    // -- Phase G/H/I: per-expert FFN — concurrent across all top_k experts -
+    // Previous revision iterated `j = 0 .. k_iters` sequentially with three
+    // grid barriers per iteration (~24 total at K_top=8). This dispatch
+    // assigns every block to one of `K_top` expert "groups" via cyclic
+    // partitioning and runs all groups in parallel for each of G, H, I —
+    // collapsing to three grid barriers total.
     //
-    // Within each iteration:
+    // Block partitioning (cyclic; distributes any leftover blocks evenly):
+    //   group_id = blockIdx.x % top_k
+    //   sub_id   = blockIdx.x / top_k
+    // For 35B-A3B on gfx1100 (num_blocks=96, top_k=8) every group gets
+    // exactly 12 blocks. On other geometries the residual `num_blocks %
+    // top_k` blocks fall into the early groups; those groups simply have
+    // one extra block contending the same counter slot, which is fine.
+    //
+    // Workspace layout (set up at the OFF_* constants above):
+    //   EXPERT_GU [k * 2*I]   — group g writes [g*2*I .. (g+1)*2*I)
+    //   EXPERT_MID [k * I]    — group g writes [g*I   .. (g+1)*I)
+    //   EXPERT_STACK [k * hidden] — group g writes [g*hidden .. (g+1)*hidden)
+    //
+    // Counter slots (in `counters[]`, all zeroed by `reset_sync_buf` on the
+    // host before each launch — see the sync_buf docstring in
+    // `crates/kernel-ffi/src/qwen36_moe.rs`):
+    //   counters[g]            — Phase G work-stealing for group g (0..2*I)
+    //   counters[top_k + g]    — Phase I work-stealing for group g (0..hidden)
+    //   counters[0]            — re-used by Phase J / K (reset before each)
+    //
+    // Phase shape:
+    //   Phase G (parallel across active groups, work-stealing on counters[g])
+    //   → grid_barrier
+    //   Phase H (one block per active group: sub_id==0, distributes I
+    //            elements via tid-stride; other blocks idle)
+    //   → grid_barrier
+    //   Phase I (parallel, work-stealing on counters[top_k+g])
+    //   → if (stage < 4) return            ← stage 3 exits here
+    //   → grid_barrier_reset_counter(&counters[0])  ← gate Phase J
+    //
+    // Stage 3 dispatches only group 0 by setting `active_groups = 1`. All
+    // blocks still hit the unconditional barriers (the grid barrier needs
+    // every block to participate or it hangs); only the work bodies are
+    // gated on `group_active`. Stage 3's parity-output write fires when
+    // `group_id == 0` (mirrors the old `j == 0` condition).
+    //
+    // Within each group g (`e = topk_idx[g]`):
     //   gu  = gate_up_proj_w[e] @ h_norm                            [2*I]
     //   mid = silu(gu[:I]) * gu[I:]                                 [I]
     //   eo  = down_proj_w[e].T @ mid                                [hidden]
@@ -2338,174 +2379,191 @@ __global__ void qwen36_moe_ffn_step_kernel(
 
     const int I_ = moe_intermediate;
     const int two_I = 2 * I_;
-    const int k_iters = (stage == 3) ? 1 : top_k;
+    const int K_ = top_k;
+    const int active_groups = (stage == 3) ? 1 : K_;
+    const int group_id = blockIdx.x % K_;
+    const bool group_active = (group_id < active_groups);
 
-    for (int j = 0; j < k_iters; j++) {
-        // Per-iteration: every block reads the chosen expert index for
-        // this slot from workspace. Visible across blocks because the
-        // last grid barrier (Phase F's reset, plus any from the
-        // previous iteration's Phase I) ordered the writes.
-        grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
-                                   &counters[0]);
+    // Phase F left counters[0] at `hidden` (atomicAdds during work-stealing).
+    // Phase G of group 0 uses that same slot, so reset it here before any
+    // group reads its counter. counters[1..K_] and counters[K_..2*K_] were
+    // zeroed by `reset_sync_buf` before launch and stay zero through all of
+    // attn/Phase A..F (which only touch counters[0]).
+    grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
+                               &counters[0]);
 
-        __shared__ int s_expert_idx;
-        if (tid == 0) {
-            s_expert_idx = __float_as_int(workspace[OFF_TOPK_IDX + j]);
+    // Each block reads its own group's expert index. All blocks within a
+    // group compute the same `e`; different groups compute different `e`.
+    __shared__ int s_expert_idx;
+    if (tid == 0) {
+        s_expert_idx = __float_as_int(workspace[OFF_TOPK_IDX + group_id]);
+    }
+    __syncthreads();
+    const int e = s_expert_idx;
+
+    // Phase G: matvec gate_up_proj_w[e] @ h_norm → EXPERT_GU[g*2*I..].
+    // BF16 layout: gate_up_proj_w[E, 2*I, hidden] — slab `e` base is
+    // `e * 2*I * hidden`; row `r` adds `r * hidden`.
+    // INT4 layout (when `gate_up_proj_scale != nullptr`):
+    //   weights : [E, 2*I, hidden/2] u8   — slab `e` base in bytes is
+    //                                        `e * 2*I * (hidden/2)`.
+    //   scale   : [E, 2*I/gsz, hidden/gsz] BF16 — slab `e` base in
+    //                                        BF16 elems is
+    //                                        `e * (2*I/gsz) * (hidden/gsz)`.
+    if (group_active) {
+        const bool gu_int4 = (gate_up_proj_scale != nullptr);
+        const T* gu_slab_bf16 =
+            gate_up_proj_w + static_cast<size_t>(e) * two_I * hidden;
+        const uint8_t*      gu_slab_packed = nullptr;
+        const hip_bfloat16* gu_slab_scale  = nullptr;
+        const hip_bfloat16* gu_slab_zero   = nullptr;
+        if (gu_int4) {
+            gu_slab_packed = reinterpret_cast<const uint8_t*>(gate_up_proj_w)
+                           + static_cast<size_t>(e) * two_I
+                             * (hidden / 2);
+            const int gsr = two_I  / int4_group_size;
+            const int gsc = hidden / int4_group_size;
+            gu_slab_scale = gate_up_proj_scale
+                          + static_cast<size_t>(e) * gsr * gsc;
+            gu_slab_zero  = gate_up_proj_zero
+                          + static_cast<size_t>(e) * gsr * gsc;
         }
-        __syncthreads();
-        const int e = s_expert_idx;
+        const int gu_off = OFF_EXPERT_GU + group_id * two_I;
+        for (;;) {
+            __shared__ unsigned int my_row_g_s;
+            if (tid == 0) {
+                my_row_g_s = atomicAdd(&counters[group_id], 1u);
+            }
+            __syncthreads();
+            const int my_row = static_cast<int>(my_row_g_s);
+            if (my_row >= two_I) break;
 
-        // Phase G: matvec gate_up_proj_w[e] @ h_norm → EXPERT_GU[2*I].
-        // BF16 layout: gate_up_proj_w[E, 2*I, hidden] — slab `e` base is
-        // `e * 2*I * hidden`; row `r` adds `r * hidden`.
-        // INT4 layout (when `gate_up_proj_scale != nullptr`):
-        //   weights : [E, 2*I, hidden/2] u8   — slab `e` base in bytes is
-        //                                        `e * 2*I * (hidden/2)`.
-        //   scale   : [E, 2*I/gsz, hidden/gsz] BF16 — slab `e` base in
-        //                                        BF16 elems is
-        //                                        `e * (2*I/gsz) * (hidden/gsz)`.
-        // Same dequant + reduction discipline as the shared-expert INT4
-        // path (step 3); only the per-expert slab base offsets differ.
-        {
-            const bool gu_int4 = (gate_up_proj_scale != nullptr);
-            const T* gu_slab_bf16 =
-                gate_up_proj_w + static_cast<size_t>(e) * two_I * hidden;
-            const uint8_t*      gu_slab_packed = nullptr;
-            const hip_bfloat16* gu_slab_scale  = nullptr;
-            const hip_bfloat16* gu_slab_zero   = nullptr;
+            float partial = 0.0f;
             if (gu_int4) {
-                gu_slab_packed = reinterpret_cast<const uint8_t*>(gate_up_proj_w)
-                               + static_cast<size_t>(e) * two_I
-                                 * (hidden / 2);
-                const int gsr = two_I  / int4_group_size;
-                const int gsc = hidden / int4_group_size;
-                gu_slab_scale = gate_up_proj_scale
-                              + static_cast<size_t>(e) * gsr * gsc;
-                gu_slab_zero  = gate_up_proj_zero
-                              + static_cast<size_t>(e) * gsr * gsc;
+                partial = int4_dq8_matvec_partial(
+                    gu_slab_packed, gu_slab_scale, gu_slab_zero,
+                    h_norm_lds,
+                    my_row, hidden, int4_group_size,
+                    tid, block_size);
+            } else {
+                const T* w_row =
+                    gu_slab_bf16 + static_cast<size_t>(my_row) * hidden;
+                for (int col = tid; col < hidden; col += block_size) {
+                    partial += static_cast<float>(w_row[col])
+                               * h_norm_lds[col];
+                }
             }
-            for (;;) {
-                __shared__ unsigned int my_row_g_s;
-                if (tid == 0) {
-                    my_row_g_s = atomicAdd(&counters[0], 1u);
-                }
-                __syncthreads();
-                const int my_row = static_cast<int>(my_row_g_s);
-                if (my_row >= two_I) break;
-
-                float partial = 0.0f;
-                if (gu_int4) {
-                    partial = int4_dq8_matvec_partial(
-                        gu_slab_packed, gu_slab_scale, gu_slab_zero,
-                        h_norm_lds,
-                        my_row, hidden, int4_group_size,
-                        tid, block_size);
-                } else {
-                    const T* w_row =
-                        gu_slab_bf16 + static_cast<size_t>(my_row) * hidden;
-                    for (int col = tid; col < hidden; col += block_size) {
-                        partial += static_cast<float>(w_row[col])
-                                   * h_norm_lds[col];
-                    }
-                }
-                shared_scratch[tid] = partial;
-                __syncthreads();
-                for (int s = block_size / 2; s > 0; s >>= 1) {
-                    if (tid < s) shared_scratch[tid] += shared_scratch[tid + s];
-                    __syncthreads();
-                }
-                if (tid == 0) {
-                    workspace[OFF_EXPERT_GU + my_row] = shared_scratch[0];
-                }
+            shared_scratch[tid] = partial;
+            __syncthreads();
+            for (int s = block_size / 2; s > 0; s >>= 1) {
+                if (tid < s) shared_scratch[tid] += shared_scratch[tid + s];
                 __syncthreads();
             }
-        }
-
-        // Phase H: smid = silu(gu[:I]) * gu[I:] (block-0 only, F32 throughout).
-        grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
-                                   &counters[0]);
-        if (blockIdx.x == 0) {
-            for (int i = tid; i < I_; i += block_size) {
-                const float gp = workspace[OFF_EXPERT_GU + i];
-                const float up = workspace[OFF_EXPERT_GU + I_ + i];
-                const float sigmoid_gp = 1.0f / (1.0f + expf(-gp));
-                const float silu_gp    = gp * sigmoid_gp;
-                workspace[OFF_EXPERT_MID + i] = silu_gp * up;
+            if (tid == 0) {
+                workspace[gu_off + my_row] = shared_scratch[0];
             }
             __syncthreads();
         }
+    }
 
-        // Phase I: matvec down_proj_w[e].T @ mid → EXPERT_STACK[j*hidden..].
-        // BF16 layout: down_proj_w[E, hidden, I]; slab `e` base is
-        // `e * hidden * I`, row `r` adds `r * I`. Contracts over I → one
-        // F32 per output row.
-        // INT4 layout (when `down_proj_scale != nullptr`):
-        //   weights : [E, hidden, I/2] u8   — slab `e` base in bytes is
-        //                                      `e * hidden * (I/2)`.
-        //   scale   : [E, hidden/gsz, I/gsz] BF16 — slab `e` base in BF16
-        //                                      elems is
-        //                                      `e * (hidden/gsz) * (I/gsz)`.
-        grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
-                                   &counters[0]);
-        {
-            const bool dp_int4 = (down_proj_scale != nullptr);
-            const T* dp_slab_bf16 =
-                down_proj_w + static_cast<size_t>(e) * hidden * I_;
-            const uint8_t*      dp_slab_packed = nullptr;
-            const hip_bfloat16* dp_slab_scale  = nullptr;
-            const hip_bfloat16* dp_slab_zero   = nullptr;
+    // Barrier 1: publish EXPERT_GU writes (all groups) before Phase H reads.
+    // Every block must reach the barrier even if its group is inactive.
+    grid_barrier(barrier_counter, barrier_flag, num_blocks);
+
+    // Phase H: mid = silu(gu[:I]) * gu[I:], one block per active group.
+    // sub_id 0 of each active group does its own group's I elements; with
+    // block_size=256 and I<=1024 a single block easily covers the slab.
+    // Other blocks idle (they hit barrier 2 below).
+    {
+        const int sub_id = blockIdx.x / K_;
+        if (sub_id == 0 && group_active) {
+            const int gu_off  = OFF_EXPERT_GU + group_id * two_I;
+            const int mid_off = OFF_EXPERT_MID + group_id * I_;
+            for (int i = tid; i < I_; i += block_size) {
+                const float gp = workspace[gu_off + i];
+                const float up = workspace[gu_off + I_ + i];
+                const float sigmoid_gp = 1.0f / (1.0f + expf(-gp));
+                const float silu_gp    = gp * sigmoid_gp;
+                workspace[mid_off + i] = silu_gp * up;
+            }
+            __syncthreads();
+        }
+    }
+
+    // Barrier 2: publish EXPERT_MID writes (all groups) before Phase I reads.
+    grid_barrier(barrier_counter, barrier_flag, num_blocks);
+
+    // Phase I: matvec down_proj_w[e].T @ mid → EXPERT_STACK[g*hidden..].
+    // BF16 layout: down_proj_w[E, hidden, I]; slab `e` base is
+    // `e * hidden * I`, row `r` adds `r * I`. Contracts over I → one
+    // F32 per output row.
+    // INT4 layout (when `down_proj_scale != nullptr`):
+    //   weights : [E, hidden, I/2] u8   — slab `e` base in bytes is
+    //                                      `e * hidden * (I/2)`.
+    //   scale   : [E, hidden/gsz, I/gsz] BF16 — slab `e` base in BF16
+    //                                      elems is
+    //                                      `e * (hidden/gsz) * (I/gsz)`.
+    // Stage-3 parity output (BF16 cast of EXPERT_STACK[0]) is emitted by
+    // group 0 only — same per-row write the previous `j==0` branch did.
+    if (group_active) {
+        const bool dp_int4 = (down_proj_scale != nullptr);
+        const T* dp_slab_bf16 =
+            down_proj_w + static_cast<size_t>(e) * hidden * I_;
+        const uint8_t*      dp_slab_packed = nullptr;
+        const hip_bfloat16* dp_slab_scale  = nullptr;
+        const hip_bfloat16* dp_slab_zero   = nullptr;
+        if (dp_int4) {
+            dp_slab_packed = reinterpret_cast<const uint8_t*>(down_proj_w)
+                           + static_cast<size_t>(e) * hidden
+                             * (I_ / 2);
+            const int gsr = hidden / int4_group_size;
+            const int gsc = I_     / int4_group_size;
+            dp_slab_scale = down_proj_scale
+                          + static_cast<size_t>(e) * gsr * gsc;
+            dp_slab_zero  = down_proj_zero
+                          + static_cast<size_t>(e) * gsr * gsc;
+        }
+        const int slot_off = OFF_EXPERT_STACK + group_id * hidden;
+        const int mid_off  = OFF_EXPERT_MID   + group_id * I_;
+        for (;;) {
+            __shared__ unsigned int my_row_i_s;
+            if (tid == 0) {
+                my_row_i_s = atomicAdd(&counters[K_ + group_id], 1u);
+            }
+            __syncthreads();
+            const int my_row = static_cast<int>(my_row_i_s);
+            if (my_row >= hidden) break;
+
+            float partial = 0.0f;
             if (dp_int4) {
-                dp_slab_packed = reinterpret_cast<const uint8_t*>(down_proj_w)
-                               + static_cast<size_t>(e) * hidden
-                                 * (I_ / 2);
-                const int gsr = hidden / int4_group_size;
-                const int gsc = I_     / int4_group_size;
-                dp_slab_scale = down_proj_scale
-                              + static_cast<size_t>(e) * gsr * gsc;
-                dp_slab_zero  = down_proj_zero
-                              + static_cast<size_t>(e) * gsr * gsc;
+                partial = int4_dq8_matvec_partial(
+                    dp_slab_packed, dp_slab_scale, dp_slab_zero,
+                    workspace + mid_off,
+                    my_row, I_, int4_group_size,
+                    tid, block_size);
+            } else {
+                const T* w_row =
+                    dp_slab_bf16 + static_cast<size_t>(my_row) * I_;
+                for (int col = tid; col < I_; col += block_size) {
+                    partial += static_cast<float>(w_row[col])
+                               * workspace[mid_off + col];
+                }
             }
-            const int slot_off = OFF_EXPERT_STACK + j * hidden;
-            for (;;) {
-                __shared__ unsigned int my_row_i_s;
-                if (tid == 0) {
-                    my_row_i_s = atomicAdd(&counters[0], 1u);
-                }
-                __syncthreads();
-                const int my_row = static_cast<int>(my_row_i_s);
-                if (my_row >= hidden) break;
-
-                float partial = 0.0f;
-                if (dp_int4) {
-                    partial = int4_dq8_matvec_partial(
-                        dp_slab_packed, dp_slab_scale, dp_slab_zero,
-                        workspace + OFF_EXPERT_MID,
-                        my_row, I_, int4_group_size,
-                        tid, block_size);
-                } else {
-                    const T* w_row =
-                        dp_slab_bf16 + static_cast<size_t>(my_row) * I_;
-                    for (int col = tid; col < I_; col += block_size) {
-                        partial += static_cast<float>(w_row[col])
-                                   * workspace[OFF_EXPERT_MID + col];
-                    }
-                }
-                shared_scratch[tid] = partial;
-                __syncthreads();
-                for (int s = block_size / 2; s > 0; s >>= 1) {
-                    if (tid < s) shared_scratch[tid] += shared_scratch[tid + s];
-                    __syncthreads();
-                }
-                if (tid == 0) {
-                    const float val = shared_scratch[0];
-                    workspace[slot_off + my_row] = val;
-                    if (stage == 3 && j == 0) {
-                        // Match oracle's `expert_stack.to(dtype)` exposure.
-                        output[my_row] = static_cast<T>(bf16_round_rne_f32(val));
-                    }
-                }
+            shared_scratch[tid] = partial;
+            __syncthreads();
+            for (int s = block_size / 2; s > 0; s >>= 1) {
+                if (tid < s) shared_scratch[tid] += shared_scratch[tid + s];
                 __syncthreads();
             }
+            if (tid == 0) {
+                const float val = shared_scratch[0];
+                workspace[slot_off + my_row] = val;
+                if (stage == 3 && group_id == 0) {
+                    // Match oracle's `expert_stack.to(dtype)` exposure.
+                    output[my_row] = static_cast<T>(bf16_round_rne_f32(val));
+                }
+            }
+            __syncthreads();
         }
     }
 
@@ -2525,7 +2583,6 @@ __global__ void qwen36_moe_ffn_step_kernel(
     grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
                                &counters[0]);
     {
-        const int K_ = top_k;
         for (;;) {
             __shared__ unsigned int my_row_j_s;
             if (tid == 0) {

--- a/kernels/qwen36_moe.hip
+++ b/kernels/qwen36_moe.hip
@@ -1344,8 +1344,11 @@ __global__ void qwen36_moe_linear_step_kernel(
         return;
     }
 
-    grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
-                               &counters[0]);
+    // No barrier here: post-Phase-B barrier above already published Phase B's
+    // writes (qkv_raw etc.), and Phase C uses strided thread-per-channel
+    // distribution — it never touches counters[0]. The pre-D barrier below
+    // resets counters[0] for Phase D. (Earlier revisions had a redundant
+    // grid_barrier_reset_counter here; it was pure vestige.)
 
     // -- Phase C: depthwise conv1d + silu + state update -------------------
     //
@@ -1544,9 +1547,6 @@ __global__ void qwen36_moe_linear_step_kernel(
 
     if (stage < 4) return;
 
-    grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
-                               &counters[0]);
-
     const int OFF_BETA    = OFF_K_REP + V * k_dim;
     const int OFF_G       = OFF_BETA + V;
     const int OFF_REC_OUT = OFF_G + V;
@@ -1556,7 +1556,13 @@ __global__ void qwen36_moe_linear_step_kernel(
     // g[h]    = -softplus(a_raw[h] + dt_bias[h]) * exp(A_log[h])   (F32)
     //
     // V is small (32 on 35B-A3B) so we do this on block 0 only — every
-    // other block parks at the next grid barrier.
+    // other block parks at the post-F grid_barrier below.
+    //
+    // No pre-F barrier: Phase F reads only `a_raw`, `b_raw` (Phase B writes,
+    // long since published) and the host-uploaded BF16 tables `dt_bias` /
+    // `a_log`. Phase F doesn't touch counters[0] (block-0-only, no atomic
+    // claim). counters[0] is left at V from Phase E's work-stealing; the
+    // post-F barrier (below) resets it to 0 in time for Phase G.
     if (blockIdx.x == 0) {
         for (int h = tid; h < V; h += block_size) {
             const float a_v       = workspace[OFF_A_RAW + h];
@@ -1570,7 +1576,11 @@ __global__ void qwen36_moe_linear_step_kernel(
             workspace[OFF_G + h]    = -softplus * a_log_exp;
         }
     }
-    grid_barrier(barrier_counter, barrier_flag, num_blocks);
+    // Post-F barrier: publishes Phase F (beta, g) AND transitively Phase E's
+    // writes (q_rep, k_rep) to all blocks, AND resets counters[0] (left at V
+    // by Phase E) for Phase G's per-V-head work-stealing.
+    grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
+                               &counters[0]);
 
     // -- Phase G: delta-rule recurrent update --------------------------------
     //

--- a/kernels/qwen36_moe_bridge.cpp
+++ b/kernels/qwen36_moe_bridge.cpp
@@ -457,7 +457,13 @@ extern "C" int qwen36_moe_hip_ffn_step_launch(
         props.multiProcessorCount > 0 ? props.multiProcessorCount : 16;
     constexpr int block_size = 256;
 
-    if (hipMemsetAsync(counters, 0, sizeof(unsigned int)) != hipSuccess) {
+    // Zero the 2*top_k work-stealing counter slots used by the concurrent
+    // per-expert G/I phases. The engine's `reset_sync_buf` covers the full
+    // 96-byte buffer (counters + barrier counter + flag); this paranoid
+    // memset just guards single-launch callers (parity tests) that allocate
+    // sync_buf via `GpuBuffer::zeros` (already zero) and would only fail if
+    // someone reused a sync_buf without resetting.
+    if (hipMemsetAsync(counters, 0, 2 * top_k * sizeof(unsigned int)) != hipSuccess) {
         return 200;
     }
 

--- a/kernels/qwen36_moe_bridge.cpp
+++ b/kernels/qwen36_moe_bridge.cpp
@@ -419,6 +419,13 @@ extern "C" int qwen36_moe_hip_ffn_step_launch(
         shared_intermediate <= 0 || top_k <= 0 || top_k > num_experts) {
         return 132;
     }
+    // The concurrent-experts FFN dispatch (qwen36_moe_ffn_step_kernel)
+    // uses 2*top_k counter slots, and the host-side sync_buf reserves 16
+    // u32 slots before barrier_counter at +64. Pushing past slot 15 (i.e.
+    // top_k > 8) would clobber barrier state and likely hang. The safe
+    // wrapper in `kernel-ffi/src/qwen36_moe.rs::ffn_step_launch` enforces
+    // the same cap; this is the bridge-side belt-and-braces.
+    if (top_k > 8) return 138;
     if (input_hidden == nullptr || post_attn_norm_w == nullptr ||
         gate_w == nullptr || output == nullptr || output_idx == nullptr ||
         workspace == nullptr || counters == nullptr ||


### PR DESCRIPTION
## Summary

- Phase G/H/I in the qwen3.6-MoE FFN now dispatches all `K_top` routed experts concurrently via cyclic block partitioning (`group_id = blockIdx.x % top_k`); the prior sequential `for j in 0..k_iters` loop with per-iteration grid barriers is gone. Three grid barriers per FFN instead of ~24 at K_top=8.
- Linear-attn step audit: removed two grid barriers that weren't load-bearing (pre-Phase-C, pre-Phase-F). Net 6 barriers per linear layer instead of 8.

Combined effect, head-to-head on local 35B-A3B v2-int4-gptq, 16-token greedy "The quick brown fox jumps over":

|                  | baseline | after    | change   |
|------------------|----------|----------|----------|
| ffn_ms_avg       | 37.78    | 36.29    | -1.49 ms |
| linear_attn_ms_avg | 22.93  | 22.69    | -0.24 ms |
| chain_ms_avg     | 65.12    | 63.62    | -1.50 ms |
| total_ms_avg     | 86.81    | 85.32    | -1.49 ms |

About 2.3% per-token speedup. Smaller than the original 25-30 ms estimate — the bulk of FFN cost is INT4 matmul bandwidth, not barrier orchestration. Concurrent dispatch reclaims only the barrier overhead, and each grid barrier on RDNA3 is already cheap. Still worth landing: simpler structure, prerequisite for the persistent-megakernel folding planned downstream.

### Why two commits

- **Commit 1 (FFN concurrent dispatch)** — the architectural change. EXPERT_GU/MID slabs grow K_top-wide, sync_buf grows from 32→96 bytes (16 counter slots + barrier), all four qwen36_moe FFI launchers move barrier offsets from +16/+20 to +64/+68.
- **Commit 2 (linear-attn barrier cleanup)** — small, isolated, only `kernels/qwen36_moe.hip`. Easier to bisect if a regression surfaces.

### Considered alternative (not in this PR)

Extending the unified dispatch to `K_top + 1` groups by treating the shared expert as a 9th concurrent group was prototyped end-to-end (parity-clean, same generated tokens). It regressed FFN by +4.4 ms vs this PR — per-group block count drops from 12 to 10, and 9 concurrent slab reads thrash the L2 vs the prior staggered "shared-then-routed" pattern. Reverted; the barrier savings (~3 grid barriers per FFN ≈ 0.1 ms/token) didn't cover the memory-bandwidth cost.

## Test plan

- [x] All 26/26 `qwen36_moe` parity tests pass at top_k=2 (synthetic, hidden=64 / num_experts=8 / I=16) and top_k=8 (synthetic, hidden=256 / num_experts=32 / I=128, covers the 35B-A3B production geometry; BF16 + INT4 across stages 1–5 for both attn variants and FFN).
- [x] End-to-end greedy on the canonical "The quick brown fox jumps over" prompt produces bit-identical generated ids vs `main`.
- [x] Head-to-head timing run reproduced under the same thermal state (multiple consecutive runs each direction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)