### PR TITLE
Prefetch Qwen3.6 MoE expert islands from router top-k

### DIFF
--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -13,6 +13,7 @@ mod qwen36_moe_decode;
 mod qwen36_moe_engine;
 mod qwen36_moe_mtp;
 mod qwen36_moe_persistent_decode;
+mod qwen36_moe_residency;
 mod qwen36_moe_speculative;
 mod qwen36_moe_state;
 mod registry;

--- a/crates/runner/src/qwen36_moe_decode.rs
+++ b/crates/runner/src/qwen36_moe_decode.rs
@@ -565,6 +565,34 @@ pub fn run_chained_decode_fast(
     )
 }
 
+pub type ExpertPrefetchCallback<'a> = dyn FnMut(usize, &[usize]) -> Result<()> + 'a;
+
+/// Production chained decode with a host-side hook between router top-k and
+/// routed expert GEMVs. The hook is intended for sparse VMM MoE residency:
+/// stage 1 computes top-k indices, the callback pins those expert slices, and
+/// the normal stage-5 FFN launch then consumes the same stable expert pointers.
+pub fn run_chained_decode_fast_with_expert_prefetch(
+    ordinal: usize,
+    geom: &MultiLayerGeom,
+    layers: &mut [LayerBuffers],
+    initial_hidden_bytes: &[u8],
+    position: i32,
+    accurate_stage_timings: bool,
+    expert_prefetch: &mut ExpertPrefetchCallback<'_>,
+) -> Result<DecodeOutputs> {
+    let mut options = ChainedDecodeOptions::from_env();
+    options.accurate_stage_timings = accurate_stage_timings;
+    run_chained_decode_impl(
+        ordinal,
+        geom,
+        layers,
+        initial_hidden_bytes,
+        position,
+        options,
+        Some(expert_prefetch),
+    )
+}
+
 pub fn run_chained_decode_with_options(
     ordinal: usize,
     geom: &MultiLayerGeom,
@@ -572,6 +600,26 @@ pub fn run_chained_decode_with_options(
     initial_hidden_bytes: &[u8],
     position: i32,
     options: ChainedDecodeOptions,
+) -> Result<DecodeOutputs> {
+    run_chained_decode_impl(
+        ordinal,
+        geom,
+        layers,
+        initial_hidden_bytes,
+        position,
+        options,
+        None,
+    )
+}
+
+fn run_chained_decode_impl(
+    ordinal: usize,
+    geom: &MultiLayerGeom,
+    layers: &mut [LayerBuffers],
+    initial_hidden_bytes: &[u8],
+    position: i32,
+    options: ChainedDecodeOptions,
+    mut expert_prefetch: Option<&mut ExpertPrefetchCallback<'_>>,
 ) -> Result<DecodeOutputs> {
     let hidden = geom.hidden as usize;
     if initial_hidden_bytes.len() != hidden * 2 {
@@ -911,7 +959,7 @@ pub fn run_chained_decode_with_options(
         };
 
         let ffn = &layer.ffn;
-        let params = Qwen36MoeFfnStepParams {
+        let params_stage5 = Qwen36MoeFfnStepParams {
             stage: 5,
             hidden: geom.hidden,
             num_experts: geom.num_experts,
@@ -970,11 +1018,42 @@ pub fn run_chained_decode_with_options(
             }
             None => Qwen36MoeFfnStepInt4::disabled(),
         };
+        if let Some(prefetch) = expert_prefetch.as_mut() {
+            let params_stage1 = Qwen36MoeFfnStepParams {
+                stage: 1,
+                ..params_stage5
+            };
+            let t_router = std::time::Instant::now();
+            ffn_step_launch(
+                ordinal,
+                ScalarType::BF16,
+                params_stage1,
+                &ffn_weights,
+                &ffn_int4_ptrs,
+                &mut ffn_output,
+                &mut ffn_output_idx,
+                &mut ffn_workspace,
+                &mut sync_buf,
+            )
+            .with_context(|| format!("ffn_step_launch router prefetch (layer {layer_idx})"))?;
+            if options.accurate_stage_timings {
+                gpu_hal::sync(ordinal)
+                    .context("sync_after_ffn_router_prefetch (accurate_stage_timings)")?;
+            }
+            t_ffn += t_router.elapsed();
+
+            let topk = download_topk_indices(&ffn_output_idx, geom.top_k as usize)
+                .with_context(|| format!("download FFN top-k indices (layer {layer_idx})"))?;
+            prefetch(layer_idx, &topk)
+                .with_context(|| format!("prefetch routed experts (layer {layer_idx})"))?;
+            reset_sync_buf(ordinal, &mut sync_buf)
+                .context("reset sync_buf (ffn after prefetch)")?;
+        }
         let t_k = std::time::Instant::now();
         ffn_step_launch(
             ordinal,
             ScalarType::BF16,
-            params,
+            params_stage5,
             &ffn_weights,
             &ffn_int4_ptrs,
             &mut ffn_output,
@@ -1026,6 +1105,24 @@ pub fn run_chained_decode_with_options(
         kernel_linear_attn_us: t_linear_attn.as_micros() as u64,
         kernel_ffn_us: t_ffn.as_micros() as u64,
     })
+}
+
+fn download_topk_indices(buf: &GpuBuffer, top_k: usize) -> Result<Vec<usize>> {
+    let bytes = buf.to_host_bytes().context("d2h top-k indices")?;
+    let needed = top_k * std::mem::size_of::<u32>();
+    if bytes.len() < needed {
+        return Err(anyhow!(
+            "top-k index buffer has {} bytes, need {needed}",
+            bytes.len()
+        ));
+    }
+    Ok(bytes[..needed]
+        .chunks_exact(4)
+        .map(|chunk| {
+            let raw = u32::from_ne_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+            raw as usize
+        })
+        .collect())
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -27,9 +27,13 @@ use qwen36_moe::weights::{
 
 use crate::qwen36_moe_decode::{
     argmax_bf16_logits, dequant_int4_to_bf16_bytes, host_final_norm_lm_head, run_chained_decode,
-    run_chained_decode_fast, sample_bf16_logits, AttnLayerBuffers, FfnInt4Sidecars,
-    FfnLayerBuffers, FullAttnInt4Sidecars, FullAttnKvCache, LayerBuffers, LinearAttnInt4Sidecars,
-    MtpLayerBuffers, MultiLayerGeom, ResidentWeight, XorshiftRng,
+    run_chained_decode_fast, run_chained_decode_fast_with_expert_prefetch, sample_bf16_logits,
+    AttnLayerBuffers, FfnInt4Sidecars, FfnLayerBuffers, FullAttnInt4Sidecars, FullAttnKvCache,
+    LayerBuffers, LinearAttnInt4Sidecars, MtpLayerBuffers, MultiLayerGeom, ResidentWeight,
+    XorshiftRng,
+};
+use crate::qwen36_moe_residency::{
+    MoeExpertKey, MoeExpertProjection, MoeExpertResidencyConfig, MoeExpertResidencyManager,
 };
 use crate::qwen36_moe_speculative::{
     run_speculative_decode_step, run_speculative_decode_step_batched,
@@ -968,6 +972,29 @@ fn load_to_virtual_resident_weight(
     })
 }
 
+fn load_to_sparse_resident_weight(
+    store: &BakedStore,
+    manager: &mut MoeExpertResidencyManager,
+    layer_idx: usize,
+    projection: MoeExpertProjection,
+    name: &str,
+    expert_count: usize,
+) -> Result<ResidentWeight> {
+    let resolved = resolve_qwen36_store_name(store, name);
+    manager
+        .register_tensor(
+            store,
+            layer_idx,
+            projection,
+            resolved.as_ref(),
+            expert_count,
+        )
+        .with_context(|| format!("reserve sparse MoE expert tensor {name}"))?;
+    manager
+        .resident_weight(layer_idx, projection)
+        .with_context(|| format!("build sparse resident weight for {name}"))
+}
+
 fn store_contains_qwen36(store: &BakedStore, name: &str) -> bool {
     store.contains(resolve_qwen36_store_name(store, name).as_ref())
 }
@@ -1025,6 +1052,19 @@ impl MoeExpertVmmMode {
     }
 }
 
+fn moe_island_cap_experts_from_env() -> Result<Option<usize>> {
+    let Some(raw) = std::env::var("SUPERSONIC_MOE_ISLAND_CAP_EXPERTS").ok() else {
+        return Ok(None);
+    };
+    let cap = raw.parse::<usize>().with_context(|| {
+        format!("parse SUPERSONIC_MOE_ISLAND_CAP_EXPERTS={raw:?} as positive integer")
+    })?;
+    if cap == 0 {
+        anyhow::bail!("SUPERSONIC_MOE_ISLAND_CAP_EXPERTS must be > 0");
+    }
+    Ok(Some(cap))
+}
+
 /// Build one layer's worth of GPU-resident weight + state buffers from a
 /// BakedStore. Decides full-attn vs linear-attn by consulting the config's
 /// `layer_types` (every 4th layer is full per the standard hybrid pattern).
@@ -1050,6 +1090,7 @@ fn load_layer_buffers(
     // kernel falls back to kv_len=1 (back-compat for the parity test).
     kv_max_t: usize,
     mut expert_arena: Option<&mut VirtualArena>,
+    mut expert_residency: Option<&mut MoeExpertResidencyManager>,
 ) -> Result<LayerBuffers> {
     let lp = format!("{weight_prefix}.layers.{layer_idx}");
 
@@ -1336,21 +1377,47 @@ fn load_layer_buffers(
         gate_w: load_to_gpu(store, ordinal, &format!("{mp}.gate.weight"))?,
         // Note: experts.gate_up_proj / experts.down_proj have NO `.weight`
         // suffix in the published checkpoint — see expected_tensor_specs.
-        gate_up_proj_w: match expert_arena.as_mut() {
-            Some(arena) => load_to_virtual_resident_weight(
+        gate_up_proj_w: if let Some(manager) = expert_residency.as_mut() {
+            load_to_sparse_resident_weight(
                 store,
-                &mut **arena,
+                &mut **manager,
+                layer_idx,
+                MoeExpertProjection::GateUp,
                 &format!("{mp}.experts.gate_up_proj"),
-            )?,
-            None => load_to_resident_weight(store, ordinal, &format!("{mp}.experts.gate_up_proj"))?,
+                geom.num_experts as usize,
+            )?
+        } else {
+            match expert_arena.as_mut() {
+                Some(arena) => load_to_virtual_resident_weight(
+                    store,
+                    &mut **arena,
+                    &format!("{mp}.experts.gate_up_proj"),
+                )?,
+                None => {
+                    load_to_resident_weight(store, ordinal, &format!("{mp}.experts.gate_up_proj"))?
+                }
+            }
         },
-        down_proj_w: match expert_arena.as_mut() {
-            Some(arena) => load_to_virtual_resident_weight(
+        down_proj_w: if let Some(manager) = expert_residency.as_mut() {
+            load_to_sparse_resident_weight(
                 store,
-                &mut **arena,
+                &mut **manager,
+                layer_idx,
+                MoeExpertProjection::Down,
                 &format!("{mp}.experts.down_proj"),
-            )?,
-            None => load_to_resident_weight(store, ordinal, &format!("{mp}.experts.down_proj"))?,
+                geom.num_experts as usize,
+            )?
+        } else {
+            match expert_arena.as_mut() {
+                Some(arena) => load_to_virtual_resident_weight(
+                    store,
+                    &mut **arena,
+                    &format!("{mp}.experts.down_proj"),
+                )?,
+                None => {
+                    load_to_resident_weight(store, ordinal, &format!("{mp}.experts.down_proj"))?
+                }
+            }
         },
         shared_gate_proj_w: load_to_gpu(
             store,
@@ -1387,6 +1454,7 @@ fn load_all_layer_buffers(
     weight_mode: Qwen36WeightMode,
     kv_max_t: usize,
     mut expert_arena: Option<&mut VirtualArena>,
+    mut expert_residency: Option<&mut MoeExpertResidencyManager>,
 ) -> Result<Vec<LayerBuffers>> {
     let mut layers = Vec::with_capacity(geom.num_layers as usize);
     for li in 0..geom.num_layers as usize {
@@ -1400,6 +1468,7 @@ fn load_all_layer_buffers(
             weight_mode,
             kv_max_t,
             expert_arena.as_deref_mut(),
+            expert_residency.as_deref_mut(),
         )
         .with_context(|| format!("load layer {li} weights"))?;
         layers.push(layer);
@@ -1760,8 +1829,68 @@ fn decode_text(
     );
 
     let moe_vmm_mode = MoeExpertVmmMode::from_env()?;
+    let moe_island_cap_experts = moe_island_cap_experts_from_env()?;
+    if moe_island_cap_experts.is_some() && speculative_decode {
+        anyhow::bail!(
+            "SUPERSONIC_MOE_ISLAND_CAP_EXPERTS sparse residency is not wired through speculative decode yet"
+        );
+    }
+    if moe_island_cap_experts.is_some() && moe_vmm_mode == MoeExpertVmmMode::Disabled {
+        anyhow::bail!(
+            "SUPERSONIC_MOE_ISLAND_CAP_EXPERTS requires VMM expert slabs; unset SUPERSONIC_VMM_MOE_ISLANDS=0"
+        );
+    }
     let mut _moe_expert_arena = None;
-    let mut layers = if should_try_moe_expert_vmm(moe_vmm_mode, weight_mode, ordinal)? {
+    let mut _moe_expert_residency = None;
+    let sparse_moe_requested = moe_island_cap_experts.is_some();
+    let mut layers = if let Some(cap_experts) = moe_island_cap_experts {
+        if cap_experts < geom.top_k as usize {
+            anyhow::bail!(
+                "SUPERSONIC_MOE_ISLAND_CAP_EXPERTS={cap_experts} is smaller than model top_k={}; \
+                 sparse decode needs at least one layer's routed experts resident",
+                geom.top_k
+            );
+        }
+        if !should_try_moe_expert_vmm(MoeExpertVmmMode::Force, weight_mode, ordinal)? {
+            unreachable!("forced VMM expert check should either return true or error");
+        }
+        let max_resident_slices = cap_experts
+            .checked_mul(2)
+            .ok_or_else(|| anyhow!("SUPERSONIC_MOE_ISLAND_CAP_EXPERTS overflows slice cap"))?;
+        let config = MoeExpertResidencyConfig::new(max_resident_slices)?;
+        let mut manager = MoeExpertResidencyManager::new(ordinal, config);
+        let layers = load_all_layer_buffers(
+            &store,
+            ordinal,
+            &geom,
+            &report.config.text_config,
+            weight_prefix,
+            weight_mode,
+            kv_max_t,
+            None,
+            Some(&mut manager),
+        )
+        .context("reserve Qwen3.6-MoE routed experts for sparse VMM residency")?;
+        let arena_stats = manager.arena().stats();
+        let residency_stats = manager.stats();
+        println!(
+            "  [vmm] Qwen3.6-MoE sparse routed expert residency active on device {ordinal}: \
+             tensors={} max_slices={} logical={:.2}MiB resident={:.2}MiB reserved={:.2}MiB",
+            residency_stats.registered_tensors,
+            max_resident_slices,
+            arena_stats.logical_bytes as f64 / MIB,
+            arena_stats.resident_bytes as f64 / MIB,
+            arena_stats.reserved_bytes as f64 / MIB,
+        );
+        if persistent_decode {
+            println!(
+                "  [vmm] sparse MoE residency uses chained decode for router prefetch; \
+                 persistent megakernel disabled for this run"
+            );
+        }
+        _moe_expert_residency = Some(manager);
+        layers
+    } else if should_try_moe_expert_vmm(moe_vmm_mode, weight_mode, ordinal)? {
         let mut arena = BakedStore::virtual_weight_arena(ordinal);
         match load_all_layer_buffers(
             &store,
@@ -1772,6 +1901,7 @@ fn decode_text(
             weight_mode,
             kv_max_t,
             Some(&mut arena),
+            None,
         ) {
             Ok(layers) => {
                 let stats = arena.stats();
@@ -1801,6 +1931,7 @@ fn decode_text(
                     weight_mode,
                     kv_max_t,
                     None,
+                    None,
                 )?
             }
             Err(err) => return Err(err.context("load Qwen3.6-MoE routed experts into VMM")),
@@ -1815,8 +1946,10 @@ fn decode_text(
             weight_mode,
             kv_max_t,
             None,
+            None,
         )?
     };
+    let persistent_decode = persistent_decode && !sparse_moe_requested;
 
     // Phase 6 self-speculative decode: load the multi-token-prediction
     // (MTP) head from the bake when --speculative-decode is set.
@@ -2127,14 +2260,47 @@ fn decode_text(
             // launches separately below on gen steps.
             lm_head_folded = false;
             drop(fold);
-            run_chained_decode_fast(
-                ordinal,
-                &geom,
-                &mut layers,
-                &initial_hidden,
-                position,
-                emit_stage_timings,
-            )
+            if let Some(manager) = _moe_expert_residency.as_mut() {
+                let mut prefetch = |layer_idx: usize, topk: &[usize]| -> Result<()> {
+                    for &expert_idx in topk {
+                        manager.ensure_resident(
+                            &store,
+                            MoeExpertKey {
+                                layer_idx,
+                                expert_idx,
+                                projection: MoeExpertProjection::GateUp,
+                            },
+                        )?;
+                        manager.ensure_resident(
+                            &store,
+                            MoeExpertKey {
+                                layer_idx,
+                                expert_idx,
+                                projection: MoeExpertProjection::Down,
+                            },
+                        )?;
+                    }
+                    Ok(())
+                };
+                run_chained_decode_fast_with_expert_prefetch(
+                    ordinal,
+                    &geom,
+                    &mut layers,
+                    &initial_hidden,
+                    position,
+                    emit_stage_timings,
+                    &mut prefetch,
+                )
+            } else {
+                run_chained_decode_fast(
+                    ordinal,
+                    &geom,
+                    &mut layers,
+                    &initial_hidden,
+                    position,
+                    emit_stage_timings,
+                )
+            }
             .with_context(|| format!("chained decode (step {step}, position {position})"))?
         };
         let t_chain_step = t1.elapsed();
@@ -2571,6 +2737,22 @@ fn decode_text(
     if !generated_ids.is_empty() {
         println!("  Generated ids: {generated_ids:?}");
     }
+    if let Some(manager) = _moe_expert_residency.as_ref() {
+        let residency = manager.stats();
+        let arena = manager.arena().stats();
+        println!(
+            "  [vmm] MoE island residency: resident_slices={} hits={} misses={} \
+             evicted_slices={} uploaded={:.2}MiB unmapped={:.2}MiB resident={:.2}MiB reserved={:.2}MiB",
+            residency.resident_slices,
+            residency.hits,
+            residency.misses,
+            residency.evicted_slices,
+            residency.uploaded_bytes as f64 / MIB,
+            residency.unmapped_bytes as f64 / MIB,
+            arena.resident_bytes as f64 / MIB,
+            arena.reserved_bytes as f64 / MIB,
+        );
+    }
     if emit_stage_timings && gen_steps > 0 {
         let to_ms = |d: std::time::Duration| d.as_secs_f64() * 1000.0;
         let chain_ms = to_ms(t_chain);
@@ -2720,6 +2902,7 @@ fn decode_first_token(model_dir: &Path, report: &DryRunReport) -> Result<u32> {
             weight_prefix,
             weight_mode,
             0, // legacy single-token path: no KV cache, kv_len=1 fast path.
+            None,
             None,
         )
         .with_context(|| format!("load layer {li} weights"))?;

--- a/crates/runner/src/qwen36_moe_residency.rs
+++ b/crates/runner/src/qwen36_moe_residency.rs
@@ -60,6 +60,7 @@ pub struct MoeExpertResidencyStats {
 }
 
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub struct MoeExpertTensorReservation {
     pub allocation_id: usize,
     pub ptr: *const c_void,
@@ -128,6 +129,7 @@ impl MoeExpertResidencyManager {
         &self.arena
     }
 
+    #[allow(dead_code)]
     pub fn arena_mut(&mut self) -> &mut VirtualArena {
         &mut self.arena
     }
@@ -213,6 +215,7 @@ impl MoeExpertResidencyManager {
         })
     }
 
+    #[allow(dead_code)]
     pub fn is_resident(&self, key: MoeExpertKey) -> bool {
         self.resident.contains_key(&key)
     }

--- a/docs/lowlevel-memory.md
+++ b/docs/lowlevel-memory.md
@@ -42,9 +42,15 @@ Current scope:
   `mlp.experts.gate_up_proj` / `mlp.experts.down_proj` slabs, pins individual
   `(layer, expert, projection)` slices from the mmap-backed bake, evicts with a
   bounded LRU policy, and invalidates every resident slice covered by an
-  unmapped VMM page. This is the foundation for router-driven MoE islands; the
-  current decode path still maps all routed expert slabs when
-  `SUPERSONIC_VMM_MOE_ISLANDS` is active.
+  unmapped VMM page.
+- `SUPERSONIC_MOE_ISLAND_CAP_EXPERTS=N` activates router-driven sparse MoE
+  islands for Qwen3.6-MoE INT4 decode. The chained decode path runs FFN stage 1
+  first, downloads the `top_k` expert ids, pins those experts' gate/up and down
+  slices, then runs the normal stage-5 FFN launch against the stable virtual
+  slab pointers. The cap is expressed in experts and reserves `2*N` logical
+  resident slices because each expert needs both fused projections. Sparse
+  islands currently disable the persistent megakernel for that run; persistent
+  router prefetch needs a future split or in-kernel residency protocol.
 - `SUPERSONIC_VMM_WEIGHT_PROBE=1` makes Qwen3.6-MoE dry-run load
   `lm_head.weight` into a virtual `Weights` allocation when an INT4 bake is
   present.
@@ -57,6 +63,9 @@ Current scope:
   supported HIP devices and falls back to dense expert buffers if VMM loading
   fails. `SUPERSONIC_VMM_MOE_ISLANDS=1` makes unsupported or failed VMM expert
   loading a hard error.
+- `SUPERSONIC_MOE_ISLAND_CAP_EXPERTS=N` switches Qwen3.6-MoE INT4 decode from
+  fully resident virtual expert slabs to sparse router-prefetched islands with
+  at most `N` experts' two routed projections tracked resident at once.
 - `SUPERSONIC_VMM_KV=0` disables the Qwen3.5 integration.
 - `SUPERSONIC_VMM_KV=1` requests it and logs if the backend cannot support it.
 - `SUPERSONIC_VMM_KV_EVICT_AFTER_PREFILL=1` backs virtual KV to host RAM after
@@ -87,6 +96,10 @@ The branch was validated on HIP/gfx1100 with ROCm VMM support:
   `SUPERSONIC_BACKENDS=hip cargo test -p model-store virtual_arena_loads_baked_weight_and_expert_tensors -- --nocapture`
 - Qwen3.6-MoE sparse residency manager tests:
   `SUPERSONIC_BACKENDS=hip cargo test -p runner qwen36_moe_residency -- --nocapture`
+- Qwen3.6-MoE sparse router-prefetch smoke:
+  `SUPERSONIC_BACKENDS=hip SUPERSONIC_VMM_MOE_ISLANDS=1 SUPERSONIC_MOE_ISLAND_CAP_EXPERTS=8 cargo run --release --bin supersonic -- --backend hip --model qwen3.6-35b-a3b --model-dir /mnt/data/models/Qwen3.6-35B-A3B --int4 --prompt "Hello" --max-new-tokens 1`
+  generated `[11]` and reported `resident=32.00MiB` for the 15 GiB routed
+  expert VA reservation after the run.
 - Qwen3.5 virtual KV e2e with eviction and restore-to-VMM:
   `SUPERSONIC_VMM_KV=1 SUPERSONIC_VMM_KV_EVICT_AFTER_PREFILL=1 SUPERSONIC_VMM_KV_RESTORE_TO_VMM=1 ... --validate`
   passed and kept stable VMM pointers through decode.


### PR DESCRIPTION
## Summary\n- add a chained-decode router prefetch hook that runs FFN stage 1, downloads top-k expert ids, pins sparse VMM expert slices, then runs the normal stage-5 FFN\n- wire Qwen3.6-MoE sparse expert reservations behind `SUPERSONIC_MOE_ISLAND_CAP_EXPERTS=N`\n- keep stable virtual expert pointers while only router-selected gate/up and down projection slices become resident\n- disable persistent decode for sparse-island runs until the megakernel has an equivalent in-kernel or split-phase residency protocol\n- document the new runtime knob and sparse smoke result\n\n## Validation\n- `SUPERSONIC_BACKENDS=hip cargo check -p runner --bin supersonic`\n- `SUPERSONIC_BACKENDS=hip cargo test -p runner qwen36_moe_residency -- --nocapture`\n- `SUPERSONIC_BACKENDS=hip SUPERSONIC_VMM_MOE_ISLANDS=1 SUPERSONIC_MOE_ISLAND_CAP_EXPERTS=8 cargo run --release --bin supersonic -- --backend hip --model qwen3.6-35b-a3b --model-dir /mnt/data/models/Qwen3.6-35B-A3B --int4 --prompt "Hello" --max-new-tokens 1`\n  - generated id `[11]`\n  - sparse residency summary: `resident_slices=16 hits=0 misses=640 evicted_slices=624 uploaded=480.00MiB unmapped=1216.00MiB resident=32.00MiB reserved=15360.00MiB`