### PR TITLE
qwen36-moe: bake mtp.* tensors (Phase 6.1, speculative-decode prep)

### DIFF
--- a/crates/model-store/src/baker.rs
+++ b/crates/model-store/src/baker.rs
@@ -176,7 +176,17 @@ pub fn bake_qwen35(
                     && (weight_name.starts_with(&format!("{weight_prefix}."))
                         || weight_name == "lm_head.weight");
             }
-            name.starts_with(&format!("{weight_prefix}.")) || *name == "lm_head.weight"
+            // Phase 6.1: also include `mtp.*` (multi-token prediction
+            // head — used by Qwen3.6 self-speculative decode). The MTP
+            // block in 35B-A3B is structurally one full-attention MoE
+            // layer plus three small fusion layernorms and a fusion
+            // linear (`mtp.fc`). HuggingFace's `Qwen3_5MoeForCausalLM`
+            // strips these (`_keys_to_ignore_on_load_unexpected =
+            // [r"^mtp.*"]`); the bake reads them directly from
+            // safetensors so the runtime can drive a draft pass.
+            name.starts_with(&format!("{weight_prefix}."))
+                || *name == "lm_head.weight"
+                || name.starts_with("mtp.")
         })
         .cloned()
         .collect();

--- a/crates/model-store/src/manifest.rs
+++ b/crates/model-store/src/manifest.rs
@@ -2,6 +2,11 @@ use serde::{Deserialize, Serialize};
 
 pub const FORMAT_VERSION: u32 = 2;
 pub const CONVERTER_VERSION: u32 = 1;
+// Phase 6.1 (this PR) extends the baker to capture `mtp.*` tensors for
+// Qwen3.6-MoE self-speculative decode. The change is purely additive —
+// existing bakes don't have MTP tensors but the production decode path
+// doesn't read them, so the bake is still valid. Bump CONVERTER_VERSION
+// when the runtime starts CONSUMING the MTP weights (Phase 6.2+).
 
 /// Describes the layout transformation applied to a tensor at bake time.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/oracle/bake_int4.py
+++ b/oracle/bake_int4.py
@@ -1603,6 +1603,41 @@ def main() -> None:
         ]
         eligible.sort()
 
+        # ------------------------------------------------------------------
+        # Phase 6.1: pass-through `mtp.*` tensors (multi-token-prediction
+        # head) directly from safetensors. HF's `Qwen3_5MoeForCausalLM`
+        # strips them via `_keys_to_ignore_on_load_unexpected = [r"^mtp.*"]`,
+        # so `named_parameters()` doesn't see them, but the bake reader
+        # (`crates/model-store/src/baker.rs`) does include them in the
+        # raw_keys filter (PR shipped alongside this change). Stored as
+        # raw BF16 — no INT4 calibration this round; the MTP block is
+        # one layer's worth of compute and BF16 vs INT4 is a wash for
+        # speculative-decode draft pass throughput.
+        mtp_raw_keys = sorted(
+            k for k in raw_keys if k.startswith("mtp.")
+        )
+        for raw_name in mtp_raw_keys:
+            if writer.has(raw_name):
+                continue
+            t = load_raw_tensor(model_dir, raw_name)
+            if t is None:
+                log(f"[bake-int4] WARNING mtp passthrough: failed to load "
+                    f"{raw_name} — skipping")
+                continue
+            t = t.detach().to(device="cpu")
+            shape = list(t.shape)
+            # MTP tensors don't match any of `classify_tensor`'s
+            # weight_prefix.layers.* patterns, so they fall through to
+            # LAYOUT_RAW. Explicit here for clarity.
+            layout = LAYOUT_RAW
+            dtype_str = torch_dtype_to_str(t.dtype)
+            b, final_shape, final_dtype = apply_layout(t, shape, layout, dtype_str)
+            writer.write_tensor(raw_name, b, final_shape, final_dtype, layout)
+            del t, b
+        if mtp_raw_keys:
+            log(f"[bake-int4] passed through {len(mtp_raw_keys)} mtp.* "
+                f"tensor(s) (BF16 raw)")
+
         # When `lm_head.weight` is tied to `embed_tokens.weight`, the HF state
         # dict entry usually has no safetensors counterpart and the eligible
         # loop above skips it. But if quantize_model just ran GPTQ on


### PR DESCRIPTION
## Summary

First step of the Phase 6 (self-speculative decode) plan. Qwen3.6-35B-A3B ships an MTP head — 19 `mtp.*` tensors implementing one MoE-attention block for next-1 prediction, fused into the base hidden state via three small layernorms (`mtp.pre_fc_norm_{hidden,embedding}`, `mtp.norm`) and an `mtp.fc` linear, sharing `embed_tokens` and `lm_head` with the base model. Used by vLLM's `qwen3_next_mtp` and SGLang's NEXTN; HF transformers strips it via `_keys_to_ignore_on_load_unexpected = [r"^mtp.*"]`.

The local v2-int4-gptq bake currently has 0 of 1355 tensors named `mtp.*` because both bakers filter them out. Both fixed:

- **`crates/model-store/src/baker.rs`**: filter now accepts `name.starts_with("mtp.")` alongside the existing `weight_prefix.*` and `lm_head.weight` patterns.
- **`oracle/bake_int4.py`**: after the main eligible loop, iterate raw safetensors keys for `mtp.*`, load each via `load_raw_tensor` (which reads safetensors directly, bypassing HF's strip), classify as `LAYOUT_RAW`, and write to the bake.

MTP tensors are stored BF16 in the FP8 release (verified by direct safetensors read). No FP8 dequant or INT4 calibration this round — the MTP block is one layer's worth of compute and BF16 vs INT4 is a wash for draft-pass throughput. INT4 calibration can be a follow-up if memory becomes tight.

**Bake size impact**: +~1.6 GiB BF16 → 16.9 → ~18.5 GiB, still fits in the 24 GiB 7900 XTX budget alongside KV cache and scratch.

**Purely additive**: existing bakes don't have MTP tensors but the production decode path doesn't read them, so the bake stays valid. `CONVERTER_VERSION` is **not** bumped — that comes when the runtime starts consuming MTP weights (Phase 6.2+). Bumping now would invalidate every in-the-wild bake for no reason.

## Test plan

- [x] `model-store` test suite (12/12) passes.
- [x] End-to-end greedy on the existing v2-int4-gptq bake produces the same 4 tokens for `--prompt "Hello" --max-new-tokens 4` — bake-load path unchanged.

## Followups

- **Phase 6.2**: MTP draft-pass kernel + parity test against vLLM oracle.
- **Phase 6.3**: speculative driver with sequential verification — measures empirical acceptance rate.
- **Phase 6.4**: batched verification kernel — only build if 6.3 shows acceptance >50% (otherwise sequential verify is slower than no speculative at K=3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)