### PR TITLE
[codex] Enable CDNA Phi-4 mini INT4

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ see [docs/dflash.md](docs/dflash.md).
 | qwen3.6-35b-a3b  |  —   | ✅⁴  |      —      |   —    |
 | gemma4-e2b       | ✅³  | ✅⁵  |      —      |   —    |
 | gemma4-e4b       | ✅⁶  |  —   |      —      |   —    |
-| phi4-mini        | ✅⁷  |  —   |      —      |   —    |
+| phi4-mini        | ✅⁷  | ✅⁸  |      —      |   —    |
 
 ¹ CDNA single-sequence decode uses the persistent megakernel by default.
   `--force-replay-decode` remains available as the slower GPU-prefill
@@ -96,6 +96,8 @@ see [docs/dflash.md](docs/dflash.md).
   performance tuning is still pending.
 ⁷ Phi-4-mini BF16 uses a correctness-first single-block CDNA fallback in the
   existing Phi-4 HIP kernel path; performance tuning is still pending.
+⁸ Phi-4-mini INT4 uses the GPTQ bake and the same correctness-first
+  single-block CDNA fallback as BF16.
 
 ### CUDA on `sm86`
 

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -1270,9 +1270,6 @@ fn main() -> Result<()> {
         if matches!(model_variant, ModelVariant::Gemma4_E4B) && cli.int4 {
             anyhow::bail!("HIP gfx942 Gemma 4 E4B bring-up currently validates only BF16");
         }
-        if matches!(model_variant, ModelVariant::Phi4_Mini) && cli.int4 {
-            anyhow::bail!("HIP gfx942 Phi-4-mini bring-up currently validates only BF16");
-        }
         if cli.batch_size != 1 {
             anyhow::bail!("HIP gfx942 bring-up currently supports only --batch-size 1");
         }


### PR DESCRIPTION
## Summary
- remove the temporary HIP gfx942 guard that blocked `phi4-mini --int4`
- mark Phi-4-mini INT4 as supported in the gfx942 README matrix
- note that INT4 uses the same correctness-first single-block CDNA fallback as BF16

## Validation
- `python oracle/bake_int4_phi4.py --model-dir /models/supersonic-cdna/phi4-mini --num-samples 128 --seqlen 2048 --group-size 128 --ppl-chunks 16 --device cuda`
  - GPTQ completed in 2.1 min
  - PPL on WikiText-2 test, 16 chunks: 12.12
  - wrote `/models/supersonic-cdna/phi4-mini/.supersonic/v2-int4-gptq`
- confirmed release-hosted bake already exists: `phi4-mini-int4-gptq-fmt2-cvt1.tar.zst.part00/part01` on `bakes-v2`
- `SUPERSONIC_ORACLE_PYTHON=/opt/supersonic-oracle-venv/bin/python HIP_ARCH=gfx942 cargo run --release --bin supersonic -- --backend hip --model phi4-mini --model-dir /models/supersonic-cdna/phi4-mini --int4 --prompt "The quick brown fox" --max-new-tokens 4 --context-size 32 --no-download --validate`
  - generated `The quick brown fox jumps over the lazy`
  - zero token mismatches
  - max logit delta 12.5625 versus BF16 oracle
- `HIP_ARCH=gfx942 cargo check -p runner --bin supersonic`
- `HIP_ARCH=gfx942 cargo test -p runner --lib registry::tests::hip_gfx942_registry_includes_cdna_targets -- --nocapture`

## Notes
This keeps the same correctness-first single-block Phi-4 CDNA fallback added for BF16, so performance is still not the goal of this PR.