### PR TITLE
qwen36-moe: linear-attn state snapshot/restore primitive (Phase 6.4c.1)

### DIFF
--- a/crates/runner/src/lib.rs
+++ b/crates/runner/src/lib.rs
@@ -19,5 +19,6 @@ pub mod prefill_engine;
 pub mod qwen36_moe_decode;
 pub mod qwen36_moe_mtp;
 pub mod qwen36_moe_speculative;
+pub mod qwen36_moe_state;
 pub mod registry;
 pub mod validate;

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -13,6 +13,7 @@ mod qwen36_moe_decode;
 mod qwen36_moe_engine;
 mod qwen36_moe_mtp;
 mod qwen36_moe_speculative;
+mod qwen36_moe_state;
 mod registry;
 mod validate;
 

--- a/crates/runner/src/qwen36_moe_state.rs
+++ b/crates/runner/src/qwen36_moe_state.rs
@@ -1,0 +1,321 @@
+//! Qwen3.6-MoE linear-attention state snapshot/restore primitives.
+//!
+//! Phase 6.4c.1: foundation for any operation that needs to checkpoint
+//! the linear-attention layers' mutable state. The intended consumer is
+//! the speculative-decode driver (Phase 6.4c+) — it needs to save state
+//! before running speculative verify chains and restore on rejection
+//! (since linear-attention's `conv_state` + `recurrent_state` mutate per
+//! token and don't naturally roll back).
+//!
+//! ## What's stateful
+//!
+//! Each linear-attention layer in `LayerBuffers::Linear` holds two
+//! mutable GpuBuffers:
+//!   - `conv_state`: `[qkv_dim, kernel-1]` BF16 — the depthwise conv1d
+//!     window state.
+//!   - `recurrent_state`: `[V * K * Vd]` F32 — the linear-attn delta-rule
+//!     recurrent state.
+//!
+//! Full-attention layers don't carry state (their KV cache is positional
+//! — overwriting a slot is a free rollback). So a snapshot only needs
+//! per-linear-layer copies.
+//!
+//! ## Cost
+//!
+//! At 35B-A3B (30 linear layers, qkv_dim≈3168, recurrent_state ≈ 60 MiB
+//! F32 across all layers — `[V=2 × K=16 × Vd=128]` per layer per
+//! the docstring): a full snapshot copies ~62 MiB GPU→GPU. At 7900 XTX
+//! peak ~960 GB/s, that's ~65 µs of D2D bandwidth — negligible.
+//!
+//! ## Allocation model
+//!
+//! [`LinearAttnSnapshot`] owns its shadow buffers. The intended pattern
+//! for the speculative-decode driver is to allocate ONE snapshot at
+//! engine startup and reuse it across speculative iterations:
+//!
+//! ```ignore
+//! let mut snap = save_linear_attn_state(ordinal, &layers)?;
+//! // ... per-spec-step:
+//! refresh_linear_attn_state(ordinal, &layers, &mut snap)?;
+//! // ... run K verify chains (state mutates) ...
+//! if rejected {
+//!     restore_linear_attn_state(ordinal, &mut layers, &snap)?;
+//! }
+//! ```
+//!
+//! [`refresh_linear_attn_state`] reuses the snapshot's buffers without
+//! re-allocating; [`save_linear_attn_state`] does both alloc and copy
+//! in one call (convenience for the first save).
+
+use anyhow::{Context, Result};
+use gpu_hal::{copy_d2d, GpuBuffer};
+
+use crate::qwen36_moe_decode::{AttnLayerBuffers, LayerBuffers};
+
+/// Per-linear-attn-layer state shadow buffers. Only `Linear` layers
+/// have state; `Full` layers are represented as `None` in the parent
+/// snapshot's vec.
+pub struct LinearAttnLayerSnapshot {
+    /// Shadow of `LayerBuffers::Linear::conv_state`. Same shape +
+    /// dtype (BF16 `[qkv_dim, kernel-1]`).
+    pub conv_state: GpuBuffer,
+    /// Shadow of `LayerBuffers::Linear::recurrent_state`. Same shape
+    /// + dtype (F32 `[V * K * Vd]`).
+    pub recurrent_state: GpuBuffer,
+}
+
+/// Snapshot of every linear-attn layer's state across a `LayerBuffers`
+/// slice. Indexed by layer position (0..num_layers); `None` entries
+/// correspond to `Full` layers that don't have state.
+pub struct LinearAttnSnapshot {
+    pub layers: Vec<Option<LinearAttnLayerSnapshot>>,
+}
+
+impl LinearAttnSnapshot {
+    /// Returns the count of Linear layers actually captured (= count
+    /// of `Some` entries).
+    pub fn linear_layer_count(&self) -> usize {
+        self.layers.iter().filter(|l| l.is_some()).count()
+    }
+}
+
+/// Allocate fresh shadow buffers for every Linear layer + copy the
+/// current state into them. The convenience entry point — for steady-
+/// state speculative use prefer [`refresh_linear_attn_state`] which
+/// reuses an existing snapshot's buffers.
+pub fn save_linear_attn_state(
+    ordinal: usize,
+    layers: &[LayerBuffers],
+) -> Result<LinearAttnSnapshot> {
+    let mut snap_layers: Vec<Option<LinearAttnLayerSnapshot>> =
+        Vec::with_capacity(layers.len());
+    for (idx, layer) in layers.iter().enumerate() {
+        match &layer.attn {
+            AttnLayerBuffers::Full { .. } => snap_layers.push(None),
+            AttnLayerBuffers::Linear {
+                conv_state,
+                recurrent_state,
+                ..
+            } => {
+                let conv_shadow = GpuBuffer::zeros(
+                    ordinal,
+                    conv_state.dtype(),
+                    conv_state.shape(),
+                )
+                .with_context(|| {
+                    format!("alloc conv_state shadow for linear layer {idx}")
+                })?;
+                let rec_shadow = GpuBuffer::zeros(
+                    ordinal,
+                    recurrent_state.dtype(),
+                    recurrent_state.shape(),
+                )
+                .with_context(|| {
+                    format!("alloc recurrent_state shadow for linear layer {idx}")
+                })?;
+                let mut layer_snap = LinearAttnLayerSnapshot {
+                    conv_state: conv_shadow,
+                    recurrent_state: rec_shadow,
+                };
+                copy_into_layer(ordinal, idx, conv_state, recurrent_state, &mut layer_snap)?;
+                snap_layers.push(Some(layer_snap));
+            }
+        }
+    }
+    Ok(LinearAttnSnapshot {
+        layers: snap_layers,
+    })
+}
+
+/// Refresh an existing snapshot in place. Caller must ensure the
+/// snapshot was originally created against the SAME `layers` slice
+/// (same Linear/Full layout, same per-layer shapes); otherwise the
+/// shape sanity checks will fail. Cheaper than rebuilding the
+/// snapshot from scratch — D2D copies only, no allocations.
+pub fn refresh_linear_attn_state(
+    ordinal: usize,
+    layers: &[LayerBuffers],
+    snapshot: &mut LinearAttnSnapshot,
+) -> Result<()> {
+    if snapshot.layers.len() != layers.len() {
+        anyhow::bail!(
+            "refresh_linear_attn_state: snapshot has {} layer slots but \
+             layers slice has {} entries — snapshot/layers shape mismatch",
+            snapshot.layers.len(),
+            layers.len()
+        );
+    }
+    for (idx, (layer, slot)) in layers.iter().zip(snapshot.layers.iter_mut()).enumerate() {
+        match (&layer.attn, slot.as_mut()) {
+            (AttnLayerBuffers::Full { .. }, None) => {
+                // Both agree: no state to copy.
+            }
+            (AttnLayerBuffers::Full { .. }, Some(_)) => {
+                anyhow::bail!(
+                    "refresh_linear_attn_state: layer {idx} is Full but \
+                     snapshot has a Linear slot — snapshot/layers \
+                     pattern mismatch (Full↔Linear swap)"
+                );
+            }
+            (AttnLayerBuffers::Linear { .. }, None) => {
+                anyhow::bail!(
+                    "refresh_linear_attn_state: layer {idx} is Linear but \
+                     snapshot has no slot — snapshot/layers pattern \
+                     mismatch (Linear↔Full swap)"
+                );
+            }
+            (
+                AttnLayerBuffers::Linear {
+                    conv_state,
+                    recurrent_state,
+                    ..
+                },
+                Some(layer_snap),
+            ) => {
+                copy_into_layer(ordinal, idx, conv_state, recurrent_state, layer_snap)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Restore the layers' state from `snapshot`. Inverse of
+/// [`save_linear_attn_state`] / [`refresh_linear_attn_state`]: D2D
+/// copies snapshot → layers for every Linear layer.
+pub fn restore_linear_attn_state(
+    ordinal: usize,
+    layers: &mut [LayerBuffers],
+    snapshot: &LinearAttnSnapshot,
+) -> Result<()> {
+    if snapshot.layers.len() != layers.len() {
+        anyhow::bail!(
+            "restore_linear_attn_state: snapshot has {} layer slots but \
+             layers slice has {} entries — snapshot/layers shape mismatch",
+            snapshot.layers.len(),
+            layers.len()
+        );
+    }
+    for (idx, (layer, slot)) in layers
+        .iter_mut()
+        .zip(snapshot.layers.iter())
+        .enumerate()
+    {
+        match (&mut layer.attn, slot) {
+            (AttnLayerBuffers::Full { .. }, None) => {}
+            (AttnLayerBuffers::Full { .. }, Some(_)) => {
+                anyhow::bail!(
+                    "restore_linear_attn_state: layer {idx} is Full but \
+                     snapshot has a Linear slot"
+                );
+            }
+            (AttnLayerBuffers::Linear { .. }, None) => {
+                anyhow::bail!(
+                    "restore_linear_attn_state: layer {idx} is Linear but \
+                     snapshot has no slot"
+                );
+            }
+            (
+                AttnLayerBuffers::Linear {
+                    conv_state,
+                    recurrent_state,
+                    ..
+                },
+                Some(layer_snap),
+            ) => {
+                let n_conv = conv_state.len_bytes();
+                if n_conv != layer_snap.conv_state.len_bytes() {
+                    anyhow::bail!(
+                        "restore_linear_attn_state: layer {idx} conv_state \
+                         size mismatch (live={n_conv}, snapshot={})",
+                        layer_snap.conv_state.len_bytes()
+                    );
+                }
+                copy_d2d(
+                    ordinal,
+                    conv_state.as_mut_ptr(),
+                    layer_snap.conv_state.as_ptr(),
+                    n_conv,
+                )
+                .with_context(|| format!("restore conv_state for layer {idx}"))?;
+
+                let n_rec = recurrent_state.len_bytes();
+                if n_rec != layer_snap.recurrent_state.len_bytes() {
+                    anyhow::bail!(
+                        "restore_linear_attn_state: layer {idx} recurrent_state \
+                         size mismatch (live={n_rec}, snapshot={})",
+                        layer_snap.recurrent_state.len_bytes()
+                    );
+                }
+                copy_d2d(
+                    ordinal,
+                    recurrent_state.as_mut_ptr(),
+                    layer_snap.recurrent_state.as_ptr(),
+                    n_rec,
+                )
+                .with_context(|| {
+                    format!("restore recurrent_state for layer {idx}")
+                })?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Copy live state → snapshot for one Linear layer. Shared between
+/// `save_linear_attn_state` (initial copy) and `refresh_linear_attn_state`
+/// (per-spec-step refresh).
+fn copy_into_layer(
+    ordinal: usize,
+    idx: usize,
+    conv_state: &GpuBuffer,
+    recurrent_state: &GpuBuffer,
+    layer_snap: &mut LinearAttnLayerSnapshot,
+) -> Result<()> {
+    let n_conv = conv_state.len_bytes();
+    if n_conv != layer_snap.conv_state.len_bytes() {
+        anyhow::bail!(
+            "linear_attn_snapshot: layer {idx} conv_state size mismatch \
+             (live={n_conv}, snapshot={})",
+            layer_snap.conv_state.len_bytes()
+        );
+    }
+    copy_d2d(
+        ordinal,
+        layer_snap.conv_state.as_mut_ptr(),
+        conv_state.as_ptr(),
+        n_conv,
+    )
+    .with_context(|| format!("snapshot conv_state for layer {idx}"))?;
+
+    let n_rec = recurrent_state.len_bytes();
+    if n_rec != layer_snap.recurrent_state.len_bytes() {
+        anyhow::bail!(
+            "linear_attn_snapshot: layer {idx} recurrent_state size mismatch \
+             (live={n_rec}, snapshot={})",
+            layer_snap.recurrent_state.len_bytes()
+        );
+    }
+    copy_d2d(
+        ordinal,
+        layer_snap.recurrent_state.as_mut_ptr(),
+        recurrent_state.as_ptr(),
+        n_rec,
+    )
+    .with_context(|| format!("snapshot recurrent_state for layer {idx}"))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    // Library-level tests that don't require GPU. Tests that exercise
+    // the actual GPU copy paths live in
+    // `crates/runner/tests/qwen36_moe_linear_state.rs` (skipped when
+    // HIP isn't compiled).
+    use super::*;
+
+    #[test]
+    fn snapshot_count_with_no_layers() {
+        let snap = LinearAttnSnapshot { layers: Vec::new() };
+        assert_eq!(snap.linear_layer_count(), 0);
+    }
+}

--- a/crates/runner/tests/qwen36_moe_linear_state.rs
+++ b/crates/runner/tests/qwen36_moe_linear_state.rs
@@ -1,0 +1,314 @@
+//! Phase 6.4c.1 GPU integration test for linear-attn state snapshot /
+//! refresh / restore.
+//!
+//! Builds a minimal `LayerBuffers` slice (no real weights — just the
+//! state buffers we want to snapshot), seeds the live state with
+//! known patterns, takes a snapshot, mutates the live state, then
+//! restores and checks the live state matches the original snapshot
+//! byte-for-byte.
+//!
+//! Mirrors the engine's intended use: snapshot before speculative
+//! verify chains run, restore on rejection. This test doesn't run any
+//! kernels — just exercises the D2D copy paths in
+//! `runner::qwen36_moe_state`.
+//!
+//! Skipped silently when HIP isn't compiled.
+
+use anyhow::Result;
+use gpu_hal::{copy_d2h, is_backend_compiled, set_backend, Backend, GpuBuffer, ScalarType};
+use runner::qwen36_moe_decode::{
+    AttnLayerBuffers, FfnLayerBuffers, FullAttnInt4Sidecars, FullAttnKvCache, LayerBuffers,
+};
+use runner::qwen36_moe_state::{
+    refresh_linear_attn_state, restore_linear_attn_state, save_linear_attn_state,
+};
+
+fn stub_bf16(ordinal: usize) -> Result<GpuBuffer> {
+    Ok(GpuBuffer::zeros(ordinal, ScalarType::BF16, &[1])?)
+}
+fn stub_u8(ordinal: usize) -> Result<GpuBuffer> {
+    Ok(GpuBuffer::zeros(ordinal, ScalarType::U8, &[1])?)
+}
+
+/// Build a minimal Linear-attn LayerBuffers using small dummy
+/// shapes. Conv state and recurrent state are the only fields the
+/// snapshot helpers touch — every other field gets a 1-element
+/// stub buffer to satisfy the struct shape.
+fn make_linear_layer(
+    ordinal: usize,
+    conv_bytes: &[u8],
+    recurrent_floats: &[f32],
+) -> Result<LayerBuffers> {
+    let conv_state = GpuBuffer::from_host_bytes(
+        ordinal,
+        ScalarType::BF16,
+        &[conv_bytes.len() / 2],
+        conv_bytes,
+    )?;
+    let mut rec_bytes: Vec<u8> = Vec::with_capacity(recurrent_floats.len() * 4);
+    for &f in recurrent_floats {
+        rec_bytes.extend_from_slice(&f.to_le_bytes());
+    }
+    let recurrent_state = GpuBuffer::from_host_bytes(
+        ordinal,
+        ScalarType::F32,
+        &[recurrent_floats.len()],
+        &rec_bytes,
+    )?;
+
+    Ok(LayerBuffers {
+        attn: AttnLayerBuffers::Linear {
+            input_norm_w: stub_bf16(ordinal)?,
+            in_proj_qkv_w: stub_u8(ordinal)?,
+            in_proj_z_w: stub_u8(ordinal)?,
+            in_proj_a_w: stub_bf16(ordinal)?,
+            in_proj_b_w: stub_bf16(ordinal)?,
+            conv1d_w: stub_bf16(ordinal)?,
+            conv1d_bias: None,
+            dt_bias: stub_bf16(ordinal)?,
+            a_log: stub_bf16(ordinal)?,
+            norm_w: stub_bf16(ordinal)?,
+            out_proj_w: stub_u8(ordinal)?,
+            conv_state,
+            recurrent_state,
+            int4: None,
+        },
+        ffn: FfnLayerBuffers {
+            post_attn_norm_w: stub_bf16(ordinal)?,
+            gate_w: stub_bf16(ordinal)?,
+            gate_up_proj_w: stub_u8(ordinal)?,
+            down_proj_w: stub_u8(ordinal)?,
+            shared_gate_proj_w: stub_u8(ordinal)?,
+            shared_up_proj_w: stub_u8(ordinal)?,
+            shared_down_proj_w: stub_u8(ordinal)?,
+            shared_expert_gate_w: stub_bf16(ordinal)?,
+            int4: None,
+        },
+    })
+}
+
+/// Build a minimal Full-attn LayerBuffers (used to verify the
+/// snapshot's None-slot handling).
+fn make_full_layer(ordinal: usize) -> Result<LayerBuffers> {
+    Ok(LayerBuffers {
+        attn: AttnLayerBuffers::Full {
+            input_norm_w: stub_bf16(ordinal)?,
+            q_proj_w: stub_u8(ordinal)?,
+            k_proj_w: stub_u8(ordinal)?,
+            v_proj_w: stub_u8(ordinal)?,
+            q_norm_w: stub_bf16(ordinal)?,
+            k_norm_w: stub_bf16(ordinal)?,
+            o_proj_w: stub_u8(ordinal)?,
+            int4: Some(FullAttnInt4Sidecars {
+                group_size: 128,
+                q_proj_scale: stub_bf16(ordinal)?,
+                q_proj_zero: stub_bf16(ordinal)?,
+                k_proj_scale: stub_bf16(ordinal)?,
+                k_proj_zero: stub_bf16(ordinal)?,
+                v_proj_scale: stub_bf16(ordinal)?,
+                v_proj_zero: stub_bf16(ordinal)?,
+                o_proj_scale: stub_bf16(ordinal)?,
+                o_proj_zero: stub_bf16(ordinal)?,
+            }),
+            kv_cache: Some(FullAttnKvCache {
+                k: stub_bf16(ordinal)?,
+                v: stub_bf16(ordinal)?,
+                kv_max_t: 1,
+            }),
+        },
+        ffn: FfnLayerBuffers {
+            post_attn_norm_w: stub_bf16(ordinal)?,
+            gate_w: stub_bf16(ordinal)?,
+            gate_up_proj_w: stub_u8(ordinal)?,
+            down_proj_w: stub_u8(ordinal)?,
+            shared_gate_proj_w: stub_u8(ordinal)?,
+            shared_up_proj_w: stub_u8(ordinal)?,
+            shared_down_proj_w: stub_u8(ordinal)?,
+            shared_expert_gate_w: stub_bf16(ordinal)?,
+            int4: None,
+        },
+    })
+}
+
+fn d2h_bytes(buf: &GpuBuffer) -> Vec<u8> {
+    let mut out = vec![0u8; buf.len_bytes()];
+    copy_d2h(0usize, out.as_mut_ptr() as *mut _, buf.as_ptr(), out.len())
+        .expect("d2h");
+    out
+}
+
+fn live_conv_bytes(layer: &LayerBuffers) -> Vec<u8> {
+    match &layer.attn {
+        AttnLayerBuffers::Linear { conv_state, .. } => d2h_bytes(conv_state),
+        AttnLayerBuffers::Full { .. } => Vec::new(),
+    }
+}
+fn live_rec_bytes(layer: &LayerBuffers) -> Vec<u8> {
+    match &layer.attn {
+        AttnLayerBuffers::Linear { recurrent_state, .. } => d2h_bytes(recurrent_state),
+        AttnLayerBuffers::Full { .. } => Vec::new(),
+    }
+}
+
+/// Mutate the live state of a Linear layer to a known different
+/// pattern. Used between save and restore to confirm restore
+/// actually overwrites with the snapshot's contents.
+fn mutate_linear_state(layer: &mut LayerBuffers, byte_fill: u8, float_fill: f32) {
+    if let AttnLayerBuffers::Linear {
+        conv_state,
+        recurrent_state,
+        ..
+    } = &mut layer.attn
+    {
+        let conv_bytes = vec![byte_fill; conv_state.len_bytes()];
+        gpu_hal::copy_h2d(
+            0usize,
+            conv_state.as_mut_ptr(),
+            conv_bytes.as_ptr() as *const _,
+            conv_bytes.len(),
+        )
+        .expect("h2d mutated conv");
+        let n_rec = recurrent_state.len_bytes() / 4;
+        let mut rec_bytes: Vec<u8> = Vec::with_capacity(n_rec * 4);
+        for _ in 0..n_rec {
+            rec_bytes.extend_from_slice(&float_fill.to_le_bytes());
+        }
+        gpu_hal::copy_h2d(
+            0usize,
+            recurrent_state.as_mut_ptr(),
+            rec_bytes.as_ptr() as *const _,
+            rec_bytes.len(),
+        )
+        .expect("h2d mutated rec");
+    }
+}
+
+#[test]
+fn linear_attn_state_save_restore_roundtrip() {
+    if !is_backend_compiled(Backend::Hip) {
+        eprintln!("skip: HIP backend not compiled");
+        return;
+    }
+    set_backend(Backend::Hip);
+    let ordinal = 0usize;
+
+    // Two linear layers with distinct seeded state, plus a Full
+    // layer in the middle to verify None-slot handling.
+    let conv0: Vec<u8> = (0..128).map(|i| (i as u8) ^ 0xA5).collect();
+    let rec0: Vec<f32> = (0..32).map(|i| (i as f32) * 0.125).collect();
+    let conv1: Vec<u8> = (0..128).map(|i| (i as u8).wrapping_mul(7)).collect();
+    let rec1: Vec<f32> = (0..32).map(|i| (i as f32) * -0.5 + 1.0).collect();
+
+    let l0 = make_linear_layer(ordinal, &conv0, &rec0).expect("linear layer 0");
+    let l_full = make_full_layer(ordinal).expect("full layer");
+    let l2 = make_linear_layer(ordinal, &conv1, &rec1).expect("linear layer 2");
+    let mut layers: Vec<LayerBuffers> = vec![l0, l_full, l2];
+
+    // ---- Initial save ----
+    let snap = save_linear_attn_state(ordinal, &layers).expect("save snapshot");
+    assert_eq!(
+        snap.linear_layer_count(), 2,
+        "snapshot should capture exactly 2 Linear layers (full layer is None)"
+    );
+    assert_eq!(snap.layers.len(), 3, "snapshot has one slot per source layer");
+    assert!(snap.layers[0].is_some(), "linear layer 0 captured");
+    assert!(snap.layers[1].is_none(), "full layer => None slot");
+    assert!(snap.layers[2].is_some(), "linear layer 2 captured");
+
+    // ---- Capture a baseline of live bytes for comparison ----
+    let pre_l0_conv = live_conv_bytes(&layers[0]);
+    let pre_l0_rec = live_rec_bytes(&layers[0]);
+    let pre_l2_conv = live_conv_bytes(&layers[2]);
+    let pre_l2_rec = live_rec_bytes(&layers[2]);
+    assert_eq!(pre_l0_conv.len(), conv0.len());
+    assert_eq!(pre_l0_rec.len(), rec0.len() * 4);
+
+    // ---- Mutate live state away from the snapshot ----
+    mutate_linear_state(&mut layers[0], 0xFF, 99.0);
+    mutate_linear_state(&mut layers[2], 0x11, -7.5);
+
+    let mid_l0_conv = live_conv_bytes(&layers[0]);
+    let mid_l2_rec = live_rec_bytes(&layers[2]);
+    assert_ne!(
+        mid_l0_conv, pre_l0_conv,
+        "mutation should have changed live conv_state"
+    );
+    assert_ne!(
+        mid_l2_rec, pre_l2_rec,
+        "mutation should have changed live recurrent_state"
+    );
+
+    // ---- Restore from snapshot ----
+    restore_linear_attn_state(ordinal, &mut layers, &snap).expect("restore");
+
+    let post_l0_conv = live_conv_bytes(&layers[0]);
+    let post_l0_rec = live_rec_bytes(&layers[0]);
+    let post_l2_conv = live_conv_bytes(&layers[2]);
+    let post_l2_rec = live_rec_bytes(&layers[2]);
+
+    assert_eq!(post_l0_conv, pre_l0_conv, "restored conv0 matches pre-mutate");
+    assert_eq!(post_l0_rec, pre_l0_rec, "restored rec0 matches pre-mutate");
+    assert_eq!(post_l2_conv, pre_l2_conv, "restored conv2 matches pre-mutate");
+    assert_eq!(post_l2_rec, pre_l2_rec, "restored rec2 matches pre-mutate");
+
+    eprintln!(
+        "[linear-state] save+restore roundtrip green over {} linear layers (skipping {} Full layer)",
+        snap.linear_layer_count(), snap.layers.len() - snap.linear_layer_count()
+    );
+}
+
+#[test]
+fn linear_attn_state_refresh_in_place_reuses_buffers() {
+    if !is_backend_compiled(Backend::Hip) {
+        eprintln!("skip: HIP backend not compiled");
+        return;
+    }
+    set_backend(Backend::Hip);
+    let ordinal = 0usize;
+
+    let conv0: Vec<u8> = (0..64).collect();
+    let rec0: Vec<f32> = (0..16).map(|i| i as f32).collect();
+    let l0 = make_linear_layer(ordinal, &conv0, &rec0).expect("linear layer");
+    let mut layers = vec![l0];
+
+    let mut snap = save_linear_attn_state(ordinal, &layers).expect("save");
+    let snap_conv_ptr_before = match &snap.layers[0] {
+        Some(s) => s.conv_state.as_ptr() as usize,
+        None => panic!("expected snapshot for linear layer 0"),
+    };
+
+    // Mutate live state to a NEW pattern, then refresh the snapshot
+    // (NOT save_linear_attn_state, which would re-allocate). The
+    // snapshot's underlying GpuBuffer pointer should be unchanged.
+    mutate_linear_state(&mut layers[0], 0xCC, 42.0);
+    let new_pattern_conv = live_conv_bytes(&layers[0]);
+    let new_pattern_rec = live_rec_bytes(&layers[0]);
+
+    refresh_linear_attn_state(ordinal, &layers, &mut snap).expect("refresh");
+
+    let snap_conv_ptr_after = match &snap.layers[0] {
+        Some(s) => s.conv_state.as_ptr() as usize,
+        None => panic!("expected snapshot for linear layer 0 after refresh"),
+    };
+    assert_eq!(
+        snap_conv_ptr_before, snap_conv_ptr_after,
+        "refresh must reuse the snapshot's existing GPU allocation \
+         (otherwise it'd be equivalent to save and offer no win)"
+    );
+
+    // Mutate live again, then restore — snapshot now has the second
+    // pattern, NOT the first.
+    mutate_linear_state(&mut layers[0], 0x00, 0.0);
+    restore_linear_attn_state(ordinal, &mut layers, &snap).expect("restore");
+
+    let restored_conv = live_conv_bytes(&layers[0]);
+    let restored_rec = live_rec_bytes(&layers[0]);
+    assert_eq!(
+        restored_conv, new_pattern_conv,
+        "restore should have brought back the refreshed (second) pattern"
+    );
+    assert_eq!(
+        restored_rec, new_pattern_rec,
+        "restore should have brought back the refreshed recurrent state"
+    );
+}


### PR DESCRIPTION
## Summary
Foundation primitive for any operation that needs to checkpoint linear-attn mutable state. Intended consumer is the speculative-decode driver: it needs to save state before running speculative verify chains and restore on rejection. This is the gap that tripped PR #113's batched-verify wiring attempt — linear-attn's `conv_state` + `recurrent_state` mutate per token and don't roll back naturally.

## API

```rust
pub struct LinearAttnSnapshot {
    pub layers: Vec<Option<LinearAttnLayerSnapshot>>,
}

pub fn save_linear_attn_state(ordinal, &[LayerBuffers])
    -> Result<LinearAttnSnapshot>;
pub fn refresh_linear_attn_state(ordinal, &[LayerBuffers], &mut LinearAttnSnapshot)
    -> Result<()>;
pub fn restore_linear_attn_state(ordinal, &mut [LayerBuffers], &LinearAttnSnapshot)
    -> Result<()>;
```

- `save_*` allocates shadow buffers + copies (one-time setup).
- `refresh_*` reuses existing shadows (per-spec-step refresh, D2D only, no allocs).
- `restore_*` is the inverse: snapshot → live, D2D copies.

None-slots in the snapshot vec correspond to Full layers — only Linear layers carry state.

## Cost
At 35B-A3B (30 linear layers): full snapshot copies ~62 MiB GPU→GPU. At 7900 XTX peak ~960 GB/s, that's ~65 µs of D2D bandwidth — negligible vs the ~26 ms/token chain cost.

## Tests
- `linear_attn_state_save_restore_roundtrip`: 3-layer mix (Linear, Full, Linear) with seeded state. Snapshot → mutate live state → restore → assert byte-identical to pre-mutation. Confirms None-slot handling for Full layers.
- `linear_attn_state_refresh_in_place_reuses_buffers`: takes a snapshot, captures the shadow buffer's pointer, calls `refresh_*`, asserts the pointer is unchanged (reused allocation, not re-allocated). Then mutates + restores and asserts the restored state matches the **refreshed** pattern (not the original) — pins the contract that `refresh_*` actually updates the shadow.

Both green on the local 7900 XTX.

## Phase 6.4 sequencing
- ✅ 6.4a (PR #109, merged): batched lm_head WMMA template
- 🔍 6.4b (PR #113, pending review): batched-K speculative driver primitive
- ✅ 6.4c.1 (this PR): linear-attn state save/restore primitive
- ⏳ 6.4c.2: wire snapshot + batched closure into engine. State-mgmt protocol: snapshot before verify, restore on rejection then replay accepted prefix sequentially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)