### PR TITLE
qwen36-moe: flip --persistent-decode to default-on (Phase 3e.4)

### DIFF
--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -437,25 +437,31 @@ pub(crate) struct Cli {
     #[arg(long)]
     batched_spec_verify: bool,
 
-    /// Phase 3e.2: route the Qwen3.6-MoE decode chain through the
-    /// persistent megakernel
+    /// **No-op.** The Qwen3.6-MoE persistent megakernel
     /// (`kernels/qwen36_moe_persistent/persistent_decode.hip`,
-    /// PR #126) instead of the chained per-step launcher.
+    /// PR #126) is now the default decode path; this flag is kept as
+    /// a no-op so existing benchmark harnesses don't break. Use
+    /// `--no-persistent-decode` to opt out into the legacy chained
+    /// per-step launcher.
     ///
-    /// One cooperative HIP launch processes all 40 layers ({attn or
-    /// linear-attn, FFN}) per token vs. 80 step launches in the
-    /// chained path — recovers ~30 µs × 80 = ~2.4 ms of HIP launch
-    /// overhead per token (~9% of the 27 ms chain time on local
-    /// 7900 XTX bring-up). Bit-identical greedy output to the chained
-    /// path (gated by the
-    /// `multilayer_persistent_decode_matches_chained` parity test).
-    ///
-    /// Currently HIP/qwen3.6-MoE only and only on the non-speculative
-    /// decode path. Combining with `--speculative-decode` falls back to
-    /// the chained path for the verify-loop chains; the persistent path
-    /// gates a follow-up after spec-verify perf is in.
-    #[arg(long)]
+    /// Background: one cooperative HIP launch processes all 40
+    /// layers per token vs. 80 step launches in the chained path —
+    /// recovers ~2.5-3 ms/token of HIP launch overhead. Validated
+    /// bit-identical across PG-19 + RULER × {128, 512, 2K, 4K, 8K}
+    /// at INT4 (verify-suite `chained_vs_persistent` block, all
+    /// 10/10 cases logits/hidden/generated_ids byte-identical).
+    /// Mode-agnostic: the kernel handles INT4 / BF16 / FP8 sidecars
+    /// identically. HIP/qwen3.6-MoE only.
+    #[arg(long, hide = true)]
     persistent_decode: bool,
+
+    /// Opt out of the persistent-decode megakernel and run the
+    /// legacy chained per-step launcher (~80 step launches per
+    /// token, ~2.5-3 ms/token slower than the persistent path on
+    /// gfx1100). Use for A/B perf comparison or to bisect a
+    /// suspected megakernel-side regression.
+    #[arg(long)]
+    no_persistent_decode: bool,
 
     /// Emit the generated suffix as a JSON string for benchmark harnesses.
     #[arg(long)]

--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -754,7 +754,11 @@ pub fn run(cli: &crate::Cli, entry: &RegistryEntry, total_vram: u64) -> Result<(
         cli.speculative_decode,
         cli.fp8_runtime,
         cli.batched_spec_verify,
-        cli.persistent_decode,
+        // Phase 3e.4: persistent decode is now the default. The legacy
+        // `--persistent-decode` flag is a hidden no-op (kept for harness
+        // back-compat); `--no-persistent-decode` is the documented
+        // opt-out for A/B comparison or bisecting megakernel regressions.
+        !cli.no_persistent_decode,
     )?;
     Ok(())
 }

--- a/oracle/qwen36_verify_suite.py
+++ b/oracle/qwen36_verify_suite.py
@@ -366,9 +366,16 @@ def run_once(
         raise ValueError(f"unknown mode {mode}")
     if args.emit_stage_timings:
         cmd.append("--emit-stage-timings")
-    if decode_path == "persistent":
+    if decode_path == "chained":
+        # Persistent megakernel is the default since the post-Phase-3e.4
+        # flip; force the legacy chained path with the documented opt-out.
+        cmd.append("--no-persistent-decode")
+    elif decode_path == "persistent":
+        # `--persistent-decode` is now a hidden no-op (default-on);
+        # passing it explicitly is redundant but harmless and keeps the
+        # supersonic command line self-documenting in the captured logs.
         cmd.append("--persistent-decode")
-    elif decode_path != "chained":
+    else:
         raise ValueError(f"unknown decode_path {decode_path}")
 
     start = time.perf_counter()


### PR DESCRIPTION
## Summary
After the long-context sweep validated the persistent megakernel — **10/10 cases byte-identical**, all positive perf delta — flip the persistent path to be the default for qwen3.6-MoE on HIP. Adds `--no-persistent-decode` as the documented opt-out; keeps `--persistent-decode` as a hidden no-op for harness back-compat.

## Sweep data (PG-19 + RULER × {128, 512, 2K, 4K, 8K} × INT4)
| Family | Context | Δ chain | Δ total |
|---|---|---:|---:|
| pg19 | 128 | +8.4% | +7.9% |
| pg19 | 512 | +7.7% | +7.5% |
| pg19 |  2K | +4.5% | +4.5% |
| pg19 |  4K | +3.8% | +3.9% |
| pg19 |  8K | +2.6% | +2.6% |
| ruler | 128 | +7.3% | +6.7% |
| ruler | 512 | +7.6% | +7.3% |
| ruler |  2K | +5.3% | +5.2% |
| ruler |  4K | +1.0% | +1.1% |
| ruler |  8K | +2.5% | +2.6% |

Speedup decreases at longer context (chain compute scales with context, launch overhead doesn't), but **absolute reclaim is ~2.5-3 ms/token across the entire sweep**. ruler/4K's small +0.98% is single-repeat noise — same family at 8K rebounded to +2.5%. All 10 cases produce **byte-identical** logits + hidden + generated_ids.

## CLI surface
- `--persistent-decode` is now a hidden no-op (`#[arg(long, hide = true)]`). Back-compat for existing benchmark harnesses; the persistent path was already what they were exercising.
- `--no-persistent-decode` is the new documented opt-out — for A/B comparison, bisecting a suspected megakernel regression, or anyone explicitly wanting the legacy chained path.

## Verify suite update
The suite's `--decode-paths chained` cell now passes `--no-persistent-decode` to the binary instead of an empty flag list. Without this fix, post-flip "chained" runs would have silently used the persistent path and the `chained_vs_persistent` block would always report 0% delta (persistent-vs-persistent).

## Validation
- [x] `cargo build --release -p runner` clean.
- [x] `python3 -m unittest tests.test_qwen36_verify_suite`: 8/8 pass.
- [x] Smoke test on the local 35B-A3B INT4 bake — all three CLI modes produce bit-identical generated_ids:
  - default (no flag) → persistent (chain 30.43 ms)
  - `--no-persistent-decode` → chained (chain 32.12 ms, ~5.5% slower as expected)
  - `--persistent-decode` → persistent, same as default

🤖 Generated with [Claude Code](https://claude.com/claude-code)