### PR TITLE
[codex] Fix gfx942 persistent decode barrier

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,13 +80,12 @@ see [docs/dflash.md](docs/dflash.md).
 | gemma4-e4b       |  —   |  —   |      —      |   —    |
 | phi4-mini        |  —   |  —   |      —      |   —    |
 
-¹ CDNA bring-up currently uses replayed GPU prefill for single-sequence decode.
-  The RDNA persistent decode megakernel compiles on `gfx942`, but its wave64
-  correctness is still under validation and is available only via the explicit
-  debug path `--force-kernel-decode`.
-² INT4 uses the published GPTQ bake and the same replayed GPU prefill
-  correctness path. The PyTorch oracle is BF16-only, so INT4 bring-up checks
-  exact agreement between native decode and replayed GPU prefill.
+¹ CDNA single-sequence decode uses the persistent megakernel by default.
+  `--force-replay-decode` remains available as the slower GPU-prefill
+  reference path.
+² INT4 uses the published GPTQ bake. The PyTorch oracle is BF16-only, so INT4
+  bring-up checks exact token agreement and BF16-scale logit drift against
+  replayed GPU prefill.
 
 ### CUDA on `sm86`
 

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -2152,9 +2152,7 @@ fn main() -> Result<()> {
         && !cli.force_component_decode
         && !cli.kv_fp8
         && use_4b_kernel
-        && (cli.force_replay_decode
-            || cuda_qwen2b_replay_default
-            || (backend == Backend::Hip && gpu_arch == GpuArch::Gfx942));
+        && (cli.force_replay_decode || cuda_qwen2b_replay_default);
     let replay_kv_fp8_enabled =
         use_4b_kernel && cli.kv_fp8 && cli.batch_size == 1 && !cli.force_kernel_decode;
     let component_single_decode_enabled =
@@ -2167,8 +2165,7 @@ fn main() -> Result<()> {
     let kernel_single_decode_enabled = cli.batch_size == 1
         && use_4b_kernel
         && !cli.force_replay_decode
-        && !cli.force_component_decode
-        && (!(backend == Backend::Hip && gpu_arch == GpuArch::Gfx942) || cli.force_kernel_decode);
+        && !cli.force_component_decode;
     let cuda_08b_hero_enabled = cuda_08b_hero_candidate;
     let cuda_fast_greedy_disabled = env::var_os("SUPERSONIC_DISABLE_CUDA_FAST_GREEDY").is_some();
     let cuda_fast_greedy_enabled = backend == Backend::Cuda
@@ -2206,10 +2203,6 @@ fn main() -> Result<()> {
         if cuda_qwen2b_replay_default {
             eprintln!(
                 "[decode] single-sequence CUDA qwen3.5-2b uses replayed GPU prefill for correctness"
-            );
-        } else if backend == Backend::Hip && gpu_arch == GpuArch::Gfx942 {
-            eprintln!(
-                "[decode] single-sequence HIP gfx942 uses replayed GPU prefill while the wave64 persistent kernel is under validation"
             );
         } else {
             eprintln!("[decode] single-sequence 4B uses replayed GPU prefill for correctness");

--- a/kernels/full_attention_4b.hip
+++ b/kernels/full_attention_4b.hip
@@ -4707,10 +4707,14 @@ __device__ inline void grid_barrier(
     __syncthreads();
     if (threadIdx.x == 0) {
         unsigned int phase = __atomic_load_n(barrier_flag, __ATOMIC_RELAXED);
+        // Publish all global-memory writes from this block before it marks
+        // itself arrived. The phase release below only covers the last
+        // arriving block's writes; CDNA can otherwise let block 0 observe
+        // stale workspace data from earlier-arriving blocks after the barrier.
+        __threadfence();
         unsigned int old = atomicAdd(barrier_counter, 1u);
         if (old == static_cast<unsigned int>(num_blocks) - 1) {
             __atomic_store_n(barrier_counter, 0u, __ATOMIC_RELAXED);
-            __threadfence();
             __atomic_store_n(barrier_flag, phase + 1, __ATOMIC_RELEASE);
         } else {
             while (__atomic_load_n(barrier_flag, __ATOMIC_ACQUIRE) == phase) {}
@@ -4729,11 +4733,13 @@ __device__ inline void grid_barrier_reset_counter(
     __syncthreads();
     if (threadIdx.x == 0) {
         unsigned int phase = __atomic_load_n(barrier_flag, __ATOMIC_RELAXED);
+        // See grid_barrier: every arriving block must publish its global
+        // writes before incrementing the arrival counter.
+        __threadfence();
         unsigned int old = atomicAdd(barrier_counter, 1u);
         if (old == static_cast<unsigned int>(num_blocks) - 1) {
             __atomic_store_n(counter_to_reset, 0u, __ATOMIC_RELAXED);
             __atomic_store_n(barrier_counter, 0u, __ATOMIC_RELAXED);
-            __threadfence();
             __atomic_store_n(barrier_flag, phase + 1, __ATOMIC_RELEASE);
         } else {
             while (__atomic_load_n(barrier_flag, __ATOMIC_ACQUIRE) == phase) {}


### PR DESCRIPTION
## Summary

Fixes the Qwen3.5 HIP 4B megakernel grid barrier so persistent decode is correct on `gfx942`/CDNA, then promotes the validated `gfx942` lanes from replay-prefill decode to the real persistent megakernel by default.

## Root Cause

The custom grid barrier only called `__threadfence()` from the last arriving block before publishing the phase flag. That was enough on the RDNA targets we had validated, but on CDNA earlier-arriving blocks could increment the arrival counter before their global-memory writes were visible to block 0 after the barrier.

In practice, layer 0 linear attention showed projection rows eventually present in workspace, while block 0 read stale zero values when immediately entering the conv-state update. That produced large token/logit mismatches in forced persistent decode.

## Changes

- Add a device fence before every block increments the barrier arrival counter in `grid_barrier` and `grid_barrier_reset_counter`.
- Remove the special `gfx942` default replay-prefill path now that persistent decode validates.
- Update the README `gfx942` note to say persistent decode is the default and replay remains the reference path.

## Validation

Built with:

- `SUPERSONIC_BACKENDS=hip HIP_ARCH=gfx942 cargo build -p runner --bin supersonic`
- `SUPERSONIC_BACKENDS=hip HIP_ARCH=gfx942 cargo test -p runner registry::tests::hip_gfx942_registry_includes_cdna_targets --lib`

Validated on `gfx942:sramecc+:xnack-` with `--gpu-validate`:

- `qwen3.5-0.8b` BF16 forced persistent: tokens match replay, max replay delta `0.1328`.
- `qwen3.5-2b` BF16 forced persistent: tokens match replay, max replay delta `0.1250`.
- `qwen3.5-4b` BF16 forced persistent: tokens match replay, max replay delta `0.1250`.
- `qwen3.5-0.8b` INT4 forced persistent: tokens match replay, max replay delta `0.1562`.
- `qwen3.5-2b` INT4 forced persistent: tokens match replay, max replay delta `0.2188`.
- `qwen3.5-4b` INT4 forced persistent: tokens match replay, max replay delta `0.1875`.
- Default `qwen3.5-0.8b` BF16 now uses persistent decode and matches replay tokens.
- Default `qwen3.5-4b` BF16 now uses persistent decode and matches replay tokens.
- Default `qwen3.5-4b` INT4 now uses persistent decode and matches replay tokens.
- Default `qwen3.5-0.8b` BF16 with CPU PyTorch oracle passes with decode delta `0.1953`.

## Notes

This PR intentionally keeps the model/backend support matrix unchanged except for the decode-path note. Larger/broader matrix work, such as 9B bake generation and Gemma 4 `gfx942` validation, can build on this barrier fix.