### PR TITLE
[codex] Add gfx942 Gemma 4 E2B BF16 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ see [docs/dflash.md](docs/dflash.md).
 | qwen3.5-4b       | ✅¹  | ✅²  |      —      |   —    |
 | qwen3.5-9b       | ✅¹  | ✅²  |      —      |   —    |
 | qwen3.6-35b-a3b  |  —   |  —   |      —      |   —    |
-| gemma4-e2b       |  —   |  —   |      —      |   —    |
+| gemma4-e2b       | ✅³  |  —   |      —      |   —    |
 | gemma4-e4b       |  —   |  —   |      —      |   —    |
 | phi4-mini        |  —   |  —   |      —      |   —    |
 
@@ -86,6 +86,8 @@ see [docs/dflash.md](docs/dflash.md).
 ² INT4 uses the published GPTQ bake. The PyTorch oracle is BF16-only, so INT4
   bring-up checks exact token agreement and BF16-scale logit drift against
   replayed GPU prefill.
+³ Gemma 4 E2B BF16 validates against the PyTorch oracle; Gemma does not yet
+  have the Qwen GPU replay validator wired up.
 
 ### CUDA on `sm86`
 

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -1236,13 +1236,19 @@ fn main() -> Result<()> {
                 | ModelVariant::Qwen3_5_2B
                 | ModelVariant::Qwen3_5_4B
                 | ModelVariant::Qwen3_5_9B
+                | ModelVariant::Gemma4_E2B
         ) {
-            anyhow::bail!("HIP gfx942 bring-up currently validates only Qwen3.5 models up to 9B");
+            anyhow::bail!(
+                "HIP gfx942 bring-up currently validates only Qwen3.5 models up to 9B and Gemma 4 E2B BF16"
+            );
         }
         if cli.fp8_runtime || cli.kv_fp8 || cli.q4km || cli.q4km_gptq {
             anyhow::bail!(
-                "HIP gfx942 bring-up currently validates only BF16 and INT4 Qwen3.5 lanes"
+                "HIP gfx942 bring-up currently validates only BF16 and INT4 Qwen3.5 lanes, plus Gemma 4 E2B BF16"
             );
+        }
+        if matches!(model_variant, ModelVariant::Gemma4_E2B) && cli.int4 {
+            anyhow::bail!("HIP gfx942 Gemma 4 E2B bring-up currently validates only BF16");
         }
         if cli.batch_size != 1 {
             anyhow::bail!("HIP gfx942 bring-up currently supports only --batch-size 1");

--- a/crates/runner/src/registry.rs
+++ b/crates/runner/src/registry.rs
@@ -676,6 +676,19 @@ static REGISTRY: &[RegistryEntry] = &[
             kv_chunk_size: 256,
         }),
     },
+    RegistryEntry {
+        model: ModelVariant::Gemma4_E2B,
+        backend: Backend::Hip,
+        arch: GpuArch::Gfx942,
+        vram: VramBudget {
+            fixed_bytes: 11 * GIB,
+            overhead_factor: 1.1,
+        },
+        params: FamilyParams::Gemma4(Gemma4KernelParams {
+            weight_prefix: "model.language_model",
+            kv_chunk_size: 256,
+        }),
+    },
     // Phi-4-mini: 3.8B dense, full-attention all 32 layers, LongRoPE.
     // BF16 weights ≈ 7.6 GiB; KV cache at 4K ctx ≈ 520 MiB (32 layers × 2 × 8 kv_heads × 128 head_dim × 2 B).
     // Fits gfx1150 with headroom. Weight prefix is bare `model` (Phi stores tensors as `model.*`).
@@ -869,6 +882,7 @@ mod tests {
             ModelVariant::Qwen3_5_2B,
             ModelVariant::Qwen3_5_4B,
             ModelVariant::Qwen3_5_9B,
+            ModelVariant::Gemma4_E2B,
         ] {
             assert!(lookup(&model, &Backend::Hip, &GpuArch::Gfx942).is_some());
         }

--- a/kernels/gemma4.hip
+++ b/kernels/gemma4.hip
@@ -1729,6 +1729,7 @@ __device__ inline void g4_grid_barrier(
     __syncthreads();
     if (threadIdx.x == 0) {
         unsigned int phase = __atomic_load_n(barrier_flag, __ATOMIC_RELAXED);
+        __threadfence();
         unsigned int old = atomicAdd(barrier_counter, 1u);
         if (old == static_cast<unsigned int>(num_blocks) - 1) {
             __atomic_store_n(barrier_counter, 0u, __ATOMIC_RELAXED);


### PR DESCRIPTION
## Summary

Adds the next gfx942/CDNA bring-up target: Gemma 4 E2B BF16 on the HIP backend.

- adds a HIP `gfx942` registry entry for `gemma4-e2b`
- extends the gfx942 runtime guard to allow Gemma 4 E2B BF16 while continuing to block unvalidated Gemma INT4/FP8/Q4 lanes
- marks Gemma 4 E2B BF16 in the README support matrix
- adds the same pre-barrier `__threadfence()` pattern to the Gemma 4 grid barrier that fixed stale workspace reads for Qwen on CDNA

## Validation

- `SUPERSONIC_BACKENDS=hip HIP_ARCH=gfx942 cargo test -p runner registry::tests::hip_gfx942_registry_includes_cdna_targets --lib`
- `SUPERSONIC_BACKENDS=hip HIP_ARCH=gfx942 cargo build -p runner --bin supersonic`
- downloaded `google/gemma-4-E2B` to `/models/supersonic-cdna/gemma4-e2b`
- Gemma 4 E2B BF16 smoke run, 1 token, HIP backend
- Gemma 4 E2B BF16 `--validate`, 2 tokens, PyTorch oracle: prefill max delta `0.3581`, decode max delta `0.2804`, `token_mismatches=0`

Gemma does not currently have the Qwen GPU replay validator wired up, so this PR validates against the PyTorch oracle rather than replaying GPU prefill.