### PR TITLE
[codex] Add gfx942 HIP bring-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ Measured decode throughput: see [docs/performance.md](docs/performance.md).
 
 ## Supported Matrix
 
-Four backend surfaces are validated today:
+Five backend surfaces are validated or in bring-up today:
 
 - **HIP / `gfx1100`** — AMD Radeon RX 7900 XTX (RDNA 3, 24 GiB)
 - **HIP / `gfx1150`** — AMD Radeon 890M iGPU (RDNA 3.5)
+- **HIP / `gfx942`** — AMD Instinct MI300X-class (CDNA 3, wave64 bring-up)
 - **CUDA / `sm86`** — NVIDIA RTX 3090-class (Ampere)
 - **Metal / `apple-m4`** — Apple M4, BF16 Qwen3.5 0.8B (CLI + `supersonic-serve`)
 
@@ -65,6 +66,27 @@ Four backend surfaces are validated today:
 
 DFlash speculative decode is available for `qwen3.5-9b` INT4 on HIP —
 see [docs/dflash.md](docs/dflash.md).
+
+### HIP on `gfx942`
+
+| Model            | BF16 | INT4 | FP8 runtime | FP8 KV |
+|------------------|:----:|:----:|:-----------:|:------:|
+| qwen3.5-0.8b     | ✅¹  | ✅²  |      —      |   —    |
+| qwen3.5-2b       | ✅¹  | ✅²  |      —      |   —    |
+| qwen3.5-4b       | ✅¹  | ✅²  |      —      |   —    |
+| qwen3.5-9b       |  —   |  —   |      —      |   —    |
+| qwen3.6-35b-a3b  |  —   |  —   |      —      |   —    |
+| gemma4-e2b       |  —   |  —   |      —      |   —    |
+| gemma4-e4b       |  —   |  —   |      —      |   —    |
+| phi4-mini        |  —   |  —   |      —      |   —    |
+
+¹ CDNA bring-up currently uses replayed GPU prefill for single-sequence decode.
+  The RDNA persistent decode megakernel compiles on `gfx942`, but its wave64
+  correctness is still under validation and is available only via the explicit
+  debug path `--force-kernel-decode`.
+² INT4 uses the published GPTQ bake and the same replayed GPU prefill
+  correctness path. The PyTorch oracle is BF16-only, so INT4 bring-up checks
+  exact agreement between native decode and replayed GPU prefill.
 
 ### CUDA on `sm86`
 

--- a/crates/kernel-ffi/build.rs
+++ b/crates/kernel-ffi/build.rs
@@ -139,6 +139,41 @@ fn has_libcudart(dir: &Path) -> bool {
         })
 }
 
+fn detect_rocm_lib_dir() -> Option<PathBuf> {
+    let mut candidates = Vec::new();
+    for var in ["ROCM_PATH", "HIP_PATH"] {
+        if let Ok(value) = env::var(var) {
+            let root = PathBuf::from(value);
+            candidates.extend([root.join("lib"), root.join("lib64")]);
+        }
+    }
+    candidates.extend([
+        PathBuf::from("/opt/rocm/lib"),
+        PathBuf::from("/opt/rocm/lib64"),
+        PathBuf::from("/opt/rocm-7.0.0/lib"),
+        PathBuf::from("/usr/lib/x86_64-linux-gnu"),
+        PathBuf::from("/usr/lib64"),
+        PathBuf::from("/usr/lib"),
+    ]);
+    candidates.into_iter().find(|dir| has_libamdhip64(dir))
+}
+
+fn has_libamdhip64(dir: &Path) -> bool {
+    if dir.join("libamdhip64.so").exists() {
+        return true;
+    }
+    fs::read_dir(dir)
+        .ok()
+        .into_iter()
+        .flat_map(|entries| entries.filter_map(Result::ok))
+        .any(|entry| {
+            entry
+                .file_name()
+                .to_string_lossy()
+                .starts_with("libamdhip64.so.")
+        })
+}
+
 fn run(cmd: &mut Command, context: &str) {
     let status = cmd.status().unwrap_or_else(|err| {
         panic!("{context}: failed to start command {:?}: {err}", cmd);
@@ -234,6 +269,13 @@ fn compile_hip(kernel_dir: &Path, out_dir: &Path) {
         &objects,
         "archiving qwen35 megakernel HIP bridges",
     );
+    if let Some(rocm_lib_dir) = detect_rocm_lib_dir() {
+        println!("cargo:rustc-link-search=native={}", rocm_lib_dir.display());
+    } else {
+        println!(
+            "cargo:warning=could not locate libamdhip64 under ROCM_PATH/HIP_PATH or common system library paths; falling back to linker search path"
+        );
+    }
     println!("cargo:rustc-link-lib=dylib=amdhip64");
     println!("cargo:rustc-link-lib=dylib=stdc++");
     println!("cargo:rustc-cfg=supersonic_backend_hip");
@@ -335,6 +377,8 @@ fn compile_metal_stubs(manifest_dir: &Path) {
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-env-changed=HIP_ARCH");
+    println!("cargo:rerun-if-env-changed=ROCM_PATH");
+    println!("cargo:rerun-if-env-changed=HIP_PATH");
     println!("cargo:rerun-if-env-changed=CUDA_ARCH");
     println!("cargo:rerun-if-env-changed=CUDA_HOME");
     println!("cargo:rerun-if-env-changed=CUDA_PATH");

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -1169,7 +1169,13 @@ fn main() -> Result<()> {
         Backend::Hip => {
             let (arch_name, total_vram) = kernel_ffi::query_gpu_info(ordinal)
                 .map_err(|e| anyhow::anyhow!("GPU query failed for device {ordinal}: {e}"))?;
-            (arch_name, total_vram, 32)
+            let base_arch = arch_name.split(':').next().unwrap_or(&arch_name);
+            let warp_size = if base_arch.starts_with("gfx9") {
+                64
+            } else {
+                32
+            };
+            (arch_name, total_vram, warp_size)
         }
         Backend::Cuda => {
             let info = gpu_hal::query_device_info(backend, ordinal)
@@ -1223,6 +1229,26 @@ fn main() -> Result<()> {
             }
         }
     };
+    if backend == Backend::Hip && gpu_arch == GpuArch::Gfx942 {
+        if !matches!(
+            model_variant,
+            ModelVariant::Qwen3_5_0_8B
+                | ModelVariant::Qwen3_5_2B
+                | ModelVariant::Qwen3_5_4B
+        ) {
+            anyhow::bail!(
+                "HIP gfx942 bring-up currently validates only Qwen3.5 BF16 models up to 4B"
+            );
+        }
+        if cli.fp8_runtime || cli.kv_fp8 || cli.q4km || cli.q4km_gptq {
+            anyhow::bail!(
+                "HIP gfx942 bring-up currently validates only BF16 and INT4 Qwen3.5 lanes"
+            );
+        }
+        if cli.batch_size != 1 {
+            anyhow::bail!("HIP gfx942 bring-up currently supports only --batch-size 1");
+        }
+    }
 
     // Install per-arch policy so gpu_hal::alloc dispatches correctly.
     // `MemoryArchitecture` is informational (used downstream for VRAM
@@ -2126,7 +2152,9 @@ fn main() -> Result<()> {
         && !cli.force_component_decode
         && !cli.kv_fp8
         && use_4b_kernel
-        && (cli.force_replay_decode || cuda_qwen2b_replay_default);
+        && (cli.force_replay_decode
+            || cuda_qwen2b_replay_default
+            || (backend == Backend::Hip && gpu_arch == GpuArch::Gfx942));
     let replay_kv_fp8_enabled =
         use_4b_kernel && cli.kv_fp8 && cli.batch_size == 1 && !cli.force_kernel_decode;
     let component_single_decode_enabled =
@@ -2139,7 +2167,8 @@ fn main() -> Result<()> {
     let kernel_single_decode_enabled = cli.batch_size == 1
         && use_4b_kernel
         && !cli.force_replay_decode
-        && !cli.force_component_decode;
+        && !cli.force_component_decode
+        && (!(backend == Backend::Hip && gpu_arch == GpuArch::Gfx942) || cli.force_kernel_decode);
     let cuda_08b_hero_enabled = cuda_08b_hero_candidate;
     let cuda_fast_greedy_disabled = env::var_os("SUPERSONIC_DISABLE_CUDA_FAST_GREEDY").is_some();
     let cuda_fast_greedy_enabled = backend == Backend::Cuda
@@ -2177,6 +2206,10 @@ fn main() -> Result<()> {
         if cuda_qwen2b_replay_default {
             eprintln!(
                 "[decode] single-sequence CUDA qwen3.5-2b uses replayed GPU prefill for correctness"
+            );
+        } else if backend == Backend::Hip && gpu_arch == GpuArch::Gfx942 {
+            eprintln!(
+                "[decode] single-sequence HIP gfx942 uses replayed GPU prefill while the wave64 persistent kernel is under validation"
             );
         } else {
             eprintln!("[decode] single-sequence 4B uses replayed GPU prefill for correctness");

--- a/crates/runner/src/oracle.rs
+++ b/crates/runner/src/oracle.rs
@@ -231,6 +231,9 @@ fn resolve_oracle_python() -> String {
     if let Some(value) = env::var_os("SUPERSONIC_ORACLE_PYTHON") {
         return value.to_string_lossy().into_owned();
     }
+    if let Some(value) = env::var_os("PYTHON") {
+        return value.to_string_lossy().into_owned();
+    }
 
     for candidate in ["/opt/homebrew/bin/python3.11", "python3.11", "python3"] {
         if let Ok(status) = Command::new(candidate).arg("--version").status() {
@@ -438,7 +441,8 @@ pub fn run_gemma4_oracle(
     max_new_tokens: usize,
     dtype: &str,
 ) -> Result<OracleOutput> {
-    let mut cmd = Command::new("python3");
+    let python = resolve_oracle_python();
+    let mut cmd = Command::new(&python);
     cmd.arg(oracle_script)
         .arg("--model-dir")
         .arg(model_dir)
@@ -450,7 +454,8 @@ pub fn run_gemma4_oracle(
         .arg(dtype);
 
     eprintln!(
-        "[oracle] running: python3 {} --model-dir {} --prompt <...> --max-new-tokens {max_new_tokens} --dtype {dtype}",
+        "[oracle] running: {} {} --model-dir {} --prompt <...> --max-new-tokens {max_new_tokens} --dtype {dtype}",
+        python,
         oracle_script.display(),
         model_dir.display(),
     );

--- a/crates/runner/src/registry.rs
+++ b/crates/runner/src/registry.rs
@@ -109,6 +109,7 @@ impl fmt::Display for ModelVariant {
 pub enum GpuArch {
     Gfx1100,
     Gfx1150,
+    Gfx942,
     Sm86,
     AppleM4,
     Unknown(String),
@@ -117,9 +118,10 @@ pub enum GpuArch {
 impl GpuArch {
     pub fn from_backend_name(backend: &Backend, name: &str) -> Self {
         match backend {
-            Backend::Hip => match name.trim() {
+            Backend::Hip => match name.trim().split(':').next().unwrap_or(name.trim()) {
                 "gfx1100" => Self::Gfx1100,
                 "gfx1150" => Self::Gfx1150,
+                "gfx942" => Self::Gfx942,
                 other => Self::Unknown(other.to_owned()),
             },
             Backend::Cuda => match name.trim() {
@@ -139,6 +141,7 @@ impl fmt::Display for GpuArch {
         match self {
             Self::Gfx1100 => write!(f, "gfx1100"),
             Self::Gfx1150 => write!(f, "gfx1150"),
+            Self::Gfx942 => write!(f, "gfx942"),
             Self::Sm86 => write!(f, "sm86"),
             Self::AppleM4 => write!(f, "apple-m4"),
             Self::Unknown(s) => write!(f, "{s}"),
@@ -164,7 +167,7 @@ pub struct ArchProfile {
 impl ArchProfile {
     pub fn for_arch(arch: &GpuArch) -> Self {
         let memory = match arch {
-            GpuArch::Gfx1100 | GpuArch::Sm86 => MemoryArchitecture::Discrete,
+            GpuArch::Gfx1100 | GpuArch::Gfx942 | GpuArch::Sm86 => MemoryArchitecture::Discrete,
             GpuArch::Gfx1150 | GpuArch::AppleM4 => MemoryArchitecture::Unified,
             GpuArch::Unknown(_) => MemoryArchitecture::Discrete,
         };
@@ -428,6 +431,54 @@ static REGISTRY: &[RegistryEntry] = &[
         arch: GpuArch::Gfx1150,
         vram: VramBudget {
             fixed_bytes: 18 * GIB,
+            overhead_factor: 1.1,
+        },
+        params: FamilyParams::Qwen35(Qwen35KernelParams {
+            proj_buf_floats: 12352,
+            attn_scratch_floats: 16384,
+            weight_prefix: "model.language_model",
+            kv_chunk_size: 256,
+            use_4b_kernel: true,
+        }),
+    },
+    RegistryEntry {
+        model: ModelVariant::Qwen3_5_0_8B,
+        backend: Backend::Hip,
+        arch: GpuArch::Gfx942,
+        vram: VramBudget {
+            fixed_bytes: 2 * GIB,
+            overhead_factor: 1.1,
+        },
+        params: FamilyParams::Qwen35(Qwen35KernelParams {
+            proj_buf_floats: 8224,
+            attn_scratch_floats: 16384,
+            weight_prefix: "model.language_model",
+            kv_chunk_size: 256,
+            use_4b_kernel: true,
+        }),
+    },
+    RegistryEntry {
+        model: ModelVariant::Qwen3_5_2B,
+        backend: Backend::Hip,
+        arch: GpuArch::Gfx942,
+        vram: VramBudget {
+            fixed_bytes: 5 * GIB,
+            overhead_factor: 1.1,
+        },
+        params: FamilyParams::Qwen35(Qwen35KernelParams {
+            proj_buf_floats: 8224,
+            attn_scratch_floats: 16384,
+            weight_prefix: "model.language_model",
+            kv_chunk_size: 256,
+            use_4b_kernel: true,
+        }),
+    },
+    RegistryEntry {
+        model: ModelVariant::Qwen3_5_4B,
+        backend: Backend::Hip,
+        arch: GpuArch::Gfx942,
+        vram: VramBudget {
+            fixed_bytes: 10 * GIB,
             overhead_factor: 1.1,
         },
         params: FamilyParams::Qwen35(Qwen35KernelParams {
@@ -782,6 +833,29 @@ mod tests {
         ] {
             assert!(lookup(&model, &Backend::Hip, &GpuArch::Gfx1100).is_some());
         }
+    }
+
+    #[test]
+    fn hip_gfx942_registry_includes_cdna_targets() {
+        assert_eq!(
+            GpuArch::from_backend_name(&Backend::Hip, "gfx942"),
+            GpuArch::Gfx942
+        );
+        assert_eq!(
+            GpuArch::from_backend_name(&Backend::Hip, "gfx942:sramecc+:xnack-"),
+            GpuArch::Gfx942
+        );
+        let profile = ArchProfile::for_arch(&GpuArch::Gfx942);
+        assert_eq!(profile.memory, MemoryArchitecture::Discrete);
+        assert_eq!(profile.buffer_policy, BufferPolicy::all_default());
+        for model in [
+            ModelVariant::Qwen3_5_0_8B,
+            ModelVariant::Qwen3_5_2B,
+            ModelVariant::Qwen3_5_4B,
+        ] {
+            assert!(lookup(&model, &Backend::Hip, &GpuArch::Gfx942).is_some());
+        }
+        assert!(lookup(&ModelVariant::Qwen3_5_9B, &Backend::Hip, &GpuArch::Gfx942).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds the first HIP `gfx942`/CDNA bring-up checkpoint for SuperSonic.

- Detects `gfx942` device names that include ROCm suffixes such as `gfx942:sramecc+:xnack-`.
- Treats `gfx942` as a discrete-memory HIP target with wave64 warp size reporting.
- Adds registry entries for Qwen3.5 `0.8B`, `2B`, and `4B` on HIP `gfx942`.
- Keeps `gfx942` single-sequence decode on replayed GPU prefill by default while the RDNA persistent decode megakernel is still wave64-incorrect.
- Allows BF16 and INT4 Qwen3.5 lanes up to 4B, while continuing to block FP8 runtime, FP8 KV, Q4, batch, and unvalidated model families.
- Fixes ROCm `libamdhip64` link discovery in the HIP build script.
- Lets oracle execution respect `PYTHON` and applies the same resolver to the Gemma oracle helper.
- Updates the README support matrix with the validated `gfx942` lanes and current limitations.

## Validation

Installed the Python oracle environment at `/opt/supersonic-oracle-venv` and used bakes/models under `/models/supersonic-cdna`.

Validated on MI300X-class `gfx942:sramecc+:xnack-`:

- `qwen3.5-0.8b` BF16: GPU replay exact match, CPU PyTorch oracle BF16-scale delta.
- `qwen3.5-2b` BF16: GPU replay exact match, CPU PyTorch oracle BF16-scale delta.
- `qwen3.5-4b` BF16: GPU replay exact match, CPU PyTorch oracle BF16-scale delta.
- `qwen3.5-0.8b` INT4 GPTQ: published bake loads, native decode and replayed GPU prefill exact match.
- `qwen3.5-2b` INT4 GPTQ: published bake loads, native decode and replayed GPU prefill exact match.
- `qwen3.5-4b` INT4 GPTQ: published bake loads, native decode and replayed GPU prefill exact match.
- `SUPERSONIC_BACKENDS=hip HIP_ARCH=gfx942 cargo test -p runner registry::tests::hip_gfx942_registry_includes_cdna_targets --lib`
- `SUPERSONIC_BACKENDS=hip HIP_ARCH=gfx942 cargo build -p runner --bin supersonic`

## Notes

`qwen3.5-9b` remains unsupported on `gfx942` because the current `bakes-v2` release does not include a BF16 bake for that model.

The persistent decode megakernel compiles on `gfx942`, but forced kernel decode currently mismatches badly on wave64, so this PR deliberately leaves it behind `--force-kernel-decode` and defaults to replayed GPU prefill for correctness.