### PR TITLE
[codex] Add Qwen3.6 FP8 verification suite

### DIFF
--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -1278,7 +1278,7 @@ fn main() -> Result<()> {
                 | ModelVariant::Phi4_Mini
         ) {
             anyhow::bail!(
-                "HIP gfx942 bring-up currently validates only Qwen3.5 models up to 9B BF16/INT4/FP8-runtime/KV-FP8, Qwen3.6 35B A3B INT4, Gemma 4 E2B BF16/INT4, Gemma 4 E4B BF16, and Phi-4-mini BF16/INT4/FP8-runtime/KV-FP8"
+                "HIP gfx942 bring-up currently validates only Qwen3.5 models up to 9B BF16/INT4/FP8-runtime/KV-FP8, Qwen3.6 35B A3B INT4/FP8-runtime, Gemma 4 E2B BF16/INT4, Gemma 4 E4B BF16, and Phi-4-mini BF16/INT4/FP8-runtime/KV-FP8"
             );
         }
         let qwen35_model = matches!(
@@ -1288,17 +1288,24 @@ fn main() -> Result<()> {
                 | ModelVariant::Qwen3_5_4B
                 | ModelVariant::Qwen3_5_9B
         );
-        if (cli.fp8_runtime && !(qwen35_model || matches!(model_variant, ModelVariant::Phi4_Mini)))
+        if (cli.fp8_runtime
+            && !(qwen35_model
+                || matches!(
+                    model_variant,
+                    ModelVariant::Qwen3_6_35B_A3B | ModelVariant::Phi4_Mini
+                )))
             || (cli.kv_fp8 && !(qwen35_model || matches!(model_variant, ModelVariant::Phi4_Mini)))
             || cli.q4km
             || cli.q4km_gptq
         {
             anyhow::bail!(
-                "HIP gfx942 bring-up currently validates only BF16/INT4/FP8-runtime/KV-FP8 Qwen3.5 lanes, Qwen3.6 35B A3B INT4, Gemma 4 E2B BF16/INT4, Gemma 4 E4B BF16, and Phi-4-mini BF16/INT4/FP8-runtime/KV-FP8"
+                "HIP gfx942 bring-up currently validates only BF16/INT4/FP8-runtime/KV-FP8 Qwen3.5 lanes, Qwen3.6 35B A3B INT4/FP8-runtime, Gemma 4 E2B BF16/INT4, Gemma 4 E4B BF16, and Phi-4-mini BF16/INT4/FP8-runtime/KV-FP8"
             );
         }
-        if matches!(model_variant, ModelVariant::Qwen3_6_35B_A3B) && !cli.int4 {
-            anyhow::bail!("HIP gfx942 Qwen3.6 35B A3B bring-up currently validates only --int4");
+        if matches!(model_variant, ModelVariant::Qwen3_6_35B_A3B) && !(cli.int4 || cli.fp8_runtime) {
+            anyhow::bail!(
+                "HIP gfx942 Qwen3.6 35B A3B bring-up currently validates only --int4 or --fp8-runtime"
+            );
         }
         if matches!(model_variant, ModelVariant::Gemma4_E4B) && cli.int4 {
             anyhow::bail!("HIP gfx942 Gemma 4 E4B bring-up currently validates only BF16");

--- a/crates/runner/src/qwen36_moe_decode.rs
+++ b/crates/runner/src/qwen36_moe_decode.rs
@@ -652,17 +652,20 @@ pub fn run_chained_decode_with_options(
                     kv_max_t,
                 };
                 let int4_ptrs = match int4 {
-                    Some(s) => Qwen36MoeAttnStepInt4 {
-                        group_size: s.group_size,
-                        q_proj_scale: s.q_proj_scale.as_ptr(),
-                        q_proj_zero: s.q_proj_zero.as_ptr(),
-                        k_proj_scale: s.k_proj_scale.as_ptr(),
-                        k_proj_zero: s.k_proj_zero.as_ptr(),
-                        v_proj_scale: s.v_proj_scale.as_ptr(),
-                        v_proj_zero: s.v_proj_zero.as_ptr(),
-                        o_proj_scale: s.o_proj_scale.as_ptr(),
-                        o_proj_zero: s.o_proj_zero.as_ptr(),
-                    },
+                    Some(s) => {
+                        let fp8 = s.group_size < 0;
+                        Qwen36MoeAttnStepInt4 {
+                            group_size: s.group_size,
+                            q_proj_scale: s.q_proj_scale.as_ptr(),
+                            q_proj_zero: if fp8 { ptr::null() } else { s.q_proj_zero.as_ptr() },
+                            k_proj_scale: s.k_proj_scale.as_ptr(),
+                            k_proj_zero: if fp8 { ptr::null() } else { s.k_proj_zero.as_ptr() },
+                            v_proj_scale: s.v_proj_scale.as_ptr(),
+                            v_proj_zero: if fp8 { ptr::null() } else { s.v_proj_zero.as_ptr() },
+                            o_proj_scale: s.o_proj_scale.as_ptr(),
+                            o_proj_zero: if fp8 { ptr::null() } else { s.o_proj_zero.as_ptr() },
+                        }
+                    }
                     None => Qwen36MoeAttnStepInt4::disabled(),
                 };
                 let t_k = std::time::Instant::now();
@@ -729,15 +732,18 @@ pub fn run_chained_decode_with_options(
                     recurrent_state: recurrent_state.as_mut_ptr() as *mut f32,
                 };
                 let int4_ptrs = match int4 {
-                    Some(s) => Qwen36MoeLinearStepInt4 {
-                        group_size: s.group_size,
-                        in_proj_qkv_scale: s.in_proj_qkv_scale.as_ptr(),
-                        in_proj_qkv_zero: s.in_proj_qkv_zero.as_ptr(),
-                        in_proj_z_scale: s.in_proj_z_scale.as_ptr(),
-                        in_proj_z_zero: s.in_proj_z_zero.as_ptr(),
-                        out_proj_scale: s.out_proj_scale.as_ptr(),
-                        out_proj_zero: s.out_proj_zero.as_ptr(),
-                    },
+                    Some(s) => {
+                        let fp8 = s.group_size < 0;
+                        Qwen36MoeLinearStepInt4 {
+                            group_size: s.group_size,
+                            in_proj_qkv_scale: s.in_proj_qkv_scale.as_ptr(),
+                            in_proj_qkv_zero: if fp8 { ptr::null() } else { s.in_proj_qkv_zero.as_ptr() },
+                            in_proj_z_scale: s.in_proj_z_scale.as_ptr(),
+                            in_proj_z_zero: if fp8 { ptr::null() } else { s.in_proj_z_zero.as_ptr() },
+                            out_proj_scale: s.out_proj_scale.as_ptr(),
+                            out_proj_zero: if fp8 { ptr::null() } else { s.out_proj_zero.as_ptr() },
+                        }
+                    }
                     None => Qwen36MoeLinearStepInt4::disabled(),
                 };
                 let t_k = std::time::Instant::now();
@@ -819,19 +825,22 @@ pub fn run_chained_decode_with_options(
             shared_expert_gate_w: ffn.shared_expert_gate_w.as_ptr(),
         };
         let ffn_int4_ptrs = match &ffn.int4 {
-            Some(s) => Qwen36MoeFfnStepInt4 {
-                group_size: s.group_size,
-                gate_up_proj_scale: s.gate_up_proj_scale.as_ptr(),
-                gate_up_proj_zero: s.gate_up_proj_zero.as_ptr(),
-                down_proj_scale: s.down_proj_scale.as_ptr(),
-                down_proj_zero: s.down_proj_zero.as_ptr(),
-                shared_gate_proj_scale: s.shared_gate_proj_scale.as_ptr(),
-                shared_gate_proj_zero: s.shared_gate_proj_zero.as_ptr(),
-                shared_up_proj_scale: s.shared_up_proj_scale.as_ptr(),
-                shared_up_proj_zero: s.shared_up_proj_zero.as_ptr(),
-                shared_down_proj_scale: s.shared_down_proj_scale.as_ptr(),
-                shared_down_proj_zero: s.shared_down_proj_zero.as_ptr(),
-            },
+            Some(s) => {
+                let fp8 = s.group_size < 0;
+                Qwen36MoeFfnStepInt4 {
+                    group_size: s.group_size,
+                    gate_up_proj_scale: s.gate_up_proj_scale.as_ptr(),
+                    gate_up_proj_zero: if fp8 { ptr::null() } else { s.gate_up_proj_zero.as_ptr() },
+                    down_proj_scale: s.down_proj_scale.as_ptr(),
+                    down_proj_zero: if fp8 { ptr::null() } else { s.down_proj_zero.as_ptr() },
+                    shared_gate_proj_scale: s.shared_gate_proj_scale.as_ptr(),
+                    shared_gate_proj_zero: if fp8 { ptr::null() } else { s.shared_gate_proj_zero.as_ptr() },
+                    shared_up_proj_scale: s.shared_up_proj_scale.as_ptr(),
+                    shared_up_proj_zero: if fp8 { ptr::null() } else { s.shared_up_proj_zero.as_ptr() },
+                    shared_down_proj_scale: s.shared_down_proj_scale.as_ptr(),
+                    shared_down_proj_zero: if fp8 { ptr::null() } else { s.shared_down_proj_zero.as_ptr() },
+                }
+            }
             None => Qwen36MoeFfnStepInt4::disabled(),
         };
         let t_k = std::time::Instant::now();

--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -28,8 +28,8 @@ use qwen36_moe::weights::{
 use crate::qwen36_moe_decode::{
     argmax_bf16_logits, dequant_int4_to_bf16_bytes, host_final_norm_lm_head, run_chained_decode,
     run_chained_decode_fast, sample_bf16_logits, AttnLayerBuffers, FfnInt4Sidecars,
-    FfnLayerBuffers, FullAttnInt4Sidecars, FullAttnKvCache, LayerBuffers,
-    LinearAttnInt4Sidecars, MtpLayerBuffers, MultiLayerGeom, XorshiftRng,
+    FfnLayerBuffers, FullAttnInt4Sidecars, FullAttnKvCache, LayerBuffers, LinearAttnInt4Sidecars,
+    MtpLayerBuffers, MultiLayerGeom, XorshiftRng,
 };
 use crate::qwen36_moe_speculative::{
     run_speculative_decode_step, run_speculative_decode_step_batched,
@@ -207,11 +207,10 @@ pub fn run_qwen36_moe_dry_run(
         }
     }
 
-    let kv_bytes_per_token =
-        config.text_config.kv_bytes_per_token(if kv_fp8 { 1 } else { 2 });
-    let registry_budget_bytes = entry
-        .vram
-        .estimate_total(context_size, kv_bytes_per_token);
+    let kv_bytes_per_token = config
+        .text_config
+        .kv_bytes_per_token(if kv_fp8 { 1 } else { 2 });
+    let registry_budget_bytes = entry.vram.estimate_total(context_size, kv_bytes_per_token);
 
     Ok(DryRunReport {
         config,
@@ -247,10 +246,8 @@ fn inspect_bake(
     // Re-parse the manifest header even though BakedStore does too — we
     // expose format/converter versions in the report so a stale bake is
     // visible without having to dig into the file by hand.
-    let manifest_text =
-        std::fs::read_to_string(model_store::manifest_path(&bake_dir)).ok()?;
-    let manifest: model_store::manifest::Manifest =
-        serde_json::from_str(&manifest_text).ok()?;
+    let manifest_text = std::fs::read_to_string(model_store::manifest_path(&bake_dir)).ok()?;
+    let manifest: model_store::manifest::Manifest = serde_json::from_str(&manifest_text).ok()?;
     let store = BakedStore::open(&bake_dir).ok()?;
     let weights_bin_bytes = std::fs::metadata(model_store::weights_bin_path(&bake_dir))
         .ok()?
@@ -330,10 +327,7 @@ fn scalar_to_checkpoint_dtype(s: ScalarKind) -> Option<CheckpointDtype> {
     }
 }
 
-fn sanity_check_kernel_params(
-    config: &TextConfig,
-    params: &Qwen36MoeKernelParams,
-) -> Result<()> {
+fn sanity_check_kernel_params(config: &TextConfig, params: &Qwen36MoeKernelParams) -> Result<()> {
     if config.num_experts as u32 > params.num_experts {
         return Err(anyhow!(
             "config has num_experts={} but registry kernel scratch is sized for at most {}; \
@@ -582,12 +576,8 @@ pub fn print_report(report: &DryRunReport) {
                 println!("    - layer {li}: {n}");
             }
         }
-        let bake_ok = bake.missing_specs.is_empty()
-            && bake.bad_expert_tensors.is_empty();
-        println!(
-            "  ready-for-decode: {}",
-            if bake_ok { "YES" } else { "NO" }
-        );
+        let bake_ok = bake.missing_specs.is_empty() && bake.bad_expert_tensors.is_empty();
+        println!("  ready-for-decode: {}", if bake_ok { "YES" } else { "NO" });
         println!();
     } else {
         println!(
@@ -623,17 +613,14 @@ pub fn print_report(report: &DryRunReport) {
             "  WARNING: context_size defaulted to max_new_tokens={}. KV cache for a real",
             report.context_size_used,
         );
-        println!(
-            "  decode session will be larger; pass --context-size <N> (or --prompt) for an",
-        );
+        println!("  decode session will be larger; pass --context-size <N> (or --prompt) for an",);
         println!(
             "  honest fit number. Worst case at the model's max ({} tokens) needs",
             max_pos,
         );
         // Quick worst-case KV estimate at model max — gives the user one
         // concrete data point before they have to re-run with a flag.
-        let worst_kv = report.config.text_config.kv_bytes_per_token(2)
-            * max_pos as u64;
+        let worst_kv = report.config.text_config.kv_bytes_per_token(2) * max_pos as u64;
         println!(
             "  ~{:.2} GiB of KV cache alone (BF16).",
             worst_kv as f64 / GIB,
@@ -641,11 +628,7 @@ pub fn print_report(report: &DryRunReport) {
     }
 }
 
-pub fn run(
-    cli: &crate::Cli,
-    entry: &RegistryEntry,
-    total_vram: u64,
-) -> Result<()> {
+pub fn run(cli: &crate::Cli, entry: &RegistryEntry, total_vram: u64) -> Result<()> {
     // Derive context_size + an honest source flag so the printed report can
     // tell the user which of three answers they got: explicit, prompt-derived
     // estimate, or worst-case defaults-only. The `--context-size` path is
@@ -658,7 +641,10 @@ pub fn run(
     let (context_size, context_size_source) = if let Some(ctx) = cli.context_size {
         (ctx, ContextSizeSource::Explicit)
     } else if !cli.prompt.is_empty() {
-        (cli.prompt.chars().count() + max_new, ContextSizeSource::EstimatedFromPrompt)
+        (
+            cli.prompt.chars().count() + max_new,
+            ContextSizeSource::EstimatedFromPrompt,
+        )
     } else {
         (max_new, ContextSizeSource::MaxNewTokensOnly)
     };
@@ -694,15 +680,19 @@ pub fn run(
         );
     }
 
-    // Auto-download the INT4 bake from the GitHub release if missing or
-    // stale. The qwen3.6-MoE engine had been missing this wiring — an
+    // Auto-download the requested release bake if missing or stale. The
+    // qwen3.6-MoE engine had been missing this wiring for INT4 — an
     // oversight visible during Phase 6 bring-up: 35B-A3B INT4
     // calibration OOMs on 24 GiB hosts, so release-hosted bakes are
     // the only realistic way to ship updates (e.g. the post-#84 bake
     // that includes mtp.* tensors for self-speculative decode). Mirrors
     // the Phi-4 / Llama-3.1 / Qwen3.5 paths.
     {
-        let variant = model_store::fetch::BakeVariant::Int4Gptq;
+        let variant = if cli.fp8_runtime {
+            model_store::fetch::BakeVariant::Fp8Native
+        } else {
+            model_store::fetch::BakeVariant::Int4Gptq
+        };
         let bake_dir = variant.bake_dir(&cli.model_dir);
         let _lock = model_store::BakeLock::acquire(&cli.model_dir)
             .map_err(|e| anyhow!("acquire bake lock: {e}"))?;
@@ -715,11 +705,15 @@ pub fn run(
             let canonical_model = entry.model.to_string();
             match crate::try_download_bake(cli, variant, &canonical_model, &bake_dir) {
                 Ok(true) => eprintln!(
-                    "[fetch] installed qwen3.6-MoE INT4 bake at {}",
+                    "[fetch] installed qwen3.6-MoE {} bake at {}",
+                    if cli.fp8_runtime { "FP8" } else { "INT4" },
                     bake_dir.display()
                 ),
                 Ok(false) => {}
-                Err(e) => eprintln!("[fetch] qwen3.6-MoE INT4 bake fetch failed: {e}"),
+                Err(e) => eprintln!(
+                    "[fetch] qwen3.6-MoE {} bake fetch failed: {e}",
+                    if cli.fp8_runtime { "FP8" } else { "INT4" }
+                ),
             }
         }
     }
@@ -758,6 +752,7 @@ pub fn run(
         sampling,
         cli.emit_stage_timings,
         cli.speculative_decode,
+        cli.fp8_runtime,
         cli.batched_spec_verify,
     )?;
     Ok(())
@@ -847,16 +842,26 @@ fn resolve_qwen36_store_name<'a>(store: &BakedStore, name: &'a str) -> Cow<'a, s
 /// `*_int4_scale` sidecar; if any quantizable tensor is present and
 /// uses a different group_size we'd surface that as an error.
 const QWEN36_MOE_INT4_GROUP_SIZE: i32 = 128;
+const QWEN36_MOE_FP8_BLOCK_SIZE: i32 = 128;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Qwen36WeightMode {
+    Bf16,
+    Int4,
+    Fp8,
+}
 
 /// Build one layer's worth of GPU-resident weight + state buffers from a
 /// BakedStore. Decides full-attn vs linear-attn by consulting the config's
 /// `layer_types` (every 4th layer is full per the standard hybrid pattern).
-/// `int4_enabled` controls whether the weight tensors are loaded as packed
-/// nibbles + sidecars or as BF16. The bake naming convention pairs
+/// `weight_mode` controls whether the weight tensors are loaded as BF16,
+/// packed INT4 nibbles + sidecars, or native FP8 bytes + scale sidecars. The
+/// INT4 bake naming convention pairs
 /// `<name>.weight` (packed) with `<name>.weight_int4_scale`/`_int4_zero`
 /// for dense projections, and `<name>` (packed) with `<name>_int4_scale`/
 /// `_int4_zero` for fused-expert tensors (no `.weight` suffix in the
-/// HuggingFace checkpoint).
+/// HuggingFace checkpoint). FP8 uses the same weight names plus
+/// `<name>_scale_inv`.
 fn load_layer_buffers(
     store: &BakedStore,
     ordinal: usize,
@@ -864,7 +869,7 @@ fn load_layer_buffers(
     geom: &MultiLayerGeom,
     text_config: &TextConfig,
     weight_prefix: &str,
-    int4_enabled: bool,
+    weight_mode: Qwen36WeightMode,
     // When > 0, allocate a KV cache for full-attention layers sized for
     // `kv_max_t` past tokens. Linear-attn layers use `conv_state` +
     // `recurrent_state` instead (always allocated). 0 = no KV cache,
@@ -875,20 +880,62 @@ fn load_layer_buffers(
 
     let attn = if text_config.is_full_attention(layer_idx) {
         let fa = format!("{lp}.self_attn");
-        let int4 = if int4_enabled {
-            Some(FullAttnInt4Sidecars {
+        let int4 = match weight_mode {
+            Qwen36WeightMode::Int4 => Some(FullAttnInt4Sidecars {
                 group_size: QWEN36_MOE_INT4_GROUP_SIZE,
-                q_proj_scale: load_to_gpu(store, ordinal, &format!("{fa}.q_proj.weight_int4_scale"))?,
-                q_proj_zero:  load_to_gpu(store, ordinal, &format!("{fa}.q_proj.weight_int4_zero"))?,
-                k_proj_scale: load_to_gpu(store, ordinal, &format!("{fa}.k_proj.weight_int4_scale"))?,
-                k_proj_zero:  load_to_gpu(store, ordinal, &format!("{fa}.k_proj.weight_int4_zero"))?,
-                v_proj_scale: load_to_gpu(store, ordinal, &format!("{fa}.v_proj.weight_int4_scale"))?,
-                v_proj_zero:  load_to_gpu(store, ordinal, &format!("{fa}.v_proj.weight_int4_zero"))?,
-                o_proj_scale: load_to_gpu(store, ordinal, &format!("{fa}.o_proj.weight_int4_scale"))?,
-                o_proj_zero:  load_to_gpu(store, ordinal, &format!("{fa}.o_proj.weight_int4_zero"))?,
-            })
-        } else {
-            None
+                q_proj_scale: load_to_gpu(
+                    store,
+                    ordinal,
+                    &format!("{fa}.q_proj.weight_int4_scale"),
+                )?,
+                q_proj_zero: load_to_gpu(store, ordinal, &format!("{fa}.q_proj.weight_int4_zero"))?,
+                k_proj_scale: load_to_gpu(
+                    store,
+                    ordinal,
+                    &format!("{fa}.k_proj.weight_int4_scale"),
+                )?,
+                k_proj_zero: load_to_gpu(store, ordinal, &format!("{fa}.k_proj.weight_int4_zero"))?,
+                v_proj_scale: load_to_gpu(
+                    store,
+                    ordinal,
+                    &format!("{fa}.v_proj.weight_int4_scale"),
+                )?,
+                v_proj_zero: load_to_gpu(store, ordinal, &format!("{fa}.v_proj.weight_int4_zero"))?,
+                o_proj_scale: load_to_gpu(
+                    store,
+                    ordinal,
+                    &format!("{fa}.o_proj.weight_int4_scale"),
+                )?,
+                o_proj_zero: load_to_gpu(store, ordinal, &format!("{fa}.o_proj.weight_int4_zero"))?,
+            }),
+            Qwen36WeightMode::Fp8 => Some(FullAttnInt4Sidecars {
+                group_size: -QWEN36_MOE_FP8_BLOCK_SIZE,
+                q_proj_scale: load_to_gpu(
+                    store,
+                    ordinal,
+                    &format!("{fa}.q_proj.weight_scale_inv"),
+                )?,
+                q_proj_zero: GpuBuffer::zeros(ordinal, ScalarType::U8, &[1])?,
+                k_proj_scale: load_to_gpu(
+                    store,
+                    ordinal,
+                    &format!("{fa}.k_proj.weight_scale_inv"),
+                )?,
+                k_proj_zero: GpuBuffer::zeros(ordinal, ScalarType::U8, &[1])?,
+                v_proj_scale: load_to_gpu(
+                    store,
+                    ordinal,
+                    &format!("{fa}.v_proj.weight_scale_inv"),
+                )?,
+                v_proj_zero: GpuBuffer::zeros(ordinal, ScalarType::U8, &[1])?,
+                o_proj_scale: load_to_gpu(
+                    store,
+                    ordinal,
+                    &format!("{fa}.o_proj.weight_scale_inv"),
+                )?,
+                o_proj_zero: GpuBuffer::zeros(ordinal, ScalarType::U8, &[1])?,
+            }),
+            Qwen36WeightMode::Bf16 => None,
         };
         // KV cache: allocate per-layer when multi-token decode is requested.
         // Layout: BF16 [kv_max_t, num_kv_heads * head_dim] for both K and V.
@@ -933,18 +980,62 @@ fn load_layer_buffers(
         let recurrent_state = GpuBuffer::zeros(ordinal, ScalarType::F32, &[state_elems])
             .with_context(|| format!("alloc recurrent_state (layer {layer_idx})"))?;
 
-        let int4 = if int4_enabled {
-            Some(LinearAttnInt4Sidecars {
+        let int4 = match weight_mode {
+            Qwen36WeightMode::Int4 => Some(LinearAttnInt4Sidecars {
                 group_size: QWEN36_MOE_INT4_GROUP_SIZE,
-                in_proj_qkv_scale: load_to_gpu(store, ordinal, &format!("{la}.in_proj_qkv.weight_int4_scale"))?,
-                in_proj_qkv_zero:  load_to_gpu(store, ordinal, &format!("{la}.in_proj_qkv.weight_int4_zero"))?,
-                in_proj_z_scale:   load_to_gpu(store, ordinal, &format!("{la}.in_proj_z.weight_int4_scale"))?,
-                in_proj_z_zero:    load_to_gpu(store, ordinal, &format!("{la}.in_proj_z.weight_int4_zero"))?,
-                out_proj_scale:    load_to_gpu(store, ordinal, &format!("{la}.out_proj.weight_int4_scale"))?,
-                out_proj_zero:     load_to_gpu(store, ordinal, &format!("{la}.out_proj.weight_int4_zero"))?,
-            })
-        } else {
-            None
+                in_proj_qkv_scale: load_to_gpu(
+                    store,
+                    ordinal,
+                    &format!("{la}.in_proj_qkv.weight_int4_scale"),
+                )?,
+                in_proj_qkv_zero: load_to_gpu(
+                    store,
+                    ordinal,
+                    &format!("{la}.in_proj_qkv.weight_int4_zero"),
+                )?,
+                in_proj_z_scale: load_to_gpu(
+                    store,
+                    ordinal,
+                    &format!("{la}.in_proj_z.weight_int4_scale"),
+                )?,
+                in_proj_z_zero: load_to_gpu(
+                    store,
+                    ordinal,
+                    &format!("{la}.in_proj_z.weight_int4_zero"),
+                )?,
+                out_proj_scale: load_to_gpu(
+                    store,
+                    ordinal,
+                    &format!("{la}.out_proj.weight_int4_scale"),
+                )?,
+                out_proj_zero: load_to_gpu(
+                    store,
+                    ordinal,
+                    &format!("{la}.out_proj.weight_int4_zero"),
+                )?,
+            }),
+            Qwen36WeightMode::Fp8 => Some(LinearAttnInt4Sidecars {
+                group_size: -QWEN36_MOE_FP8_BLOCK_SIZE,
+                in_proj_qkv_scale: load_to_gpu(
+                    store,
+                    ordinal,
+                    &format!("{la}.in_proj_qkv.weight_scale_inv"),
+                )?,
+                in_proj_qkv_zero: GpuBuffer::zeros(ordinal, ScalarType::U8, &[1])?,
+                in_proj_z_scale: load_to_gpu(
+                    store,
+                    ordinal,
+                    &format!("{la}.in_proj_z.weight_scale_inv"),
+                )?,
+                in_proj_z_zero: GpuBuffer::zeros(ordinal, ScalarType::U8, &[1])?,
+                out_proj_scale: load_to_gpu(
+                    store,
+                    ordinal,
+                    &format!("{la}.out_proj.weight_scale_inv"),
+                )?,
+                out_proj_zero: GpuBuffer::zeros(ordinal, ScalarType::U8, &[1])?,
+            }),
+            Qwen36WeightMode::Bf16 => None,
         };
 
         AttnLayerBuffers::Linear {
@@ -972,34 +1063,126 @@ fn load_layer_buffers(
     let mp = format!("{lp}.mlp");
     // Fused-expert sidecars use `_int4_scale`/`_int4_zero` (no `.weight`).
     // Shared-expert MLPs use the dense `<name>.weight_int4_scale` form.
-    let ffn_int4 = if int4_enabled {
-        Some(FfnInt4Sidecars {
+    let ffn_int4 = match weight_mode {
+        Qwen36WeightMode::Int4 => Some(FfnInt4Sidecars {
             group_size: QWEN36_MOE_INT4_GROUP_SIZE,
-            gate_up_proj_scale: load_to_gpu(store, ordinal, &format!("{mp}.experts.gate_up_proj_int4_scale"))?,
-            gate_up_proj_zero:  load_to_gpu(store, ordinal, &format!("{mp}.experts.gate_up_proj_int4_zero"))?,
-            down_proj_scale:    load_to_gpu(store, ordinal, &format!("{mp}.experts.down_proj_int4_scale"))?,
-            down_proj_zero:     load_to_gpu(store, ordinal, &format!("{mp}.experts.down_proj_int4_zero"))?,
-            shared_gate_proj_scale: load_to_gpu(store, ordinal, &format!("{mp}.shared_expert.gate_proj.weight_int4_scale"))?,
-            shared_gate_proj_zero:  load_to_gpu(store, ordinal, &format!("{mp}.shared_expert.gate_proj.weight_int4_zero"))?,
-            shared_up_proj_scale:   load_to_gpu(store, ordinal, &format!("{mp}.shared_expert.up_proj.weight_int4_scale"))?,
-            shared_up_proj_zero:    load_to_gpu(store, ordinal, &format!("{mp}.shared_expert.up_proj.weight_int4_zero"))?,
-            shared_down_proj_scale: load_to_gpu(store, ordinal, &format!("{mp}.shared_expert.down_proj.weight_int4_scale"))?,
-            shared_down_proj_zero:  load_to_gpu(store, ordinal, &format!("{mp}.shared_expert.down_proj.weight_int4_zero"))?,
-        })
-    } else {
-        None
+            gate_up_proj_scale: load_to_gpu(
+                store,
+                ordinal,
+                &format!("{mp}.experts.gate_up_proj_int4_scale"),
+            )?,
+            gate_up_proj_zero: load_to_gpu(
+                store,
+                ordinal,
+                &format!("{mp}.experts.gate_up_proj_int4_zero"),
+            )?,
+            down_proj_scale: load_to_gpu(
+                store,
+                ordinal,
+                &format!("{mp}.experts.down_proj_int4_scale"),
+            )?,
+            down_proj_zero: load_to_gpu(
+                store,
+                ordinal,
+                &format!("{mp}.experts.down_proj_int4_zero"),
+            )?,
+            shared_gate_proj_scale: load_to_gpu(
+                store,
+                ordinal,
+                &format!("{mp}.shared_expert.gate_proj.weight_int4_scale"),
+            )?,
+            shared_gate_proj_zero: load_to_gpu(
+                store,
+                ordinal,
+                &format!("{mp}.shared_expert.gate_proj.weight_int4_zero"),
+            )?,
+            shared_up_proj_scale: load_to_gpu(
+                store,
+                ordinal,
+                &format!("{mp}.shared_expert.up_proj.weight_int4_scale"),
+            )?,
+            shared_up_proj_zero: load_to_gpu(
+                store,
+                ordinal,
+                &format!("{mp}.shared_expert.up_proj.weight_int4_zero"),
+            )?,
+            shared_down_proj_scale: load_to_gpu(
+                store,
+                ordinal,
+                &format!("{mp}.shared_expert.down_proj.weight_int4_scale"),
+            )?,
+            shared_down_proj_zero: load_to_gpu(
+                store,
+                ordinal,
+                &format!("{mp}.shared_expert.down_proj.weight_int4_zero"),
+            )?,
+        }),
+        Qwen36WeightMode::Fp8 => Some(FfnInt4Sidecars {
+            group_size: -QWEN36_MOE_FP8_BLOCK_SIZE,
+            gate_up_proj_scale: load_to_gpu(
+                store,
+                ordinal,
+                &format!("{mp}.experts.gate_up_proj_scale_inv"),
+            )?,
+            gate_up_proj_zero: GpuBuffer::zeros(ordinal, ScalarType::U8, &[1])?,
+            down_proj_scale: load_to_gpu(
+                store,
+                ordinal,
+                &format!("{mp}.experts.down_proj_scale_inv"),
+            )?,
+            down_proj_zero: GpuBuffer::zeros(ordinal, ScalarType::U8, &[1])?,
+            shared_gate_proj_scale: load_to_gpu(
+                store,
+                ordinal,
+                &format!("{mp}.shared_expert.gate_proj.weight_scale_inv"),
+            )?,
+            shared_gate_proj_zero: GpuBuffer::zeros(ordinal, ScalarType::U8, &[1])?,
+            shared_up_proj_scale: load_to_gpu(
+                store,
+                ordinal,
+                &format!("{mp}.shared_expert.up_proj.weight_scale_inv"),
+            )?,
+            shared_up_proj_zero: GpuBuffer::zeros(ordinal, ScalarType::U8, &[1])?,
+            shared_down_proj_scale: load_to_gpu(
+                store,
+                ordinal,
+                &format!("{mp}.shared_expert.down_proj.weight_scale_inv"),
+            )?,
+            shared_down_proj_zero: GpuBuffer::zeros(ordinal, ScalarType::U8, &[1])?,
+        }),
+        Qwen36WeightMode::Bf16 => None,
     };
     let ffn = FfnLayerBuffers {
-        post_attn_norm_w: load_to_gpu(store, ordinal, &format!("{lp}.post_attention_layernorm.weight"))?,
+        post_attn_norm_w: load_to_gpu(
+            store,
+            ordinal,
+            &format!("{lp}.post_attention_layernorm.weight"),
+        )?,
         gate_w: load_to_gpu(store, ordinal, &format!("{mp}.gate.weight"))?,
         // Note: experts.gate_up_proj / experts.down_proj have NO `.weight`
         // suffix in the published checkpoint — see expected_tensor_specs.
         gate_up_proj_w: load_to_gpu(store, ordinal, &format!("{mp}.experts.gate_up_proj"))?,
         down_proj_w: load_to_gpu(store, ordinal, &format!("{mp}.experts.down_proj"))?,
-        shared_gate_proj_w: load_to_gpu(store, ordinal, &format!("{mp}.shared_expert.gate_proj.weight"))?,
-        shared_up_proj_w: load_to_gpu(store, ordinal, &format!("{mp}.shared_expert.up_proj.weight"))?,
-        shared_down_proj_w: load_to_gpu(store, ordinal, &format!("{mp}.shared_expert.down_proj.weight"))?,
-        shared_expert_gate_w: load_to_gpu(store, ordinal, &format!("{mp}.shared_expert_gate.weight"))?,
+        shared_gate_proj_w: load_to_gpu(
+            store,
+            ordinal,
+            &format!("{mp}.shared_expert.gate_proj.weight"),
+        )?,
+        shared_up_proj_w: load_to_gpu(
+            store,
+            ordinal,
+            &format!("{mp}.shared_expert.up_proj.weight"),
+        )?,
+        shared_down_proj_w: load_to_gpu(
+            store,
+            ordinal,
+            &format!("{mp}.shared_expert.down_proj.weight"),
+        )?,
+        shared_expert_gate_w: load_to_gpu(
+            store,
+            ordinal,
+            &format!("{mp}.shared_expert_gate.weight"),
+        )?,
         int4: ffn_int4,
     };
 
@@ -1188,6 +1371,7 @@ fn decode_text(
     sampling: SamplingParams,
     emit_stage_timings: bool,
     speculative_decode: bool,
+    fp8_runtime: bool,
     batched_spec_verify: bool,
 ) -> Result<()> {
     use std::io::Write as _;
@@ -1206,8 +1390,7 @@ fn decode_text(
     // any of `temperature > 0`, `top_k != 1`, `top_p < 1.0` — counts
     // as non-greedy and is rejected here.
     if speculative_decode {
-        let is_greedy = sampling.temperature <= 0.0
-            || sampling.top_k == 1;
+        let is_greedy = sampling.temperature <= 0.0 || sampling.top_k == 1;
         if !is_greedy {
             anyhow::bail!(
                 "--speculative-decode currently supports greedy sampling \
@@ -1216,7 +1399,9 @@ fn decode_text(
                  verification (rejection sampling); until then, re-run with \
                  `--temperature 0` for speculative decode, or drop \
                  `--speculative-decode` for non-greedy sampling.",
-                sampling.temperature, sampling.top_k, sampling.top_p
+                sampling.temperature,
+                sampling.top_k,
+                sampling.top_p
             );
         }
     }
@@ -1245,7 +1430,8 @@ fn decode_text(
 
     let prompt_ids: Vec<u32> = match (&tokenizer, prompt.is_empty()) {
         (Some(tok), false) => {
-            let enc = tok.encode(prompt, true)
+            let enc = tok
+                .encode(prompt, true)
                 .map_err(|e| anyhow!("tokenize prompt: {e}"))?;
             let ids: Vec<u32> = enc.get_ids().to_vec();
             if ids.is_empty() {
@@ -1264,18 +1450,31 @@ fn decode_text(
         if prompt_ids.len() > 8 { ", " } else { "" },
     );
 
-    // Pick the bake. INT4 is the realistic path on 24 GiB VRAM.
+    // Pick the bake. INT4 remains the default small-VRAM path; explicit
+    // --fp8-runtime selects the native FP8 bake.
+    let fp8_dir = model_store::bake_dir_fp8(model_dir);
     let int4_dir = model_store::bake_dir_int4(model_dir);
     let bf16_dir = model_store::bake_dir(model_dir);
-    let (bake_dir, int4_enabled) = if int4_dir.exists() {
-        (int4_dir, true)
+    let (bake_dir, weight_mode) = if fp8_runtime {
+        if !fp8_dir.exists() {
+            return Err(anyhow!(
+                "--fp8-runtime requested but no FP8-native bake exists at {}. \
+                 Create one with `python3 oracle/bake_fp8.py --model-dir {}`.",
+                fp8_dir.display(),
+                model_dir.display()
+            ));
+        }
+        (fp8_dir, Qwen36WeightMode::Fp8)
+    } else if int4_dir.exists() {
+        (int4_dir, Qwen36WeightMode::Int4)
     } else if bf16_dir.exists() {
-        (bf16_dir, false)
+        (bf16_dir, Qwen36WeightMode::Bf16)
     } else {
         return Err(anyhow!(
-            "decode requires a baked package — neither INT4-GPTQ ({}) nor \
-             BF16 ({}) exists. Create one with the standard bake pipeline \
+            "decode requires a baked package — neither FP8-native ({}), \
+             INT4-GPTQ ({}) nor BF16 ({}) exists. Create one with the standard bake pipeline \
              or re-run with --dry-run for analytic accounting only.",
+            fp8_dir.display(),
             int4_dir.display(),
             bf16_dir.display()
         ));
@@ -1283,7 +1482,11 @@ fn decode_text(
     println!(
         "  loading from bake: {} ({})",
         bake_dir.display(),
-        if int4_enabled { "INT4 GPTQ" } else { "BF16" }
+        match weight_mode {
+            Qwen36WeightMode::Bf16 => "BF16",
+            Qwen36WeightMode::Int4 => "INT4 GPTQ",
+            Qwen36WeightMode::Fp8 => "FP8 native",
+        }
     );
     let store = BakedStore::open(&bake_dir)
         .with_context(|| format!("open BakedStore at {}", bake_dir.display()))?;
@@ -1302,7 +1505,11 @@ fn decode_text(
     println!(
         "  loading {} layers ({} INT4 sidecar sets, KV cache cap = {} tokens)…",
         geom.num_layers,
-        if int4_enabled { geom.num_layers } else { 0 },
+        if weight_mode == Qwen36WeightMode::Int4 {
+            geom.num_layers
+        } else {
+            0
+        },
         kv_max_t,
     );
     for li in 0..geom.num_layers as usize {
@@ -1313,7 +1520,7 @@ fn decode_text(
             &geom,
             &report.config.text_config,
             weight_prefix,
-            int4_enabled,
+            weight_mode,
             kv_max_t,
         )
         .with_context(|| format!("load layer {li} weights"))?;
@@ -1378,8 +1585,9 @@ fn decode_text(
     // budget alongside the 17 GiB INT4 weight bake.
     let final_norm_bytes = host_load_bytes(&store, &format!("{weight_prefix}.norm.weight"))
         .context("load final norm")?;
-    let lm_head_bf16_bytes = load_lm_head_bf16(&store, &report.config.text_config, weight_prefix, &geom)
-        .context("prepare lm_head BF16 buffer")?;
+    let lm_head_bf16_bytes =
+        load_lm_head_bf16(&store, &report.config.text_config, weight_prefix, &geom)
+            .context("prepare lm_head BF16 buffer")?;
     println!(
         "  uploading lm_head BF16 ({:.1} MiB) and final norm ({:.1} KiB) to GPU…",
         lm_head_bf16_bytes.len() as f64 / MIB,
@@ -1399,17 +1607,12 @@ fn decode_text(
         &lm_head_bf16_bytes,
     )
     .context("upload lm_head BF16 to GPU")?;
-    let mut logits_buf = GpuBuffer::zeros(
-        ordinal,
-        ScalarType::BF16,
-        &[geom.vocab as usize],
-    )
-    .context("alloc logits_buf on GPU")?;
+    let mut logits_buf = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[geom.vocab as usize])
+        .context("alloc logits_buf on GPU")?;
     let mut counter_buf = GpuBuffer::zeros(ordinal, ScalarType::U32, &[1])
         .context("alloc lm_head counter_buf on GPU")?;
-    let mut final_hidden_buf =
-        GpuBuffer::zeros(ordinal, ScalarType::BF16, &[geom.hidden as usize])
-            .context("alloc final_hidden_buf on GPU")?;
+    let mut final_hidden_buf = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[geom.hidden as usize])
+        .context("alloc final_hidden_buf on GPU")?;
     drop(lm_head_bf16_bytes);
     drop(final_norm_bytes);
 
@@ -1567,10 +1770,14 @@ fn decode_text(
         // because `run_chained_decode_fast` ends with a D2H copy that
         // implicitly drains the queue.
         let outputs = run_chained_decode_fast(
-            ordinal, &geom, &mut layers, &initial_hidden, position,
+            ordinal,
+            &geom,
+            &mut layers,
+            &initial_hidden,
+            position,
             emit_stage_timings,
         )
-            .with_context(|| format!("chained decode (step {step}, position {position})"))?;
+        .with_context(|| format!("chained decode (step {step}, position {position})"))?;
         let t_chain_step = t1.elapsed();
         position += 1;
 
@@ -1740,15 +1947,21 @@ fn decode_text(
                         for &(pos, input) in inputs {
                             let t_embed_start = std::time::Instant::now();
                             let initial_hidden = lookup_embed_row(
-                                &store, weight_prefix,
-                                input as usize, geom.hidden as usize,
+                                &store,
+                                weight_prefix,
+                                input as usize,
+                                geom.hidden as usize,
                             )?;
                             t_embed += t_embed_start.elapsed();
 
                             let t_chain_start = std::time::Instant::now();
                             let chain_outputs = run_chained_decode_fast(
-                                ordinal, &geom, &mut layers,
-                                &initial_hidden, pos, emit_stage_timings,
+                                ordinal,
+                                &geom,
+                                &mut layers,
+                                &initial_hidden,
+                                pos,
+                                emit_stage_timings,
                             )?;
                             t_chain += t_chain_start.elapsed();
                             t_chain_full_attn_us += chain_outputs.kernel_full_attn_us;
@@ -1765,22 +1978,30 @@ fn decode_text(
                             concat.extend_from_slice(fh);
                         }
                         let fh_buf = gpu_hal::GpuBuffer::from_host_bytes(
-                            ordinal, gpu_hal::ScalarType::BF16,
-                            &[n, hidden], &concat,
+                            ordinal,
+                            gpu_hal::ScalarType::BF16,
+                            &[n, hidden],
+                            &concat,
                         )?;
                         let mut logits_buf_b = gpu_hal::GpuBuffer::zeros(
-                            ordinal, gpu_hal::ScalarType::BF16,
+                            ordinal,
+                            gpu_hal::ScalarType::BF16,
                             &[n, geom.vocab as usize],
                         )?;
                         kernel_ffi::qwen36_moe::lm_head_batched_launch(
-                            ordinal, n as i32, geom.hidden, geom.vocab,
+                            ordinal,
+                            n as i32,
+                            geom.hidden,
+                            geom.vocab,
                             geom.rms_norm_eps,
-                            &fh_buf, &final_norm_w_buf, &lm_head_w_buf,
-                            &mut logits_buf_b, None,
+                            &fh_buf,
+                            &final_norm_w_buf,
+                            &lm_head_w_buf,
+                            &mut logits_buf_b,
+                            None,
                         )?;
-                        let logits_bytes = logits_buf_b
-                            .to_host_bytes()
-                            .context("d2h batched logits")?;
+                        let logits_bytes =
+                            logits_buf_b.to_host_bytes().context("d2h batched logits")?;
                         t_lm_head += t_lm_head_start.elapsed();
 
                         let row_bytes = geom.vocab as usize * 2;
@@ -1814,14 +2035,20 @@ fn decode_text(
                     for &(pos, input) in &replay {
                         let t_embed_start = std::time::Instant::now();
                         let initial_hidden = lookup_embed_row(
-                            &store, weight_prefix,
-                            input as usize, geom.hidden as usize,
+                            &store,
+                            weight_prefix,
+                            input as usize,
+                            geom.hidden as usize,
                         )?;
                         t_embed += t_embed_start.elapsed();
                         let t_chain_start = std::time::Instant::now();
                         let replay_outputs = run_chained_decode_fast(
-                            ordinal, &geom, &mut layers,
-                            &initial_hidden, pos, emit_stage_timings,
+                            ordinal,
+                            &geom,
+                            &mut layers,
+                            &initial_hidden,
+                            pos,
+                            emit_stage_timings,
                         )?;
                         t_chain += t_chain_start.elapsed();
                         // Per-kernel-class breakdown for replay chains
@@ -1960,7 +2187,10 @@ fn decode_text(
         if generated_ids.len() == 1 { "" } else { "s" },
         prompt_ids.len(),
         generated_ids.len(),
-        if eos_id.map(|e| generated_ids.last() == Some(&e)).unwrap_or(false) {
+        if eos_id
+            .map(|e| generated_ids.last() == Some(&e))
+            .unwrap_or(false)
+        {
             "yes"
         } else {
             "no (max_new_tokens hit)"
@@ -2066,10 +2296,10 @@ fn decode_first_token(model_dir: &Path, report: &DryRunReport) -> Result<u32> {
     // Pick the bake. INT4 is the realistic path on 24 GiB VRAM.
     let int4_dir = model_store::bake_dir_int4(model_dir);
     let bf16_dir = model_store::bake_dir(model_dir);
-    let (bake_dir, int4_enabled) = if int4_dir.exists() {
-        (int4_dir, true)
+    let (bake_dir, weight_mode) = if int4_dir.exists() {
+        (int4_dir, Qwen36WeightMode::Int4)
     } else if bf16_dir.exists() {
-        (bf16_dir, false)
+        (bf16_dir, Qwen36WeightMode::Bf16)
     } else {
         return Err(anyhow!(
             "decode requires a baked package — neither INT4-GPTQ ({}) nor \
@@ -2082,7 +2312,11 @@ fn decode_first_token(model_dir: &Path, report: &DryRunReport) -> Result<u32> {
     println!(
         "  loading from bake: {} ({})",
         bake_dir.display(),
-        if int4_enabled { "INT4 GPTQ" } else { "BF16" }
+        if weight_mode == Qwen36WeightMode::Int4 {
+            "INT4 GPTQ"
+        } else {
+            "BF16"
+        }
     );
     let store = BakedStore::open(&bake_dir)
         .with_context(|| format!("open BakedStore at {}", bake_dir.display()))?;
@@ -2097,7 +2331,11 @@ fn decode_first_token(model_dir: &Path, report: &DryRunReport) -> Result<u32> {
         "  loading {} layer{} ({} INT4 sidecar set{})…",
         geom.num_layers,
         if geom.num_layers == 1 { "" } else { "s" },
-        if int4_enabled { geom.num_layers } else { 0 },
+        if weight_mode == Qwen36WeightMode::Int4 {
+            geom.num_layers
+        } else {
+            0
+        },
         if geom.num_layers == 1 { "" } else { "s" },
     );
     for li in 0..geom.num_layers as usize {
@@ -2108,7 +2346,7 @@ fn decode_first_token(model_dir: &Path, report: &DryRunReport) -> Result<u32> {
             &geom,
             &report.config.text_config,
             weight_prefix,
-            int4_enabled,
+            weight_mode,
             0, // legacy single-token path: no KV cache, kv_len=1 fast path.
         )
         .with_context(|| format!("load layer {li} weights"))?;
@@ -2127,15 +2365,21 @@ fn decode_first_token(model_dir: &Path, report: &DryRunReport) -> Result<u32> {
         .unwrap_or(0) as usize;
     let initial_hidden = lookup_embed_row(&store, weight_prefix, bos, geom.hidden as usize)
         .with_context(|| format!("lookup embed row {bos}"))?;
-    println!("  embedding row {bos} loaded ({} BF16 bytes)", initial_hidden.len());
+    println!(
+        "  embedding row {bos} loaded ({} BF16 bytes)",
+        initial_hidden.len()
+    );
 
     println!("  running chained decode…");
-    let outputs =
-        run_chained_decode(ordinal, &geom, &mut layers, &initial_hidden, 0).context("chained decode")?;
+    let outputs = run_chained_decode(ordinal, &geom, &mut layers, &initial_hidden, 0)
+        .context("chained decode")?;
     println!(
         "  decode done; final hidden norm = {:.4}",
         crate::qwen36_moe_decode::bf16_bytes_to_f32(&outputs.final_hidden_bytes)
-            .iter().map(|x| x * x).sum::<f32>().sqrt()
+            .iter()
+            .map(|x| x * x)
+            .sum::<f32>()
+            .sqrt()
     );
 
     let final_norm_bytes = host_load_bytes(&store, &format!("{weight_prefix}.norm.weight"))

--- a/docs/qwen36-verification-suite.md
+++ b/docs/qwen36-verification-suite.md
@@ -1,0 +1,85 @@
+# Qwen3.6 Verification Suite
+
+`oracle/qwen36_verify_suite.py` is the first gate for making the native FP8
+Qwen3.6-35B-A3B path usable as a verification base for quantized variants.
+It does not assume correctness from PyTorch. Instead, it checks whether a
+given SuperSonic lane is repeatable enough to become an oracle candidate.
+
+The suite runs deterministic prompts, captures
+`SUPERSONIC_QWEN36_DUMP_FINAL_HIDDEN` and `SUPERSONIC_QWEN36_DUMP_LOGITS`,
+hashes the dumped BF16 bytes, and fails if identical runs produce different
+hidden states, logits, generated ids, or all-zero logits.
+
+## Setup
+
+The harness only needs the Rust binary plus the lightweight Hugging Face
+`tokenizers` package:
+
+```bash
+python3 -m venv .venv-verify
+. .venv-verify/bin/activate
+pip install tokenizers
+```
+
+For real streamed PG-19 instead of the default synthetic PG-19 text, install
+`datasets` in the same venv and pass `--pg19-source dataset`.
+
+## Quick Smoke
+
+This intentionally fails today while Qwen3.6 decode nondeterminism is still
+unfixed, but it proves the harness can catch the issue:
+
+```bash
+. .venv-verify/bin/activate
+python oracle/qwen36_verify_suite.py \
+  --binary target/release/supersonic \
+  --model-dir /models/supersonic-cdna/qwen3.6-35b-a3b-fp8 \
+  --backend hip \
+  --contexts 8 \
+  --families pg19 \
+  --modes fp8,int4 \
+  --repeats 2 \
+  --pg19-source synthetic \
+  --out target/qwen36_verify_repeat_smoke.json
+```
+
+## gfx942 Sweep
+
+The wrapper builds `supersonic` and runs a broader PG-19 plus RULER-like
+repeatability matrix:
+
+```bash
+tests/gfx942/run_qwen36_verify_suite.sh
+```
+
+Useful overrides:
+
+```bash
+MODEL_DIR=/models/supersonic-cdna/qwen3.6-35b-a3b-fp8 \
+CONTEXTS=512,2K,8K \
+FAMILIES=pg19,ruler \
+MODES=fp8,int4 \
+REPEATS=3 \
+PG19_SOURCE=synthetic \
+OUT=target/qwen36_verify_results.json \
+tests/gfx942/run_qwen36_verify_suite.sh
+```
+
+For a real PG-19 run:
+
+```bash
+PG19_SOURCE=dataset tests/gfx942/run_qwen36_verify_suite.sh
+```
+
+## Reading Results
+
+The output JSON has:
+
+- `summary`: per case and mode, including deterministic flags for logits,
+  hidden state, and generated ids.
+- `runs`: per subprocess run, including dump hashes, generated ids, vector
+  stats, timing, and stdout/stderr tails.
+- `failures`: the exact gate failures that caused a non-zero exit.
+
+Until both FP8 and INT4 pass repeatability, FP8 should be treated as a
+functional native-weight path, not yet as a strict verification oracle.

--- a/kernels/qwen36_moe_bridge.cpp
+++ b/kernels/qwen36_moe_bridge.cpp
@@ -188,11 +188,11 @@ extern "C" int qwen36_moe_hip_attn_step_launch(
         barrier_flag == nullptr) {
         return 113;
     }
-    // INT4 sidecars: each scale must be paired with a zero. group_size==0
-    // disables INT4 entirely; otherwise it must be positive.
-    if (int4_group_size < 0) return 114;
-    auto pair_ok = [](const void* s, const void* z) -> bool {
-        return (s == nullptr) == (z == nullptr);
+    // Quant sidecars: positive group_size = INT4 (scale+zero pairs),
+    // negative group_size = FP8-native (scale only), 0 = disabled.
+    const bool fp8_mode = int4_group_size < 0;
+    auto pair_ok = [fp8_mode](const void* s, const void* z) -> bool {
+        return fp8_mode ? (z == nullptr) : ((s == nullptr) == (z == nullptr));
     };
     if (!pair_ok(q_proj_scale, q_proj_zero) ||
         !pair_ok(k_proj_scale, k_proj_zero) ||
@@ -200,11 +200,11 @@ extern "C" int qwen36_moe_hip_attn_step_launch(
         !pair_ok(o_proj_scale, o_proj_zero)) {
         return 115;
     }
-    const bool any_int4 =
+    const bool any_quant =
         (q_proj_scale != nullptr) || (k_proj_scale != nullptr) ||
         (v_proj_scale != nullptr) || (o_proj_scale != nullptr);
-    if (any_int4 && int4_group_size <= 0) return 116;
-    if (!any_int4 && int4_group_size != 0) return 117;
+    if (any_quant && int4_group_size == 0) return 116;
+    if (!any_quant && int4_group_size != 0) return 117;
 
     // KV cache: pointers must be paired (both null or both non-null), and
     // kv_max_t must be positive when enabled + the *effective* slot
@@ -243,10 +243,11 @@ extern "C" int qwen36_moe_hip_attn_step_launch(
     // K-chunk is 16; per-lane `in_range` checks handle non-16-aligned
     // output dims (`q_out_dim = 2*H*d`, `Hkv*d`, `hidden`).
     const bool any_int4_attn =
-        (q_proj_scale != nullptr) ||
-        (k_proj_scale != nullptr) ||
-        (v_proj_scale != nullptr) ||
-        (o_proj_scale != nullptr);
+        (int4_group_size > 0) &&
+        ((q_proj_scale != nullptr) ||
+         (k_proj_scale != nullptr) ||
+         (v_proj_scale != nullptr) ||
+         (o_proj_scale != nullptr));
     const bool wmma_dims_ok_attn =
         (hidden % 16 == 0) &&
         (int4_group_size > 0) &&
@@ -388,23 +389,23 @@ extern "C" int qwen36_moe_hip_linear_step_launch(
         barrier_flag == nullptr) {
         return 123;
     }
-    // INT4 sidecars: each scale must be paired with a zero. group_size==0
-    // disables INT4 entirely; otherwise it must be positive.
-    if (int4_group_size < 0) return 124;
-    auto pair_ok = [](const void* s, const void* z) -> bool {
-        return (s == nullptr) == (z == nullptr);
+    // Quant sidecars: positive group_size = INT4 (scale+zero pairs),
+    // negative group_size = FP8-native (scale only), 0 = disabled.
+    const bool fp8_mode = int4_group_size < 0;
+    auto pair_ok = [fp8_mode](const void* s, const void* z) -> bool {
+        return fp8_mode ? (z == nullptr) : ((s == nullptr) == (z == nullptr));
     };
     if (!pair_ok(in_proj_qkv_scale, in_proj_qkv_zero) ||
         !pair_ok(in_proj_z_scale, in_proj_z_zero) ||
         !pair_ok(out_proj_scale, out_proj_zero)) {
         return 125;
     }
-    const bool any_int4 =
+    const bool any_quant =
         (in_proj_qkv_scale != nullptr) ||
         (in_proj_z_scale != nullptr) ||
         (out_proj_scale != nullptr);
-    if (any_int4 && int4_group_size <= 0) return 126;
-    if (!any_int4 && int4_group_size != 0) return 127;
+    if (any_quant && int4_group_size == 0) return 126;
+    if (!any_quant && int4_group_size != 0) return 127;
 
     ScopedHipDevice scoped(static_cast<int>(device_ordinal));
 
@@ -431,9 +432,10 @@ extern "C" int qwen36_moe_hip_linear_step_launch(
     // the K-chunk size (16) divides hidden and the quant group_size.
     // 35B-A3B (hidden=2048, group_size=128) satisfies both.
     const bool any_int4_routed_lin =
-        (in_proj_qkv_scale != nullptr) ||
-        (in_proj_z_scale   != nullptr) ||
-        (out_proj_scale    != nullptr);
+        (int4_group_size > 0) &&
+        ((in_proj_qkv_scale != nullptr) ||
+         (in_proj_z_scale   != nullptr) ||
+         (out_proj_scale    != nullptr));
     const bool wmma_dims_ok_lin =
         (hidden % 16 == 0) &&
         (int4_group_size > 0) &&
@@ -574,11 +576,11 @@ extern "C" int qwen36_moe_hip_ffn_step_launch(
         barrier_counter == nullptr || barrier_flag == nullptr) {
         return 133;
     }
-    // INT4 mode: group_size must divide the relevant dims and each scale
-    // must be paired with a zero. group_size==0 disables INT4 entirely.
-    if (int4_group_size < 0) return 134;
-    auto pair_ok = [](const void* s, const void* z) -> bool {
-        return (s == nullptr) == (z == nullptr);
+    // Quant mode: positive group_size = INT4 (scale+zero pairs),
+    // negative group_size = FP8-native (scale only), 0 = disabled.
+    const bool fp8_mode = int4_group_size < 0;
+    auto pair_ok = [fp8_mode](const void* s, const void* z) -> bool {
+        return fp8_mode ? (z == nullptr) : ((s == nullptr) == (z == nullptr));
     };
     if (!pair_ok(gate_up_proj_scale, gate_up_proj_zero) ||
         !pair_ok(down_proj_scale, down_proj_zero) ||
@@ -587,13 +589,13 @@ extern "C" int qwen36_moe_hip_ffn_step_launch(
         !pair_ok(shared_down_proj_scale, shared_down_proj_zero)) {
         return 135;
     }
-    const bool any_int4 =
+    const bool any_quant =
         (gate_up_proj_scale != nullptr) || (down_proj_scale != nullptr) ||
         (shared_gate_proj_scale != nullptr) ||
         (shared_up_proj_scale != nullptr) ||
         (shared_down_proj_scale != nullptr);
-    if (any_int4 && int4_group_size <= 0) return 136;
-    if (!any_int4 && int4_group_size != 0) return 137;
+    if (any_quant && int4_group_size == 0) return 136;
+    if (!any_quant && int4_group_size != 0) return 137;
 
     ScopedHipDevice scoped(static_cast<int>(device_ordinal));
 
@@ -627,6 +629,7 @@ extern "C" int qwen36_moe_hip_ffn_step_launch(
     // synthetic fixtures use 16-divisible dims too. The shared expert path
     // (Phase D/F) stays scalar in both variants — Phase 2 of the roadmap.
     const bool routed_int4 =
+        (int4_group_size > 0) &&
         (gate_up_proj_scale != nullptr) && (down_proj_scale != nullptr);
     const bool wmma_dims_ok =
         (hidden % 16 == 0) &&

--- a/kernels/qwen36_moe_persistent/ffn_phase.cuh
+++ b/kernels/qwen36_moe_persistent/ffn_phase.cuh
@@ -106,6 +106,8 @@ __device__ inline void qwen36_moe_ffn_step_device(
     const int num_blocks = static_cast<int>(gridDim.x);
     const int tid        = threadIdx.x;
     const int block_size = static_cast<int>(blockDim.x);
+    const bool fp8_mode = int4_group_size < 0;
+    const int quant_group_size = fp8_mode ? -int4_group_size : int4_group_size;
 
     extern __shared__ float lds[];
     float* h_norm_lds     = lds;             // [hidden]
@@ -388,11 +390,18 @@ __device__ inline void qwen36_moe_ffn_step_device(
         }
 
         float partial = 0.0f;
-        if (i4_scale != nullptr) {
+        if (i4_scale != nullptr && !fp8_mode) {
             partial = int4_dq8_matvec_partial(
                 static_cast<const uint8_t*>(i4_slab),
                 i4_scale, i4_zero, h_norm_lds,
-                i4_row, hidden, int4_group_size,
+                i4_row, hidden, quant_group_size,
+                tid, block_size);
+        } else if (i4_scale != nullptr) {
+            partial = fp8_matvec_partial(
+                i4_slab,
+                i4_scale,
+                h_norm_lds,
+                i4_row, hidden, quant_group_size,
                 tid, block_size);
         } else {
             for (int col = tid; col < hidden; col += block_size) {
@@ -444,13 +453,20 @@ __device__ inline void qwen36_moe_ffn_step_device(
             if (my_row >= hidden) break;
 
             float partial = 0.0f;
-            if (shared_down_proj_scale != nullptr) {
+            if (shared_down_proj_scale != nullptr && !fp8_mode) {
                 partial = int4_dq8_matvec_partial(
                     reinterpret_cast<const uint8_t*>(shared_down_proj_w),
                     static_cast<const hip_bfloat16*>(shared_down_proj_scale),
                     static_cast<const hip_bfloat16*>(shared_down_proj_zero),
                     workspace + OFF_SHARED_MID,
-                    my_row, Is_, int4_group_size,
+                    my_row, Is_, quant_group_size,
+                    tid, block_size);
+            } else if (shared_down_proj_scale != nullptr) {
+                partial = fp8_matvec_partial(
+                    reinterpret_cast<const void*>(shared_down_proj_w),
+                    static_cast<const hip_bfloat16*>(shared_down_proj_scale),
+                    workspace + OFF_SHARED_MID,
+                    my_row, Is_, quant_group_size,
                     tid, block_size);
             } else {
                 const T* w_row =
@@ -525,21 +541,22 @@ __device__ inline void qwen36_moe_ffn_step_device(
 
     // Phase G: matvec gate_up_proj_w[e] @ h_norm → EXPERT_GU[g*2*I..].
     if (group_active) {
-        const bool gu_int4 = (gate_up_proj_scale != nullptr);
+        const bool gu_quant = (gate_up_proj_scale != nullptr);
+        const bool gu_int4 = gu_quant && !fp8_mode;
         const T* gu_slab_bf16 =
             gate_up_proj_w + static_cast<size_t>(e) * two_I * hidden;
         const uint8_t*      gu_slab_packed = nullptr;
         const hip_bfloat16* gu_slab_scale  = nullptr;
         const hip_bfloat16* gu_slab_zero   = nullptr;
-        if (gu_int4) {
+        if (gu_quant) {
             gu_slab_packed = reinterpret_cast<const uint8_t*>(gate_up_proj_w)
                            + static_cast<size_t>(e) * two_I
-                             * (hidden / 2);
-            const int gsr = two_I  / int4_group_size;
-            const int gsc = hidden / int4_group_size;
+                             * (fp8_mode ? hidden : (hidden / 2));
+            const int gsr = two_I  / quant_group_size;
+            const int gsc = hidden / quant_group_size;
             gu_slab_scale = gate_up_proj_scale
                           + static_cast<size_t>(e) * gsr * gsc;
-            gu_slab_zero  = gate_up_proj_zero
+            gu_slab_zero  = fp8_mode ? nullptr : gate_up_proj_zero
                           + static_cast<size_t>(e) * gsr * gsc;
         }
         const int gu_off = OFF_EXPERT_GU + group_id * two_I;
@@ -551,7 +568,7 @@ __device__ inline void qwen36_moe_ffn_step_device(
 #ifdef SUPERSONIC_QWEN36_HAS_WMMA_BF16
         if constexpr (USE_WMMA) {
             if (gu_int4) {
-                const int gsc_gu = hidden / int4_group_size;
+                const int gsc_gu = hidden / quant_group_size;
                 const int wave_id = tid >> 5;
                 const int lane = tid & 31;
                 const int lane_row = lane & 15;
@@ -577,7 +594,7 @@ __device__ inline void qwen36_moe_ffn_step_device(
                         slab_row, gu_slab_scale, gu_slab_zero,
                         rhs_row_idx, rhs_in_range,
                         h_norm_lds, hidden,
-                        gsc_gu, int4_group_size, lane_row);
+                        gsc_gu, quant_group_size, lane_row);
 
                     if (lane_half == 0 && rhs_in_range) {
                         workspace[gu_off + rhs_row_idx] = acc[0];
@@ -603,7 +620,13 @@ __device__ inline void qwen36_moe_ffn_step_device(
                     partial = int4_dq8_matvec_partial(
                         gu_slab_packed, gu_slab_scale, gu_slab_zero,
                         h_norm_lds,
-                        my_row, hidden, int4_group_size,
+                        my_row, hidden, quant_group_size,
+                        tid, block_size);
+                } else if (gu_quant) {
+                    partial = fp8_matvec_partial(
+                        gu_slab_packed, gu_slab_scale,
+                        h_norm_lds,
+                        my_row, hidden, quant_group_size,
                         tid, block_size);
                 } else {
                     const T* w_row =
@@ -652,21 +675,22 @@ __device__ inline void qwen36_moe_ffn_step_device(
 
     // Phase I: matvec down_proj_w[e].T @ mid → EXPERT_STACK[g*hidden..].
     if (group_active) {
-        const bool dp_int4 = (down_proj_scale != nullptr);
+        const bool dp_quant = (down_proj_scale != nullptr);
+        const bool dp_int4 = dp_quant && !fp8_mode;
         const T* dp_slab_bf16 =
             down_proj_w + static_cast<size_t>(e) * hidden * I_;
         const uint8_t*      dp_slab_packed = nullptr;
         const hip_bfloat16* dp_slab_scale  = nullptr;
         const hip_bfloat16* dp_slab_zero   = nullptr;
-        if (dp_int4) {
+        if (dp_quant) {
             dp_slab_packed = reinterpret_cast<const uint8_t*>(down_proj_w)
                            + static_cast<size_t>(e) * hidden
-                             * (I_ / 2);
-            const int gsr = hidden / int4_group_size;
-            const int gsc = I_     / int4_group_size;
+                             * (fp8_mode ? I_ : (I_ / 2));
+            const int gsr = hidden / quant_group_size;
+            const int gsc = I_     / quant_group_size;
             dp_slab_scale = down_proj_scale
                           + static_cast<size_t>(e) * gsr * gsc;
-            dp_slab_zero  = down_proj_zero
+            dp_slab_zero  = fp8_mode ? nullptr : down_proj_zero
                           + static_cast<size_t>(e) * gsr * gsc;
         }
         const int slot_off = OFF_EXPERT_STACK + group_id * hidden;
@@ -676,7 +700,7 @@ __device__ inline void qwen36_moe_ffn_step_device(
 #ifdef SUPERSONIC_QWEN36_HAS_WMMA_BF16
         if constexpr (USE_WMMA) {
             if (dp_int4) {
-                const int gsc_dp = I_ / int4_group_size;
+                const int gsc_dp = I_ / quant_group_size;
                 const int wave_id = tid >> 5;
                 const int lane = tid & 31;
                 const int lane_row = lane & 15;
@@ -703,7 +727,7 @@ __device__ inline void qwen36_moe_ffn_step_device(
                         slab_row, dp_slab_scale, dp_slab_zero,
                         rhs_row_idx, rhs_in_range,
                         mid_lds_f32, I_,
-                        gsc_dp, int4_group_size, lane_row);
+                        gsc_dp, quant_group_size, lane_row);
 
                     if (lane_half == 0 && rhs_in_range) {
                         const float val = acc[0];
@@ -734,7 +758,13 @@ __device__ inline void qwen36_moe_ffn_step_device(
                     partial = int4_dq8_matvec_partial(
                         dp_slab_packed, dp_slab_scale, dp_slab_zero,
                         workspace + mid_off,
-                        my_row, I_, int4_group_size,
+                        my_row, I_, quant_group_size,
+                        tid, block_size);
+                } else if (dp_quant) {
+                    partial = fp8_matvec_partial(
+                        dp_slab_packed, dp_slab_scale,
+                        workspace + mid_off,
+                        my_row, I_, quant_group_size,
                         tid, block_size);
                 } else {
                     const T* w_row =

--- a/kernels/qwen36_moe_persistent/full_attn_phase.cuh
+++ b/kernels/qwen36_moe_persistent/full_attn_phase.cuh
@@ -154,7 +154,10 @@ __device__ inline void qwen36_moe_attn_step_device(
     // INT4 (when `q_proj_scale != nullptr`): treat `q_proj_w` as
     // `[2*H*d, hidden/2]` u8 and dequant per element. Same matvec stride.
     const int q_out_dim = 2 * num_heads * head_dim;
-    const bool q_int4 = (q_proj_scale != nullptr);
+    const bool fp8_mode = int4_group_size < 0;
+    const int quant_group_size = fp8_mode ? -int4_group_size : int4_group_size;
+    const bool q_quant = (q_proj_scale != nullptr);
+    const bool q_int4 = q_quant && !fp8_mode;
 
     bool wmma_handled_qproj = false;
 #ifdef SUPERSONIC_QWEN36_HAS_WMMA_BF16
@@ -164,7 +167,7 @@ __device__ inline void qwen36_moe_attn_step_device(
             // tiles. Same `wmma_int4_matvec_partial_16rows` helper as the
             // FFN/linear-attn WMMA paths; output is BF16-rounded to match
             // the scalar path's `workspace[my_row] = bf16_round_rne_f32(...)`.
-            const int gsc_q = hidden / int4_group_size;
+            const int gsc_q = hidden / quant_group_size;
             const int wave_id = tid >> 5;
             const int lane_in_wave = tid & 31;
             const int lane_row = lane_in_wave & 15;
@@ -190,7 +193,7 @@ __device__ inline void qwen36_moe_attn_step_device(
                     static_cast<const hip_bfloat16*>(q_proj_zero),
                     rhs_row, in_range,
                     x_norm_lds, hidden,
-                    gsc_q, int4_group_size, lane_row);
+                    gsc_q, quant_group_size, lane_row);
                 if (lane_half == 0 && in_range) {
                     workspace[rhs_row] = bf16_round_rne_f32(acc[0]);
                 }
@@ -221,7 +224,14 @@ __device__ inline void qwen36_moe_attn_step_device(
                     static_cast<const hip_bfloat16*>(q_proj_scale),
                     static_cast<const hip_bfloat16*>(q_proj_zero),
                     x_norm_lds,
-                    my_row, hidden, int4_group_size,
+                    my_row, hidden, quant_group_size,
+                    tid, block_size);
+            } else if (q_quant) {
+                partial = fp8_matvec_partial(
+                    reinterpret_cast<const void*>(q_proj_w),
+                    static_cast<const hip_bfloat16*>(q_proj_scale),
+                    x_norm_lds,
+                    my_row, hidden, quant_group_size,
                     tid, block_size);
             } else {
                 const T* w_row = q_proj_w + static_cast<size_t>(my_row) * hidden;
@@ -352,14 +362,14 @@ __device__ inline void qwen36_moe_attn_step_device(
 
 #ifdef SUPERSONIC_QWEN36_HAS_WMMA_BF16
     if constexpr (USE_WMMA) {
-        const int gsc_kv = hidden / int4_group_size;
+        const int gsc_kv = hidden / quant_group_size;
         const int wave_id = tid >> 5;
         const int lane_in_wave = tid & 31;
         const int lane_row = lane_in_wave & 15;
         const int lane_half = lane_in_wave >> 4;
 
         // ------- Sub-pool 1: k_proj -------
-        if (k_proj_scale != nullptr) {
+        if (k_proj_scale != nullptr && !fp8_mode) {
             const uint8_t* slab_packed =
                 reinterpret_cast<const uint8_t*>(k_proj_w);
             for (;;) {
@@ -381,7 +391,7 @@ __device__ inline void qwen36_moe_attn_step_device(
                     static_cast<const hip_bfloat16*>(k_proj_zero),
                     rhs_row, in_range,
                     x_norm_lds, hidden,
-                    gsc_kv, int4_group_size, lane_row);
+                    gsc_kv, quant_group_size, lane_row);
                 if (lane_half == 0 && in_range) {
                     workspace[OFF_K_RAW + rhs_row] =
                         bf16_round_rne_f32(acc[0]);
@@ -389,18 +399,27 @@ __device__ inline void qwen36_moe_attn_step_device(
                 __syncthreads();
             }
         } else {
-            // BF16 fallback for k_proj.
+            // BF16/FP8 fallback for k_proj.
             for (;;) {
                 __shared__ unsigned int my_row_s;
                 if (tid == 0) my_row_s = atomicAdd(&counters[0], 1u);
                 __syncthreads();
                 const int my_row = static_cast<int>(my_row_s);
                 if (my_row >= Hkv * d) break;
-                const T* w_row =
-                    k_proj_w + static_cast<size_t>(my_row) * hidden;
                 float partial = 0.0f;
-                for (int col = tid; col < hidden; col += block_size) {
-                    partial += load_as_float<T>(w_row, col) * x_norm_lds[col];
+                if (k_proj_scale != nullptr) {
+                    partial = fp8_matvec_partial(
+                        reinterpret_cast<const void*>(k_proj_w),
+                        static_cast<const hip_bfloat16*>(k_proj_scale),
+                        x_norm_lds,
+                        my_row, hidden, quant_group_size,
+                        tid, block_size);
+                } else {
+                    const T* w_row =
+                        k_proj_w + static_cast<size_t>(my_row) * hidden;
+                    for (int col = tid; col < hidden; col += block_size) {
+                        partial += load_as_float<T>(w_row, col) * x_norm_lds[col];
+                    }
                 }
                 shared_scratch[tid] = partial;
                 __syncthreads();
@@ -421,7 +440,7 @@ __device__ inline void qwen36_moe_attn_step_device(
                                    &counters[0]);
 
         // ------- Sub-pool 2: v_proj -------
-        if (v_proj_scale != nullptr) {
+        if (v_proj_scale != nullptr && !fp8_mode) {
             const uint8_t* slab_packed =
                 reinterpret_cast<const uint8_t*>(v_proj_w);
             for (;;) {
@@ -443,7 +462,7 @@ __device__ inline void qwen36_moe_attn_step_device(
                     static_cast<const hip_bfloat16*>(v_proj_zero),
                     rhs_row, in_range,
                     x_norm_lds, hidden,
-                    gsc_kv, int4_group_size, lane_row);
+                    gsc_kv, quant_group_size, lane_row);
                 if (lane_half == 0 && in_range) {
                     workspace[OFF_V_RAW + rhs_row] =
                         bf16_round_rne_f32(acc[0]);
@@ -451,18 +470,27 @@ __device__ inline void qwen36_moe_attn_step_device(
                 __syncthreads();
             }
         } else {
-            // BF16 fallback for v_proj.
+            // BF16/FP8 fallback for v_proj.
             for (;;) {
                 __shared__ unsigned int my_row_s;
                 if (tid == 0) my_row_s = atomicAdd(&counters[0], 1u);
                 __syncthreads();
                 const int my_row = static_cast<int>(my_row_s);
                 if (my_row >= Hkv * d) break;
-                const T* w_row =
-                    v_proj_w + static_cast<size_t>(my_row) * hidden;
                 float partial = 0.0f;
-                for (int col = tid; col < hidden; col += block_size) {
-                    partial += load_as_float<T>(w_row, col) * x_norm_lds[col];
+                if (v_proj_scale != nullptr) {
+                    partial = fp8_matvec_partial(
+                        reinterpret_cast<const void*>(v_proj_w),
+                        static_cast<const hip_bfloat16*>(v_proj_scale),
+                        x_norm_lds,
+                        my_row, hidden, quant_group_size,
+                        tid, block_size);
+                } else {
+                    const T* w_row =
+                        v_proj_w + static_cast<size_t>(my_row) * hidden;
+                    for (int col = tid; col < hidden; col += block_size) {
+                        partial += load_as_float<T>(w_row, col) * x_norm_lds[col];
+                    }
                 }
                 shared_scratch[tid] = partial;
                 __syncthreads();
@@ -498,11 +526,17 @@ __device__ inline void qwen36_moe_attn_step_device(
             const int dst_off = (is_v ? OFF_V_RAW : OFF_K_RAW) + proj_row;
 
             float partial = 0.0f;
-            if (i4_scale != nullptr) {
+            if (i4_scale != nullptr && !fp8_mode) {
                 partial = int4_dq8_matvec_partial(
                     reinterpret_cast<const uint8_t*>(w_slab),
                     i4_scale, i4_zero, x_norm_lds,
-                    proj_row, hidden, int4_group_size,
+                    proj_row, hidden, quant_group_size,
+                    tid, block_size);
+            } else if (i4_scale != nullptr) {
+                partial = fp8_matvec_partial(
+                    reinterpret_cast<const void*>(w_slab),
+                    i4_scale, x_norm_lds,
+                    proj_row, hidden, quant_group_size,
                     tid, block_size);
             } else {
                 const T* w_row = w_slab + static_cast<size_t>(proj_row) * hidden;
@@ -872,13 +906,14 @@ __device__ inline void qwen36_moe_attn_step_device(
     // (when stage == 5) the host-visible output buffer.
     {
         const int qd = H * d;
-        const bool o_int4 = (o_proj_scale != nullptr);
+        const bool o_quant = (o_proj_scale != nullptr);
+        const bool o_int4 = o_quant && !fp8_mode;
 
         bool wmma_handled_oproj = false;
 #ifdef SUPERSONIC_QWEN36_HAS_WMMA_BF16
         if constexpr (USE_WMMA) {
             if (o_int4) {
-                const int gsc_o = qd / int4_group_size;
+                const int gsc_o = qd / quant_group_size;
                 const int wave_id = tid >> 5;
                 const int lane_in_wave = tid & 31;
                 const int lane_row = lane_in_wave & 15;
@@ -905,7 +940,7 @@ __device__ inline void qwen36_moe_attn_step_device(
                         static_cast<const hip_bfloat16*>(o_proj_zero),
                         rhs_row, in_range,
                         gated_lds_f32, qd,
-                        gsc_o, int4_group_size, lane_row);
+                        gsc_o, quant_group_size, lane_row);
                     if (lane_half == 0 && in_range) {
                         const float o_out  = bf16_round_rne_f32(acc[0]);
                         const float in_f   =
@@ -939,7 +974,14 @@ __device__ inline void qwen36_moe_attn_step_device(
                         static_cast<const hip_bfloat16*>(o_proj_scale),
                         static_cast<const hip_bfloat16*>(o_proj_zero),
                         workspace + OFF_GATED,
-                        my_row, qd, int4_group_size,
+                        my_row, qd, quant_group_size,
+                        tid, block_size);
+                } else if (o_quant) {
+                    partial = fp8_matvec_partial(
+                        reinterpret_cast<const void*>(o_proj_w),
+                        static_cast<const hip_bfloat16*>(o_proj_scale),
+                        workspace + OFF_GATED,
+                        my_row, qd, quant_group_size,
                         tid, block_size);
                 } else {
                     const T* w_row = o_proj_w + static_cast<size_t>(my_row) * qd;

--- a/kernels/qwen36_moe_persistent/helpers.cuh
+++ b/kernels/qwen36_moe_persistent/helpers.cuh
@@ -298,6 +298,44 @@ __device__ inline float int4_dequant_scalar(
         static_cast<float>(nibble) * s - static_cast<float>(zeros[si]) * s);
 }
 
+__device__ inline float fp8_e4m3_to_float(uint8_t byte) {
+    const int sign = (byte & 0x80) ? -1 : 1;
+    const int exp = (byte >> 3) & 0x0F;
+    const int mant = byte & 0x07;
+    if (exp == 0) {
+        if (mant == 0) return sign < 0 ? -0.0f : 0.0f;
+        return sign * ldexpf(static_cast<float>(mant) / 8.0f, -6);
+    }
+    if (exp == 0x0F) {
+        return sign * 448.0f;
+    }
+    return sign * ldexpf(1.0f + static_cast<float>(mant) / 8.0f, exp - 7);
+}
+
+__device__ inline float fp8_dequant_scalar(
+    const void* w_ptr, const void* scale_ptr,
+    int row, int col, int cols, int block_size
+) {
+    const uint8_t* data = static_cast<const uint8_t*>(w_ptr);
+    const hip_bfloat16* scales = static_cast<const hip_bfloat16*>(scale_ptr);
+    const int scale_cols = (cols + block_size - 1) / block_size;
+    const int si = row * scale_cols + col / block_size;
+    const uint8_t byte = data[static_cast<size_t>(row) * cols + col];
+    return bf16_round_rne_f32(fp8_e4m3_to_float(byte) * static_cast<float>(scales[si]));
+}
+
+__device__ inline float fp8_matvec_partial(
+    const void* w_ptr, const void* scale_ptr, const float* __restrict__ x,
+    int row, int cols, int block_size,
+    int tid, int block_threads
+) {
+    float partial = 0.0f;
+    for (int col = tid; col < cols; col += block_threads) {
+        partial += fp8_dequant_scalar(w_ptr, scale_ptr, row, col, cols, block_size) * x[col];
+    }
+    return partial;
+}
+
 // -- Grid barrier (verbatim from full_attention_4b.hip)
 //
 // Acquire/release ordering on `barrier_flag` makes this safe across CUs.

--- a/kernels/qwen36_moe_persistent/linear_attn_phase.cuh
+++ b/kernels/qwen36_moe_persistent/linear_attn_phase.cuh
@@ -175,6 +175,8 @@ __device__ inline void qwen36_moe_linear_step_device(
     //   [qkv_dim + V*v_dim,       qkv_dim + V*v_dim + V):  a   (in_proj_a)
     //   [qkv_dim + V*v_dim + V,   qkv_dim + V*v_dim + 2V): b   (in_proj_b)
     const int total_rows = qkv_dim + val_dim + 2 * V;
+    const bool fp8_mode = int4_group_size < 0;
+    const int quant_group_size = fp8_mode ? -int4_group_size : int4_group_size;
 
 #ifdef SUPERSONIC_QWEN36_HAS_WMMA_BF16
     if constexpr (USE_WMMA) {
@@ -184,8 +186,8 @@ __device__ inline void qwen36_moe_linear_step_device(
         const int lane_half = lane_in_wave >> 4;
 
         // ------- Sub-pool 1: in_proj_qkv -------
-        if (in_proj_qkv_scale != nullptr) {
-            const int gsc_q = hidden / int4_group_size;
+        if (in_proj_qkv_scale != nullptr && !fp8_mode) {
+            const int gsc_q = hidden / quant_group_size;
             const uint8_t* slab_packed =
                 reinterpret_cast<const uint8_t*>(in_proj_qkv_w);
             for (;;) {
@@ -205,7 +207,7 @@ __device__ inline void qwen36_moe_linear_step_device(
                     slab_row, in_proj_qkv_scale, in_proj_qkv_zero,
                     rhs_row, in_range,
                     x_norm_lds, hidden,
-                    gsc_q, int4_group_size, lane_row);
+                    gsc_q, quant_group_size, lane_row);
                 if (lane_half == 0 && in_range) {
                     workspace[OFF_QKV_RAW + rhs_row] =
                         bf16_round_rne_f32(acc[0]);
@@ -213,18 +215,27 @@ __device__ inline void qwen36_moe_linear_step_device(
                 __syncthreads();
             }
         } else {
-            // BF16 fallback for qkv (parity-test path; bake is INT4).
+            // BF16/FP8 fallback for qkv.
             for (;;) {
                 __shared__ unsigned int my_row_s;
                 if (tid == 0) my_row_s = atomicAdd(&counters[0], 1u);
                 __syncthreads();
                 const int my_row = static_cast<int>(my_row_s);
                 if (my_row >= qkv_dim) break;
-                const T* w_row =
-                    in_proj_qkv_w + static_cast<size_t>(my_row) * hidden;
                 float partial = 0.0f;
-                for (int col = tid; col < hidden; col += block_size) {
-                    partial += static_cast<float>(w_row[col]) * x_norm_lds[col];
+                if (in_proj_qkv_scale != nullptr) {
+                    partial = fp8_matvec_partial(
+                        reinterpret_cast<const void*>(in_proj_qkv_w),
+                        in_proj_qkv_scale,
+                        x_norm_lds,
+                        my_row, hidden, quant_group_size,
+                        tid, block_size);
+                } else {
+                    const T* w_row =
+                        in_proj_qkv_w + static_cast<size_t>(my_row) * hidden;
+                    for (int col = tid; col < hidden; col += block_size) {
+                        partial += static_cast<float>(w_row[col]) * x_norm_lds[col];
+                    }
                 }
                 shared_scratch[tid] = partial;
                 __syncthreads();
@@ -245,8 +256,8 @@ __device__ inline void qwen36_moe_linear_step_device(
                                    &counters[0]);
 
         // ------- Sub-pool 2: in_proj_z -------
-        if (in_proj_z_scale != nullptr) {
-            const int gsc_z = hidden / int4_group_size;
+        if (in_proj_z_scale != nullptr && !fp8_mode) {
+            const int gsc_z = hidden / quant_group_size;
             const uint8_t* slab_packed =
                 reinterpret_cast<const uint8_t*>(in_proj_z_w);
             for (;;) {
@@ -266,7 +277,7 @@ __device__ inline void qwen36_moe_linear_step_device(
                     slab_row, in_proj_z_scale, in_proj_z_zero,
                     rhs_row, in_range,
                     x_norm_lds, hidden,
-                    gsc_z, int4_group_size, lane_row);
+                    gsc_z, quant_group_size, lane_row);
                 if (lane_half == 0 && in_range) {
                     workspace[OFF_Z_RAW + rhs_row] =
                         bf16_round_rne_f32(acc[0]);
@@ -274,18 +285,27 @@ __device__ inline void qwen36_moe_linear_step_device(
                 __syncthreads();
             }
         } else {
-            // BF16 fallback for z.
+            // BF16/FP8 fallback for z.
             for (;;) {
                 __shared__ unsigned int my_row_s;
                 if (tid == 0) my_row_s = atomicAdd(&counters[0], 1u);
                 __syncthreads();
                 const int my_row = static_cast<int>(my_row_s);
                 if (my_row >= val_dim) break;
-                const T* w_row =
-                    in_proj_z_w + static_cast<size_t>(my_row) * hidden;
                 float partial = 0.0f;
-                for (int col = tid; col < hidden; col += block_size) {
-                    partial += static_cast<float>(w_row[col]) * x_norm_lds[col];
+                if (in_proj_z_scale != nullptr) {
+                    partial = fp8_matvec_partial(
+                        reinterpret_cast<const void*>(in_proj_z_w),
+                        in_proj_z_scale,
+                        x_norm_lds,
+                        my_row, hidden, quant_group_size,
+                        tid, block_size);
+                } else {
+                    const T* w_row =
+                        in_proj_z_w + static_cast<size_t>(my_row) * hidden;
+                    for (int col = tid; col < hidden; col += block_size) {
+                        partial += static_cast<float>(w_row[col]) * x_norm_lds[col];
+                    }
                 }
                 shared_scratch[tid] = partial;
                 __syncthreads();
@@ -395,11 +415,18 @@ __device__ inline void qwen36_moe_linear_step_device(
             }
 
             float partial = 0.0f;
-            if (i4_scale != nullptr) {
+            if (i4_scale != nullptr && !fp8_mode) {
                 partial = int4_dq8_matvec_partial(
                     static_cast<const uint8_t*>(i4_slab),
                     i4_scale, i4_zero, x_norm_lds,
-                    i4_row, hidden, int4_group_size,
+                    i4_row, hidden, quant_group_size,
+                    tid, block_size);
+            } else if (i4_scale != nullptr) {
+                partial = fp8_matvec_partial(
+                    i4_slab,
+                    i4_scale,
+                    x_norm_lds,
+                    i4_row, hidden, quant_group_size,
                     tid, block_size);
             } else {
                 for (int col = tid; col < hidden; col += block_size) {
@@ -869,7 +896,8 @@ __device__ inline void qwen36_moe_linear_step_device(
     // and `output_hidden = input_hidden + o_out` in the oracle.
     {
         const int qd = V * v_dim;
-        const bool out_int4 = (out_proj_scale != nullptr);
+        const bool out_quant = (out_proj_scale != nullptr);
+        const bool out_int4 = out_quant && !fp8_mode;
 
         // WMMA path: claim 128 output rows per atomicAdd, 8 waves × 16-row
         // tiles each. Same shape as FFN's Phase I (PR #77). The reduction
@@ -880,7 +908,7 @@ __device__ inline void qwen36_moe_linear_step_device(
 #ifdef SUPERSONIC_QWEN36_HAS_WMMA_BF16
         if constexpr (USE_WMMA) {
             if (out_int4) {
-                const int gsc_o = qd / int4_group_size;
+                const int gsc_o = qd / quant_group_size;
                 const int wave_id = tid >> 5;
                 const int lane_in_wave = tid & 31;
                 const int lane_row = lane_in_wave & 15;
@@ -907,7 +935,7 @@ __device__ inline void qwen36_moe_linear_step_device(
                         static_cast<const hip_bfloat16*>(out_proj_zero),
                         rhs_row, in_range,
                         mid_lds_f32, qd,
-                        gsc_o, int4_group_size, lane_row);
+                        gsc_o, quant_group_size, lane_row);
                     if (lane_half == 0 && in_range) {
                         const float o_out =
                             bf16_round_rne_f32(acc[0]);
@@ -942,7 +970,14 @@ __device__ inline void qwen36_moe_linear_step_device(
                         static_cast<const hip_bfloat16*>(out_proj_scale),
                         static_cast<const hip_bfloat16*>(out_proj_zero),
                         workspace + OFF_REC_OUT,
-                        my_row, qd, int4_group_size,
+                        my_row, qd, quant_group_size,
+                        tid, block_size);
+                } else if (out_quant) {
+                    partial = fp8_matvec_partial(
+                        reinterpret_cast<const void*>(out_proj_w),
+                        static_cast<const hip_bfloat16*>(out_proj_scale),
+                        workspace + OFF_REC_OUT,
+                        my_row, qd, quant_group_size,
                         tid, block_size);
                 } else {
                     const T* w_row = out_proj_w + static_cast<size_t>(my_row) * qd;

--- a/oracle/bake_fp8.py
+++ b/oracle/bake_fp8.py
@@ -28,12 +28,16 @@ import math
 import re
 import sys
 import time
+import struct
 from pathlib import Path
 from typing import Any
 
-import numpy as np
-import torch
-from safetensors import safe_open
+try:
+    import torch
+    from safetensors import safe_open
+except ModuleNotFoundError:
+    torch = None
+    safe_open = None
 
 # -- constants mirrored from crates/model-store/src/manifest.rs --
 FORMAT_VERSION = 2
@@ -50,6 +54,10 @@ BLOCK_SIZE = 128
 MAX_E4M3 = 448.0  # finite max of float8_e4m3fn
 
 LAYER_RE = re.compile(r"^model\.language_model\.layers\.(\d+)\.")
+QWEN36_EXPERT_RE = re.compile(
+    r"^model\.language_model\.layers\.(\d+)\.mlp\.experts\.(\d+)\."
+    r"(gate_proj|up_proj|down_proj)\.weight(?:_scale_inv)?$"
+)
 
 
 def log(msg: str) -> None:
@@ -316,6 +324,202 @@ class StreamingTensorWriter:
         log(f"[bake-fp8] wrote {self.cursor / (1024 * 1024):.1f} MiB to {self.weights_path}")
 
 
+class RawSafeTensorIndex:
+    def __init__(self, model_dir: Path) -> None:
+        self.model_dir = model_dir
+        weight_map_path = model_dir / "model.safetensors.index.json"
+        if weight_map_path.exists():
+            wm = json.load(open(weight_map_path)).get("weight_map", {})
+            self.weight_map = {str(k): str(v) for k, v in wm.items()}
+            shard_names = sorted(set(self.weight_map.values()))
+        else:
+            shard_names = [p.name for p in sorted(model_dir.glob("*.safetensors"))]
+            self.weight_map = {}
+        if not shard_names:
+            raise SystemExit(f"no .safetensors found in {model_dir}")
+
+        self.shards: dict[str, tuple[int, dict[str, Any]]] = {}
+        for shard_name in shard_names:
+            path = model_dir / shard_name
+            with path.open("rb") as f:
+                header_len = struct.unpack("<Q", f.read(8))[0]
+                header = json.loads(f.read(header_len))
+            tensors = {k: v for k, v in header.items() if k != "__metadata__"}
+            self.shards[shard_name] = (8 + header_len, tensors)
+            if not self.weight_map:
+                for k in tensors:
+                    self.weight_map[k] = shard_name
+
+    def keys(self) -> list[str]:
+        return list(self.weight_map)
+
+    def meta(self, name: str) -> dict[str, Any]:
+        shard = self.weight_map[name]
+        return self.shards[shard][1][name]
+
+    def raw_bytes(self, name: str) -> bytes:
+        shard = self.weight_map[name]
+        data_start, tensors = self.shards[shard]
+        meta = tensors[name]
+        start, end = meta["data_offsets"]
+        with (self.model_dir / shard).open("rb") as f:
+            f.seek(data_start + start)
+            return f.read(end - start)
+
+
+def _bf16_to_f32_bits(u16: int) -> float:
+    return struct.unpack("<f", struct.pack("<I", u16 << 16))[0]
+
+
+def _f32_to_bf16_bytes(x: float) -> bytes:
+    bits = struct.unpack("<I", struct.pack("<f", x))[0]
+    bits += 0x7FFF + ((bits >> 16) & 1)
+    return struct.pack("<H", (bits >> 16) & 0xFFFF)
+
+
+def _a_log_raw_to_exp_bf16(raw: bytes, dtype: str) -> bytes:
+    out = bytearray()
+    if dtype == "BF16":
+        for i in range(0, len(raw), 2):
+            v = _bf16_to_f32_bits(struct.unpack_from("<H", raw, i)[0])
+            out.extend(_f32_to_bf16_bytes(math.exp(v)))
+        return bytes(out)
+    if dtype == "F32":
+        for i in range(0, len(raw), 4):
+            v = struct.unpack_from("<f", raw, i)[0]
+            out.extend(_f32_to_bf16_bytes(math.exp(v)))
+        return bytes(out)
+    raise SystemExit(f"A_log raw fallback supports BF16/F32 only, got {dtype}")
+
+
+def _safetensors_dtype_to_manifest(dtype: str) -> str:
+    return {
+        "BF16": "bf16",
+        "F32": "f32",
+        "F16": "f16",
+        "U8": "u8",
+        "F8_E4M3": "f8_e4m3",
+    }[dtype]
+
+
+def bake_qwen36_fp8_raw(model_dir: Path, out_dir: Path, block_size: int) -> None:
+    """Dependency-free FP8-native bake for Qwen3.6-MoE checkpoints."""
+    if block_size != BLOCK_SIZE:
+        raise SystemExit("raw qwen36 FP8 bake currently requires block_size=128")
+    config_path = model_dir / "config.json"
+    model_family = detect_model_family(config_path)
+    if model_family != "qwen36-moe":
+        raise SystemExit("raw fallback only supports qwen36-moe FP8 checkpoints")
+    linear_idx = linear_attn_layer_indices(config_path)
+    raw = RawSafeTensorIndex(model_dir)
+    keys = raw.keys()
+    log(f"[bake-fp8/raw] {len(set(raw.weight_map.values()))} shard(s), {len(keys)} tensors")
+
+    weight_prefix = "model.language_model"
+    eligible = sorted(n for n in keys if n.startswith(f"{weight_prefix}.") or n == "lm_head.weight")
+    writer = StreamingTensorWriter(out_dir)
+
+    per_layer: dict[int, set[int]] = {}
+    skip_names: set[str] = set()
+    for name in keys:
+        m = QWEN36_EXPERT_RE.match(name)
+        if not m:
+            continue
+        layer = int(m.group(1))
+        expert = int(m.group(2))
+        per_layer.setdefault(layer, set()).add(expert)
+        skip_names.add(name)
+
+    log(f"[bake-fp8/raw] qwen36-moe fused experts: {len(per_layer)} layer(s)")
+    for layer in sorted(per_layer):
+        experts = sorted(per_layer[layer])
+        base = f"{weight_prefix}.layers.{layer}.mlp.experts"
+        gate_up = bytearray()
+        gate_up_scale = bytearray()
+        down = bytearray()
+        down_scale = bytearray()
+        gate_shape = up_shape = down_shape = None
+        gate_scale_shape = up_scale_shape = down_scale_shape = None
+        for expert in experts:
+            eb = f"{base}.{expert}"
+            gate_n = f"{eb}.gate_proj.weight"
+            up_n = f"{eb}.up_proj.weight"
+            down_n = f"{eb}.down_proj.weight"
+            gate_m = raw.meta(gate_n)
+            up_m = raw.meta(up_n)
+            down_m = raw.meta(down_n)
+            if gate_m["dtype"] != "F8_E4M3" or up_m["dtype"] != "F8_E4M3" or down_m["dtype"] != "F8_E4M3":
+                raise SystemExit(f"qwen36 raw FP8 experts must be F8_E4M3 at layer={layer} expert={expert}")
+            gate_shape, up_shape, down_shape = gate_m["shape"], up_m["shape"], down_m["shape"]
+            gate_up.extend(raw.raw_bytes(gate_n))
+            gate_up.extend(raw.raw_bytes(up_n))
+            down.extend(raw.raw_bytes(down_n))
+            gate_s = f"{gate_n}_scale_inv"
+            up_s = f"{up_n}_scale_inv"
+            down_s = f"{down_n}_scale_inv"
+            gate_scale_shape = raw.meta(gate_s)["shape"]
+            up_scale_shape = raw.meta(up_s)["shape"]
+            down_scale_shape = raw.meta(down_s)["shape"]
+            gate_up_scale.extend(raw.raw_bytes(gate_s))
+            gate_up_scale.extend(raw.raw_bytes(up_s))
+            down_scale.extend(raw.raw_bytes(down_s))
+
+        writer.add(
+            f"{base}.gate_up_proj",
+            bytes(gate_up),
+            [len(experts), gate_shape[0] + up_shape[0], gate_shape[1]],
+            "f8_e4m3",
+            LAYOUT_FP8_NATIVE,
+        )
+        writer.add(
+            f"{base}.gate_up_proj_scale_inv",
+            bytes(gate_up_scale),
+            [len(experts), gate_scale_shape[0] + up_scale_shape[0], gate_scale_shape[1]],
+            "bf16",
+            LAYOUT_RAW,
+        )
+        writer.add(
+            f"{base}.down_proj",
+            bytes(down),
+            [len(experts), down_shape[0], down_shape[1]],
+            "f8_e4m3",
+            LAYOUT_FP8_NATIVE,
+        )
+        writer.add(
+            f"{base}.down_proj_scale_inv",
+            bytes(down_scale),
+            [len(experts), down_scale_shape[0], down_scale_shape[1]],
+            "bf16",
+            LAYOUT_RAW,
+        )
+        log(f"[bake-fp8/raw]   layer {layer}: fused {len(experts)} experts")
+
+    n_skip = 0
+    for name in eligible:
+        if name in skip_names:
+            continue
+        meta = raw.meta(name)
+        shape = list(meta["shape"])
+        dtype = meta["dtype"]
+        data = raw.raw_bytes(name)
+        layout = classify_layout(name, tuple(shape), linear_idx)
+        if layout == LAYOUT_DEPTHWISE_CONV_SQUEEZED:
+            shape = [shape[0], shape[2]]
+        elif layout == LAYOUT_HEAD_BIAS_RESHAPED:
+            shape = [1, 1, shape[0]]
+        elif layout == LAYOUT_HEAD_EXP_RESHAPED:
+            data = _a_log_raw_to_exp_bf16(data, dtype)
+            shape = [1, 1, shape[0]]
+            dtype = "BF16"
+        elif dtype == "F8_E4M3" and is_fp8_quant_target(name, tuple(shape), block_size):
+            layout = LAYOUT_FP8_NATIVE
+        writer.add(name, data, shape, _safetensors_dtype_to_manifest(dtype), layout)
+        n_skip += 1
+
+    writer.close(model_family=model_family)
+    log(f"[bake-fp8/raw] wrote {n_skip} non-fused tensors. Output: {out_dir}")
+
+
 # ---------------------------------------------------------------------------
 # Driver
 # ---------------------------------------------------------------------------
@@ -360,6 +564,12 @@ def main() -> None:
         raise SystemExit(f"missing config.json under {model_dir}")
     model_family = args.model_family or detect_model_family(config_path)
     log(f"[bake-fp8] model_family={model_family}")
+    if (torch is None or safe_open is None) and model_family == "qwen36-moe":
+        log("[bake-fp8] torch/safetensors not available; using raw qwen36 FP8 path")
+        bake_qwen36_fp8_raw(model_dir, out_dir, block_size)
+        return
+    if torch is None or safe_open is None:
+        raise SystemExit("bake_fp8.py needs torch+safetensors for non-qwen36 FP8 bakes")
     linear_idx = linear_attn_layer_indices(config_path)
     log(f"[bake-fp8] linear-attn layer indices ({len(linear_idx)}): "
         f"{sorted(linear_idx)[:8]}{' ...' if len(linear_idx) > 8 else ''}")
@@ -386,11 +596,112 @@ def main() -> None:
             open_shards[idx] = h
         return h
 
+    def load_tensor(name: str) -> torch.Tensor:
+        shard_idx = index[name]
+        return get_handle(shard_idx).get_tensor(name)
+
+    def fuse_qwen36_experts() -> set[str]:
+        """Emit runtime-fused Qwen3.6-MoE expert slabs.
+
+        The published FP8 checkpoint stores experts as
+        `experts.{id}.{gate,up,down}_proj.weight` plus per-expert
+        `*_scale_inv`. SuperSonic's qwen36 runtime consumes the same fused
+        names as the INT4 bake: `experts.gate_up_proj` and
+        `experts.down_proj`, each with one fused `_scale_inv` sidecar.
+        """
+        if model_family != "qwen36-moe":
+            return set()
+
+        per_layer: dict[int, set[int]] = {}
+        skipped: set[str] = set()
+        for name in index:
+            m = QWEN36_EXPERT_RE.match(name)
+            if not m:
+                continue
+            layer = int(m.group(1))
+            expert = int(m.group(2))
+            per_layer.setdefault(layer, set()).add(expert)
+            skipped.add(name)
+
+        if not per_layer:
+            return skipped
+
+        log(f"[bake-fp8] qwen36-moe fused experts: {len(per_layer)} layer(s)")
+        for layer in sorted(per_layer):
+            experts = sorted(per_layer[layer])
+            base = f"model.language_model.layers.{layer}.mlp.experts"
+
+            gate_up_bytes = bytearray()
+            gate_up_scale_chunks: list[torch.Tensor] = []
+            down_bytes = bytearray()
+            down_scale_chunks: list[torch.Tensor] = []
+
+            for expert in experts:
+                eb = f"{base}.{expert}"
+                gate = load_tensor(f"{eb}.gate_proj.weight")
+                up = load_tensor(f"{eb}.up_proj.weight")
+                down = load_tensor(f"{eb}.down_proj.weight")
+                if gate.dtype != torch.float8_e4m3fn or up.dtype != torch.float8_e4m3fn or down.dtype != torch.float8_e4m3fn:
+                    raise SystemExit(
+                        f"qwen36 FP8 fused expert source must be float8_e4m3fn "
+                        f"(layer={layer}, expert={expert})"
+                    )
+                gate_up_bytes.extend(tensor_to_bytes(gate, "f8_e4m3"))
+                gate_up_bytes.extend(tensor_to_bytes(up, "f8_e4m3"))
+                down_bytes.extend(tensor_to_bytes(down, "f8_e4m3"))
+
+                gate_s = load_tensor(f"{eb}.gate_proj.weight_scale_inv").to(torch.bfloat16)
+                up_s = load_tensor(f"{eb}.up_proj.weight_scale_inv").to(torch.bfloat16)
+                down_s = load_tensor(f"{eb}.down_proj.weight_scale_inv").to(torch.bfloat16)
+                gate_up_scale_chunks.append(torch.cat([gate_s, up_s], dim=0).unsqueeze(0))
+                down_scale_chunks.append(down_s.unsqueeze(0))
+
+            gate_shape = [len(experts), int(gate.shape[0] + up.shape[0]), int(gate.shape[1])]
+            down_shape = [len(experts), int(down.shape[0]), int(down.shape[1])]
+            writer.add(
+                f"{base}.gate_up_proj",
+                bytes(gate_up_bytes),
+                gate_shape,
+                "f8_e4m3",
+                LAYOUT_FP8_NATIVE,
+            )
+            gate_up_scale = torch.cat(gate_up_scale_chunks, dim=0).contiguous()
+            writer.add(
+                f"{base}.gate_up_proj_scale_inv",
+                tensor_to_bytes(gate_up_scale, "bf16"),
+                list(gate_up_scale.shape),
+                "bf16",
+                LAYOUT_RAW,
+            )
+            writer.add(
+                f"{base}.down_proj",
+                bytes(down_bytes),
+                down_shape,
+                "f8_e4m3",
+                LAYOUT_FP8_NATIVE,
+            )
+            down_scale = torch.cat(down_scale_chunks, dim=0).contiguous()
+            writer.add(
+                f"{base}.down_proj_scale_inv",
+                tensor_to_bytes(down_scale, "bf16"),
+                list(down_scale.shape),
+                "bf16",
+                LAYOUT_RAW,
+            )
+            log(f"[bake-fp8]   layer {layer}: fused {len(experts)} experts")
+            del gate_up_bytes, down_bytes, gate_up_scale_chunks, down_scale_chunks
+            del gate_up_scale, down_scale
+
+        return skipped
+
     t0 = time.perf_counter()
     n_quant = 0
     n_skip = 0
     try:
+        skip_names = fuse_qwen36_experts()
         for name in eligible:
+            if name in skip_names:
+                continue
             shard_idx = index[name]
             handle = get_handle(shard_idx)
             t = handle.get_tensor(name)

--- a/oracle/qwen36_verify_suite.py
+++ b/oracle/qwen36_verify_suite.py
@@ -1,0 +1,596 @@
+#!/usr/bin/env python3
+"""Deterministic Qwen3.6 MoE verification suite.
+
+The suite shells out to `supersonic`, captures Qwen3.6 final-hidden/logit
+dumps, and checks repeatability across identical runs. It intentionally keeps
+the first gate simple: if the same prompt/backend/mode does not produce the
+same dumped bytes, the lane cannot be used as a quantized verification base.
+
+Prompt families:
+  - pg19: fixed token windows from PG-19, a local text file, or a synthetic
+    fallback for CI.
+  - ruler: deterministic RULER/NIAH-like retrieval haystacks.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import random
+import re
+import statistics
+import string
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+
+FILLER_BLOCK = (
+    "The archive describes a sequence of journeys, letters, instruments, "
+    "weather observations, family names, and quiet digressions about distant "
+    "cities. Each paragraph adds ordinary detail so the important facts are "
+    "embedded in a long and repetitive context rather than placed near the "
+    "question. The reader must preserve exact associations across the whole "
+    "passage while ignoring unrelated prose.\n\n"
+)
+
+SYNTHETIC_PG19_BLOCK = (
+    "In the late afternoon the house stood silent above the road, and the "
+    "pages of the old book stirred whenever the window admitted a thread of "
+    "wind. There were accounts of voyages, inventories of rooms, arguments "
+    "between cousins, and careful descriptions of towns that no one in the "
+    "family had visited for many years. The style was patient and elaborate, "
+    "as though the narrator meant to preserve every small change of light.\n\n"
+)
+
+RULER_KEYS = [
+    "amber", "basil", "cobalt", "dorian", "ember", "fable", "garnet",
+    "harbor", "ivory", "jasper", "kepler", "linen", "mistral", "nickel",
+    "opal", "prairie", "quartz", "raven", "saffron", "tundra",
+]
+
+
+@dataclass(frozen=True)
+class Case:
+    case_id: str
+    family: str
+    context: int
+    prompt: str
+    references: list[str]
+    prompt_tokens: int
+
+
+class TokenizerAdapter:
+    def __init__(self, model_dir: Path):
+        try:
+            from tokenizers import Tokenizer
+        except Exception as exc:  # pragma: no cover - environment dependent
+            raise RuntimeError(
+                "tokenizers is required for qwen36_verify_suite.py; install it with "
+                "`python3 -m pip install tokenizers`"
+            ) from exc
+        tokenizer_json = model_dir / "tokenizer.json"
+        if not tokenizer_json.exists():
+            raise FileNotFoundError(tokenizer_json)
+        self.tokenizer = Tokenizer.from_file(str(tokenizer_json))
+
+    def encode(self, text: str) -> list[int]:
+        return list(self.tokenizer.encode(text, add_special_tokens=True).ids)
+
+    def encode_plain(self, text: str) -> list[int]:
+        return list(self.tokenizer.encode(text, add_special_tokens=False).ids)
+
+    def decode_plain(self, token_ids: list[int]) -> str:
+        return str(self.tokenizer.decode(token_ids, skip_special_tokens=True))
+
+
+def parse_contexts(raw: str) -> list[int]:
+    out: list[int] = []
+    for part in raw.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        if part.lower().endswith("k"):
+            out.append(int(part[:-1]) * 1024)
+        else:
+            out.append(int(part))
+    if not out:
+        raise ValueError("no contexts specified")
+    return out
+
+
+def stable_seed(seed_base: int, *parts: object) -> int:
+    key = "|".join(str(p) for p in parts).encode()
+    return seed_base + int(hashlib.md5(key).hexdigest()[:8], 16)
+
+
+def fit_to_context(text: str, tokenizer: TokenizerAdapter, target_tokens: int) -> tuple[str, int]:
+    ids = tokenizer.encode_plain(text)
+    if len(ids) >= target_tokens:
+        prompt = tokenizer.decode_plain(ids[:target_tokens])
+        return prompt, len(tokenizer.encode(prompt))
+
+    pieces = [text]
+    while len(tokenizer.encode_plain("".join(pieces))) < target_tokens:
+        pieces.append(FILLER_BLOCK)
+    ids = tokenizer.encode_plain("".join(pieces))
+    prompt = tokenizer.decode_plain(ids[:target_tokens])
+    return prompt, len(tokenizer.encode(prompt))
+
+
+def load_pg19_texts(args: argparse.Namespace) -> Iterable[str]:
+    if args.pg19_source == "text":
+        if args.pg19_text is None:
+            raise ValueError("--pg19-text is required with --pg19-source=text")
+        yield args.pg19_text.read_text()
+        return
+    if args.pg19_source == "synthetic":
+        yield SYNTHETIC_PG19_BLOCK * 20000
+        return
+
+    try:
+        from datasets import load_dataset
+    except Exception as exc:  # pragma: no cover - environment dependent
+        raise RuntimeError("datasets is required with --pg19-source=dataset") from exc
+    for row in load_dataset("emozilla/pg19", split="test", streaming=True):
+        text = str(row.get("text") or "")
+        if text.strip():
+            yield text
+
+
+def build_pg19_cases(
+    args: argparse.Namespace,
+    tokenizer: TokenizerAdapter,
+    contexts: list[int],
+) -> list[Case]:
+    cases: list[Case] = []
+    for ctx in contexts:
+        wanted = max(1, ctx - args.max_new_tokens)
+        made = 0
+        for doc_idx, text in enumerate(load_pg19_texts(args)):
+            ids = tokenizer.encode_plain(text)
+            if len(ids) < wanted:
+                continue
+            stride = args.pg19_stride or wanted
+            for start in range(0, len(ids) - wanted + 1, stride):
+                prompt = tokenizer.decode_plain(ids[start : start + wanted])
+                prompt_tokens = len(tokenizer.encode(prompt))
+                cases.append(Case(
+                    case_id=f"pg19_ctx{ctx}_doc{doc_idx}_off{start}",
+                    family="pg19",
+                    context=ctx,
+                    prompt=prompt,
+                    references=[],
+                    prompt_tokens=prompt_tokens,
+                ))
+                made += 1
+                if made >= args.pg19_samples:
+                    break
+            if made >= args.pg19_samples:
+                break
+        if made < args.pg19_samples:
+            raise RuntimeError(f"only built {made} PG-19 cases for context {ctx}")
+    return cases
+
+
+def make_ruler_prompt(
+    rng: random.Random,
+    context: int,
+    tokenizer: TokenizerAdapter,
+    max_new: int,
+) -> tuple[str, int, list[str]]:
+    key = rng.choice(RULER_KEYS)
+    value = "".join(rng.choice(string.digits) for _ in range(8))
+    payload = f"\nThe verification code paired with key {key} is {value}.\n\n"
+    question = (
+        f"\nQuestion: What is the verification code paired with key {key}? "
+        f"Answer with only the code.\nAnswer:"
+    )
+    target = max(1, context - max_new)
+
+    filler_tokens = max(1, len(tokenizer.encode_plain(FILLER_BLOCK)))
+    payload_tokens = len(tokenizer.encode_plain(payload + question))
+    filler_count = max(0, (target - payload_tokens) // filler_tokens)
+    while True:
+        insert_at = rng.randrange(0, filler_count + 1) if filler_count else 0
+        parts: list[str] = []
+        for idx in range(filler_count):
+            if idx == insert_at:
+                parts.append(payload)
+            parts.append(FILLER_BLOCK)
+        if insert_at == filler_count:
+            parts.append(payload)
+        parts.append(question)
+        prompt = "".join(parts)
+        prompt_tokens = len(tokenizer.encode(prompt))
+        if prompt_tokens <= target or filler_count == 0:
+            break
+        filler_count -= 1
+    return prompt, prompt_tokens, [value]
+
+
+def build_ruler_cases(
+    args: argparse.Namespace,
+    tokenizer: TokenizerAdapter,
+    contexts: list[int],
+) -> list[Case]:
+    cases: list[Case] = []
+    for ctx in contexts:
+        for sample_idx in range(args.ruler_samples):
+            rng = random.Random(stable_seed(args.seed, "ruler", ctx, sample_idx))
+            prompt, prompt_tokens, refs = make_ruler_prompt(rng, ctx, tokenizer, args.max_new_tokens)
+            cases.append(Case(
+                case_id=f"ruler_niah_ctx{ctx}_sample{sample_idx}",
+                family="ruler",
+                context=ctx,
+                prompt=prompt,
+                references=refs,
+                prompt_tokens=prompt_tokens,
+            ))
+    return cases
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def bf16_values(path: Path) -> list[float]:
+    data = path.read_bytes()
+    out: list[float] = []
+    for i in range(0, len(data), 2):
+        u = int.from_bytes(data[i : i + 2], "little")
+        out.append(float_from_u32(u << 16))
+    return out
+
+
+def float_from_u32(raw: int) -> float:
+    import struct
+    return struct.unpack("<f", raw.to_bytes(4, "little"))[0]
+
+
+def vector_stats(path: Path) -> dict[str, Any]:
+    vals = bf16_values(path)
+    finite = [v for v in vals if math.isfinite(v)]
+    if not vals:
+        return {"len": 0, "finite": 0, "nan": 0, "all_zero": True}
+    argmax = max(range(len(vals)), key=vals.__getitem__)
+    return {
+        "len": len(vals),
+        "finite": len(finite),
+        "nan": len(vals) - len(finite),
+        "all_zero": all(v == 0.0 for v in vals),
+        "argmax": argmax,
+        "max": vals[argmax],
+        "min": min(vals),
+    }
+
+
+def compare_vectors(a_path: Path, b_path: Path) -> dict[str, float]:
+    a = bf16_values(a_path)
+    b = bf16_values(b_path)
+    n = min(len(a), len(b))
+    if n == 0:
+        return {"max_abs": math.inf, "rmse": math.inf, "cosine": 0.0}
+    max_abs = 0.0
+    ss = 0.0
+    dot = 0.0
+    aa = 0.0
+    bb = 0.0
+    for x, y in zip(a[:n], b[:n]):
+        d = x - y
+        max_abs = max(max_abs, abs(d))
+        ss += d * d
+        dot += x * y
+        aa += x * x
+        bb += y * y
+    denom = math.sqrt(aa) * math.sqrt(bb)
+    return {
+        "max_abs": max_abs,
+        "rmse": math.sqrt(ss / n),
+        "cosine": dot / denom if denom else 0.0,
+    }
+
+
+def parse_generated_ids(output: str) -> list[int]:
+    match = re.search(r"Generated ids:\s*\[([^\]]*)\]", output)
+    if not match:
+        return []
+    raw = match.group(1).strip()
+    if not raw:
+        return []
+    return [int(x.strip()) for x in raw.split(",") if x.strip()]
+
+
+def parse_stage_timings(output: str) -> dict[str, float]:
+    match = re.search(r"\[qwen36-moe stage-timings\]\s+(.+)", output)
+    if not match:
+        return {}
+    out: dict[str, float] = {}
+    for part in match.group(1).split():
+        if "=" not in part:
+            continue
+        k, v = part.split("=", 1)
+        try:
+            out[k] = float(v)
+        except ValueError:
+            pass
+    return out
+
+
+def run_once(args: argparse.Namespace, case: Case, mode: str, repeat_idx: int, tmp: Path) -> dict[str, Any]:
+    logits = tmp / f"{case.case_id}_{mode}_{repeat_idx}_logits.bin"
+    hidden = tmp / f"{case.case_id}_{mode}_{repeat_idx}_hidden.bin"
+    env = os.environ.copy()
+    env["SUPERSONIC_QWEN36_DUMP_LOGITS"] = str(logits)
+    env["SUPERSONIC_QWEN36_DUMP_FINAL_HIDDEN"] = str(hidden)
+    env.setdefault("SUPERSONIC_BACKENDS", args.backend)
+
+    cmd = [
+        str(args.binary),
+        "--backend", args.backend,
+        "--model", "qwen3.6-35b-a3b",
+        "--model-dir", str(args.model_dir),
+        "--prompt", case.prompt,
+        "--context-size", str(max(case.context, case.prompt_tokens + args.max_new_tokens)),
+        "--max-new-tokens", str(args.max_new_tokens),
+        "--temperature", "0",
+        "--top-k", "1",
+        "--sampling-seed", str(args.seed),
+    ]
+    if mode == "fp8":
+        cmd.append("--fp8-runtime")
+    elif mode == "int4":
+        cmd.append("--int4")
+    else:
+        raise ValueError(f"unknown mode {mode}")
+    if args.emit_stage_timings:
+        cmd.append("--emit-stage-timings")
+
+    start = time.perf_counter()
+    try:
+        proc = subprocess.run(cmd, text=True, capture_output=True, timeout=args.timeout, env=env)
+    except subprocess.TimeoutExpired as exc:
+        wall = time.perf_counter() - start
+        stdout = exc.stdout or ""
+        stderr = exc.stderr or ""
+        if isinstance(stdout, bytes):
+            stdout = stdout.decode(errors="replace")
+        if isinstance(stderr, bytes):
+            stderr = stderr.decode(errors="replace")
+        output = stdout + stderr
+        return {
+            "mode": mode,
+            "repeat_idx": repeat_idx,
+            "returncode": None,
+            "timed_out": True,
+            "timeout_seconds": args.timeout,
+            "wall_seconds": wall,
+            "generated_ids": parse_generated_ids(output),
+            "stage": parse_stage_timings(output),
+            "stdout_tail": stdout[-1200:],
+            "stderr_tail": stderr[-1200:],
+            "error": f"supersonic timed out after {args.timeout}s",
+        }
+    wall = time.perf_counter() - start
+    output = proc.stdout + proc.stderr
+    row: dict[str, Any] = {
+        "mode": mode,
+        "repeat_idx": repeat_idx,
+        "returncode": proc.returncode,
+        "wall_seconds": wall,
+        "generated_ids": parse_generated_ids(output),
+        "stage": parse_stage_timings(output),
+        "stdout_tail": proc.stdout[-1200:],
+        "stderr_tail": proc.stderr[-1200:],
+    }
+    if proc.returncode != 0:
+        row["error"] = output[-4000:]
+        return row
+    if not logits.exists() or not hidden.exists():
+        row["error"] = "missing qwen36 dump files"
+        return row
+    row["logits_path"] = str(logits)
+    row["hidden_path"] = str(hidden)
+    row["logits_sha256"] = sha256_file(logits)
+    row["hidden_sha256"] = sha256_file(hidden)
+    row["logits_stats"] = vector_stats(logits)
+    row["hidden_stats"] = vector_stats(hidden)
+    return row
+
+
+def summarize_case(case: Case, runs: list[dict[str, Any]]) -> dict[str, Any]:
+    by_mode: dict[str, list[dict[str, Any]]] = {}
+    for row in runs:
+        by_mode.setdefault(str(row["mode"]), []).append(row)
+    summary: dict[str, Any] = {
+        "case_id": case.case_id,
+        "family": case.family,
+        "context": case.context,
+        "prompt_tokens": case.prompt_tokens,
+        "references": case.references,
+        "modes": {},
+    }
+    for mode, rows in by_mode.items():
+        ok_rows = [r for r in rows if r.get("returncode") == 0 and not r.get("error")]
+        logits_hashes = {r.get("logits_sha256") for r in ok_rows}
+        hidden_hashes = {r.get("hidden_sha256") for r in ok_rows}
+        generated = {tuple(r.get("generated_ids") or []) for r in ok_rows}
+        all_zero = [bool((r.get("logits_stats") or {}).get("all_zero")) for r in ok_rows]
+        wall = [float(r.get("wall_seconds") or 0.0) for r in ok_rows]
+        mode_summary = {
+            "runs": len(rows),
+            "ok_runs": len(ok_rows),
+            "deterministic_logits": len(logits_hashes) == 1 and len(ok_rows) == len(rows),
+            "deterministic_hidden": len(hidden_hashes) == 1 and len(ok_rows) == len(rows),
+            "deterministic_generated_ids": len(generated) == 1 and len(ok_rows) == len(rows),
+            "any_all_zero_logits": any(all_zero),
+            "logits_hashes": sorted(h for h in logits_hashes if h),
+            "hidden_hashes": sorted(h for h in hidden_hashes if h),
+            "generated_ids": [list(x) for x in sorted(generated)],
+            "wall_seconds_mean": statistics.mean(wall) if wall else None,
+            "errors": [r.get("error") for r in rows if r.get("error") or r.get("returncode") != 0],
+        }
+        summary["modes"][mode] = mode_summary
+
+    if "fp8" in by_mode and "int4" in by_mode:
+        fp8_ok = [r for r in by_mode["fp8"] if r.get("logits_path") and not r.get("error")]
+        int4_ok = [r for r in by_mode["int4"] if r.get("logits_path") and not r.get("error")]
+        if fp8_ok and int4_ok:
+            summary["fp8_vs_int4_logits"] = compare_vectors(
+                Path(fp8_ok[0]["logits_path"]),
+                Path(int4_ok[0]["logits_path"]),
+            )
+    return summary
+
+
+def evaluate_failures(payload: dict[str, Any], args: argparse.Namespace) -> list[str]:
+    failures: list[str] = []
+    for case in payload["summary"]:
+        for mode, row in case["modes"].items():
+            label = f"{case['case_id']}:{mode}"
+            if row["ok_runs"] != row["runs"]:
+                failures.append(f"{label} had {row['runs'] - row['ok_runs']} failed runs")
+            if args.fail_on_nondeterminism:
+                if not row["deterministic_logits"]:
+                    failures.append(f"{label} logits are nondeterministic")
+                if not row["deterministic_hidden"]:
+                    failures.append(f"{label} hidden state is nondeterministic")
+                if not row["deterministic_generated_ids"]:
+                    failures.append(f"{label} generated ids are nondeterministic")
+            if row["any_all_zero_logits"]:
+                failures.append(f"{label} produced all-zero logits")
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--binary", type=Path, default=Path("target/release/supersonic"))
+    parser.add_argument("--model-dir", type=Path, required=True)
+    parser.add_argument("--backend", default="hip")
+    parser.add_argument("--contexts", default="512,2K,8K")
+    parser.add_argument("--families", default="pg19,ruler", help="comma list: pg19,ruler")
+    parser.add_argument("--modes", default="fp8,int4", help="comma list: fp8,int4")
+    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument("--max-new-tokens", type=int, default=1)
+    parser.add_argument("--timeout", type=int, default=600)
+    parser.add_argument("--seed", type=int, default=20260502)
+    parser.add_argument("--out", type=Path, default=Path("qwen36_verify_results.json"))
+    parser.add_argument("--tmp-dir", type=Path)
+    parser.add_argument("--emit-stage-timings", action="store_true")
+    parser.add_argument("--fail-on-nondeterminism", action="store_true", default=True)
+    parser.add_argument("--no-fail-on-nondeterminism", dest="fail_on_nondeterminism", action="store_false")
+    parser.add_argument("--continue-on-error", action="store_true")
+
+    parser.add_argument("--pg19-source", choices=["dataset", "text", "synthetic"], default="synthetic")
+    parser.add_argument("--pg19-text", type=Path)
+    parser.add_argument("--pg19-samples", type=int, default=1)
+    parser.add_argument("--pg19-stride", type=int)
+    parser.add_argument("--ruler-samples", type=int, default=1)
+    args = parser.parse_args()
+
+    contexts = parse_contexts(args.contexts)
+    families = [x.strip() for x in args.families.split(",") if x.strip()]
+    modes = [x.strip() for x in args.modes.split(",") if x.strip()]
+    if args.repeats < 1:
+        raise ValueError("--repeats must be >= 1")
+    if not args.binary.exists():
+        raise FileNotFoundError(args.binary)
+
+    tokenizer = TokenizerAdapter(args.model_dir)
+    cases: list[Case] = []
+    if "pg19" in families:
+        cases.extend(build_pg19_cases(args, tokenizer, contexts))
+    if "ruler" in families:
+        cases.extend(build_ruler_cases(args, tokenizer, contexts))
+
+    tmp_owner: tempfile.TemporaryDirectory[str] | None = None
+    if args.tmp_dir is None:
+        tmp_owner = tempfile.TemporaryDirectory(prefix="qwen36-verify-")
+        tmp = Path(tmp_owner.name)
+    else:
+        args.tmp_dir.mkdir(parents=True, exist_ok=True)
+        tmp = args.tmp_dir
+
+    all_runs: list[dict[str, Any]] = []
+    summary: list[dict[str, Any]] = []
+    try:
+        for case in cases:
+            case_runs: list[dict[str, Any]] = []
+            print(
+                f"[case] {case.case_id} family={case.family} "
+                f"ctx={case.context} prompt_tokens={case.prompt_tokens}",
+                flush=True,
+            )
+            for mode in modes:
+                for repeat_idx in range(args.repeats):
+                    row = run_once(args, case, mode, repeat_idx, tmp)
+                    row["case_id"] = case.case_id
+                    row["family"] = case.family
+                    row["context"] = case.context
+                    row["prompt_tokens"] = case.prompt_tokens
+                    case_runs.append(row)
+                    all_runs.append(row)
+                    status = "ok" if row.get("returncode") == 0 and not row.get("error") else "FAIL"
+                    print(
+                        f"  {mode:<4} repeat={repeat_idx} {status} "
+                        f"ids={row.get('generated_ids')} "
+                        f"logits={str(row.get('logits_sha256', ''))[:12]} "
+                        f"zero={(row.get('logits_stats') or {}).get('all_zero')}"
+                        ,
+                        flush=True,
+                    )
+                    if status != "ok" and not args.continue_on_error:
+                        raise RuntimeError(str(row.get("error") or "run failed"))
+            case_summary = summarize_case(case, case_runs)
+            summary.append(case_summary)
+            for mode, row in case_summary["modes"].items():
+                print(
+                    f"  summary {mode:<4} logits_det={row['deterministic_logits']} "
+                    f"hidden_det={row['deterministic_hidden']} ids_det={row['deterministic_generated_ids']} "
+                    f"all_zero={row['any_all_zero_logits']}"
+                    ,
+                    flush=True,
+                )
+
+        payload = {
+            "schema": "qwen36-verify-suite-v1",
+            "model": "qwen3.6-35b-a3b",
+            "model_dir": str(args.model_dir),
+            "contexts": contexts,
+            "families": families,
+            "modes": modes,
+            "repeats": args.repeats,
+            "max_new_tokens": args.max_new_tokens,
+            "summary": summary,
+            "runs": all_runs,
+        }
+        failures = evaluate_failures(payload, args)
+        payload["failures"] = failures
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(json.dumps(payload, indent=2))
+        print(f"[qwen36-verify] wrote {args.out}", flush=True)
+        if failures:
+            print("[qwen36-verify] FAIL", flush=True)
+            for failure in failures:
+                print(f"  - {failure}", flush=True)
+            return 1
+        print("[qwen36-verify] PASS", flush=True)
+        return 0
+    finally:
+        if tmp_owner is not None:
+            tmp_owner.cleanup()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/gfx942/run_qwen36_verify_suite.sh
+++ b/tests/gfx942/run_qwen36_verify_suite.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODEL_DIR="${MODEL_DIR:-/models/supersonic-cdna/qwen3.6-35b-a3b-fp8}"
+BINARY="${BINARY:-target/release/supersonic}"
+CONTEXTS="${CONTEXTS:-512,2K,8K}"
+FAMILIES="${FAMILIES:-pg19,ruler}"
+MODES="${MODES:-fp8,int4}"
+REPEATS="${REPEATS:-3}"
+PG19_SOURCE="${PG19_SOURCE:-synthetic}"
+OUT="${OUT:-target/qwen36_verify_results.json}"
+if [[ -z "${PYTHON_BIN:-}" ]]; then
+  if [[ -x ".venv-verify/bin/python" ]]; then
+    PYTHON_BIN=".venv-verify/bin/python"
+  else
+    PYTHON_BIN="python3"
+  fi
+fi
+
+cargo build --release --bin supersonic
+
+"${PYTHON_BIN}" oracle/qwen36_verify_suite.py \
+  --binary "${BINARY}" \
+  --model-dir "${MODEL_DIR}" \
+  --backend hip \
+  --contexts "${CONTEXTS}" \
+  --families "${FAMILIES}" \
+  --modes "${MODES}" \
+  --repeats "${REPEATS}" \
+  --pg19-source "${PG19_SOURCE}" \
+  --emit-stage-timings \
+  --out "${OUT}"

--- a/tests/test_qwen36_verify_suite.py
+++ b/tests/test_qwen36_verify_suite.py
@@ -1,0 +1,141 @@
+import json
+import subprocess
+import tempfile
+import unittest
+from argparse import Namespace
+from pathlib import Path
+
+from oracle.qwen36_verify_suite import (
+    Case,
+    build_ruler_cases,
+    evaluate_failures,
+    parse_contexts,
+    parse_generated_ids,
+    run_once,
+    stable_seed,
+    summarize_case,
+)
+import oracle.qwen36_verify_suite as verify_suite
+
+
+class TinyTokenizer:
+    def encode(self, text, add_special_tokens=True):
+        del add_special_tokens
+        return text.split()
+
+    def encode_plain(self, text):
+        return text.split()
+
+    def decode_plain(self, token_ids):
+        return " ".join(token_ids)
+
+
+class Qwen36VerifySuiteTests(unittest.TestCase):
+    def test_parse_contexts_accepts_k_suffix(self):
+        self.assertEqual(parse_contexts("512,2K,8192"), [512, 2048, 8192])
+
+    def test_stable_seed_changes_by_case(self):
+        self.assertEqual(stable_seed(7, "ruler", 512, 0), stable_seed(7, "ruler", 512, 0))
+        self.assertNotEqual(stable_seed(7, "ruler", 512, 0), stable_seed(7, "ruler", 512, 1))
+
+    def test_ruler_cases_are_repeatable_and_contain_reference(self):
+        args = Namespace(seed=123, ruler_samples=2, max_new_tokens=1)
+        a = build_ruler_cases(args, TinyTokenizer(), [128])
+        b = build_ruler_cases(args, TinyTokenizer(), [128])
+        self.assertEqual([x.prompt for x in a], [x.prompt for x in b])
+        self.assertEqual(len(a), 2)
+        self.assertEqual(len(a[0].references), 1)
+        self.assertIn(a[0].references[0], a[0].prompt)
+
+    def test_generated_ids_parser(self):
+        self.assertEqual(parse_generated_ids("Generated ids: [12, 34]\n"), [12, 34])
+        self.assertEqual(parse_generated_ids("no ids"), [])
+
+    def test_summary_detects_nondeterministic_hashes(self):
+        case = Case("c0", "pg19", 512, "prompt", [], 511)
+        runs = [
+            {
+                "mode": "fp8",
+                "repeat_idx": 0,
+                "returncode": 0,
+                "generated_ids": [1],
+                "logits_sha256": "a",
+                "hidden_sha256": "h",
+                "logits_stats": {"all_zero": False},
+                "wall_seconds": 1.0,
+            },
+            {
+                "mode": "fp8",
+                "repeat_idx": 1,
+                "returncode": 0,
+                "generated_ids": [2],
+                "logits_sha256": "b",
+                "hidden_sha256": "h",
+                "logits_stats": {"all_zero": False},
+                "wall_seconds": 1.0,
+            },
+        ]
+        summary = summarize_case(case, runs)
+        self.assertFalse(summary["modes"]["fp8"]["deterministic_logits"])
+        self.assertTrue(summary["modes"]["fp8"]["deterministic_hidden"])
+        payload = {"summary": [summary]}
+        failures = evaluate_failures(payload, Namespace(fail_on_nondeterminism=True))
+        self.assertIn("c0:fp8 logits are nondeterministic", failures)
+
+    def test_failures_detect_all_zero_logits(self):
+        payload = {
+            "summary": [
+                {
+                    "case_id": "c1",
+                    "modes": {
+                        "int4": {
+                            "runs": 1,
+                            "ok_runs": 1,
+                            "deterministic_logits": True,
+                            "deterministic_hidden": True,
+                            "deterministic_generated_ids": True,
+                            "any_all_zero_logits": True,
+                        }
+                    },
+                }
+            ]
+        }
+        failures = evaluate_failures(payload, Namespace(fail_on_nondeterminism=True))
+        self.assertEqual(failures, ["c1:int4 produced all-zero logits"])
+
+    def test_run_once_records_timeout_as_failed_row(self):
+        def fake_run(*args, **kwargs):
+            del args, kwargs
+            raise subprocess.TimeoutExpired(
+                cmd=["supersonic"],
+                timeout=3,
+                output=b"Generated ids: [7]\n",
+                stderr=b"[qwen36-moe stage-timings] gen_steps=1 total_ms_avg=1\n",
+            )
+
+        old_run = verify_suite.subprocess.run
+        verify_suite.subprocess.run = fake_run
+        try:
+            with tempfile.TemporaryDirectory() as td:
+                args = Namespace(
+                    binary=Path("target/release/supersonic"),
+                    backend="hip",
+                    model_dir=Path("/tmp/model"),
+                    max_new_tokens=1,
+                    seed=42,
+                    timeout=3,
+                    emit_stage_timings=True,
+                )
+                case = Case("c_timeout", "pg19", 8, "hello", [], 7)
+                row = run_once(args, case, "fp8", 0, Path(td))
+        finally:
+            verify_suite.subprocess.run = old_run
+
+        self.assertTrue(row["timed_out"])
+        self.assertEqual(row["returncode"], None)
+        self.assertEqual(row["generated_ids"], [7])
+        self.assertIn("timed out", row["error"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- enable Qwen3.6 35B A3B `--fp8-runtime` loading from the native FP8 bake
- add FP8 scale-only sidecar plumbing through Rust, HIP bridge validation, and scalar E4M3 dequant in the Qwen3.6 kernels
- add a repeatability verification suite for synthetic PG-19 and RULER/NIAH-like prompts across FP8 and INT4

## Why
The Qwen3.6 checkpoint ships decoder weights in FP8, so BF16 is not the right native verification base. This makes the FP8 path runnable and adds a deterministic gate that captures whether FP8 or INT4 is stable enough to use as an oracle candidate.

## Validation
- `. .venv-verify/bin/activate && python -m py_compile oracle/qwen36_verify_suite.py oracle/bake_fp8.py`
- `. .venv-verify/bin/activate && python -m unittest tests.test_qwen36_verify_suite`
- `cargo check -p runner`
- one-run FP8 Qwen3.6 smoke passed and produced non-zero logits
- repeatability smoke intentionally fails today for both FP8 and INT4, capturing nondeterministic hidden/logit/generated-id output in `target/qwen36_verify_repeat_smoke.json`

## Notes
This PR does not fix the Qwen3.6 nondeterminism. It makes it reproducible and machine-readable so the next investigation can bisect the decode path and use FP8 as the native-weight lane once repeatability is restored.
