### PR TITLE
Add sparse MoE VMM telemetry smoke

### DIFF
--- a/crates/gpu-hal/src/vmm.rs
+++ b/crates/gpu-hal/src/vmm.rs
@@ -378,11 +378,6 @@ impl VirtualBuffer {
             ops::sync(self.device_ordinal)?;
         }
         for (seg_offset, seg_len) in self.missing_segments(aligned_offset, aligned_end) {
-            let prefix_end = self.contiguous_prefix_end();
-            if seg_offset == prefix_end && prefix_end > 0 {
-                self.remap_contiguous_prefix(seg_offset + seg_len)?;
-                continue;
-            }
             let mapping = hal_profile_time("vmm_map", seg_len, || {
                 map_physical(
                     self.backend,
@@ -793,76 +788,6 @@ impl VirtualBuffer {
             return false;
         }
         self.missing_segments(offset, end).is_empty()
-    }
-
-    fn contiguous_prefix_end(&self) -> usize {
-        let mut ranges: Vec<(usize, usize)> = self
-            .mappings
-            .iter()
-            .map(|mapping| (mapping.offset, mapping.offset + mapping.len))
-            .collect();
-        ranges.sort_by_key(|(start, _)| *start);
-
-        let mut cursor = 0;
-        for (start, end) in ranges {
-            if start > cursor {
-                break;
-            }
-            cursor = cursor.max(end);
-        }
-        cursor
-    }
-
-    fn remap_contiguous_prefix(&mut self, new_end: usize) -> Result<()> {
-        let old_end = self.contiguous_prefix_end();
-        if old_end == 0 || new_end <= old_end {
-            return Ok(());
-        }
-
-        let mut old = vec![0u8; old_end];
-        ops::copy_d2h(
-            self.device_ordinal,
-            old.as_mut_ptr() as *mut c_void,
-            self.ptr.as_ptr(),
-            old.len(),
-        )?;
-        ops::sync(self.device_ordinal)?;
-
-        let mut i = 0;
-        while i < self.mappings.len() {
-            let map_end = self.mappings[i].offset + self.mappings[i].len;
-            if self.mappings[i].offset < old_end && map_end <= old_end {
-                let mapping = self.mappings.remove(i);
-                hal_profile_time("vmm_unmap", mapping.len, || {
-                    unmap_and_release(self.backend, self.device_ordinal, self.ptr, mapping)
-                })?;
-            } else {
-                i += 1;
-            }
-        }
-
-        let mapping = hal_profile_time("vmm_map", new_end, || {
-            map_physical(
-                self.backend,
-                self.device_ordinal,
-                self.ptr,
-                0,
-                new_end,
-                0,
-                new_end,
-            )
-        })?;
-        self.mappings.push(mapping);
-        self.mapped_bytes = self.mapped_bytes.max(new_end);
-        ops::memset_zeros(self.device_ordinal, self.ptr.as_ptr(), new_end)?;
-        ops::sync(self.device_ordinal)?;
-        ops::copy_h2d(
-            self.device_ordinal,
-            self.ptr.as_ptr(),
-            old.as_ptr() as *const c_void,
-            old.len(),
-        )?;
-        Ok(())
     }
 }
 

--- a/crates/gpu-hal/tests/vmm_round_trip.rs
+++ b/crates/gpu-hal/tests/vmm_round_trip.rs
@@ -74,11 +74,12 @@ fn vmm_sparse_range_round_trip_stable_pointer() {
         return;
     }
 
-    let mut buf = VirtualBuffer::reserve(0, ScalarType::U8, &[1 << 20], VirtualBacking::Discard)
+    let mut buf = VirtualBuffer::reserve(0, ScalarType::U8, &[8 << 20], VirtualBacking::Discard)
         .expect("reserve virtual buffer");
     let base = buf.as_ptr();
+    let page = buf.granularity();
     let first_offset = 0;
-    let second_offset = 512 * 1024;
+    let second_offset = 2 * page;
     let len = 4096;
 
     buf.map_range_bytes(first_offset, len)
@@ -86,6 +87,11 @@ fn vmm_sparse_range_round_trip_stable_pointer() {
     buf.map_range_bytes(second_offset, len)
         .expect("map second island");
     assert_eq!(buf.as_ptr(), base, "sparse mapping changed base VA");
+    assert_eq!(
+        buf.mapping_count(),
+        2,
+        "disjoint sparse VMM islands should remain separate mappings"
+    );
 
     let first = pattern_bytes(len);
     let second = pattern_bytes(len)

--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -1065,6 +1065,120 @@ fn moe_island_cap_experts_from_env() -> Result<Option<usize>> {
     Ok(Some(cap))
 }
 
+#[derive(Debug, Clone, Copy)]
+struct MoeSparseTelemetrySnapshot {
+    stats: crate::qwen36_moe_residency::MoeExpertResidencyStats,
+    arena: gpu_hal::VirtualArenaStats,
+}
+
+impl MoeSparseTelemetrySnapshot {
+    fn capture(manager: &MoeExpertResidencyManager) -> Self {
+        Self {
+            stats: manager.stats(),
+            arena: manager.arena().stats(),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct MoeSparseTelemetry {
+    dump_path: Option<PathBuf>,
+    steps: Vec<serde_json::Value>,
+    peak_resident_slices: usize,
+    peak_resident_bytes: usize,
+    peak_logical_resident_bytes: usize,
+}
+
+impl MoeSparseTelemetry {
+    fn from_env(active: bool) -> Result<Option<Self>> {
+        if !active {
+            return Ok(None);
+        }
+        let dump_path = std::env::var_os("SUPERSONIC_MOE_ISLAND_TELEMETRY_JSON").map(PathBuf::from);
+        Ok(Some(Self {
+            dump_path,
+            steps: Vec::new(),
+            peak_resident_slices: 0,
+            peak_resident_bytes: 0,
+            peak_logical_resident_bytes: 0,
+        }))
+    }
+
+    fn record_step(
+        &mut self,
+        step: usize,
+        position: i32,
+        is_generation_step: bool,
+        before: MoeSparseTelemetrySnapshot,
+        after: MoeSparseTelemetrySnapshot,
+    ) {
+        self.peak_resident_slices = self.peak_resident_slices.max(after.stats.resident_slices);
+        self.peak_resident_bytes = self.peak_resident_bytes.max(after.arena.resident_bytes);
+        self.peak_logical_resident_bytes = self
+            .peak_logical_resident_bytes
+            .max(after.arena.logical_resident_bytes);
+
+        if self.dump_path.is_none() {
+            return;
+        }
+
+        self.steps.push(serde_json::json!({
+            "step": step,
+            "position": position,
+            "kind": if is_generation_step { "generate" } else { "prefill" },
+            "delta": {
+                "hits": after.stats.hits.saturating_sub(before.stats.hits),
+                "misses": after.stats.misses.saturating_sub(before.stats.misses),
+                "evicted_slices": after.stats.evicted_slices.saturating_sub(before.stats.evicted_slices),
+                "uploaded_bytes": after.stats.uploaded_bytes.saturating_sub(before.stats.uploaded_bytes),
+                "unmapped_bytes": after.stats.unmapped_bytes.saturating_sub(before.stats.unmapped_bytes),
+            },
+            "resident": {
+                "slices": after.stats.resident_slices,
+                "logical_bytes": after.arena.logical_resident_bytes,
+                "physical_bytes": after.arena.resident_bytes,
+                "mappings": after.arena.mapping_count,
+            },
+            "cumulative": {
+                "hits": after.stats.hits,
+                "misses": after.stats.misses,
+                "evicted_slices": after.stats.evicted_slices,
+                "uploaded_bytes": after.stats.uploaded_bytes,
+                "unmapped_bytes": after.stats.unmapped_bytes,
+            }
+        }));
+    }
+
+    fn write_json(&self, manager: &MoeExpertResidencyManager, generated_ids: &[u32]) -> Result<()> {
+        let Some(path) = self.dump_path.as_ref() else {
+            return Ok(());
+        };
+        let final_snapshot = MoeSparseTelemetrySnapshot::capture(manager);
+        let payload = serde_json::json!({
+            "schema": "supersonic-qwen36-moe-sparse-vmm-telemetry-v1",
+            "summary": {
+                "registered_tensors": final_snapshot.stats.registered_tensors,
+                "final_resident_slices": final_snapshot.stats.resident_slices,
+                "peak_resident_slices": self.peak_resident_slices,
+                "peak_resident_bytes": self.peak_resident_bytes,
+                "peak_logical_resident_bytes": self.peak_logical_resident_bytes,
+                "reserved_bytes": final_snapshot.arena.reserved_bytes,
+                "logical_bytes": final_snapshot.arena.logical_bytes,
+                "hits": final_snapshot.stats.hits,
+                "misses": final_snapshot.stats.misses,
+                "evicted_slices": final_snapshot.stats.evicted_slices,
+                "uploaded_bytes": final_snapshot.stats.uploaded_bytes,
+                "unmapped_bytes": final_snapshot.stats.unmapped_bytes,
+            },
+            "generated_ids": generated_ids,
+            "steps": self.steps,
+        });
+        let bytes = serde_json::to_vec_pretty(&payload)?;
+        std::fs::write(path, bytes)
+            .with_context(|| format!("write MoE sparse VMM telemetry to {}", path.display()))
+    }
+}
+
 /// Build one layer's worth of GPU-resident weight + state buffers from a
 /// BakedStore. Decides full-attn vs linear-attn by consulting the config's
 /// `layer_types` (every 4th layer is full per the standard hybrid pattern).
@@ -1843,6 +1957,16 @@ fn decode_text(
     let mut _moe_expert_arena = None;
     let mut _moe_expert_residency = None;
     let sparse_moe_requested = moe_island_cap_experts.is_some();
+    let mut moe_sparse_telemetry = MoeSparseTelemetry::from_env(sparse_moe_requested)?;
+    if let Some(path) = moe_sparse_telemetry
+        .as_ref()
+        .and_then(|telemetry| telemetry.dump_path.as_ref())
+    {
+        println!(
+            "  [vmm] sparse MoE residency telemetry will be written to {}",
+            path.display()
+        );
+    }
     let mut layers = if let Some(cap_experts) = moe_island_cap_experts {
         if cap_experts < geom.top_k as usize {
             anyhow::bail!(
@@ -2250,6 +2374,9 @@ fn decode_text(
             None
         };
         let lm_head_folded;
+        let moe_telemetry_before = _moe_expert_residency
+            .as_ref()
+            .map(MoeSparseTelemetrySnapshot::capture);
         let outputs = if let Some(scratch) = persistent_scratch.as_mut() {
             lm_head_folded = fold.is_some();
             scratch
@@ -2303,6 +2430,14 @@ fn decode_text(
             }
             .with_context(|| format!("chained decode (step {step}, position {position})"))?
         };
+        if let (Some(telemetry), Some(before), Some(manager)) = (
+            moe_sparse_telemetry.as_mut(),
+            moe_telemetry_before,
+            _moe_expert_residency.as_ref(),
+        ) {
+            let after = MoeSparseTelemetrySnapshot::capture(manager);
+            telemetry.record_step(step, position, is_gen_step, before, after);
+        }
         let t_chain_step = t1.elapsed();
         position += 1;
 
@@ -2740,18 +2875,37 @@ fn decode_text(
     if let Some(manager) = _moe_expert_residency.as_ref() {
         let residency = manager.stats();
         let arena = manager.arena().stats();
-        println!(
-            "  [vmm] MoE island residency: resident_slices={} hits={} misses={} \
-             evicted_slices={} uploaded={:.2}MiB unmapped={:.2}MiB resident={:.2}MiB reserved={:.2}MiB",
-            residency.resident_slices,
-            residency.hits,
-            residency.misses,
-            residency.evicted_slices,
-            residency.uploaded_bytes as f64 / MIB,
-            residency.unmapped_bytes as f64 / MIB,
-            arena.resident_bytes as f64 / MIB,
-            arena.reserved_bytes as f64 / MIB,
-        );
+        if let Some(telemetry) = moe_sparse_telemetry.as_ref() {
+            println!(
+                "  [vmm] MoE island residency: resident_slices={} peak_slices={} \
+                 hits={} misses={} evicted_slices={} uploaded={:.2}MiB unmapped={:.2}MiB \
+                 resident={:.2}MiB peak_resident={:.2}MiB reserved={:.2}MiB",
+                residency.resident_slices,
+                telemetry.peak_resident_slices,
+                residency.hits,
+                residency.misses,
+                residency.evicted_slices,
+                residency.uploaded_bytes as f64 / MIB,
+                residency.unmapped_bytes as f64 / MIB,
+                arena.resident_bytes as f64 / MIB,
+                telemetry.peak_resident_bytes as f64 / MIB,
+                arena.reserved_bytes as f64 / MIB,
+            );
+            telemetry.write_json(manager, &generated_ids)?;
+        } else {
+            println!(
+                "  [vmm] MoE island residency: resident_slices={} hits={} misses={} \
+                 evicted_slices={} uploaded={:.2}MiB unmapped={:.2}MiB resident={:.2}MiB reserved={:.2}MiB",
+                residency.resident_slices,
+                residency.hits,
+                residency.misses,
+                residency.evicted_slices,
+                residency.uploaded_bytes as f64 / MIB,
+                residency.unmapped_bytes as f64 / MIB,
+                arena.resident_bytes as f64 / MIB,
+                arena.reserved_bytes as f64 / MIB,
+            );
+        }
     }
     if emit_stage_timings && gen_steps > 0 {
         let to_ms = |d: std::time::Duration| d.as_secs_f64() * 1000.0;

--- a/crates/runner/src/qwen36_moe_residency.rs
+++ b/crates/runner/src/qwen36_moe_residency.rs
@@ -222,7 +222,7 @@ impl MoeExpertResidencyManager {
 
     pub fn ensure_resident(&mut self, store: &BakedStore, key: MoeExpertKey) -> Result<()> {
         let tensor_idx = self.tensor_idx(key.layer_idx, key.projection)?;
-        let (name, allocation_id, logical_offset, logical_len, page_offset, page_len) = {
+        let (name, allocation_id, logical_offset, logical_len, page_offset, page_len, copy_len) = {
             let tensor = &self.tensors[tensor_idx];
             if key.expert_idx >= tensor.expert_count {
                 return Err(anyhow!(
@@ -237,6 +237,7 @@ impl MoeExpertResidencyManager {
             let logical_len = tensor.expert_bytes;
             let (page_offset, page_len) =
                 page_range(tensor.page_bytes, logical_offset, logical_len);
+            let copy_len = page_len.min(tensor.len_bytes.saturating_sub(page_offset));
             (
                 tensor.name.clone(),
                 tensor.allocation_id,
@@ -244,6 +245,7 @@ impl MoeExpertResidencyManager {
                 logical_len,
                 page_offset,
                 page_len,
+                copy_len,
             )
         };
 
@@ -264,8 +266,8 @@ impl MoeExpertResidencyManager {
                 &mut self.arena,
                 allocation_id,
                 &name,
-                logical_offset,
-                logical_len,
+                page_offset,
+                copy_len,
             )
             .with_context(|| {
                 format!(
@@ -273,7 +275,7 @@ impl MoeExpertResidencyManager {
                     key.layer_idx, key.expert_idx, key.projection
                 )
             })?;
-        self.uploaded_bytes += logical_len;
+        self.uploaded_bytes += copy_len;
         self.resident.insert(
             key,
             ResidentSlice {

--- a/crates/runner/tests/qwen36_moe_sparse_vmm_smoke.rs
+++ b/crates/runner/tests/qwen36_moe_sparse_vmm_smoke.rs
@@ -1,0 +1,178 @@
+#[cfg(target_os = "linux")]
+use std::path::Path;
+#[cfg(target_os = "linux")]
+use std::process::Command;
+
+#[cfg(target_os = "linux")]
+fn model_dir() -> Option<String> {
+    std::env::var("SUPERSONIC_TEST_QWEN36_MOE_MODEL_DIR")
+        .or_else(|_| std::env::var("SUPERSONIC_QWEN36_MTP_MODEL_DIR"))
+        .ok()
+}
+
+#[cfg(target_os = "linux")]
+fn combined_output(output: &std::process::Output) -> String {
+    format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+#[cfg(target_os = "linux")]
+fn generated_ids(output: &str) -> Vec<u32> {
+    let line = output
+        .lines()
+        .find(|line| line.trim_start().starts_with("Generated ids: "))
+        .expect("supersonic output should contain generated ids");
+    let (_, ids) = line
+        .split_once(':')
+        .expect("generated ids line should contain ':'");
+    serde_json::from_str(ids.trim()).expect("generated ids should parse as a JSON array")
+}
+
+#[cfg(target_os = "linux")]
+fn hip_vmm_supported() -> bool {
+    gpu_hal::set_backend(gpu_hal::Backend::Hip);
+    gpu_hal::vmm_is_supported(gpu_hal::Backend::Hip, 0)
+}
+
+#[cfg(target_os = "linux")]
+fn sparse_cap_experts() -> usize {
+    std::env::var("SUPERSONIC_TEST_QWEN36_MOE_SPARSE_CAP_EXPERTS")
+        .ok()
+        .and_then(|raw| raw.parse::<usize>().ok())
+        .unwrap_or(256)
+}
+
+#[cfg(target_os = "linux")]
+fn run_qwen36_moe(
+    model_dir: &str,
+    sparse_cap_experts: Option<usize>,
+    telemetry_path: Option<&Path>,
+) -> std::process::Output {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_supersonic"));
+    cmd.env("SUPERSONIC_BACKENDS", "hip")
+        .env("SUPERSONIC_VMM_MOE_ISLANDS", "1")
+        .env_remove("SUPERSONIC_MOE_ISLAND_CAP_EXPERTS")
+        .env_remove("SUPERSONIC_MOE_ISLAND_TELEMETRY_JSON")
+        .args([
+            "--backend",
+            "hip",
+            "--model",
+            "qwen3.6-35b-a3b",
+            "--model-dir",
+            model_dir,
+            "--int4",
+            "--prompt",
+            "Hello",
+            "--max-new-tokens",
+            "2",
+            "--context-size",
+            "16",
+            "--temperature",
+            "0",
+            "--no-download",
+        ]);
+    if let Some(cap) = sparse_cap_experts {
+        cmd.env("SUPERSONIC_MOE_ISLAND_CAP_EXPERTS", cap.to_string());
+    }
+    if let Some(path) = telemetry_path {
+        cmd.env("SUPERSONIC_MOE_ISLAND_TELEMETRY_JSON", path);
+    }
+    cmd.output()
+        .unwrap_or_else(|e| panic!("run supersonic qwen36 sparse VMM smoke: {e}"))
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+#[ignore = "requires HIP, VMM, and a local Qwen3.6-35B-A3B dir via SUPERSONIC_TEST_QWEN36_MOE_MODEL_DIR"]
+fn qwen36_moe_sparse_vmm_matches_dense_virtual_slabs() {
+    if !hip_vmm_supported() {
+        eprintln!("skipping: HIP VMM unsupported on this device/runtime");
+        return;
+    }
+
+    let Some(model_dir) = model_dir() else {
+        eprintln!(
+            "skipping: SUPERSONIC_TEST_QWEN36_MOE_MODEL_DIR/SUPERSONIC_QWEN36_MTP_MODEL_DIR not set"
+        );
+        return;
+    };
+
+    let dense = run_qwen36_moe(&model_dir, None, None);
+    let dense_combined = combined_output(&dense);
+    assert!(
+        dense.status.success(),
+        "dense virtual-slab Qwen3.6-MoE smoke failed with status {:?}:\n{}",
+        dense.status.code(),
+        dense_combined
+    );
+    assert!(
+        dense_combined.contains("[vmm] Qwen3.6-MoE routed expert slabs active"),
+        "dense run did not report VMM expert slabs:\n{}",
+        dense_combined
+    );
+    let dense_ids = generated_ids(&dense_combined);
+
+    let temp = tempfile::tempdir().expect("create sparse telemetry tempdir");
+    let telemetry_path = temp.path().join("qwen36_sparse_telemetry.json");
+    let cap_experts = sparse_cap_experts();
+    let sparse = run_qwen36_moe(&model_dir, Some(cap_experts), Some(&telemetry_path));
+    let sparse_combined = combined_output(&sparse);
+    assert!(
+        sparse.status.success(),
+        "sparse VMM Qwen3.6-MoE smoke failed with status {:?}:\n{}",
+        sparse.status.code(),
+        sparse_combined
+    );
+    assert!(
+        sparse_combined.contains("[vmm] Qwen3.6-MoE sparse routed expert residency active")
+            && sparse_combined.contains("peak_slices="),
+        "sparse run did not report sparse residency telemetry:\n{}",
+        sparse_combined
+    );
+    assert_eq!(
+        generated_ids(&sparse_combined),
+        dense_ids,
+        "sparse VMM and dense virtual-slab VMM generated different token IDs"
+    );
+
+    let raw = std::fs::read_to_string(&telemetry_path).expect("read sparse telemetry JSON");
+    let json: serde_json::Value = serde_json::from_str(&raw).expect("parse sparse telemetry JSON");
+    assert_eq!(
+        json["schema"],
+        "supersonic-qwen36-moe-sparse-vmm-telemetry-v1"
+    );
+    let summary = &json["summary"];
+    let max_slices = (cap_experts * 2) as u64;
+    assert!(
+        summary["peak_resident_slices"].as_u64().unwrap() <= max_slices,
+        "peak slices exceeded sparse cap: {summary:?}"
+    );
+    assert!(
+        summary["final_resident_slices"].as_u64().unwrap() <= max_slices,
+        "final slices exceeded sparse cap: {summary:?}"
+    );
+    assert!(
+        summary["peak_resident_bytes"].as_u64().unwrap()
+            < summary["reserved_bytes"].as_u64().unwrap(),
+        "sparse resident bytes should stay below full VA reservation: {summary:?}"
+    );
+    assert!(
+        summary["misses"].as_u64().unwrap() > 0 && summary["uploaded_bytes"].as_u64().unwrap() > 0,
+        "sparse run did not exercise uploads/misses: {summary:?}"
+    );
+    assert!(
+        json["steps"].as_array().unwrap().len() >= 2,
+        "sparse telemetry should include multiple forward steps"
+    );
+    assert!(
+        json["steps"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|step| step["kind"] == "generate"),
+        "sparse telemetry should mark generation steps"
+    );
+}

--- a/docs/lowlevel-memory.md
+++ b/docs/lowlevel-memory.md
@@ -50,8 +50,21 @@ Current scope:
   slices, then runs the normal stage-5 FFN launch against the stable virtual
   slab pointers. The cap is expressed in experts and reserves `2*N` logical
   resident slices because each expert needs both fused projections. Sparse
-  islands currently disable the persistent megakernel for that run; persistent
-  router prefetch needs a future split or in-kernel residency protocol.
+  islands copy the full VMM backing page for any touched expert slice, so every
+  expert sharing that resident page contains real bake data rather than zero
+  fill. Sparse islands currently disable the persistent megakernel for that
+  run; persistent router prefetch needs a future split or in-kernel residency
+  protocol.
+- `SUPERSONIC_MOE_ISLAND_TELEMETRY_JSON=/path/report.json` records sparse
+  MoE residency telemetry for Qwen3.6-MoE runs: per-forward hits, misses,
+  uploads, evictions, resident slices, resident physical bytes, plus summary
+  peaks. This is intended for tuning `SUPERSONIC_MOE_ISLAND_CAP_EXPERTS`
+  against real prompts instead of relying on one-token smoke numbers.
+- On the HIP/gfx1100 validation machine, sparse MoE caps through 312 experts
+  passed the two-token Qwen3.6-MoE smoke, while caps around 316+ reproduced a
+  HIP page-not-present fault after retaining roughly a full token's routed
+  expert working set. Keep validation caps below that high-water mark until the
+  ROCm VMM mapping-limit behavior is isolated further.
 - `SUPERSONIC_VMM_WEIGHT_PROBE=1` makes Qwen3.6-MoE dry-run load
   `lm_head.weight` into a virtual `Weights` allocation when an INT4 bake is
   present.
@@ -106,6 +119,14 @@ on CUDA devices with `SUPERSONIC_VMM_KV=1`:
   `SUPERSONIC_BACKENDS=hip SUPERSONIC_VMM_MOE_ISLANDS=1 SUPERSONIC_MOE_ISLAND_CAP_EXPERTS=8 cargo run --release --bin supersonic -- --backend hip --model qwen3.6-35b-a3b --model-dir /mnt/data/models/Qwen3.6-35B-A3B --int4 --prompt "Hello" --max-new-tokens 1`
   generated `[11]` and reported `resident=32.00MiB` for the 15 GiB routed
   expert VA reservation after the run.
+- Qwen3.6-MoE sparse-vs-dense VMM e2e gate:
+  `SUPERSONIC_BACKENDS=hip SUPERSONIC_TEST_QWEN36_MOE_MODEL_DIR=/mnt/data/models/Qwen3.6-35B-A3B cargo test --release -p runner --test qwen36_moe_sparse_vmm_smoke -- --ignored --nocapture`
+  compares dense virtual expert slabs with sparse router-prefetched slabs over
+  multiple generated tokens and validates the telemetry JSON cap/peak fields.
+  The default test cap is 256 experts; override with
+  `SUPERSONIC_TEST_QWEN36_MOE_SPARSE_CAP_EXPERTS=8` for the smallest
+  top-k-sized residency window, or with a larger value when investigating HIP
+  live-mapping limits.
 - Qwen3.5 virtual KV e2e with eviction and restore-to-VMM:
   `SUPERSONIC_VMM_KV=1 SUPERSONIC_VMM_KV_EVICT_AFTER_PREFILL=1 SUPERSONIC_VMM_KV_RESTORE_TO_VMM=1 ... --validate`
   passed and kept stable VMM pointers through decode.


### PR DESCRIPTION
## Summary
- add Qwen3.6-MoE sparse VMM telemetry JSON and peak residency reporting
- upload full VMM backing pages for sparse expert slices so page-neighbor experts contain real bake data
- keep sparse VMM mappings as independent pages and add HIP sparse-vs-dense smoke coverage

## Validation
- cargo fmt --all --check
- SUPERSONIC_BACKENDS=hip cargo check -p runner --bin supersonic
- SUPERSONIC_BACKENDS=hip cargo test -p runner qwen36_moe_residency -- --nocapture
- SUPERSONIC_BACKENDS=hip cargo test -p gpu-hal --test vmm_round_trip vmm_sparse_range_round_trip_stable_pointer -- --nocapture
- SUPERSONIC_BACKENDS=hip SUPERSONIC_TEST_QWEN36_MOE_MODEL_DIR=/mnt/data/models/Qwen3.6-35B-A3B cargo test --release -p runner --test qwen36_moe_sparse_vmm_smoke -- --ignored --nocapture
- SUPERSONIC_BACKENDS=hip SUPERSONIC_TEST_QWEN36_MOE_MODEL_DIR=/mnt/data/models/Qwen3.6-35B-A3B SUPERSONIC_TEST_QWEN36_MOE_SPARSE_CAP_EXPERTS=8 cargo test --release -p runner --test qwen36_moe_sparse_vmm_smoke -- --ignored --nocapture

## Notes
- Bracketed the HIP high-cap sparse path: caps through 312 experts pass the two-token smoke on gfx1100; caps around 316+ reproduce a HIP page-not-present fault. The ignored e2e gate defaults to cap 256 and documents the high-cap behavior for follow-up.