### PR TITLE
[codex] Split Gemma CUDA argmax tail

### DIFF
--- a/kernels/gemma4_bridge_cuda.cu
+++ b/kernels/gemma4_bridge_cuda.cu
@@ -918,8 +918,14 @@ int persistent_decode_fused_input_argmax_device(
     if (cudaGetDeviceProperties(&props, device_ordinal) != cudaSuccess) return 741;
     const int num_blocks =
         props.multiProcessorCount > 0 ? props.multiProcessorCount : 1;
+    // The decode megakernel uses grid barriers, so keep it resident-sized.
+    // The split LM-head tail has no grid barrier and can oversubscribe rows.
+    const int argmax_blocks =
+        props.multiProcessorCount > 0 ? props.multiProcessorCount * 4 : 1;
     constexpr int BLOCK = 256;
     const size_t lds_bytes = (BLOCK + 256) * sizeof(float);
+    const size_t norm_lds_bytes = BLOCK * sizeof(float);
+    const size_t reduce_lds_bytes = 2 * BLOCK * sizeof(float);
 
     if (cudaMemset(barrier_counter, 0, sizeof(unsigned int)) != cudaSuccess) return 742;
     if (cudaMemset(barrier_flag, 0, sizeof(unsigned int)) != cudaSuccess) return 743;
@@ -942,11 +948,39 @@ int persistent_decode_fused_input_argmax_device(
         static_cast<T*>(per_layer_inputs),
         static_cast<float*>(workspace),
         matvec_counter, barrier_counter, barrier_flag,
-        static_cast<const T*>(final_norm_w),
-        static_cast<const T*>(lm_head_w),
-        out_token,
+        nullptr,
+        nullptr,
+        nullptr,
         profile_cycles);
     if (cudaGetLastError() != cudaSuccess) return 744;
+
+    float* normed_f32 = static_cast<float*>(workspace);
+    float* partial_vals = normed_f32 + hidden_size;
+    float* partial_idx_bits = partial_vals + argmax_blocks;
+    g4_final_norm_argmax_norm_kernel<T><<<dim3(1), dim3(BLOCK), norm_lds_bytes, 0>>>(
+        hidden_size, eps,
+        static_cast<const T*>(hidden_io),
+        static_cast<const T*>(final_norm_w),
+        normed_f32,
+        profile_cycles);
+    if (cudaGetLastError() != cudaSuccess) return 746;
+
+    g4_lm_head_argmax_partial_kernel<T><<<dim3(argmax_blocks), dim3(BLOCK), reduce_lds_bytes, 0>>>(
+        hidden_size, vocab_size,
+        static_cast<const T*>(lm_head_w),
+        normed_f32,
+        partial_vals,
+        partial_idx_bits,
+        profile_cycles);
+    if (cudaGetLastError() != cudaSuccess) return 747;
+
+    g4_lm_head_argmax_reduce_kernel<<<dim3(1), dim3(BLOCK), reduce_lds_bytes, 0>>>(
+        argmax_blocks,
+        partial_vals,
+        partial_idx_bits,
+        out_token,
+        profile_cycles);
+    if (cudaGetLastError() != cudaSuccess) return 748;
     if (cudaDeviceSynchronize() != cudaSuccess) return 745;
     g4_cuda_profile.collect(profile_cycles);
     return 0;

--- a/kernels/gemma4_cuda.cuh
+++ b/kernels/gemma4_cuda.cuh
@@ -3740,6 +3740,148 @@ __device__ void g4_final_norm_lm_head_argmax_body(
 }
 
 template <typename T>
+__global__ void g4_final_norm_argmax_norm_kernel(
+    int hidden_size,
+    float eps,
+    const T* __restrict__ hidden_io,
+    const T* __restrict__ final_norm_w,
+    float* __restrict__ normed_f32,
+    unsigned long long* __restrict__ profile_cycles
+) __launch_bounds__(256, 1) {
+    extern __shared__ float lds[];
+    const unsigned long long g4_prof = g4_profile_begin(profile_cycles);
+    g4_block_rms_norm_t_to_f32<T>(
+        normed_f32, hidden_io, final_norm_w, hidden_size, eps, lds);
+    g4_profile_end(profile_cycles, G4_PROFILE_ARGMAX_TAIL, g4_prof);
+}
+
+template <typename T>
+__global__ void g4_lm_head_argmax_partial_kernel(
+    int hidden_size,
+    int vocab_size,
+    const T* __restrict__ lm_head_w,
+    const float* __restrict__ normed_f32,
+    float* __restrict__ partial_vals,
+    float* __restrict__ partial_idx_bits,
+    unsigned long long* __restrict__ profile_cycles
+) __launch_bounds__(256, 1) {
+    extern __shared__ float lds[];
+    const int tid = threadIdx.x;
+    const int bs = blockDim.x;
+    const int lane = tid % warpSize;
+    const int warp_id = tid / warpSize;
+    const int warps_per_block = bs / warpSize;
+    const int partial_id = blockIdx.x;
+
+    const unsigned long long g4_prof = g4_profile_begin(profile_cycles);
+    float best = -INFINITY;
+    unsigned int best_idx = 0u;
+    const int vd4 = hidden_size & ~3;
+    for (int row = blockIdx.x * warps_per_block + warp_id;
+         row < vocab_size;
+         row += gridDim.x * warps_per_block) {
+        const T* wr = lm_head_w + static_cast<size_t>(row) * hidden_size;
+        float p = 0.0f;
+        for (int c = lane * 4; c < vd4; c += warpSize * 4) {
+            float w0, w1, w2, w3;
+            g4_load_pair_as_float(wr + c, w0, w1);
+            g4_load_pair_as_float(wr + c + 2, w2, w3);
+            p += w0 * normed_f32[c]
+               + w1 * normed_f32[c + 1]
+               + w2 * normed_f32[c + 2]
+               + w3 * normed_f32[c + 3];
+        }
+        for (int c = vd4 + lane; c < hidden_size; c += warpSize) {
+            p += g4_to_float(wr[c]) * normed_f32[c];
+        }
+        const float result = g4_wave_reduce_sum_f32(p);
+        if (lane == 0) {
+            const float rounded = g4_to_float(g4_from_float<T>(result));
+            const unsigned int urow = static_cast<unsigned int>(row);
+            if (rounded > best || (rounded == best && urow < best_idx)) {
+                best = rounded;
+                best_idx = urow;
+            }
+        }
+    }
+
+    float* idx_bits = lds + bs;
+    if (lane == 0) {
+        lds[warp_id] = best;
+        idx_bits[warp_id] = __uint_as_float(best_idx);
+    }
+    __syncthreads();
+    if (tid >= warps_per_block) {
+        lds[tid] = -INFINITY;
+        idx_bits[tid] = __uint_as_float(0u);
+    }
+    __syncthreads();
+    for (int s = bs / 2; s > 0; s >>= 1) {
+        if (tid < s) {
+            const float other_v = lds[tid + s];
+            const unsigned int other_idx = __float_as_uint(idx_bits[tid + s]);
+            const unsigned int cur_idx = __float_as_uint(idx_bits[tid]);
+            if (other_v > lds[tid] ||
+                (other_v == lds[tid] && other_idx < cur_idx)) {
+                lds[tid] = other_v;
+                idx_bits[tid] = __uint_as_float(other_idx);
+            }
+        }
+        __syncthreads();
+    }
+    if (tid == 0) {
+        partial_vals[partial_id] = lds[0];
+        partial_idx_bits[partial_id] = idx_bits[0];
+    }
+    g4_profile_end(profile_cycles, G4_PROFILE_ARGMAX_TAIL, g4_prof);
+}
+
+__global__ void g4_lm_head_argmax_reduce_kernel(
+    int num_partials,
+    const float* __restrict__ partial_vals,
+    const float* __restrict__ partial_idx_bits,
+    unsigned int* __restrict__ out_token,
+    unsigned long long* __restrict__ profile_cycles
+) {
+    extern __shared__ float lds[];
+    const int tid = threadIdx.x;
+    const int bs = blockDim.x;
+    float* idx_bits = lds + bs;
+
+    const unsigned long long g4_prof = g4_profile_begin(profile_cycles);
+    float best = -INFINITY;
+    unsigned int best_idx = 0u;
+    for (int i = tid; i < num_partials; i += bs) {
+        const float v = partial_vals[i];
+        const unsigned int idx = __float_as_uint(partial_idx_bits[i]);
+        if (v > best || (v == best && idx < best_idx)) {
+            best = v;
+            best_idx = idx;
+        }
+    }
+    lds[tid] = best;
+    idx_bits[tid] = __uint_as_float(best_idx);
+    __syncthreads();
+    for (int s = bs / 2; s > 0; s >>= 1) {
+        if (tid < s) {
+            const float other_v = lds[tid + s];
+            const unsigned int other_idx = __float_as_uint(idx_bits[tid + s]);
+            const unsigned int cur_idx = __float_as_uint(idx_bits[tid]);
+            if (other_v > lds[tid] ||
+                (other_v == lds[tid] && other_idx < cur_idx)) {
+                lds[tid] = other_v;
+                idx_bits[tid] = __uint_as_float(other_idx);
+            }
+        }
+        __syncthreads();
+    }
+    if (tid == 0) {
+        out_token[0] = __float_as_uint(idx_bits[0]);
+    }
+    g4_profile_end(profile_cycles, G4_PROFILE_ARGMAX_TAIL, g4_prof);
+}
+
+template <typename T>
 __global__ void g4_persistent_decode_fused_input_kernel(
     int num_layers,
     int hidden_size,


### PR DESCRIPTION
## Summary

Split the Gemma 4 CUDA fused-input argmax tail into standalone kernels:

- final RMSNorm to F32 workspace
- oversubscribed LM-head partial argmax
- one-block partial reduction

The decode megakernel still launches one block per SM because it uses grid barriers. Only the standalone LM-head tail oversubscribes rows at `SM * 4` blocks.

## Why

The profiler showed `argmax_tail` as a remaining hot path after the recent Gemma CUDA MLP fusion work. Keeping the decode kernel resident-sized avoids the grid-barrier deadlock risk, while moving LM-head argmax out into independent kernels lets that row scan use more blocks.

## Validation

- `git diff --check`
- `SUPERSONIC_BACKENDS=cuda cargo build --release --bin supersonic`
- `HF_HOME=/dev/shm/hf_home_gemma4 SUPERSONIC_BACKENDS=cuda TIMEOUT=900 ./tests/sm86/run_gemma4.sh /dev/shm/gemma-4-E2B`
  - `token_mismatches=0`
  - `decode_max_delta=0.3767`
- 32-token CUDA profile:
  - before: `argmax_tail approx_ms=34.410`, `decode_ms=268`
  - after: `argmax_tail approx_ms=33.854`, `decode_ms=267`
- 64-token smoke:
  - before: about `decode_ms=558`
  - after: `decode_ms=557`
- final rebuilt 8-token smoke:
  - `decode_ms=63`