### PR TITLE
[codex] Enable Gemma 4 E4B BF16 on CDNA

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ see [docs/dflash.md](docs/dflash.md).
 | qwen3.5-9b       | ✅¹  | ✅²  |      —      |   —    |
 | qwen3.6-35b-a3b  |  —   | ✅⁴  |      —      |   —    |
 | gemma4-e2b       | ✅³  | ✅⁵  |      —      |   —    |
-| gemma4-e4b       |  —   |  —   |      —      |   —    |
+| gemma4-e4b       | ✅⁶  |  —   |      —      |   —    |
 | phi4-mini        |  —   |  —   |      —      |   —    |
 
 ¹ CDNA single-sequence decode uses the persistent megakernel by default.
@@ -92,6 +92,8 @@ see [docs/dflash.md](docs/dflash.md).
   HIP chained decode path; performance work is still pending.
 ⁵ Gemma 4 E2B INT4 uses the GPTQ bake and the existing Gemma 4 INT4 primitive
   chain on CDNA; performance tuning is still pending.
+⁶ Gemma 4 E4B BF16 uses the existing Gemma 4 HIP kernel path on CDNA;
+  performance tuning is still pending.
 
 ### CUDA on `sm86`
 

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -1255,16 +1255,19 @@ fn main() -> Result<()> {
                 | ModelVariant::Gemma4_E4B
         ) {
             anyhow::bail!(
-                "HIP gfx942 bring-up currently validates only Qwen3.5 models up to 9B, Qwen3.6 35B A3B INT4, and Gemma 4 E2B/E4B BF16/INT4"
+                "HIP gfx942 bring-up currently validates only Qwen3.5 models up to 9B, Qwen3.6 35B A3B INT4, Gemma 4 E2B BF16/INT4, and Gemma 4 E4B BF16"
             );
         }
         if cli.fp8_runtime || cli.kv_fp8 || cli.q4km || cli.q4km_gptq {
             anyhow::bail!(
-                "HIP gfx942 bring-up currently validates only BF16 and INT4 Qwen3.5 lanes, Qwen3.6 35B A3B INT4, and Gemma 4 E2B/E4B BF16/INT4"
+                "HIP gfx942 bring-up currently validates only BF16 and INT4 Qwen3.5 lanes, Qwen3.6 35B A3B INT4, Gemma 4 E2B BF16/INT4, and Gemma 4 E4B BF16"
             );
         }
         if matches!(model_variant, ModelVariant::Qwen3_6_35B_A3B) && !cli.int4 {
             anyhow::bail!("HIP gfx942 Qwen3.6 35B A3B bring-up currently validates only --int4");
+        }
+        if matches!(model_variant, ModelVariant::Gemma4_E4B) && cli.int4 {
+            anyhow::bail!("HIP gfx942 Gemma 4 E4B bring-up currently validates only BF16");
         }
         if cli.batch_size != 1 {
             anyhow::bail!("HIP gfx942 bring-up currently supports only --batch-size 1");

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -1252,14 +1252,15 @@ fn main() -> Result<()> {
                 | ModelVariant::Qwen3_5_9B
                 | ModelVariant::Qwen3_6_35B_A3B
                 | ModelVariant::Gemma4_E2B
+                | ModelVariant::Gemma4_E4B
         ) {
             anyhow::bail!(
-                "HIP gfx942 bring-up currently validates only Qwen3.5 models up to 9B, Qwen3.6 35B A3B INT4, and Gemma 4 E2B BF16/INT4"
+                "HIP gfx942 bring-up currently validates only Qwen3.5 models up to 9B, Qwen3.6 35B A3B INT4, and Gemma 4 E2B/E4B BF16/INT4"
             );
         }
         if cli.fp8_runtime || cli.kv_fp8 || cli.q4km || cli.q4km_gptq {
             anyhow::bail!(
-                "HIP gfx942 bring-up currently validates only BF16 and INT4 Qwen3.5 lanes, Qwen3.6 35B A3B INT4, and Gemma 4 E2B BF16/INT4"
+                "HIP gfx942 bring-up currently validates only BF16 and INT4 Qwen3.5 lanes, Qwen3.6 35B A3B INT4, and Gemma 4 E2B/E4B BF16/INT4"
             );
         }
         if matches!(model_variant, ModelVariant::Qwen3_6_35B_A3B) && !cli.int4 {

--- a/crates/runner/src/registry.rs
+++ b/crates/runner/src/registry.rs
@@ -689,6 +689,19 @@ static REGISTRY: &[RegistryEntry] = &[
             kv_chunk_size: 256,
         }),
     },
+    RegistryEntry {
+        model: ModelVariant::Gemma4_E4B,
+        backend: Backend::Hip,
+        arch: GpuArch::Gfx942,
+        vram: VramBudget {
+            fixed_bytes: 10 * GIB,
+            overhead_factor: 1.1,
+        },
+        params: FamilyParams::Gemma4(Gemma4KernelParams {
+            weight_prefix: "model.language_model",
+            kv_chunk_size: 256,
+        }),
+    },
     // Phi-4-mini: 3.8B dense, full-attention all 32 layers, LongRoPE.
     // BF16 weights ≈ 7.6 GiB; KV cache at 4K ctx ≈ 520 MiB (32 layers × 2 × 8 kv_heads × 128 head_dim × 2 B).
     // Fits gfx1150 with headroom. Weight prefix is bare `model` (Phi stores tensors as `model.*`).
@@ -908,6 +921,7 @@ mod tests {
             ModelVariant::Qwen3_5_9B,
             ModelVariant::Qwen3_6_35B_A3B,
             ModelVariant::Gemma4_E2B,
+            ModelVariant::Gemma4_E4B,
         ] {
             assert!(lookup(&model, &Backend::Hip, &GpuArch::Gfx942).is_some());
         }


### PR DESCRIPTION
## Summary
- add a HIP `gfx942` registry entry for `gemma4-e4b`
- allow Gemma 4 E4B through the CDNA bring-up gate
- update the README support matrix for the E4B BF16 CDNA lane

## Validation
- Downloaded `google/gemma-4-E4B` into `/models/supersonic-cdna/gemma4-e4b` with the HF CLI
- `HIP_ARCH=gfx942 cargo check -p runner --bin supersonic`
- `HIP_ARCH=gfx942 cargo test -p runner --lib registry::tests::hip_gfx942_registry_includes_cdna_targets -- --nocapture`
- `HIP_ARCH=gfx942 cargo test --release -p runner gfx942 -- --nocapture`
- `SUPERSONIC_ORACLE_PYTHON=/opt/supersonic-oracle-venv/bin/python HIP_ARCH=gfx942 ./target/release/supersonic --backend hip --model gemma4-e4b --model-dir /models/supersonic-cdna/gemma4-e4b --prompt "The quick brown fox" --max-new-tokens 4 --context-size 32 --no-download --emit-stage-timings --validate`

## Runtime Notes
- Four-token BF16 validation produced `token_mismatches=0`
- `prefill logit delta=0.4752`
- `decode_max_delta=0.4127`
- Generated tokens: `[38167, 1024, 506, 31770]`
- Decode timing in the smoke was about `69 ms/step`; performance tuning is intentionally left for later.
