### PR TITLE
[codex] add CUDA VMM Qwen3.5 smoke coverage

### DIFF
--- a/crates/gpu-hal/src/cuda_sys.rs
+++ b/crates/gpu-hal/src/cuda_sys.rs
@@ -35,6 +35,7 @@ pub(crate) struct CuMemAllocationPropAllocFlags {
     pub compression_type: u8,
     pub gpu_direct_rdma_capable: u8,
     pub usage: u16,
+    pub reserved: [u8; 4],
 }
 
 #[repr(C)]

--- a/crates/gpu-hal/src/vmm.rs
+++ b/crates/gpu-hal/src/vmm.rs
@@ -901,6 +901,7 @@ fn allocation_prop_cuda(ordinal: usize) -> CuMemAllocationProp {
             compression_type: 0,
             gpu_direct_rdma_capable: 0,
             usage: 0,
+            reserved: [0; 4],
         },
     }
 }

--- a/crates/gpu-hal/tests/cuda_vmm_round_trip.rs
+++ b/crates/gpu-hal/tests/cuda_vmm_round_trip.rs
@@ -1,0 +1,277 @@
+#![cfg(supersonic_backend_cuda)]
+
+use gpu_hal::{
+    copy_h2d, set_backend, sync, vmm_is_supported, Backend, ScalarType, VirtualAllocationRole,
+    VirtualArena, VirtualBacking, VirtualBuffer,
+};
+
+fn require_cuda_vmm() -> bool {
+    set_backend(Backend::Cuda);
+    if !vmm_is_supported(Backend::Cuda, 0) {
+        eprintln!("skip: CUDA VMM unsupported on this device/runtime");
+        return false;
+    }
+    true
+}
+
+fn pattern_bytes(n: usize) -> Vec<u8> {
+    (0..n)
+        .map(|i| (i as u8).wrapping_mul(17).wrapping_add(3))
+        .collect()
+}
+
+fn first_diff(a: &[u8], b: &[u8]) -> Option<usize> {
+    a.iter()
+        .zip(b.iter())
+        .position(|(left, right)| left != right)
+        .or_else(|| (a.len() != b.len()).then_some(a.len().min(b.len())))
+}
+
+fn assert_bytes_eq(label: &str, got: &[u8], expected: &[u8]) {
+    let diff = first_diff(got, expected);
+    let window = diff.unwrap_or(0);
+    let start = window.saturating_sub(8);
+    let end = (window + 24).min(got.len()).min(expected.len());
+    assert!(
+        diff.is_none(),
+        "{label} mismatch first_diff={diff:?} got_prefix={:?} expected_prefix={:?} got_at_diff={:?} expected_at_diff={:?}",
+        &got[..got.len().min(16)],
+        &expected[..expected.len().min(16)],
+        &got[start..end],
+        &expected[start..end]
+    );
+}
+
+#[test]
+fn cuda_vmm_reserve_map_round_trip_stable_pointer() {
+    if !require_cuda_vmm() {
+        return;
+    }
+
+    let mut buf = VirtualBuffer::reserve(0, ScalarType::U8, &[1 << 20], VirtualBacking::Discard)
+        .expect("reserve CUDA virtual buffer");
+    let base = buf.as_ptr();
+    assert_eq!(buf.mapped_bytes(), 0);
+
+    buf.map_prefix_bytes(4096).expect("map first page");
+    assert_eq!(buf.as_ptr(), base, "mapping changed base VA");
+    let first = pattern_bytes(4096);
+    copy_h2d(0, buf.as_mut_ptr(), first.as_ptr() as *const _, first.len()).expect("H2D first");
+    sync(0).expect("sync first");
+
+    buf.map_prefix_bytes(128 * 1024).expect("map larger prefix");
+    assert_eq!(buf.as_ptr(), base, "growing mapping changed base VA");
+    let second = pattern_bytes(128 * 1024);
+    copy_h2d(
+        0,
+        buf.as_mut_ptr(),
+        second.as_ptr() as *const _,
+        second.len(),
+    )
+    .expect("H2D second");
+    sync(0).expect("sync second");
+    assert_bytes_eq(
+        "stable pointer remap",
+        &buf.to_host_prefix_bytes(second.len()).expect("D2H"),
+        &second,
+    );
+}
+
+#[test]
+fn cuda_vmm_sparse_range_round_trip_stable_pointer() {
+    if !require_cuda_vmm() {
+        return;
+    }
+
+    let mut buf = VirtualBuffer::reserve(0, ScalarType::U8, &[1 << 20], VirtualBacking::Discard)
+        .expect("reserve CUDA virtual buffer");
+    let base = buf.as_ptr();
+    let first_offset = 0;
+    let second_offset = 512 * 1024;
+    let len = 4096;
+
+    buf.map_range_bytes(first_offset, len)
+        .expect("map first island");
+    buf.map_range_bytes(second_offset, len)
+        .expect("map second island");
+    assert_eq!(buf.as_ptr(), base, "sparse mapping changed base VA");
+
+    let first = pattern_bytes(len);
+    let second = pattern_bytes(len)
+        .into_iter()
+        .map(|byte| byte.wrapping_add(91))
+        .collect::<Vec<_>>();
+    copy_h2d(
+        0,
+        buf.offset_ptr(first_offset) as *mut _,
+        first.as_ptr() as *const _,
+        first.len(),
+    )
+    .expect("H2D first island");
+    copy_h2d(
+        0,
+        buf.offset_ptr(second_offset) as *mut _,
+        second.as_ptr() as *const _,
+        second.len(),
+    )
+    .expect("H2D second island");
+    sync(0).expect("sync sparse H2D");
+
+    assert_bytes_eq(
+        "first island",
+        &buf.to_host_range_bytes(first_offset, len)
+            .expect("D2H first island"),
+        &first,
+    );
+    assert_bytes_eq(
+        "second island",
+        &buf.to_host_range_bytes(second_offset, len)
+            .expect("D2H second island"),
+        &second,
+    );
+}
+
+#[test]
+fn cuda_vmm_cpu_backup_restore_round_trip() {
+    if !require_cuda_vmm() {
+        return;
+    }
+
+    let data = pattern_bytes(64 * 1024);
+    let mut buf =
+        VirtualBuffer::reserve(0, ScalarType::U8, &[data.len()], VirtualBacking::CpuBackup)
+            .expect("reserve CUDA virtual buffer");
+    buf.map_prefix_bytes(data.len()).expect("map prefix");
+    copy_h2d(0, buf.as_mut_ptr(), data.as_ptr() as *const _, data.len()).expect("H2D");
+    sync(0).expect("sync H2D");
+
+    buf.backup_mapped_to_host().expect("backup");
+    buf.unmap_all().expect("unmap");
+    assert_eq!(buf.mapped_bytes(), 0);
+    buf.restore_backup().expect("restore");
+    sync(0).expect("sync restore");
+    assert_bytes_eq("restored buffer", &buf.to_host_bytes().expect("D2H"), &data);
+}
+
+#[test]
+fn cuda_vmm_cpu_evict_restore_packed_kv_round_trip() {
+    if !require_cuda_vmm() {
+        return;
+    }
+
+    let nkv = 2;
+    let cap = 384;
+    let head_dim = 256;
+    let elem_bytes = ScalarType::BF16.size_in_bytes();
+    let logical_len = 2 * nkv * cap * head_dim * elem_bytes;
+    let half_len = logical_len / 2;
+    let head_stride = cap * head_dim * elem_bytes;
+    let prefix = 16 * head_dim * elem_bytes;
+
+    let mut buf = VirtualBuffer::reserve(
+        0,
+        ScalarType::BF16,
+        &[2, nkv, cap, head_dim],
+        VirtualBacking::CpuBackup,
+    )
+    .expect("reserve packed KV CUDA virtual buffer");
+    buf.map_prefix_bytes(logical_len).expect("map packed KV");
+
+    let data = pattern_bytes(logical_len);
+    copy_h2d(0, buf.as_mut_ptr(), data.as_ptr() as *const _, data.len()).expect("H2D packed KV");
+    sync(0).expect("sync packed KV H2D");
+
+    let before_k0 = buf
+        .to_host_range_bytes(0, prefix)
+        .expect("D2H K head 0 before");
+    let before_k1 = buf
+        .to_host_range_bytes(head_stride, prefix)
+        .expect("D2H K head 1 before");
+    let before_v0 = buf
+        .to_host_range_bytes(half_len, prefix)
+        .expect("D2H V head 0 before");
+    let before_v1 = buf
+        .to_host_range_bytes(half_len + head_stride, prefix)
+        .expect("D2H V head 1 before");
+
+    buf.evict_to_host().expect("evict packed KV");
+    assert_eq!(buf.resident_bytes(), 0);
+    assert_eq!(buf.logical_resident_bytes(), 0);
+    assert_eq!(buf.mapping_count(), 0);
+    assert_eq!(buf.logical_backup_bytes(), logical_len);
+    buf.restore_backup().expect("restore packed KV");
+    let stats = buf.stats();
+    assert_eq!(stats.logical_bytes, logical_len);
+    assert_eq!(stats.logical_resident_bytes, logical_len);
+    assert_eq!(stats.logical_backup_bytes, logical_len);
+    assert!(
+        stats.resident_bytes >= stats.logical_resident_bytes,
+        "physical residency must cover logical residency"
+    );
+
+    let restored = buf
+        .to_host_prefix_bytes(logical_len)
+        .expect("D2H restored packed KV");
+    let checks = [
+        ("K head 0", 0, before_k0),
+        ("K head 1", head_stride, before_k1),
+        ("V head 0", half_len, before_v0),
+        ("V head 1", half_len + head_stride, before_v1),
+    ];
+    for (label, offset, expected) in checks {
+        assert_bytes_eq(label, &restored[offset..offset + prefix], &expected);
+    }
+}
+
+#[test]
+fn cuda_vmm_arena_tracks_allocation_residency() {
+    if !require_cuda_vmm() {
+        return;
+    }
+
+    let mut arena = VirtualArena::new(0, VirtualBacking::CpuBackup);
+    let k_id = arena
+        .reserve(
+            "layer0.k",
+            VirtualAllocationRole::KvCache,
+            ScalarType::BF16,
+            &[1, 2, 384, 256],
+        )
+        .expect("reserve K allocation");
+    let v_id = arena
+        .reserve(
+            "layer0.v",
+            VirtualAllocationRole::KvCache,
+            ScalarType::BF16,
+            &[1, 2, 384, 256],
+        )
+        .expect("reserve V allocation");
+
+    assert_eq!(arena.stats().allocations, 2);
+    assert_eq!(
+        arena.allocation(k_id).expect("K allocation").name(),
+        "layer0.k"
+    );
+    assert_eq!(
+        arena.allocation(v_id).expect("V allocation").role(),
+        VirtualAllocationRole::KvCache
+    );
+
+    let logical_len = 2 * 384 * 256 * ScalarType::BF16.size_in_bytes();
+    for id in [k_id, v_id] {
+        let allocation = arena.allocation_mut(id).expect("allocation");
+        allocation
+            .buffer_mut()
+            .map_prefix_bytes(logical_len)
+            .expect("map allocation");
+    }
+
+    let stats = arena.stats();
+    assert_eq!(stats.allocations, 2);
+    assert_eq!(stats.logical_bytes, logical_len * 2);
+    assert_eq!(stats.logical_resident_bytes, logical_len * 2);
+    assert!(
+        stats.resident_bytes >= stats.logical_resident_bytes,
+        "physical residency must cover logical residency"
+    );
+}

--- a/crates/runner/tests/qwen35_vmm_smoke.rs
+++ b/crates/runner/tests/qwen35_vmm_smoke.rs
@@ -17,6 +17,7 @@ struct SmokeCase {
 
 #[cfg(target_os = "linux")]
 fn run_supersonic(
+    backend: &str,
     model_dir: &str,
     case: &SmokeCase,
     vmm: &str,
@@ -26,7 +27,7 @@ fn run_supersonic(
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_supersonic"));
     cmd.env("SUPERSONIC_VMM_KV", vmm).args([
         "--backend",
-        "hip",
+        backend,
         "--model",
         "qwen3.5-0.8b",
         "--model-dir",
@@ -49,7 +50,8 @@ fn run_supersonic(
     if let Some(chunk_size) = case.prefill_chunk_size {
         cmd.args(["--prefill-chunk-size", chunk_size]);
     }
-    cmd.output().expect("run supersonic qwen35 HIP smoke")
+    cmd.output()
+        .unwrap_or_else(|e| panic!("run supersonic qwen35 {backend} smoke: {e}"))
 }
 
 #[cfg(target_os = "linux")]
@@ -70,9 +72,23 @@ fn tokens_line(output: &str) -> &str {
 }
 
 #[cfg(target_os = "linux")]
-#[test]
-#[ignore = "requires HIP and a local Qwen3.5-0.8B model dir via SUPERSONIC_TEST_QWEN35_08B_MODEL_DIR"]
-fn qwen35_hip_virtual_kv_matches_dense_tokens() {
+fn backend_vmm_supported(backend: &str) -> bool {
+    let backend = match backend {
+        "hip" => gpu_hal::Backend::Hip,
+        "cuda" => gpu_hal::Backend::Cuda,
+        other => panic!("unsupported smoke backend {other}"),
+    };
+    gpu_hal::set_backend(backend);
+    gpu_hal::vmm_is_supported(backend, 0)
+}
+
+#[cfg(target_os = "linux")]
+fn qwen35_virtual_kv_matches_dense_tokens_for_backend(backend: &str) {
+    if !backend_vmm_supported(backend) {
+        eprintln!("skipping: {backend} VMM unsupported on this device/runtime");
+        return;
+    }
+
     let Some(model_dir) = model_dir() else {
         eprintln!("skipping: SUPERSONIC_TEST_QWEN35_08B_MODEL_DIR is not set");
         return;
@@ -105,11 +121,11 @@ fn qwen35_hip_virtual_kv_matches_dense_tokens() {
     ];
 
     for case in cases {
-        let dense = run_supersonic(&model_dir, &case, "0", false, false);
+        let dense = run_supersonic(backend, &model_dir, &case, "0", false, false);
         let dense_combined = combined_output(&dense);
         assert!(
             dense.status.success(),
-            "dense Qwen3.5 HIP smoke case={} failed with status {:?}:\n{}",
+            "dense Qwen3.5 {backend} smoke case={} failed with status {:?}:\n{}",
             case.name,
             dense.status.code(),
             dense_combined
@@ -121,11 +137,11 @@ fn qwen35_hip_virtual_kv_matches_dense_tokens() {
             dense_combined
         );
 
-        let virtual_kv = run_supersonic(&model_dir, &case, "1", false, false);
+        let virtual_kv = run_supersonic(backend, &model_dir, &case, "1", false, false);
         let virtual_combined = combined_output(&virtual_kv);
         assert!(
             virtual_kv.status.success(),
-            "virtual-KV Qwen3.5 HIP smoke case={} failed with status {:?}:\n{}",
+            "virtual-KV Qwen3.5 {backend} smoke case={} failed with status {:?}:\n{}",
             case.name,
             virtual_kv.status.code(),
             virtual_combined
@@ -151,7 +167,7 @@ fn qwen35_hip_virtual_kv_matches_dense_tokens() {
         );
 
         if case.name == "chunked_prefill" {
-            let evicted = run_supersonic(&model_dir, &case, "1", true, false);
+            let evicted = run_supersonic(backend, &model_dir, &case, "1", true, false);
             let evicted_combined = combined_output(&evicted);
             assert!(
                 evicted.status.success(),
@@ -180,7 +196,7 @@ fn qwen35_hip_virtual_kv_matches_dense_tokens() {
                 case.name
             );
 
-            let restored_vmm = run_supersonic(&model_dir, &case, "1", true, true);
+            let restored_vmm = run_supersonic(backend, &model_dir, &case, "1", true, true);
             let restored_vmm_combined = combined_output(&restored_vmm);
             assert!(
                 restored_vmm.status.success(),
@@ -205,4 +221,18 @@ fn qwen35_hip_virtual_kv_matches_dense_tokens() {
             );
         }
     }
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+#[ignore = "requires HIP and a local Qwen3.5-0.8B model dir via SUPERSONIC_TEST_QWEN35_08B_MODEL_DIR"]
+fn qwen35_hip_virtual_kv_matches_dense_tokens() {
+    qwen35_virtual_kv_matches_dense_tokens_for_backend("hip");
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+#[ignore = "requires CUDA and a local Qwen3.5-0.8B model dir via SUPERSONIC_TEST_QWEN35_08B_MODEL_DIR"]
+fn qwen35_cuda_virtual_kv_matches_dense_tokens() {
+    qwen35_virtual_kv_matches_dense_tokens_for_backend("cuda");
 }

--- a/docs/lowlevel-memory.md
+++ b/docs/lowlevel-memory.md
@@ -7,9 +7,10 @@ the existing allocator.
 
 The first consumer is Qwen3.5 BF16 dense KV in single-sequence mode. When a
 context limit is known and VMM support probes successfully, full-attention K/V
-caches reserve stable virtual addresses for the full context. On the current
-HIP path Qwen uses separate K and V reservations per full-attention layer.
-HIP VMM mappings use a conservative 2 MiB minimum page size even when ROCm
+caches reserve stable virtual addresses for the full context. On HIP and CUDA,
+Qwen uses separate K and V reservations per full-attention layer. CUDA remains
+opt-in with `SUPERSONIC_VMM_KV=1` for this first runtime lane. HIP VMM mappings
+use a conservative 2 MiB minimum page size even when ROCm
 reports a smaller recommended granularity; raw HIP repro tests showed repeated
 sub-2 MiB remap/restore corrupts earlier mappings on gfx1100, while the same
 sequence with 2 MiB mappings survives. The floor can be overridden for
@@ -54,6 +55,7 @@ Current scope:
   loading a hard error.
 - `SUPERSONIC_VMM_KV=0` disables the Qwen3.5 integration.
 - `SUPERSONIC_VMM_KV=1` requests it and logs if the backend cannot support it.
+  HIP may auto-enable when unset; CUDA requires this explicit opt-in.
 - `SUPERSONIC_VMM_KV_EVICT_AFTER_PREFILL=1` backs virtual KV to host RAM after
   prefill, unmaps the device pages, reports zero resident bytes, then restores
   decode state before decode. By default this uses a compact logical-prefix
@@ -68,16 +70,20 @@ The HAL type also carries explicit `CpuBackup` versus `Discard` backing tags.
 The Qwen3.5 dense KV proof reserves VMM-backed caches and uses compact CPU
 logical backups for the opt-in eviction policy. The lower-level HAL still
 exercises real D2H backup, unmap/release, remap, and H2D restore in focused HIP
-tests.
+and CUDA tests.
 
 ## Validation Snapshot
 
-The branch was validated on HIP/gfx1100 with ROCm VMM support:
+The branch was validated on HIP/gfx1100 with ROCm VMM support. CUDA coverage
+uses the same HAL VMM primitives and the Qwen3.5 ignored smoke test can be run
+on CUDA devices with `SUPERSONIC_VMM_KV=1`:
 
 - Raw HIP VMM repro: repeated sub-2 MiB remap/restore corrupts earlier mappings
   on gfx1100; the same sequence passes with a 2 MiB mapping floor.
 - HAL arena tests:
   `SUPERSONIC_BACKENDS=hip cargo test -p gpu-hal --test vmm_round_trip vmm_arena_ -- --nocapture`
+- CUDA HAL VMM primitive tests:
+  `SUPERSONIC_BACKENDS=cuda cargo test -p gpu-hal --test cuda_vmm_round_trip -- --nocapture`
 - Baked tensor VMM upload test:
   `SUPERSONIC_BACKENDS=hip cargo test -p model-store virtual_arena_loads_baked_weight_and_expert_tensors -- --nocapture`
 - Qwen3.5 virtual KV e2e with eviction and restore-to-VMM:


### PR DESCRIPTION
## Summary

This PR enables the first CUDA VMM validation lane for Qwen3.5 BF16 virtual KV work.

- Fixes the CUDA `CUmemAllocationProp` FFI layout by adding the missing `allocFlags.reserved[4]` field. Without this, `vmm_is_supported(Cuda)` could succeed but `cuMemCreate` failed with status 1 when mapping real physical pages.
- Adds CUDA-only HAL VMM round-trip tests for stable VA growth, sparse range mapping, CPU backup/restore, packed KV eviction/restore, and arena residency accounting.
- Refactors the Qwen3.5 virtual-KV smoke test so the same dense-vs-virtual token assertions can run on HIP or CUDA.
- Updates low-level VMM docs to describe the CUDA opt-in lane and validation command.

## Impact

CUDA VMM now has direct primitive coverage, and the Qwen3.5 BF16 virtual-KV path can be validated end-to-end with `SUPERSONIC_VMM_KV=1` on `sm86`. This does not add Qwen3.6-MoE CUDA VMM support; that remains out of scope for this first PR.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `SUPERSONIC_BACKENDS=cuda cargo test -p gpu-hal --test cuda_vmm_round_trip -- --nocapture`
  - 5 passed
- `SUPERSONIC_BACKENDS=cuda cargo test -p runner --test qwen35_vmm_smoke --no-run`
- `SUPERSONIC_BACKENDS=cuda cargo test -p runner --test qwen35_vmm_smoke -- --list`
  - shows both HIP and CUDA ignored smoke tests
- `SUPERSONIC_BACKENDS=cuda cargo build --release --bin supersonic`
- Pulled `Qwen/Qwen3.5-0.8B` locally after freeing old model dirs, then ran:
  - `SUPERSONIC_BACKENDS=cuda SUPERSONIC_TEST_QWEN35_08B_MODEL_DIR=/workspace/models/Qwen3.5-0.8B cargo test -p runner --test qwen35_vmm_smoke qwen35_cuda_virtual_kv_matches_dense_tokens -- --ignored --nocapture`
  - 1 passed, finished in 87.51s