### PR TITLE
[codex] Use static Gemma CUDA B4 down rows

### DIFF
--- a/kernels/gemma4_cuda.cuh
+++ b/kernels/gemma4_cuda.cuh
@@ -3335,14 +3335,10 @@ __device__ void g4_persistent_decode_body(
         g4_prof = g4_profile_begin(profile_cycles);
         g4_profile_end(profile_cycles, G4_PROFILE_B3_GELU_UP, g4_prof);
 
-        // B4: work-stealing down_proj.
+        // B4: static down_proj matvec.
         g4_prof = g4_profile_begin(profile_cycles);
-        if (blockIdx.x == 0 && tid == 0) {
-            __atomic_store_n(matvec_counter, 0u, __ATOMIC_RELAXED);
-        }
-        g4_grid_barrier(barrier_counter, barrier_flag, nb);
-
-        // B4 wave-per-row.
+        // B4 static wave-per-row. All down_proj rows have the same width, so
+        // static row assignment avoids per-row atomic claims.
         {
             const int lane = tid % warpSize;
             const int warp_id = tid / warpSize;
@@ -3351,23 +3347,12 @@ __device__ void g4_persistent_decode_body(
             const int group_id = warp_id / warps_per_row;
             const int group_lane = (warp_id % warps_per_row) * warpSize + lane;
             const int vd4 = intermediate_size & ~3;
-            __shared__ unsigned int claimed_rows[rows_per_block];
-            while (true) {
-                if (group_lane == 0) {
-                    claimed_rows[group_id] = atomicAdd(matvec_counter, 1u);
-                }
-                __syncthreads();
-
-                const unsigned int row = claimed_rows[group_id];
-                bool any_active = false;
-                for (int i = 0; i < rows_per_block; ++i) {
-                    any_active = any_active ||
-                        claimed_rows[i] < static_cast<unsigned int>(hidden_size);
-                }
-                if (!any_active) break;
-
+            for (int row_base = blockIdx.x * rows_per_block;
+                 row_base < hidden_size;
+                 row_base += nb * rows_per_block) {
+                const int row = row_base + group_id;
                 float p = 0.0f;
-                const bool active = row < static_cast<unsigned int>(hidden_size);
+                const bool active = row < hidden_size;
                 if (active && use_fp8_w) {
                     const void* wbase = static_cast<const void*>(down_proj_w);
                     const void* sbase = Sfp8.down_proj_scale;


### PR DESCRIPTION
## Summary

Switch Gemma 4 CUDA B4 `down_proj` from atomic work-stealing to static row assignment.

Every B4 output row has the same `intermediate_size` width, so static assignment avoids the per-row atomic claim path and removes the B4 counter-reset/grid-barrier setup while preserving each row's accumulation order.

## Validation

- `git diff --check`
- `SUPERSONIC_BACKENDS=cuda cargo build --release --bin supersonic`
- `HF_HOME=/dev/shm/hf_home_gemma4 SUPERSONIC_BACKENDS=cuda TIMEOUT=900 ./tests/sm86/run_gemma4.sh /dev/shm/gemma-4-E2B`
  - `token_mismatches=0`
  - `decode_max_delta=0.3767`
- 32-token CUDA profile:
  - before: `B4_down approx_ms=53.131`, `decode_ms=268`
  - after: `B4_down approx_ms=50.343`, `decode_ms=266`
- 64-token smoke:
  - before: about `decode_ms=557`
  - after: `decode_ms=553`
- final rebuilt 8-token smoke:
  - `decode_ms=62`

## Notes

Rejected during profiling:

- shared B2 hidden cache regressed B2
- B4 one-warp and four-warp row variants regressed
- B2 8-wide BF16 unroll regressed and changed token output