### PR TITLE
docs: surface qwen3.6-35b-a3b INT4 support on gfx1100

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Four backend surfaces are validated today:
 | qwen3.5-2b       |  ✅  |  ✅  |      ✅     |   ✅   |
 | qwen3.5-4b       |  ✅  |  ✅  |      ✅     |   ✅   |
 | qwen3.5-9b       |  ✅  |  ✅  |      ✅     |   ✅   |
+| qwen3.6-35b-a3b  |  —³  |  ✅³ |      —      |    —   |
 | gemma4-e2b       |  ✅  |  ✅  |     ✅²    |   ✅²  |
 | gemma4-e4b       |  ✅  |  ✅¹ |     ✅²    |   ✅²  |
 | phi4-mini        |  ✅  |  ✅  |      ✅     |   ✅   |
@@ -35,6 +36,16 @@ Four backend surfaces are validated today:
   cannot combine with `--int4` (the INT4 kernel doesn't yet route the
   FP8 paths). Prefill under either FP8 mode runs per-token through the
   same persistent kernel rather than the BF16 prefill primitive chain.
+³ `qwen3.6-35b-a3b` is the Qwen3.6 hybrid linear/full-attention MoE
+  (40 layers, 256 experts, top-8 routing, ~3B active per token; HF
+  release ships in FP8). The published source weights total ~64 GiB
+  on disk, so BF16 cannot run inside 24 GiB. INT4-GPTQ is the only
+  HIP lane: the bake is ~16.9 GiB on-disk and ~21 GiB at runtime (KV
+  + scratch). Calibration needs more host RAM than typical 7900 XTX
+  rigs carry, so consumers pull the published bake from GitHub
+  releases (see [docs/bake-distribution.md](docs/bake-distribution.md));
+  producer workflow is unchanged. `--fp8-runtime` and `--kv-fp8` are
+  not wired for the MoE family.
 
 ### HIP on `gfx1150`
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -96,6 +96,56 @@ BF16 `fixed_bytes` × the engine's quant scale factor (0.37× for INT4,
 the VRAM admission preflight, so memory-constrained cards that pass
 preflight will fit at runtime.
 
+### Qwen3.6-MoE on `gfx1100`
+
+`qwen3.6-35b-a3b` is the first MoE model shipped on SuperSonic: 40
+layers (30 linear-attention + 10 full-attention in a hybrid pattern),
+256 experts with top-8 routing, ~3B active parameters per token,
+INT4-GPTQ from the published FP8 source weights. BF16 doesn't fit in
+24 GiB; the INT4 bake is the only HIP lane. Steady-state, single-
+sequence on RX 7900 XTX with the published v2-int4-gptq bake,
+6-token prompt + 16-token generation:
+
+| Stage          | ms/step | share |
+|----------------|--------:|------:|
+| chain (40 L)   |   60.3  |   76% |
+| ↳ FFN (40 L)   |   34.6  |   44% |
+| ↳ linear-attn (30 L) | 21.2  |   27% |
+| ↳ full-attn (10 L)   |  4.2  |    5% |
+| lm_head        |   18.8  |   24% |
+| sample/detok   |    0.3  |    0% |
+| **total**      | **79.3**| 100%  |
+
+Roughly **12.6 tok/s** on greedy decode. The chain wall-clock is
+host-orchestrated: each layer's attention and FFN are separate HIP
+launches today (`run_chained_decode` in
+`crates/runner/src/qwen36_moe_decode.rs`). The persistent megakernel
+(planned PR 4c step 4) will fold the per-token 80 launches into one
+cooperative kernel and is expected to reclaim several ms of launch
+overhead. Within FFN, the K_top=8 routed experts dispatch
+concurrently via cyclic block partitioning (`group_id = blockIdx.x %
+top_k`) — see PR #74. The shared expert still runs sequentially
+ahead of the routed dispatch; folding it as a 9th concurrent group
+was prototyped (parity-clean) but regressed FFN by ~4 ms due to L2
+cache pressure from 9 simultaneous slab reads, so it's not shipped.
+
+INT4 weight + scratch on the 35B-A3B bake: ~17 GiB on disk, ~21 GiB
+runtime including KV cache at the default context. Within the 24 GiB
+budget. Calibration needs more host RAM than typical 7900 XTX rigs
+carry, so the bake is produced on a bigger box and distributed via
+GitHub releases (see [bake-distribution.md](bake-distribution.md));
+consumers pull it automatically on first run.
+
+Reproduce:
+
+```bash
+cargo build --release --bin supersonic
+./target/release/supersonic --model qwen3.6-35b-a3b \
+  --model-dir /path/to/Qwen3.6-35B-A3B-FP8 \
+  --prompt "The quick brown fox jumps over" \
+  --max-new-tokens 16 --emit-stage-timings
+```
+
 ## HIP — `gfx1150` (AMD Radeon 890M iGPU)
 
 16 CUs, 2.9 GHz core, shared with system memory. Measurements on


### PR DESCRIPTION
## Summary

- README support matrix gains a `qwen3.6-35b-a3b` row in the HIP/gfx1100 table (INT4 only — BF16 can't fit 24 GiB, FP8 paths aren't wired for the MoE family). New footnote explains the model shape (256 experts, top-8 routing, ~3B active per token), the published-weights size, and why the bake distribution path is the only practical onramp.
- `docs/performance.md` gains a "Qwen3.6-MoE on gfx1100" subsection under the gfx1100 block with the current steady-state stage breakdown.

Stage timings recorded on local RX 7900 XTX with the v2-int4-gptq bake, "The quick brown fox jumps over" prompt, 16-token greedy:

| Stage          | ms/step | share |
|----------------|--------:|------:|
| chain (40 L)   |   60.3  |   76% |
| ↳ FFN (40 L)   |   34.6  |   44% |
| ↳ linear-attn (30 L) | 21.2  |   27% |
| ↳ full-attn (10 L)   |  4.2  |    5% |
| lm_head        |   18.8  |   24% |
| **total**      | **79.3**| 100%  |

~12.6 tok/s greedy.

## Test plan

- [x] Numbers reproduced via 3 consecutive runs of the documented command (`--emit-stage-timings`); run 1 was a cold-thermal outlier, runs 2/3 stabilised at the values quoted.
- [x] Cross-references resolve: `docs/bake-distribution.md` and PR #74 both already in main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)