### PR TITLE
[codex] Enable CDNA Phi-4 mini KV FP8

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ see [docs/dflash.md](docs/dflash.md).
 | qwen3.6-35b-a3b  |  —   | ✅⁴  |      —      |   —    |
 | gemma4-e2b       | ✅³  | ✅⁵  |      —      |   —    |
 | gemma4-e4b       | ✅⁶  |  —   |      —      |   —    |
-| phi4-mini        | ✅⁷  | ✅⁸  |     ✅⁹     |   —    |
+| phi4-mini        | ✅⁷  | ✅⁸  |     ✅⁹     |  ✅¹²  |
 
 ¹ CDNA single-sequence decode uses the persistent megakernel by default.
   `--force-replay-decode` remains available as the slower GPU-prefill
@@ -104,6 +104,9 @@ see [docs/dflash.md](docs/dflash.md).
    existing HIP golden-token outputs with zero GPU replay delta.
 ¹¹ Qwen3.5 KV-FP8 uses replayed GPU prefill for the single-sequence path and
    matches the existing HIP golden-token outputs with zero GPU replay delta.
+¹² Phi-4-mini KV-FP8 uses the correctness-first single-block CDNA fallback and
+   matches the PyTorch oracle tokens; logit drift is higher than BF16 but below
+   the INT4 lane observed during bring-up.
 
 ### CUDA on `sm86`
 

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -1258,7 +1258,7 @@ fn main() -> Result<()> {
                 | ModelVariant::Phi4_Mini
         ) {
             anyhow::bail!(
-                "HIP gfx942 bring-up currently validates only Qwen3.5 models up to 9B BF16/INT4/FP8-runtime/KV-FP8, Qwen3.6 35B A3B INT4, Gemma 4 E2B BF16/INT4, Gemma 4 E4B BF16, and Phi-4-mini BF16/INT4/FP8-runtime"
+                "HIP gfx942 bring-up currently validates only Qwen3.5 models up to 9B BF16/INT4/FP8-runtime/KV-FP8, Qwen3.6 35B A3B INT4, Gemma 4 E2B BF16/INT4, Gemma 4 E4B BF16, and Phi-4-mini BF16/INT4/FP8-runtime/KV-FP8"
             );
         }
         let qwen35_model = matches!(
@@ -1269,12 +1269,12 @@ fn main() -> Result<()> {
                 | ModelVariant::Qwen3_5_9B
         );
         if (cli.fp8_runtime && !(qwen35_model || matches!(model_variant, ModelVariant::Phi4_Mini)))
-            || (cli.kv_fp8 && !qwen35_model)
+            || (cli.kv_fp8 && !(qwen35_model || matches!(model_variant, ModelVariant::Phi4_Mini)))
             || cli.q4km
             || cli.q4km_gptq
         {
             anyhow::bail!(
-                "HIP gfx942 bring-up currently validates only BF16/INT4/FP8-runtime/KV-FP8 Qwen3.5 lanes, Qwen3.6 35B A3B INT4, Gemma 4 E2B BF16/INT4, Gemma 4 E4B BF16, and Phi-4-mini BF16/INT4/FP8-runtime"
+                "HIP gfx942 bring-up currently validates only BF16/INT4/FP8-runtime/KV-FP8 Qwen3.5 lanes, Qwen3.6 35B A3B INT4, Gemma 4 E2B BF16/INT4, Gemma 4 E4B BF16, and Phi-4-mini BF16/INT4/FP8-runtime/KV-FP8"
             );
         }
         if matches!(model_variant, ModelVariant::Qwen3_6_35B_A3B) && !cli.int4 {


### PR DESCRIPTION
## Summary
- allow Phi-4-mini `--kv-fp8` on HIP gfx942
- update the gfx942 support matrix for Phi-4-mini FP8 KV
- document that this lane uses the correctness-first single-block CDNA fallback and has higher BF16-scale logit drift than BF16/FP8-runtime, but still matches oracle tokens

## Validation
- `SUPERSONIC_ORACLE_PYTHON=/opt/supersonic-oracle-venv/bin/python HIP_ARCH=gfx942 cargo run --release --bin supersonic -- --backend hip --model phi4-mini --model-dir /models/supersonic-cdna/phi4-mini --kv-fp8 --prompt "The quick brown fox" --max-new-tokens 4 --context-size 32 --validate`
  - max_delta=6.7500, token_mismatches=0
  - generated tokens: `65613 1072 290 29082`
  - generated text: `The quick brown fox jumps over the lazy`
- `export SUPERSONIC_ORACLE_PYTHON=/opt/supersonic-oracle-venv/bin/python && HIP_ARCH=gfx942 cargo run --release --bin supersonic -- --backend hip --model phi4-mini --model-dir /models/supersonic-cdna/phi4-mini --kv-fp8 --prompt "The quick brown fox" --max-new-tokens 2 --context-size 32 --validate`
  - max_delta=6.3750, token_mismatches=0
  - generated tokens: `65613 1072`
- `HIP_ARCH=gfx942 cargo check -p runner --bin supersonic`
- `HIP_ARCH=gfx942 cargo test -p runner --lib registry::tests::hip_gfx942_registry_includes_cdna_targets -- --nocapture`

Note: one intermediate rerun omitted the oracle venv export and failed before model execution with `ModuleNotFoundError: No module named torch`; the command above is the successful rerun with the correct oracle Python.
