### PR TITLE
Make Qwen3.6 MoE sparse residency page-aware

### DIFF
--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -1086,6 +1086,8 @@ struct MoeSparseTelemetry {
     dump_path: Option<PathBuf>,
     steps: Vec<serde_json::Value>,
     peak_resident_slices: usize,
+    peak_resident_pages: usize,
+    peak_page_backed_slices: usize,
     peak_resident_bytes: usize,
     peak_logical_resident_bytes: usize,
 }
@@ -1100,6 +1102,8 @@ impl MoeSparseTelemetry {
             dump_path,
             steps: Vec::new(),
             peak_resident_slices: 0,
+            peak_resident_pages: 0,
+            peak_page_backed_slices: 0,
             peak_resident_bytes: 0,
             peak_logical_resident_bytes: 0,
         }))
@@ -1114,6 +1118,10 @@ impl MoeSparseTelemetry {
         after: MoeSparseTelemetrySnapshot,
     ) {
         self.peak_resident_slices = self.peak_resident_slices.max(after.stats.resident_slices);
+        self.peak_resident_pages = self.peak_resident_pages.max(after.stats.resident_pages);
+        self.peak_page_backed_slices = self
+            .peak_page_backed_slices
+            .max(after.stats.page_backed_slices);
         self.peak_resident_bytes = self.peak_resident_bytes.max(after.arena.resident_bytes);
         self.peak_logical_resident_bytes = self
             .peak_logical_resident_bytes
@@ -1130,12 +1138,17 @@ impl MoeSparseTelemetry {
             "delta": {
                 "hits": after.stats.hits.saturating_sub(before.stats.hits),
                 "misses": after.stats.misses.saturating_sub(before.stats.misses),
+                "page_hits": after.stats.page_hits.saturating_sub(before.stats.page_hits),
+                "page_misses": after.stats.page_misses.saturating_sub(before.stats.page_misses),
                 "evicted_slices": after.stats.evicted_slices.saturating_sub(before.stats.evicted_slices),
+                "evicted_pages": after.stats.evicted_pages.saturating_sub(before.stats.evicted_pages),
                 "uploaded_bytes": after.stats.uploaded_bytes.saturating_sub(before.stats.uploaded_bytes),
                 "unmapped_bytes": after.stats.unmapped_bytes.saturating_sub(before.stats.unmapped_bytes),
             },
             "resident": {
                 "slices": after.stats.resident_slices,
+                "pages": after.stats.resident_pages,
+                "page_backed_slices": after.stats.page_backed_slices,
                 "logical_bytes": after.arena.logical_resident_bytes,
                 "physical_bytes": after.arena.resident_bytes,
                 "mappings": after.arena.mapping_count,
@@ -1143,7 +1156,10 @@ impl MoeSparseTelemetry {
             "cumulative": {
                 "hits": after.stats.hits,
                 "misses": after.stats.misses,
+                "page_hits": after.stats.page_hits,
+                "page_misses": after.stats.page_misses,
                 "evicted_slices": after.stats.evicted_slices,
+                "evicted_pages": after.stats.evicted_pages,
                 "uploaded_bytes": after.stats.uploaded_bytes,
                 "unmapped_bytes": after.stats.unmapped_bytes,
             }
@@ -1160,14 +1176,21 @@ impl MoeSparseTelemetry {
             "summary": {
                 "registered_tensors": final_snapshot.stats.registered_tensors,
                 "final_resident_slices": final_snapshot.stats.resident_slices,
+                "final_resident_pages": final_snapshot.stats.resident_pages,
+                "final_page_backed_slices": final_snapshot.stats.page_backed_slices,
                 "peak_resident_slices": self.peak_resident_slices,
+                "peak_resident_pages": self.peak_resident_pages,
+                "peak_page_backed_slices": self.peak_page_backed_slices,
                 "peak_resident_bytes": self.peak_resident_bytes,
                 "peak_logical_resident_bytes": self.peak_logical_resident_bytes,
                 "reserved_bytes": final_snapshot.arena.reserved_bytes,
                 "logical_bytes": final_snapshot.arena.logical_bytes,
                 "hits": final_snapshot.stats.hits,
                 "misses": final_snapshot.stats.misses,
+                "page_hits": final_snapshot.stats.page_hits,
+                "page_misses": final_snapshot.stats.page_misses,
                 "evicted_slices": final_snapshot.stats.evicted_slices,
+                "evicted_pages": final_snapshot.stats.evicted_pages,
                 "uploaded_bytes": final_snapshot.stats.uploaded_bytes,
                 "unmapped_bytes": final_snapshot.stats.unmapped_bytes,
             },
@@ -1981,10 +2004,10 @@ fn decode_text(
         if !should_try_moe_expert_vmm(MoeExpertVmmMode::Force, backend, weight_mode, ordinal)? {
             unreachable!("forced VMM expert check should either return true or error");
         }
-        let max_resident_slices = cap_experts
+        let max_resident_pages = cap_experts
             .checked_mul(2)
-            .ok_or_else(|| anyhow!("SUPERSONIC_MOE_ISLAND_CAP_EXPERTS overflows slice cap"))?;
-        let config = MoeExpertResidencyConfig::new(max_resident_slices)?;
+            .ok_or_else(|| anyhow!("SUPERSONIC_MOE_ISLAND_CAP_EXPERTS overflows page cap"))?;
+        let config = MoeExpertResidencyConfig::new(max_resident_pages)?;
         let mut manager = MoeExpertResidencyManager::new(ordinal, config);
         let layers = load_all_layer_buffers(
             &store,
@@ -2002,10 +2025,10 @@ fn decode_text(
         let residency_stats = manager.stats();
         println!(
             "  [vmm] Qwen3.6-MoE sparse routed expert residency active on backend={} device {ordinal}: \
-             tensors={} max_slices={} logical={:.2}MiB resident={:.2}MiB reserved={:.2}MiB",
+             tensors={} max_pages={} logical={:.2}MiB resident={:.2}MiB reserved={:.2}MiB",
             backend,
             residency_stats.registered_tensors,
-            max_resident_slices,
+            max_resident_pages,
             arena_stats.logical_bytes as f64 / MIB,
             arena_stats.resident_bytes as f64 / MIB,
             arena_stats.reserved_bytes as f64 / MIB,
@@ -2883,13 +2906,21 @@ fn decode_text(
         if let Some(telemetry) = moe_sparse_telemetry.as_ref() {
             println!(
                 "  [vmm] MoE island residency: resident_slices={} peak_slices={} \
-                 hits={} misses={} evicted_slices={} uploaded={:.2}MiB unmapped={:.2}MiB \
+                 resident_pages={} peak_pages={} page_backed_slices={} \
+                 hits={} misses={} page_hits={} page_misses={} evicted_slices={} evicted_pages={} \
+                 uploaded={:.2}MiB unmapped={:.2}MiB \
                  resident={:.2}MiB peak_resident={:.2}MiB reserved={:.2}MiB",
                 residency.resident_slices,
                 telemetry.peak_resident_slices,
+                residency.resident_pages,
+                telemetry.peak_resident_pages,
+                residency.page_backed_slices,
                 residency.hits,
                 residency.misses,
+                residency.page_hits,
+                residency.page_misses,
                 residency.evicted_slices,
+                residency.evicted_pages,
                 residency.uploaded_bytes as f64 / MIB,
                 residency.unmapped_bytes as f64 / MIB,
                 arena.resident_bytes as f64 / MIB,
@@ -2899,12 +2930,19 @@ fn decode_text(
             telemetry.write_json(manager, &generated_ids)?;
         } else {
             println!(
-                "  [vmm] MoE island residency: resident_slices={} hits={} misses={} \
-                 evicted_slices={} uploaded={:.2}MiB unmapped={:.2}MiB resident={:.2}MiB reserved={:.2}MiB",
+                "  [vmm] MoE island residency: resident_slices={} resident_pages={} \
+                 page_backed_slices={} hits={} misses={} page_hits={} page_misses={} \
+                 evicted_slices={} evicted_pages={} uploaded={:.2}MiB unmapped={:.2}MiB \
+                 resident={:.2}MiB reserved={:.2}MiB",
                 residency.resident_slices,
+                residency.resident_pages,
+                residency.page_backed_slices,
                 residency.hits,
                 residency.misses,
+                residency.page_hits,
+                residency.page_misses,
                 residency.evicted_slices,
+                residency.evicted_pages,
                 residency.uploaded_bytes as f64 / MIB,
                 residency.unmapped_bytes as f64 / MIB,
                 arena.resident_bytes as f64 / MIB,

--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -1175,6 +1175,7 @@ impl MoeSparseTelemetry {
             "schema": "supersonic-qwen36-moe-sparse-vmm-telemetry-v1",
             "summary": {
                 "registered_tensors": final_snapshot.stats.registered_tensors,
+                "max_resident_pages": manager.max_resident_pages(),
                 "final_resident_slices": final_snapshot.stats.resident_slices,
                 "final_resident_pages": final_snapshot.stats.resident_pages,
                 "final_page_backed_slices": final_snapshot.stats.page_backed_slices,
@@ -2004,10 +2005,7 @@ fn decode_text(
         if !should_try_moe_expert_vmm(MoeExpertVmmMode::Force, backend, weight_mode, ordinal)? {
             unreachable!("forced VMM expert check should either return true or error");
         }
-        let max_resident_pages = cap_experts
-            .checked_mul(2)
-            .ok_or_else(|| anyhow!("SUPERSONIC_MOE_ISLAND_CAP_EXPERTS overflows page cap"))?;
-        let config = MoeExpertResidencyConfig::new(max_resident_pages)?;
+        let config = MoeExpertResidencyConfig::new(1)?;
         let mut manager = MoeExpertResidencyManager::new(ordinal, config);
         let layers = load_all_layer_buffers(
             &store,
@@ -2021,6 +2019,12 @@ fn decode_text(
             Some(&mut manager),
         )
         .context("reserve Qwen3.6-MoE routed experts for sparse VMM residency")?;
+        let max_resident_pages = manager
+            .page_budget_for_routed_experts(cap_experts)
+            .context("derive sparse MoE page budget from routed expert tensor layout")?;
+        manager
+            .set_max_resident_pages(max_resident_pages)
+            .context("apply sparse MoE page budget")?;
         let arena_stats = manager.arena().stats();
         let residency_stats = manager.stats();
         println!(

--- a/crates/runner/src/qwen36_moe_residency.rs
+++ b/crates/runner/src/qwen36_moe_residency.rs
@@ -78,6 +78,7 @@ pub struct MoeExpertTensorReservation {
 #[derive(Debug, Clone)]
 struct ExpertTensor {
     name: String,
+    projection: MoeExpertProjection,
     allocation_id: usize,
     ptr: *const c_void,
     dtype: ScalarType,
@@ -181,6 +182,49 @@ impl MoeExpertResidencyManager {
         }
     }
 
+    pub fn max_resident_pages(&self) -> usize {
+        self.config.max_resident_pages
+    }
+
+    pub fn set_max_resident_pages(&mut self, max_resident_pages: usize) -> Result<()> {
+        self.config = MoeExpertResidencyConfig::new(max_resident_pages)?;
+        while self.resident_pages.len() > self.config.max_resident_pages {
+            self.evict_lru_page()?;
+        }
+        Ok(())
+    }
+
+    pub fn page_budget_for_routed_experts(&self, routed_experts: usize) -> Result<usize> {
+        if routed_experts == 0 {
+            return Err(anyhow!("routed_experts must be > 0"));
+        }
+        let mut pages_by_projection: HashMap<MoeExpertProjection, usize> = HashMap::new();
+        for tensor in &self.tensors {
+            let pages_per_slice = tensor.max_pages_per_expert_slice();
+            pages_by_projection
+                .entry(tensor.projection)
+                .and_modify(|current| *current = (*current).max(pages_per_slice))
+                .or_insert(pages_per_slice);
+        }
+        let pages_per_routed_expert = pages_by_projection
+            .values()
+            .try_fold(0usize, |acc, pages| acc.checked_add(*pages))
+            .ok_or_else(|| anyhow!("routed expert page footprint overflows"))?;
+        if pages_per_routed_expert == 0 {
+            return Err(anyhow!(
+                "cannot derive sparse MoE page budget before registering expert tensors"
+            ));
+        }
+        routed_experts
+            .checked_mul(pages_per_routed_expert)
+            .ok_or_else(|| {
+                anyhow!(
+                    "sparse MoE page budget overflows: routed_experts={routed_experts} \
+                     pages_per_routed_expert={pages_per_routed_expert}"
+                )
+            })
+    }
+
     pub fn register_tensor(
         &mut self,
         store: &BakedStore,
@@ -218,6 +262,7 @@ impl MoeExpertResidencyManager {
 
         let tensor = ExpertTensor {
             name: name.to_string(),
+            projection,
             allocation_id,
             ptr: buffer.as_ptr(),
             dtype: buffer.dtype(),
@@ -541,6 +586,21 @@ impl ExpertTensor {
             expert_bytes: self.expert_bytes,
         }
     }
+
+    fn max_pages_per_expert_slice(&self) -> usize {
+        (0..self.expert_count)
+            .map(|expert_idx| {
+                page_spans(
+                    self.page_bytes,
+                    expert_idx * self.expert_bytes,
+                    self.expert_bytes,
+                    self.len_bytes,
+                )
+                .len()
+            })
+            .max()
+            .unwrap_or(0)
+    }
 }
 
 fn page_spans(page_bytes: usize, offset: usize, len: usize, total_len: usize) -> Vec<PageSpan> {
@@ -797,6 +857,60 @@ mod tests {
                 .expect("read expert 1");
             assert!(bytes.iter().all(|b| *b == 2));
         });
+    }
+
+    #[test]
+    fn page_budget_uses_registered_projection_footprint() {
+        with_supported_vmm_backend(
+            "page_budget_uses_registered_projection_footprint",
+            |_backend| {
+                let probe_tmp = synthetic_store(1, 4096);
+                let probe_store = BakedStore::open(probe_tmp.path()).expect("open probe store");
+                let mut probe =
+                    MoeExpertResidencyManager::new(0, MoeExpertResidencyConfig::new(1).unwrap());
+                probe
+                    .register_tensor(
+                        &probe_store,
+                        0,
+                        MoeExpertProjection::GateUp,
+                        "model.layers.0.mlp.experts.gate_up_proj",
+                        1,
+                    )
+                    .expect("register probe tensor");
+                let page_bytes = probe.tensors[0].page_bytes;
+
+                let expert_bytes = page_bytes + 1;
+                let tmp = synthetic_store(2, expert_bytes);
+                let store = BakedStore::open(tmp.path()).expect("open synthetic store");
+                let mut manager =
+                    MoeExpertResidencyManager::new(0, MoeExpertResidencyConfig::new(1).unwrap());
+                manager
+                    .register_tensor(
+                        &store,
+                        0,
+                        MoeExpertProjection::GateUp,
+                        "model.layers.0.mlp.experts.gate_up_proj",
+                        2,
+                    )
+                    .expect("register gate/up tensor");
+                manager
+                    .register_tensor(
+                        &store,
+                        0,
+                        MoeExpertProjection::Down,
+                        "model.layers.0.mlp.experts.gate_up_proj",
+                        2,
+                    )
+                    .expect("register down tensor");
+
+                assert_eq!(
+                    manager
+                        .page_budget_for_routed_experts(3)
+                        .expect("derive page budget"),
+                    12
+                );
+            },
+        );
     }
 
     #[test]

--- a/crates/runner/src/qwen36_moe_residency.rs
+++ b/crates/runner/src/qwen36_moe_residency.rs
@@ -3,9 +3,9 @@
 //! The decode descriptors need stable base pointers for the fused
 //! `experts.gate_up_proj` and `experts.down_proj` tensors. This manager
 //! reserves those full virtual address ranges up front, but only uploads and
-//! maps the expert slices that are explicitly pinned resident.
+//! maps the expert pages that are explicitly pinned resident.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::ffi::c_void;
 
 use anyhow::{anyhow, Context, Result};
@@ -29,22 +29,21 @@ pub struct MoeExpertKey {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MoeExpertResidencyConfig {
-    /// Maximum number of logical expert slices marked resident at once.
+    /// Maximum number of VMM backing pages resident at once.
     ///
-    /// HIP maps at the VMM page granularity, so resident physical bytes can be
-    /// wider than this logical count implies. The policy tracks the logical
-    /// slices because the router naturally speaks in `(layer, expert)` terms.
-    pub max_resident_slices: usize,
+    /// The environment knob is still expressed in experts because the router
+    /// naturally speaks in `(layer, expert)` terms, but physical residency is
+    /// page-granular on HIP/CUDA. The engine converts that expert cap into this
+    /// page budget conservatively.
+    pub max_resident_pages: usize,
 }
 
 impl MoeExpertResidencyConfig {
-    pub fn new(max_resident_slices: usize) -> Result<Self> {
-        if max_resident_slices == 0 {
-            return Err(anyhow!("max_resident_slices must be > 0"));
+    pub fn new(max_resident_pages: usize) -> Result<Self> {
+        if max_resident_pages == 0 {
+            return Err(anyhow!("max_resident_pages must be > 0"));
         }
-        Ok(Self {
-            max_resident_slices,
-        })
+        Ok(Self { max_resident_pages })
     }
 }
 
@@ -52,9 +51,14 @@ impl MoeExpertResidencyConfig {
 pub struct MoeExpertResidencyStats {
     pub registered_tensors: usize,
     pub resident_slices: usize,
+    pub resident_pages: usize,
+    pub page_backed_slices: usize,
     pub hits: u64,
     pub misses: u64,
+    pub page_hits: u64,
+    pub page_misses: u64,
     pub evicted_slices: u64,
+    pub evicted_pages: u64,
     pub uploaded_bytes: usize,
     pub unmapped_bytes: usize,
 }
@@ -87,11 +91,29 @@ struct ExpertTensor {
 #[derive(Debug, Clone)]
 struct ResidentSlice {
     tensor_idx: usize,
-    logical_offset: usize,
-    logical_len: usize,
+    page_offset: usize,
+    page_len: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct ResidentPageKey {
+    tensor_idx: usize,
+    page_offset: usize,
+}
+
+#[derive(Debug, Clone)]
+struct ResidentPage {
+    tensor_idx: usize,
     page_offset: usize,
     page_len: usize,
     last_used: u64,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PageSpan {
+    offset: usize,
+    len: usize,
+    copy_len: usize,
 }
 
 pub struct MoeExpertResidencyManager {
@@ -100,10 +122,14 @@ pub struct MoeExpertResidencyManager {
     tensors: Vec<ExpertTensor>,
     tensor_by_layer_projection: HashMap<(usize, MoeExpertProjection), usize>,
     resident: HashMap<MoeExpertKey, ResidentSlice>,
+    resident_pages: HashMap<ResidentPageKey, ResidentPage>,
     clock: u64,
     hits: u64,
     misses: u64,
+    page_hits: u64,
+    page_misses: u64,
     evicted_slices: u64,
+    evicted_pages: u64,
     uploaded_bytes: usize,
     unmapped_bytes: usize,
 }
@@ -116,10 +142,14 @@ impl MoeExpertResidencyManager {
             tensors: Vec::new(),
             tensor_by_layer_projection: HashMap::new(),
             resident: HashMap::new(),
+            resident_pages: HashMap::new(),
             clock: 0,
             hits: 0,
             misses: 0,
+            page_hits: 0,
+            page_misses: 0,
             evicted_slices: 0,
+            evicted_pages: 0,
             uploaded_bytes: 0,
             unmapped_bytes: 0,
         }
@@ -138,9 +168,14 @@ impl MoeExpertResidencyManager {
         MoeExpertResidencyStats {
             registered_tensors: self.tensors.len(),
             resident_slices: self.resident.len(),
+            resident_pages: self.resident_pages.len(),
+            page_backed_slices: self.page_backed_slices(),
             hits: self.hits,
             misses: self.misses,
+            page_hits: self.page_hits,
+            page_misses: self.page_misses,
             evicted_slices: self.evicted_slices,
+            evicted_pages: self.evicted_pages,
             uploaded_bytes: self.uploaded_bytes,
             unmapped_bytes: self.unmapped_bytes,
         }
@@ -222,7 +257,7 @@ impl MoeExpertResidencyManager {
 
     pub fn ensure_resident(&mut self, store: &BakedStore, key: MoeExpertKey) -> Result<()> {
         let tensor_idx = self.tensor_idx(key.layer_idx, key.projection)?;
-        let (name, allocation_id, logical_offset, logical_len, page_offset, page_len, copy_len) = {
+        let (name, allocation_id, logical_offset, logical_len, pages) = {
             let tensor = &self.tensors[tensor_idx];
             if key.expert_idx >= tensor.expert_count {
                 return Err(anyhow!(
@@ -235,96 +270,199 @@ impl MoeExpertResidencyManager {
             }
             let logical_offset = key.expert_idx * tensor.expert_bytes;
             let logical_len = tensor.expert_bytes;
-            let (page_offset, page_len) =
-                page_range(tensor.page_bytes, logical_offset, logical_len);
-            let copy_len = page_len.min(tensor.len_bytes.saturating_sub(page_offset));
+            let pages = page_spans(
+                tensor.page_bytes,
+                logical_offset,
+                logical_len,
+                tensor.len_bytes,
+            );
             (
                 tensor.name.clone(),
                 tensor.allocation_id,
                 logical_offset,
                 logical_len,
-                page_offset,
-                page_len,
-                copy_len,
+                pages,
             )
         };
+        if pages.len() > self.config.max_resident_pages {
+            return Err(anyhow!(
+                "MoE expert slice layer={} expert={} projection={:?} spans {} VMM pages, \
+                 exceeding max_resident_pages={}",
+                key.layer_idx,
+                key.expert_idx,
+                key.projection,
+                pages.len(),
+                self.config.max_resident_pages
+            ));
+        }
+        let slice_page_offset = pages
+            .first()
+            .map(|page| page.offset)
+            .unwrap_or(logical_offset);
+        let slice_page_end = pages
+            .last()
+            .map(|page| page.offset + page.len)
+            .unwrap_or(logical_offset + logical_len);
 
         self.clock += 1;
-        if let Some(entry) = self.resident.get_mut(&key) {
-            entry.last_used = self.clock;
-            self.hits += 1;
-            return Ok(());
+        if self.resident.contains_key(&key) {
+            let all_pages_resident = pages.iter().all(|span| {
+                self.resident_pages.contains_key(&ResidentPageKey {
+                    tensor_idx,
+                    page_offset: span.offset,
+                })
+            });
+            if all_pages_resident {
+                self.hits += 1;
+                for span in &pages {
+                    self.page_hits += 1;
+                    if let Some(page) = self.resident_pages.get_mut(&ResidentPageKey {
+                        tensor_idx,
+                        page_offset: span.offset,
+                    }) {
+                        page.last_used = self.clock;
+                    }
+                }
+                return Ok(());
+            }
+            self.resident.remove(&key);
         }
 
         self.misses += 1;
-        while self.resident.len() >= self.config.max_resident_slices {
-            self.evict_lru_slice()?;
+        let mut missing_pages = Vec::new();
+        for span in &pages {
+            let page_key = ResidentPageKey {
+                tensor_idx,
+                page_offset: span.offset,
+            };
+            if let Some(page) = self.resident_pages.get_mut(&page_key) {
+                page.last_used = self.clock;
+                self.page_hits += 1;
+            } else {
+                missing_pages.push(*span);
+            }
         }
 
-        store
-            .load_range_to_virtual_arena(
-                &mut self.arena,
-                allocation_id,
-                &name,
-                page_offset,
-                copy_len,
-            )
-            .with_context(|| {
-                format!(
-                    "load MoE expert slice layer={} expert={} projection={:?}",
-                    key.layer_idx, key.expert_idx, key.projection
+        self.page_misses += missing_pages.len() as u64;
+        for span in missing_pages {
+            while self.resident_pages.len() >= self.config.max_resident_pages {
+                self.evict_lru_page()?;
+            }
+
+            store
+                .load_range_to_virtual_arena(
+                    &mut self.arena,
+                    allocation_id,
+                    &name,
+                    span.offset,
+                    span.copy_len,
                 )
-            })?;
-        self.uploaded_bytes += copy_len;
+                .with_context(|| {
+                    format!(
+                        "load MoE expert page layer={} expert={} projection={:?} offset={} len={}",
+                        key.layer_idx, key.expert_idx, key.projection, span.offset, span.copy_len
+                    )
+                })?;
+            self.uploaded_bytes += span.copy_len;
+            self.resident_pages.insert(
+                ResidentPageKey {
+                    tensor_idx,
+                    page_offset: span.offset,
+                },
+                ResidentPage {
+                    tensor_idx,
+                    page_offset: span.offset,
+                    page_len: span.len,
+                    last_used: self.clock,
+                },
+            );
+        }
         self.resident.insert(
             key,
             ResidentSlice {
                 tensor_idx,
-                logical_offset,
-                logical_len,
-                page_offset,
-                page_len,
-                last_used: self.clock,
+                page_offset: slice_page_offset,
+                page_len: slice_page_end - slice_page_offset,
             },
         );
         Ok(())
     }
 
-    fn evict_lru_slice(&mut self) -> Result<()> {
-        let Some((victim, entry)) = self
-            .resident
+    fn evict_lru_page(&mut self) -> Result<()> {
+        let Some((victim, page)) = self
+            .resident_pages
             .iter()
-            .min_by_key(|(_, entry)| entry.last_used)
-            .map(|(key, entry)| (*key, entry.clone()))
+            .min_by_key(|(_, page)| page.last_used)
+            .map(|(key, page)| (*key, page.clone()))
         else {
             return Ok(());
         };
 
-        let tensor = &self.tensors[entry.tensor_idx];
+        let tensor = &self.tensors[page.tensor_idx];
         let allocation = self
             .arena
             .allocation_mut(tensor.allocation_id)
             .ok_or_else(|| anyhow!("virtual allocation id {} missing", tensor.allocation_id))?;
         let removed_ranges = allocation
             .buffer_mut()
-            .unmap_range_discard(entry.logical_offset, entry.logical_len)
+            .unmap_range_discard(page.page_offset, page.page_len)
             .with_context(|| {
                 format!(
-                    "evict MoE expert slice layer={} expert={} projection={:?}",
-                    victim.layer_idx, victim.expert_idx, victim.projection
+                    "evict MoE expert page tensor={} offset={} len={}",
+                    tensor.name, page.page_offset, page.page_len
                 )
             })?;
         self.unmapped_bytes += removed_ranges.iter().map(|(_, len)| *len).sum::<usize>();
         if removed_ranges.is_empty() {
-            self.resident.remove(&victim);
-            self.evicted_slices += 1;
+            self.resident_pages.remove(&victim);
+            let removed_slices = self.remove_resident_slices_overlapping(
+                page.tensor_idx,
+                page.page_offset,
+                page.page_offset + page.page_len,
+            );
+            self.evicted_pages += 1;
+            self.evicted_slices += removed_slices as u64;
             return Ok(());
         }
 
+        let removed_pages =
+            self.remove_resident_pages_overlapping(page.tensor_idx, &removed_ranges);
+        let removed_slices =
+            self.remove_resident_slices_overlapping_ranges(page.tensor_idx, &removed_ranges);
+        self.evicted_pages += removed_pages as u64;
+        self.evicted_slices += removed_slices as u64;
+        Ok(())
+    }
+
+    fn remove_resident_pages_overlapping(
+        &mut self,
+        tensor_idx: usize,
+        ranges: &[(usize, usize)],
+    ) -> usize {
+        let before = self.resident_pages.len();
+        self.resident_pages.retain(|_, page| {
+            page.tensor_idx != tensor_idx
+                || !ranges.iter().any(|(offset, len)| {
+                    ranges_overlap(
+                        page.page_offset,
+                        page.page_offset + page.page_len,
+                        *offset,
+                        *offset + *len,
+                    )
+                })
+        });
+        before - self.resident_pages.len()
+    }
+
+    fn remove_resident_slices_overlapping_ranges(
+        &mut self,
+        tensor_idx: usize,
+        ranges: &[(usize, usize)],
+    ) -> usize {
         let before = self.resident.len();
         self.resident.retain(|_, resident| {
-            resident.tensor_idx != entry.tensor_idx
-                || !removed_ranges.iter().any(|(offset, len)| {
+            resident.tensor_idx != tensor_idx
+                || !ranges.iter().any(|(offset, len)| {
                     ranges_overlap(
                         resident.page_offset,
                         resident.page_offset + resident.page_len,
@@ -333,8 +471,26 @@ impl MoeExpertResidencyManager {
                     )
                 })
         });
-        self.evicted_slices += (before - self.resident.len()) as u64;
-        Ok(())
+        before - self.resident.len()
+    }
+
+    fn remove_resident_slices_overlapping(
+        &mut self,
+        tensor_idx: usize,
+        offset: usize,
+        end: usize,
+    ) -> usize {
+        let before = self.resident.len();
+        self.resident.retain(|_, resident| {
+            resident.tensor_idx != tensor_idx
+                || !ranges_overlap(
+                    resident.page_offset,
+                    resident.page_offset + resident.page_len,
+                    offset,
+                    end,
+                )
+        });
+        before - self.resident.len()
     }
 
     fn tensor(&self, layer_idx: usize, projection: MoeExpertProjection) -> Result<&ExpertTensor> {
@@ -349,6 +505,27 @@ impl MoeExpertResidencyManager {
             .ok_or_else(|| {
                 anyhow!("no MoE expert tensor registered for layer {layer_idx} {projection:?}")
             })
+    }
+
+    fn page_backed_slices(&self) -> usize {
+        let mut backed = HashSet::new();
+        for page in self.resident_pages.values() {
+            let tensor = &self.tensors[page.tensor_idx];
+            if tensor.expert_bytes == 0 || page.page_len == 0 {
+                continue;
+            }
+            let page_end = page.page_offset + page.page_len;
+            let first = page.page_offset / tensor.expert_bytes;
+            let last = (page_end - 1) / tensor.expert_bytes;
+            for expert_idx in first..=last.min(tensor.expert_count.saturating_sub(1)) {
+                let offset = expert_idx * tensor.expert_bytes;
+                let end = offset + tensor.expert_bytes;
+                if ranges_overlap(offset, end, page.page_offset, page_end) {
+                    backed.insert((page.tensor_idx, expert_idx));
+                }
+            }
+        }
+        backed.len()
     }
 }
 
@@ -366,11 +543,22 @@ impl ExpertTensor {
     }
 }
 
-fn page_range(page_bytes: usize, offset: usize, len: usize) -> (usize, usize) {
+fn page_spans(page_bytes: usize, offset: usize, len: usize, total_len: usize) -> Vec<PageSpan> {
     let end = offset + len;
-    let page_start = offset / page_bytes * page_bytes;
+    let mut cursor = offset / page_bytes * page_bytes;
     let page_end = end.div_ceil(page_bytes) * page_bytes;
-    (page_start, page_end - page_start)
+    let mut spans = Vec::new();
+    while cursor < page_end {
+        let len = page_bytes.min(page_end - cursor);
+        let copy_len = len.min(total_len.saturating_sub(cursor));
+        spans.push(PageSpan {
+            offset: cursor,
+            len,
+            copy_len,
+        });
+        cursor += len;
+    }
+    spans
 }
 
 fn ranges_overlap(a_start: usize, a_end: usize, b_start: usize, b_end: usize) -> bool {
@@ -477,9 +665,9 @@ mod tests {
     }
 
     #[test]
-    fn lru_eviction_invalidates_page_overlapping_slices() {
+    fn shared_page_reuses_backing_for_neighbor_slice() {
         with_supported_vmm_backend(
-            "lru_eviction_invalidates_page_overlapping_slices",
+            "shared_page_reuses_backing_for_neighbor_slice",
             |_backend| {
                 let tmp = synthetic_store(4, 4096);
                 let store = BakedStore::open(tmp.path()).expect("open synthetic store");
@@ -508,13 +696,20 @@ mod tests {
                 manager.ensure_resident(&store, e0).expect("load expert 0");
                 assert!(manager.is_resident(e0));
                 assert_eq!(manager.stats().resident_slices, 1);
+                assert_eq!(manager.stats().resident_pages, 1);
+                assert_eq!(manager.stats().page_misses, 1);
 
                 manager.ensure_resident(&store, e1).expect("load expert 1");
-                assert!(!manager.is_resident(e0));
+                assert!(manager.is_resident(e0));
                 assert!(manager.is_resident(e1));
-                assert_eq!(manager.stats().resident_slices, 1);
+                assert_eq!(manager.stats().resident_slices, 2);
+                assert_eq!(manager.stats().resident_pages, 1);
+                assert!(manager.stats().page_backed_slices >= 2);
                 assert_eq!(manager.stats().misses, 2);
-                assert_eq!(manager.stats().evicted_slices, 1);
+                assert_eq!(manager.stats().page_hits, 1);
+                assert_eq!(manager.stats().page_misses, 1);
+                assert_eq!(manager.stats().evicted_pages, 0);
+                assert_eq!(manager.stats().evicted_slices, 0);
 
                 let allocation_id = manager
                     .resident_weight(0, MoeExpertProjection::GateUp)
@@ -531,6 +726,77 @@ mod tests {
                 assert!(bytes.iter().all(|b| *b == 2));
             },
         );
+    }
+
+    #[test]
+    fn lru_eviction_invalidates_whole_pages() {
+        with_supported_vmm_backend("lru_eviction_invalidates_whole_pages", |_backend| {
+            let probe_tmp = synthetic_store(1, 4096);
+            let probe_store = BakedStore::open(probe_tmp.path()).expect("open probe store");
+            let mut probe =
+                MoeExpertResidencyManager::new(0, MoeExpertResidencyConfig::new(1).unwrap());
+            probe
+                .register_tensor(
+                    &probe_store,
+                    0,
+                    MoeExpertProjection::GateUp,
+                    "model.layers.0.mlp.experts.gate_up_proj",
+                    1,
+                )
+                .expect("register probe tensor");
+            let expert_bytes = probe.tensors[0].page_bytes;
+
+            let tmp = synthetic_store(3, expert_bytes);
+            let store = BakedStore::open(tmp.path()).expect("open synthetic store");
+            let mut manager =
+                MoeExpertResidencyManager::new(0, MoeExpertResidencyConfig::new(1).unwrap());
+            manager
+                .register_tensor(
+                    &store,
+                    0,
+                    MoeExpertProjection::GateUp,
+                    "model.layers.0.mlp.experts.gate_up_proj",
+                    3,
+                )
+                .expect("register tensor");
+
+            let e0 = MoeExpertKey {
+                layer_idx: 0,
+                expert_idx: 0,
+                projection: MoeExpertProjection::GateUp,
+            };
+            let e1 = MoeExpertKey {
+                layer_idx: 0,
+                expert_idx: 1,
+                projection: MoeExpertProjection::GateUp,
+            };
+
+            manager.ensure_resident(&store, e0).expect("load expert 0");
+            assert!(manager.is_resident(e0));
+            assert_eq!(manager.stats().resident_pages, 1);
+
+            manager.ensure_resident(&store, e1).expect("load expert 1");
+            assert!(!manager.is_resident(e0));
+            assert!(manager.is_resident(e1));
+            assert_eq!(manager.stats().resident_pages, 1);
+            assert_eq!(manager.stats().page_misses, 2);
+            assert!(manager.stats().evicted_pages >= 1);
+            assert!(manager.stats().evicted_slices >= 1);
+
+            let allocation_id = manager
+                .resident_weight(0, MoeExpertProjection::GateUp)
+                .expect("resident weight")
+                .allocation_id()
+                .expect("virtual allocation");
+            let bytes = manager
+                .arena()
+                .allocation(allocation_id)
+                .expect("allocation")
+                .buffer()
+                .to_host_range_bytes(expert_bytes, 4096)
+                .expect("read expert 1");
+            assert!(bytes.iter().all(|b| *b == 2));
+        });
     }
 
     #[test]

--- a/crates/runner/tests/qwen36_moe_sparse_vmm_smoke.rs
+++ b/crates/runner/tests/qwen36_moe_sparse_vmm_smoke.rs
@@ -145,14 +145,19 @@ fn qwen36_moe_sparse_vmm_matches_dense_virtual_slabs() {
         "supersonic-qwen36-moe-sparse-vmm-telemetry-v1"
     );
     let summary = &json["summary"];
-    let max_slices = (cap_experts * 2) as u64;
+    let max_pages = (cap_experts * 2) as u64;
     assert!(
-        summary["peak_resident_slices"].as_u64().unwrap() <= max_slices,
-        "peak slices exceeded sparse cap: {summary:?}"
+        summary["peak_resident_pages"].as_u64().unwrap() <= max_pages,
+        "peak pages exceeded sparse cap: {summary:?}"
     );
     assert!(
-        summary["final_resident_slices"].as_u64().unwrap() <= max_slices,
-        "final slices exceeded sparse cap: {summary:?}"
+        summary["final_resident_pages"].as_u64().unwrap() <= max_pages,
+        "final pages exceeded sparse cap: {summary:?}"
+    );
+    assert!(
+        summary["peak_page_backed_slices"].as_u64().unwrap()
+            >= summary["peak_resident_slices"].as_u64().unwrap(),
+        "page-backed slice telemetry should cover requested resident slices: {summary:?}"
     );
     assert!(
         summary["peak_resident_bytes"].as_u64().unwrap()
@@ -162,6 +167,10 @@ fn qwen36_moe_sparse_vmm_matches_dense_virtual_slabs() {
     assert!(
         summary["misses"].as_u64().unwrap() > 0 && summary["uploaded_bytes"].as_u64().unwrap() > 0,
         "sparse run did not exercise uploads/misses: {summary:?}"
+    );
+    assert!(
+        summary["page_misses"].as_u64().unwrap() > 0,
+        "sparse run did not exercise page uploads: {summary:?}"
     );
     assert!(
         json["steps"].as_array().unwrap().len() >= 2,

--- a/crates/runner/tests/qwen36_moe_sparse_vmm_smoke.rs
+++ b/crates/runner/tests/qwen36_moe_sparse_vmm_smoke.rs
@@ -145,7 +145,9 @@ fn qwen36_moe_sparse_vmm_matches_dense_virtual_slabs() {
         "supersonic-qwen36-moe-sparse-vmm-telemetry-v1"
     );
     let summary = &json["summary"];
-    let max_pages = (cap_experts * 2) as u64;
+    let max_pages = summary["max_resident_pages"]
+        .as_u64()
+        .expect("sparse telemetry summary should report max_resident_pages");
     assert!(
         summary["peak_resident_pages"].as_u64().unwrap() <= max_pages,
         "peak pages exceeded sparse cap: {summary:?}"

--- a/docs/lowlevel-memory.md
+++ b/docs/lowlevel-memory.md
@@ -52,14 +52,15 @@ Current scope:
   islands for Qwen3.6-MoE INT4 decode. The chained decode path runs FFN stage 1
   first, downloads the `top_k` expert ids, pins those experts' gate/up and down
   slices, then runs the normal stage-5 FFN launch against the stable virtual
-  slab pointers. The cap is expressed in experts, but the residency budget is
-  `2*N` VMM pages because each expert may touch both fused projections. Logical
-  slice hit/miss counters still track router demand; page hit/miss counters
-  track physical residency. Sparse islands copy the full VMM backing page for
-  any touched expert slice, so every expert sharing that resident page contains
-  real bake data rather than zero fill. Sparse islands currently disable the
-  persistent megakernel for that run; persistent router prefetch needs a future
-  split or in-kernel residency protocol.
+  slab pointers. The cap is expressed in experts; after all sparse expert
+  tensors are registered, SuperSonic derives the VMM page budget from the
+  actual worst-case gate/up and down page footprint for one routed expert.
+  Logical slice hit/miss counters still track router demand; page hit/miss
+  counters track physical residency. Sparse islands copy the full VMM backing
+  page for any touched expert slice, so every expert sharing that resident page
+  contains real bake data rather than zero fill. Sparse islands currently
+  disable the persistent megakernel for that run; persistent router prefetch
+  needs a future split or in-kernel residency protocol.
 - `SUPERSONIC_MOE_ISLAND_TELEMETRY_JSON=/path/report.json` records sparse
   MoE residency telemetry for Qwen3.6-MoE runs: per-forward hits, misses,
   uploads, evictions, resident slices, resident pages, page-backed slice count,

--- a/docs/lowlevel-memory.md
+++ b/docs/lowlevel-memory.md
@@ -40,10 +40,10 @@ Current scope:
   only selected byte ranges are made resident.
 - Qwen3.6-MoE has a sparse routed-expert residency manager in
   `runner::qwen36_moe_residency`. It reserves the fused
-  `mlp.experts.gate_up_proj` / `mlp.experts.down_proj` slabs, pins individual
-  `(layer, expert, projection)` slices from the mmap-backed bake, evicts with a
-  bounded LRU policy, and invalidates every resident slice covered by an
-  unmapped VMM page.
+  `mlp.experts.gate_up_proj` / `mlp.experts.down_proj` slabs, pins the VMM
+  backing pages that contain routed `(layer, expert, projection)` slices from
+  the mmap-backed bake, evicts with a bounded page-LRU policy, and invalidates
+  every logical resident slice covered by an unmapped VMM page.
 - Qwen3.6-MoE sparse expert residency is backend-aware at the VMM policy layer
   and is unit-tested on supported HIP/CUDA VMM backends. Full Qwen3.6-MoE
   decode kernels are still HIP-only; CUDA runtime decode remains blocked before
@@ -52,23 +52,25 @@ Current scope:
   islands for Qwen3.6-MoE INT4 decode. The chained decode path runs FFN stage 1
   first, downloads the `top_k` expert ids, pins those experts' gate/up and down
   slices, then runs the normal stage-5 FFN launch against the stable virtual
-  slab pointers. The cap is expressed in experts and reserves `2*N` logical
-  resident slices because each expert needs both fused projections. Sparse
-  islands copy the full VMM backing page for any touched expert slice, so every
-  expert sharing that resident page contains real bake data rather than zero
-  fill. Sparse islands currently disable the persistent megakernel for that
-  run; persistent router prefetch needs a future split or in-kernel residency
-  protocol.
+  slab pointers. The cap is expressed in experts, but the residency budget is
+  `2*N` VMM pages because each expert may touch both fused projections. Logical
+  slice hit/miss counters still track router demand; page hit/miss counters
+  track physical residency. Sparse islands copy the full VMM backing page for
+  any touched expert slice, so every expert sharing that resident page contains
+  real bake data rather than zero fill. Sparse islands currently disable the
+  persistent megakernel for that run; persistent router prefetch needs a future
+  split or in-kernel residency protocol.
 - `SUPERSONIC_MOE_ISLAND_TELEMETRY_JSON=/path/report.json` records sparse
   MoE residency telemetry for Qwen3.6-MoE runs: per-forward hits, misses,
-  uploads, evictions, resident slices, resident physical bytes, plus summary
-  peaks. This is intended for tuning `SUPERSONIC_MOE_ISLAND_CAP_EXPERTS`
-  against real prompts instead of relying on one-token smoke numbers.
-- On the HIP/gfx1100 validation machine, sparse MoE caps through 312 experts
-  passed the two-token Qwen3.6-MoE smoke, while caps around 316+ reproduced a
-  HIP page-not-present fault after retaining roughly a full token's routed
-  expert working set. Keep validation caps below that high-water mark until the
-  ROCm VMM mapping-limit behavior is isolated further.
+  uploads, evictions, resident slices, resident pages, page-backed slice count,
+  resident physical bytes, plus summary peaks. This is intended for tuning
+  `SUPERSONIC_MOE_ISLAND_CAP_EXPERTS` against real prompts instead of relying
+  on one-token smoke numbers.
+- On the HIP/gfx1100 validation machine, page-budgeted sparse MoE passed the
+  two-token Qwen3.6-MoE smoke at the default 256-expert cap, the smallest
+  top-k-sized 8-expert cap, and a 320-expert cap (`640` resident VMM pages).
+  The earlier high-cap page-not-present fault was tied to slice-budgeting more
+  logical residents than the physical VMM page working set could represent.
 - `SUPERSONIC_VMM_WEIGHT_PROBE=1` makes Qwen3.6-MoE dry-run load
   `lm_head.weight` into a virtual `Weights` allocation when an INT4 bake is
   present.


### PR DESCRIPTION
## Summary
- move Qwen3.6-MoE sparse residency from logical slice budgeting to VMM page budgeting
- track resident pages, page hits/misses, page evictions, and page-backed slice telemetry
- add HIP/CUDA VMM unit coverage for shared-page reuse and page-LRU eviction
- update sparse VMM smoke assertions and low-level memory docs for page-budget semantics

## Validation
- `SUPERSONIC_BACKENDS=hip cargo test -p runner qwen36_moe_residency -- --nocapture`
- `SUPERSONIC_BACKENDS=hip cargo check -p runner --bin supersonic`
- `SUPERSONIC_BACKENDS=hip SUPERSONIC_TEST_QWEN36_MOE_MODEL_DIR=/mnt/data/models/Qwen3.6-35B-A3B cargo test --release -p runner --test qwen36_moe_sparse_vmm_smoke -- --ignored --nocapture`
- `SUPERSONIC_BACKENDS=hip SUPERSONIC_TEST_QWEN36_MOE_MODEL_DIR=/mnt/data/models/Qwen3.6-35B-A3B SUPERSONIC_TEST_QWEN36_MOE_SPARSE_CAP_EXPERTS=8 cargo test --release -p runner --test qwen36_moe_sparse_vmm_smoke -- --ignored --nocapture`
- `SUPERSONIC_BACKENDS=hip SUPERSONIC_VMM_MOE_ISLANDS=1 SUPERSONIC_MOE_ISLAND_CAP_EXPERTS=320 target/release/supersonic --backend hip --model qwen3.6-35b-a3b --model-dir /mnt/data/models/Qwen3.6-35B-A3B --int4 --prompt Hello --max-new-tokens 2 --context-size 16 --temperature 0 --no-download`
- `cargo fmt --all --check`
- `git diff --check`