### PR TITLE
[codex] Enable CDNA Qwen3.5 KV FP8

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,10 @@ see [docs/dflash.md](docs/dflash.md).
 
 | Model            | BF16 | INT4 | FP8 runtime | FP8 KV |
 |------------------|:----:|:----:|:-----------:|:------:|
-| qwen3.5-0.8b     | ✅¹  | ✅²  |     ✅¹⁰    |   —    |
-| qwen3.5-2b       | ✅¹  | ✅²  |     ✅¹⁰    |   —    |
-| qwen3.5-4b       | ✅¹  | ✅²  |     ✅¹⁰    |   —    |
-| qwen3.5-9b       | ✅¹  | ✅²  |     ✅¹⁰    |   —    |
+| qwen3.5-0.8b     | ✅¹  | ✅²  |     ✅¹⁰    |  ✅¹¹  |
+| qwen3.5-2b       | ✅¹  | ✅²  |     ✅¹⁰    |  ✅¹¹  |
+| qwen3.5-4b       | ✅¹  | ✅²  |     ✅¹⁰    |  ✅¹¹  |
+| qwen3.5-9b       | ✅¹  | ✅²  |     ✅¹⁰    |  ✅¹¹  |
 | qwen3.6-35b-a3b  |  —   | ✅⁴  |      —      |   —    |
 | gemma4-e2b       | ✅³  | ✅⁵  |      —      |   —    |
 | gemma4-e4b       | ✅⁶  |  —   |      —      |   —    |
@@ -102,6 +102,8 @@ see [docs/dflash.md](docs/dflash.md).
   correctness-first single-block CDNA fallback as BF16.
 ¹⁰ Qwen3.5 FP8-runtime uses the published FP8-native bakes and matches the
    existing HIP golden-token outputs with zero GPU replay delta.
+¹¹ Qwen3.5 KV-FP8 uses replayed GPU prefill for the single-sequence path and
+   matches the existing HIP golden-token outputs with zero GPU replay delta.
 
 ### CUDA on `sm86`
 

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -1258,7 +1258,7 @@ fn main() -> Result<()> {
                 | ModelVariant::Phi4_Mini
         ) {
             anyhow::bail!(
-                "HIP gfx942 bring-up currently validates only Qwen3.5 models up to 9B BF16/INT4/FP8-runtime, Qwen3.6 35B A3B INT4, Gemma 4 E2B BF16/INT4, Gemma 4 E4B BF16, and Phi-4-mini BF16/INT4/FP8-runtime"
+                "HIP gfx942 bring-up currently validates only Qwen3.5 models up to 9B BF16/INT4/FP8-runtime/KV-FP8, Qwen3.6 35B A3B INT4, Gemma 4 E2B BF16/INT4, Gemma 4 E4B BF16, and Phi-4-mini BF16/INT4/FP8-runtime"
             );
         }
         let qwen35_model = matches!(
@@ -1269,12 +1269,12 @@ fn main() -> Result<()> {
                 | ModelVariant::Qwen3_5_9B
         );
         if (cli.fp8_runtime && !(qwen35_model || matches!(model_variant, ModelVariant::Phi4_Mini)))
-            || cli.kv_fp8
+            || (cli.kv_fp8 && !qwen35_model)
             || cli.q4km
             || cli.q4km_gptq
         {
             anyhow::bail!(
-                "HIP gfx942 bring-up currently validates only BF16/INT4/FP8-runtime Qwen3.5 lanes, Qwen3.6 35B A3B INT4, Gemma 4 E2B BF16/INT4, Gemma 4 E4B BF16, and Phi-4-mini BF16/INT4/FP8-runtime"
+                "HIP gfx942 bring-up currently validates only BF16/INT4/FP8-runtime/KV-FP8 Qwen3.5 lanes, Qwen3.6 35B A3B INT4, Gemma 4 E2B BF16/INT4, Gemma 4 E4B BF16, and Phi-4-mini BF16/INT4/FP8-runtime"
             );
         }
         if matches!(model_variant, ModelVariant::Qwen3_6_35B_A3B) && !cli.int4 {
@@ -2246,15 +2246,15 @@ fn main() -> Result<()> {
             eprintln!("[decode] single-sequence 4B uses replayed GPU prefill for correctness");
         }
     } else if replay_kv_fp8_enabled && cli.batch_size == 1 {
-        eprintln!("[decode] single-sequence CUDA KV-FP8 uses replayed GPU prefill for correctness");
+        eprintln!("[decode] single-sequence KV-FP8 uses replayed GPU prefill for correctness");
     } else if cli.batch_size > 1 && use_4b_kernel && cli.kv_fp8 {
-        eprintln!("[decode] batched CUDA KV-FP8 uses the persistent kernel path");
+        eprintln!("[decode] batched KV-FP8 uses the persistent kernel path");
     } else if component_single_decode_enabled {
         eprintln!("[decode] WARNING: forcing single-sequence 4B onto the component decode path");
     } else if cli.batch_size == 1 && use_4b_kernel && cli.force_kernel_decode {
         eprintln!("[decode] WARNING: forcing single-sequence 4B onto the kernel decode path");
     } else if cli.batch_size == 1 && use_4b_kernel && cli.kv_fp8 {
-        eprintln!("[decode] WARNING: single-sequence CUDA KV-FP8 uses the b=1 kernel path");
+        eprintln!("[decode] WARNING: single-sequence KV-FP8 uses the b=1 kernel path");
     } else if cuda_08b_hero_enabled {
         eprintln!("[decode] CUDA 0.8B sm86 hero path enabled");
     } else if cuda_fast_greedy_enabled {


### PR DESCRIPTION
## Summary
- allow Qwen3.5 `--kv-fp8` on HIP gfx942 while keeping KV-FP8 blocked for non-Qwen3.5 families
- update the gfx942 support matrix for Qwen3.5 FP8 KV across 0.8B/2B/4B/9B
- make KV-FP8 decode log messages backend-neutral now that HIP uses the same replayed-prefill path

## Validation
- `SUPERSONIC_ORACLE_PYTHON=/opt/supersonic-oracle-venv/bin/python HIP_ARCH=gfx942 cargo run --release --bin supersonic -- --backend hip --model qwen3.5-0.8b --model-dir /models/supersonic-cdna/qwen3.5-0.8b --kv-fp8 --prompt "The quick brown fox" --max-new-tokens 6 --context-size 32 --validate`
  - prefill logit delta=0.3232
  - decode_max_delta=0.2578, gpu_oracle_max_delta=0.0000
  - generated tokens: `33075 888 279 5983 40289 13`
- `SUPERSONIC_ORACLE_PYTHON=/opt/supersonic-oracle-venv/bin/python HIP_ARCH=gfx942 cargo run --release --bin supersonic -- --backend hip --model qwen3.5-2b --model-dir /models/supersonic-cdna/qwen3.5-2b --kv-fp8 --prompt "The quick brown fox" --max-new-tokens 6 --context-size 32 --validate`
  - prefill logit delta=0.2969
  - decode_max_delta=0.3438, gpu_oracle_max_delta=0.0000
  - generated tokens: `33075 888 279 15217 5388 13`
- `HIP_ARCH=gfx942 cargo run --release --bin supersonic -- --backend hip --model qwen3.5-4b --model-dir /models/supersonic-cdna/qwen3.5-4b --kv-fp8 --prompt "The quick brown fox" --max-new-tokens 6 --context-size 32`
  - generated tokens: `33075 888 279 15217 5388 13`; `gpu_oracle_max_delta=0.0000`
- `HIP_ARCH=gfx942 cargo run --release --bin supersonic -- --backend hip --model qwen3.5-9b --model-dir /models/supersonic-cdna/qwen3.5-9b --kv-fp8 --prompt "The quick brown fox" --max-new-tokens 6 --context-size 32`
  - generated tokens: `33075 888 279 15217 5388 13`; `gpu_oracle_max_delta=0.0000`
- `HIP_ARCH=gfx942 cargo check -p runner --bin supersonic`
- `HIP_ARCH=gfx942 cargo test -p runner --lib registry::tests::hip_gfx942_registry_includes_cdna_targets -- --nocapture`
