### PR TITLE
qwen36-moe: --persistent-decode through speculative path (Phase 3e.3)

### DIFF
--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -1687,28 +1687,35 @@ fn decode_text(
 
     // Phase 3e.2: pre-allocate the persistent megakernel's scratch
     // (descriptor array + ping/pong residual + workspace + sync_buf) once
-    // before the decode loop. Reused for every step. Disabled when
-    // `--speculative-decode` is set since the spec verify loop runs
-    // multiple chains per step and isn't yet wired to the persistent
-    // path.
-    let mut persistent_scratch = if persistent_decode && !speculative_decode {
+    // before the decode loop. Reused for every step.
+    //
+    // Phase 3e.3: also enabled under `--speculative-decode`. Each verify
+    // chain (K+1 of them per spec iter, plus replay chains on partial-
+    // accept) currently pays the same 80 step-launch overhead as a plain
+    // base step, so the persistent path saves the same ~2.7 ms/chain
+    // there as on the plain decode path. The persistent kernel mutates
+    // linear-attn state in-place via cached descriptor pointers, so the
+    // existing `save_linear_attn_state` / `restore_linear_attn_state`
+    // round-trip works transparently — the kernel reads the latest state
+    // through the same pointers after the host D2D-copies fresh state
+    // back into the LayerBuffer slots.
+    let mut persistent_scratch = if persistent_decode {
         let scratch =
             crate::qwen36_moe_persistent_decode::PersistentScratch::new(ordinal, &geom, &mut layers)
                 .context("alloc PersistentScratch for --persistent-decode")?;
         println!(
             "  --persistent-decode: megakernel scratch allocated \
-             (descs={}KiB, workspace={}KiB, ping/pong={}KiB)",
+             (descs={}KiB, workspace={}KiB, ping/pong={}KiB){}",
             scratch.layer_descs_dev.len_bytes() / 1024,
             scratch.workspace.len_bytes() / 1024,
             scratch.hidden_ping.len_bytes() / 1024,
+            if speculative_decode {
+                " — also routes spec-verify chains through persistent"
+            } else {
+                ""
+            },
         );
         Some(scratch)
-    } else if persistent_decode && speculative_decode {
-        eprintln!(
-            "  --persistent-decode: ignored when --speculative-decode is set \
-             (verify loop not yet wired to persistent path; falling back to chained)"
-        );
-        None
     } else {
         None
     };
@@ -1993,14 +2000,19 @@ fn decode_text(
                             t_embed += t_embed_start.elapsed();
 
                             let t_chain_start = std::time::Instant::now();
-                            let chain_outputs = run_chained_decode_fast(
-                                ordinal,
-                                &geom,
-                                &mut layers,
-                                &initial_hidden,
-                                pos,
-                                emit_stage_timings,
-                            )?;
+                            let chain_outputs =
+                                if let Some(scratch) = persistent_scratch.as_mut() {
+                                    scratch.run(ordinal, &initial_hidden, pos)?
+                                } else {
+                                    run_chained_decode_fast(
+                                        ordinal,
+                                        &geom,
+                                        &mut layers,
+                                        &initial_hidden,
+                                        pos,
+                                        emit_stage_timings,
+                                    )?
+                                };
                             t_chain += t_chain_start.elapsed();
                             t_chain_full_attn_us += chain_outputs.kernel_full_attn_us;
                             t_chain_linear_attn_us += chain_outputs.kernel_linear_attn_us;
@@ -2080,14 +2092,18 @@ fn decode_text(
                         )?;
                         t_embed += t_embed_start.elapsed();
                         let t_chain_start = std::time::Instant::now();
-                        let replay_outputs = run_chained_decode_fast(
-                            ordinal,
-                            &geom,
-                            &mut layers,
-                            &initial_hidden,
-                            pos,
-                            emit_stage_timings,
-                        )?;
+                        let replay_outputs = if let Some(scratch) = persistent_scratch.as_mut() {
+                            scratch.run(ordinal, &initial_hidden, pos)?
+                        } else {
+                            run_chained_decode_fast(
+                                ordinal,
+                                &geom,
+                                &mut layers,
+                                &initial_hidden,
+                                pos,
+                                emit_stage_timings,
+                            )?
+                        };
                         t_chain += t_chain_start.elapsed();
                         // Per-kernel-class breakdown for replay chains
                         // contributes to the same accumulators as the
@@ -2132,14 +2148,18 @@ fn decode_text(
                         t_embed += t_embed_start.elapsed();
 
                         let t_chain_start = std::time::Instant::now();
-                        let outputs = run_chained_decode_fast(
-                            ordinal,
-                            &geom,
-                            &mut layers,
-                            &initial_hidden,
-                            pos,
-                            emit_stage_timings,
-                        )?;
+                        let outputs = if let Some(scratch) = persistent_scratch.as_mut() {
+                            scratch.run(ordinal, &initial_hidden, pos)?
+                        } else {
+                            run_chained_decode_fast(
+                                ordinal,
+                                &geom,
+                                &mut layers,
+                                &initial_hidden,
+                                pos,
+                                emit_stage_timings,
+                            )?
+                        };
                         t_chain += t_chain_start.elapsed();
                         t_chain_full_attn_us += outputs.kernel_full_attn_us;
                         t_chain_linear_attn_us += outputs.kernel_linear_attn_us;


### PR DESCRIPTION
## Summary
Drops the "ignored when `--speculative-decode` is set" gate around `PersistentScratch::new` and routes the K+1 verify chains + partial-accept replay chains through `scratch.run(...)` when the persistent flag is on. Combines Phase 3e.2 (#128) with Phase 6's speculative path so both opt-ins compose.

## Why
Phase 3e.2 wired `--persistent-decode` only on the plain decode path. With `--speculative-decode` set, every verify chain (K+1 per spec iter + replays on partial-accept) still went through `run_chained_decode_fast` — same 80 step launches per chain, same ~2.7 ms launch overhead. At K=2 with ~70% accept rate that's roughly K+1 = 3 chains per emitted token, so leaving spec mode on the chained path was costing ~8 ms/iter the persistent path could reclaim.

## What changed
Three call sites in `decode_text` get an inline branch:

```rust
let outputs = if let Some(scratch) = persistent_scratch.as_mut() {
    scratch.run(ordinal, &initial_hidden, pos)?
} else {
    run_chained_decode_fast(ordinal, &geom, &mut layers, ...)?
};
```

| Site | Phase |
|---|---|
| Batched closure's K+1 sequential chains | the main verify body |
| Partial-accept replay loop | runs after `restore_linear_attn_state` to re-advance state |
| Per-step (non-batched) closure | fallback when `--batched-spec-verify` isn't set |

The startup gate is also relaxed:
```rust
let mut persistent_scratch = if persistent_decode {  // was: && !speculative_decode
    Some(PersistentScratch::new(ordinal, &geom, &mut layers)?)
} else { None };
```

## State-restore correctness
`save_linear_attn_state` / `restore_linear_attn_state` (PR #115) D2D-copy state INTO the live `LayerBuffer` slots. The persistent kernel's descriptor pointers (cached at `PersistentScratch::new` time) point at those same slots, so after a restore the next persistent kernel call reads the restored bytes through the same pointers. No scratch rebuild needed.

## Validation

**Build clean**: `cargo build --release -p runner` passes.

**Existing parity test still passes**: `multilayer_persistent_decode_matches_chained` exercises `PersistentScratch::run` directly; that path is unchanged.

**E2E A/B on the 35B-A3B INT4 bake** (8-token fox prompt × 32 gen, local 7900 XTX):

| Mode | chain ms_avg | total ms_avg | tok/s | Δ |
|---|---:|---:|---:|---:|
| `--speculative-decode` | 29.59 | 31.22 | 32.03 | (baseline) |
| `--speculative-decode --persistent-decode` | 26.65 | 28.22 | 35.44 | **+10.7%** |

Generated tokens **bit-identical** between the two runs:
```
[5388, 13, 271, 760, 3841, 13477, 37550, 33075, 888, 279, 15217, 5388, 13, ...]
```

Reclaim per chain (~2.94 ms) matches the plain-decode A/B from #128 (~2.72 ms) within timing noise — confirms the spec verify chains pay the same launch overhead the plain decode chains did.

## Try it
```bash
cargo run --release --bin supersonic -- \
  --model qwen3.6-35b-a3b --model-dir /path/to/Qwen3.6-35B-A3B \
  --int4 --speculative-decode --persistent-decode \
  --prompt "..." --max-new-tokens 32 --emit-stage-timings
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)