### PR TITLE
qwen36-moe: MTP pre-fusion HIP kernel + parity (Phase 6.2c.1)

### DIFF
--- a/crates/kernel-ffi/src/qwen36_moe.rs
+++ b/crates/kernel-ffi/src/qwen36_moe.rs
@@ -474,6 +474,27 @@ extern "C" {
         logits: *mut c_void,
         counter: *mut c_uint,
     ) -> c_int;
+
+    /// FFI bridge for the MTP pre-fusion kernel (Phase 6.2c.1). Single-block
+    /// launch: BF16 RMSNorms over `e_in` and `h_base` followed by a
+    /// `mtp.fc @ cat([e_norm, h_norm])` matvec into `fused_out`. All buffers
+    /// must be device-resident on `device_ordinal` and BF16. See
+    /// `qwen36_moe_hip_mtp_pre_fusion_launch` in `kernels/qwen36_moe_bridge.cpp`
+    /// for the error code matrix.
+    pub fn qwen36_moe_hip_mtp_pre_fusion_launch(
+        dtype: c_int,
+        device_ordinal: usize,
+        hidden: c_int,
+        rms_norm_eps: f32,
+        e_in: *const c_void,
+        h_base: *const c_void,
+        pre_fc_norm_embedding_w: *const c_void,
+        pre_fc_norm_hidden_w: *const c_void,
+        fc_w: *const c_void,
+        e_norm_out: *mut c_void,
+        h_norm_out: *mut c_void,
+        fused_out: *mut c_void,
+    ) -> c_int;
 }
 
 /// Safe wrapper over the stub launch. The engine pre-allocates `sync_buf`
@@ -1316,6 +1337,104 @@ pub fn lm_head_launch(
         return Err(GpuError::backend(
             backend,
             format!("qwen36_moe lm_head_launch failed with status {status}"),
+        ));
+    }
+    Ok(())
+}
+
+/// Safe wrapper for the GPU MTP pre-fusion kernel (Phase 6.2c.1).
+///
+/// Computes the byte-for-byte equivalent of vLLM's
+/// `Qwen3NextMultiTokenPredictor` pre-fusion stage:
+///
+/// ```text
+/// e_norm = rmsnorm(e_in,   pre_fc_norm_embedding_w, eps)   # [hidden]
+/// h_norm = rmsnorm(h_base, pre_fc_norm_hidden_w,    eps)   # [hidden]
+/// fused  = mtp.fc @ cat([e_norm, h_norm], dim=-1)          # [hidden]
+/// ```
+///
+/// All buffers are BF16 and must live on `ordinal`. The caller pre-extracts
+/// the embedding row (`embed_tokens.weight[next_token_id, :]`) on the host
+/// before calling — the kernel doesn't do the gather. `e_norm_out` and
+/// `h_norm_out` are produced too (cheap, useful for downstream stages and
+/// for parity testing); pass scratch buffers if you don't need them
+/// kept around.
+///
+/// Shapes:
+///   - `e_in`, `h_base`, `pre_fc_norm_embedding_w`, `pre_fc_norm_hidden_w`,
+///     `e_norm_out`, `h_norm_out`, `fused_out`: `[hidden]`
+///   - `fc_w`: `[hidden, 2 * hidden]` (HF row-major; first half coefficients
+///     `e_norm`, second half coefficients `h_norm`).
+#[allow(clippy::too_many_arguments)]
+pub fn mtp_pre_fusion_launch(
+    ordinal: usize,
+    hidden: i32,
+    rms_norm_eps: f32,
+    e_in_buf: &GpuBuffer,
+    h_base_buf: &GpuBuffer,
+    pre_fc_norm_embedding_w_buf: &GpuBuffer,
+    pre_fc_norm_hidden_w_buf: &GpuBuffer,
+    fc_w_buf: &GpuBuffer,
+    e_norm_out_buf: &mut GpuBuffer,
+    h_norm_out_buf: &mut GpuBuffer,
+    fused_out_buf: &mut GpuBuffer,
+) -> Result<(), GpuError> {
+    if hidden <= 0 {
+        return Err(GpuError::InvalidArg(format!(
+            "qwen36_moe::mtp_pre_fusion_launch: positive hidden required, got {hidden}"
+        )));
+    }
+    let block_size: i32 = 256;
+    if hidden % block_size != 0 {
+        return Err(GpuError::InvalidArg(format!(
+            "qwen36_moe::mtp_pre_fusion_launch: hidden ({hidden}) must be a \
+             multiple of block_size ({block_size}) — the per-block reduction \
+             across hidden assumes that"
+        )));
+    }
+
+    let backend = fc_w_buf.backend();
+    let status: c_int = match backend {
+        Backend::Hip => {
+            #[cfg(supersonic_backend_hip)]
+            unsafe {
+                qwen36_moe_hip_mtp_pre_fusion_launch(
+                    /* dtype = bf16 */ 2,
+                    ordinal,
+                    hidden as c_int,
+                    rms_norm_eps,
+                    e_in_buf.as_ptr(),
+                    h_base_buf.as_ptr(),
+                    pre_fc_norm_embedding_w_buf.as_ptr(),
+                    pre_fc_norm_hidden_w_buf.as_ptr(),
+                    fc_w_buf.as_ptr(),
+                    e_norm_out_buf.as_mut_ptr(),
+                    h_norm_out_buf.as_mut_ptr(),
+                    fused_out_buf.as_mut_ptr(),
+                )
+            }
+            #[cfg(not(supersonic_backend_hip))]
+            {
+                return Err(GpuError::InvalidArg(
+                    "qwen36_moe::mtp_pre_fusion_launch: HIP backend not compiled".into(),
+                ));
+            }
+        }
+        Backend::Cuda => {
+            return Err(GpuError::InvalidArg(
+                "qwen36_moe::mtp_pre_fusion_launch: CUDA backend not yet wired".into(),
+            ));
+        }
+        Backend::Metal => {
+            return Err(GpuError::InvalidArg(
+                "qwen36_moe::mtp_pre_fusion_launch: Metal backend not yet wired".into(),
+            ));
+        }
+    };
+    if status != 0 {
+        return Err(GpuError::backend(
+            backend,
+            format!("qwen36_moe mtp_pre_fusion_launch failed with status {status}"),
         ));
     }
     Ok(())
@@ -5407,5 +5526,186 @@ mod tests {
                  in case it's a real ordering bug"
             );
         }
+    }
+
+    // ---- Phase 6.2c.1: MTP pre-fusion parity vs the Python oracle ---------
+    //
+    // Validates that `mtp_pre_fusion_launch` reproduces the
+    // `Qwen3NextMultiTokenPredictor` pre-fusion stage byte-for-byte through
+    // the BF16 rounding boundary. Reads the `qwen36-moe-mtp-oracle-v1`
+    // fixture produced by `oracle/qwen36_moe_mtp_oracle.py`, feeds the
+    // step-0 inputs (h_base, embed_tokens row, mtp.fc, two RMSNorm gains)
+    // into the kernel, and compares the three outputs (e_norm, h_norm,
+    // fused) against the oracle's intermediates.
+    //
+    // To run:
+    //   .venv-bake/bin/python oracle/qwen36_moe_mtp_oracle.py \
+    //     --model-dir /path/to/Qwen3.6-35B-A3B \
+    //     --num-speculative-tokens 1 --seed 42 \
+    //     --out /tmp/qwen36_mtp.json
+    //   SUPERSONIC_QWEN36_MTP_ORACLE_JSON=/tmp/qwen36_mtp.json \
+    //     cargo test --release -p kernel-ffi qwen36_moe_mtp_pre_fusion
+    //
+    // Without the env var the test prints a clear skip message and exits.
+    #[cfg(supersonic_backend_hip)]
+    #[test]
+    fn qwen36_moe_mtp_pre_fusion_matches_oracle() {
+        use gpu_hal::{copy_d2h, set_backend, Backend, GpuBuffer, ScalarType};
+
+        let Ok(json_path) = std::env::var("SUPERSONIC_QWEN36_MTP_ORACLE_JSON") else {
+            eprintln!(
+                "skip: SUPERSONIC_QWEN36_MTP_ORACLE_JSON not set. Generate \
+                 a fixture with `python oracle/qwen36_moe_mtp_oracle.py \
+                 --model-dir <Qwen3.6-35B-A3B> --num-speculative-tokens 1 \
+                 --out /tmp/qwen36_mtp.json` and re-run."
+            );
+            return;
+        };
+        let raw = std::fs::read_to_string(&json_path)
+            .unwrap_or_else(|e| panic!("read mtp oracle json {json_path}: {e}"));
+        let json: serde_json::Value =
+            serde_json::from_str(&raw).expect("mtp oracle json parse");
+
+        assert_eq!(
+            json["schema"].as_str().unwrap_or(""), "qwen36-moe-mtp-oracle-v1",
+            "MTP parity test expects schema qwen36-moe-mtp-oracle-v1; \
+             regenerate the fixture if the oracle has bumped its schema."
+        );
+
+        let cfg = &json["config"];
+        let hidden = cfg["hidden"].as_i64().expect("config.hidden") as i32;
+        let rms_norm_eps =
+            cfg["rms_norm_eps"].as_f64().expect("config.rms_norm_eps") as f32;
+
+        let prefusion = &json["prefusion_weights"];
+        assert!(
+            prefusion.is_object(),
+            "oracle JSON missing `prefusion_weights` block — regenerate with \
+             the Phase 6.2c.1 oracle (it adds fc_w + RMSNorm gains)"
+        );
+        let fc_w_bytes = b64_decode(
+            prefusion["fc_w_bf16"].as_str().expect("prefusion_weights.fc_w_bf16"),
+        );
+        let pre_fc_norm_embedding_w_bytes = b64_decode(
+            prefusion["pre_fc_norm_embedding_w_bf16"]
+                .as_str().expect("prefusion_weights.pre_fc_norm_embedding_w_bf16"),
+        );
+        let pre_fc_norm_hidden_w_bytes = b64_decode(
+            prefusion["pre_fc_norm_hidden_w_bf16"]
+                .as_str().expect("prefusion_weights.pre_fc_norm_hidden_w_bf16"),
+        );
+
+        let h_base_bytes = b64_decode(
+            json["h_base_step0_bf16"].as_str().expect("h_base_step0_bf16"),
+        );
+
+        let step0 = &json["steps"][0];
+        let e_in_bytes = b64_decode(
+            step0["input_token_embed_bf16"]
+                .as_str().expect("steps[0].input_token_embed_bf16"),
+        );
+        let want_e_norm_bytes = b64_decode(
+            step0["e_norm_bf16"].as_str().expect("steps[0].e_norm_bf16"),
+        );
+        let want_h_norm_bytes = b64_decode(
+            step0["h_norm_bf16"].as_str().expect("steps[0].h_norm_bf16"),
+        );
+        let want_fused_bytes = b64_decode(
+            step0["fused_bf16"].as_str().expect("steps[0].fused_bf16"),
+        );
+
+        let hidden_usz = hidden as usize;
+        assert_eq!(e_in_bytes.len(), hidden_usz * 2, "e_in shape");
+        assert_eq!(h_base_bytes.len(), hidden_usz * 2, "h_base shape");
+        assert_eq!(
+            pre_fc_norm_embedding_w_bytes.len(), hidden_usz * 2,
+            "pre_fc_norm_embedding_w shape"
+        );
+        assert_eq!(
+            pre_fc_norm_hidden_w_bytes.len(), hidden_usz * 2,
+            "pre_fc_norm_hidden_w shape"
+        );
+        assert_eq!(
+            fc_w_bytes.len(), hidden_usz * 2 * hidden_usz * 2,
+            "fc_w shape: expected [hidden, 2*hidden] BF16"
+        );
+
+        set_backend(Backend::Hip);
+        let ordinal = 0usize;
+
+        let e_in_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_usz], &e_in_bytes,
+        ).expect("upload e_in");
+        let h_base_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_usz], &h_base_bytes,
+        ).expect("upload h_base");
+        let pre_fc_norm_embedding_w_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_usz], &pre_fc_norm_embedding_w_bytes,
+        ).expect("upload pre_fc_norm_embedding_w");
+        let pre_fc_norm_hidden_w_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16, &[hidden_usz], &pre_fc_norm_hidden_w_bytes,
+        ).expect("upload pre_fc_norm_hidden_w");
+        let fc_w_buf = GpuBuffer::from_host_bytes(
+            ordinal, ScalarType::BF16,
+            &[hidden_usz, 2 * hidden_usz], &fc_w_bytes,
+        ).expect("upload fc_w");
+        let mut e_norm_out_buf = GpuBuffer::zeros(
+            ordinal, ScalarType::BF16, &[hidden_usz],
+        ).expect("alloc e_norm_out");
+        let mut h_norm_out_buf = GpuBuffer::zeros(
+            ordinal, ScalarType::BF16, &[hidden_usz],
+        ).expect("alloc h_norm_out");
+        let mut fused_out_buf = GpuBuffer::zeros(
+            ordinal, ScalarType::BF16, &[hidden_usz],
+        ).expect("alloc fused_out");
+
+        super::mtp_pre_fusion_launch(
+            ordinal, hidden, rms_norm_eps,
+            &e_in_buf, &h_base_buf,
+            &pre_fc_norm_embedding_w_buf, &pre_fc_norm_hidden_w_buf,
+            &fc_w_buf,
+            &mut e_norm_out_buf, &mut h_norm_out_buf, &mut fused_out_buf,
+        ).expect("mtp_pre_fusion launch");
+
+        let mut got_e_norm = vec![0u8; hidden_usz * 2];
+        let mut got_h_norm = vec![0u8; hidden_usz * 2];
+        let mut got_fused = vec![0u8; hidden_usz * 2];
+        copy_d2h(
+            ordinal, got_e_norm.as_mut_ptr() as *mut _,
+            e_norm_out_buf.as_ptr(), got_e_norm.len(),
+        ).expect("d2h e_norm");
+        copy_d2h(
+            ordinal, got_h_norm.as_mut_ptr() as *mut _,
+            h_norm_out_buf.as_ptr(), got_h_norm.len(),
+        ).expect("d2h h_norm");
+        copy_d2h(
+            ordinal, got_fused.as_mut_ptr() as *mut _,
+            fused_out_buf.as_ptr(), got_fused.len(),
+        ).expect("d2h fused");
+
+        // The two RMSNorm outputs go through one BF16 round each — single
+        // `(x * inv_rms * (1+w))` pass — so they should be effectively
+        // bit-exact against PyTorch (modulo the F32 reduction tree, which
+        // the kernel matches via the same single-block sum). max_abs ≤ 1
+        // ULP-of-BF16 at any reasonable magnitude is comfortable.
+        assert_parity(
+            "mtp.e_norm",
+            &got_e_norm, &want_e_norm_bytes,
+            /* max_abs */ 1e-2, /* cos_sim_floor */ 0.99999,
+        );
+        assert_parity(
+            "mtp.h_norm",
+            &got_h_norm, &want_h_norm_bytes,
+            1e-2, 0.99999,
+        );
+        // fused is a `[hidden, 2*hidden]` matvec; F32 accumulation order on
+        // the GPU differs from PyTorch's per-row reduction tree. cos_sim
+        // ≥ 0.999 is the bar the other Qwen3.6-MoE matvec parity tests use
+        // (FFN, lm_head), and it's well within the BF16 rounding floor.
+        assert_parity(
+            "mtp.fused",
+            &got_fused, &want_fused_bytes,
+            /* max_abs */ 5e-2, /* cos_sim_floor */ 0.999,
+        );
     }
 }

--- a/kernels/qwen36_moe.hip
+++ b/kernels/qwen36_moe.hip
@@ -3707,4 +3707,142 @@ void qwen36_moe_lm_head_wmma_kernel(
 #endif
 }
 
+// =============================================================================
+// Qwen3.6-MoE multi-token-prediction (MTP) pre-fusion kernel — Phase 6.2c.1.
+//
+// Reproduces the vLLM `Qwen3NextMultiTokenPredictor.forward` "pre-fusion"
+// stage byte-for-byte through the BF16 rounding boundary. This is the part
+// of the MTP draft step that runs BEFORE the (single-layer) MoE block:
+//
+//   e_norm = rmsnorm(embed_tokens[next_token_id], pre_fc_norm_embedding, eps)
+//   h_norm = rmsnorm(h_base, pre_fc_norm_hidden, eps)
+//   fused  = mtp.fc @ cat([e_norm, h_norm], dim=-1)            # cat: e first
+//
+// Numerics match `oracle/qwen36_moe_mtp_oracle.py`: RMSNorm reduction in F32,
+// `(1 + gain)` HF Qwen3_5MoeRMSNorm unit offset, BF16-round at every store.
+// `mtp.fc.weight` is `[hidden, 2*hidden]` in HF row-major; first half of each
+// row coefficients e_norm, second half h_norm (vLLM cat order).
+//
+// Inputs (all BF16, `ordinal`-resident):
+//   e_in                     [hidden]            — host-extracted embedding row
+//   h_base                   [hidden]            — base model's last hidden state
+//   pre_fc_norm_embedding_w  [hidden]
+//   pre_fc_norm_hidden_w     [hidden]
+//   fc_w                     [hidden, 2*hidden]
+//
+// Outputs (all BF16, written by the kernel):
+//   e_norm_out               [hidden]
+//   h_norm_out               [hidden]
+//   fused_out                [hidden]
+//
+// Block strategy: single block, block_size=256. Memory budget at hidden=2048:
+//   shared_scratch [block_size]  F32 → 1 KiB
+//   e_norm_lds     [hidden]      F32 → 8 KiB (BF16-rounded post-RMSNorm)
+//   h_norm_lds     [hidden]      F32 → 8 KiB (BF16-rounded post-RMSNorm)
+// Total: 17 KiB / 64 KiB CU cap. Comfortably under.
+//
+// Phase G (the matmul) is the cost driver: hidden output rows × 2*hidden
+// reduction = ~8.4M FMAs. Striped across 256 threads → ~32K FMAs/thread.
+// At hidden=2048 the kernel completes in ~30-50 µs; the speculative loop
+// runs it once per draft step, so absolute cost is small. Multi-block
+// work-stealing on the matmul phase is a future optimization (would need
+// grid_barrier between Phases F and G).
+//
+// Used by `mtp_pre_fusion_launch` in `crates/kernel-ffi/src/qwen36_moe.rs`.
+// =============================================================================
+template <typename T>
+__global__ void qwen36_moe_mtp_pre_fusion_kernel(
+    int                    hidden,
+    float                  rms_norm_eps,
+    const T*  __restrict__ e_in,                      // [hidden]
+    const T*  __restrict__ h_base,                    // [hidden]
+    const T*  __restrict__ pre_fc_norm_embedding_w,   // [hidden]
+    const T*  __restrict__ pre_fc_norm_hidden_w,      // [hidden]
+    const T*  __restrict__ fc_w,                      // [hidden, 2*hidden]
+    T*        __restrict__ e_norm_out,                // [hidden]
+    T*        __restrict__ h_norm_out,                // [hidden]
+    T*        __restrict__ fused_out                  // [hidden]
+) {
+    const int tid        = threadIdx.x;
+    const int block_size = blockDim.x;
+
+    extern __shared__ unsigned char lds_raw[];
+    float* shared_scratch = reinterpret_cast<float*>(lds_raw);
+    float* e_norm_lds     = shared_scratch + block_size;
+    float* h_norm_lds     = e_norm_lds + hidden;
+
+    // -- Phase A: load e_in, accumulate partial squared sum ----------------
+    float partial_sq = 0.0f;
+    for (int col = tid; col < hidden; col += block_size) {
+        const float v = load_as_float<T>(e_in, col);
+        e_norm_lds[col] = v;
+        partial_sq += v * v;
+    }
+    shared_scratch[tid] = partial_sq;
+    __syncthreads();
+    for (int s = block_size / 2; s > 0; s >>= 1) {
+        if (tid < s) shared_scratch[tid] += shared_scratch[tid + s];
+        __syncthreads();
+    }
+    __shared__ float e_inv_rms;
+    if (tid == 0) {
+        e_inv_rms =
+            rsqrtf(shared_scratch[0] / static_cast<float>(hidden) + rms_norm_eps);
+    }
+    __syncthreads();
+
+    // -- Phase B: apply `(1 + w)` RMSNorm to e, BF16-round, store ---------
+    for (int col = tid; col < hidden; col += block_size) {
+        const float w = load_as_float<T>(pre_fc_norm_embedding_w, col);
+        const float val = bf16_round_rne_f32(e_norm_lds[col] * e_inv_rms * (1.0f + w));
+        e_norm_lds[col] = val;
+        e_norm_out[col] = static_cast<T>(val);
+    }
+    __syncthreads();
+
+    // -- Phase C: load h_base, accumulate partial squared sum --------------
+    partial_sq = 0.0f;
+    for (int col = tid; col < hidden; col += block_size) {
+        const float v = load_as_float<T>(h_base, col);
+        h_norm_lds[col] = v;
+        partial_sq += v * v;
+    }
+    shared_scratch[tid] = partial_sq;
+    __syncthreads();
+    for (int s = block_size / 2; s > 0; s >>= 1) {
+        if (tid < s) shared_scratch[tid] += shared_scratch[tid + s];
+        __syncthreads();
+    }
+    __shared__ float h_inv_rms;
+    if (tid == 0) {
+        h_inv_rms =
+            rsqrtf(shared_scratch[0] / static_cast<float>(hidden) + rms_norm_eps);
+    }
+    __syncthreads();
+
+    // -- Phase D: apply `(1 + w)` RMSNorm to h, BF16-round, store ---------
+    for (int col = tid; col < hidden; col += block_size) {
+        const float w = load_as_float<T>(pre_fc_norm_hidden_w, col);
+        const float val = bf16_round_rne_f32(h_norm_lds[col] * h_inv_rms * (1.0f + w));
+        h_norm_lds[col] = val;
+        h_norm_out[col] = static_cast<T>(val);
+    }
+    __syncthreads();
+
+    // -- Phase E: matmul fc_w @ cat([e_norm, h_norm]) → fused -------------
+    // fc_w[row, k]    for k in [0, hidden)        → e_norm[k] coefficients
+    // fc_w[row, k]    for k in [hidden, 2*hidden) → h_norm[k - hidden] coefficients
+    for (int row = tid; row < hidden; row += block_size) {
+        const T* w_row = fc_w + static_cast<size_t>(row) * 2 * hidden;
+        float acc = 0.0f;
+        for (int k = 0; k < hidden; ++k) {
+            acc += load_as_float<T>(w_row, k) * e_norm_lds[k];
+        }
+        for (int k = 0; k < hidden; ++k) {
+            acc += load_as_float<T>(w_row, hidden + k) * h_norm_lds[k];
+        }
+        fused_out[row] = static_cast<T>(bf16_round_rne_f32(acc));
+    }
+}
+
 } // namespace qwen36_moe

--- a/kernels/qwen36_moe_bridge.cpp
+++ b/kernels/qwen36_moe_bridge.cpp
@@ -852,3 +852,68 @@ extern "C" int qwen36_moe_hip_lm_head_launch(
     if (sync_err != hipSuccess) return 255;
     return 0;
 }
+
+// MTP pre-fusion launcher (Phase 6.2c.1).
+//
+// Single-block kernel: 256 threads, ~17 KiB LDS at hidden=2048. Computes
+//   e_norm = rmsnorm(e_in,   pre_fc_norm_embedding_w, eps)
+//   h_norm = rmsnorm(h_base, pre_fc_norm_hidden_w,    eps)
+//   fused  = mtp.fc @ cat([e_norm, h_norm], dim=-1)
+// All BF16-rounded to match the Phase 6.2a Python oracle byte-for-byte
+// through the rounding boundary. Status codes match the lm_head launcher.
+extern "C" int qwen36_moe_hip_mtp_pre_fusion_launch(
+    int           dtype,
+    size_t        device_ordinal,
+    int           hidden,
+    float         rms_norm_eps,
+    const void*   e_in,
+    const void*   h_base,
+    const void*   pre_fc_norm_embedding_w,
+    const void*   pre_fc_norm_hidden_w,
+    const void*   fc_w,
+    void*         e_norm_out,
+    void*         h_norm_out,
+    void*         fused_out) {
+    if (dtype != 2) return 130;            // only bf16 supported
+    if (hidden <= 0) return 132;
+    if (e_in == nullptr || h_base == nullptr ||
+        pre_fc_norm_embedding_w == nullptr || pre_fc_norm_hidden_w == nullptr ||
+        fc_w == nullptr ||
+        e_norm_out == nullptr || h_norm_out == nullptr || fused_out == nullptr) {
+        return 133;
+    }
+
+    ScopedHipDevice scoped(static_cast<int>(device_ordinal));
+
+    constexpr int block_size = 256;
+    if (hidden % block_size != 0) {
+        // The block-reduction loop assumes hidden % block_size == 0 (no
+        // tail elements after the strided pass). 35B-A3B has hidden=2048
+        // which divides cleanly; reject anything else loudly.
+        return 134;
+    }
+
+    // shared_scratch [block_size] + e_norm_lds [hidden] + h_norm_lds [hidden],
+    // all F32. = (256 + 2*2048) * 4 = 17,408 bytes at hidden=2048.
+    const size_t lds_bytes =
+        static_cast<size_t>(block_size + 2 * hidden) * sizeof(float);
+
+    hipLaunchKernelGGL(
+        qwen36_moe::qwen36_moe_mtp_pre_fusion_kernel<hip_bfloat16>,
+        dim3(1), dim3(block_size), lds_bytes, 0,
+        hidden, rms_norm_eps,
+        static_cast<const hip_bfloat16*>(e_in),
+        static_cast<const hip_bfloat16*>(h_base),
+        static_cast<const hip_bfloat16*>(pre_fc_norm_embedding_w),
+        static_cast<const hip_bfloat16*>(pre_fc_norm_hidden_w),
+        static_cast<const hip_bfloat16*>(fc_w),
+        static_cast<hip_bfloat16*>(e_norm_out),
+        static_cast<hip_bfloat16*>(h_norm_out),
+        static_cast<hip_bfloat16*>(fused_out));
+
+    hipError_t launch_err = hipGetLastError();
+    hipError_t sync_err   = hipDeviceSynchronize();
+    if (launch_err != hipSuccess) return 254;
+    if (sync_err != hipSuccess) return 255;
+    return 0;
+}

--- a/oracle/qwen36_moe_mtp_oracle.py
+++ b/oracle/qwen36_moe_mtp_oracle.py
@@ -343,11 +343,17 @@ def main():
             past_kv=mtp_kv,
             device=args.device,
         )
+        # Per-step embed row for the input token. Lets the SuperSonic-side
+        # parity test feed the same `e_in` the oracle saw (avoids re-loading
+        # 970 MiB of `embed_tokens.weight` on the Rust side just to gather
+        # one row).
+        input_embed_row = embed_w[next_tok : next_tok + 1].squeeze(0).to(torch.bfloat16)
         steps.append(dict(
             step=k,
             position=base_seq_len + k,
             input_token_id=next_tok,
             draft_token_id=out["next_tok"],
+            input_token_embed_bf16=b64_bf16(input_embed_row),
             e_norm_bf16=b64_bf16(out["e_norm"].squeeze(0)),
             h_norm_bf16=b64_bf16(out["h_norm"].squeeze(0)),
             fused_bf16=b64_bf16(out["fused"].squeeze(0)),
@@ -373,6 +379,16 @@ def main():
         rng2.standard_normal((1, hidden)).astype(np.float32) * 0.5
     ).to(torch.bfloat16).squeeze(0)  # [hidden]
 
+    # Pre-fusion weights — the SuperSonic kernel under test (Phase 6.2c.1)
+    # reads exactly these three tensors, so dumping them into the JSON keeps
+    # the parity test self-contained (no need to re-open safetensors on the
+    # Rust side just to load 16 MiB of fc_w + 8 KiB of norm gains).
+    prefusion_weights = dict(
+        fc_w_bf16=b64_bf16(fc_w),                       # [hidden, 2*hidden]
+        pre_fc_norm_embedding_w_bf16=b64_bf16(pre_fc_e),  # [hidden]
+        pre_fc_norm_hidden_w_bf16=b64_bf16(pre_fc_h),     # [hidden]
+    )
+
     fixture = dict(
         schema="qwen36-moe-mtp-oracle-v1",
         mode="synthetic",
@@ -394,6 +410,7 @@ def main():
         base_seq_len=base_seq_len,
         base_next_token_id=base_next_tok,
         h_base_step0_bf16=b64_bf16(h_base_step0),
+        prefusion_weights=prefusion_weights,
         draft_token_ids=[s["draft_token_id"] for s in steps],
         steps=steps,
     )


### PR DESCRIPTION
## Summary
- First SuperSonic-side piece of the Qwen3.6-MoE multi-token-prediction (MTP) draft path. Phase 6.2c.1 in the master plan.
- New HIP kernel `qwen36_moe_mtp_pre_fusion_kernel<T>` reproduces vLLM's `Qwen3NextMultiTokenPredictor` pre-fusion stage:

  ```
  e_norm = rmsnorm(e_in,   pre_fc_norm_embedding_w, eps)
  h_norm = rmsnorm(h_base, pre_fc_norm_hidden_w,    eps)
  fused  = mtp.fc @ cat([e_norm, h_norm], dim=-1)
  ```

  Numerics match the Phase 6.2a Python oracle (`oracle/qwen36_moe_mtp_oracle.py`) byte-for-byte through the BF16 rounding boundary — observed bit-exact (n=2048 / exact=2048 / cos_sim=1.0000000) on the local fixture for all three intermediates.

## Plumbing
- `kernels/qwen36_moe.hip` — new templated kernel. Single-block, 256 threads, ~17 KiB LDS at `hidden=2048` (`shared_scratch [256] + e_norm_lds [hidden] + h_norm_lds [hidden]`, all F32). RMSNorm phases use the same per-block reduction the existing `lm_head_kernel` uses; matmul phase strips `hidden` output rows across threads.
- `kernels/qwen36_moe_bridge.cpp` — `qwen36_moe_hip_mtp_pre_fusion_launch`. Same status code matrix as the lm_head launcher (130/132/133/134/254/255).
- `crates/kernel-ffi/src/qwen36_moe.rs` — FFI extern + safe `mtp_pre_fusion_launch` wrapper + parity test `qwen36_moe_mtp_pre_fusion_matches_oracle`.
- `oracle/qwen36_moe_mtp_oracle.py` — emits new `prefusion_weights` block (fc_w + two RMSNorm gains, ~16 MiB BF16) and per-step `input_token_embed_bf16` so the parity test is self-contained from one JSON. Schema string `qwen36-moe-mtp-oracle-v1` is preserved (additive fields only).

The kernel is wired end-to-end through the FFI but **nothing in the runner calls it yet**. Phase 6.2c.2 (MTP layer forward, reuses `attn_step_launch` + `ffn_step_launch`) and 6.2c.3 (post-norm + lm_head) will wire the full draft step.

## Performance
Single block at `hidden=2048` is the smallest viable layout. Matmul phase is the cost driver: ~8.4M FMAs across 256 threads → ~32K FMAs/thread, ~30–50 µs end-to-end. The speculative loop runs it once per draft step; absolute cost is small. Multi-block work-stealing on the matmul is a future optimization (would need a grid_barrier between Phases F and G).

## Test plan
- [x] Skip path: `cargo test --release -p kernel-ffi qwen36_moe_mtp_pre_fusion` without the env var prints a clear skip and exits 0.
- [x] Parity path: `SUPERSONIC_QWEN36_MTP_ORACLE_JSON=/tmp/qwen36_mtp.json cargo test ...` runs and passes with bit-exact match across `e_norm`, `h_norm`, `fused`.
- [x] Pre-existing kernel-ffi qwen36 tests still pass (lm_head, descriptor smoke, INT4 dequant, stub launch).
- [x] `cargo build --release --bin supersonic` clean. Pre-existing `server` crate non-exhaustive-match error is unrelated to this PR (verified by stashing the diff).

To regenerate the fixture (synthetic mode, fits on the local 24 GiB box, ~3.5 GiB host):
```bash
.venv-bake/bin/python oracle/qwen36_moe_mtp_oracle.py \
  --model-dir /path/to/Qwen3.6-35B-A3B \
  --num-speculative-tokens 1 --seed 42 \
  --out /tmp/qwen36_mtp.json
SUPERSONIC_QWEN36_MTP_ORACLE_JSON=/tmp/qwen36_mtp.json \
  cargo test --release -p kernel-ffi qwen36_moe_mtp_pre_fusion -- --nocapture
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)