### PR TITLE
[codex] Fuse Gemma CUDA greedy decode tail

### DIFF
--- a/crates/kernel-ffi/src/gemma4.rs
+++ b/crates/kernel-ffi/src/gemma4.rs
@@ -536,6 +536,42 @@ unsafe extern "C" {
     ) -> c_int;
 
     #[cfg(supersonic_backend_cuda)]
+    #[link_name = "supersonic_gemma4_cuda_persistent_decode_fused_input_argmax"]
+    fn supersonic_gemma4_cuda_persistent_decode_fused_input_argmax(
+        dtype: c_int,
+        device_ordinal: usize,
+        num_layers: usize,
+        hidden_size: usize,
+        ple_hidden: usize,
+        vocab_size: usize,
+        token_id: c_uint,
+        position: usize,
+        eps: f32,
+        scale: f32,
+        embed_scale: f32,
+        proj_scale: f32,
+        ple_scale: f32,
+        combine_scale: f32,
+        layers: *const c_void,
+        embed_tokens: *const c_void,
+        embed_tokens_per_layer: *const c_void,
+        per_layer_model_projection_w: *const c_void,
+        per_layer_projection_norm_w: *const c_void,
+        final_norm_w: *const c_void,
+        lm_head_w: *const c_void,
+        hidden_io: *mut c_void,
+        pli_proj: *mut c_void,
+        pli_normed: *mut c_void,
+        ple_raw: *mut c_void,
+        per_layer_inputs: *mut c_void,
+        workspace: *mut c_void,
+        out_token: *mut c_uint,
+        matvec_counter: *mut c_uint,
+        barrier_counter: *mut c_uint,
+        barrier_flag: *mut c_uint,
+    ) -> c_int;
+
+    #[cfg(supersonic_backend_cuda)]
     #[link_name = "supersonic_gemma4_cuda_final_norm_lm_head_argmax"]
     fn supersonic_gemma4_cuda_final_norm_lm_head_argmax(
         dtype: c_int,
@@ -2223,6 +2259,135 @@ pub fn persistent_decode_fused_input(
         );
         Err(GpuError::InvalidArg(
             "gemma4 persistent_decode_fused_input requires a CUDA build".into(),
+        ))
+    }
+}
+
+/// CUDA-only one-launch greedy path for Gemma 4 BF16 batch-1 decode:
+/// input staging + persistent decode + final RMSNorm + LM-head argmax.
+#[allow(clippy::too_many_arguments)]
+pub fn persistent_decode_fused_input_argmax(
+    ordinal: usize,
+    dtype: ScalarType,
+    layers: &GpuBuffer,
+    embed_tokens: &GpuBuffer,
+    embed_tokens_per_layer: &GpuBuffer,
+    per_layer_model_projection_w: &GpuBuffer,
+    per_layer_projection_norm_w: &GpuBuffer,
+    final_norm_w: &GpuBuffer,
+    lm_head_w: &GpuBuffer,
+    hidden_io: &mut GpuBuffer,
+    pli_proj: &mut GpuBuffer,
+    pli_normed: &mut GpuBuffer,
+    ple_raw: &mut GpuBuffer,
+    per_layer_inputs: &mut GpuBuffer,
+    workspace: &mut GpuBuffer,
+    out_token: &mut GpuBuffer,
+    matvec_counter: &mut GpuBuffer,
+    barrier_counter: &mut GpuBuffer,
+    barrier_flag: &mut GpuBuffer,
+    num_layers: usize,
+    hidden_size: usize,
+    ple_hidden: usize,
+    vocab_size: usize,
+    token_id: u32,
+    position: usize,
+    eps: f32,
+    scale: f32,
+    embed_scale: f32,
+    proj_scale: f32,
+    ple_scale: f32,
+    combine_scale: f32,
+) -> Result<(), GpuError> {
+    if hidden_io.backend() != Backend::Cuda {
+        return Err(GpuError::InvalidArg(
+            "gemma4 persistent_decode_fused_input_argmax is CUDA-only".into(),
+        ));
+    }
+
+    #[cfg(supersonic_backend_cuda)]
+    {
+        let status = unsafe {
+            supersonic_gemma4_cuda_persistent_decode_fused_input_argmax(
+                dtype.kernel_dtype_code(),
+                ordinal,
+                num_layers,
+                hidden_size,
+                ple_hidden,
+                vocab_size,
+                token_id as c_uint,
+                position,
+                eps,
+                scale,
+                embed_scale,
+                proj_scale,
+                ple_scale,
+                combine_scale,
+                layers.as_ptr(),
+                embed_tokens.as_ptr(),
+                embed_tokens_per_layer.as_ptr(),
+                per_layer_model_projection_w.as_ptr(),
+                per_layer_projection_norm_w.as_ptr(),
+                final_norm_w.as_ptr(),
+                lm_head_w.as_ptr(),
+                hidden_io.as_mut_ptr(),
+                pli_proj.as_mut_ptr(),
+                pli_normed.as_mut_ptr(),
+                ple_raw.as_mut_ptr(),
+                per_layer_inputs.as_mut_ptr(),
+                workspace.as_mut_ptr(),
+                out_token.as_mut_ptr() as *mut c_uint,
+                matvec_counter.as_mut_ptr() as *mut c_uint,
+                barrier_counter.as_mut_ptr() as *mut c_uint,
+                barrier_flag.as_mut_ptr() as *mut c_uint,
+            )
+        };
+        if status != 0 {
+            return Err(GpuError::backend(
+                Backend::Cuda,
+                format!("gemma4 persistent_decode_fused_input_argmax failed with status {status}"),
+            ));
+        }
+        Ok(())
+    }
+
+    #[cfg(not(supersonic_backend_cuda))]
+    {
+        let _ = (
+            ordinal,
+            dtype,
+            layers,
+            embed_tokens,
+            embed_tokens_per_layer,
+            per_layer_model_projection_w,
+            per_layer_projection_norm_w,
+            final_norm_w,
+            lm_head_w,
+            hidden_io,
+            pli_proj,
+            pli_normed,
+            ple_raw,
+            per_layer_inputs,
+            workspace,
+            out_token,
+            matvec_counter,
+            barrier_counter,
+            barrier_flag,
+            num_layers,
+            hidden_size,
+            ple_hidden,
+            vocab_size,
+            token_id,
+            position,
+            eps,
+            scale,
+            embed_scale,
+            proj_scale,
+            ple_scale,
+            combine_scale,
+        );
+        Err(GpuError::InvalidArg(
+            "gemma4 persistent_decode_fused_input_argmax requires a CUDA build".into(),
         ))
     }
 }

--- a/crates/runner/src/gemma4_engine.rs
+++ b/crates/runner/src/gemma4_engine.rs
@@ -1936,21 +1936,63 @@ impl Gemma4Engine {
         let vocab_size = self.tcfg.vocab_size;
         let eps = self.tcfg.rms_norm_eps as f32;
 
-        self.run_decode_body_seq(seq_idx, input_token_id, pos)?;
-        g4::final_norm_lm_head_argmax(
-            device,
-            dtype,
-            &self.decode_hidden_io,
-            &self.final_norm_w,
-            &self.lm_head_w,
-            &mut self.mega_workspace,
-            &mut self.decode_next_token,
-            &mut self.mega_barrier_counter,
-            &mut self.mega_barrier_flag,
-            hidden_size,
-            vocab_size,
-            eps,
-        )?;
+        if let Some(embed_tokens_per_layer_w) = self.embed_tokens_per_layer_w.as_ref() {
+            let ple_hidden = self.tcfg.hidden_size_per_layer_input;
+            let num_layers = self.tcfg.num_hidden_layers;
+            let embed_scale = bf16::from_f32((hidden_size as f32).sqrt()).to_f32();
+            let proj_scale = bf16::from_f32((hidden_size as f32).powf(-0.5)).to_f32();
+            let ple_scale = (ple_hidden as f32).sqrt();
+            let combine_scale = bf16::from_f32(2.0f32.powf(-0.5)).to_f32();
+            g4::persistent_decode_fused_input_argmax(
+                device,
+                dtype,
+                &self.layers_gpu[seq_idx],
+                &self.lm_head_w,
+                embed_tokens_per_layer_w,
+                &self.per_layer_model_projection_w,
+                &self.per_layer_projection_norm_w,
+                &self.final_norm_w,
+                &self.lm_head_w,
+                &mut self.decode_hidden_io,
+                &mut self.decode_pli_proj,
+                &mut self.decode_pli_normed,
+                &mut self.decode_ple_raw,
+                &mut self.decode_pli,
+                &mut self.mega_workspace,
+                &mut self.decode_next_token,
+                &mut self.mega_matvec_counter,
+                &mut self.mega_barrier_counter,
+                &mut self.mega_barrier_flag,
+                num_layers,
+                hidden_size,
+                ple_hidden,
+                vocab_size,
+                input_token_id,
+                pos,
+                eps,
+                1.0f32,
+                embed_scale,
+                proj_scale,
+                ple_scale,
+                combine_scale,
+            )?;
+        } else {
+            self.run_decode_body_seq(seq_idx, input_token_id, pos)?;
+            g4::final_norm_lm_head_argmax(
+                device,
+                dtype,
+                &self.decode_hidden_io,
+                &self.final_norm_w,
+                &self.lm_head_w,
+                &mut self.mega_workspace,
+                &mut self.decode_next_token,
+                &mut self.mega_barrier_counter,
+                &mut self.mega_barrier_flag,
+                hidden_size,
+                vocab_size,
+                eps,
+            )?;
+        }
         let mut token_bytes = [0u8; 4];
         gpu_hal::copy_d2h(
             device,

--- a/crates/runner/src/gemma4_engine.rs
+++ b/crates/runner/src/gemma4_engine.rs
@@ -1930,6 +1930,9 @@ impl Gemma4Engine {
         if gpu_hal::current_backend() != Backend::Cuda || self.batch_size != 1 || seq_idx != 0 {
             return Ok(None);
         }
+        if pos >= self.max_t {
+            bail!("decode_step_seq: pos {pos} >= max_t {}", self.max_t);
+        }
         let device = self.device;
         let dtype = ScalarType::BF16;
         let hidden_size = self.tcfg.hidden_size;

--- a/kernels/gemma4_bridge_cuda.cu
+++ b/kernels/gemma4_bridge_cuda.cu
@@ -772,9 +772,70 @@ int persistent_decode_fused_input_device(
         static_cast<T*>(ple_raw),
         static_cast<T*>(per_layer_inputs),
         static_cast<float*>(workspace),
-        matvec_counter, barrier_counter, barrier_flag);
+        matvec_counter, barrier_counter, barrier_flag,
+        nullptr, nullptr, nullptr);
     if (cudaGetLastError() != cudaSuccess) return 724;
     if (cudaDeviceSynchronize() != cudaSuccess) return 725;
+    return 0;
+}
+
+template <typename T>
+int persistent_decode_fused_input_argmax_device(
+    int device_ordinal,
+    int num_layers, int hidden_size, int ple_hidden, int vocab_size,
+    unsigned int token_id, int position, float eps, float scale,
+    float embed_scale, float proj_scale, float ple_scale, float combine_scale,
+    const void* layers,
+    const void* embed_tokens,
+    const void* embed_tokens_per_layer,
+    const void* per_layer_model_projection_w,
+    const void* per_layer_projection_norm_w,
+    const void* final_norm_w,
+    const void* lm_head_w,
+    void* hidden_io,
+    void* pli_proj,
+    void* pli_normed,
+    void* ple_raw,
+    void* per_layer_inputs,
+    void* workspace,
+    unsigned int* out_token,
+    unsigned int* matvec_counter,
+    unsigned int* barrier_counter,
+    unsigned int* barrier_flag) {
+    ScopedCudaDevice scoped(device_ordinal);
+
+    cudaDeviceProp props;
+    if (cudaGetDeviceProperties(&props, device_ordinal) != cudaSuccess) return 741;
+    const int num_blocks =
+        props.multiProcessorCount > 0 ? props.multiProcessorCount : 1;
+    constexpr int BLOCK = 256;
+    const size_t lds_bytes = (BLOCK + 256) * sizeof(float);
+
+    if (cudaMemset(barrier_counter, 0, sizeof(unsigned int)) != cudaSuccess) return 742;
+    if (cudaMemset(barrier_flag, 0, sizeof(unsigned int)) != cudaSuccess) return 743;
+
+    g4_persistent_decode_fused_input_kernel<T><<<dim3(num_blocks), dim3(BLOCK), lds_bytes, 0>>>(
+        num_layers, hidden_size, ple_hidden, vocab_size, token_id, position,
+        eps, scale, embed_scale, proj_scale, ple_scale, combine_scale,
+        static_cast<const Gemma4DecodeLayerDesc*>(layers),
+        nullptr,
+        nullptr,
+        static_cast<const T*>(embed_tokens),
+        static_cast<const T*>(embed_tokens_per_layer),
+        static_cast<const T*>(per_layer_model_projection_w),
+        static_cast<const T*>(per_layer_projection_norm_w),
+        static_cast<T*>(hidden_io),
+        static_cast<T*>(pli_proj),
+        static_cast<T*>(pli_normed),
+        static_cast<T*>(ple_raw),
+        static_cast<T*>(per_layer_inputs),
+        static_cast<float*>(workspace),
+        matvec_counter, barrier_counter, barrier_flag,
+        static_cast<const T*>(final_norm_w),
+        static_cast<const T*>(lm_head_w),
+        out_token);
+    if (cudaGetLastError() != cudaSuccess) return 744;
+    if (cudaDeviceSynchronize() != cudaSuccess) return 745;
     return 0;
 }
 
@@ -1536,6 +1597,49 @@ extern "C" int supersonic_gemma4_cuda_persistent_decode_fused_input(
     default: return 720;
     }
     #undef G4_PERSIST_FUSED_INPUT_ARGS
+}
+
+extern "C" int supersonic_gemma4_cuda_persistent_decode_fused_input_argmax(
+    int dtype, size_t device_ordinal,
+    size_t num_layers, size_t hidden_size, size_t ple_hidden, size_t vocab_size,
+    unsigned int token_id, size_t position, float eps, float scale,
+    float embed_scale, float proj_scale, float ple_scale, float combine_scale,
+    const void* layers,
+    const void* embed_tokens,
+    const void* embed_tokens_per_layer,
+    const void* per_layer_model_projection_w,
+    const void* per_layer_projection_norm_w,
+    const void* final_norm_w,
+    const void* lm_head_w,
+    void* hidden_io,
+    void* pli_proj,
+    void* pli_normed,
+    void* ple_raw,
+    void* per_layer_inputs,
+    void* workspace,
+    unsigned int* out_token,
+    unsigned int* matvec_counter,
+    unsigned int* barrier_counter,
+    unsigned int* barrier_flag
+) {
+    #define G4_PERSIST_FUSED_INPUT_ARGMAX_ARGS                               \
+        static_cast<int>(device_ordinal),                                    \
+        static_cast<int>(num_layers), static_cast<int>(hidden_size),         \
+        static_cast<int>(ple_hidden), static_cast<int>(vocab_size),          \
+        token_id, static_cast<int>(position), eps, scale,                    \
+        embed_scale, proj_scale, ple_scale, combine_scale,                   \
+        layers, embed_tokens, embed_tokens_per_layer,                        \
+        per_layer_model_projection_w, per_layer_projection_norm_w,           \
+        final_norm_w, lm_head_w, hidden_io, pli_proj, pli_normed, ple_raw,   \
+        per_layer_inputs, workspace, out_token,                              \
+        matvec_counter, barrier_counter, barrier_flag
+    switch (dtype) {
+    case 0: return persistent_decode_fused_input_argmax_device<__half>(G4_PERSIST_FUSED_INPUT_ARGMAX_ARGS);
+    case 1: return persistent_decode_fused_input_argmax_device<float>(G4_PERSIST_FUSED_INPUT_ARGMAX_ARGS);
+    case 2: return persistent_decode_fused_input_argmax_device<__nv_bfloat16>(G4_PERSIST_FUSED_INPUT_ARGMAX_ARGS);
+    default: return 740;
+    }
+    #undef G4_PERSIST_FUSED_INPUT_ARGMAX_ARGS
 }
 
 extern "C" int supersonic_gemma4_cuda_final_norm_lm_head_argmax(

--- a/kernels/gemma4_cuda.cuh
+++ b/kernels/gemma4_cuda.cuh
@@ -3405,6 +3405,145 @@ __global__ void g4_persistent_decode_kernel(
 }
 
 template <typename T>
+__device__ void g4_final_norm_lm_head_argmax_body(
+    int hidden_size,
+    int vocab_size,
+    float eps,
+    const T* __restrict__ hidden_io,
+    const T* __restrict__ final_norm_w,
+    const T* __restrict__ lm_head_w,
+    float* __restrict__ workspace,
+    unsigned int* __restrict__ out_token,
+    unsigned int* __restrict__ barrier_counter,
+    unsigned int* __restrict__ barrier_flag,
+    float* __restrict__ lds
+) {
+    const int tid = threadIdx.x;
+    const int bs = blockDim.x;
+    const int nb = gridDim.x;
+
+    float* hidden_f32 = workspace;
+    float* normed_f32 = hidden_f32 + hidden_size;
+    float* partial_vals = normed_f32 + hidden_size;
+    float* partial_idx_bits = partial_vals + nb;
+    float* reduce_idx_bits = partial_idx_bits + nb;
+
+    if (blockIdx.x == 0) {
+        for (int c = tid; c < hidden_size; c += bs) {
+            hidden_f32[c] = g4_to_float(hidden_io[c]);
+        }
+        __syncthreads();
+        g4_block_rms_norm_f32<T>(
+            normed_f32, hidden_f32, final_norm_w, hidden_size, eps, lds);
+    }
+    g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+    const int lane = tid % warpSize;
+    const int warp_id = tid / warpSize;
+    const int warps_per_block = bs / warpSize;
+    float best = -INFINITY;
+    unsigned int best_idx = 0u;
+    const int vd4 = hidden_size & ~3;
+    for (int row = blockIdx.x * warps_per_block + warp_id;
+         row < vocab_size;
+         row += nb * warps_per_block) {
+        const T* wr = lm_head_w + static_cast<size_t>(row) * hidden_size;
+        float p = 0.0f;
+        for (int c = lane * 4; c < vd4; c += warpSize * 4) {
+            const float w0 = g4_to_float(wr[c]);
+            const float w1 = g4_to_float(wr[c + 1]);
+            const float w2 = g4_to_float(wr[c + 2]);
+            const float w3 = g4_to_float(wr[c + 3]);
+            p += w0 * normed_f32[c]
+               + w1 * normed_f32[c + 1]
+               + w2 * normed_f32[c + 2]
+               + w3 * normed_f32[c + 3];
+        }
+        for (int c = vd4 + lane; c < hidden_size; c += warpSize) {
+            p += g4_to_float(wr[c]) * normed_f32[c];
+        }
+        const float result = g4_wave_reduce_sum_f32(p);
+        if (lane == 0) {
+            // Match the validated logits path: the standalone matvec rounds
+            // each logit to BF16 before host argmax/softcap.
+            const float rounded = g4_to_float(g4_from_float<T>(result));
+            const unsigned int urow = static_cast<unsigned int>(row);
+            if (rounded > best || (rounded == best && urow < best_idx)) {
+                best = rounded;
+                best_idx = urow;
+            }
+        }
+    }
+
+    float* block_idx_bits = lds + bs;
+    if (lane == 0) {
+        lds[warp_id] = best;
+        block_idx_bits[warp_id] = __uint_as_float(best_idx);
+    }
+    __syncthreads();
+    if (tid >= warps_per_block) {
+        lds[tid] = -INFINITY;
+        block_idx_bits[tid] = __uint_as_float(0u);
+    }
+    __syncthreads();
+    for (int s = bs / 2; s > 0; s >>= 1) {
+        if (tid < s) {
+            const float other_v = lds[tid + s];
+            const unsigned int other_idx =
+                __float_as_uint(block_idx_bits[tid + s]);
+            const unsigned int cur_idx =
+                __float_as_uint(block_idx_bits[tid]);
+            if (other_v > lds[tid] ||
+                (other_v == lds[tid] && other_idx < cur_idx)) {
+                lds[tid] = other_v;
+                block_idx_bits[tid] = __uint_as_float(other_idx);
+            }
+        }
+        __syncthreads();
+    }
+
+    if (tid == 0) {
+        partial_vals[blockIdx.x] = lds[0];
+        partial_idx_bits[blockIdx.x] = block_idx_bits[0];
+    }
+    g4_grid_barrier(barrier_counter, barrier_flag, nb);
+
+    if (blockIdx.x == 0) {
+        float block_best = -INFINITY;
+        unsigned int block_best_idx = 0u;
+        for (int i = tid; i < nb; i += bs) {
+            const float v = partial_vals[i];
+            const unsigned int idx = __float_as_uint(partial_idx_bits[i]);
+            if (v > block_best || (v == block_best && idx < block_best_idx)) {
+                block_best = v;
+                block_best_idx = idx;
+            }
+        }
+        lds[tid] = block_best;
+        reduce_idx_bits[tid] = __uint_as_float(block_best_idx);
+        __syncthreads();
+        for (int s = bs / 2; s > 0; s >>= 1) {
+            if (tid < s) {
+                const float other_v = lds[tid + s];
+                const unsigned int other_idx =
+                    __float_as_uint(reduce_idx_bits[tid + s]);
+                const unsigned int cur_idx =
+                    __float_as_uint(reduce_idx_bits[tid]);
+                if (other_v > lds[tid] ||
+                    (other_v == lds[tid] && other_idx < cur_idx)) {
+                    lds[tid] = other_v;
+                    reduce_idx_bits[tid] = __uint_as_float(other_idx);
+                }
+            }
+            __syncthreads();
+        }
+        if (tid == 0) {
+            out_token[0] = __float_as_uint(reduce_idx_bits[0]);
+        }
+    }
+}
+
+template <typename T>
 __global__ void g4_persistent_decode_fused_input_kernel(
     int num_layers,
     int hidden_size,
@@ -3433,7 +3572,10 @@ __global__ void g4_persistent_decode_fused_input_kernel(
     float* __restrict__ workspace,
     unsigned int* __restrict__ matvec_counter,
     unsigned int* __restrict__ barrier_counter,
-    unsigned int* __restrict__ barrier_flag
+    unsigned int* __restrict__ barrier_flag,
+    const T* __restrict__ final_norm_w,
+    const T* __restrict__ lm_head_w,
+    unsigned int* __restrict__ out_token
 ) __launch_bounds__(256, 1) {
     const int tid = threadIdx.x;
     const int bs = blockDim.x;
@@ -3539,6 +3681,13 @@ __global__ void g4_persistent_decode_fused_input_kernel(
         num_layers, hidden_size, ple_hidden, position, eps, scale,
         layers, kv_fp8_descs, fp8_scales, hidden_io, per_layer_inputs,
         workspace, matvec_counter, barrier_counter, barrier_flag, lds);
+
+    if (out_token != nullptr) {
+        g4_grid_barrier(barrier_counter, barrier_flag, nb);
+        g4_final_norm_lm_head_argmax_body<T>(
+            hidden_size, vocab_size, eps, hidden_io, final_norm_w, lm_head_w,
+            workspace, out_token, barrier_counter, barrier_flag, lds);
+    }
 }
 
 template <typename T>
@@ -3554,99 +3703,10 @@ __global__ void g4_final_norm_lm_head_argmax_kernel(
     unsigned int* __restrict__ barrier_counter,
     unsigned int* __restrict__ barrier_flag
 ) __launch_bounds__(256, 1) {
-    const int tid = threadIdx.x;
-    const int bs = blockDim.x;
-    const int nb = gridDim.x;
     extern __shared__ float lds[];
-
-    float* hidden_f32 = workspace;
-    float* normed_f32 = hidden_f32 + hidden_size;
-    float* partial_vals = normed_f32 + hidden_size;
-    float* partial_idx_bits = partial_vals + nb;
-    float* reduce_idx_bits = partial_idx_bits + nb;
-
-    if (blockIdx.x == 0) {
-        for (int c = tid; c < hidden_size; c += bs) {
-            hidden_f32[c] = g4_to_float(hidden_io[c]);
-        }
-        __syncthreads();
-        g4_block_rms_norm_f32<T>(
-            normed_f32, hidden_f32, final_norm_w, hidden_size, eps, lds);
-    }
-    g4_grid_barrier(barrier_counter, barrier_flag, nb);
-
-    float best = -INFINITY;
-    unsigned int best_idx = 0u;
-    const int lane = tid % warpSize;
-    const int vd4 = hidden_size & ~3;
-    for (int row = blockIdx.x; row < vocab_size; row += nb) {
-        const T* wr = lm_head_w + static_cast<size_t>(row) * hidden_size;
-        float p = 0.0f;
-        for (int c = lane * 4; c < vd4; c += warpSize * 4) {
-            const float w0 = g4_to_float(wr[c]);
-            const float w1 = g4_to_float(wr[c + 1]);
-            const float w2 = g4_to_float(wr[c + 2]);
-            const float w3 = g4_to_float(wr[c + 3]);
-            p += w0 * normed_f32[c]
-               + w1 * normed_f32[c + 1]
-               + w2 * normed_f32[c + 2]
-               + w3 * normed_f32[c + 3];
-        }
-        for (int c = vd4 + lane; c < hidden_size; c += warpSize) {
-            p += g4_to_float(wr[c]) * normed_f32[c];
-        }
-        const float result = g4_wave_reduce_sum_f32(p);
-        if (lane == 0) {
-            // Match the validated logits path: the standalone matvec rounds
-            // each logit to BF16 before host argmax/softcap.
-            const float rounded = g4_to_float(g4_from_float<T>(result));
-            const unsigned int urow = static_cast<unsigned int>(row);
-            if (rounded > best || (rounded == best && urow < best_idx)) {
-                best = rounded;
-                best_idx = urow;
-            }
-        }
-    }
-
-    if (tid == 0) {
-        partial_vals[blockIdx.x] = best;
-        partial_idx_bits[blockIdx.x] = __uint_as_float(best_idx);
-    }
-    g4_grid_barrier(barrier_counter, barrier_flag, nb);
-
-    if (blockIdx.x == 0) {
-        float block_best = -INFINITY;
-        unsigned int block_best_idx = 0u;
-        for (int i = tid; i < nb; i += bs) {
-            const float v = partial_vals[i];
-            const unsigned int idx = __float_as_uint(partial_idx_bits[i]);
-            if (v > block_best || (v == block_best && idx < block_best_idx)) {
-                block_best = v;
-                block_best_idx = idx;
-            }
-        }
-        lds[tid] = block_best;
-        reduce_idx_bits[tid] = __uint_as_float(block_best_idx);
-        __syncthreads();
-        for (int s = bs / 2; s > 0; s >>= 1) {
-            if (tid < s) {
-                const float other_v = lds[tid + s];
-                const unsigned int other_idx =
-                    __float_as_uint(reduce_idx_bits[tid + s]);
-                const unsigned int cur_idx =
-                    __float_as_uint(reduce_idx_bits[tid]);
-                if (other_v > lds[tid] ||
-                    (other_v == lds[tid] && other_idx < cur_idx)) {
-                    lds[tid] = other_v;
-                    reduce_idx_bits[tid] = __uint_as_float(other_idx);
-                }
-            }
-            __syncthreads();
-        }
-        if (tid == 0) {
-            out_token[0] = __float_as_uint(reduce_idx_bits[0]);
-        }
-    }
+    g4_final_norm_lm_head_argmax_body<T>(
+        hidden_size, vocab_size, eps, hidden_io, final_norm_w, lm_head_w,
+        workspace, out_token, barrier_counter, barrier_flag, lds);
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

- Fuse Gemma CUDA BF16 batch-1 greedy decode input staging, persistent decode, final RMSNorm, LM-head scan, and argmax into one CUDA launch when the per-layer embedding table is resident.
- Keep the existing standalone final RMSNorm + LM-head argmax path as a fallback.
- Rework the CUDA greedy tail so every warp in a block scans a distinct vocab row stream, instead of redundantly scanning the same rows and discarding seven warp results.

## Impact

This keeps validation/full-logits paths unchanged while improving the non-validation greedy decode path for Gemma CUDA E2B BF16.

Perf on sm86 for `gemma4-e2b`, prompt `Hello, world`, 64 generated tokens:

- Before tail row-distribution fix in this pass: `decode_ms=833`, `ms_per_step=13`
- After: `decode_ms=563`, `ms_per_step=9`

The generated token stream was unchanged.

## Validation

- `SUPERSONIC_BACKENDS=cuda cargo build --release --bin supersonic`
- `HF_HOME=/dev/shm/hf_home_gemma4 SUPERSONIC_BACKENDS=cuda TIMEOUT=900 ./tests/sm86/run_gemma4.sh /dev/shm/gemma-4-E2B`
  - `token_mismatches=0`
  - `decode_max_delta=0.3542`
- Greedy timing:
  - `HF_HOME=/dev/shm/hf_home_gemma4 SUPERSONIC_BACKENDS=cuda timeout 900 ./target/release/supersonic --backend cuda --model gemma4-e2b --model-dir /dev/shm/gemma-4-E2B --prompt "Hello, world" --max-new-tokens 64 --batch-size 1`
  - `decode_ms=563`, `ms_per_step=9`

The downloaded model/cache were cleaned from `/dev/shm` after validation.