### PR TITLE
[codex] Fuse Gemma4 CUDA decode tail argmax

### DIFF
--- a/crates/kernel-ffi/src/gemma4.rs
+++ b/crates/kernel-ffi/src/gemma4.rs
@@ -535,6 +535,23 @@ unsafe extern "C" {
         barrier_flag: *mut c_uint,
     ) -> c_int;
 
+    #[cfg(supersonic_backend_cuda)]
+    #[link_name = "supersonic_gemma4_cuda_final_norm_lm_head_argmax"]
+    fn supersonic_gemma4_cuda_final_norm_lm_head_argmax(
+        dtype: c_int,
+        device_ordinal: usize,
+        hidden_size: usize,
+        vocab_size: usize,
+        eps: f32,
+        hidden_io: *const c_void,
+        final_norm_w: *const c_void,
+        lm_head_w: *const c_void,
+        workspace: *mut c_void,
+        out_token: *mut c_uint,
+        barrier_counter: *mut c_uint,
+        barrier_flag: *mut c_uint,
+    ) -> c_int;
+
     #[cfg_attr(
         supersonic_backend_cuda,
         link_name = "supersonic_gemma4_cuda_persistent_decode_batch"
@@ -2206,6 +2223,79 @@ pub fn persistent_decode_fused_input(
         );
         Err(GpuError::InvalidArg(
             "gemma4 persistent_decode_fused_input requires a CUDA build".into(),
+        ))
+    }
+}
+
+/// CUDA-only final RMSNorm + LM-head greedy argmax. This deliberately returns
+/// only the selected token, so validation paths that need full logits should
+/// keep using `rms_norm` + `matvec`.
+#[allow(clippy::too_many_arguments)]
+pub fn final_norm_lm_head_argmax(
+    ordinal: usize,
+    dtype: ScalarType,
+    hidden_io: &GpuBuffer,
+    final_norm_w: &GpuBuffer,
+    lm_head_w: &GpuBuffer,
+    workspace: &mut GpuBuffer,
+    out_token: &mut GpuBuffer,
+    barrier_counter: &mut GpuBuffer,
+    barrier_flag: &mut GpuBuffer,
+    hidden_size: usize,
+    vocab_size: usize,
+    eps: f32,
+) -> Result<(), GpuError> {
+    if hidden_io.backend() != Backend::Cuda {
+        return Err(GpuError::InvalidArg(
+            "gemma4 final_norm_lm_head_argmax is CUDA-only".into(),
+        ));
+    }
+
+    #[cfg(supersonic_backend_cuda)]
+    {
+        let status = unsafe {
+            supersonic_gemma4_cuda_final_norm_lm_head_argmax(
+                dtype.kernel_dtype_code(),
+                ordinal,
+                hidden_size,
+                vocab_size,
+                eps,
+                hidden_io.as_ptr(),
+                final_norm_w.as_ptr(),
+                lm_head_w.as_ptr(),
+                workspace.as_mut_ptr(),
+                out_token.as_mut_ptr() as *mut c_uint,
+                barrier_counter.as_mut_ptr() as *mut c_uint,
+                barrier_flag.as_mut_ptr() as *mut c_uint,
+            )
+        };
+        if status != 0 {
+            return Err(GpuError::backend(
+                Backend::Cuda,
+                format!("gemma4 final_norm_lm_head_argmax failed with status {status}"),
+            ));
+        }
+        Ok(())
+    }
+
+    #[cfg(not(supersonic_backend_cuda))]
+    {
+        let _ = (
+            ordinal,
+            dtype,
+            hidden_io,
+            final_norm_w,
+            lm_head_w,
+            workspace,
+            out_token,
+            barrier_counter,
+            barrier_flag,
+            hidden_size,
+            vocab_size,
+            eps,
+        );
+        Err(GpuError::InvalidArg(
+            "gemma4 final_norm_lm_head_argmax requires a CUDA build".into(),
         ))
     }
 }

--- a/crates/runner/src/gemma4_engine.rs
+++ b/crates/runner/src/gemma4_engine.rs
@@ -591,6 +591,7 @@ pub struct Gemma4Engine {
     decode_pli: GpuBuffer,
     decode_post_norm: GpuBuffer,
     decode_logits: GpuBuffer,
+    decode_next_token: GpuBuffer,
 
     /// Per-(seq, layer) F32 absmax scale buffers for FP8 KV cache. Populated
     /// only when `--kv-fp8` is active (alloc path lands in the engine-wiring
@@ -1112,6 +1113,7 @@ impl Gemma4Engine {
         )?;
         let decode_post_norm = GpuBuffer::zeros(device, dtype, &[tcfg.hidden_size])?;
         let decode_logits = GpuBuffer::zeros(device, dtype, &[tcfg.vocab_size])?;
+        let decode_next_token = GpuBuffer::zeros(device, ScalarType::U32, &[1])?;
 
         Ok(Self {
             tcfg,
@@ -1150,6 +1152,7 @@ impl Gemma4Engine {
             decode_pli,
             decode_post_norm,
             decode_logits,
+            decode_next_token,
             kv_scale_k: if kv_fp8 { Some(kv_scale_k_buf) } else { None },
             kv_scale_v: if kv_fp8 { Some(kv_scale_v_buf) } else { None },
             kv_fp8_descs_gpu,
@@ -1781,16 +1784,12 @@ impl Gemma4Engine {
         self.decode_step_seq(0, input_token_id, pos)
     }
 
-    /// Run one decode step on sequence `seq_idx` via the persistent
-    /// megakernel. Writes a new K/V slot at `pos` in every non-shared layer
-    /// of that sequence's caches; shared layers read the source's cache via
-    /// descriptor aliasing. Returns softcapped logits.
-    pub fn decode_step_seq(
+    fn run_decode_body_seq(
         &mut self,
         seq_idx: usize,
         input_token_id: u32,
         pos: usize,
-    ) -> Result<Vec<f32>> {
+    ) -> Result<()> {
         if seq_idx >= self.batch_size {
             bail!(
                 "decode_step_seq: seq_idx {seq_idx} >= batch_size {}",
@@ -1870,6 +1869,26 @@ impl Gemma4Engine {
                 1.0f32,
             )?;
         }
+        Ok(())
+    }
+
+    /// Run one decode step on sequence `seq_idx` via the persistent
+    /// megakernel. Writes a new K/V slot at `pos` in every non-shared layer
+    /// of that sequence's caches; shared layers read the source's cache via
+    /// descriptor aliasing. Returns softcapped logits.
+    pub fn decode_step_seq(
+        &mut self,
+        seq_idx: usize,
+        input_token_id: u32,
+        pos: usize,
+    ) -> Result<Vec<f32>> {
+        let device = self.device;
+        let dtype = ScalarType::BF16;
+        let hidden_size = self.tcfg.hidden_size;
+        let eps = self.tcfg.rms_norm_eps as f32;
+        let vocab_size = self.tcfg.vocab_size;
+
+        self.run_decode_body_seq(seq_idx, input_token_id, pos)?;
 
         g4::rms_norm(
             device,
@@ -1896,6 +1915,51 @@ impl Gemma4Engine {
             *v = cap * (*v / cap).tanh();
         }
         Ok(logits_host)
+    }
+
+    /// CUDA fast path for greedy generation. Runs the normal single-sequence
+    /// decode body, then computes final RMSNorm + LM-head argmax on GPU and
+    /// downloads only the selected token. Returns `None` when the current
+    /// engine/backend should use the full-logits path instead.
+    pub fn decode_step_seq_greedy_cuda(
+        &mut self,
+        seq_idx: usize,
+        input_token_id: u32,
+        pos: usize,
+    ) -> Result<Option<u32>> {
+        if gpu_hal::current_backend() != Backend::Cuda || self.batch_size != 1 || seq_idx != 0 {
+            return Ok(None);
+        }
+        let device = self.device;
+        let dtype = ScalarType::BF16;
+        let hidden_size = self.tcfg.hidden_size;
+        let vocab_size = self.tcfg.vocab_size;
+        let eps = self.tcfg.rms_norm_eps as f32;
+
+        self.run_decode_body_seq(seq_idx, input_token_id, pos)?;
+        g4::final_norm_lm_head_argmax(
+            device,
+            dtype,
+            &self.decode_hidden_io,
+            &self.final_norm_w,
+            &self.lm_head_w,
+            &mut self.mega_workspace,
+            &mut self.decode_next_token,
+            &mut self.mega_barrier_counter,
+            &mut self.mega_barrier_flag,
+            hidden_size,
+            vocab_size,
+            eps,
+        )?;
+        let mut token_bytes = [0u8; 4];
+        gpu_hal::copy_d2h(
+            device,
+            token_bytes.as_mut_ptr() as *mut c_void,
+            self.decode_next_token.as_ptr(),
+            token_bytes.len(),
+        )
+        .map_err(|e| anyhow!("download decode next token: {e}"))?;
+        Ok(Some(u32::from_le_bytes(token_bytes)))
     }
 
     /// Run one decode step on every sequence in the batch and return one set

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -69,6 +69,24 @@ impl Gemma4Runtime {
         }
     }
 
+    fn decode_step_batch_greedy_cuda(
+        &mut self,
+        input_tokens: &[u32],
+        positions: &[usize],
+    ) -> anyhow::Result<Option<Vec<u32>>> {
+        match self {
+            Self::Bf16(e) => {
+                if input_tokens.len() == 1 && positions.len() == 1 {
+                    Ok(e.decode_step_seq_greedy_cuda(0, input_tokens[0], positions[0])?
+                        .map(|tok| vec![tok]))
+                } else {
+                    Ok(None)
+                }
+            }
+            Self::Int4(_) => Ok(None),
+        }
+    }
+
     /// Replicate seq 0's K/V cache contents into every other sequence's
     /// caches. Applies to both BF16 and INT4 engines.
     fn replicate_seq0_kv(&mut self) -> anyhow::Result<()> {
@@ -3226,9 +3244,18 @@ fn run_gemma4(
         }
         let pos = seqlen_start + step;
         let positions: Vec<usize> = vec![pos; batch_size];
-        let logits_per_seq = engine.decode_step_batch(&next_tokens, &positions)?;
+        let fast_sampled = if oracle_output.is_none() {
+            engine.decode_step_batch_greedy_cuda(&next_tokens, &positions)?
+        } else {
+            None
+        };
+        let logits_per_seq = if fast_sampled.is_none() {
+            Some(engine.decode_step_batch(&next_tokens, &positions)?)
+        } else {
+            None
+        };
 
-        if let Some(ref oracle) = oracle_output {
+        if let (Some(ref oracle), Some(ref logits_per_seq)) = (&oracle_output, &logits_per_seq) {
             if step < oracle.decode_logits.len() {
                 let oracle_logits = &oracle.decode_logits[step];
                 // Always compare against sequence 0 (canonical run).
@@ -3262,7 +3289,14 @@ fn run_gemma4(
             if seq_done[b] {
                 continue;
             }
-            let sampled = Gemma4Runtime::greedy_sample(&logits_per_seq[b]);
+            let sampled = if let Some(ref sampled_tokens) = fast_sampled {
+                sampled_tokens[b]
+            } else {
+                let logits_per_seq = logits_per_seq
+                    .as_ref()
+                    .expect("full logits populated when fast sampling is unavailable");
+                Gemma4Runtime::greedy_sample(&logits_per_seq[b])
+            };
             generated_per_seq[b].push(next_tokens[b]);
             next_tokens[b] = sampled;
         }

--- a/kernels/gemma4_bridge_cuda.cu
+++ b/kernels/gemma4_bridge_cuda.cu
@@ -779,6 +779,42 @@ int persistent_decode_fused_input_device(
 }
 
 template <typename T>
+int final_norm_lm_head_argmax_device(int device_ordinal,
+                                     int hidden_size,
+                                     int vocab_size,
+                                     float eps,
+                                     const void* hidden_io,
+                                     const void* final_norm_w,
+                                     const void* lm_head_w,
+                                     void* workspace,
+                                     unsigned int* out_token,
+                                     unsigned int* barrier_counter,
+                                     unsigned int* barrier_flag) {
+    ScopedCudaDevice scoped(device_ordinal);
+
+    cudaDeviceProp props;
+    if (cudaGetDeviceProperties(&props, device_ordinal) != cudaSuccess) return 731;
+    const int num_blocks =
+        props.multiProcessorCount > 0 ? props.multiProcessorCount : 1;
+    constexpr int BLOCK = 256;
+    const size_t lds_bytes = BLOCK * sizeof(float);
+
+    if (cudaMemset(barrier_counter, 0, sizeof(unsigned int)) != cudaSuccess) return 732;
+    if (cudaMemset(barrier_flag, 0, sizeof(unsigned int)) != cudaSuccess) return 733;
+
+    g4_final_norm_lm_head_argmax_kernel<T><<<dim3(num_blocks), dim3(BLOCK), lds_bytes, 0>>>(
+        hidden_size, vocab_size, eps,
+        static_cast<const T*>(hidden_io),
+        static_cast<const T*>(final_norm_w),
+        static_cast<const T*>(lm_head_w),
+        static_cast<float*>(workspace),
+        out_token, barrier_counter, barrier_flag);
+    if (cudaGetLastError() != cudaSuccess) return 734;
+    if (cudaDeviceSynchronize() != cudaSuccess) return 735;
+    return 0;
+}
+
+template <typename T>
 int persistent_decode_batch_device(int device_ordinal,
                                    int num_layers, int hidden_size, int ple_hidden,
                                    float eps, float scale,
@@ -1500,6 +1536,31 @@ extern "C" int supersonic_gemma4_cuda_persistent_decode_fused_input(
     default: return 720;
     }
     #undef G4_PERSIST_FUSED_INPUT_ARGS
+}
+
+extern "C" int supersonic_gemma4_cuda_final_norm_lm_head_argmax(
+    int dtype, size_t device_ordinal,
+    size_t hidden_size, size_t vocab_size, float eps,
+    const void* hidden_io,
+    const void* final_norm_w,
+    const void* lm_head_w,
+    void* workspace,
+    unsigned int* out_token,
+    unsigned int* barrier_counter,
+    unsigned int* barrier_flag
+) {
+    #define G4_FINAL_ARGMAX_ARGS                                             \
+        static_cast<int>(device_ordinal),                                    \
+        static_cast<int>(hidden_size), static_cast<int>(vocab_size), eps,    \
+        hidden_io, final_norm_w, lm_head_w, workspace, out_token,            \
+        barrier_counter, barrier_flag
+    switch (dtype) {
+    case 0: return final_norm_lm_head_argmax_device<__half>(G4_FINAL_ARGMAX_ARGS);
+    case 1: return final_norm_lm_head_argmax_device<float>(G4_FINAL_ARGMAX_ARGS);
+    case 2: return final_norm_lm_head_argmax_device<__nv_bfloat16>(G4_FINAL_ARGMAX_ARGS);
+    default: return 730;
+    }
+    #undef G4_FINAL_ARGMAX_ARGS
 }
 
 extern "C" int supersonic_gemma4_cuda_persistent_decode_batch(

--- a/kernels/gemma4_cuda.cuh
+++ b/kernels/gemma4_cuda.cuh
@@ -3541,6 +3541,114 @@ __global__ void g4_persistent_decode_fused_input_kernel(
         workspace, matvec_counter, barrier_counter, barrier_flag, lds);
 }
 
+template <typename T>
+__global__ void g4_final_norm_lm_head_argmax_kernel(
+    int hidden_size,
+    int vocab_size,
+    float eps,
+    const T* __restrict__ hidden_io,
+    const T* __restrict__ final_norm_w,
+    const T* __restrict__ lm_head_w,
+    float* __restrict__ workspace,
+    unsigned int* __restrict__ out_token,
+    unsigned int* __restrict__ barrier_counter,
+    unsigned int* __restrict__ barrier_flag
+) __launch_bounds__(256, 1) {
+    const int tid = threadIdx.x;
+    const int bs = blockDim.x;
+    const int nb = gridDim.x;
+    extern __shared__ float lds[];
+
+    float* hidden_f32 = workspace;
+    float* normed_f32 = hidden_f32 + hidden_size;
+    float* partial_vals = normed_f32 + hidden_size;
+    float* partial_idx_bits = partial_vals + nb;
+    float* reduce_idx_bits = partial_idx_bits + nb;
+
+    if (blockIdx.x == 0) {
+        for (int c = tid; c < hidden_size; c += bs) {
+            hidden_f32[c] = g4_to_float(hidden_io[c]);
+        }
+        __syncthreads();
+        g4_block_rms_norm_f32<T>(
+            normed_f32, hidden_f32, final_norm_w, hidden_size, eps, lds);
+    }
+    g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+    float best = -INFINITY;
+    unsigned int best_idx = 0u;
+    const int lane = tid % warpSize;
+    const int vd4 = hidden_size & ~3;
+    for (int row = blockIdx.x; row < vocab_size; row += nb) {
+        const T* wr = lm_head_w + static_cast<size_t>(row) * hidden_size;
+        float p = 0.0f;
+        for (int c = lane * 4; c < vd4; c += warpSize * 4) {
+            const float w0 = g4_to_float(wr[c]);
+            const float w1 = g4_to_float(wr[c + 1]);
+            const float w2 = g4_to_float(wr[c + 2]);
+            const float w3 = g4_to_float(wr[c + 3]);
+            p += w0 * normed_f32[c]
+               + w1 * normed_f32[c + 1]
+               + w2 * normed_f32[c + 2]
+               + w3 * normed_f32[c + 3];
+        }
+        for (int c = vd4 + lane; c < hidden_size; c += warpSize) {
+            p += g4_to_float(wr[c]) * normed_f32[c];
+        }
+        const float result = g4_wave_reduce_sum_f32(p);
+        if (lane == 0) {
+            // Match the validated logits path: the standalone matvec rounds
+            // each logit to BF16 before host argmax/softcap.
+            const float rounded = g4_to_float(g4_from_float<T>(result));
+            const unsigned int urow = static_cast<unsigned int>(row);
+            if (rounded > best || (rounded == best && urow < best_idx)) {
+                best = rounded;
+                best_idx = urow;
+            }
+        }
+    }
+
+    if (tid == 0) {
+        partial_vals[blockIdx.x] = best;
+        partial_idx_bits[blockIdx.x] = __uint_as_float(best_idx);
+    }
+    g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+    if (blockIdx.x == 0) {
+        float block_best = -INFINITY;
+        unsigned int block_best_idx = 0u;
+        for (int i = tid; i < nb; i += bs) {
+            const float v = partial_vals[i];
+            const unsigned int idx = __float_as_uint(partial_idx_bits[i]);
+            if (v > block_best || (v == block_best && idx < block_best_idx)) {
+                block_best = v;
+                block_best_idx = idx;
+            }
+        }
+        lds[tid] = block_best;
+        reduce_idx_bits[tid] = __uint_as_float(block_best_idx);
+        __syncthreads();
+        for (int s = bs / 2; s > 0; s >>= 1) {
+            if (tid < s) {
+                const float other_v = lds[tid + s];
+                const unsigned int other_idx =
+                    __float_as_uint(reduce_idx_bits[tid + s]);
+                const unsigned int cur_idx =
+                    __float_as_uint(reduce_idx_bits[tid]);
+                if (other_v > lds[tid] ||
+                    (other_v == lds[tid] && other_idx < cur_idx)) {
+                    lds[tid] = other_v;
+                    reduce_idx_bits[tid] = __uint_as_float(other_idx);
+                }
+            }
+            __syncthreads();
+        }
+        if (tid == 0) {
+            out_token[0] = __float_as_uint(reduce_idx_bits[0]);
+        }
+    }
+}
+
 // =============================================================================
 // Persistent decode megakernel — batched variant (Phase 2).
 //


### PR DESCRIPTION
## Summary
- Adds a CUDA-only Gemma 4 BF16 final RMSNorm + LM-head greedy argmax kernel.
- Routes non-validation Gemma CUDA batch-1 generation through the token-only fast path.
- Keeps full logits for `--validate` and all fallback paths.

## Details
- The fast tail rounds each LM-head logit to BF16 before argmax to match the existing `matvec -> download -> softcap -> greedy` behavior.
- The runner calls the fast path only when oracle validation is inactive; validation still compares full logits against the Python oracle.
- The existing decode-body/input-staging fallback behavior remains unchanged.

## Validation
- `SUPERSONIC_BACKENDS=cuda cargo build --release --bin supersonic`
- `HF_HOME=/dev/shm/hf_home_gemma4 SUPERSONIC_BACKENDS=cuda TIMEOUT=900 ./tests/sm86/run_gemma4.sh /dev/shm/gemma-4-E2B`
  - `token_mismatches=0`
  - `decode_max_delta=0.3542`
  - validation full-logits path: `decode_ms=152`, `ms_per_step=19`
- 64-token non-validation greedy timing:
  - same token sequence as the prior full-logits baseline
  - `decode_ms=831`, `ms_per_step=13`

## Notes
- The validation timing intentionally does not show the fast-tail win because it keeps full logits for oracle comparison.
