### PR TITLE
[codex] Enable CUDA Qwen3.6 MoE VMM residency tests

### DIFF
--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -839,6 +839,7 @@ pub fn run(cli: &crate::Cli, entry: &RegistryEntry, total_vram: u64) -> Result<(
         cli.speculative_decode,
         cli.fp8_runtime,
         cli.batched_spec_verify,
+        entry.backend,
         cli.device,
         // Phase 3e.4: persistent decode is now the default. The legacy
         // `--persistent-decode` flag is a hidden no-op (kept for harness
@@ -1478,6 +1479,7 @@ fn load_all_layer_buffers(
 
 fn should_try_moe_expert_vmm(
     mode: MoeExpertVmmMode,
+    backend: Backend,
     weight_mode: Qwen36WeightMode,
     ordinal: usize,
 ) -> Result<bool> {
@@ -1492,11 +1494,11 @@ fn should_try_moe_expert_vmm(
         }
         return Ok(false);
     }
-    let supported = gpu_hal::vmm_is_supported(Backend::Hip, ordinal);
+    let supported = gpu_hal::vmm_is_supported(backend, ordinal);
     if !supported {
         if mode == MoeExpertVmmMode::Force {
             anyhow::bail!(
-                "SUPERSONIC_VMM_MOE_ISLANDS=1 requested but HIP VMM is unsupported on device {ordinal}"
+                "SUPERSONIC_VMM_MOE_ISLANDS=1 requested but backend={backend} VMM is unsupported on device {ordinal}"
             );
         }
         return Ok(false);
@@ -1688,6 +1690,7 @@ fn decode_text(
     speculative_decode: bool,
     fp8_runtime: bool,
     batched_spec_verify: bool,
+    backend: Backend,
     ordinal: usize,
     persistent_decode: bool,
 ) -> Result<()> {
@@ -1810,7 +1813,7 @@ fn decode_text(
 
     let geom = build_multi_layer_geom(&report.config.text_config, &report.kernel_params);
 
-    set_backend(Backend::Hip);
+    set_backend(backend);
 
     // KV cache size: needs to fit prompt_len + max_new past tokens. Sized
     // generously here since per-layer KV is small (10 full-attn layers ×
@@ -1851,7 +1854,7 @@ fn decode_text(
                 geom.top_k
             );
         }
-        if !should_try_moe_expert_vmm(MoeExpertVmmMode::Force, weight_mode, ordinal)? {
+        if !should_try_moe_expert_vmm(MoeExpertVmmMode::Force, backend, weight_mode, ordinal)? {
             unreachable!("forced VMM expert check should either return true or error");
         }
         let max_resident_slices = cap_experts
@@ -1874,8 +1877,9 @@ fn decode_text(
         let arena_stats = manager.arena().stats();
         let residency_stats = manager.stats();
         println!(
-            "  [vmm] Qwen3.6-MoE sparse routed expert residency active on device {ordinal}: \
+            "  [vmm] Qwen3.6-MoE sparse routed expert residency active on backend={} device {ordinal}: \
              tensors={} max_slices={} logical={:.2}MiB resident={:.2}MiB reserved={:.2}MiB",
+            backend,
             residency_stats.registered_tensors,
             max_resident_slices,
             arena_stats.logical_bytes as f64 / MIB,
@@ -1890,7 +1894,7 @@ fn decode_text(
         }
         _moe_expert_residency = Some(manager);
         layers
-    } else if should_try_moe_expert_vmm(moe_vmm_mode, weight_mode, ordinal)? {
+    } else if should_try_moe_expert_vmm(moe_vmm_mode, backend, weight_mode, ordinal)? {
         let mut arena = BakedStore::virtual_weight_arena(ordinal);
         match load_all_layer_buffers(
             &store,
@@ -1906,8 +1910,9 @@ fn decode_text(
             Ok(layers) => {
                 let stats = arena.stats();
                 println!(
-                    "  [vmm] Qwen3.6-MoE routed expert slabs active on device {ordinal}: \
+                    "  [vmm] Qwen3.6-MoE routed expert slabs active on backend={} device {ordinal}: \
                      allocations={} mappings={} logical={:.2}MiB resident={:.2}MiB reserved={:.2}MiB",
+                    backend,
                     stats.allocations,
                     stats.mapping_count,
                     stats.logical_bytes as f64 / MIB,

--- a/crates/runner/src/qwen36_moe_residency.rs
+++ b/crates/runner/src/qwen36_moe_residency.rs
@@ -416,129 +416,138 @@ mod tests {
         tmp
     }
 
-    fn require_hip_vmm() -> bool {
-        gpu_hal::set_backend(Backend::Hip);
-        if !gpu_hal::vmm_is_supported(Backend::Hip, 0) {
-            eprintln!("skip: HIP VMM unsupported on this device/runtime");
-            return false;
+    fn vmm_backends() -> [Backend; 2] {
+        [Backend::Hip, Backend::Cuda]
+    }
+
+    fn with_supported_vmm_backend(test_name: &str, mut f: impl FnMut(Backend)) {
+        for backend in vmm_backends() {
+            gpu_hal::set_backend(backend);
+            if !gpu_hal::vmm_is_supported(backend, 0) {
+                eprintln!("skip: {backend} VMM unsupported on this device/runtime for {test_name}");
+                continue;
+            }
+            f(backend);
         }
-        true
     }
 
     #[test]
     fn reserves_expert_slab_without_resident_pages() {
-        if !require_hip_vmm() {
-            return;
-        }
-        let tmp = synthetic_store(4, 4096);
-        let store = BakedStore::open(tmp.path()).expect("open synthetic store");
-        let mut manager =
-            MoeExpertResidencyManager::new(0, MoeExpertResidencyConfig::new(2).unwrap());
-        let reservation = manager
-            .register_tensor(
-                &store,
-                0,
-                MoeExpertProjection::GateUp,
-                "model.layers.0.mlp.experts.gate_up_proj",
-                4,
-            )
-            .expect("register tensor");
+        with_supported_vmm_backend("reserves_expert_slab_without_resident_pages", |_backend| {
+            let tmp = synthetic_store(4, 4096);
+            let store = BakedStore::open(tmp.path()).expect("open synthetic store");
+            let mut manager =
+                MoeExpertResidencyManager::new(0, MoeExpertResidencyConfig::new(2).unwrap());
+            let reservation = manager
+                .register_tensor(
+                    &store,
+                    0,
+                    MoeExpertProjection::GateUp,
+                    "model.layers.0.mlp.experts.gate_up_proj",
+                    4,
+                )
+                .expect("register tensor");
 
-        assert_eq!(reservation.expert_count, 4);
-        assert_eq!(reservation.expert_bytes, 4096);
-        let arena_stats = manager.arena().stats();
-        assert_eq!(arena_stats.allocations, 1);
-        assert_eq!(arena_stats.logical_bytes, 16 * 1024);
-        assert_eq!(arena_stats.logical_resident_bytes, 0);
-        assert_eq!(arena_stats.mapping_count, 0);
+            assert_eq!(reservation.expert_count, 4);
+            assert_eq!(reservation.expert_bytes, 4096);
+            let arena_stats = manager.arena().stats();
+            assert_eq!(arena_stats.allocations, 1);
+            assert_eq!(arena_stats.logical_bytes, 16 * 1024);
+            assert_eq!(arena_stats.logical_resident_bytes, 0);
+            assert_eq!(arena_stats.mapping_count, 0);
+        });
     }
 
     #[test]
     fn lru_eviction_invalidates_page_overlapping_slices() {
-        if !require_hip_vmm() {
-            return;
-        }
-        let tmp = synthetic_store(4, 4096);
-        let store = BakedStore::open(tmp.path()).expect("open synthetic store");
-        let mut manager =
-            MoeExpertResidencyManager::new(0, MoeExpertResidencyConfig::new(1).unwrap());
-        manager
-            .register_tensor(
-                &store,
-                0,
-                MoeExpertProjection::GateUp,
-                "model.layers.0.mlp.experts.gate_up_proj",
-                4,
-            )
-            .expect("register tensor");
+        with_supported_vmm_backend(
+            "lru_eviction_invalidates_page_overlapping_slices",
+            |_backend| {
+                let tmp = synthetic_store(4, 4096);
+                let store = BakedStore::open(tmp.path()).expect("open synthetic store");
+                let mut manager =
+                    MoeExpertResidencyManager::new(0, MoeExpertResidencyConfig::new(1).unwrap());
+                manager
+                    .register_tensor(
+                        &store,
+                        0,
+                        MoeExpertProjection::GateUp,
+                        "model.layers.0.mlp.experts.gate_up_proj",
+                        4,
+                    )
+                    .expect("register tensor");
 
-        let e0 = MoeExpertKey {
-            layer_idx: 0,
-            expert_idx: 0,
-            projection: MoeExpertProjection::GateUp,
-        };
-        let e1 = MoeExpertKey {
-            layer_idx: 0,
-            expert_idx: 1,
-            projection: MoeExpertProjection::GateUp,
-        };
-        manager.ensure_resident(&store, e0).expect("load expert 0");
-        assert!(manager.is_resident(e0));
-        assert_eq!(manager.stats().resident_slices, 1);
+                let e0 = MoeExpertKey {
+                    layer_idx: 0,
+                    expert_idx: 0,
+                    projection: MoeExpertProjection::GateUp,
+                };
+                let e1 = MoeExpertKey {
+                    layer_idx: 0,
+                    expert_idx: 1,
+                    projection: MoeExpertProjection::GateUp,
+                };
+                manager.ensure_resident(&store, e0).expect("load expert 0");
+                assert!(manager.is_resident(e0));
+                assert_eq!(manager.stats().resident_slices, 1);
 
-        manager.ensure_resident(&store, e1).expect("load expert 1");
-        assert!(!manager.is_resident(e0));
-        assert!(manager.is_resident(e1));
-        assert_eq!(manager.stats().resident_slices, 1);
-        assert_eq!(manager.stats().misses, 2);
-        assert_eq!(manager.stats().evicted_slices, 1);
+                manager.ensure_resident(&store, e1).expect("load expert 1");
+                assert!(!manager.is_resident(e0));
+                assert!(manager.is_resident(e1));
+                assert_eq!(manager.stats().resident_slices, 1);
+                assert_eq!(manager.stats().misses, 2);
+                assert_eq!(manager.stats().evicted_slices, 1);
 
-        let allocation_id = manager
-            .resident_weight(0, MoeExpertProjection::GateUp)
-            .expect("resident weight")
-            .allocation_id()
-            .expect("virtual allocation");
-        let bytes = manager
-            .arena()
-            .allocation(allocation_id)
-            .expect("allocation")
-            .buffer()
-            .to_host_range_bytes(4096, 4096)
-            .expect("read expert 1");
-        assert!(bytes.iter().all(|b| *b == 2));
+                let allocation_id = manager
+                    .resident_weight(0, MoeExpertProjection::GateUp)
+                    .expect("resident weight")
+                    .allocation_id()
+                    .expect("virtual allocation");
+                let bytes = manager
+                    .arena()
+                    .allocation(allocation_id)
+                    .expect("allocation")
+                    .buffer()
+                    .to_host_range_bytes(4096, 4096)
+                    .expect("read expert 1");
+                assert!(bytes.iter().all(|b| *b == 2));
+            },
+        );
     }
 
     #[test]
     fn store_range_upload_keeps_stable_virtual_pointer() {
-        if !require_hip_vmm() {
-            return;
-        }
-        let tmp = synthetic_store(2, 4096);
-        let store = BakedStore::open(tmp.path()).expect("open synthetic store");
-        let mut arena = VirtualArena::new(0, VirtualBacking::Discard);
-        let id = store
-            .reserve_virtual_arena(
-                &mut arena,
-                "model.layers.0.mlp.experts.gate_up_proj",
-                VirtualAllocationRole::MoeExpert,
-            )
-            .expect("reserve tensor");
-        let ptr = arena.allocation(id).expect("allocation").buffer().as_ptr();
-        store
-            .load_range_to_virtual_arena(
-                &mut arena,
-                id,
-                "model.layers.0.mlp.experts.gate_up_proj",
-                4096,
-                4096,
-            )
-            .expect("upload expert 1");
-        let allocation = arena.allocation(id).expect("allocation after upload");
-        assert_eq!(allocation.buffer().as_ptr(), ptr);
-        let bytes = allocation
-            .buffer()
-            .to_host_range_bytes(4096, 4096)
-            .expect("read expert 1");
-        assert!(bytes.iter().all(|b| *b == 2));
+        with_supported_vmm_backend(
+            "store_range_upload_keeps_stable_virtual_pointer",
+            |_backend| {
+                let tmp = synthetic_store(2, 4096);
+                let store = BakedStore::open(tmp.path()).expect("open synthetic store");
+                let mut arena = VirtualArena::new(0, VirtualBacking::Discard);
+                let id = store
+                    .reserve_virtual_arena(
+                        &mut arena,
+                        "model.layers.0.mlp.experts.gate_up_proj",
+                        VirtualAllocationRole::MoeExpert,
+                    )
+                    .expect("reserve tensor");
+                let ptr = arena.allocation(id).expect("allocation").buffer().as_ptr();
+                store
+                    .load_range_to_virtual_arena(
+                        &mut arena,
+                        id,
+                        "model.layers.0.mlp.experts.gate_up_proj",
+                        4096,
+                        4096,
+                    )
+                    .expect("upload expert 1");
+                let allocation = arena.allocation(id).expect("allocation after upload");
+                assert_eq!(allocation.buffer().as_ptr(), ptr);
+                let bytes = allocation
+                    .buffer()
+                    .to_host_range_bytes(4096, 4096)
+                    .expect("read expert 1");
+                assert!(bytes.iter().all(|b| *b == 2));
+            },
+        );
     }
 }

--- a/crates/runner/src/qwen36_moe_residency.rs
+++ b/crates/runner/src/qwen36_moe_residency.rs
@@ -380,6 +380,17 @@ mod tests {
     use super::*;
     use gpu_hal::{Backend, VirtualAllocationRole};
     use model_store::manifest::{LayoutTag, Manifest, TensorMeta, FORMAT_VERSION};
+    use std::sync::Mutex;
+
+    static VMM_BACKEND_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    struct BackendRestore(Backend);
+
+    impl Drop for BackendRestore {
+        fn drop(&mut self) {
+            gpu_hal::set_backend(self.0);
+        }
+    }
 
     fn synthetic_store(expert_count: usize, expert_bytes: usize) -> tempfile::TempDir {
         let tmp = tempfile::tempdir().expect("tempdir");
@@ -421,6 +432,11 @@ mod tests {
     }
 
     fn with_supported_vmm_backend(test_name: &str, mut f: impl FnMut(Backend)) {
+        let _lock = VMM_BACKEND_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _restore_backend = BackendRestore(gpu_hal::current_backend());
+
         for backend in vmm_backends() {
             gpu_hal::set_backend(backend);
             if !gpu_hal::vmm_is_supported(backend, 0) {

--- a/docs/lowlevel-memory.md
+++ b/docs/lowlevel-memory.md
@@ -44,6 +44,10 @@ Current scope:
   `(layer, expert, projection)` slices from the mmap-backed bake, evicts with a
   bounded LRU policy, and invalidates every resident slice covered by an
   unmapped VMM page.
+- Qwen3.6-MoE sparse expert residency is backend-aware at the VMM policy layer
+  and is unit-tested on supported HIP/CUDA VMM backends. Full Qwen3.6-MoE
+  decode kernels are still HIP-only; CUDA runtime decode remains blocked before
+  kernel launch.
 - `SUPERSONIC_MOE_ISLAND_CAP_EXPERTS=N` activates router-driven sparse MoE
   islands for Qwen3.6-MoE INT4 decode. The chained decode path runs FFN stage 1
   first, downloads the `top_k` expert ids, pins those experts' gate/up and down
@@ -102,6 +106,8 @@ on CUDA devices with `SUPERSONIC_VMM_KV=1`:
   `SUPERSONIC_BACKENDS=hip cargo test -p model-store virtual_arena_loads_baked_weight_and_expert_tensors -- --nocapture`
 - Qwen3.6-MoE sparse residency manager tests:
   `SUPERSONIC_BACKENDS=hip cargo test -p runner qwen36_moe_residency -- --nocapture`
+- CUDA Qwen3.6-MoE sparse residency manager tests:
+  `SUPERSONIC_BACKENDS=cuda cargo test -p runner qwen36_moe_residency -- --nocapture`
 - Qwen3.6-MoE sparse router-prefetch smoke:
   `SUPERSONIC_BACKENDS=hip SUPERSONIC_VMM_MOE_ISLANDS=1 SUPERSONIC_MOE_ISLAND_CAP_EXPERTS=8 cargo run --release --bin supersonic -- --backend hip --model qwen3.6-35b-a3b --model-dir /mnt/data/models/Qwen3.6-35B-A3B --int4 --prompt "Hello" --max-new-tokens 1`
   generated `[11]` and reported `resident=32.00MiB` for the 15 GiB routed


### PR DESCRIPTION
## Summary

- Make the Qwen3.6-MoE expert VMM policy gate backend-aware instead of hardcoding HIP support checks.
- Thread the registry-selected backend into decode-side VMM residency setup and logging while preserving the existing HIP-only CUDA decode guard.
- Run sparse expert residency unit tests against every supported VMM backend, including CUDA, and document the CUDA validation command.

## Impact

This lets the Qwen3.6-MoE VMM residency manager exercise CUDA VMM with synthetic expert slabs. It does not enable full CUDA Qwen3.6-MoE decode; that path still exits before kernel launch because the decode kernels remain HIP-only.

## Validation

- `cargo fmt --check`
- `SUPERSONIC_BACKENDS=cuda cargo test -p gpu-hal --test cuda_vmm_round_trip -- --nocapture`
- `SUPERSONIC_BACKENDS=cuda cargo test -p runner qwen36_moe_residency -- --nocapture`
- `SUPERSONIC_BACKENDS=cuda cargo build --release --bin supersonic`