### PR TITLE
qwen36-moe: WMMA-tile the lm_head GEMV (~14.7 ms/token, 24% total)

### DIFF
--- a/kernels/qwen36_moe.hip
+++ b/kernels/qwen36_moe.hip
@@ -2810,4 +2810,185 @@ __global__ void qwen36_moe_lm_head_kernel(
     }
 }
 
+// =============================================================================
+// RDNA3 WMMA BF16 lm_head GEMV (wave32, 16x16x16 f32-accumulate),
+// one-wavefront-per-16-vocab-tile.
+//
+// Companion to `qwen36_moe_lm_head_kernel` above; same math, same numerics
+// boundary, but routes the matvec through `__builtin_amdgcn_wmma_f32_16x16x16_bf16_w32`
+// for ~3-5x speedup over the scalar work-stealing path on hidden=2048,
+// vocab=248k. Adapts the small-m WMMA pattern from
+// `supersonic_qwen35_matmul_int4_dequant_wmma_small_m_kernel` (m=1 query,
+// no INT4 dequant — lm_head weights are pre-dequantized BF16 by the engine
+// at startup).
+//
+//   final_hidden  [hidden]         BF16
+//   final_norm_w  [hidden]         BF16 (Qwen3_5MoeRMSNorm `(1.0 + w)`)
+//   lm_head_w     [vocab, hidden]  BF16
+//   logits        [vocab]          BF16
+//
+// Grid : (ceil(vocab / 16), 1, 1)
+// Block: 32 threads = one wave32
+//
+// Each block computes 16 vocab logits. Per-block phases:
+//   A: RMSNorm of final_hidden into LDS x_norm (BF16-rounded, F32→BF16 once).
+//   B: K-loop, each iter loads 16 BF16 of x_norm into the WMMA A operand
+//      (only lane_row==0 carries real data — m=1 means rows 1..15 of A are
+//      zero-padded; the WMMA still does 16x16x16 muls but only row 0 of C
+//      is read out, the rest is ignored).
+//   C: lanes 0..15 (lane_half==0) write `acc[0] = C[0, lane_row]` to logits.
+//
+// Bandwidth: weights read once per element (~970 MiB BF16 for vocab=248k).
+// At 960 GB/s on 7900 XTX, theoretical floor ~1 ms; observed end-to-end
+// drops the lm_head stage from ~18.8 ms (scalar) to ~3-5 ms.
+// =============================================================================
+
+#if defined(__gfx1100__) || defined(__gfx1101__) || defined(__gfx1102__) || \
+    defined(__gfx1103__) || defined(__gfx1150__) || defined(__gfx1151__) || \
+    defined(__gfx1152__)
+#define SUPERSONIC_QWEN36_HAS_WMMA_BF16 1
+#endif
+
+#ifdef SUPERSONIC_QWEN36_HAS_WMMA_BF16
+typedef short  qwen36_short16 __attribute__((ext_vector_type(16)));
+typedef float  qwen36_float8  __attribute__((ext_vector_type(8)));
+#endif
+
+template <typename T>
+__global__ __launch_bounds__(32, 4)
+void qwen36_moe_lm_head_wmma_kernel(
+    const T*               __restrict__ final_hidden,    // [hidden] BF16
+    const T*               __restrict__ final_norm_w,    // [hidden] BF16
+    const T*               __restrict__ lm_head_w,       // [vocab, hidden] BF16
+    T*                     __restrict__ logits,          // [vocab] BF16
+    int                                  hidden,
+    int                                  vocab,
+    float                                rms_norm_eps) {
+#ifdef SUPERSONIC_QWEN36_HAS_WMMA_BF16
+    const int lane = threadIdx.x;          // 0..31
+    const int lane_row = lane & 15;        // 0..15 (replicates across lane halves)
+    const int lane_half = lane >> 4;       // 0 for lanes 0-15, 1 for lanes 16-31
+    const int tile_col = blockIdx.x * 16;  // first vocab row of this tile
+
+    // LDS layout:
+    //   shared_scratch [32]      F32  — RMSNorm wave reduction
+    //   x_norm_lds_u16 [hidden]  u16  — BF16-rounded RMSNorm output
+    extern __shared__ unsigned char lds_raw[];
+    float*    shared_scratch = reinterpret_cast<float*>(lds_raw);
+    uint16_t* x_norm_lds_u16 = reinterpret_cast<uint16_t*>(shared_scratch + 32);
+
+    // -- Phase A: per-wave RMSNorm of final_hidden -------------------------
+    // Each lane processes hidden/32 elements, accumulates F32 squares,
+    // then we tree-reduce across the 32 lanes via LDS.
+    float partial_sq = 0.0f;
+    for (int col = lane; col < hidden; col += 32) {
+        const float v = load_as_float<T>(final_hidden, col);
+        partial_sq += v * v;
+    }
+    shared_scratch[lane] = partial_sq;
+    __syncthreads();
+    for (int s = 16; s > 0; s >>= 1) {
+        if (lane < s) shared_scratch[lane] += shared_scratch[lane + s];
+        __syncthreads();
+    }
+    const float inv_rms =
+        rsqrtf(shared_scratch[0] / static_cast<float>(hidden) + rms_norm_eps);
+
+    // Apply `(1.0 + w)` HF unit offset, BF16-round, store as BF16 bit pattern
+    // (top 16 bits of the F32) so the WMMA A loads can read it as `short`.
+    for (int col = lane; col < hidden; col += 32) {
+        const float vh = load_as_float<T>(final_hidden, col);
+        const float vw = load_as_float<T>(final_norm_w, col);
+        const float val = bf16_round_rne_f32(vh * inv_rms * (1.0f + vw));
+        uint32_t bits;
+        __builtin_memcpy(&bits, &val, 4);
+        x_norm_lds_u16[col] = static_cast<uint16_t>(bits >> 16);
+    }
+    __syncthreads();
+
+    // -- Phase B: WMMA over (1 query) × hidden contraction × 16 vocab -----
+    const int rhs_row_idx = tile_col + lane_row;
+    const bool rhs_in_range = rhs_row_idx < vocab;
+
+    const uint16_t* lm_head_w_u16 = reinterpret_cast<const uint16_t*>(lm_head_w);
+    const size_t rhs_row_base = static_cast<size_t>(rhs_row_idx) * hidden;
+
+    qwen36_float8 acc = {0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f};
+
+    const int k_main = hidden & ~15;
+    for (int kk = 0; kk < k_main; kk += 16) {
+        // A operand: each lane_row maps to one of the 16 M-rows of A. With
+        // m=1, only lane_row==0 carries real activation; lanes with
+        // lane_row>0 zero-fill. The WMMA still fires 4096 muls but only
+        // row 0 of C contributes useful output (it's a 1x16 GEMV result).
+        // Bandwidth-bound on the B operand, so the wasted compute is free.
+        qwen36_short16 a;
+        if (lane_row == 0) {
+            #pragma unroll
+            for (int i = 0; i < 16; ++i) {
+                a[i] = static_cast<short>(x_norm_lds_u16[kk + i]);
+            }
+        } else {
+            #pragma unroll
+            for (int i = 0; i < 16; ++i) a[i] = 0;
+        }
+
+        // B operand: 16 vocab rows × 16 K elements. Each lane reads its
+        // own vocab row's K-slab; lanes 0..15 and 16..31 duplicate
+        // lane_row, so both halves load the same row (the WMMA hardware
+        // handles the duplicate as one operand).
+        qwen36_short16 b;
+        if (rhs_in_range) {
+            #pragma unroll
+            for (int i = 0; i < 16; ++i) {
+                b[i] = static_cast<short>(lm_head_w_u16[rhs_row_base + kk + i]);
+            }
+        } else {
+            #pragma unroll
+            for (int i = 0; i < 16; ++i) b[i] = 0;
+        }
+
+        acc = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a, b, acc);
+    }
+
+    // K tail (defensive — hidden=2048 is a multiple of 16 in production).
+    if (k_main != hidden) {
+        qwen36_short16 a = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
+        qwen36_short16 b = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
+        if (lane_row == 0) {
+            #pragma unroll
+            for (int i = 0; i < 16; ++i) {
+                int kc = k_main + i;
+                if (kc < hidden) a[i] = static_cast<short>(x_norm_lds_u16[kc]);
+            }
+        }
+        if (rhs_in_range) {
+            #pragma unroll
+            for (int i = 0; i < 16; ++i) {
+                int kc = k_main + i;
+                if (kc < hidden) {
+                    b[i] = static_cast<short>(lm_head_w_u16[rhs_row_base + kc]);
+                }
+            }
+        }
+        acc = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a, b, acc);
+    }
+
+    // -- Phase C: write the M=0 row of C ----------------------------------
+    // RDNA3 wave32 WMMA acc layout: acc[i] -> C[2*i + lane_half, lane_row].
+    // Row 0 lives at acc[0] of lanes with lane_half==0 (lanes 0..15);
+    // lane_row enumerates the 16 output columns of this tile.
+    if (lane_half == 0) {
+        const int out_col = tile_col + lane_row;
+        if (out_col < vocab) {
+            const float val = bf16_round_rne_f32(acc[0]);
+            logits[out_col] = static_cast<T>(val);
+        }
+    }
+#else
+    (void)final_hidden; (void)final_norm_w; (void)lm_head_w;
+    (void)logits; (void)hidden; (void)vocab; (void)rms_norm_eps;
+#endif
+}
+
 } // namespace qwen36_moe

--- a/kernels/qwen36_moe_bridge.cpp
+++ b/kernels/qwen36_moe_bridge.cpp
@@ -10,9 +10,48 @@
 
 #include <cstdlib>
 #include <hip/hip_runtime.h>
+#include <mutex>
 #include <stdint.h>
 
 namespace {
+
+// Cache the per-device gfx11xx detection result. WMMA bf16 is RDNA3-only
+// (gfx1100..gfx1152). Mirrors the helper in `full_attention_bridge_4b.cpp`
+// — we keep an independent copy here rather than introduce a shared header
+// because each model family's bridge is its own compilation unit (hipcc
+// codegen on gfx11xx is sensitive to cross-contamination, see CLAUDE.md).
+//
+// Honors `SUPERSONIC_QWEN4B_DISABLE_WMMA` (the existing global override
+// shared with the qwen35-4b/Gemma 4 prefill paths) so a single env var
+// disables every WMMA route in the runtime; useful for A/B perf work.
+bool device_supports_wmma_bf16(int device_ordinal) {
+    static std::once_flag env_once;
+    static bool env_disabled = false;
+    std::call_once(env_once, [] {
+        const char* env = std::getenv("SUPERSONIC_QWEN4B_DISABLE_WMMA");
+        env_disabled = (env != nullptr && env[0] != '\0' && env[0] != '0');
+    });
+    if (env_disabled) return false;
+
+    auto probe_arch = [](int ordinal) -> bool {
+        hipDeviceProp_t props;
+        if (hipGetDeviceProperties(&props, ordinal) != hipSuccess) return false;
+        const char* arch = props.gcnArchName;
+        return arch && arch[0] == 'g' && arch[1] == 'f' && arch[2] == 'x' &&
+               arch[3] == '1' && arch[4] == '1';
+    };
+
+    if (device_ordinal < 0 || device_ordinal >= 16) {
+        return probe_arch(device_ordinal);
+    }
+    static std::once_flag device_once[16];
+    static bool cached[16] = {false};
+    std::call_once(device_once[device_ordinal], [&] {
+        cached[device_ordinal] = probe_arch(device_ordinal);
+    });
+    return cached[device_ordinal];
+}
+
 
 struct ScopedHipDevice {
     int  previous = -1;
@@ -598,6 +637,44 @@ extern "C" int qwen36_moe_hip_lm_head_launch(
         hipSuccess) {
         return 250;
     }
+
+    const int ordinal_int = static_cast<int>(device_ordinal);
+
+    // WMMA path: gfx11xx only, BF16 weights, hidden divisible by 16. Drops
+    // ~14 ms / token vs the scalar work-stealing path on 35B-A3B (vocab=248k).
+    // Falls back to the scalar kernel on non-gfx11xx, on group-size mismatch,
+    // or when SUPERSONIC_QWEN4B_DISABLE_WMMA is set.
+    if (device_supports_wmma_bf16(ordinal_int) && (hidden % 16 == 0)) {
+        // Grid: one wave32 per 16-vocab tile. block_size=32 (one wave).
+        // LDS: 32 F32 (RMSNorm reduction) + hidden u16 (BF16 staged x_norm).
+        const int wmma_block_size = 32;
+        const int grid_x = (vocab + 15) / 16;
+        const size_t lds_bytes_wmma =
+            static_cast<size_t>(wmma_block_size) * sizeof(float) +
+            static_cast<size_t>(hidden) * sizeof(uint16_t);
+
+        hipLaunchKernelGGL(
+            qwen36_moe::qwen36_moe_lm_head_wmma_kernel<hip_bfloat16>,
+            dim3(static_cast<unsigned int>(grid_x)),
+            dim3(static_cast<unsigned int>(wmma_block_size)),
+            lds_bytes_wmma, 0,
+            static_cast<const hip_bfloat16*>(final_hidden),
+            static_cast<const hip_bfloat16*>(final_norm_w),
+            static_cast<const hip_bfloat16*>(lm_head_w),
+            static_cast<hip_bfloat16*>(logits),
+            hidden,
+            vocab,
+            rms_norm_eps);
+        // No counter needed by the WMMA path (one block per tile, no
+        // atomic claim). The host-passed counter buffer is ignored here.
+        hipError_t launch_err = hipGetLastError();
+        hipError_t sync_err   = hipDeviceSynchronize();
+        if (launch_err != hipSuccess) return 254;
+        if (sync_err != hipSuccess) return 255;
+        return 0;
+    }
+
+    // Scalar fallback path. Requires the work-stealing counter zeroed.
     const int num_blocks =
         props.multiProcessorCount > 0 ? props.multiProcessorCount : 16;
     constexpr int block_size = 256;


### PR DESCRIPTION
## Summary

Phase 1 of the [qwen3.6-MoE 100+ tok/s roadmap](../../discussions). The lm_head was the single biggest non-FFN wedge in decode at ~18.8 ms/step (24% of total), running a scalar work-stealing GEMV ~19× over the bandwidth-bound floor.

Adds `qwen36_moe_lm_head_wmma_kernel<T>` that routes the matvec through RDNA3's `__builtin_amdgcn_wmma_f32_16x16x16_bf16_w32` intrinsic. Pattern adapted from `supersonic_qwen35_matmul_int4_dequant_wmma_small_m_kernel` (the prefill small-m/INT4 path that already handles m<16 via wave32 WMMA), simplified for BF16-only weights (lm_head is pre-dequantized at startup by PR #68).

- Grid: `ceil(vocab / 16)` blocks, one per 16-vocab-row tile
- Block: 32 threads (one wave32)
- LDS: ~4.1 KiB (32 F32 reduction scratch + hidden u16 BF16-staged x_norm)
- Each block: per-wave RMSNorm into LDS, then one WMMA per k-chunk of 16 vs the 16 vocab rows in this tile, store `acc[0]` from lanes 0..15

Bridge gates on `device_supports_wmma_bf16(ordinal)` (gfx11xx detection) and honors the existing `SUPERSONIC_QWEN4B_DISABLE_WMMA` global override. Scalar fallback (`qwen36_moe_lm_head_kernel`) stays unchanged for non-gfx11xx and for A/B comparison.

## Measured impact

35B-A3B v2-int4-gptq, 16-token greedy "The quick brown fox jumps over", head-to-head same thermal state:

|                  | WMMA disabled | WMMA enabled | change            |
|------------------|--------------:|-------------:|-------------------|
| lm_head_ms_avg   |         16.22 |         1.52 | -14.70 ms (10.7×) |
| chain_ms_avg     |         57.38 |        54.11 | -3.27 ms          |
| total_ms_avg     |         73.88 |        55.93 | **-17.95 ms (24%)** |
| **tok/s**        |          13.5 |         17.9 | **+33%**          |

(`chain_ms_avg` shrinks too because the host's chain stopwatch encloses the lm_head launch — internal-bookkeeping coupling, not a chain compute change.)

## Test plan

- [x] `qwen36_moe_lm_head_matches_host_f32_reference` parity test passes (cos_sim ≥ 0.999 on synthetic vocab=512 / hidden=256).
- [x] All 26/26 `qwen36_moe::tests::*` parity tests pass at top_k=2 and top_k=8 (BF16 + INT4 across stages 1-5).
- [x] End-to-end greedy on the canonical prompt produces bit-identical generated ids vs both main and the scalar fallback (same 16 tokens).
- [x] `SUPERSONIC_QWEN4B_DISABLE_WMMA=1` cleanly routes back to the scalar path.

## Followups

- Phase 2: WMMA-tile the MoE FFN INT4 matmuls (target: 34.6 → ~12 ms — this is the biggest single wedge remaining).
- Phase 3: persistent megakernel (target: -5 ms launch overhead).
- Phases 4-5: linear-attn + full-attn WMMA.
- Phase 6: speculative decode (separate planning pass) — needed to cross 100 tok/s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)