### PR TITLE
Add Qwen3.6 MoE expert residency manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1736,6 +1736,7 @@ dependencies = [
  "safetensors",
  "serde",
  "serde_json",
+ "tempfile",
  "tokenizers",
 ]
 

--- a/crates/gpu-hal/src/vmm.rs
+++ b/crates/gpu-hal/src/vmm.rs
@@ -436,6 +436,60 @@ impl VirtualBuffer {
         self.unmap_all_discard()
     }
 
+    /// Unmap any resident physical mappings that overlap the requested byte
+    /// range, without first copying data to the CPU backup image.
+    ///
+    /// The actual unmapped ranges are VMM-page aligned and may be wider than
+    /// the logical range. Callers that maintain their own backing store should
+    /// treat every returned range as non-resident.
+    pub fn unmap_range_discard(
+        &mut self,
+        offset: usize,
+        len: usize,
+    ) -> Result<Vec<(usize, usize)>> {
+        if len == 0 || self.mappings.is_empty() {
+            return Ok(Vec::new());
+        }
+        let end = offset.checked_add(len).ok_or_else(|| {
+            GpuError::InvalidArg(format!(
+                "virtual unmap range overflows: offset={offset} len={len}"
+            ))
+        })?;
+        if end > self.reserved_bytes {
+            return Err(GpuError::InvalidArg(format!(
+                "virtual unmap range [{offset}, {end}) exceeds reservation {}",
+                self.reserved_bytes
+            )));
+        }
+
+        let aligned_offset = align_down(offset, self.granularity);
+        let aligned_end = align_up(end, self.granularity);
+        ops::sync(self.device_ordinal)?;
+
+        let mut kept = Vec::with_capacity(self.mappings.len());
+        let mut removed = Vec::new();
+        for mapping in self.mappings.drain(..) {
+            let map_end = mapping.offset + mapping.len;
+            if ranges_overlap(mapping.offset, map_end, aligned_offset, aligned_end) {
+                let removed_range = (mapping.offset, mapping.len);
+                hal_profile_time("vmm_unmap", mapping.len, || {
+                    unmap_and_release(self.backend, self.device_ordinal, self.ptr, mapping)
+                })?;
+                removed.push(removed_range);
+            } else {
+                kept.push(mapping);
+            }
+        }
+        self.mappings = kept;
+        self.mapped_bytes = self
+            .mappings
+            .iter()
+            .map(|mapping| mapping.offset + mapping.len)
+            .max()
+            .unwrap_or(0);
+        Ok(removed)
+    }
+
     fn unmap_all_discard(&mut self) -> Result<()> {
         if self.mapped_bytes == 0 && self.mappings.is_empty() {
             return Ok(());
@@ -847,6 +901,10 @@ fn align_up(value: usize, alignment: usize) -> usize {
 fn align_down(value: usize, alignment: usize) -> usize {
     debug_assert!(alignment > 0);
     (value / alignment) * alignment
+}
+
+fn ranges_overlap(a_start: usize, a_end: usize, b_start: usize, b_end: usize) -> bool {
+    a_start < b_end && b_start < a_end
 }
 
 const VMM_BACKUP_COPY_CHUNK_BYTES: usize = usize::MAX;

--- a/crates/model-store/src/store.rs
+++ b/crates/model-store/src/store.rs
@@ -122,6 +122,24 @@ impl BakedStore {
         name: &str,
         role: VirtualAllocationRole,
     ) -> Result<usize, Error> {
+        let id = self.reserve_virtual_arena(arena, name, role)?;
+        let len = self
+            .index
+            .get(name)
+            .ok_or_else(|| Error::NotFound(name.to_string()))?
+            .byte_len as usize;
+        self.load_range_to_virtual_arena(arena, id, name, 0, len)?;
+        Ok(id)
+    }
+
+    /// Reserve a stable virtual address range for one baked tensor without
+    /// making any physical pages resident yet.
+    pub fn reserve_virtual_arena(
+        &self,
+        arena: &mut VirtualArena,
+        name: &str,
+        role: VirtualAllocationRole,
+    ) -> Result<usize, Error> {
         let meta = self
             .index
             .get(name)
@@ -159,21 +177,72 @@ impl BakedStore {
                 expected_len,
             )));
         }
+        arena
+            .reserve(name.to_string(), role, dtype, &meta.shape)
+            .map_err(Error::from)
+    }
+
+    /// Upload a byte range from a baked tensor into an existing virtual
+    /// allocation. The allocation must have been reserved from the same tensor.
+    pub fn load_range_to_virtual_arena(
+        &self,
+        arena: &mut VirtualArena,
+        allocation_id: usize,
+        name: &str,
+        byte_offset: usize,
+        byte_len: usize,
+    ) -> Result<(), Error> {
+        let meta = self
+            .index
+            .get(name)
+            .ok_or_else(|| Error::NotFound(name.to_string()))?;
+        let tensor_end = (meta.offset as usize)
+            .checked_add(meta.byte_len as usize)
+            .ok_or_else(|| {
+                Error::Other(format!(
+                    "tensor '{name}' byte range overflows (offset={}, len={})",
+                    meta.offset, meta.byte_len
+                ))
+            })?;
+        if tensor_end > self.data_len {
+            return Err(Error::Other(format!(
+                "tensor '{}' extends past end of weights.bin (offset={}, len={}, file_len={})",
+                name, meta.offset, meta.byte_len, self.data_len,
+            )));
+        }
+        let range_end = byte_offset.checked_add(byte_len).ok_or_else(|| {
+            Error::Other(format!(
+                "tensor '{name}' load range overflows: offset={byte_offset} len={byte_len}"
+            ))
+        })?;
+        if range_end > meta.byte_len as usize {
+            return Err(Error::Other(format!(
+                "tensor '{name}' load range [{byte_offset}, {range_end}) exceeds byte_len={}",
+                meta.byte_len
+            )));
+        }
+
+        let dtype = parse_dtype(&meta.dtype)?;
         let ordinal = arena.device_ordinal();
-        let id = arena.reserve(name.to_string(), role, dtype, &meta.shape)?;
-        let allocation = arena
-            .allocation_mut(id)
-            .ok_or_else(|| Error::Other(format!("virtual allocation id {id} disappeared")))?;
+        let allocation = arena.allocation_mut(allocation_id).ok_or_else(|| {
+            Error::Other(format!("virtual allocation id {allocation_id} missing"))
+        })?;
         let buffer = allocation.buffer_mut();
-        buffer.map_prefix_bytes(buffer.len_bytes())?;
-        copy_h2d(
-            ordinal,
-            buffer.as_mut_ptr(),
-            slice.as_ptr() as *const _,
-            slice.len(),
-        )?;
+        if buffer.dtype() != dtype || buffer.shape() != meta.shape.as_slice() {
+            return Err(Error::Other(format!(
+                "virtual allocation id {allocation_id} does not match tensor '{name}' \
+                 (allocation dtype={:?} shape={:?}, tensor dtype={} shape={:?})",
+                buffer.dtype(),
+                buffer.shape(),
+                meta.dtype,
+                meta.shape
+            )));
+        }
+        buffer.map_range_bytes(byte_offset, byte_len)?;
+        let src = unsafe { self.data.add(meta.offset as usize).add(byte_offset) as *const _ };
+        copy_h2d(ordinal, buffer.offset_mut_ptr(byte_offset), src, byte_len)?;
         sync(ordinal)?;
-        Ok(id)
+        Ok(())
     }
 
     /// Convenience constructor for a virtual arena using this store's common

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -90,3 +90,6 @@ base64 = "0.22"
 half = "2.4"
 safetensors = "0.5"
 memmap2 = "0.9"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/runner/src/lib.rs
+++ b/crates/runner/src/lib.rs
@@ -19,6 +19,7 @@ pub mod prefill_engine;
 pub mod qwen36_moe_decode;
 pub mod qwen36_moe_mtp;
 pub mod qwen36_moe_persistent_decode;
+pub mod qwen36_moe_residency;
 pub mod qwen36_moe_speculative;
 pub mod qwen36_moe_state;
 pub mod registry;

--- a/crates/runner/src/qwen36_moe_residency.rs
+++ b/crates/runner/src/qwen36_moe_residency.rs
@@ -1,0 +1,541 @@
+//! Sparse VMM residency policy for Qwen3.6-MoE routed expert slabs.
+//!
+//! The decode descriptors need stable base pointers for the fused
+//! `experts.gate_up_proj` and `experts.down_proj` tensors. This manager
+//! reserves those full virtual address ranges up front, but only uploads and
+//! maps the expert slices that are explicitly pinned resident.
+
+use std::collections::HashMap;
+use std::ffi::c_void;
+
+use anyhow::{anyhow, Context, Result};
+use gpu_hal::{ScalarType, VirtualAllocationRole, VirtualArena, VirtualBacking};
+use model_store::BakedStore;
+
+use crate::qwen36_moe_decode::ResidentWeight;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MoeExpertProjection {
+    GateUp,
+    Down,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct MoeExpertKey {
+    pub layer_idx: usize,
+    pub expert_idx: usize,
+    pub projection: MoeExpertProjection,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MoeExpertResidencyConfig {
+    /// Maximum number of logical expert slices marked resident at once.
+    ///
+    /// HIP maps at the VMM page granularity, so resident physical bytes can be
+    /// wider than this logical count implies. The policy tracks the logical
+    /// slices because the router naturally speaks in `(layer, expert)` terms.
+    pub max_resident_slices: usize,
+}
+
+impl MoeExpertResidencyConfig {
+    pub fn new(max_resident_slices: usize) -> Result<Self> {
+        if max_resident_slices == 0 {
+            return Err(anyhow!("max_resident_slices must be > 0"));
+        }
+        Ok(Self {
+            max_resident_slices,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct MoeExpertResidencyStats {
+    pub registered_tensors: usize,
+    pub resident_slices: usize,
+    pub hits: u64,
+    pub misses: u64,
+    pub evicted_slices: u64,
+    pub uploaded_bytes: usize,
+    pub unmapped_bytes: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct MoeExpertTensorReservation {
+    pub allocation_id: usize,
+    pub ptr: *const c_void,
+    pub dtype: ScalarType,
+    pub shape: Vec<usize>,
+    pub len_bytes: usize,
+    pub expert_count: usize,
+    pub expert_bytes: usize,
+}
+
+#[derive(Debug, Clone)]
+struct ExpertTensor {
+    name: String,
+    allocation_id: usize,
+    ptr: *const c_void,
+    dtype: ScalarType,
+    shape: Vec<usize>,
+    len_bytes: usize,
+    expert_count: usize,
+    expert_bytes: usize,
+    page_bytes: usize,
+}
+
+#[derive(Debug, Clone)]
+struct ResidentSlice {
+    tensor_idx: usize,
+    logical_offset: usize,
+    logical_len: usize,
+    page_offset: usize,
+    page_len: usize,
+    last_used: u64,
+}
+
+pub struct MoeExpertResidencyManager {
+    arena: VirtualArena,
+    config: MoeExpertResidencyConfig,
+    tensors: Vec<ExpertTensor>,
+    tensor_by_layer_projection: HashMap<(usize, MoeExpertProjection), usize>,
+    resident: HashMap<MoeExpertKey, ResidentSlice>,
+    clock: u64,
+    hits: u64,
+    misses: u64,
+    evicted_slices: u64,
+    uploaded_bytes: usize,
+    unmapped_bytes: usize,
+}
+
+impl MoeExpertResidencyManager {
+    pub fn new(device_ordinal: usize, config: MoeExpertResidencyConfig) -> Self {
+        Self {
+            arena: VirtualArena::new(device_ordinal, VirtualBacking::Discard),
+            config,
+            tensors: Vec::new(),
+            tensor_by_layer_projection: HashMap::new(),
+            resident: HashMap::new(),
+            clock: 0,
+            hits: 0,
+            misses: 0,
+            evicted_slices: 0,
+            uploaded_bytes: 0,
+            unmapped_bytes: 0,
+        }
+    }
+
+    pub fn arena(&self) -> &VirtualArena {
+        &self.arena
+    }
+
+    pub fn arena_mut(&mut self) -> &mut VirtualArena {
+        &mut self.arena
+    }
+
+    pub fn stats(&self) -> MoeExpertResidencyStats {
+        MoeExpertResidencyStats {
+            registered_tensors: self.tensors.len(),
+            resident_slices: self.resident.len(),
+            hits: self.hits,
+            misses: self.misses,
+            evicted_slices: self.evicted_slices,
+            uploaded_bytes: self.uploaded_bytes,
+            unmapped_bytes: self.unmapped_bytes,
+        }
+    }
+
+    pub fn register_tensor(
+        &mut self,
+        store: &BakedStore,
+        layer_idx: usize,
+        projection: MoeExpertProjection,
+        name: &str,
+        expert_count: usize,
+    ) -> Result<MoeExpertTensorReservation> {
+        if expert_count == 0 {
+            return Err(anyhow!("expert_count must be > 0 for {name}"));
+        }
+        if self
+            .tensor_by_layer_projection
+            .contains_key(&(layer_idx, projection))
+        {
+            return Err(anyhow!(
+                "duplicate MoE expert tensor registration for layer {layer_idx} {projection:?}"
+            ));
+        }
+
+        let allocation_id = store
+            .reserve_virtual_arena(&mut self.arena, name, VirtualAllocationRole::MoeExpert)
+            .with_context(|| format!("reserve virtual MoE expert tensor {name}"))?;
+        let allocation = self
+            .arena
+            .allocation(allocation_id)
+            .ok_or_else(|| anyhow!("virtual allocation id {allocation_id} missing"))?;
+        let buffer = allocation.buffer();
+        let len_bytes = buffer.len_bytes();
+        if len_bytes % expert_count != 0 {
+            return Err(anyhow!(
+                "MoE expert tensor {name} has {len_bytes} bytes, not divisible by {expert_count} experts"
+            ));
+        }
+
+        let tensor = ExpertTensor {
+            name: name.to_string(),
+            allocation_id,
+            ptr: buffer.as_ptr(),
+            dtype: buffer.dtype(),
+            shape: buffer.shape().to_vec(),
+            len_bytes,
+            expert_count,
+            expert_bytes: len_bytes / expert_count,
+            page_bytes: buffer.granularity(),
+        };
+        let reservation = tensor.reservation();
+        let tensor_idx = self.tensors.len();
+        self.tensors.push(tensor);
+        self.tensor_by_layer_projection
+            .insert((layer_idx, projection), tensor_idx);
+        Ok(reservation)
+    }
+
+    pub fn resident_weight(
+        &self,
+        layer_idx: usize,
+        projection: MoeExpertProjection,
+    ) -> Result<ResidentWeight> {
+        let tensor = self.tensor(layer_idx, projection)?;
+        Ok(ResidentWeight::Virtual {
+            allocation_id: tensor.allocation_id,
+            ptr: tensor.ptr,
+            dtype: tensor.dtype,
+            shape: tensor.shape.clone(),
+            len_bytes: tensor.len_bytes,
+        })
+    }
+
+    pub fn is_resident(&self, key: MoeExpertKey) -> bool {
+        self.resident.contains_key(&key)
+    }
+
+    pub fn ensure_resident(&mut self, store: &BakedStore, key: MoeExpertKey) -> Result<()> {
+        let tensor_idx = self.tensor_idx(key.layer_idx, key.projection)?;
+        let (name, allocation_id, logical_offset, logical_len, page_offset, page_len) = {
+            let tensor = &self.tensors[tensor_idx];
+            if key.expert_idx >= tensor.expert_count {
+                return Err(anyhow!(
+                    "expert {} out of range for layer {} {:?} (expert_count={})",
+                    key.expert_idx,
+                    key.layer_idx,
+                    key.projection,
+                    tensor.expert_count
+                ));
+            }
+            let logical_offset = key.expert_idx * tensor.expert_bytes;
+            let logical_len = tensor.expert_bytes;
+            let (page_offset, page_len) =
+                page_range(tensor.page_bytes, logical_offset, logical_len);
+            (
+                tensor.name.clone(),
+                tensor.allocation_id,
+                logical_offset,
+                logical_len,
+                page_offset,
+                page_len,
+            )
+        };
+
+        self.clock += 1;
+        if let Some(entry) = self.resident.get_mut(&key) {
+            entry.last_used = self.clock;
+            self.hits += 1;
+            return Ok(());
+        }
+
+        self.misses += 1;
+        while self.resident.len() >= self.config.max_resident_slices {
+            self.evict_lru_slice()?;
+        }
+
+        store
+            .load_range_to_virtual_arena(
+                &mut self.arena,
+                allocation_id,
+                &name,
+                logical_offset,
+                logical_len,
+            )
+            .with_context(|| {
+                format!(
+                    "load MoE expert slice layer={} expert={} projection={:?}",
+                    key.layer_idx, key.expert_idx, key.projection
+                )
+            })?;
+        self.uploaded_bytes += logical_len;
+        self.resident.insert(
+            key,
+            ResidentSlice {
+                tensor_idx,
+                logical_offset,
+                logical_len,
+                page_offset,
+                page_len,
+                last_used: self.clock,
+            },
+        );
+        Ok(())
+    }
+
+    fn evict_lru_slice(&mut self) -> Result<()> {
+        let Some((victim, entry)) = self
+            .resident
+            .iter()
+            .min_by_key(|(_, entry)| entry.last_used)
+            .map(|(key, entry)| (*key, entry.clone()))
+        else {
+            return Ok(());
+        };
+
+        let tensor = &self.tensors[entry.tensor_idx];
+        let allocation = self
+            .arena
+            .allocation_mut(tensor.allocation_id)
+            .ok_or_else(|| anyhow!("virtual allocation id {} missing", tensor.allocation_id))?;
+        let removed_ranges = allocation
+            .buffer_mut()
+            .unmap_range_discard(entry.logical_offset, entry.logical_len)
+            .with_context(|| {
+                format!(
+                    "evict MoE expert slice layer={} expert={} projection={:?}",
+                    victim.layer_idx, victim.expert_idx, victim.projection
+                )
+            })?;
+        self.unmapped_bytes += removed_ranges.iter().map(|(_, len)| *len).sum::<usize>();
+        if removed_ranges.is_empty() {
+            self.resident.remove(&victim);
+            self.evicted_slices += 1;
+            return Ok(());
+        }
+
+        let before = self.resident.len();
+        self.resident.retain(|_, resident| {
+            resident.tensor_idx != entry.tensor_idx
+                || !removed_ranges.iter().any(|(offset, len)| {
+                    ranges_overlap(
+                        resident.page_offset,
+                        resident.page_offset + resident.page_len,
+                        *offset,
+                        *offset + *len,
+                    )
+                })
+        });
+        self.evicted_slices += (before - self.resident.len()) as u64;
+        Ok(())
+    }
+
+    fn tensor(&self, layer_idx: usize, projection: MoeExpertProjection) -> Result<&ExpertTensor> {
+        let idx = self.tensor_idx(layer_idx, projection)?;
+        Ok(&self.tensors[idx])
+    }
+
+    fn tensor_idx(&self, layer_idx: usize, projection: MoeExpertProjection) -> Result<usize> {
+        self.tensor_by_layer_projection
+            .get(&(layer_idx, projection))
+            .copied()
+            .ok_or_else(|| {
+                anyhow!("no MoE expert tensor registered for layer {layer_idx} {projection:?}")
+            })
+    }
+}
+
+impl ExpertTensor {
+    fn reservation(&self) -> MoeExpertTensorReservation {
+        MoeExpertTensorReservation {
+            allocation_id: self.allocation_id,
+            ptr: self.ptr,
+            dtype: self.dtype,
+            shape: self.shape.clone(),
+            len_bytes: self.len_bytes,
+            expert_count: self.expert_count,
+            expert_bytes: self.expert_bytes,
+        }
+    }
+}
+
+fn page_range(page_bytes: usize, offset: usize, len: usize) -> (usize, usize) {
+    let end = offset + len;
+    let page_start = offset / page_bytes * page_bytes;
+    let page_end = end.div_ceil(page_bytes) * page_bytes;
+    (page_start, page_end - page_start)
+}
+
+fn ranges_overlap(a_start: usize, a_end: usize, b_start: usize, b_end: usize) -> bool {
+    a_start < b_end && b_start < a_end
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gpu_hal::{Backend, VirtualAllocationRole};
+    use model_store::manifest::{LayoutTag, Manifest, TensorMeta, FORMAT_VERSION};
+
+    fn synthetic_store(expert_count: usize, expert_bytes: usize) -> tempfile::TempDir {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let bake_dir = tmp.path();
+        let total_bytes = expert_count * expert_bytes;
+        let mut weights = vec![0u8; total_bytes];
+        for expert in 0..expert_count {
+            let fill = (expert as u8).wrapping_add(1);
+            weights[expert * expert_bytes..(expert + 1) * expert_bytes].fill(fill);
+        }
+        std::fs::write(model_store::weights_bin_path(bake_dir), &weights)
+            .expect("write weights.bin");
+        let manifest = Manifest {
+            format_version: FORMAT_VERSION,
+            converter_version: 1,
+            model_family: "test-qwen36-moe".to_string(),
+            quant_profile: None,
+            source_format: None,
+            source_quant: None,
+            tensors: vec![TensorMeta {
+                name: "model.layers.0.mlp.experts.gate_up_proj".to_string(),
+                shape: vec![total_bytes],
+                dtype: "u8".to_string(),
+                layout: LayoutTag::Int4Quantized,
+                offset: 0,
+                byte_len: total_bytes as u64,
+            }],
+        };
+        std::fs::write(
+            model_store::manifest_path(bake_dir),
+            serde_json::to_string(&manifest).expect("serialize manifest"),
+        )
+        .expect("write manifest");
+        tmp
+    }
+
+    fn require_hip_vmm() -> bool {
+        gpu_hal::set_backend(Backend::Hip);
+        if !gpu_hal::vmm_is_supported(Backend::Hip, 0) {
+            eprintln!("skip: HIP VMM unsupported on this device/runtime");
+            return false;
+        }
+        true
+    }
+
+    #[test]
+    fn reserves_expert_slab_without_resident_pages() {
+        if !require_hip_vmm() {
+            return;
+        }
+        let tmp = synthetic_store(4, 4096);
+        let store = BakedStore::open(tmp.path()).expect("open synthetic store");
+        let mut manager =
+            MoeExpertResidencyManager::new(0, MoeExpertResidencyConfig::new(2).unwrap());
+        let reservation = manager
+            .register_tensor(
+                &store,
+                0,
+                MoeExpertProjection::GateUp,
+                "model.layers.0.mlp.experts.gate_up_proj",
+                4,
+            )
+            .expect("register tensor");
+
+        assert_eq!(reservation.expert_count, 4);
+        assert_eq!(reservation.expert_bytes, 4096);
+        let arena_stats = manager.arena().stats();
+        assert_eq!(arena_stats.allocations, 1);
+        assert_eq!(arena_stats.logical_bytes, 16 * 1024);
+        assert_eq!(arena_stats.logical_resident_bytes, 0);
+        assert_eq!(arena_stats.mapping_count, 0);
+    }
+
+    #[test]
+    fn lru_eviction_invalidates_page_overlapping_slices() {
+        if !require_hip_vmm() {
+            return;
+        }
+        let tmp = synthetic_store(4, 4096);
+        let store = BakedStore::open(tmp.path()).expect("open synthetic store");
+        let mut manager =
+            MoeExpertResidencyManager::new(0, MoeExpertResidencyConfig::new(1).unwrap());
+        manager
+            .register_tensor(
+                &store,
+                0,
+                MoeExpertProjection::GateUp,
+                "model.layers.0.mlp.experts.gate_up_proj",
+                4,
+            )
+            .expect("register tensor");
+
+        let e0 = MoeExpertKey {
+            layer_idx: 0,
+            expert_idx: 0,
+            projection: MoeExpertProjection::GateUp,
+        };
+        let e1 = MoeExpertKey {
+            layer_idx: 0,
+            expert_idx: 1,
+            projection: MoeExpertProjection::GateUp,
+        };
+        manager.ensure_resident(&store, e0).expect("load expert 0");
+        assert!(manager.is_resident(e0));
+        assert_eq!(manager.stats().resident_slices, 1);
+
+        manager.ensure_resident(&store, e1).expect("load expert 1");
+        assert!(!manager.is_resident(e0));
+        assert!(manager.is_resident(e1));
+        assert_eq!(manager.stats().resident_slices, 1);
+        assert_eq!(manager.stats().misses, 2);
+        assert_eq!(manager.stats().evicted_slices, 1);
+
+        let allocation_id = manager
+            .resident_weight(0, MoeExpertProjection::GateUp)
+            .expect("resident weight")
+            .allocation_id()
+            .expect("virtual allocation");
+        let bytes = manager
+            .arena()
+            .allocation(allocation_id)
+            .expect("allocation")
+            .buffer()
+            .to_host_range_bytes(4096, 4096)
+            .expect("read expert 1");
+        assert!(bytes.iter().all(|b| *b == 2));
+    }
+
+    #[test]
+    fn store_range_upload_keeps_stable_virtual_pointer() {
+        if !require_hip_vmm() {
+            return;
+        }
+        let tmp = synthetic_store(2, 4096);
+        let store = BakedStore::open(tmp.path()).expect("open synthetic store");
+        let mut arena = VirtualArena::new(0, VirtualBacking::Discard);
+        let id = store
+            .reserve_virtual_arena(
+                &mut arena,
+                "model.layers.0.mlp.experts.gate_up_proj",
+                VirtualAllocationRole::MoeExpert,
+            )
+            .expect("reserve tensor");
+        let ptr = arena.allocation(id).expect("allocation").buffer().as_ptr();
+        store
+            .load_range_to_virtual_arena(
+                &mut arena,
+                id,
+                "model.layers.0.mlp.experts.gate_up_proj",
+                4096,
+                4096,
+            )
+            .expect("upload expert 1");
+        let allocation = arena.allocation(id).expect("allocation after upload");
+        assert_eq!(allocation.buffer().as_ptr(), ptr);
+        let bytes = allocation
+            .buffer()
+            .to_host_range_bytes(4096, 4096)
+            .expect("read expert 1");
+        assert!(bytes.iter().all(|b| *b == 2));
+    }
+}

--- a/docs/lowlevel-memory.md
+++ b/docs/lowlevel-memory.md
@@ -29,17 +29,22 @@ by allocation role.
 
 Current scope:
 
-- Decode-active VMM is enabled internally for Qwen3.5 BF16 dense KV only.
+- Decode-active VMM is enabled internally for Qwen3.5 BF16 dense KV and for
+  Qwen3.6-MoE INT4 routed expert slabs when the VMM expert mode is active.
 - Disabled for FP8-KV, certified-KV, batch decode, Qwen3.5 4B/component
-  decode, DFlash cloned states, Gemma4, Qwen3.6-MoE decode descriptors, and
-  Llama3.1.
+  decode, DFlash cloned states, Gemma4, and Llama3.1.
 - Baked tensors can now be loaded into `VirtualArena` allocations through
-  `model-store::BakedStore::load_to_virtual_arena`. Qwen3.6-MoE INT4 decode
-  auto-uses this path for routed expert slabs on HIP devices with VMM support:
-  descriptors consume stable virtual pointers for `mlp.experts.gate_up_proj`
-  and `mlp.experts.down_proj`, while all pages remain resident for this first
-  decode-active identity milestone. Other weights still use dense
-  `GpuBuffer`s.
+  `model-store::BakedStore::load_to_virtual_arena`. `BakedStore` also exposes
+  split reserve/upload APIs so a tensor can reserve a stable virtual base while
+  only selected byte ranges are made resident.
+- Qwen3.6-MoE has a sparse routed-expert residency manager in
+  `runner::qwen36_moe_residency`. It reserves the fused
+  `mlp.experts.gate_up_proj` / `mlp.experts.down_proj` slabs, pins individual
+  `(layer, expert, projection)` slices from the mmap-backed bake, evicts with a
+  bounded LRU policy, and invalidates every resident slice covered by an
+  unmapped VMM page. This is the foundation for router-driven MoE islands; the
+  current decode path still maps all routed expert slabs when
+  `SUPERSONIC_VMM_MOE_ISLANDS` is active.
 - `SUPERSONIC_VMM_WEIGHT_PROBE=1` makes Qwen3.6-MoE dry-run load
   `lm_head.weight` into a virtual `Weights` allocation when an INT4 bake is
   present.
@@ -80,6 +85,8 @@ The branch was validated on HIP/gfx1100 with ROCm VMM support:
   `SUPERSONIC_BACKENDS=hip cargo test -p gpu-hal --test vmm_round_trip vmm_arena_ -- --nocapture`
 - Baked tensor VMM upload test:
   `SUPERSONIC_BACKENDS=hip cargo test -p model-store virtual_arena_loads_baked_weight_and_expert_tensors -- --nocapture`
+- Qwen3.6-MoE sparse residency manager tests:
+  `SUPERSONIC_BACKENDS=hip cargo test -p runner qwen36_moe_residency -- --nocapture`
 - Qwen3.5 virtual KV e2e with eviction and restore-to-VMM:
   `SUPERSONIC_VMM_KV=1 SUPERSONIC_VMM_KV_EVICT_AFTER_PREFILL=1 SUPERSONIC_VMM_KV_RESTORE_TO_VMM=1 ... --validate`
   passed and kept stable VMM pointers through decode.


### PR DESCRIPTION
## Summary\n- add a sparse Qwen3.6-MoE routed-expert residency manager with stable VMM slab reservations, per-expert range uploads, LRU eviction, and page-overlap invalidation\n- split model-store virtual tensor loading into reserve-only and range-upload APIs while preserving the existing full-load API\n- add HAL range unmap support for discard-backed residency policies\n- document the new sparse MoE-islands foundation\n\n## Validation\n- `SUPERSONIC_BACKENDS=hip cargo check -p runner --lib -p model-store -p gpu-hal`\n- `SUPERSONIC_BACKENDS=hip cargo test -p runner qwen36_moe_residency -- --nocapture`\n- `SUPERSONIC_BACKENDS=hip cargo test -p model-store virtual_arena -- --nocapture`\n- `SUPERSONIC_BACKENDS=hip cargo check -p runner --bin supersonic`