### PR TITLE
[codex] Add CDNA Phi-4 mini BF16 bring-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ see [docs/dflash.md](docs/dflash.md).
 | qwen3.6-35b-a3b  |  —   | ✅⁴  |      —      |   —    |
 | gemma4-e2b       | ✅³  | ✅⁵  |      —      |   —    |
 | gemma4-e4b       | ✅⁶  |  —   |      —      |   —    |
-| phi4-mini        |  —   |  —   |      —      |   —    |
+| phi4-mini        | ✅⁷  |  —   |      —      |   —    |
 
 ¹ CDNA single-sequence decode uses the persistent megakernel by default.
   `--force-replay-decode` remains available as the slower GPU-prefill
@@ -94,6 +94,8 @@ see [docs/dflash.md](docs/dflash.md).
   chain on CDNA; performance tuning is still pending.
 ⁶ Gemma 4 E4B BF16 uses the existing Gemma 4 HIP kernel path on CDNA;
   performance tuning is still pending.
+⁷ Phi-4-mini BF16 uses a correctness-first single-block CDNA fallback in the
+  existing Phi-4 HIP kernel path; performance tuning is still pending.
 
 ### CUDA on `sm86`
 

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -1253,14 +1253,15 @@ fn main() -> Result<()> {
                 | ModelVariant::Qwen3_6_35B_A3B
                 | ModelVariant::Gemma4_E2B
                 | ModelVariant::Gemma4_E4B
+                | ModelVariant::Phi4_Mini
         ) {
             anyhow::bail!(
-                "HIP gfx942 bring-up currently validates only Qwen3.5 models up to 9B, Qwen3.6 35B A3B INT4, Gemma 4 E2B BF16/INT4, and Gemma 4 E4B BF16"
+                "HIP gfx942 bring-up currently validates only Qwen3.5 models up to 9B, Qwen3.6 35B A3B INT4, Gemma 4 E2B BF16/INT4, Gemma 4 E4B BF16, and Phi-4-mini BF16"
             );
         }
         if cli.fp8_runtime || cli.kv_fp8 || cli.q4km || cli.q4km_gptq {
             anyhow::bail!(
-                "HIP gfx942 bring-up currently validates only BF16 and INT4 Qwen3.5 lanes, Qwen3.6 35B A3B INT4, Gemma 4 E2B BF16/INT4, and Gemma 4 E4B BF16"
+                "HIP gfx942 bring-up currently validates only BF16 and INT4 Qwen3.5 lanes, Qwen3.6 35B A3B INT4, Gemma 4 E2B BF16/INT4, Gemma 4 E4B BF16, and Phi-4-mini BF16"
             );
         }
         if matches!(model_variant, ModelVariant::Qwen3_6_35B_A3B) && !cli.int4 {
@@ -1268,6 +1269,9 @@ fn main() -> Result<()> {
         }
         if matches!(model_variant, ModelVariant::Gemma4_E4B) && cli.int4 {
             anyhow::bail!("HIP gfx942 Gemma 4 E4B bring-up currently validates only BF16");
+        }
+        if matches!(model_variant, ModelVariant::Phi4_Mini) && cli.int4 {
+            anyhow::bail!("HIP gfx942 Phi-4-mini bring-up currently validates only BF16");
         }
         if cli.batch_size != 1 {
             anyhow::bail!("HIP gfx942 bring-up currently supports only --batch-size 1");

--- a/crates/runner/src/registry.rs
+++ b/crates/runner/src/registry.rs
@@ -733,6 +733,19 @@ static REGISTRY: &[RegistryEntry] = &[
     },
     RegistryEntry {
         model: ModelVariant::Phi4_Mini,
+        backend: Backend::Hip,
+        arch: GpuArch::Gfx942,
+        vram: VramBudget {
+            fixed_bytes: 8 * GIB,
+            overhead_factor: 1.1,
+        },
+        params: FamilyParams::Phi4(Phi4KernelParams {
+            weight_prefix: "model",
+            kv_chunk_size: 256,
+        }),
+    },
+    RegistryEntry {
+        model: ModelVariant::Phi4_Mini,
         backend: Backend::Cuda,
         arch: GpuArch::Sm86,
         vram: VramBudget {
@@ -922,6 +935,7 @@ mod tests {
             ModelVariant::Qwen3_6_35B_A3B,
             ModelVariant::Gemma4_E2B,
             ModelVariant::Gemma4_E4B,
+            ModelVariant::Phi4_Mini,
         ] {
             assert!(lookup(&model, &Backend::Hip, &GpuArch::Gfx942).is_some());
         }

--- a/kernels/phi4_bridge.cpp
+++ b/kernels/phi4_bridge.cpp
@@ -69,7 +69,16 @@ int persistent_decode_phi4_device(
     hipDeviceProp_t props;
     if (hipGetDeviceProperties(&props, device_ordinal) != hipSuccess) return 250;
 
-    const int num_blocks = props.multiProcessorCount > 0 ? props.multiProcessorCount : 16;
+    int num_blocks = props.multiProcessorCount > 0 ? props.multiProcessorCount : 16;
+    // The Phi-4 HIP megakernel was tuned around RDNA wave32. On CDNA wave64,
+    // the multi-block work-stealing path diverges from the HF oracle; keep the
+    // initial CDNA bring-up on a single block for correctness and revisit the
+    // work distribution when optimizing performance.
+    if (props.warpSize > 32) num_blocks = 1;
+    if (const char* override_blocks = std::getenv("SUPERSONIC_PHI4_NUM_BLOCKS")) {
+        const int requested = std::atoi(override_blocks);
+        if (requested > 0) num_blocks = requested;
+    }
     constexpr int block_size = 256;
     // LDS layout matches the 4B kernel: reduction scratch [block_size] + input
     // cache [max(B*hidden_dim, intermediate_size)] + FP8 LUT [256].


### PR DESCRIPTION
## Summary
- add Phi-4-mini BF16 to the HIP gfx942 registry and CLI allowlist
- document gfx942 support as a correctness-first single-block fallback
- force the Phi-4 HIP launch to one block on wave64 devices, with an env override for debugging

## Root Cause
The existing Phi-4 HIP megakernel was tuned around RDNA wave32. On gfx942 wave64, the multi-block work-stealing path diverges from the HF oracle in the first attention layer. A one-block launch matches the oracle within BF16 noise, so this PR prioritizes correctness and leaves performance tuning for a follow-up.

## Validation
- `HIP_ARCH=gfx942 cargo check -p runner --bin supersonic`
- `HIP_ARCH=gfx942 cargo test -p runner --lib registry::tests::hip_gfx942_registry_includes_cdna_targets -- --nocapture`
- `SUPERSONIC_ORACLE_PYTHON=/opt/supersonic-oracle-venv/bin/python HIP_ARCH=gfx942 cargo run --release --bin supersonic -- --backend hip --model phi4-mini --model-dir /models/supersonic-cdna/phi4-mini --prompt "The quick brown fox" --max-new-tokens 4 --context-size 32 --no-download --no-bake --validate`
- `SUPERSONIC_ORACLE_PYTHON=/opt/supersonic-oracle-venv/bin/python HIP_ARCH=gfx942 cargo run --release --bin supersonic -- --backend hip --model phi4-mini --model-dir /models/supersonic-cdna/phi4-mini --prompt "The quick brown fox" --max-new-tokens 2 --context-size 32 --no-download --validate`

Both validation runs produced zero token mismatches; the 4-token raw-safetensors run generated `The quick brown fox jumps over the lazy`.

## Notes
Decode speed is intentionally poor on gfx942 for now, roughly 1.47s/token on this prompt, because the CDNA launch is single-block until the wave64 multi-block path is fixed.