### PR TITLE
qwen36-moe: MTP layer forward (Phase 6.2c.2)

### DIFF
--- a/crates/kernel-ffi/src/qwen36_moe.rs
+++ b/crates/kernel-ffi/src/qwen36_moe.rs
@@ -261,6 +261,7 @@ extern "C" {
         rope_theta: f32,
         rms_norm_eps: f32,
         position: c_int,
+        cache_pos: c_int,
         input_hidden: *const c_void,
         input_norm_w: *const c_void,
         q_proj_w: *const c_void,
@@ -586,6 +587,22 @@ pub struct Qwen36MoeAttnStepParams {
     pub rope_theta: f32,
     pub rms_norm_eps: f32,
     pub position: i32,
+    /// Optional override for the KV cache slot index. `< 0` (the default
+    /// constructor sets `-1`) ⇒ inherit from `position` — the base-model
+    /// decode case where RoPE position == cache slot. Set to ≥ 0 to
+    /// decouple the two: used by the Qwen3.6-MoE self-speculative MTP
+    /// layer, where RoPE rotates at absolute position `base_seq_len + k`
+    /// but the per-MTP-session cache is fresh per draft session and
+    /// writes step `k` at slot `k`. Phase G writes at `cache_pos` and
+    /// attends over `kv_len = cache_pos + 1`; RoPE still uses `position`.
+    pub cache_pos: i32,
+}
+
+impl Qwen36MoeAttnStepParams {
+    /// Sentinel value for `cache_pos` meaning "inherit from `position`".
+    /// Use this in places that don't yet need MTP semantics so the call
+    /// site reads as "default". Equivalent to `-1`.
+    pub const CACHE_POS_INHERIT: i32 = -1;
 }
 
 /// Weight pointers for the staged-attention parity launcher. Pointers
@@ -727,6 +744,7 @@ pub fn attn_step_launch(
                     params.rope_theta,
                     params.rms_norm_eps,
                     params.position as c_int,
+                    params.cache_pos as c_int,
                     weights.input_hidden,
                     weights.input_norm_w,
                     weights.q_proj_w,
@@ -1885,6 +1903,7 @@ mod tests {
             rope_theta: 0.0,
             rms_norm_eps: geom.rms_norm_eps,
             position: 0,
+            cache_pos: Qwen36MoeAttnStepParams::CACHE_POS_INHERIT,
         };
         let weight_ptrs = Qwen36MoeAttnStepWeights {
             input_hidden: input_hidden.as_ptr(),
@@ -2006,6 +2025,7 @@ mod tests {
             rope_theta: 0.0,
             rms_norm_eps: geom.rms_norm_eps,
             position: 0,
+            cache_pos: Qwen36MoeAttnStepParams::CACHE_POS_INHERIT,
         };
         let weight_ptrs = Qwen36MoeAttnStepWeights {
             input_hidden: input_hidden.as_ptr(),
@@ -2136,6 +2156,7 @@ mod tests {
             rope_theta,
             rms_norm_eps: geom.rms_norm_eps,
             position,
+            cache_pos: Qwen36MoeAttnStepParams::CACHE_POS_INHERIT,
         };
         let weight_ptrs = Qwen36MoeAttnStepWeights {
             input_hidden: input_hidden.as_ptr(),
@@ -2257,6 +2278,7 @@ mod tests {
             rope_theta,
             rms_norm_eps: geom.rms_norm_eps,
             position,
+            cache_pos: Qwen36MoeAttnStepParams::CACHE_POS_INHERIT,
         };
         let weight_ptrs = Qwen36MoeAttnStepWeights {
             input_hidden: input_hidden.as_ptr(),
@@ -2381,6 +2403,7 @@ mod tests {
             rope_theta,
             rms_norm_eps: geom.rms_norm_eps,
             position,
+            cache_pos: Qwen36MoeAttnStepParams::CACHE_POS_INHERIT,
         };
         let weight_ptrs = Qwen36MoeAttnStepWeights {
             input_hidden: input_hidden.as_ptr(),
@@ -2597,6 +2620,7 @@ mod tests {
             rope_theta,
             rms_norm_eps: geom.rms_norm_eps,
             position,
+            cache_pos: Qwen36MoeAttnStepParams::CACHE_POS_INHERIT,
         };
         // Projection weight pointers point at the packed u8 buffers.
         let weight_ptrs = Qwen36MoeAttnStepWeights {

--- a/crates/runner/src/lib.rs
+++ b/crates/runner/src/lib.rs
@@ -17,5 +17,6 @@ pub mod gemma4_int4_engine;
 pub mod oracle;
 pub mod prefill_engine;
 pub mod qwen36_moe_decode;
+pub mod qwen36_moe_mtp;
 pub mod registry;
 pub mod validate;

--- a/crates/runner/src/qwen36_moe_decode.rs
+++ b/crates/runner/src/qwen36_moe_decode.rs
@@ -270,7 +270,7 @@ pub struct DecodeOutputs {
 /// Workspace floats sufficient for the full-attn parity launcher's stage 5
 /// (the largest stage). Mirrors `parity_workspace_floats` in the per-block
 /// test file: 6*H*d + 4*Hkv*d + hidden.
-fn full_attn_workspace_floats(geom: &MultiLayerGeom) -> usize {
+pub(crate) fn full_attn_workspace_floats(geom: &MultiLayerGeom) -> usize {
     let h = geom.num_attention_heads as usize;
     let hkv = geom.num_kv_heads as usize;
     let d = geom.head_dim as usize;
@@ -279,7 +279,7 @@ fn full_attn_workspace_floats(geom: &MultiLayerGeom) -> usize {
 
 /// BF16 elements sufficient for the full-attn parity launcher's largest
 /// stage (stage 3 publishes q_rot || k_rot, the widest output).
-fn full_attn_output_elems(geom: &MultiLayerGeom) -> usize {
+pub(crate) fn full_attn_output_elems(geom: &MultiLayerGeom) -> usize {
     let h = geom.num_attention_heads as usize;
     let hkv = geom.num_kv_heads as usize;
     let d = geom.head_dim as usize;
@@ -320,7 +320,7 @@ fn linear_attn_output_elems(geom: &MultiLayerGeom) -> usize {
 /// The per-expert scratch slabs (`EXPERT_GU`, `EXPERT_MID`) are sized
 /// `k * 2*I` and `k * I` respectively so all `top_k` experts can run
 /// G/H/I concurrently (one block-group per expert).
-fn ffn_workspace_floats(geom: &MultiLayerGeom) -> usize {
+pub(crate) fn ffn_workspace_floats(geom: &MultiLayerGeom) -> usize {
     let hidden = geom.hidden as usize;
     let e = geom.num_experts as usize;
     let k = geom.top_k as usize;
@@ -331,7 +331,7 @@ fn ffn_workspace_floats(geom: &MultiLayerGeom) -> usize {
 
 /// FFN output BF16 elements — stage 5 publishes `[hidden]`, which is also
 /// the upper bound (stages 2..=4 fit in a strict subset).
-fn ffn_output_elems(geom: &MultiLayerGeom) -> usize {
+pub(crate) fn ffn_output_elems(geom: &MultiLayerGeom) -> usize {
     geom.hidden as usize
 }
 
@@ -345,7 +345,7 @@ fn ffn_output_elems(geom: &MultiLayerGeom) -> usize {
 ///   barrier_counter      bytes 64..67
 ///   barrier_flag         bytes 68..71
 ///   (padding to 96 bytes for alignment headroom)
-fn reset_sync_buf(ordinal: usize, sync_buf: &mut GpuBuffer) -> Result<(), GpuError> {
+pub(crate) fn reset_sync_buf(ordinal: usize, sync_buf: &mut GpuBuffer) -> Result<(), GpuError> {
     memset_zeros(ordinal, sync_buf.as_mut_ptr(), 96)
 }
 
@@ -632,6 +632,7 @@ pub fn run_chained_decode_with_options(
                     rope_theta: geom.rope_theta,
                     rms_norm_eps: geom.rms_norm_eps,
                     position,
+                    cache_pos: Qwen36MoeAttnStepParams::CACHE_POS_INHERIT,
                 };
                 let (kv_k_ptr, kv_v_ptr, kv_max_t) = match kv_cache {
                     Some(c) => (c.k.as_mut_ptr(), c.v.as_mut_ptr(), c.kv_max_t),

--- a/crates/runner/src/qwen36_moe_mtp.rs
+++ b/crates/runner/src/qwen36_moe_mtp.rs
@@ -1,0 +1,277 @@
+//! Qwen3.6-MoE multi-token-prediction (MTP) forward pass — Phase 6.2c.2.
+//!
+//! Builds on top of the Phase 6.2b weight loader (`MtpLayerBuffers`) and
+//! the Phase 6.2c.1 pre-fusion kernel. Drives one MTP draft step's
+//! single-layer transformer block (full-attention + MoE FFN) by
+//! reusing the existing per-block FFI launchers
+//! [`kernel_ffi::qwen36_moe::attn_step_launch`] and
+//! [`kernel_ffi::qwen36_moe::ffn_step_launch`] — the same kernels the
+//! base-model decode chain calls. The MTP block is structurally one
+//! Qwen3.6 full-attention layer, so the only differences from a base
+//! step are:
+//!
+//!   1. The cache is per-MTP-session (fresh per draft chain).
+//!   2. RoPE rotates at absolute position `base_seq_len + k` while the
+//!      cache slot is just `k` — handled by the `cache_pos` parameter
+//!      added to [`Qwen36MoeAttnStepParams`] in this PR.
+//!
+//! The pre-fusion kernel (Phase 6.2c.1) feeds `fused_in` into this
+//! function; the post-norm + lm_head (Phase 6.2c.3) consumes the output
+//! and produces the next draft token. Nothing in the production decode
+//! path calls this module today — wiring lands in the speculative driver
+//! (Phase 6.3).
+
+use anyhow::{anyhow, Context, Result};
+use gpu_hal::{copy_d2d, GpuBuffer, ScalarType};
+use kernel_ffi::qwen36_moe::{
+    attn_step_launch, ffn_step_launch, Qwen36MoeAttnStepInt4, Qwen36MoeAttnStepParams,
+    Qwen36MoeAttnStepWeights, Qwen36MoeFfnStepInt4, Qwen36MoeFfnStepParams, Qwen36MoeFfnStepWeights,
+};
+use std::ptr;
+
+use crate::qwen36_moe_decode::{
+    ffn_output_elems, ffn_workspace_floats, full_attn_output_elems, full_attn_workspace_floats,
+    reset_sync_buf, MtpLayerBuffers, MultiLayerGeom,
+};
+
+/// Pre-allocated GPU scratch buffers for one MTP forward call. The MTP
+/// session reuses the same scratch across all `K` draft steps — allocate
+/// once at the start of a speculative pass, drop when the pass ends.
+///
+/// All buffers live on `ordinal`; the caller must not mix scratches
+/// across devices.
+pub struct MtpForwardScratch {
+    /// Stage-5 attn output. Sized for the wider of (full, linear) attn
+    /// staged intermediates so the same allocator can serve both base
+    /// and MTP-style chains; the MTP path always uses the full-attn
+    /// half. BF16, `[full_attn_output_elems(geom)]` elements.
+    pub attn_output: GpuBuffer,
+
+    /// F32 scratch consumed by the attn kernel. Sized for the largest
+    /// stage with optional KV-cache score region (`H * kv_max_t`).
+    pub attn_workspace: GpuBuffer,
+
+    /// Mid-layer residual (input to the FFN). The attn kernel publishes
+    /// `input + o_proj(...)` into the leading `hidden` BF16 elements of
+    /// `attn_output`; we D2D-copy that into `attn_residual` before
+    /// calling the FFN, exactly mirroring the base-decode chain's
+    /// hidden_a/hidden_b ping-pong (only here we ping-pong via two
+    /// dedicated buffers since the MTP pass writes its final output
+    /// into the caller's `out`).
+    pub attn_residual: GpuBuffer,
+
+    /// Stage-5 FFN output. BF16, `[ffn_output_elems(geom)]` elements.
+    pub ffn_output: GpuBuffer,
+
+    /// FFN top-k indices buffer. U32, `[top_k]` elements.
+    pub ffn_output_idx: GpuBuffer,
+
+    /// FFN F32 workspace, sized for the per-stage footprint.
+    pub ffn_workspace: GpuBuffer,
+
+    /// 96-byte zeroed scratch for the cooperative-launch counters +
+    /// barrier state. Must be reset between attn and FFN launches.
+    pub sync_buf: GpuBuffer,
+}
+
+/// Allocate a fresh [`MtpForwardScratch`] sized for `geom`. `kv_max_t` is
+/// the MTP cache capacity in tokens (typically `K`, the
+/// `num_speculative_tokens` in the speculative driver). It only affects
+/// the F32 attn workspace size — the cache buffers themselves live
+/// inside `MtpLayerBuffers::kv_cache`, allocated by the Phase 6.2b
+/// loader.
+pub fn alloc_mtp_forward_scratch(
+    ordinal: usize,
+    geom: &MultiLayerGeom,
+    kv_max_t: usize,
+) -> Result<MtpForwardScratch> {
+    let attn_extra = if kv_max_t > 0 {
+        (geom.num_attention_heads as usize) * kv_max_t
+    } else {
+        0
+    };
+    let attn_output = GpuBuffer::zeros(
+        ordinal,
+        ScalarType::BF16,
+        &[full_attn_output_elems(geom)],
+    )
+    .context("alloc mtp attn_output")?;
+    let attn_workspace = GpuBuffer::zeros(
+        ordinal,
+        ScalarType::F32,
+        &[full_attn_workspace_floats(geom) + attn_extra],
+    )
+    .context("alloc mtp attn_workspace")?;
+    let attn_residual = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[geom.hidden as usize])
+        .context("alloc mtp attn_residual")?;
+    let ffn_output = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[ffn_output_elems(geom)])
+        .context("alloc mtp ffn_output")?;
+    let ffn_output_idx = GpuBuffer::zeros(ordinal, ScalarType::U32, &[geom.top_k as usize])
+        .context("alloc mtp ffn_output_idx")?;
+    let ffn_workspace = GpuBuffer::zeros(
+        ordinal,
+        ScalarType::F32,
+        &[ffn_workspace_floats(geom)],
+    )
+    .context("alloc mtp ffn_workspace")?;
+    let sync_buf = GpuBuffer::zeros(ordinal, ScalarType::U8, &[96])
+        .context("alloc mtp sync_buf")?;
+
+    Ok(MtpForwardScratch {
+        attn_output,
+        attn_workspace,
+        attn_residual,
+        ffn_output,
+        ffn_output_idx,
+        ffn_workspace,
+        sync_buf,
+    })
+}
+
+/// Run one MTP-layer forward step.
+///
+/// Computes the byte-equivalent of the vLLM
+/// `Qwen3NextMultiTokenPredictor` post-fusion stage:
+///
+/// ```text
+/// out = mtp.layers.0(fused_in, position=base_seq_len+k, kv=mtp_kv)
+/// ```
+///
+/// Internally:
+///   1. `attn_step_launch` (stage 5, full-attn path) on `fused_in` →
+///      `attn_residual = fused_in + o_proj(...)`. Writes K/V at MTP
+///      cache slot `cache_pos = k`, attends over `kv_len = k + 1`.
+///   2. `ffn_step_launch` (stage 5) on `attn_residual` →
+///      `out = attn_residual + moe_out + shared_out`.
+///
+/// `position` is the absolute RoPE position (`base_seq_len + k`).
+/// `cache_pos` is the MTP cache slot for this draft step (`k` in 0..K).
+/// `out` is filled with the layer's final BF16 hidden state, matching
+/// the oracle's `attn_out` field per draft step.
+#[allow(clippy::too_many_arguments)]
+pub fn run_mtp_layer_step(
+    ordinal: usize,
+    geom: &MultiLayerGeom,
+    mtp: &mut MtpLayerBuffers,
+    position: i32,
+    cache_pos: i32,
+    fused_in: &GpuBuffer,
+    out: &mut GpuBuffer,
+    scratch: &mut MtpForwardScratch,
+) -> Result<()> {
+    if cache_pos < 0 {
+        return Err(anyhow!(
+            "run_mtp_layer_step: cache_pos must be ≥ 0 (got {cache_pos}); \
+             the kernel sentinel `-1` means \"inherit position\" which \
+             defeats MTP's per-session cache semantics."
+        ));
+    }
+    let hidden = geom.hidden as usize;
+
+    // ---- attention ----------------------------------------------------
+    reset_sync_buf(ordinal, &mut scratch.sync_buf)
+        .context("reset sync_buf (mtp attn)")?;
+    let (kv_k_ptr, kv_v_ptr, kv_max_t) = match &mut mtp.kv_cache {
+        Some(c) => (c.k.as_mut_ptr(), c.v.as_mut_ptr(), c.kv_max_t),
+        None => (ptr::null_mut(), ptr::null_mut(), 0),
+    };
+    let attn_params = Qwen36MoeAttnStepParams {
+        stage: 5,
+        hidden: geom.hidden,
+        num_heads: geom.num_attention_heads,
+        num_kv_heads: geom.num_kv_heads,
+        head_dim: geom.head_dim,
+        rotary_dim: geom.rotary_dim,
+        rope_theta: geom.rope_theta,
+        rms_norm_eps: geom.rms_norm_eps,
+        position,
+        cache_pos,
+    };
+    let attn_weights = Qwen36MoeAttnStepWeights {
+        input_hidden: fused_in.as_ptr(),
+        input_norm_w: mtp.input_norm_w.as_ptr(),
+        q_proj_w: mtp.q_proj_w.as_ptr(),
+        k_proj_w: mtp.k_proj_w.as_ptr(),
+        v_proj_w: mtp.v_proj_w.as_ptr(),
+        q_norm_w: mtp.q_norm_w.as_ptr(),
+        k_norm_w: mtp.k_norm_w.as_ptr(),
+        o_proj_w: mtp.o_proj_w.as_ptr(),
+        kv_cache_k: kv_k_ptr,
+        kv_cache_v: kv_v_ptr,
+        kv_max_t,
+    };
+    attn_step_launch(
+        ordinal,
+        ScalarType::BF16,
+        attn_params,
+        &attn_weights,
+        // BF16 path only — the production-bake INT4 path is a
+        // follow-up; the MTP weights are emitted as raw BF16 by the
+        // current `oracle/bake_int4.py` pass-through, and even if we
+        // bake INT4 later, that's a parallel sidecar struct switch.
+        &Qwen36MoeAttnStepInt4::disabled(),
+        &mut scratch.attn_output,
+        &mut scratch.attn_workspace,
+        &mut scratch.sync_buf,
+    )
+    .context("mtp attn_step_launch")?;
+
+    // attn_output[..hidden] is `fused_in + o_proj(...)`. Copy into the
+    // dedicated mid-residual buffer so the FFN reads contiguous BF16
+    // (attn_output is sized for the wider of full/linear stages, the
+    // FFN expects exactly `hidden` elements).
+    copy_d2d(
+        ordinal,
+        scratch.attn_residual.as_mut_ptr(),
+        scratch.attn_output.as_ptr(),
+        hidden * 2,
+    )
+    .context("mtp d2d attn_output -> attn_residual")?;
+
+    // ---- FFN ----------------------------------------------------------
+    reset_sync_buf(ordinal, &mut scratch.sync_buf)
+        .context("reset sync_buf (mtp ffn)")?;
+    let ffn_params = Qwen36MoeFfnStepParams {
+        stage: 5,
+        hidden: geom.hidden,
+        num_experts: geom.num_experts,
+        moe_intermediate: geom.moe_intermediate,
+        shared_intermediate: geom.shared_intermediate,
+        top_k: geom.top_k,
+        rms_norm_eps: geom.rms_norm_eps,
+    };
+    let ffn_weights = Qwen36MoeFfnStepWeights {
+        input_hidden: scratch.attn_residual.as_ptr(),
+        post_attn_norm_w: mtp.post_attn_norm_w.as_ptr(),
+        gate_w: mtp.gate_w.as_ptr(),
+        gate_up_proj_w: mtp.gate_up_proj_w.as_ptr(),
+        down_proj_w: mtp.down_proj_w.as_ptr(),
+        shared_gate_proj_w: mtp.shared_gate_proj_w.as_ptr(),
+        shared_up_proj_w: mtp.shared_up_proj_w.as_ptr(),
+        shared_down_proj_w: mtp.shared_down_proj_w.as_ptr(),
+        shared_expert_gate_w: mtp.shared_expert_gate_w.as_ptr(),
+    };
+    ffn_step_launch(
+        ordinal,
+        ScalarType::BF16,
+        ffn_params,
+        &ffn_weights,
+        &Qwen36MoeFfnStepInt4::disabled(),
+        &mut scratch.ffn_output,
+        &mut scratch.ffn_output_idx,
+        &mut scratch.ffn_workspace,
+        &mut scratch.sync_buf,
+    )
+    .context("mtp ffn_step_launch")?;
+
+    // ffn_output[..hidden] is `attn_residual + moe_out + shared_out` —
+    // the layer's final residual output. Hand it back via `out`.
+    copy_d2d(
+        ordinal,
+        out.as_mut_ptr(),
+        scratch.ffn_output.as_ptr(),
+        hidden * 2,
+    )
+    .context("mtp d2d ffn_output -> out")?;
+    Ok(())
+}

--- a/crates/runner/src/qwen36_moe_mtp.rs
+++ b/crates/runner/src/qwen36_moe_mtp.rs
@@ -27,7 +27,6 @@ use kernel_ffi::qwen36_moe::{
     attn_step_launch, ffn_step_launch, Qwen36MoeAttnStepInt4, Qwen36MoeAttnStepParams,
     Qwen36MoeAttnStepWeights, Qwen36MoeFfnStepInt4, Qwen36MoeFfnStepParams, Qwen36MoeFfnStepWeights,
 };
-use std::ptr;
 
 use crate::qwen36_moe_decode::{
     ffn_output_elems, ffn_workspace_floats, full_attn_output_elems, full_attn_workspace_floats,
@@ -166,15 +165,36 @@ pub fn run_mtp_layer_step(
              defeats MTP's per-session cache semantics."
         ));
     }
+    // MTP requires an allocated KV cache. If `kv_cache` is `None` the
+    // attn kernel silently falls back to its kv_len=1 self-attention
+    // path (back-compat for the per-block parity tests) — that happens
+    // to look correct for `cache_pos == 0` (only one K to attend to)
+    // but for `cache_pos > 0` it makes every draft step attend only to
+    // itself instead of accumulated prior K/V. Reject up front rather
+    // than ship a silent correctness bug.
+    let kv = mtp.kv_cache.as_mut().ok_or_else(|| anyhow!(
+        "run_mtp_layer_step: MtpLayerBuffers.kv_cache is None — MTP \
+         self-attention requires an allocated cache. Construct the \
+         buffers via `load_mtp_buffers(..., kv_max_t > 0)` (Phase 6.2b \
+         loader); without it the kernel falls back to kv_len=1 which \
+         produces wrong outputs for any `cache_pos > 0`."
+    ))?;
+    if cache_pos >= kv.kv_max_t {
+        return Err(anyhow!(
+            "run_mtp_layer_step: cache_pos {cache_pos} ≥ kv_max_t {} — \
+             grow the MTP cache to at least `num_speculative_tokens` \
+             slots when calling the loader.",
+            kv.kv_max_t
+        ));
+    }
     let hidden = geom.hidden as usize;
 
     // ---- attention ----------------------------------------------------
     reset_sync_buf(ordinal, &mut scratch.sync_buf)
         .context("reset sync_buf (mtp attn)")?;
-    let (kv_k_ptr, kv_v_ptr, kv_max_t) = match &mut mtp.kv_cache {
-        Some(c) => (c.k.as_mut_ptr(), c.v.as_mut_ptr(), c.kv_max_t),
-        None => (ptr::null_mut(), ptr::null_mut(), 0),
-    };
+    let kv_k_ptr = kv.k.as_mut_ptr();
+    let kv_v_ptr = kv.v.as_mut_ptr();
+    let kv_max_t = kv.kv_max_t;
     let attn_params = Qwen36MoeAttnStepParams {
         stage: 5,
         hidden: geom.hidden,

--- a/crates/runner/tests/qwen36_moe_mtp_parity.rs
+++ b/crates/runner/tests/qwen36_moe_mtp_parity.rs
@@ -1,0 +1,332 @@
+//! Phase 6.2c.2 parity test for the SuperSonic-side MTP layer forward.
+//!
+//! Drives [`runner::qwen36_moe_mtp::run_mtp_layer_step`] against the
+//! Phase 6.2a Python oracle. Reads `steps[0].fused_bf16` (the pre-fusion
+//! kernel's output, validated bit-exact in Phase 6.2c.1) as input,
+//! produces the layer's post-residual output, and compares against the
+//! oracle's `steps[0].attn_out_bf16` (which despite the name is the FULL
+//! layer output — vLLM's HF `Qwen3_5MoeDecoderLayer` returns
+//! `residual + attn + mlp`).
+//!
+//! The MTP MoE FFN is ~1.6 GiB BF16 — too large to round-trip through
+//! the oracle JSON (the existing `prefusion_weights` block is already
+//! 16 MiB). The test instead loads `mtp.*` tensors directly from the
+//! model's safetensors at the path given by
+//! `SUPERSONIC_QWEN36_MTP_MODEL_DIR`, exactly mirroring the Phase 6.2a
+//! oracle's load path.
+//!
+//! Skipped silently when either env var isn't set so CI / non-HIP
+//! machines stay green. To run locally:
+//!
+//! ```bash
+//! .venv-bake/bin/python oracle/qwen36_moe_mtp_oracle.py \
+//!     --model-dir /path/to/Qwen3.6-35B-A3B \
+//!     --num-speculative-tokens 1 --seed 42 \
+//!     --out /tmp/qwen36_mtp.json
+//! SUPERSONIC_QWEN36_MTP_ORACLE_JSON=/tmp/qwen36_mtp.json \
+//!   SUPERSONIC_QWEN36_MTP_MODEL_DIR=/path/to/Qwen3.6-35B-A3B \
+//!   cargo test --release -p runner --test qwen36_moe_mtp_parity \
+//!     -- --nocapture
+//! ```
+
+use std::collections::BTreeMap;
+use std::fs::File;
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, Context, Result};
+use base64::Engine;
+use gpu_hal::{copy_d2h, is_backend_compiled, set_backend, Backend, GpuBuffer, ScalarType};
+use memmap2::Mmap;
+use runner::qwen36_moe_decode::{FullAttnKvCache, MtpLayerBuffers, MultiLayerGeom};
+use runner::qwen36_moe_mtp::{alloc_mtp_forward_scratch, run_mtp_layer_step};
+use safetensors::SafeTensors;
+use serde_json::Value;
+
+fn b64(input: &str) -> Vec<u8> {
+    base64::engine::general_purpose::STANDARD
+        .decode(input)
+        .expect("base64 decode")
+}
+
+fn bf16_bytes_to_f32(bytes: &[u8]) -> Vec<f32> {
+    bytes
+        .chunks_exact(2)
+        .map(|c| {
+            let bits = u32::from(c[0]) | (u32::from(c[1]) << 8);
+            f32::from_bits(bits << 16)
+        })
+        .collect()
+}
+
+/// Inline sharded-safetensors loader. Mirrors `UnbakedLoader` in
+/// `gemma4_engine.rs` (which is private). We only need to read 19
+/// `mtp.*` tensors, all of them BF16.
+struct SafetensorsShards {
+    shards: Vec<Mmap>,
+    /// tensor name → shard index in `shards`.
+    index: BTreeMap<String, usize>,
+}
+
+impl SafetensorsShards {
+    fn open(model_dir: &Path) -> Result<Self> {
+        let index_path = model_dir.join("model.safetensors.index.json");
+        let raw: Value = serde_json::from_str(
+            &std::fs::read_to_string(&index_path)
+                .with_context(|| format!("read {}", index_path.display()))?,
+        )?;
+        let weight_map = raw["weight_map"]
+            .as_object()
+            .ok_or_else(|| anyhow!("weight_map missing in {}", index_path.display()))?;
+
+        // Collect distinct shard filenames in deterministic order.
+        let mut filename_to_idx: BTreeMap<String, usize> = BTreeMap::new();
+        let mut shard_files: Vec<String> = Vec::new();
+        for v in weight_map.values() {
+            let filename = v.as_str().unwrap_or("").to_string();
+            if !filename_to_idx.contains_key(&filename) {
+                filename_to_idx.insert(filename.clone(), shard_files.len());
+                shard_files.push(filename);
+            }
+        }
+
+        let mut shards: Vec<Mmap> = Vec::with_capacity(shard_files.len());
+        for filename in &shard_files {
+            let p = model_dir.join(filename);
+            let f = File::open(&p)
+                .with_context(|| format!("open shard {}", p.display()))?;
+            shards.push(unsafe { Mmap::map(&f)? });
+        }
+        let mut index: BTreeMap<String, usize> = BTreeMap::new();
+        for (name, fname) in weight_map {
+            if let Some(&idx) = filename_to_idx.get(fname.as_str().unwrap_or("")) {
+                index.insert(name.clone(), idx);
+            }
+        }
+        Ok(Self { shards, index })
+    }
+
+    fn load_bf16_to_gpu(&self, ordinal: usize, name: &str) -> Result<GpuBuffer> {
+        let &shard_idx = self
+            .index
+            .get(name)
+            .ok_or_else(|| anyhow!("safetensors index missing tensor: {name}"))?;
+        let st = SafeTensors::deserialize(&self.shards[shard_idx])?;
+        let view = st.tensor(name)?;
+        if view.dtype() != safetensors::Dtype::BF16 {
+            return Err(anyhow!(
+                "tensor {name} dtype {:?}, expected BF16",
+                view.dtype()
+            ));
+        }
+        Ok(GpuBuffer::from_host_bytes(
+            ordinal,
+            ScalarType::BF16,
+            view.shape(),
+            view.data(),
+        )?)
+    }
+}
+
+fn load_mtp_buffers_from_safetensors(
+    shards: &SafetensorsShards,
+    ordinal: usize,
+    geom: &MultiLayerGeom,
+    kv_max_t: usize,
+) -> Result<MtpLayerBuffers> {
+    let kv_dim = (geom.num_kv_heads as usize) * (geom.head_dim as usize);
+    let kv_cache = if kv_max_t > 0 {
+        Some(FullAttnKvCache {
+            k: GpuBuffer::zeros(ordinal, ScalarType::BF16, &[kv_max_t, kv_dim])
+                .context("alloc mtp kv_cache_k")?,
+            v: GpuBuffer::zeros(ordinal, ScalarType::BF16, &[kv_max_t, kv_dim])
+                .context("alloc mtp kv_cache_v")?,
+            kv_max_t: kv_max_t as i32,
+        })
+    } else {
+        None
+    };
+
+    Ok(MtpLayerBuffers {
+        pre_fc_norm_hidden_w: shards
+            .load_bf16_to_gpu(ordinal, "mtp.pre_fc_norm_hidden.weight")?,
+        pre_fc_norm_embedding_w: shards
+            .load_bf16_to_gpu(ordinal, "mtp.pre_fc_norm_embedding.weight")?,
+        fc_w: shards.load_bf16_to_gpu(ordinal, "mtp.fc.weight")?,
+        norm_w: shards.load_bf16_to_gpu(ordinal, "mtp.norm.weight")?,
+        input_norm_w: shards
+            .load_bf16_to_gpu(ordinal, "mtp.layers.0.input_layernorm.weight")?,
+        post_attn_norm_w: shards
+            .load_bf16_to_gpu(ordinal, "mtp.layers.0.post_attention_layernorm.weight")?,
+        q_proj_w: shards.load_bf16_to_gpu(ordinal, "mtp.layers.0.self_attn.q_proj.weight")?,
+        k_proj_w: shards.load_bf16_to_gpu(ordinal, "mtp.layers.0.self_attn.k_proj.weight")?,
+        v_proj_w: shards.load_bf16_to_gpu(ordinal, "mtp.layers.0.self_attn.v_proj.weight")?,
+        o_proj_w: shards.load_bf16_to_gpu(ordinal, "mtp.layers.0.self_attn.o_proj.weight")?,
+        q_norm_w: shards.load_bf16_to_gpu(ordinal, "mtp.layers.0.self_attn.q_norm.weight")?,
+        k_norm_w: shards.load_bf16_to_gpu(ordinal, "mtp.layers.0.self_attn.k_norm.weight")?,
+        gate_w: shards.load_bf16_to_gpu(ordinal, "mtp.layers.0.mlp.gate.weight")?,
+        gate_up_proj_w: shards
+            .load_bf16_to_gpu(ordinal, "mtp.layers.0.mlp.experts.gate_up_proj")?,
+        down_proj_w: shards
+            .load_bf16_to_gpu(ordinal, "mtp.layers.0.mlp.experts.down_proj")?,
+        shared_gate_proj_w: shards
+            .load_bf16_to_gpu(ordinal, "mtp.layers.0.mlp.shared_expert.gate_proj.weight")?,
+        shared_up_proj_w: shards
+            .load_bf16_to_gpu(ordinal, "mtp.layers.0.mlp.shared_expert.up_proj.weight")?,
+        shared_down_proj_w: shards
+            .load_bf16_to_gpu(ordinal, "mtp.layers.0.mlp.shared_expert.down_proj.weight")?,
+        shared_expert_gate_w: shards
+            .load_bf16_to_gpu(ordinal, "mtp.layers.0.mlp.shared_expert_gate.weight")?,
+        kv_cache,
+    })
+}
+
+fn parse_geom(json: &Value) -> MultiLayerGeom {
+    let cfg = &json["config"];
+    let head_dim = cfg["head_dim"].as_i64().unwrap() as i32;
+    let partial = cfg["partial_rotary_factor"].as_f64().unwrap() as f32;
+    let rotary_dim = (head_dim as f32 * partial) as i32;
+    MultiLayerGeom {
+        hidden: cfg["hidden"].as_i64().unwrap() as i32,
+        vocab: cfg["vocab"].as_i64().unwrap() as i32,
+        // num_layers / linear-attn fields aren't read by the MTP path; the
+        // MoE FFN + full-attn fields below are what `run_mtp_layer_step`
+        // actually consumes.
+        num_layers: 1,
+        rms_norm_eps: cfg["rms_norm_eps"].as_f64().unwrap() as f32,
+
+        num_attention_heads: cfg["num_attention_heads"].as_i64().unwrap() as i32,
+        num_kv_heads: cfg["num_kv_heads"].as_i64().unwrap() as i32,
+        head_dim,
+        rotary_dim,
+        rope_theta: cfg["rope_theta"].as_f64().unwrap() as f32,
+
+        // Linear-attn fields — unused by MTP, set to 0.
+        num_k_heads: 0,
+        num_v_heads: 0,
+        head_k_dim: 0,
+        head_v_dim: 0,
+        conv_kernel_dim: 0,
+
+        num_experts: cfg["num_experts"].as_i64().unwrap() as i32,
+        moe_intermediate: cfg["moe_intermediate_size"].as_i64().unwrap() as i32,
+        shared_intermediate: cfg["shared_expert_intermediate_size"].as_i64().unwrap() as i32,
+        top_k: cfg["top_k"].as_i64().unwrap() as i32,
+    }
+}
+
+#[test]
+fn qwen36_moe_mtp_layer_forward_matches_oracle() {
+    if !is_backend_compiled(Backend::Hip) {
+        eprintln!("skip: HIP backend not compiled");
+        return;
+    }
+    let Ok(json_path) = std::env::var("SUPERSONIC_QWEN36_MTP_ORACLE_JSON") else {
+        eprintln!(
+            "skip: SUPERSONIC_QWEN36_MTP_ORACLE_JSON not set. Generate a \
+             fixture with `python oracle/qwen36_moe_mtp_oracle.py --model-dir \
+             <Qwen3.6-35B-A3B> --num-speculative-tokens 1 --out /tmp/qwen36_mtp.json` \
+             and re-run with both env vars."
+        );
+        return;
+    };
+    let Ok(model_dir) = std::env::var("SUPERSONIC_QWEN36_MTP_MODEL_DIR") else {
+        eprintln!(
+            "skip: SUPERSONIC_QWEN36_MTP_MODEL_DIR not set. Point this at the \
+             same model_dir the oracle used (the test loads `mtp.*` tensors \
+             directly from safetensors — they're too big to round-trip through \
+             the oracle JSON)."
+        );
+        return;
+    };
+    let model_dir = PathBuf::from(model_dir);
+
+    let raw =
+        std::fs::read_to_string(&json_path).expect("read mtp oracle json");
+    let json: Value = serde_json::from_str(&raw).expect("mtp oracle json parse");
+    assert_eq!(
+        json["schema"].as_str().unwrap_or(""),
+        "qwen36-moe-mtp-oracle-v1",
+        "oracle JSON schema mismatch — regenerate with the Phase 6.2a oracle."
+    );
+
+    let geom = parse_geom(&json);
+    let base_seq_len = json["base_seq_len"].as_i64().unwrap() as i32;
+    let step0 = &json["steps"][0];
+    let fused_bytes = b64(step0["fused_bf16"].as_str().unwrap());
+    let want_bytes = b64(step0["attn_out_bf16"].as_str().unwrap());
+    assert_eq!(fused_bytes.len(), (geom.hidden as usize) * 2);
+    assert_eq!(want_bytes.len(), (geom.hidden as usize) * 2);
+
+    set_backend(Backend::Hip);
+    let ordinal = 0usize;
+
+    eprintln!("[mtp parity] loading mtp.* tensors from {} ...", model_dir.display());
+    let shards = SafetensorsShards::open(&model_dir).expect("open safetensors");
+    // Cache big enough to hold all draft steps if the test grew. K=1 here
+    // is enough for the first step but we size for K=4 to give headroom.
+    let kv_max_t = 4usize;
+    let mut mtp = load_mtp_buffers_from_safetensors(&shards, ordinal, &geom, kv_max_t)
+        .expect("load MtpLayerBuffers from safetensors");
+    let mut scratch = alloc_mtp_forward_scratch(ordinal, &geom, kv_max_t)
+        .expect("alloc mtp scratch");
+
+    let fused_buf = GpuBuffer::from_host_bytes(
+        ordinal, ScalarType::BF16, &[geom.hidden as usize], &fused_bytes,
+    ).expect("upload fused");
+    let mut out_buf = GpuBuffer::zeros(
+        ordinal, ScalarType::BF16, &[geom.hidden as usize],
+    ).expect("alloc out");
+
+    eprintln!("[mtp parity] running layer forward (position={base_seq_len}, cache_pos=0)...");
+    run_mtp_layer_step(
+        ordinal, &geom, &mut mtp,
+        /* position */ base_seq_len,
+        /* cache_pos */ 0,
+        &fused_buf, &mut out_buf,
+        &mut scratch,
+    ).expect("run_mtp_layer_step");
+
+    let mut got_bytes = vec![0u8; (geom.hidden as usize) * 2];
+    copy_d2h(
+        ordinal, got_bytes.as_mut_ptr() as *mut _,
+        out_buf.as_ptr(), got_bytes.len(),
+    ).expect("d2h out");
+
+    let got = bf16_bytes_to_f32(&got_bytes);
+    let want = bf16_bytes_to_f32(&want_bytes);
+    let n = got.len();
+    let mut max_abs = 0.0f32;
+    let mut sum_abs = 0.0f32;
+    let mut dot = 0.0f64;
+    let mut got_sq = 0.0f64;
+    let mut want_sq = 0.0f64;
+    let mut exact = 0usize;
+    for i in 0..n {
+        let d = (got[i] - want[i]).abs();
+        if d == 0.0 { exact += 1; }
+        max_abs = max_abs.max(d);
+        sum_abs += d;
+        dot += got[i] as f64 * want[i] as f64;
+        got_sq += (got[i] as f64).powi(2);
+        want_sq += (want[i] as f64).powi(2);
+    }
+    let cos_sim = dot / (got_sq.sqrt() * want_sq.sqrt() + 1e-30);
+    let mean_abs = sum_abs / n as f32;
+    eprintln!(
+        "[mtp parity attn_out] n={n} exact={exact} max_abs={max_abs:.5e} \
+         mean_abs={mean_abs:.5e} cos_sim={cos_sim:.7}"
+    );
+
+    // Same envelope as the multi-layer parity test: cos_sim ≥ 0.999, max
+    // abs ≤ 0.05 BF16 (the per-block tests' ULP envelope at hidden=2048
+    // matvec scale).
+    assert!(
+        cos_sim >= 0.999,
+        "MTP layer cos_sim {cos_sim:.7} below floor 0.999 — likely a \
+         kernel/weights/cache_pos mismatch, not BF16 noise"
+    );
+    assert!(
+        max_abs <= 0.05,
+        "MTP layer max_abs {max_abs:.5e} exceeds 0.05 envelope"
+    );
+}

--- a/kernels/qwen36_moe.hip
+++ b/kernels/qwen36_moe.hip
@@ -546,6 +546,15 @@ __global__ void qwen36_moe_attn_step_kernel(
     float                          rope_theta,    // unused at stage 1
     float                          rms_norm_eps,
     int                            position,      // unused at stage 1
+    // Optional override for the KV cache slot index. Negative ⇒ "same as
+    // `position`" (the base-model decode case where RoPE position == cache
+    // slot). Set to a non-negative value to decouple the two — used by
+    // self-speculative MTP, where RoPE rotates at absolute position
+    // `base_seq_len + k` but the per-MTP-session cache writes at slot
+    // `k` (the cache is fresh per draft session). When `cache_pos >= 0`,
+    // Phase G writes K/V at `cache_pos` and attends over
+    // `kv_len = cache_pos + 1`; RoPE still uses `position`.
+    int                            cache_pos,
     const T* __restrict__          input_hidden,  // [hidden]
     const T* __restrict__          input_norm_w,  // [hidden]
     const T* __restrict__          q_proj_w,      // [2*H*d, hidden]
@@ -574,9 +583,10 @@ __global__ void qwen36_moe_attn_step_kernel(
     float* __restrict__             workspace,    // F32 scratch, see header comment
     // PR 4d KV cache extension. When `kv_cache_k`/`kv_cache_v` are non-null
     // and `kv_max_t > 0`, Phase G writes the current step's K/V at slot
-    // `position` and attends over `kv_len = position + 1` past tokens. When
-    // both pointers are null, falls back to the kv_len=1 self-attention
-    // path (PR 4b2 behavior — back-compat for the parity tests).
+    // `eff_cache_pos = (cache_pos >= 0 ? cache_pos : position)` and attends
+    // over `kv_len = eff_cache_pos + 1` past tokens. When both pointers are
+    // null, falls back to the kv_len=1 self-attention path (PR 4b2 behavior —
+    // back-compat for the parity tests).
     T* __restrict__                kv_cache_k,    // [kv_max_t, Hkv*d] BF16 (mut, nullable)
     T* __restrict__                kv_cache_v,    // [kv_max_t, Hkv*d] BF16 (mut, nullable)
     int                            kv_max_t,      // capacity bound; 0 ⇔ no cache
@@ -1167,13 +1177,16 @@ __global__ void qwen36_moe_attn_step_kernel(
         const int rep   = H / Hkv;
         const float scale = rsqrtf(static_cast<float>(d));
         const bool use_kv_cache = (kv_cache_k != nullptr && kv_cache_v != nullptr);
-        const int kv_len = use_kv_cache ? (position + 1) : 1;
+        // Effective cache slot. `cache_pos < 0` ⇒ inherit from `position`
+        // (base-model decode); `cache_pos >= 0` ⇒ MTP-style decoupled write.
+        const int eff_cache_pos = (cache_pos >= 0) ? cache_pos : position;
+        const int kv_len = use_kv_cache ? (eff_cache_pos + 1) : 1;
 
         // Step 1: write current K/V into the cache (if enabled). All blocks
         // cooperate via a flat work-stealing index since the writes are
         // independent across (h_kv, i).
         if (use_kv_cache) {
-            const int slot_base = position * Hkv * d;
+            const int slot_base = eff_cache_pos * Hkv * d;
             const int total = Hkv * d;
             for (int idx = blockIdx.x * block_size + tid;
                  idx < total;

--- a/kernels/qwen36_moe_bridge.cpp
+++ b/kernels/qwen36_moe_bridge.cpp
@@ -148,6 +148,9 @@ extern "C" int qwen36_moe_hip_attn_step_launch(
     float         rope_theta,
     float         rms_norm_eps,
     int           position,
+    int           cache_pos,    // -1 ⇒ inherit from `position` (base-model
+                                //      decode); ≥0 ⇒ MTP-style decoupled
+                                //      KV-cache slot (see kernel comment).
     const void*   input_hidden,
     const void*   input_norm_w,
     const void*   q_proj_w,
@@ -204,13 +207,14 @@ extern "C" int qwen36_moe_hip_attn_step_launch(
     if (!any_int4 && int4_group_size != 0) return 117;
 
     // KV cache: pointers must be paired (both null or both non-null), and
-    // kv_max_t must be positive when enabled + ≥ position+1 to fit the
-    // current write.
+    // kv_max_t must be positive when enabled + the *effective* slot
+    // (cache_pos ≥ 0 ? cache_pos : position) must fit.
     const bool kv_enabled = (kv_cache_k != nullptr || kv_cache_v != nullptr);
     if ((kv_cache_k == nullptr) != (kv_cache_v == nullptr)) return 118;
     if (kv_enabled) {
         if (kv_max_t <= 0) return 119;
-        if (position < 0 || position >= kv_max_t) return 120;
+        const int eff_slot = (cache_pos >= 0) ? cache_pos : position;
+        if (eff_slot < 0 || eff_slot >= kv_max_t) return 120;
     }
 
     ScopedHipDevice scoped(static_cast<int>(device_ordinal));
@@ -259,7 +263,7 @@ extern "C" int qwen36_moe_hip_attn_step_launch(
             dim3(block_size),
             lds_bytes, 0,
             stage, hidden, num_heads, num_kv_heads, head_dim, rotary_dim,
-            rope_theta, rms_norm_eps, position,
+            rope_theta, rms_norm_eps, position, cache_pos,
             static_cast<const hip_bfloat16*>(input_hidden),
             static_cast<const hip_bfloat16*>(input_norm_w),
             static_cast<const hip_bfloat16*>(q_proj_w),
@@ -290,7 +294,7 @@ extern "C" int qwen36_moe_hip_attn_step_launch(
             dim3(block_size),
             lds_bytes, 0,
             stage, hidden, num_heads, num_kv_heads, head_dim, rotary_dim,
-            rope_theta, rms_norm_eps, position,
+            rope_theta, rms_norm_eps, position, cache_pos,
             static_cast<const hip_bfloat16*>(input_hidden),
             static_cast<const hip_bfloat16*>(input_norm_w),
             static_cast<const hip_bfloat16*>(q_proj_w),


### PR DESCRIPTION
## Summary
- Drives one full-attention MoE block on the SuperSonic side for multi-token-prediction draft steps, reusing the existing per-block `attn_step` + `ffn_step` launchers. Together with Phase 6.2c.1's pre-fusion kernel this produces the layer's `attn_out` byte-equivalent of vLLM's `Qwen3NextMultiTokenPredictor.forward` post-fusion stage.
- One additive (back-compat) kernel API change: a new `cache_pos` parameter on `qwen36_moe_attn_step_kernel` to decouple the KV cache slot from the RoPE position. Required for MTP where RoPE rotates at absolute position `base_seq_len + k` while the per-MTP-session cache is fresh and step `k` writes at slot `k`. Negative ⇒ inherit from `position` (default; current base-model decode behavior is bit-identical).

## Plumbing
- `kernels/qwen36_moe.hip` — kernel signature + Phase G branch on `eff_cache_pos = (cache_pos >= 0 ? cache_pos : position)`.
- `kernels/qwen36_moe_bridge.cpp` — launcher signature + capacity check now uses `eff_slot`.
- `crates/kernel-ffi/src/qwen36_moe.rs` — FFI extern + `Qwen36MoeAttnStepParams::cache_pos` + `CACHE_POS_INHERIT = -1` sentinel; all 7 existing kernel-ffi parity-test param-construction sites updated to pass the inherit sentinel.
- `crates/runner/src/qwen36_moe_decode.rs` — base decode chain passes `CACHE_POS_INHERIT`. Helpers (`reset_sync_buf`, workspace sizers) made `pub(crate)` so the new MTP module can reuse them.
- `crates/runner/src/qwen36_moe_mtp.rs` — new module:
  - `MtpForwardScratch` (pre-allocated GPU scratch).
  - `alloc_mtp_forward_scratch(ordinal, geom, kv_max_t)`.
  - `run_mtp_layer_step(ordinal, geom, mtp, position, cache_pos, fused_in, out, scratch)` — calls `attn_step_launch` then `ffn_step_launch`, BF16 only.
- `crates/runner/tests/qwen36_moe_mtp_parity.rs` — Phase 6.2c.2 parity test:
  - Reads `SUPERSONIC_QWEN36_MTP_ORACLE_JSON` for inputs + expected `attn_out`.
  - Reads `SUPERSONIC_QWEN36_MTP_MODEL_DIR` and loads the 19 `mtp.*` tensors directly from safetensors (the MoE FFN alone is ~1 GiB BF16 — too big to round-trip through JSON; the existing oracle JSON only carries pre-fusion weights + intermediates).
  - Skips silently when either env var is absent.

INT4 sidecars are wired but disabled this PR (`Qwen36MoeAttnStepInt4::disabled()`). The current `oracle/bake_int4.py` MTP pass-through emits `mtp.*` as raw BF16; INT4 calibration of MTP is a parallel change.

## Local parity result
```
[mtp parity] running layer forward (position=12, cache_pos=0)...
[mtp parity attn_out] n=2048 exact=1022 max_abs=7.81250e-3 mean_abs=6.32625e-4 cos_sim=0.9999947
test qwen36_moe_mtp_layer_forward_matches_oracle ... ok
```

~50% bit-exact, the rest within 1 ULP of BF16 — exactly the F32-accumulation-order envelope the multilayer parity test runs under (cos_sim ≥ 0.999 floor; 0.05 max-abs envelope; here 0.0078 max abs).

## Test plan
- [x] New parity test passes against the synthetic-mode oracle JSON + local model_dir (cos_sim ≥ 0.999, max_abs ≤ 0.05).
- [x] Skip path: clean exit when either env var is absent.
- [x] Multilayer parity test (`qwen36_moe_multilayer_parity`) still passes — confirms the `cache_pos = -1` inherit path is bit-identical to pre-PR behavior end-to-end across 4 hybrid layers.
- [x] All 27 kernel-ffi parity tests (attn 1-5 + INT4 / linear 1-5 + INT4 / FFN 1-5 + INT4 / lm_head / int4_dequant smoke / pre-fusion) still pass.
- [x] `cargo build --release --bin supersonic` clean.

To regenerate the fixture + run:
```bash
.venv-bake/bin/python oracle/qwen36_moe_mtp_oracle.py \
  --model-dir /path/to/Qwen3.6-35B-A3B \
  --num-speculative-tokens 1 --seed 42 \
  --out /tmp/qwen36_mtp.json
SUPERSONIC_QWEN36_MTP_ORACLE_JSON=/tmp/qwen36_mtp.json \
  SUPERSONIC_QWEN36_MTP_MODEL_DIR=/path/to/Qwen3.6-35B-A3B \
  cargo test --release -p runner --test qwen36_moe_mtp_parity -- --nocapture
```

Phase 6.2c.3 next: post-norm (`mtp.norm`) + tied lm_head + argmax → draft token, completing the synthetic-mode MTP draft step end-to-end. Phase 6.3 then wires the speculative driver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)