### PR TITLE
[codex] Enable CDNA Qwen3.5 FP8 runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,10 @@ see [docs/dflash.md](docs/dflash.md).
 
 | Model            | BF16 | INT4 | FP8 runtime | FP8 KV |
 |------------------|:----:|:----:|:-----------:|:------:|
-| qwen3.5-0.8b     | ✅¹  | ✅²  |      —      |   —    |
-| qwen3.5-2b       | ✅¹  | ✅²  |      —      |   —    |
-| qwen3.5-4b       | ✅¹  | ✅²  |      —      |   —    |
-| qwen3.5-9b       | ✅¹  | ✅²  |      —      |   —    |
+| qwen3.5-0.8b     | ✅¹  | ✅²  |     ✅¹⁰    |   —    |
+| qwen3.5-2b       | ✅¹  | ✅²  |     ✅¹⁰    |   —    |
+| qwen3.5-4b       | ✅¹  | ✅²  |     ✅¹⁰    |   —    |
+| qwen3.5-9b       | ✅¹  | ✅²  |     ✅¹⁰    |   —    |
 | qwen3.6-35b-a3b  |  —   | ✅⁴  |      —      |   —    |
 | gemma4-e2b       | ✅³  | ✅⁵  |      —      |   —    |
 | gemma4-e4b       | ✅⁶  |  —   |      —      |   —    |
@@ -100,6 +100,8 @@ see [docs/dflash.md](docs/dflash.md).
   single-block CDNA fallback as BF16.
 ⁹ Phi-4-mini FP8-runtime uses the FP8-native bake and the same
   correctness-first single-block CDNA fallback as BF16.
+¹⁰ Qwen3.5 FP8-runtime uses the published FP8-native bakes and matches the
+   existing HIP golden-token outputs with zero GPU replay delta.
 
 ### CUDA on `sm86`
 

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -1258,16 +1258,23 @@ fn main() -> Result<()> {
                 | ModelVariant::Phi4_Mini
         ) {
             anyhow::bail!(
-                "HIP gfx942 bring-up currently validates only Qwen3.5 models up to 9B, Qwen3.6 35B A3B INT4, Gemma 4 E2B BF16/INT4, Gemma 4 E4B BF16, and Phi-4-mini BF16/INT4/FP8-runtime"
+                "HIP gfx942 bring-up currently validates only Qwen3.5 models up to 9B BF16/INT4/FP8-runtime, Qwen3.6 35B A3B INT4, Gemma 4 E2B BF16/INT4, Gemma 4 E4B BF16, and Phi-4-mini BF16/INT4/FP8-runtime"
             );
         }
-        if (cli.fp8_runtime && !matches!(model_variant, ModelVariant::Phi4_Mini))
+        let qwen35_model = matches!(
+            model_variant,
+            ModelVariant::Qwen3_5_0_8B
+                | ModelVariant::Qwen3_5_2B
+                | ModelVariant::Qwen3_5_4B
+                | ModelVariant::Qwen3_5_9B
+        );
+        if (cli.fp8_runtime && !(qwen35_model || matches!(model_variant, ModelVariant::Phi4_Mini)))
             || cli.kv_fp8
             || cli.q4km
             || cli.q4km_gptq
         {
             anyhow::bail!(
-                "HIP gfx942 bring-up currently validates only BF16 and INT4 Qwen3.5 lanes, Qwen3.6 35B A3B INT4, Gemma 4 E2B BF16/INT4, Gemma 4 E4B BF16, and Phi-4-mini BF16/INT4/FP8-runtime"
+                "HIP gfx942 bring-up currently validates only BF16/INT4/FP8-runtime Qwen3.5 lanes, Qwen3.6 35B A3B INT4, Gemma 4 E2B BF16/INT4, Gemma 4 E4B BF16, and Phi-4-mini BF16/INT4/FP8-runtime"
             );
         }
         if matches!(model_variant, ModelVariant::Qwen3_6_35B_A3B) && !cli.int4 {


### PR DESCRIPTION
## Summary
- allow Qwen3.5 `--fp8-runtime` on HIP gfx942 while keeping KV-FP8 and Q4KM lanes blocked
- update the gfx942 support matrix for Qwen3.5 FP8-runtime across 0.8B/2B/4B/9B
- document the validation basis: published FP8-native bakes, existing HIP golden-token outputs, and zero GPU replay delta

## Validation
- `HIP_ARCH=gfx942 cargo run --release --bin supersonic -- --backend hip --model qwen3.5-0.8b --model-dir /models/supersonic-cdna/qwen3.5-0.8b --fp8-runtime --prompt "The quick brown fox" --max-new-tokens 4 --context-size 32 --validate`
  - downloaded `qwen3.5-0.8b-fp8-native-fmt2-cvt1.tar.zst` into `.supersonic/v2-fp8`
  - generated tokens: `33075 888 279 5983`; `gpu_oracle_max_delta=0.0000`
  - BF16 oracle token differs, matching the existing FP8-native lane behavior
- `HIP_ARCH=gfx942 cargo run --release --bin supersonic -- --backend hip --model qwen3.5-2b --model-dir /models/supersonic-cdna/qwen3.5-2b --fp8-runtime --prompt "The quick brown fox" --max-new-tokens 4 --context-size 32 --validate`
  - downloaded `qwen3.5-2b-fp8-native-fmt2-cvt1.tar.zst.part00/part01` into `.supersonic/v2-fp8`
  - generated tokens: `33075 888 279 15217`; `gpu_oracle_max_delta=0.0000`
  - BF16 oracle token differs, matching the existing FP8-native lane behavior
- `HIP_ARCH=gfx942 cargo run --release --bin supersonic -- --backend hip --model qwen3.5-0.8b --model-dir /models/supersonic-cdna/qwen3.5-0.8b --fp8-runtime --prompt "The quick brown fox" --max-new-tokens 6 --context-size 32 --no-download`
  - generated tokens: `33075 888 279 5983 40289 13`; `gpu_oracle_max_delta=0.0000`
- `HIP_ARCH=gfx942 cargo run --release --bin supersonic -- --backend hip --model qwen3.5-2b --model-dir /models/supersonic-cdna/qwen3.5-2b --fp8-runtime --prompt "The quick brown fox" --max-new-tokens 6 --context-size 32 --no-download`
  - generated tokens: `33075 888 279 15217 5388 13`; `gpu_oracle_max_delta=0.0000`
- `HIP_ARCH=gfx942 cargo run --release --bin supersonic -- --backend hip --model qwen3.5-4b --model-dir /models/supersonic-cdna/qwen3.5-4b --fp8-runtime --prompt "The quick brown fox" --max-new-tokens 6 --context-size 32`
  - downloaded `qwen3.5-4b-fp8-native-fmt2-cvt1.tar.zst.part00/part01/part02` into `.supersonic/v2-fp8`
  - generated tokens: `33075 888 279 15217 5388 13`; `gpu_oracle_max_delta=0.0000`
- `HIP_ARCH=gfx942 cargo run --release --bin supersonic -- --backend hip --model qwen3.5-9b --model-dir /models/supersonic-cdna/qwen3.5-9b --fp8-runtime --prompt "The quick brown fox" --max-new-tokens 6 --context-size 32`
  - downloaded `qwen3.5-9b-fp8-native-fmt2-cvt1.tar.zst.part00..part04` into `.supersonic/v2-fp8`
  - generated tokens: `33075 888 279 15217 5388 13`; `gpu_oracle_max_delta=0.0000`
- `HIP_ARCH=gfx942 cargo check -p runner --bin supersonic`
- `HIP_ARCH=gfx942 cargo test -p runner --lib registry::tests::hip_gfx942_registry_includes_cdna_targets -- --nocapture`
