### PR TITLE
[codex] Add gfx942 Qwen3.5 9B support

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ see [docs/dflash.md](docs/dflash.md).
 | qwen3.5-0.8b     | ✅¹  | ✅²  |      —      |   —    |
 | qwen3.5-2b       | ✅¹  | ✅²  |      —      |   —    |
 | qwen3.5-4b       | ✅¹  | ✅²  |      —      |   —    |
-| qwen3.5-9b       |  —   |  —   |      —      |   —    |
+| qwen3.5-9b       | ✅¹  | ✅²  |      —      |   —    |
 | qwen3.6-35b-a3b  |  —   |  —   |      —      |   —    |
 | gemma4-e2b       |  —   |  —   |      —      |   —    |
 | gemma4-e4b       |  —   |  —   |      —      |   —    |

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -1235,10 +1235,9 @@ fn main() -> Result<()> {
             ModelVariant::Qwen3_5_0_8B
                 | ModelVariant::Qwen3_5_2B
                 | ModelVariant::Qwen3_5_4B
+                | ModelVariant::Qwen3_5_9B
         ) {
-            anyhow::bail!(
-                "HIP gfx942 bring-up currently validates only Qwen3.5 BF16 models up to 4B"
-            );
+            anyhow::bail!("HIP gfx942 bring-up currently validates only Qwen3.5 models up to 9B");
         }
         if cli.fp8_runtime || cli.kv_fp8 || cli.q4km || cli.q4km_gptq {
             anyhow::bail!(

--- a/crates/runner/src/registry.rs
+++ b/crates/runner/src/registry.rs
@@ -490,6 +490,22 @@ static REGISTRY: &[RegistryEntry] = &[
         }),
     },
     RegistryEntry {
+        model: ModelVariant::Qwen3_5_9B,
+        backend: Backend::Hip,
+        arch: GpuArch::Gfx942,
+        vram: VramBudget {
+            fixed_bytes: 18 * GIB,
+            overhead_factor: 1.1,
+        },
+        params: FamilyParams::Qwen35(Qwen35KernelParams {
+            proj_buf_floats: 12352,
+            attn_scratch_floats: 16384,
+            weight_prefix: "model.language_model",
+            kv_chunk_size: 256,
+            use_4b_kernel: true,
+        }),
+    },
+    RegistryEntry {
         model: ModelVariant::Qwen3_5_0_8B,
         backend: Backend::Cuda,
         arch: GpuArch::Sm86,
@@ -852,10 +868,10 @@ mod tests {
             ModelVariant::Qwen3_5_0_8B,
             ModelVariant::Qwen3_5_2B,
             ModelVariant::Qwen3_5_4B,
+            ModelVariant::Qwen3_5_9B,
         ] {
             assert!(lookup(&model, &Backend::Hip, &GpuArch::Gfx942).is_some());
         }
-        assert!(lookup(&ModelVariant::Qwen3_5_9B, &Backend::Hip, &GpuArch::Gfx942).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds the HIP `gfx942` registry entry for `qwen3.5-9b`, updates the CDNA guard to include 9B, and marks the `gfx942` README support matrix for 9B BF16 and INT4.

## Validation

- `SUPERSONIC_BACKENDS=hip HIP_ARCH=gfx942 cargo test -p runner registry::tests::hip_gfx942_registry_includes_cdna_targets --lib`
- `SUPERSONIC_BACKENDS=hip HIP_ARCH=gfx942 cargo build -p runner --bin supersonic`
- Local 9B BF16 bake from `Qwen/Qwen3.5-9B` into `/models/supersonic-cdna/qwen3.5-9b/.supersonic/v2`
- `qwen3.5-9b` BF16 smoke: 1 token, persistent decode loaded and ran
- `qwen3.5-9b` BF16 `--gpu-validate`: 2 tokens, replay token agreement, max delta `0.1250`
- `qwen3.5-9b` BF16 `--validate --oracle-device cpu`: 1 token, prefill delta `0.1250`, decode delta `0.1094`
- `qwen3.5-9b` INT4 `--gpu-validate`: downloaded published GPTQ bake, 2 tokens, replay token agreement, max delta `0.1250`

Note: full `cargo fmt --check` currently reports unrelated pre-existing formatting drift outside this PR's touched files, so I did not apply a tree-wide format rewrite.