### PR TITLE
[codex] Enable Gemma 4 E2B INT4 on CDNA

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ see [docs/dflash.md](docs/dflash.md).
 | qwen3.5-4b       | ✅¹  | ✅²  |      —      |   —    |
 | qwen3.5-9b       | ✅¹  | ✅²  |      —      |   —    |
 | qwen3.6-35b-a3b  |  —   | ✅⁴  |      —      |   —    |
-| gemma4-e2b       | ✅³  |  —   |      —      |   —    |
+| gemma4-e2b       | ✅³  | ✅⁵  |      —      |   —    |
 | gemma4-e4b       |  —   |  —   |      —      |   —    |
 | phi4-mini        |  —   |  —   |      —      |   —    |
 
@@ -90,6 +90,8 @@ see [docs/dflash.md](docs/dflash.md).
   have the Qwen GPU replay validator wired up.
 ⁴ Qwen3.6 35B A3B currently uses the INT4 GPTQ bake and the host-orchestrated
   HIP chained decode path; performance work is still pending.
+⁵ Gemma 4 E2B INT4 uses the GPTQ bake and the existing Gemma 4 INT4 primitive
+  chain on CDNA; performance tuning is still pending.
 
 ### CUDA on `sm86`
 

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -1254,19 +1254,16 @@ fn main() -> Result<()> {
                 | ModelVariant::Gemma4_E2B
         ) {
             anyhow::bail!(
-                "HIP gfx942 bring-up currently validates only Qwen3.5 models up to 9B, Qwen3.6 35B A3B INT4, and Gemma 4 E2B BF16"
+                "HIP gfx942 bring-up currently validates only Qwen3.5 models up to 9B, Qwen3.6 35B A3B INT4, and Gemma 4 E2B BF16/INT4"
             );
         }
         if cli.fp8_runtime || cli.kv_fp8 || cli.q4km || cli.q4km_gptq {
             anyhow::bail!(
-                "HIP gfx942 bring-up currently validates only BF16 and INT4 Qwen3.5 lanes, Qwen3.6 35B A3B INT4, and Gemma 4 E2B BF16"
+                "HIP gfx942 bring-up currently validates only BF16 and INT4 Qwen3.5 lanes, Qwen3.6 35B A3B INT4, and Gemma 4 E2B BF16/INT4"
             );
         }
         if matches!(model_variant, ModelVariant::Qwen3_6_35B_A3B) && !cli.int4 {
             anyhow::bail!("HIP gfx942 Qwen3.6 35B A3B bring-up currently validates only --int4");
-        }
-        if matches!(model_variant, ModelVariant::Gemma4_E2B) && cli.int4 {
-            anyhow::bail!("HIP gfx942 Gemma 4 E2B bring-up currently validates only BF16");
         }
         if cli.batch_size != 1 {
             anyhow::bail!("HIP gfx942 bring-up currently supports only --batch-size 1");


### PR DESCRIPTION
## Summary
- allow Gemma 4 E2B `--int4` on HIP `gfx942`
- update the README support matrix to mark the CDNA Gemma 4 E2B INT4 lane as supported
- leave performance tuning for a later pass; this is correctness-first bring-up

## Validation
- `HIP_ARCH=gfx942 cargo check -p runner --bin supersonic`
- Gemma 4 E2B INT4 bake completed at `/models/supersonic-cdna/gemma4-e2b/.supersonic/v2-int4-gptq/` with `0/275` tensor self-check mismatches and PPL `45.41`
- `HIP_ARCH=gfx942 ./target/release/supersonic --backend hip --model gemma4-e2b --model-dir /models/supersonic-cdna/gemma4-e2b --int4 --prompt "The quick brown fox" --max-new-tokens 4 --context-size 32 --no-download --emit-stage-timings`
- `HIP_ARCH=gfx942 cargo run --release --bin gemma4_fused_int4_validate -- --model-dir /models/supersonic-cdna/gemma4-e2b --prompt "The quick brown fox" --max-new-tokens 4` matched fused vs primitive tokens `[236764, 506, 3823, 8864]`

## Notes
- `HIP_ARCH=gfx942 cargo test --release -p runner gfx942 -- --nocapture` is currently blocked by an unrelated compile error in `crates/runner/tests/qwen36_moe_mtp_parity.rs`: missing `load_mtp_buffers_from_safetensors` in the MTP/speculative area.
