### PR TITLE
[codex] Enable CDNA Phi-4 mini FP8 runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ see [docs/dflash.md](docs/dflash.md).
 | qwen3.6-35b-a3b  |  —   | ✅⁴  |      —      |   —    |
 | gemma4-e2b       | ✅³  | ✅⁵  |      —      |   —    |
 | gemma4-e4b       | ✅⁶  |  —   |      —      |   —    |
-| phi4-mini        | ✅⁷  | ✅⁸  |      —      |   —    |
+| phi4-mini        | ✅⁷  | ✅⁸  |     ✅⁹     |   —    |
 
 ¹ CDNA single-sequence decode uses the persistent megakernel by default.
   `--force-replay-decode` remains available as the slower GPU-prefill
@@ -98,6 +98,8 @@ see [docs/dflash.md](docs/dflash.md).
   existing Phi-4 HIP kernel path; performance tuning is still pending.
 ⁸ Phi-4-mini INT4 uses the GPTQ bake and the same correctness-first
   single-block CDNA fallback as BF16.
+⁹ Phi-4-mini FP8-runtime uses the FP8-native bake and the same
+  correctness-first single-block CDNA fallback as BF16.
 
 ### CUDA on `sm86`
 

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -1256,12 +1256,16 @@ fn main() -> Result<()> {
                 | ModelVariant::Phi4_Mini
         ) {
             anyhow::bail!(
-                "HIP gfx942 bring-up currently validates only Qwen3.5 models up to 9B, Qwen3.6 35B A3B INT4, Gemma 4 E2B BF16/INT4, Gemma 4 E4B BF16, and Phi-4-mini BF16"
+                "HIP gfx942 bring-up currently validates only Qwen3.5 models up to 9B, Qwen3.6 35B A3B INT4, Gemma 4 E2B BF16/INT4, Gemma 4 E4B BF16, and Phi-4-mini BF16/INT4/FP8-runtime"
             );
         }
-        if cli.fp8_runtime || cli.kv_fp8 || cli.q4km || cli.q4km_gptq {
+        if (cli.fp8_runtime && !matches!(model_variant, ModelVariant::Phi4_Mini))
+            || cli.kv_fp8
+            || cli.q4km
+            || cli.q4km_gptq
+        {
             anyhow::bail!(
-                "HIP gfx942 bring-up currently validates only BF16 and INT4 Qwen3.5 lanes, Qwen3.6 35B A3B INT4, Gemma 4 E2B BF16/INT4, Gemma 4 E4B BF16, and Phi-4-mini BF16"
+                "HIP gfx942 bring-up currently validates only BF16 and INT4 Qwen3.5 lanes, Qwen3.6 35B A3B INT4, Gemma 4 E2B BF16/INT4, Gemma 4 E4B BF16, and Phi-4-mini BF16/INT4/FP8-runtime"
             );
         }
         if matches!(model_variant, ModelVariant::Qwen3_6_35B_A3B) && !cli.int4 {


### PR DESCRIPTION
## Summary
- allow Phi-4-mini `--fp8-runtime` on HIP gfx942 while keeping KV-FP8 and Q4KM lanes blocked
- update the gfx942 support matrix for Phi-4-mini FP8-runtime
- document that the lane uses the FP8-native bake with the correctness-first single-block CDNA fallback

## Validation
- `SUPERSONIC_ORACLE_PYTHON=/opt/supersonic-oracle-venv/bin/python HIP_ARCH=gfx942 cargo run --release --bin supersonic -- --backend hip --model phi4-mini --model-dir /models/supersonic-cdna/phi4-mini --fp8-runtime --prompt "The quick brown fox" --max-new-tokens 4 --context-size 32 --validate`
  - downloaded/extracted `phi4-mini-fp8-native-fmt2-cvt1.tar.zst.part00/part01` into `/models/supersonic-cdna/phi4-mini/.supersonic/v2-fp8`
  - max_delta=1.9375, token_mismatches=0
  - generated: `The quick brown fox jumps over the lazy`
- `SUPERSONIC_ORACLE_PYTHON=/opt/supersonic-oracle-venv/bin/python HIP_ARCH=gfx942 cargo run --release --bin supersonic -- --backend hip --model phi4-mini --model-dir /models/supersonic-cdna/phi4-mini --fp8-runtime --prompt "The quick brown fox" --max-new-tokens 2 --context-size 32 --no-download --validate`
  - loaded local FP8 bake from `/models/supersonic-cdna/phi4-mini/.supersonic/v2-fp8`
  - max_delta=1.9375, token_mismatches=0
- `HIP_ARCH=gfx942 cargo check -p runner --bin supersonic`
- `HIP_ARCH=gfx942 cargo test -p runner --lib registry::tests::hip_gfx942_registry_includes_cdna_targets -- --nocapture`

Performance remains the known single-block fallback path for now (~2.1s/token on the short validation run); this PR is correctness-only.