### PR TITLE
qwen36-moe: defer per-step bridge syncs to chain-end (~1.8 ms/token, +7%)

### DIFF
--- a/crates/runner/src/qwen36_moe_decode.rs
+++ b/crates/runner/src/qwen36_moe_decode.rs
@@ -370,6 +370,16 @@ fn download_hidden_bf16(
 pub struct ChainedDecodeOptions {
     pub capture_per_layer: bool,
     pub trace_norms: bool,
+    /// When true, call `gpu_hal::sync(ordinal)` after each step launch so
+    /// the per-stage `kernel_*_us` accumulators reflect GPU execution time
+    /// rather than host dispatch queue time. Set by `--emit-stage-timings`
+    /// — production runs leave it false, paying ~80 syncs/token to keep
+    /// the chain breakdown accurate when the user asks for it.
+    /// (Codex review #80: PR #80 made the bridge step launchers async,
+    /// which silently turned the stage-breakdown numbers into host-queue
+    /// times — this flag preserves their original "GPU compute time"
+    /// semantics for users opting into the breakdown.)
+    pub accurate_stage_timings: bool,
 }
 
 impl ChainedDecodeOptions {
@@ -382,6 +392,7 @@ impl ChainedDecodeOptions {
         Self {
             capture_per_layer: false,
             trace_norms,
+            accurate_stage_timings: false,
         }
     }
 }
@@ -401,6 +412,9 @@ pub fn run_chained_decode(
             // routes through `run_chained_decode_fast` (defined below).
             capture_per_layer: true,
             trace_norms: ChainedDecodeOptions::from_env().trace_norms,
+            // The legacy capture path D2H-syncs every step anyway, so the
+            // explicit per-step sync is redundant here (kept off).
+            accurate_stage_timings: false,
         },
     )
 }
@@ -410,16 +424,25 @@ pub fn run_chained_decode(
 /// engine nor sampling consume — only the multilayer parity test
 /// reads `per_layer_*`). Reuses `run_chained_decode_with_options`'s
 /// implementation so parity guarantees are unchanged.
+///
+/// `accurate_stage_timings`: when true, synchronizes between step
+/// launches so the per-stage `kernel_*_us` numbers in `DecodeOutputs`
+/// reflect GPU compute time (not host queue time). Set this when
+/// `--emit-stage-timings` is requested. Default false in production
+/// to keep the chain async.
 pub fn run_chained_decode_fast(
     ordinal: usize,
     geom: &MultiLayerGeom,
     layers: &mut [LayerBuffers],
     initial_hidden_bytes: &[u8],
     position: i32,
+    accurate_stage_timings: bool,
 ) -> Result<DecodeOutputs> {
+    let mut options = ChainedDecodeOptions::from_env();
+    options.accurate_stage_timings = accurate_stage_timings;
     run_chained_decode_with_options(
         ordinal, geom, layers, initial_hidden_bytes, position,
-        ChainedDecodeOptions::from_env(),
+        options,
     )
 }
 
@@ -607,6 +630,10 @@ pub fn run_chained_decode_with_options(
                     &mut sync_buf,
                 )
                 .with_context(|| format!("attn_step_launch (layer {layer_idx}, full)"))?;
+                if options.accurate_stage_timings {
+                    gpu_hal::sync(ordinal)
+                        .context("sync_after_attn_step (accurate_stage_timings)")?;
+                }
                 t_full_attn += t_k.elapsed();
             }
             AttnLayerBuffers::Linear {
@@ -678,6 +705,10 @@ pub fn run_chained_decode_with_options(
                     &mut sync_buf,
                 )
                 .with_context(|| format!("linear_step_launch (layer {layer_idx})"))?;
+                if options.accurate_stage_timings {
+                    gpu_hal::sync(ordinal)
+                        .context("sync_after_linear_step (accurate_stage_timings)")?;
+                }
                 t_linear_attn += t_k.elapsed();
             }
         }
@@ -769,6 +800,10 @@ pub fn run_chained_decode_with_options(
             &mut sync_buf,
         )
         .with_context(|| format!("ffn_step_launch (layer {layer_idx})"))?;
+        if options.accurate_stage_timings {
+            gpu_hal::sync(ordinal)
+                .context("sync_after_ffn_step (accurate_stage_timings)")?;
+        }
         t_ffn += t_k.elapsed();
 
         // Same D2D + swap as the attn step.

--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -1223,7 +1223,18 @@ fn decode_text(
         // `final_hidden_bytes`. The multilayer parity test still calls
         // the legacy `run_chained_decode` which captures per-layer.
         let t1 = std::time::Instant::now();
-        let outputs = run_chained_decode_fast(ordinal, &geom, &mut layers, &initial_hidden, position)
+        // When `--emit-stage-timings` is set, sync after each step launch
+        // so the per-stage `kernel_*_us` accumulators in `outputs` reflect
+        // GPU compute time. Without it, PR #80's async dispatch path
+        // would record host queue time instead — fast but useless for
+        // stage-level perf attribution. The total `chain_ms` measured by
+        // the wall-clock around this call stays correct either way
+        // because `run_chained_decode_fast` ends with a D2H copy that
+        // implicitly drains the queue.
+        let outputs = run_chained_decode_fast(
+            ordinal, &geom, &mut layers, &initial_hidden, position,
+            emit_stage_timings,
+        )
             .with_context(|| format!("chained decode (step {step}, position {position})"))?;
         let t_chain_step = t1.elapsed();
         position += 1;

--- a/kernels/qwen36_moe_bridge.cpp
+++ b/kernels/qwen36_moe_bridge.cpp
@@ -316,10 +316,17 @@ extern "C" int qwen36_moe_hip_attn_step_launch(
             counters, barrier_counter, barrier_flag);
     }
 
+    // Async dispatch: skip the per-launch `hipDeviceSynchronize` so the host
+    // can queue the next step launch without blocking. The default stream
+    // serializes all kernel launches and D2D copies in this engine, and
+    // `run_chained_decode`'s final D2H copy of `final_hidden_bytes`
+    // implicitly drains the queue — so per-step sync is redundant. Saves
+    // ~30 µs/launch × 80 launches/token = ~2.4 ms/token. Runtime kernel
+    // errors (illegal memory access etc.) defer to that final D2H copy
+    // instead of the immediate per-step return; launch-config errors are
+    // still caught here via `hipGetLastError`.
     hipError_t launch_err = hipGetLastError();
-    hipError_t sync_err   = hipDeviceSynchronize();
     if (launch_err != hipSuccess) return 254;
-    if (sync_err != hipSuccess) return 255;
     return 0;
 }
 
@@ -498,10 +505,10 @@ extern "C" int qwen36_moe_hip_linear_step_launch(
             workspace, counters, barrier_counter, barrier_flag);
     }
 
+    // Async dispatch: see attn_step_launch above for the rationale (default
+    // stream serializes; chain-end D2H is the implicit barrier).
     hipError_t launch_err_lin = hipGetLastError();
-    hipError_t sync_err_lin   = hipDeviceSynchronize();
     if (launch_err_lin != hipSuccess) return 254;
-    if (sync_err_lin != hipSuccess) return 255;
     return 0;
 }
 
@@ -693,10 +700,9 @@ extern "C" int qwen36_moe_hip_ffn_step_launch(
             workspace, counters, barrier_counter, barrier_flag);
     }
 
+    // Async dispatch: see attn_step_launch above for the rationale.
     hipError_t launch_err_ffn = hipGetLastError();
-    hipError_t sync_err_ffn   = hipDeviceSynchronize();
     if (launch_err_ffn != hipSuccess) return 254;
-    if (sync_err_ffn != hipSuccess) return 255;
     return 0;
 }
 


### PR DESCRIPTION
## Summary

Pre-Phase-3 quick win. Each per-step bridge launcher (`qwen36_moe_hip_attn_step_launch`, `linear_step_launch`, `ffn_step_launch`) ended in `hipDeviceSynchronize`, blocking the host until the kernel completed before queueing the next step. With 80 step launches per token (10 full-attn + 30 linear-attn + 40 FFN) that's ~80 host-side pipeline drains per token, but the default stream already serializes operations and `run_chained_decode_fast`'s final `copy_d2h(final_hidden_bytes)` is the natural chain-end barrier.

Drops the per-step `hipDeviceSynchronize`. Keeps `hipGetLastError` for launch-config errors (immediate). Runtime kernel errors defer to the chain-end D2H or the lm_head launcher's sync — same blast radius, just delayed reporting. Production kernels are validated by the per-block parity tests so this has no practical impact.

Single-launch bridges (descriptor-walk stub, int4-dequant smoke, lm_head) keep their syncs — they ARE the chain-end barrier.

## Measured impact

35B-A3B v2-int4-gptq, 16-token greedy "The quick brown fox jumps over", head-to-head same thermal state:

|                  | Phase 5 | + defer-sync | change          |
|------------------|--------:|-------------:|-----------------|
| chain_ms_avg     |   26.48 |        24.72 | -1.76 ms        |
| lm_head_ms_avg   |    1.54 |         1.53 | ~same           |
| total_ms_avg     |   28.30 |        26.53 | -1.77 ms (6.3%) |
| **tok/s**        |    35.3 |         37.7 | **+6.8%**       |

**Cumulative since main** (12.6 tok/s baseline): **79.3 → 26.5 ms = 3.0× speedup, 12.6 → 37.7 tok/s = +199% throughput**.

## Test plan

- [x] All 26/26 `qwen36_moe::tests::*` parity tests pass.
- [x] `qwen36_moe_multilayer_parity::multilayer_chained_decode_matches_oracle` passes.
- [x] Generated tokens bit-identical to the previous commit (no compute changed, just the host wait pattern).

## Followups

- **Phase 3 (persistent megakernel)** still has architectural value beyond launch overhead — folding 80 launches into 1 simplifies future speculative-decode verification kernel work, even with this reclaim already done. Worth doing.
- **Phase 6 (speculative decode)** — the realistic path to 100+ tok/s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)