### PR TITLE
qwen36-moe: speculative driver orchestration primitive (Phase 6.3c)

### DIFF
--- a/crates/runner/src/qwen36_moe_speculative.rs
+++ b/crates/runner/src/qwen36_moe_speculative.rs
@@ -354,13 +354,22 @@ where
         );
     }
     if num_drafts == 0 {
-        // K=0 degenerate: no MTP work. The driver caller is expected
-        // to use plain greedy decode in this case; this branch keeps
-        // the function total in case a tunable hits 0.
+        // K=0 degenerate: no MTP work, but the contract still requires
+        // we emit one token (the function is documented as always
+        // returning a non-empty `emitted_tokens` so the caller's
+        // `position += emitted.len()` advances). Run a single base
+        // step at `base_position` with `first_token_id` — exactly
+        // what plain greedy decode would do for this token. This
+        // keeps the speculative driver a safe drop-in even when a
+        // tunable disables speculation, avoiding the stalled-loop
+        // failure mode the `--speculative-decode --num-speculative
+        // -tokens=0` knob would otherwise hit.
+        let (predicted, fh) = base_step(base_position, first_token_id)
+            .context("speculative: K=0 fallback base step")?;
         return Ok(SpeculativeStepResult {
-            emitted_tokens: Vec::new(),
+            emitted_tokens: vec![predicted],
             n_accepted: 0,
-            final_hidden_bytes: h_base_in.to_vec(),
+            final_hidden_bytes: fh,
         });
     }
 

--- a/crates/runner/src/qwen36_moe_speculative.rs
+++ b/crates/runner/src/qwen36_moe_speculative.rs
@@ -1,9 +1,30 @@
 //! Qwen3.6-MoE self-speculative decoding — Phase 6.3 building blocks.
 //!
 //! This module hosts the orchestration layer that ties the MTP draft
-//! chain (`crate::qwen36_moe_mtp`) to the base-model verifier. The
-//! current contents are pure-logic helpers — the GPU-bound speculative
-//! driver that wires this into `decode_text` lands in Phase 6.3c.
+//! chain (`crate::qwen36_moe_mtp`) to the base-model verifier.
+//!
+//! Phase 6.3b shipped the pure-logic accept-prefix helpers
+//! ([`accept_prefix_greedy`], [`accept_prefix_greedy_partial`]).
+//! Phase 6.3c (this module after the next round) adds
+//! [`run_speculative_decode_step`], which orchestrates one full
+//! speculative iteration: MTP draft chain → sequential base
+//! verification with early termination → accept-prefix → emitted
+//! tokens. The base stepper is injected as a callback so the
+//! orchestration is testable with a mock that doesn't need the
+//! full Qwen3.6-MoE model loaded; engine wiring under
+//! `--speculative-decode` is Phase 6.3d.
+//!
+//! ## Performance note
+//!
+//! Sequential verification has zero amortized speedup over plain
+//! greedy decode: each accepted draft still requires one base step
+//! (to produce the next prediction), and rejected drafts incur a
+//! base step too (for the rejection check). Total base steps per
+//! emitted token stays at 1.0 on average. The actual throughput
+//! win comes from Phase 6.4's batched verification kernel, which
+//! runs all K verify steps in a single base call (multi-query
+//! attention). Phase 6.3 builds the protocol and validates
+//! correctness; Phase 6.4 makes it fast.
 //!
 //! Speculative decoding (greedy) at a glance:
 //!
@@ -204,6 +225,222 @@ pub fn accept_prefix_greedy_partial(
         accepted_drafts: drafts.to_vec(),
         corrected_token: base_predictions[drafts.len()],
     }
+}
+
+// ============================================================================
+// Phase 6.3c: speculative-decode driver (orchestration only)
+// ----------------------------------------------------------------------------
+// `run_speculative_decode_step` runs one full speculative iteration:
+//
+//   1. Upload h_base (last base step's final-hidden) to GPU.
+//   2. Run K-step MTP draft chain → K candidate tokens.
+//   3. Sequential base verification with early termination on first
+//      mismatch. Each verify iter is one base decode step at the
+//      corresponding position, fed via the caller-supplied
+//      `base_step` closure.
+//   4. Apply the accept-prefix logic from Phase 6.3b.
+//   5. Return the emitted tokens + n_accepted + final-hidden bytes
+//      (so the next speculative step has a fresh `h_base`).
+//
+// The `base_step` callback abstraction is what makes this testable
+// without the full Qwen3.6-MoE model loaded. The real engine wraps
+// `lookup_embed_row` + `run_chained_decode_fast` + `lm_head_launch`
+// + host argmax in the closure; tests pass a mock that returns canned
+// predictions and synthesised final-hidden bytes.
+// ============================================================================
+
+use anyhow::{Context, Result};
+use gpu_hal::{GpuBuffer, ScalarType};
+
+use crate::qwen36_moe_decode::{MtpLayerBuffers, MultiLayerGeom};
+use crate::qwen36_moe_mtp::{
+    run_mtp_draft_chain, MtpChainScratch, MtpForwardScratch,
+};
+
+/// Result of one speculative-decode step.
+#[derive(Debug, Clone)]
+pub struct SpeculativeStepResult {
+    /// Tokens to commit this step, in order. Always length 1..=K+1
+    /// (always at least one token: the corrected/bonus token).
+    pub emitted_tokens: Vec<u32>,
+    /// Number of MTP drafts accepted (0..=K). Exposed for stats /
+    /// `--emit-stage-timings` / acceptance-rate logging.
+    pub n_accepted: usize,
+    /// `[hidden]` BF16 little-endian — the final-hidden bytes from
+    /// the LAST base decode step that ran during this iteration.
+    /// Becomes the next speculative step's `h_base` per the vLLM
+    /// recurrent equation.
+    pub final_hidden_bytes: Vec<u8>,
+}
+
+/// Run one speculative-decode iteration.
+///
+/// ## Inputs
+///
+/// - `mtp`, `forward_scratch`, `chain_scratch`, `embed_w_buf`,
+///   `lm_head_w_buf`: same as [`run_mtp_draft_chain`] (Phase 6.3a).
+/// - `h_base_in`: `[hidden]` BF16 — the LAST base step's final-hidden
+///   bytes (the input to the base's lm_head that produced
+///   `first_token_id`). Becomes MTP's `h_base` for step 0.
+/// - `first_token_id`: the token the base just sampled (= `T_{p+1}`
+///   in the docstring above). Becomes MTP's `next_token_id` at
+///   step 0 and the base verifier's first input.
+/// - `base_position`: absolute base position of `first_token_id` —
+///   the cache slot it WILL be written to when the verify loop
+///   feeds it. Per the engine convention, this equals
+///   `decode_text`'s `position` value AFTER the regular sample
+///   that produced `first_token_id`.
+/// - `num_drafts` (K): how many MTP drafts to generate.
+///
+/// ## `base_step` closure contract
+///
+/// Each call advances the base by one step:
+///
+///   `(predicted_next_token, final_hidden_bytes) = base_step(position, input_token)`
+///
+/// where:
+///   - `position`: cache slot to write `input_token`'s K/V into.
+///     The implementation must run the base chain at `position`
+///     and produce logits for `position + 1`.
+///   - `input_token`: token id to embed and feed at `position`.
+///   - `predicted_next_token`: greedy argmax over the produced
+///     logits (= base's prediction for `position + 1`).
+///   - `final_hidden_bytes`: `[hidden]` BF16 — the chain output the
+///     lm_head consumed.  Used both for the next speculative step's
+///     `h_base` and for diagnostics.
+///
+/// The closure is called K times when all drafts are accepted (the
+/// K-th call produces the bonus prediction), or `j+1` times when the
+/// j-th draft is rejected (j in 0..K-1).
+///
+/// ## Output
+///
+/// `emitted_tokens` is `accepted_drafts ++ [corrected_or_bonus]`,
+/// always non-empty. Caller appends to `generated_ids` and advances
+/// `position` by `emitted_tokens.len()`.
+///
+/// ## Performance
+///
+/// Sequential verification has zero amortized speedup over plain
+/// greedy decode: each iter still runs one full base step. The MTP
+/// chain is the only "free" compute (~K layers vs the base's
+/// 40 layers per step). Phase 6.4's batched verification kernel
+/// is what delivers throughput.
+#[allow(clippy::too_many_arguments)]
+pub fn run_speculative_decode_step<F>(
+    ordinal: usize,
+    geom: &MultiLayerGeom,
+    mtp: &mut MtpLayerBuffers,
+    forward_scratch: &mut MtpForwardScratch,
+    chain_scratch: &mut MtpChainScratch,
+    embed_w_buf: &GpuBuffer,
+    lm_head_w_buf: &GpuBuffer,
+    h_base_in: &[u8],
+    first_token_id: u32,
+    base_position: i32,
+    num_drafts: usize,
+    mut base_step: F,
+) -> Result<SpeculativeStepResult>
+where
+    F: FnMut(i32, u32) -> Result<(u32, Vec<u8>)>,
+{
+    let hidden = geom.hidden as usize;
+    if h_base_in.len() != hidden * 2 {
+        anyhow::bail!(
+            "run_speculative_decode_step: h_base_in.len() {} != \
+             hidden*2 ({}) BF16 bytes",
+            h_base_in.len(),
+            hidden * 2
+        );
+    }
+    if num_drafts == 0 {
+        // K=0 degenerate: no MTP work. The driver caller is expected
+        // to use plain greedy decode in this case; this branch keeps
+        // the function total in case a tunable hits 0.
+        return Ok(SpeculativeStepResult {
+            emitted_tokens: Vec::new(),
+            n_accepted: 0,
+            final_hidden_bytes: h_base_in.to_vec(),
+        });
+    }
+
+    // --- 1. Upload h_base for the MTP chain. ---
+    let h_base_buf = GpuBuffer::from_host_bytes(
+        ordinal,
+        ScalarType::BF16,
+        &[hidden],
+        h_base_in,
+    )
+    .context("speculative: upload h_base")?;
+
+    // --- 2. Generate K MTP drafts. ---
+    let drafts_records = run_mtp_draft_chain(
+        ordinal,
+        geom,
+        mtp,
+        base_position,
+        &h_base_buf,
+        first_token_id,
+        num_drafts,
+        embed_w_buf,
+        lm_head_w_buf,
+        forward_scratch,
+        chain_scratch,
+    )
+    .context("speculative: MTP draft chain")?;
+    let drafts: Vec<u32> = drafts_records.iter().map(|r| r.draft_token_id).collect();
+
+    // --- 3. Sequential verify with early termination. ---
+    //
+    // Iter k (k in 0..K):
+    //   feed `input_k` at position `base_position + k`,
+    //   read `predicted_k` = base's prediction for `base_position + k + 1`,
+    //   compare to drafts[k].
+    //
+    // input_0 = first_token_id (= T_{base_position}, just sampled).
+    // input_k (k > 0) = drafts[k-1] (the just-accepted token).
+    //
+    // First mismatch at k: emit drafts[..k] ++ [predicted_k]; n_accepted = k.
+    // No mismatch through k = K-1: emit drafts[..K] ++ [bonus]; n_accepted = K.
+    //   The bonus is computed by an extra base step at position
+    //   `base_position + K` with input = drafts[K-1] — the K+1-th
+    //   call to `base_step`.
+
+    let mut emitted: Vec<u32> = Vec::with_capacity(num_drafts + 1);
+    let mut last_final_hidden: Vec<u8> = h_base_in.to_vec();
+    let mut input = first_token_id;
+
+    for k in 0..num_drafts {
+        let pos = base_position + (k as i32);
+        let (predicted, fh) = base_step(pos, input)
+            .with_context(|| format!("speculative: base verify k={k} pos={pos}"))?;
+        last_final_hidden = fh;
+        if predicted == drafts[k] {
+            // Accept drafts[k]. Carry forward as next iter's input.
+            emitted.push(drafts[k]);
+            input = drafts[k];
+        } else {
+            // Reject. predicted replaces drafts[k]; stop here.
+            emitted.push(predicted);
+            return Ok(SpeculativeStepResult {
+                emitted_tokens: emitted,
+                n_accepted: k,
+                final_hidden_bytes: last_final_hidden,
+            });
+        }
+    }
+
+    // All K drafts accepted. Bonus base step at position p+K with
+    // input = drafts[K-1] (= last accepted token).
+    let pos = base_position + (num_drafts as i32);
+    let (bonus, fh) = base_step(pos, input)
+        .with_context(|| format!("speculative: bonus base step pos={pos}"))?;
+    emitted.push(bonus);
+    Ok(SpeculativeStepResult {
+        emitted_tokens: emitted,
+        n_accepted: num_drafts,
+        final_hidden_bytes: fh,
+    })
 }
 
 #[cfg(test)]

--- a/crates/runner/tests/qwen36_moe_mtp_parity.rs
+++ b/crates/runner/tests/qwen36_moe_mtp_parity.rs
@@ -42,6 +42,9 @@ use runner::qwen36_moe_mtp::{
     alloc_mtp_chain_scratch, alloc_mtp_forward_scratch, run_mtp_draft_chain,
     run_mtp_draft_step, run_mtp_layer_step,
 };
+use runner::qwen36_moe_speculative::{
+    run_speculative_decode_step, SpeculativeStepResult,
+};
 use safetensors::SafeTensors;
 use serde_json::Value;
 
@@ -599,4 +602,150 @@ fn qwen36_moe_mtp_draft_chain_matches_oracle() {
             /* max_abs */ 1.0, /* cos_sim_floor */ 0.999,
         );
     }
+}
+
+/// Phase 6.3c integration test: validate `run_speculative_decode_step`
+/// orchestration end-to-end using the real MTP chain on the loaded
+/// `mtp.*` weights, plus a controlled mock `base_step` closure that
+/// returns canned predictions. The mock is what makes this testable
+/// on the local 24 GiB box without needing the full ~17 GiB INT4 base
+/// model loaded — we just need to confirm the driver's verify loop +
+/// accept-prefix logic produces the right `emitted_tokens` for known
+/// mock-prediction patterns.
+///
+/// Three passes cover the three accept-prefix outcomes:
+///   - Pass 1: mock agrees with all drafts → full-accept + bonus.
+///   - Pass 2: mock disagrees on draft index 1 → partial-accept.
+///   - Pass 3: mock disagrees immediately → zero-accept.
+#[test]
+fn qwen36_moe_speculative_driver_orchestration() {
+    if !is_backend_compiled(Backend::Hip) {
+        eprintln!("skip: HIP backend not compiled");
+        return;
+    }
+    let Ok(json_path) = std::env::var("SUPERSONIC_QWEN36_MTP_ORACLE_JSON") else {
+        eprintln!("skip: SUPERSONIC_QWEN36_MTP_ORACLE_JSON not set");
+        return;
+    };
+    let Ok(model_dir) = std::env::var("SUPERSONIC_QWEN36_MTP_MODEL_DIR") else {
+        eprintln!("skip: SUPERSONIC_QWEN36_MTP_MODEL_DIR not set");
+        return;
+    };
+    let model_dir = PathBuf::from(model_dir);
+
+    let raw = std::fs::read_to_string(&json_path).expect("read mtp oracle json");
+    let json: Value = serde_json::from_str(&raw).expect("mtp oracle json parse");
+    let geom = parse_geom(&json);
+    let base_seq_len = json["base_seq_len"].as_i64().unwrap() as i32;
+    let base_next_token_id = json["base_next_token_id"].as_i64().unwrap() as u32;
+    let h_base_bytes = b64(json["h_base_step0_bf16"].as_str().unwrap());
+    let want_drafts: Vec<u32> = json["draft_token_ids"]
+        .as_array().expect("draft_token_ids")
+        .iter().map(|v| v.as_u64().expect("u64") as u32).collect();
+    let k = want_drafts.len();
+    eprintln!("[spec] K={k} oracle drafts={want_drafts:?}");
+
+    set_backend(Backend::Hip);
+    let ordinal = 0usize;
+
+    eprintln!("[spec] loading mtp.* + embed_tokens + tied lm_head ...");
+    let shards = SafetensorsShards::open(&model_dir).expect("open safetensors");
+    let mut mtp = load_mtp_buffers_from_safetensors(&shards, ordinal, &geom, k.max(1))
+        .expect("load mtp buffers");
+    let embed_w = shards
+        .load_bf16_to_gpu(ordinal, "model.language_model.embed_tokens.weight")
+        .expect("load embed_tokens.weight");
+    let lm_head_w = shards
+        .load_bf16_to_gpu(ordinal, "lm_head.weight")
+        .expect("load lm_head.weight");
+
+    let mut forward_scratch = alloc_mtp_forward_scratch(ordinal, &geom, k.max(1))
+        .expect("alloc fwd scratch");
+    let mut chain_scratch = alloc_mtp_chain_scratch(ordinal, &geom)
+        .expect("alloc chain scratch");
+
+    let synth_fh = vec![0u8; (geom.hidden as usize) * 2];
+
+    // ---- Pass 1: full-accept ----
+    let bonus_token_pass1: u32 = 999;
+    let mut step_idx = 0usize;
+    let want_drafts_p1 = want_drafts.clone();
+    let synth_fh_p1 = synth_fh.clone();
+    let base_step_p1 = move |_pos: i32, _input: u32|
+        -> anyhow::Result<(u32, Vec<u8>)>
+    {
+        let predicted = if step_idx < want_drafts_p1.len() {
+            want_drafts_p1[step_idx]
+        } else {
+            bonus_token_pass1
+        };
+        step_idx += 1;
+        Ok((predicted, synth_fh_p1.clone()))
+    };
+    eprintln!("[spec] pass 1 (full-accept)");
+    let r1 = run_speculative_decode_step(
+        ordinal, &geom, &mut mtp,
+        &mut forward_scratch, &mut chain_scratch,
+        &embed_w, &lm_head_w,
+        &h_base_bytes, base_next_token_id, base_seq_len, k,
+        base_step_p1,
+    ).expect("pass 1 run");
+    let mut want1 = want_drafts.clone();
+    want1.push(bonus_token_pass1);
+    assert_eq!(r1.emitted_tokens, want1);
+    assert_eq!(r1.n_accepted, k);
+    eprintln!("[spec] pass 1: emitted={:?} n_accepted={}", r1.emitted_tokens, r1.n_accepted);
+
+    // ---- Pass 2: partial-accept (k>=2 only) ----
+    if k >= 2 {
+        let bad_pred: u32 = 12345;
+        let mut step_idx = 0usize;
+        let first_match = want_drafts[0];
+        let synth_fh_p2 = synth_fh.clone();
+        let base_step_p2 = move |_pos: i32, _input: u32|
+            -> anyhow::Result<(u32, Vec<u8>)>
+        {
+            let predicted = if step_idx == 0 { first_match } else { bad_pred };
+            step_idx += 1;
+            Ok((predicted, synth_fh_p2.clone()))
+        };
+        eprintln!("[spec] pass 2 (reject at k=1)");
+        let r2 = run_speculative_decode_step(
+            ordinal, &geom, &mut mtp,
+            &mut forward_scratch, &mut chain_scratch,
+            &embed_w, &lm_head_w,
+            &h_base_bytes, base_next_token_id, base_seq_len, k,
+            base_step_p2,
+        ).expect("pass 2 run");
+        assert_eq!(r2.emitted_tokens, vec![want_drafts[0], bad_pred]);
+        assert_eq!(r2.n_accepted, 1);
+        eprintln!("[spec] pass 2: emitted={:?} n_accepted={}", r2.emitted_tokens, r2.n_accepted);
+    } else {
+        eprintln!("[spec] pass 2 skipped (K={k} too small)");
+    }
+
+    // ---- Pass 3: zero-accept (immediate reject) ----
+    let bad_pred: u32 = 67890;
+    let synth_fh_p3 = synth_fh.clone();
+    let base_step_p3 = move |_pos: i32, _input: u32|
+        -> anyhow::Result<(u32, Vec<u8>)>
+    {
+        Ok((bad_pred, synth_fh_p3.clone()))
+    };
+    eprintln!("[spec] pass 3 (reject at k=0)");
+    let r3 = run_speculative_decode_step(
+        ordinal, &geom, &mut mtp,
+        &mut forward_scratch, &mut chain_scratch,
+        &embed_w, &lm_head_w,
+        &h_base_bytes, base_next_token_id, base_seq_len, k,
+        base_step_p3,
+    ).expect("pass 3 run");
+    assert_eq!(r3.emitted_tokens, vec![bad_pred]);
+    assert_eq!(r3.n_accepted, 0);
+    eprintln!("[spec] pass 3: emitted={:?} n_accepted={}", r3.emitted_tokens, r3.n_accepted);
+
+    // The driver should produce a final-hidden buffer of the right size
+    // regardless of which pass ran.
+    assert_eq!(r3.final_hidden_bytes.len(), (geom.hidden as usize) * 2);
+    let _ = SpeculativeStepResult { ..r3 };
 }

--- a/crates/runner/tests/qwen36_moe_mtp_parity.rs
+++ b/crates/runner/tests/qwen36_moe_mtp_parity.rs
@@ -748,4 +748,34 @@ fn qwen36_moe_speculative_driver_orchestration() {
     // regardless of which pass ran.
     assert_eq!(r3.final_hidden_bytes.len(), (geom.hidden as usize) * 2);
     let _ = SpeculativeStepResult { ..r3 };
+
+    // ---- Pass 4: K=0 fallback (no speculation; emit one base token) ----
+    //
+    // Contract: `emitted_tokens` must always be non-empty (the
+    // engine relies on `position += emitted.len()` for forward
+    // progress). When K=0 the driver still runs one base step and
+    // emits its prediction — equivalent to plain greedy decode.
+    let k0_pred: u32 = 4242;
+    let synth_fh_p4 = synth_fh.clone();
+    let mut p4_calls = 0usize;
+    let base_step_p4 = move |_pos: i32, _input: u32|
+        -> anyhow::Result<(u32, Vec<u8>)>
+    {
+        p4_calls += 1;
+        assert_eq!(p4_calls, 1, "K=0 must run exactly one base step");
+        Ok((k0_pred, synth_fh_p4.clone()))
+    };
+    eprintln!("[spec] pass 4 (K=0 fallback)");
+    let r4 = run_speculative_decode_step(
+        ordinal, &geom, &mut mtp,
+        &mut forward_scratch, &mut chain_scratch,
+        &embed_w, &lm_head_w,
+        &h_base_bytes, base_next_token_id, base_seq_len, /* num_drafts */ 0,
+        base_step_p4,
+    ).expect("pass 4 run");
+    assert_eq!(r4.emitted_tokens, vec![k0_pred],
+        "K=0 must still emit exactly one token (the contract is non-empty)");
+    assert_eq!(r4.n_accepted, 0);
+    assert_eq!(r4.final_hidden_bytes.len(), (geom.hidden as usize) * 2);
+    eprintln!("[spec] pass 4: emitted={:?} n_accepted={}", r4.emitted_tokens, r4.n_accepted);
 }


### PR DESCRIPTION
## Summary
Orchestrates one full speculative-decode iteration: MTP draft chain → sequential base verification with early termination → accept-prefix → emitted tokens. The base-step closure abstraction makes the orchestration testable on the local 24 GiB box without needing the full ~17 GiB INT4 base model loaded — the integration test loads only the `mtp.*` weights + `embed_tokens` + tied `lm_head` (~3.6 GiB GPU) and supplies controlled mock predictions.

## API

```rust
pub struct SpeculativeStepResult {
    pub emitted_tokens: Vec<u32>,
    pub n_accepted: usize,
    pub final_hidden_bytes: Vec<u8>,
}

pub fn run_speculative_decode_step<F>(
    ordinal, geom, mtp, forward_scratch, chain_scratch,
    embed_w_buf, lm_head_w_buf,
    h_base_in, first_token_id, base_position, num_drafts,
    mut base_step: F,
) -> Result<SpeculativeStepResult>
where F: FnMut(i32, u32) -> Result<(u32, Vec<u8>)>;
```

The `base_step` closure runs one base decode step (chain at `position` with `input_token`, lm_head, host argmax) and returns `(predicted_token, final_hidden_bytes)`. Phase 6.3d's engine integration wires this to `run_chained_decode_fast` + `lm_head_launch`; the unit tests use mock closures.

## Test plan

`qwen36_moe_speculative_driver_orchestration` (new) — 3 passes covering all three accept-prefix outcomes:
```
[spec] K=3 oracle drafts=[12, 689, 12]
[spec] pass 1 (full-accept):     emitted=[12, 689, 12, 999]   n_accepted=3
[spec] pass 2 (reject at k=1):   emitted=[12, 12345]          n_accepted=1
[spec] pass 3 (reject at k=0):   emitted=[67890]              n_accepted=0
```
- [x] Full sweep: 4 integration tests + 9 unit tests, all green.
- [x] Skip path clean when env vars absent.

## Performance note (relevant to the master plan)
Sequential verification has zero amortized speedup over plain greedy decode: each accepted draft requires one base step to produce the next prediction, and rejected drafts incur a base step for the rejection check. Total base steps per emitted token stays at 1.0 average.

The actual throughput win comes from **Phase 6.4's batched verification kernel** — multi-query attention runs all K verifies in a single base call, dropping per-emitted-token base-step cost from 1.0 to ~1/(j+1) where j = avg accepted drafts. Phase 6.3 builds and validates the protocol; Phase 6.4 makes it fast.

## Phase 6.3 sequencing
- ✅ 6.3a: K-step MTP draft chain (PR #97)
- ✅ 6.3a-followups: real-prefill envelope tuning (PRs #98, follow-ups)
- ✅ 6.3b: accept-prefix helper (PR #99)
- ✅ 6.3c (this PR): speculative driver orchestration primitive
- ⏳ 6.3d: engine wiring under `--speculative-decode` flag — wraps the existing `run_chained_decode_fast` + `lm_head_launch` as the `base_step` closure, threads `MtpForwardScratch`/`MtpChainScratch` through the engine, validates by running the CLI with and without `--speculative-decode` on greedy mode (output should be identical token-for-token).

🤖 Generated with [Claude Code](https://claude.com/claude-code)