### PR TITLE
[codex] Fuse Gemma4 CUDA decode input staging

### DIFF
--- a/crates/kernel-ffi/src/gemma4.rs
+++ b/crates/kernel-ffi/src/gemma4.rs
@@ -500,6 +500,41 @@ unsafe extern "C" {
         barrier_flag: *mut c_uint,
     ) -> c_int;
 
+    #[cfg(supersonic_backend_cuda)]
+    #[link_name = "supersonic_gemma4_cuda_persistent_decode_fused_input"]
+    fn supersonic_gemma4_cuda_persistent_decode_fused_input(
+        dtype: c_int,
+        device_ordinal: usize,
+        num_layers: usize,
+        hidden_size: usize,
+        ple_hidden: usize,
+        vocab_size: usize,
+        token_id: c_uint,
+        position: usize,
+        eps: f32,
+        scale: f32,
+        embed_scale: f32,
+        proj_scale: f32,
+        ple_scale: f32,
+        combine_scale: f32,
+        layers: *const c_void,
+        kv_fp8_descs: *const c_void,
+        fp8_scales: *const c_void,
+        embed_tokens: *const c_void,
+        embed_tokens_per_layer: *const c_void,
+        per_layer_model_projection_w: *const c_void,
+        per_layer_projection_norm_w: *const c_void,
+        hidden_io: *mut c_void,
+        pli_proj: *mut c_void,
+        pli_normed: *mut c_void,
+        ple_raw: *mut c_void,
+        per_layer_inputs: *mut c_void,
+        workspace: *mut c_void,
+        matvec_counter: *mut c_uint,
+        barrier_counter: *mut c_uint,
+        barrier_flag: *mut c_uint,
+    ) -> c_int;
+
     #[cfg_attr(
         supersonic_backend_cuda,
         link_name = "supersonic_gemma4_cuda_persistent_decode_batch"
@@ -2044,6 +2079,135 @@ pub fn persistent_decode(
         ));
     }
     Ok(())
+}
+
+/// CUDA-only fused input-staging + persistent decode path for Gemma 4 BF16
+/// single-token decode. The caller keeps the staging buffers alive so the same
+/// memory can be reused by the fallback multi-launch path.
+#[allow(clippy::too_many_arguments)]
+pub fn persistent_decode_fused_input(
+    ordinal: usize,
+    dtype: ScalarType,
+    layers: &GpuBuffer,
+    kv_fp8_descs: Option<&GpuBuffer>,
+    fp8_scales: Option<&GpuBuffer>,
+    embed_tokens: &GpuBuffer,
+    embed_tokens_per_layer: &GpuBuffer,
+    per_layer_model_projection_w: &GpuBuffer,
+    per_layer_projection_norm_w: &GpuBuffer,
+    hidden_io: &mut GpuBuffer,
+    pli_proj: &mut GpuBuffer,
+    pli_normed: &mut GpuBuffer,
+    ple_raw: &mut GpuBuffer,
+    per_layer_inputs: &mut GpuBuffer,
+    workspace: &mut GpuBuffer,
+    matvec_counter: &mut GpuBuffer,
+    barrier_counter: &mut GpuBuffer,
+    barrier_flag: &mut GpuBuffer,
+    num_layers: usize,
+    hidden_size: usize,
+    ple_hidden: usize,
+    vocab_size: usize,
+    token_id: u32,
+    position: usize,
+    eps: f32,
+    scale: f32,
+    embed_scale: f32,
+    proj_scale: f32,
+    ple_scale: f32,
+    combine_scale: f32,
+) -> Result<(), GpuError> {
+    if hidden_io.backend() != Backend::Cuda {
+        return Err(GpuError::InvalidArg(
+            "gemma4 persistent_decode_fused_input is CUDA-only".into(),
+        ));
+    }
+
+    #[cfg(supersonic_backend_cuda)]
+    {
+        let kv_fp8_ptr = kv_fp8_descs.map(|b| b.as_ptr()).unwrap_or(std::ptr::null());
+        let fp8_scales_ptr = fp8_scales.map(|b| b.as_ptr()).unwrap_or(std::ptr::null());
+        let status = unsafe {
+            supersonic_gemma4_cuda_persistent_decode_fused_input(
+                dtype.kernel_dtype_code(),
+                ordinal,
+                num_layers,
+                hidden_size,
+                ple_hidden,
+                vocab_size,
+                token_id as c_uint,
+                position,
+                eps,
+                scale,
+                embed_scale,
+                proj_scale,
+                ple_scale,
+                combine_scale,
+                layers.as_ptr(),
+                kv_fp8_ptr,
+                fp8_scales_ptr,
+                embed_tokens.as_ptr(),
+                embed_tokens_per_layer.as_ptr(),
+                per_layer_model_projection_w.as_ptr(),
+                per_layer_projection_norm_w.as_ptr(),
+                hidden_io.as_mut_ptr(),
+                pli_proj.as_mut_ptr(),
+                pli_normed.as_mut_ptr(),
+                ple_raw.as_mut_ptr(),
+                per_layer_inputs.as_mut_ptr(),
+                workspace.as_mut_ptr(),
+                matvec_counter.as_mut_ptr() as *mut c_uint,
+                barrier_counter.as_mut_ptr() as *mut c_uint,
+                barrier_flag.as_mut_ptr() as *mut c_uint,
+            )
+        };
+        if status != 0 {
+            return Err(GpuError::backend(
+                Backend::Cuda,
+                format!("gemma4 persistent_decode_fused_input failed with status {status}"),
+            ));
+        }
+        Ok(())
+    }
+
+    #[cfg(not(supersonic_backend_cuda))]
+    {
+        let _ = (
+            ordinal,
+            dtype,
+            layers,
+            kv_fp8_descs,
+            fp8_scales,
+            embed_tokens,
+            embed_tokens_per_layer,
+            per_layer_model_projection_w,
+            per_layer_projection_norm_w,
+            hidden_io,
+            pli_proj,
+            pli_normed,
+            ple_raw,
+            per_layer_inputs,
+            workspace,
+            matvec_counter,
+            barrier_counter,
+            barrier_flag,
+            num_layers,
+            hidden_size,
+            ple_hidden,
+            vocab_size,
+            token_id,
+            position,
+            eps,
+            scale,
+            embed_scale,
+            proj_scale,
+            ple_scale,
+            combine_scale,
+        );
+        Err(GpuError::InvalidArg(
+            "gemma4 persistent_decode_fused_input requires a CUDA build".into(),
+        ))
+    }
 }
 
 /// Batched variant of [`persistent_decode`] — runs `batch_size` parallel

--- a/crates/runner/src/gemma4_engine.rs
+++ b/crates/runner/src/gemma4_engine.rs
@@ -19,7 +19,7 @@ use std::path::Path;
 use ::gemma4::config::{AttnKind, Config, TextConfig};
 use ::gemma4::weight_spec as g4_spec;
 use anyhow::{anyhow, bail, Context, Result};
-use gpu_hal::{GpuBuffer, ScalarType};
+use gpu_hal::{Backend, GpuBuffer, ScalarType};
 use half::bf16;
 use kernel_ffi::gemma4 as g4;
 use kernel_ffi::gemma4::{
@@ -538,6 +538,7 @@ pub struct Gemma4Engine {
 
     layers: Vec<LayerWeights>,
     lm_head_w: GpuBuffer, // tied to embed_tokens on E2B/E4B
+    embed_tokens_per_layer_w: Option<GpuBuffer>,
     final_norm_w: GpuBuffer,
     per_layer_model_projection_w: GpuBuffer,
     per_layer_projection_norm_w: GpuBuffer,
@@ -771,6 +772,24 @@ impl Gemma4Engine {
             device,
             &format!("{weight_prefix}.per_layer_projection_norm.weight"),
         )?;
+        let use_cuda_fused_input = gpu_hal::current_backend() == Backend::Cuda
+            && batch_size == 1
+            && !kv_fp8
+            && !fp8_runtime;
+        let embed_tokens_per_layer_w = if use_cuda_fused_input {
+            let name = format!("{weight_prefix}.embed_tokens_per_layer.weight");
+            match loader.load_bf16_to_gpu(device, &name) {
+                Ok(buf) => Some(buf),
+                Err(e) => {
+                    eprintln!(
+                        "[gemma4] CUDA fused input staging disabled: failed to load {name}: {e}"
+                    );
+                    None
+                }
+            }
+        } else {
+            None
+        };
 
         let num_kv_heads = tcfg.num_key_value_heads;
         let num_q_heads = tcfg.num_attention_heads;
@@ -1103,6 +1122,7 @@ impl Gemma4Engine {
             batch_size,
             layers,
             lm_head_w,
+            embed_tokens_per_layer_w,
             final_norm_w,
             per_layer_model_projection_w,
             per_layer_projection_norm_w,
@@ -1788,29 +1808,68 @@ impl Gemma4Engine {
         let num_layers = self.tcfg.num_hidden_layers;
         let vocab_size = self.tcfg.vocab_size;
 
-        self.prepare_single_decode_inputs(input_token_id)?;
+        if let Some(embed_tokens_per_layer_w) = self.embed_tokens_per_layer_w.as_ref() {
+            let embed_scale = bf16::from_f32((hidden_size as f32).sqrt()).to_f32();
+            let proj_scale = bf16::from_f32((hidden_size as f32).powf(-0.5)).to_f32();
+            let ple_scale = (ple_hidden as f32).sqrt();
+            let combine_scale = bf16::from_f32(2.0f32.powf(-0.5)).to_f32();
+            g4::persistent_decode_fused_input(
+                device,
+                dtype,
+                &self.layers_gpu[seq_idx],
+                None,
+                None,
+                &self.lm_head_w,
+                embed_tokens_per_layer_w,
+                &self.per_layer_model_projection_w,
+                &self.per_layer_projection_norm_w,
+                &mut self.decode_hidden_io,
+                &mut self.decode_pli_proj,
+                &mut self.decode_pli_normed,
+                &mut self.decode_ple_raw,
+                &mut self.decode_pli,
+                &mut self.mega_workspace,
+                &mut self.mega_matvec_counter,
+                &mut self.mega_barrier_counter,
+                &mut self.mega_barrier_flag,
+                num_layers,
+                hidden_size,
+                ple_hidden,
+                vocab_size,
+                input_token_id,
+                pos,
+                eps,
+                1.0f32,
+                embed_scale,
+                proj_scale,
+                ple_scale,
+                combine_scale,
+            )?;
+        } else {
+            self.prepare_single_decode_inputs(input_token_id)?;
 
-        g4::persistent_decode(
-            device,
-            dtype,
-            &self.layers_gpu[seq_idx],
-            self.kv_fp8_descs_gpu
-                .as_ref()
-                .map(|v| &v[seq_idx]),
-            self.fp8_scale_descs_gpu.as_ref(),
-            &mut self.decode_hidden_io,
-            &self.decode_pli,
-            &mut self.mega_workspace,
-            &mut self.mega_matvec_counter,
-            &mut self.mega_barrier_counter,
-            &mut self.mega_barrier_flag,
-            num_layers,
-            hidden_size,
-            ple_hidden,
-            pos,
-            eps,
-            1.0f32,
-        )?;
+            g4::persistent_decode(
+                device,
+                dtype,
+                &self.layers_gpu[seq_idx],
+                self.kv_fp8_descs_gpu
+                    .as_ref()
+                    .map(|v| &v[seq_idx]),
+                self.fp8_scale_descs_gpu.as_ref(),
+                &mut self.decode_hidden_io,
+                &self.decode_pli,
+                &mut self.mega_workspace,
+                &mut self.mega_matvec_counter,
+                &mut self.mega_barrier_counter,
+                &mut self.mega_barrier_flag,
+                num_layers,
+                hidden_size,
+                ple_hidden,
+                pos,
+                eps,
+                1.0f32,
+            )?;
+        }
 
         g4::rms_norm(
             device,

--- a/kernels/gemma4_bridge_cuda.cu
+++ b/kernels/gemma4_bridge_cuda.cu
@@ -723,6 +723,62 @@ int persistent_decode_device(int device_ordinal,
 }
 
 template <typename T>
+int persistent_decode_fused_input_device(
+    int device_ordinal,
+    int num_layers, int hidden_size, int ple_hidden, int vocab_size,
+    unsigned int token_id, int position, float eps, float scale,
+    float embed_scale, float proj_scale, float ple_scale, float combine_scale,
+    const void* layers,
+    const void* kv_fp8_descs,
+    const void* fp8_scales,
+    const void* embed_tokens,
+    const void* embed_tokens_per_layer,
+    const void* per_layer_model_projection_w,
+    const void* per_layer_projection_norm_w,
+    void* hidden_io,
+    void* pli_proj,
+    void* pli_normed,
+    void* ple_raw,
+    void* per_layer_inputs,
+    void* workspace,
+    unsigned int* matvec_counter,
+    unsigned int* barrier_counter,
+    unsigned int* barrier_flag) {
+    ScopedCudaDevice scoped(device_ordinal);
+
+    cudaDeviceProp props;
+    if (cudaGetDeviceProperties(&props, device_ordinal) != cudaSuccess) return 721;
+    const int num_blocks =
+        props.multiProcessorCount > 0 ? props.multiProcessorCount : 1;
+    constexpr int BLOCK = 256;
+    const size_t lds_bytes = (BLOCK + 256) * sizeof(float);
+
+    if (cudaMemset(barrier_counter, 0, sizeof(unsigned int)) != cudaSuccess) return 722;
+    if (cudaMemset(barrier_flag, 0, sizeof(unsigned int)) != cudaSuccess) return 723;
+
+    g4_persistent_decode_fused_input_kernel<T><<<dim3(num_blocks), dim3(BLOCK), lds_bytes, 0>>>(
+        num_layers, hidden_size, ple_hidden, vocab_size, token_id, position,
+        eps, scale, embed_scale, proj_scale, ple_scale, combine_scale,
+        static_cast<const Gemma4DecodeLayerDesc*>(layers),
+        static_cast<const Gemma4KVCacheFp8Desc*>(kv_fp8_descs),
+        static_cast<const Gemma4FP8ScaleDesc*>(fp8_scales),
+        static_cast<const T*>(embed_tokens),
+        static_cast<const T*>(embed_tokens_per_layer),
+        static_cast<const T*>(per_layer_model_projection_w),
+        static_cast<const T*>(per_layer_projection_norm_w),
+        static_cast<T*>(hidden_io),
+        static_cast<T*>(pli_proj),
+        static_cast<T*>(pli_normed),
+        static_cast<T*>(ple_raw),
+        static_cast<T*>(per_layer_inputs),
+        static_cast<float*>(workspace),
+        matvec_counter, barrier_counter, barrier_flag);
+    if (cudaGetLastError() != cudaSuccess) return 724;
+    if (cudaDeviceSynchronize() != cudaSuccess) return 725;
+    return 0;
+}
+
+template <typename T>
 int persistent_decode_batch_device(int device_ordinal,
                                    int num_layers, int hidden_size, int ple_hidden,
                                    float eps, float scale,
@@ -1402,6 +1458,48 @@ extern "C" int supersonic_gemma4_cuda_persistent_decode(
     default: return 700;
     }
     #undef G4_PERSIST_ARGS
+}
+
+extern "C" int supersonic_gemma4_cuda_persistent_decode_fused_input(
+    int dtype, size_t device_ordinal,
+    size_t num_layers, size_t hidden_size, size_t ple_hidden, size_t vocab_size,
+    unsigned int token_id, size_t position, float eps, float scale,
+    float embed_scale, float proj_scale, float ple_scale, float combine_scale,
+    const void* layers,
+    const void* kv_fp8_descs,
+    const void* fp8_scales,
+    const void* embed_tokens,
+    const void* embed_tokens_per_layer,
+    const void* per_layer_model_projection_w,
+    const void* per_layer_projection_norm_w,
+    void* hidden_io,
+    void* pli_proj,
+    void* pli_normed,
+    void* ple_raw,
+    void* per_layer_inputs,
+    void* workspace,
+    unsigned int* matvec_counter,
+    unsigned int* barrier_counter,
+    unsigned int* barrier_flag
+) {
+    #define G4_PERSIST_FUSED_INPUT_ARGS                                      \
+        static_cast<int>(device_ordinal),                                    \
+        static_cast<int>(num_layers), static_cast<int>(hidden_size),         \
+        static_cast<int>(ple_hidden), static_cast<int>(vocab_size),          \
+        token_id, static_cast<int>(position), eps, scale,                    \
+        embed_scale, proj_scale, ple_scale, combine_scale,                   \
+        layers, kv_fp8_descs, fp8_scales, embed_tokens,                      \
+        embed_tokens_per_layer, per_layer_model_projection_w,                \
+        per_layer_projection_norm_w, hidden_io, pli_proj, pli_normed,        \
+        ple_raw, per_layer_inputs, workspace,                                \
+        matvec_counter, barrier_counter, barrier_flag
+    switch (dtype) {
+    case 0: return persistent_decode_fused_input_device<__half>(G4_PERSIST_FUSED_INPUT_ARGS);
+    case 1: return persistent_decode_fused_input_device<float>(G4_PERSIST_FUSED_INPUT_ARGS);
+    case 2: return persistent_decode_fused_input_device<__nv_bfloat16>(G4_PERSIST_FUSED_INPUT_ARGS);
+    default: return 720;
+    }
+    #undef G4_PERSIST_FUSED_INPUT_ARGS
 }
 
 extern "C" int supersonic_gemma4_cuda_persistent_decode_batch(

--- a/kernels/gemma4_cuda.cuh
+++ b/kernels/gemma4_cuda.cuh
@@ -2649,7 +2649,7 @@ struct Gemma4FP8ScaleDesc {
 };
 
 template <typename T>
-__global__ void g4_persistent_decode_kernel(
+__device__ void g4_persistent_decode_body(
     int num_layers,
     int hidden_size,
     int ple_hidden,
@@ -2664,8 +2664,9 @@ __global__ void g4_persistent_decode_kernel(
     float* __restrict__ workspace,
     unsigned int* __restrict__ matvec_counter,
     unsigned int* __restrict__ barrier_counter,
-    unsigned int* __restrict__ barrier_flag
-) __launch_bounds__(256, 1) {
+    unsigned int* __restrict__ barrier_flag,
+    float* __restrict__ lds
+) {
     const int tid = threadIdx.x;
     const int bs = blockDim.x;
     const int nb = gridDim.x;
@@ -2674,7 +2675,6 @@ __global__ void g4_persistent_decode_kernel(
     // the FP8-runtime weight-dequant LUT. Bridge always allocates the full
     // `(bs + 256) * 4 B` so the layout is constant whether `fp8_scales` is
     // null or not.
-    extern __shared__ float lds[];
     float* fp8_lut = lds + bs;
     if (fp8_scales != nullptr) {
         if (tid < 256) {
@@ -3377,6 +3377,168 @@ __global__ void g4_persistent_decode_kernel(
         }
         g4_grid_barrier(barrier_counter, barrier_flag, nb);
     }
+}
+
+template <typename T>
+__global__ void g4_persistent_decode_kernel(
+    int num_layers,
+    int hidden_size,
+    int ple_hidden,
+    int position,
+    float eps,
+    float scale,
+    const Gemma4DecodeLayerDesc* __restrict__ layers,
+    const Gemma4KVCacheFp8Desc* __restrict__ kv_fp8_descs,
+    const Gemma4FP8ScaleDesc* __restrict__ fp8_scales,
+    T* __restrict__ hidden_io,
+    const T* __restrict__ per_layer_inputs,
+    float* __restrict__ workspace,
+    unsigned int* __restrict__ matvec_counter,
+    unsigned int* __restrict__ barrier_counter,
+    unsigned int* __restrict__ barrier_flag
+) __launch_bounds__(256, 1) {
+    extern __shared__ float lds[];
+    g4_persistent_decode_body<T>(
+        num_layers, hidden_size, ple_hidden, position, eps, scale,
+        layers, kv_fp8_descs, fp8_scales, hidden_io, per_layer_inputs,
+        workspace, matvec_counter, barrier_counter, barrier_flag, lds);
+}
+
+template <typename T>
+__global__ void g4_persistent_decode_fused_input_kernel(
+    int num_layers,
+    int hidden_size,
+    int ple_hidden,
+    int vocab_size,
+    unsigned int token_id,
+    int position,
+    float eps,
+    float scale,
+    float embed_scale,
+    float proj_scale,
+    float ple_scale,
+    float combine_scale,
+    const Gemma4DecodeLayerDesc* __restrict__ layers,
+    const Gemma4KVCacheFp8Desc* __restrict__ kv_fp8_descs,
+    const Gemma4FP8ScaleDesc* __restrict__ fp8_scales,
+    const T* __restrict__ embed_tokens,
+    const T* __restrict__ embed_tokens_per_layer,
+    const T* __restrict__ per_layer_model_projection_w,
+    const T* __restrict__ per_layer_projection_norm_w,
+    T* __restrict__ hidden_io,
+    T* __restrict__ pli_proj,
+    T* __restrict__ pli_normed,
+    T* __restrict__ ple_raw,
+    T* __restrict__ per_layer_inputs,
+    float* __restrict__ workspace,
+    unsigned int* __restrict__ matvec_counter,
+    unsigned int* __restrict__ barrier_counter,
+    unsigned int* __restrict__ barrier_flag
+) __launch_bounds__(256, 1) {
+    const int tid = threadIdx.x;
+    const int bs = blockDim.x;
+    const int nb = gridDim.x;
+    const int total = num_layers * ple_hidden;
+    extern __shared__ float lds[];
+
+    if (token_id >= static_cast<unsigned int>(vocab_size)) {
+        for (int i = tid + blockIdx.x * bs; i < hidden_size; i += bs * nb) {
+            hidden_io[i] = g4_from_float<T>(0.0f);
+        }
+        for (int i = tid + blockIdx.x * bs; i < total; i += bs * nb) {
+            per_layer_inputs[i] = g4_from_float<T>(0.0f);
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+    } else {
+        const T* embed_row =
+            embed_tokens + static_cast<size_t>(token_id) * hidden_size;
+        for (int i = tid + blockIdx.x * bs; i < hidden_size; i += bs * nb) {
+            hidden_io[i] = g4_from_float<T>(g4_to_float(embed_row[i]) * embed_scale);
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        if (blockIdx.x == 0 && tid == 0) {
+            __atomic_store_n(matvec_counter, 0u, __ATOMIC_RELAXED);
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        {
+            const int lane = tid % warpSize;
+            const int vd4 = hidden_size & ~3;
+            while (true) {
+                unsigned int row;
+                if (lane == 0) row = atomicAdd(matvec_counter, 1u);
+                row = __shfl_sync(0xffffffff, row, 0);
+                if (row >= static_cast<unsigned int>(total)) break;
+                const T* wr = per_layer_model_projection_w +
+                    static_cast<size_t>(row) * hidden_size;
+                float p = 0.0f;
+                for (int c = lane * 4; c < vd4; c += warpSize * 4) {
+                    float w0 = g4_to_float(wr[c]);
+                    float w1 = g4_to_float(wr[c + 1]);
+                    float w2 = g4_to_float(wr[c + 2]);
+                    float w3 = g4_to_float(wr[c + 3]);
+                    p += w0 * g4_to_float(hidden_io[c])
+                       + w1 * g4_to_float(hidden_io[c + 1])
+                       + w2 * g4_to_float(hidden_io[c + 2])
+                       + w3 * g4_to_float(hidden_io[c + 3]);
+                }
+                for (int c = vd4 + lane; c < hidden_size; c += warpSize) {
+                    p += g4_to_float(wr[c]) * g4_to_float(hidden_io[c]);
+                }
+                float result = g4_wave_reduce_sum_f32(p);
+                if (lane == 0) {
+                    pli_proj[row] = g4_from_float<T>(result * proj_scale);
+                }
+            }
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        for (int row = blockIdx.x; row < num_layers; row += nb) {
+            const T* in = pli_proj + static_cast<size_t>(row) * ple_hidden;
+            T* out = pli_normed + static_cast<size_t>(row) * ple_hidden;
+            float ss = 0.0f;
+            for (int c = tid; c < ple_hidden; c += bs) {
+                const float v = g4_to_float(in[c]);
+                ss += v * v;
+            }
+            lds[tid] = ss;
+            __syncthreads();
+            for (int s = bs / 2; s > 0; s >>= 1) {
+                if (tid < s) lds[tid] += lds[tid + s];
+                __syncthreads();
+            }
+            const float inv = rsqrtf(lds[0] / static_cast<float>(ple_hidden) + eps);
+            __syncthreads();
+            for (int c = tid; c < ple_hidden; c += bs) {
+                const float w = per_layer_projection_norm_w
+                    ? g4_to_float(per_layer_projection_norm_w[c])
+                    : 1.0f;
+                out[c] = g4_from_float<T>(g4_to_float(in[c]) * inv * w);
+            }
+            __syncthreads();
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        const T* ple_row =
+            embed_tokens_per_layer + static_cast<size_t>(token_id) * total;
+        for (int i = tid + blockIdx.x * bs; i < total; i += bs * nb) {
+            ple_raw[i] = g4_from_float<T>(g4_to_float(ple_row[i]) * ple_scale);
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+        for (int i = tid + blockIdx.x * bs; i < total; i += bs * nb) {
+            const float v =
+                (g4_to_float(pli_normed[i]) + g4_to_float(ple_raw[i])) * combine_scale;
+            per_layer_inputs[i] = g4_from_float<T>(v);
+        }
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+    }
+
+    g4_persistent_decode_body<T>(
+        num_layers, hidden_size, ple_hidden, position, eps, scale,
+        layers, kv_fp8_descs, fp8_scales, hidden_io, per_layer_inputs,
+        workspace, matvec_counter, barrier_counter, barrier_flag, lds);
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- Adds a CUDA-only Gemma 4 E2B BF16 fused input-staging + persistent decode launch.
- Keeps the existing multi-launch staging path as a fallback if the full per-layer embedding table cannot be loaded on GPU.
- Raises the CUDA E2B VRAM admission estimate to account for the extra per-layer embedding table.

## Details
- Refactors the CUDA persistent decode kernel into a reusable device body.
- Adds `g4_persistent_decode_fused_input_kernel` to gather the token embedding, compute per-layer input projection/RMSNorm/PLE combine, then run the persistent decode body in one launch.
- Wires a CUDA-only FFI entry point and runner dispatch for batch-1 BF16 CUDA.

## Validation
- `SUPERSONIC_BACKENDS=cuda cargo build --release --bin supersonic`
- `HF_HOME=/dev/shm/hf_home_gemma4 SUPERSONIC_BACKENDS=cuda TIMEOUT=900 ./tests/sm86/run_gemma4.sh /dev/shm/gemma-4-E2B`
  - `token_mismatches=0`
  - `decode_max_delta=0.3542`
  - `decode_ms=147`, `ms_per_step=18`
- 64-token no-oracle timing:
  - `decode_ms=1241`, `ms_per_step=19`

## Notes
- HIP build check was attempted but this environment does not have `hipcc`, so it fails at toolchain detection before compiling project code.
