### PR TITLE
Wire Qwen3.6 MoE experts through VMM

### DIFF
--- a/crates/runner/src/qwen36_moe_decode.rs
+++ b/crates/runner/src/qwen36_moe_decode.rs
@@ -24,6 +24,7 @@
 //! [`run_chained_decode`] core — the only difference is how the
 //! [`LayerBuffers`] vec gets populated.
 
+use std::ffi::c_void;
 use std::ptr;
 
 use anyhow::{anyhow, Context, Result};
@@ -172,14 +173,78 @@ pub struct FfnInt4Sidecars {
     pub shared_down_proj_zero: GpuBuffer,
 }
 
+/// GPU-resident weight pointer used by decode descriptors.
+///
+/// Most Qwen3.6-MoE weights are ordinary `GpuBuffer`s. Routed expert slabs can
+/// also live in a `VirtualArena`; in that case the engine owns the arena and
+/// this wrapper carries the stable virtual pointer plus shape metadata.
+#[allow(dead_code)]
+pub enum ResidentWeight {
+    Dense(GpuBuffer),
+    Virtual {
+        allocation_id: usize,
+        ptr: *const c_void,
+        dtype: ScalarType,
+        shape: Vec<usize>,
+        len_bytes: usize,
+    },
+}
+
+unsafe impl Send for ResidentWeight {}
+unsafe impl Sync for ResidentWeight {}
+
+#[allow(dead_code)]
+impl ResidentWeight {
+    pub fn as_ptr(&self) -> *const c_void {
+        match self {
+            Self::Dense(buf) => buf.as_ptr(),
+            Self::Virtual { ptr, .. } => *ptr,
+        }
+    }
+
+    pub fn len_bytes(&self) -> usize {
+        match self {
+            Self::Dense(buf) => buf.len_bytes(),
+            Self::Virtual { len_bytes, .. } => *len_bytes,
+        }
+    }
+
+    pub fn shape(&self) -> &[usize] {
+        match self {
+            Self::Dense(buf) => buf.shape(),
+            Self::Virtual { shape, .. } => shape.as_slice(),
+        }
+    }
+
+    pub fn dtype(&self) -> ScalarType {
+        match self {
+            Self::Dense(buf) => buf.dtype(),
+            Self::Virtual { dtype, .. } => *dtype,
+        }
+    }
+
+    pub fn allocation_id(&self) -> Option<usize> {
+        match self {
+            Self::Dense(_) => None,
+            Self::Virtual { allocation_id, .. } => Some(*allocation_id),
+        }
+    }
+}
+
+impl From<GpuBuffer> for ResidentWeight {
+    fn from(value: GpuBuffer) -> Self {
+        Self::Dense(value)
+    }
+}
+
 /// Per-layer MoE FFN weight buffers. Always present (every layer has an
 /// FFN block). When `int4` is `Some`, every `*_proj_w` field carries
 /// packed nibbles instead of BF16 weights.
 pub struct FfnLayerBuffers {
     pub post_attn_norm_w: GpuBuffer,
     pub gate_w: GpuBuffer,
-    pub gate_up_proj_w: GpuBuffer,
-    pub down_proj_w: GpuBuffer,
+    pub gate_up_proj_w: ResidentWeight,
+    pub down_proj_w: ResidentWeight,
     pub shared_gate_proj_w: GpuBuffer,
     pub shared_up_proj_w: GpuBuffer,
     pub shared_down_proj_w: GpuBuffer,

--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -15,7 +15,7 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Context, Result};
-use gpu_hal::{set_backend, Backend, GpuBuffer, ScalarType, VirtualAllocationRole};
+use gpu_hal::{set_backend, Backend, GpuBuffer, ScalarType, VirtualAllocationRole, VirtualArena};
 use model_store::manifest::LayoutTag;
 use model_store::BakedStore;
 use qwen36_moe::config::{Config, TextConfig};
@@ -29,7 +29,7 @@ use crate::qwen36_moe_decode::{
     argmax_bf16_logits, dequant_int4_to_bf16_bytes, host_final_norm_lm_head, run_chained_decode,
     run_chained_decode_fast, sample_bf16_logits, AttnLayerBuffers, FfnInt4Sidecars,
     FfnLayerBuffers, FullAttnInt4Sidecars, FullAttnKvCache, LayerBuffers, LinearAttnInt4Sidecars,
-    MtpLayerBuffers, MultiLayerGeom, XorshiftRng,
+    MtpLayerBuffers, MultiLayerGeom, ResidentWeight, XorshiftRng,
 };
 use crate::qwen36_moe_speculative::{
     run_speculative_decode_step, run_speculative_decode_step_batched,
@@ -835,6 +835,7 @@ pub fn run(cli: &crate::Cli, entry: &RegistryEntry, total_vram: u64) -> Result<(
         cli.speculative_decode,
         cli.fp8_runtime,
         cli.batched_spec_verify,
+        cli.device,
         // Phase 3e.4: persistent decode is now the default. The legacy
         // `--persistent-decode` flag is a hidden no-op (kept for harness
         // back-compat); `--no-persistent-decode` is the documented
@@ -937,6 +938,36 @@ fn load_to_gpu(store: &BakedStore, ordinal: usize, name: &str) -> Result<GpuBuff
         .with_context(|| format!("BakedStore::load_to_gpu({name})"))
 }
 
+fn load_to_resident_weight(
+    store: &BakedStore,
+    ordinal: usize,
+    name: &str,
+) -> Result<ResidentWeight> {
+    load_to_gpu(store, ordinal, name).map(ResidentWeight::Dense)
+}
+
+fn load_to_virtual_resident_weight(
+    store: &BakedStore,
+    arena: &mut VirtualArena,
+    name: &str,
+) -> Result<ResidentWeight> {
+    let resolved = resolve_qwen36_store_name(store, name);
+    let id = store
+        .load_to_virtual_arena(arena, resolved.as_ref(), VirtualAllocationRole::MoeExpert)
+        .with_context(|| format!("BakedStore::load_to_virtual_arena({name})"))?;
+    let allocation = arena
+        .allocation(id)
+        .ok_or_else(|| anyhow!("virtual allocation id {id} disappeared after loading {name}"))?;
+    let buffer = allocation.buffer();
+    Ok(ResidentWeight::Virtual {
+        allocation_id: id,
+        ptr: buffer.as_ptr(),
+        dtype: buffer.dtype(),
+        shape: buffer.shape().to_vec(),
+        len_bytes: buffer.len_bytes(),
+    })
+}
+
 fn store_contains_qwen36(store: &BakedStore, name: &str) -> bool {
     store.contains(resolve_qwen36_store_name(store, name).as_ref())
 }
@@ -974,6 +1005,26 @@ enum Qwen36WeightMode {
     Fp8,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MoeExpertVmmMode {
+    Auto,
+    Disabled,
+    Force,
+}
+
+impl MoeExpertVmmMode {
+    fn from_env() -> Result<Self> {
+        match std::env::var("SUPERSONIC_VMM_MOE_ISLANDS").ok().as_deref() {
+            None => Ok(Self::Auto),
+            Some("0") => Ok(Self::Disabled),
+            Some("1") => Ok(Self::Force),
+            Some(other) => Err(anyhow!(
+                "SUPERSONIC_VMM_MOE_ISLANDS must be unset, 0, or 1; got {other:?}"
+            )),
+        }
+    }
+}
+
 /// Build one layer's worth of GPU-resident weight + state buffers from a
 /// BakedStore. Decides full-attn vs linear-attn by consulting the config's
 /// `layer_types` (every 4th layer is full per the standard hybrid pattern).
@@ -998,6 +1049,7 @@ fn load_layer_buffers(
     // `recurrent_state` instead (always allocated). 0 = no KV cache,
     // kernel falls back to kv_len=1 (back-compat for the parity test).
     kv_max_t: usize,
+    mut expert_arena: Option<&mut VirtualArena>,
 ) -> Result<LayerBuffers> {
     let lp = format!("{weight_prefix}.layers.{layer_idx}");
 
@@ -1284,8 +1336,22 @@ fn load_layer_buffers(
         gate_w: load_to_gpu(store, ordinal, &format!("{mp}.gate.weight"))?,
         // Note: experts.gate_up_proj / experts.down_proj have NO `.weight`
         // suffix in the published checkpoint — see expected_tensor_specs.
-        gate_up_proj_w: load_to_gpu(store, ordinal, &format!("{mp}.experts.gate_up_proj"))?,
-        down_proj_w: load_to_gpu(store, ordinal, &format!("{mp}.experts.down_proj"))?,
+        gate_up_proj_w: match expert_arena.as_mut() {
+            Some(arena) => load_to_virtual_resident_weight(
+                store,
+                &mut **arena,
+                &format!("{mp}.experts.gate_up_proj"),
+            )?,
+            None => load_to_resident_weight(store, ordinal, &format!("{mp}.experts.gate_up_proj"))?,
+        },
+        down_proj_w: match expert_arena.as_mut() {
+            Some(arena) => load_to_virtual_resident_weight(
+                store,
+                &mut **arena,
+                &format!("{mp}.experts.down_proj"),
+            )?,
+            None => load_to_resident_weight(store, ordinal, &format!("{mp}.experts.down_proj"))?,
+        },
         shared_gate_proj_w: load_to_gpu(
             store,
             ordinal,
@@ -1310,6 +1376,63 @@ fn load_layer_buffers(
     };
 
     Ok(LayerBuffers { attn, ffn })
+}
+
+fn load_all_layer_buffers(
+    store: &BakedStore,
+    ordinal: usize,
+    geom: &MultiLayerGeom,
+    text_config: &TextConfig,
+    weight_prefix: &str,
+    weight_mode: Qwen36WeightMode,
+    kv_max_t: usize,
+    mut expert_arena: Option<&mut VirtualArena>,
+) -> Result<Vec<LayerBuffers>> {
+    let mut layers = Vec::with_capacity(geom.num_layers as usize);
+    for li in 0..geom.num_layers as usize {
+        let layer = load_layer_buffers(
+            store,
+            ordinal,
+            li,
+            geom,
+            text_config,
+            weight_prefix,
+            weight_mode,
+            kv_max_t,
+            expert_arena.as_deref_mut(),
+        )
+        .with_context(|| format!("load layer {li} weights"))?;
+        layers.push(layer);
+    }
+    Ok(layers)
+}
+
+fn should_try_moe_expert_vmm(
+    mode: MoeExpertVmmMode,
+    weight_mode: Qwen36WeightMode,
+    ordinal: usize,
+) -> Result<bool> {
+    if mode == MoeExpertVmmMode::Disabled {
+        return Ok(false);
+    }
+    if weight_mode != Qwen36WeightMode::Int4 {
+        if mode == MoeExpertVmmMode::Force {
+            anyhow::bail!(
+                "SUPERSONIC_VMM_MOE_ISLANDS=1 requires Qwen3.6-MoE INT4 weights; got {weight_mode:?}"
+            );
+        }
+        return Ok(false);
+    }
+    let supported = gpu_hal::vmm_is_supported(Backend::Hip, ordinal);
+    if !supported {
+        if mode == MoeExpertVmmMode::Force {
+            anyhow::bail!(
+                "SUPERSONIC_VMM_MOE_ISLANDS=1 requested but HIP VMM is unsupported on device {ordinal}"
+            );
+        }
+        return Ok(false);
+    }
+    Ok(true)
 }
 
 /// Load the Qwen3.6-MoE multi-token-prediction (MTP) head from the bake.
@@ -1496,6 +1619,7 @@ fn decode_text(
     speculative_decode: bool,
     fp8_runtime: bool,
     batched_spec_verify: bool,
+    ordinal: usize,
     persistent_decode: bool,
 ) -> Result<()> {
     use std::io::Write as _;
@@ -1618,14 +1742,12 @@ fn decode_text(
     let geom = build_multi_layer_geom(&report.config.text_config, &report.kernel_params);
 
     set_backend(Backend::Hip);
-    let ordinal = 0usize;
 
     // KV cache size: needs to fit prompt_len + max_new past tokens. Sized
     // generously here since per-layer KV is small (10 full-attn layers ×
     // [kv_max_t, Hkv*d=512] BF16 = 10 KiB per token of context).
     let kv_max_t = prompt_ids.len() + max_new;
 
-    let mut layers = Vec::with_capacity(geom.num_layers as usize);
     println!(
         "  loading {} layers ({} INT4 sidecar sets, KV cache cap = {} tokens)…",
         geom.num_layers,
@@ -1636,20 +1758,65 @@ fn decode_text(
         },
         kv_max_t,
     );
-    for li in 0..geom.num_layers as usize {
-        let layer = load_layer_buffers(
+
+    let moe_vmm_mode = MoeExpertVmmMode::from_env()?;
+    let mut _moe_expert_arena = None;
+    let mut layers = if should_try_moe_expert_vmm(moe_vmm_mode, weight_mode, ordinal)? {
+        let mut arena = BakedStore::virtual_weight_arena(ordinal);
+        match load_all_layer_buffers(
             &store,
             ordinal,
-            li,
             &geom,
             &report.config.text_config,
             weight_prefix,
             weight_mode,
             kv_max_t,
-        )
-        .with_context(|| format!("load layer {li} weights"))?;
-        layers.push(layer);
-    }
+            Some(&mut arena),
+        ) {
+            Ok(layers) => {
+                let stats = arena.stats();
+                println!(
+                    "  [vmm] Qwen3.6-MoE routed expert slabs active on device {ordinal}: \
+                     allocations={} mappings={} logical={:.2}MiB resident={:.2}MiB reserved={:.2}MiB",
+                    stats.allocations,
+                    stats.mapping_count,
+                    stats.logical_bytes as f64 / MIB,
+                    stats.resident_bytes as f64 / MIB,
+                    stats.reserved_bytes as f64 / MIB,
+                );
+                _moe_expert_arena = Some(arena);
+                layers
+            }
+            Err(err) if moe_vmm_mode == MoeExpertVmmMode::Auto => {
+                eprintln!(
+                    "[vmm] Qwen3.6-MoE routed expert VMM load failed ({err:#}); falling back to dense expert buffers"
+                );
+                drop(arena);
+                load_all_layer_buffers(
+                    &store,
+                    ordinal,
+                    &geom,
+                    &report.config.text_config,
+                    weight_prefix,
+                    weight_mode,
+                    kv_max_t,
+                    None,
+                )?
+            }
+            Err(err) => return Err(err.context("load Qwen3.6-MoE routed experts into VMM")),
+        }
+    } else {
+        load_all_layer_buffers(
+            &store,
+            ordinal,
+            &geom,
+            &report.config.text_config,
+            weight_prefix,
+            weight_mode,
+            kv_max_t,
+            None,
+        )?
+    };
 
     // Phase 6 self-speculative decode: load the multi-token-prediction
     // (MTP) head from the bake when --speculative-decode is set.
@@ -2553,6 +2720,7 @@ fn decode_first_token(model_dir: &Path, report: &DryRunReport) -> Result<u32> {
             weight_prefix,
             weight_mode,
             0, // legacy single-token path: no KV cache, kv_len=1 fast path.
+            None,
         )
         .with_context(|| format!("load layer {li} weights"))?;
         layers.push(layer);

--- a/crates/runner/src/qwen36_moe_persistent_decode.rs
+++ b/crates/runner/src/qwen36_moe_persistent_decode.rs
@@ -89,11 +89,7 @@ impl PersistentScratch {
     /// `layers` only for descriptor construction (mutable state pointers
     /// are cached into the descs); subsequent [`Self::run`] calls don't
     /// need `&mut layers`.
-    pub fn new(
-        ordinal: usize,
-        geom: &MultiLayerGeom,
-        layers: &mut [LayerBuffers],
-    ) -> Result<Self> {
+    pub fn new(ordinal: usize, geom: &MultiLayerGeom, layers: &mut [LayerBuffers]) -> Result<Self> {
         let num_layers = layers.len();
         let descs = build_layer_descs(layers);
         let layer_descs_dev =
@@ -403,4 +399,101 @@ pub fn upload_descs<T: Sized>(ordinal: usize, descs: &[T]) -> Result<GpuBuffer, 
         bytes.extend_from_slice(unsafe { std::slice::from_raw_parts(p, per) });
     }
     GpuBuffer::from_host_bytes(ordinal, ScalarType::U8, &[bytes.len()], &bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::qwen36_moe_decode::{FfnLayerBuffers, ResidentWeight};
+    use gpu_hal::{Backend, VirtualAllocationRole, VirtualArena, VirtualBacking};
+
+    fn stub_bf16(ordinal: usize) -> Result<GpuBuffer> {
+        Ok(GpuBuffer::zeros(ordinal, ScalarType::BF16, &[1])?)
+    }
+
+    fn stub_u8(ordinal: usize) -> Result<GpuBuffer> {
+        Ok(GpuBuffer::zeros(ordinal, ScalarType::U8, &[1])?)
+    }
+
+    #[test]
+    fn layer_desc_uses_virtual_expert_weight_pointers() {
+        if !gpu_hal::is_backend_compiled(Backend::Hip) {
+            eprintln!("skip: HIP backend not compiled");
+            return;
+        }
+        gpu_hal::set_backend(Backend::Hip);
+        let ordinal = 0usize;
+        if !gpu_hal::vmm_is_supported(Backend::Hip, ordinal) {
+            eprintln!("skip: HIP VMM unsupported on this device/runtime");
+            return;
+        }
+
+        let mut arena = VirtualArena::new(ordinal, VirtualBacking::CpuBackup);
+        let gate_up_id = arena
+            .reserve(
+                "test.gate_up_proj",
+                VirtualAllocationRole::MoeExpert,
+                ScalarType::U8,
+                &[4096],
+            )
+            .expect("reserve virtual gate_up");
+        let down_id = arena
+            .reserve(
+                "test.down_proj",
+                VirtualAllocationRole::MoeExpert,
+                ScalarType::U8,
+                &[4096],
+            )
+            .expect("reserve virtual down");
+        let gate_up_buf = arena.allocation(gate_up_id).unwrap().buffer();
+        let down_buf = arena.allocation(down_id).unwrap().buffer();
+        let gate_up_ptr = gate_up_buf.as_ptr();
+        let down_ptr = down_buf.as_ptr();
+
+        let mut layers = vec![LayerBuffers {
+            attn: AttnLayerBuffers::Linear {
+                input_norm_w: stub_bf16(ordinal).unwrap(),
+                in_proj_qkv_w: stub_u8(ordinal).unwrap(),
+                in_proj_z_w: stub_u8(ordinal).unwrap(),
+                in_proj_a_w: stub_bf16(ordinal).unwrap(),
+                in_proj_b_w: stub_bf16(ordinal).unwrap(),
+                conv1d_w: stub_bf16(ordinal).unwrap(),
+                conv1d_bias: None,
+                dt_bias: stub_bf16(ordinal).unwrap(),
+                a_log: stub_bf16(ordinal).unwrap(),
+                norm_w: stub_bf16(ordinal).unwrap(),
+                out_proj_w: stub_u8(ordinal).unwrap(),
+                conv_state: stub_bf16(ordinal).unwrap(),
+                recurrent_state: GpuBuffer::zeros(ordinal, ScalarType::F32, &[1]).unwrap(),
+                int4: None,
+            },
+            ffn: FfnLayerBuffers {
+                post_attn_norm_w: stub_bf16(ordinal).unwrap(),
+                gate_w: stub_bf16(ordinal).unwrap(),
+                gate_up_proj_w: ResidentWeight::Virtual {
+                    allocation_id: gate_up_id,
+                    ptr: gate_up_ptr,
+                    dtype: gate_up_buf.dtype(),
+                    shape: gate_up_buf.shape().to_vec(),
+                    len_bytes: gate_up_buf.len_bytes(),
+                },
+                down_proj_w: ResidentWeight::Virtual {
+                    allocation_id: down_id,
+                    ptr: down_ptr,
+                    dtype: down_buf.dtype(),
+                    shape: down_buf.shape().to_vec(),
+                    len_bytes: down_buf.len_bytes(),
+                },
+                shared_gate_proj_w: stub_u8(ordinal).unwrap(),
+                shared_up_proj_w: stub_u8(ordinal).unwrap(),
+                shared_down_proj_w: stub_u8(ordinal).unwrap(),
+                shared_expert_gate_w: stub_bf16(ordinal).unwrap(),
+                int4: None,
+            },
+        }];
+
+        let descs = build_layer_descs(&mut layers);
+        assert_eq!(descs[0].experts_gate_up_w, gate_up_ptr);
+        assert_eq!(descs[0].experts_down_w, down_ptr);
+    }
 }

--- a/crates/runner/tests/qwen36_moe_linear_state.rs
+++ b/crates/runner/tests/qwen36_moe_linear_state.rs
@@ -18,6 +18,7 @@ use anyhow::Result;
 use gpu_hal::{copy_d2h, is_backend_compiled, set_backend, Backend, GpuBuffer, ScalarType};
 use runner::qwen36_moe_decode::{
     AttnLayerBuffers, FfnLayerBuffers, FullAttnInt4Sidecars, FullAttnKvCache, LayerBuffers,
+    ResidentWeight,
 };
 use runner::qwen36_moe_state::{
     refresh_linear_attn_state, restore_linear_attn_state, save_linear_attn_state,
@@ -76,8 +77,8 @@ fn make_linear_layer(
         ffn: FfnLayerBuffers {
             post_attn_norm_w: stub_bf16(ordinal)?,
             gate_w: stub_bf16(ordinal)?,
-            gate_up_proj_w: stub_u8(ordinal)?,
-            down_proj_w: stub_u8(ordinal)?,
+            gate_up_proj_w: ResidentWeight::Dense(stub_u8(ordinal)?),
+            down_proj_w: ResidentWeight::Dense(stub_u8(ordinal)?),
             shared_gate_proj_w: stub_u8(ordinal)?,
             shared_up_proj_w: stub_u8(ordinal)?,
             shared_down_proj_w: stub_u8(ordinal)?,
@@ -119,8 +120,8 @@ fn make_full_layer(ordinal: usize) -> Result<LayerBuffers> {
         ffn: FfnLayerBuffers {
             post_attn_norm_w: stub_bf16(ordinal)?,
             gate_w: stub_bf16(ordinal)?,
-            gate_up_proj_w: stub_u8(ordinal)?,
-            down_proj_w: stub_u8(ordinal)?,
+            gate_up_proj_w: ResidentWeight::Dense(stub_u8(ordinal)?),
+            down_proj_w: ResidentWeight::Dense(stub_u8(ordinal)?),
             shared_gate_proj_w: stub_u8(ordinal)?,
             shared_up_proj_w: stub_u8(ordinal)?,
             shared_down_proj_w: stub_u8(ordinal)?,

--- a/crates/runner/tests/qwen36_moe_multilayer_parity.rs
+++ b/crates/runner/tests/qwen36_moe_multilayer_parity.rs
@@ -33,7 +33,7 @@ use gpu_hal::{is_backend_compiled, set_backend, Backend, GpuBuffer, ScalarType};
 use runner::qwen36_moe_decode::{
     bf16_bytes_to_f32, host_final_norm_lm_head, is_full_attn_layer, run_chained_decode,
     AttnLayerBuffers, FfnInt4Sidecars, FfnLayerBuffers, FullAttnInt4Sidecars, LayerBuffers,
-    LinearAttnInt4Sidecars, MultiLayerGeom,
+    LinearAttnInt4Sidecars, MultiLayerGeom, ResidentWeight,
 };
 use runner::qwen36_moe_persistent_decode::PersistentScratch;
 use runner::qwen36_moe_state::{restore_linear_attn_state, save_linear_attn_state};
@@ -415,8 +415,8 @@ fn build_ffn_layer(
             &b64_field(weights, "gate_w"),
             "gate_w",
         ),
-        gate_up_proj_w,
-        down_proj_w,
+        gate_up_proj_w: ResidentWeight::Dense(gate_up_proj_w),
+        down_proj_w: ResidentWeight::Dense(down_proj_w),
         shared_gate_proj_w,
         shared_up_proj_w,
         shared_down_proj_w,

--- a/docs/lowlevel-memory.md
+++ b/docs/lowlevel-memory.md
@@ -34,20 +34,24 @@ Current scope:
   decode, DFlash cloned states, Gemma4, Qwen3.6-MoE decode descriptors, and
   Llama3.1.
 - Baked tensors can now be loaded into `VirtualArena` allocations through
-  `model-store::BakedStore::load_to_virtual_arena`. This is the first real
-  virtual-weight/MoE-island path: it uses the bake mmap as the source of truth,
-  assigns allocation roles (`Weights` or `MoeExpert`), maps stable VMM
-  addresses, and uploads tensor bytes into those mappings. This is not yet a
-  decode-active weight path; existing Qwen3.6-MoE decode descriptors still own
-  and consume dense `GpuBuffer` weights.
+  `model-store::BakedStore::load_to_virtual_arena`. Qwen3.6-MoE INT4 decode
+  auto-uses this path for routed expert slabs on HIP devices with VMM support:
+  descriptors consume stable virtual pointers for `mlp.experts.gate_up_proj`
+  and `mlp.experts.down_proj`, while all pages remain resident for this first
+  decode-active identity milestone. Other weights still use dense
+  `GpuBuffer`s.
 - `SUPERSONIC_VMM_WEIGHT_PROBE=1` makes Qwen3.6-MoE dry-run load
   `lm_head.weight` into a virtual `Weights` allocation when an INT4 bake is
   present.
 - `SUPERSONIC_VMM_MOE_ISLAND_PROBE=1` or
   `SUPERSONIC_VMM_MOE_ISLAND_PROBE_LAYERS=N` makes Qwen3.6-MoE dry-run load
   the first N layers' fused expert slabs into virtual `MoeExpert` allocations
-  and report logical/resident/reserved bytes. This is a residency probe only;
-  decode still uses the existing `GpuBuffer` descriptors.
+  and report logical/resident/reserved bytes without running decode.
+- `SUPERSONIC_VMM_MOE_ISLANDS=0` disables Qwen3.6-MoE decode-active virtual
+  expert slabs. When unset, Qwen3.6-MoE INT4 decode auto-enables them on
+  supported HIP devices and falls back to dense expert buffers if VMM loading
+  fails. `SUPERSONIC_VMM_MOE_ISLANDS=1` makes unsupported or failed VMM expert
+  loading a hard error.
 - `SUPERSONIC_VMM_KV=0` disables the Qwen3.5 integration.
 - `SUPERSONIC_VMM_KV=1` requests it and logs if the backend cannot support it.
 - `SUPERSONIC_VMM_KV_EVICT_AFTER_PREFILL=1` backs virtual KV to host RAM after


### PR DESCRIPTION
## Summary\n- add a ResidentWeight wrapper so Qwen3.6 routed expert slabs can be dense GpuBuffers or VMM VirtualArena allocations\n- auto-enable VMM-backed Qwen3.6 INT4 routed expert slabs on supported HIP devices, with dense fallback unless SUPERSONIC_VMM_MOE_ISLANDS=1 forces the path\n- thread the selected CLI device ordinal into Qwen3.6 live decode and update docs/tests for the decode-active identity milestone\n\n## Validation\n- SUPERSONIC_BACKENDS=hip cargo check -p runner --bin supersonic\n- SUPERSONIC_BACKENDS=hip cargo test -p model-store virtual_arena_ -- --nocapture\n- SUPERSONIC_BACKENDS=hip cargo test -p runner qwen36 -- --nocapture\n- SUPERSONIC_BACKENDS=hip cargo run --release --bin supersonic -- --backend hip --model qwen3.6-35b-a3b --model-dir /mnt/data/models/Qwen3.6-35B-A3B --int4 --prompt "Hello" --max-new-tokens 1\n- SUPERSONIC_BACKENDS=hip SUPERSONIC_VMM_MOE_ISLANDS=0 target/release/supersonic --backend hip --model qwen3.6-35b-a3b --model-dir /mnt/data/models/Qwen3.6-35B-A3B --int4 --prompt "Hello" --max-new-tokens 1\n- SUPERSONIC_BACKENDS=hip SUPERSONIC_FORCE_VMM_UNSUPPORTED=1 target/release/supersonic --backend hip --model qwen3.6-35b-a3b --model-dir /mnt/data/models/Qwen3.6-35B-A3B --int4 --prompt "Hello" --max-new-tokens 1\n- SUPERSONIC_BACKENDS=hip SUPERSONIC_FORCE_VMM_UNSUPPORTED=1 SUPERSONIC_VMM_MOE_ISLANDS=1 target/release/supersonic --backend hip --model qwen3.6-35b-a3b --model-dir /mnt/data/models/Qwen3.6-35B-A3B --int4 --prompt "Hello" --max-new-tokens 1 (expected clear error)