### PR TITLE
[codex] Enable Qwen3.6 INT4 on gfx942

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ see [docs/dflash.md](docs/dflash.md).
 | qwen3.5-2b       | ✅¹  | ✅²  |      —      |   —    |
 | qwen3.5-4b       | ✅¹  | ✅²  |      —      |   —    |
 | qwen3.5-9b       | ✅¹  | ✅²  |      —      |   —    |
-| qwen3.6-35b-a3b  |  —   |  —   |      —      |   —    |
+| qwen3.6-35b-a3b  |  —   | ✅⁴  |      —      |   —    |
 | gemma4-e2b       | ✅³  |  —   |      —      |   —    |
 | gemma4-e4b       |  —   |  —   |      —      |   —    |
 | phi4-mini        |  —   |  —   |      —      |   —    |
@@ -88,6 +88,8 @@ see [docs/dflash.md](docs/dflash.md).
   replayed GPU prefill.
 ³ Gemma 4 E2B BF16 validates against the PyTorch oracle; Gemma does not yet
   have the Qwen GPU replay validator wired up.
+⁴ Qwen3.6 35B A3B currently uses the INT4 GPTQ bake and the host-orchestrated
+  HIP chained decode path; performance work is still pending.
 
 ### CUDA on `sm86`
 

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -1250,16 +1250,20 @@ fn main() -> Result<()> {
                 | ModelVariant::Qwen3_5_2B
                 | ModelVariant::Qwen3_5_4B
                 | ModelVariant::Qwen3_5_9B
+                | ModelVariant::Qwen3_6_35B_A3B
                 | ModelVariant::Gemma4_E2B
         ) {
             anyhow::bail!(
-                "HIP gfx942 bring-up currently validates only Qwen3.5 models up to 9B and Gemma 4 E2B BF16"
+                "HIP gfx942 bring-up currently validates only Qwen3.5 models up to 9B, Qwen3.6 35B A3B INT4, and Gemma 4 E2B BF16"
             );
         }
         if cli.fp8_runtime || cli.kv_fp8 || cli.q4km || cli.q4km_gptq {
             anyhow::bail!(
-                "HIP gfx942 bring-up currently validates only BF16 and INT4 Qwen3.5 lanes, plus Gemma 4 E2B BF16"
+                "HIP gfx942 bring-up currently validates only BF16 and INT4 Qwen3.5 lanes, Qwen3.6 35B A3B INT4, and Gemma 4 E2B BF16"
             );
+        }
+        if matches!(model_variant, ModelVariant::Qwen3_6_35B_A3B) && !cli.int4 {
+            anyhow::bail!("HIP gfx942 Qwen3.6 35B A3B bring-up currently validates only --int4");
         }
         if matches!(model_variant, ModelVariant::Gemma4_E2B) && cli.int4 {
             anyhow::bail!("HIP gfx942 Gemma 4 E2B bring-up currently validates only BF16");

--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -10,6 +10,7 @@
 //! the only meaningful runtime check is "did the safetensors index match
 //! what we expect from the config" plus a budget comparison.
 
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
@@ -22,15 +23,13 @@ use qwen36_moe::loader::{ScalarKind, WeightLoader};
 use qwen36_moe::state::{StateAccount, StateLayout};
 use qwen36_moe::weights::{
     checkpoint_dtype_acceptable, expected_tensor_specs, CheckpointAccount, CheckpointDtype,
-    DEFAULT_PREFIX,
 };
 
 use crate::qwen36_moe_decode::{
-    argmax_bf16_logits, bf16_bytes_to_f32, dequant_int4_to_bf16_bytes, host_final_norm_lm_head,
-    host_final_norm_lm_head_f32, run_chained_decode, run_chained_decode_fast,
-    sample_bf16_logits, AttnLayerBuffers, FfnInt4Sidecars, FfnLayerBuffers,
-    FullAttnInt4Sidecars, FullAttnKvCache, LayerBuffers, LinearAttnInt4Sidecars,
-    MtpLayerBuffers, MultiLayerGeom, XorshiftRng,
+    argmax_bf16_logits, dequant_int4_to_bf16_bytes, host_final_norm_lm_head, run_chained_decode,
+    run_chained_decode_fast, sample_bf16_logits, AttnLayerBuffers, FfnInt4Sidecars,
+    FfnLayerBuffers, FullAttnInt4Sidecars, FullAttnKvCache, LayerBuffers,
+    LinearAttnInt4Sidecars, MtpLayerBuffers, MultiLayerGeom, XorshiftRng,
 };
 use crate::registry::{FamilyParams, Qwen36MoeKernelParams, RegistryEntry};
 
@@ -273,7 +272,7 @@ fn inspect_bake(
     let specs = expected_tensor_specs(text_config, weight_prefix);
     let mut missing_specs = Vec::new();
     for spec in &specs {
-        if !store.contains(&spec.name) {
+        if !store_contains_qwen36(&store, &spec.name) {
             missing_specs.push(spec.name.clone());
         }
     }
@@ -285,7 +284,7 @@ fn inspect_bake(
     for li in 0..text_config.num_hidden_layers as usize {
         for kind in ["gate_up_proj", "down_proj"] {
             let name = format!("{weight_prefix}.layers.{li}.mlp.experts.{kind}");
-            match store.layout(&name) {
+            match store_layout_qwen36(&store, &name) {
                 Some(LayoutTag::Int4Quantized) => {}
                 Some(other) => bad_expert_tensors.push((li, format!("{name} (layout={other:?})"))),
                 None => bad_expert_tensors.push((li, format!("{name} (missing)"))),
@@ -779,9 +778,33 @@ fn build_multi_layer_geom(
 /// when a tensor is missing (the bake-validation in `inspect_bake` already
 /// runs as part of the dry-run, so a missing tensor here is a real bug).
 fn load_to_gpu(store: &BakedStore, ordinal: usize, name: &str) -> Result<GpuBuffer> {
+    let resolved = resolve_qwen36_store_name(store, name);
     store
-        .load_to_gpu(name, ordinal)
+        .load_to_gpu(resolved.as_ref(), ordinal)
         .with_context(|| format!("BakedStore::load_to_gpu({name})"))
+}
+
+fn store_contains_qwen36(store: &BakedStore, name: &str) -> bool {
+    store.contains(resolve_qwen36_store_name(store, name).as_ref())
+}
+
+fn store_layout_qwen36<'a>(store: &'a BakedStore, name: &str) -> Option<&'a LayoutTag> {
+    store.layout(resolve_qwen36_store_name(store, name).as_ref())
+}
+
+fn resolve_qwen36_store_name<'a>(store: &BakedStore, name: &'a str) -> Cow<'a, str> {
+    if store.contains(name) {
+        return Cow::Borrowed(name);
+    }
+    if name.contains(".mlp.experts.") {
+        if let Some(rest) = name.strip_prefix("model.language_model.") {
+            let alt = format!("model.{rest}");
+            if store.contains(&alt) {
+                return Cow::Owned(alt);
+            }
+        }
+    }
+    Cow::Borrowed(name)
 }
 
 /// Pinned by `oracle/bake_int4.py` and the kernel — every INT4 tensor in

--- a/crates/runner/src/registry.rs
+++ b/crates/runner/src/registry.rs
@@ -767,6 +767,30 @@ static REGISTRY: &[RegistryEntry] = &[
             shared_expert_intermediate_size: 512,
         }),
     },
+    // Qwen3.6-35B-A3B INT4 GPTQ on AMD gfx942. CDNA bring-up reuses the
+    // HIP Qwen3.6-MoE kernels and the same baked tensor layout as gfx1100;
+    // the larger VRAM budget reflects MI300X-class cards rather than a
+    // memory-tight 24 GiB target.
+    RegistryEntry {
+        model: ModelVariant::Qwen3_6_35B_A3B,
+        backend: Backend::Hip,
+        arch: GpuArch::Gfx942,
+        vram: VramBudget {
+            fixed_bytes: 24 * GIB,
+            overhead_factor: 1.1,
+        },
+        params: FamilyParams::Qwen36Moe(Qwen36MoeKernelParams {
+            weight_prefix: "model.language_model",
+            kv_chunk_size: 256,
+            proj_buf_floats: 16_480,
+            attn_scratch_floats: 24_576,
+            moe_scratch_floats: 4_096,
+            num_experts: 256,
+            top_k: 8,
+            moe_intermediate_size: 512,
+            shared_expert_intermediate_size: 512,
+        }),
+    },
     // Qwen3.6-35B-A3B q4km on NVIDIA sm86. Primary CUDA v1 target. PR 4 lands
     // the kernel.
     RegistryEntry {
@@ -882,6 +906,7 @@ mod tests {
             ModelVariant::Qwen3_5_2B,
             ModelVariant::Qwen3_5_4B,
             ModelVariant::Qwen3_5_9B,
+            ModelVariant::Qwen3_6_35B_A3B,
             ModelVariant::Gemma4_E2B,
         ] {
             assert!(lookup(&model, &Backend::Hip, &GpuArch::Gfx942).is_some());
@@ -927,6 +952,7 @@ mod tests {
     fn qwen36_moe_registry_entries_carry_real_geometry() {
         for (backend, arch) in [
             (Backend::Hip, GpuArch::Gfx1100),
+            (Backend::Hip, GpuArch::Gfx942),
             (Backend::Cuda, GpuArch::Sm86),
         ] {
             let entry = lookup(&ModelVariant::Qwen3_6_35B_A3B, &backend, &arch)

--- a/crates/runner/tests/qwen36_moe_mtp_parity.rs
+++ b/crates/runner/tests/qwen36_moe_mtp_parity.rs
@@ -10,10 +10,9 @@
 //!
 //! The MTP MoE FFN is ~1.6 GiB BF16 — too large to round-trip through
 //! the oracle JSON (the existing `prefusion_weights` block is already
-//! 16 MiB). The test instead loads `mtp.*` tensors directly from the
-//! model's safetensors at the path given by
-//! `SUPERSONIC_QWEN36_MTP_MODEL_DIR`, exactly mirroring the Phase 6.2a
-//! oracle's load path.
+//! 16 MiB). The test loads `mtp.*` tensors from the INT4 bake's raw BF16
+//! MTP pass-through tensors at the path given by
+//! `SUPERSONIC_QWEN36_MTP_MODEL_DIR`, matching the runtime path.
 //!
 //! Skipped silently when either env var isn't set so CI / non-HIP
 //! machines stay green. To run locally:
@@ -37,6 +36,7 @@ use anyhow::{anyhow, Context, Result};
 use base64::Engine;
 use gpu_hal::{copy_d2h, is_backend_compiled, set_backend, Backend, GpuBuffer, ScalarType};
 use memmap2::Mmap;
+use model_store::BakedStore;
 use runner::qwen36_moe_decode::{FullAttnKvCache, MtpLayerBuffers, MultiLayerGeom};
 use runner::qwen36_moe_mtp::{
     alloc_mtp_forward_scratch, run_mtp_draft_step, run_mtp_layer_step,
@@ -129,8 +129,8 @@ impl SafetensorsShards {
     }
 }
 
-fn load_mtp_buffers_from_safetensors(
-    shards: &SafetensorsShards,
+fn load_mtp_buffers_from_bake(
+    store: &BakedStore,
     ordinal: usize,
     geom: &MultiLayerGeom,
     kv_max_t: usize,
@@ -149,37 +149,38 @@ fn load_mtp_buffers_from_safetensors(
     };
 
     Ok(MtpLayerBuffers {
-        pre_fc_norm_hidden_w: shards
-            .load_bf16_to_gpu(ordinal, "mtp.pre_fc_norm_hidden.weight")?,
-        pre_fc_norm_embedding_w: shards
-            .load_bf16_to_gpu(ordinal, "mtp.pre_fc_norm_embedding.weight")?,
-        fc_w: shards.load_bf16_to_gpu(ordinal, "mtp.fc.weight")?,
-        norm_w: shards.load_bf16_to_gpu(ordinal, "mtp.norm.weight")?,
-        input_norm_w: shards
-            .load_bf16_to_gpu(ordinal, "mtp.layers.0.input_layernorm.weight")?,
-        post_attn_norm_w: shards
-            .load_bf16_to_gpu(ordinal, "mtp.layers.0.post_attention_layernorm.weight")?,
-        q_proj_w: shards.load_bf16_to_gpu(ordinal, "mtp.layers.0.self_attn.q_proj.weight")?,
-        k_proj_w: shards.load_bf16_to_gpu(ordinal, "mtp.layers.0.self_attn.k_proj.weight")?,
-        v_proj_w: shards.load_bf16_to_gpu(ordinal, "mtp.layers.0.self_attn.v_proj.weight")?,
-        o_proj_w: shards.load_bf16_to_gpu(ordinal, "mtp.layers.0.self_attn.o_proj.weight")?,
-        q_norm_w: shards.load_bf16_to_gpu(ordinal, "mtp.layers.0.self_attn.q_norm.weight")?,
-        k_norm_w: shards.load_bf16_to_gpu(ordinal, "mtp.layers.0.self_attn.k_norm.weight")?,
-        gate_w: shards.load_bf16_to_gpu(ordinal, "mtp.layers.0.mlp.gate.weight")?,
-        gate_up_proj_w: shards
-            .load_bf16_to_gpu(ordinal, "mtp.layers.0.mlp.experts.gate_up_proj")?,
-        down_proj_w: shards
-            .load_bf16_to_gpu(ordinal, "mtp.layers.0.mlp.experts.down_proj")?,
-        shared_gate_proj_w: shards
-            .load_bf16_to_gpu(ordinal, "mtp.layers.0.mlp.shared_expert.gate_proj.weight")?,
-        shared_up_proj_w: shards
-            .load_bf16_to_gpu(ordinal, "mtp.layers.0.mlp.shared_expert.up_proj.weight")?,
-        shared_down_proj_w: shards
-            .load_bf16_to_gpu(ordinal, "mtp.layers.0.mlp.shared_expert.down_proj.weight")?,
-        shared_expert_gate_w: shards
-            .load_bf16_to_gpu(ordinal, "mtp.layers.0.mlp.shared_expert_gate.weight")?,
+        pre_fc_norm_hidden_w: store.load_to_gpu("mtp.pre_fc_norm_hidden.weight", ordinal)?,
+        pre_fc_norm_embedding_w: store.load_to_gpu("mtp.pre_fc_norm_embedding.weight", ordinal)?,
+        fc_w: store.load_to_gpu("mtp.fc.weight", ordinal)?,
+        norm_w: store.load_to_gpu("mtp.norm.weight", ordinal)?,
+        input_norm_w: store.load_to_gpu("mtp.layers.0.input_layernorm.weight", ordinal)?,
+        post_attn_norm_w: store
+            .load_to_gpu("mtp.layers.0.post_attention_layernorm.weight", ordinal)?,
+        q_proj_w: store.load_to_gpu("mtp.layers.0.self_attn.q_proj.weight", ordinal)?,
+        k_proj_w: store.load_to_gpu("mtp.layers.0.self_attn.k_proj.weight", ordinal)?,
+        v_proj_w: store.load_to_gpu("mtp.layers.0.self_attn.v_proj.weight", ordinal)?,
+        o_proj_w: store.load_to_gpu("mtp.layers.0.self_attn.o_proj.weight", ordinal)?,
+        q_norm_w: store.load_to_gpu("mtp.layers.0.self_attn.q_norm.weight", ordinal)?,
+        k_norm_w: store.load_to_gpu("mtp.layers.0.self_attn.k_norm.weight", ordinal)?,
+        gate_w: store.load_to_gpu("mtp.layers.0.mlp.gate.weight", ordinal)?,
+        gate_up_proj_w: store.load_to_gpu("mtp.layers.0.mlp.experts.gate_up_proj", ordinal)?,
+        down_proj_w: store.load_to_gpu("mtp.layers.0.mlp.experts.down_proj", ordinal)?,
+        shared_gate_proj_w: store
+            .load_to_gpu("mtp.layers.0.mlp.shared_expert.gate_proj.weight", ordinal)?,
+        shared_up_proj_w: store
+            .load_to_gpu("mtp.layers.0.mlp.shared_expert.up_proj.weight", ordinal)?,
+        shared_down_proj_w: store
+            .load_to_gpu("mtp.layers.0.mlp.shared_expert.down_proj.weight", ordinal)?,
+        shared_expert_gate_w: store
+            .load_to_gpu("mtp.layers.0.mlp.shared_expert_gate.weight", ordinal)?,
         kv_cache,
     })
+}
+
+fn open_mtp_bake(model_dir: &Path) -> Result<BakedStore> {
+    let bake_dir = model_store::bake_dir_int4(model_dir);
+    BakedStore::open(&bake_dir)
+        .with_context(|| format!("open INT4 bake at {}", bake_dir.display()))
 }
 
 fn parse_geom(json: &Value) -> MultiLayerGeom {
@@ -262,13 +263,16 @@ fn qwen36_moe_mtp_layer_forward_matches_oracle() {
     set_backend(Backend::Hip);
     let ordinal = 0usize;
 
-    eprintln!("[mtp parity] loading mtp.* tensors from {} ...", model_dir.display());
-    let shards = SafetensorsShards::open(&model_dir).expect("open safetensors");
+    eprintln!(
+        "[mtp parity] loading mtp.* tensors from INT4 bake under {} ...",
+        model_dir.display()
+    );
+    let store = open_mtp_bake(&model_dir).expect("open INT4 bake");
     // Cache big enough to hold all draft steps if the test grew. K=1 here
     // is enough for the first step but we size for K=4 to give headroom.
     let kv_max_t = 4usize;
-    let mut mtp = load_mtp_buffers_from_safetensors(&shards, ordinal, &geom, kv_max_t)
-        .expect("load MtpLayerBuffers from safetensors");
+    let mut mtp = load_mtp_buffers_from_bake(&store, ordinal, &geom, kv_max_t)
+        .expect("load MtpLayerBuffers from bake");
     let mut scratch = alloc_mtp_forward_scratch(ordinal, &geom, kv_max_t)
         .expect("alloc mtp scratch");
 
@@ -383,12 +387,13 @@ fn qwen36_moe_mtp_draft_step_matches_oracle() {
     let ordinal = 0usize;
 
     eprintln!(
-        "[mtp draft] loading mtp.* + tied lm_head.weight from {} ...",
+        "[mtp draft] loading mtp.* from INT4 bake + tied lm_head.weight from safetensors under {} ...",
         model_dir.display()
     );
+    let store = open_mtp_bake(&model_dir).expect("open INT4 bake");
     let shards = SafetensorsShards::open(&model_dir).expect("open safetensors");
     let kv_max_t = 4usize;
-    let mut mtp = load_mtp_buffers_from_safetensors(&shards, ordinal, &geom, kv_max_t)
+    let mut mtp = load_mtp_buffers_from_bake(&store, ordinal, &geom, kv_max_t)
         .expect("load mtp buffers");
     let lm_head_w = shards
         .load_bf16_to_gpu(ordinal, "lm_head.weight")

--- a/oracle/bake_int4.py
+++ b/oracle/bake_int4.py
@@ -1417,8 +1417,8 @@ def load_raw_tensor_bf16(
         raise KeyError(f"raw tensor not found: {name}")
     scale_name = f"{name}_scale_inv"
     scale = loader.get(scale_name) if loader is not None else load_raw_tensor(model_dir, scale_name)
-    if scale is not None and t.dim() == 2:
-        return dequant_fp8_blocks(t, scale)
+    if scale is not None:
+        return dequant_fp8_tensor(t, scale)
     return t.to(torch.bfloat16)
 
 


### PR DESCRIPTION
## Summary

- enable the Qwen3.6 35B A3B INT4 lane for HIP `gfx942`
- allow the runtime to resolve mixed-prefix Qwen3.6 fused expert tensors in the INT4 bake
- fix INT4 bake pass-through loading so non-2D FP8 tensors, including MTP fused experts, dequantize through the generic FP8 tensor path
- update the MTP parity harness to load MTP tensors from the runtime bake instead of raw safetensors

## Validation

- `HIP_ARCH=gfx942 cargo check -p runner --bin supersonic`
- `HIP_ARCH=gfx942 cargo test --release -p runner gfx942 -- --nocapture`
- `HIP_ARCH=gfx942 cargo test --release -p runner qwen36_moe_registry_entries_carry_real_geometry -- --nocapture`
- Qwen3.6 35B A3B INT4 dry-run on this MI300X reports `ready-for-decode: YES`
- Qwen3.6 35B A3B INT4 one-token decode on this MI300X completed successfully after the refreshed bake

## Notes

The refreshed local bake lives at `/models/supersonic-cdna/qwen3.6-35b-a3b-fp8/.supersonic/v2-int4-gptq`; the previous bake was kept at `/models/supersonic-cdna/qwen3.6-35b-a3b-fp8/.supersonic/v2-int4-gptq-before-cdna-refresh`.

The MTP parity test now exercises the same bake path as runtime, but the MTP layer parity still fails numerically on a freshly generated synthetic fixture. That path is not used by normal Qwen3.6 decode; `--speculative-decode` still only loads MTP weights and does not run draft/verify yet, so this PR keeps the base CDNA INT4 lane separate from speculative decode correctness.
