### PR TITLE
Enable sparse MoE residency with persistent decode

### DIFF
--- a/crates/kernel-ffi/src/qwen36_moe.rs
+++ b/crates/kernel-ffi/src/qwen36_moe.rs
@@ -252,6 +252,9 @@ extern "C" {
         dtype: c_int,
         device_ordinal: usize,
         num_layers: c_int,
+        start_layer: c_int,
+        end_layer_exclusive: c_int,
+        mode: c_int,
         layers: *const Qwen36MoeDecodeLayerDesc,
         int4_scales: *const Qwen36MoeInt4ScaleDesc,
         hidden: c_int,
@@ -720,11 +723,67 @@ pub struct Qwen36MoePersistentLmHeadFold<'a> {
     pub vocab: i32,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Qwen36MoePersistentMode {
+    Full,
+    RouterOnly,
+    FfnOnly,
+}
+
+impl Qwen36MoePersistentMode {
+    fn as_ffi(self) -> c_int {
+        match self {
+            Self::Full => 0,
+            Self::RouterOnly => 1,
+            Self::FfnOnly => 2,
+        }
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn persistent_decode_launch(
     ordinal: usize,
     dtype: ScalarType,
     geom: Qwen36MoePersistentGeom,
+    position: i32,
+    layers_device: &GpuBuffer,
+    int4_scales_device: Option<&GpuBuffer>,
+    num_layers: usize,
+    hidden_ping: &mut GpuBuffer,
+    hidden_pong: &mut GpuBuffer,
+    workspace: &mut GpuBuffer,
+    ffn_topk_idx_scratch: &mut GpuBuffer,
+    sync_buf: &mut GpuBuffer,
+    lm_head_fold: Option<Qwen36MoePersistentLmHeadFold<'_>>,
+) -> Result<(), GpuError> {
+    persistent_decode_launch_range(
+        ordinal,
+        dtype,
+        geom,
+        0,
+        num_layers,
+        Qwen36MoePersistentMode::Full,
+        position,
+        layers_device,
+        int4_scales_device,
+        num_layers,
+        hidden_ping,
+        hidden_pong,
+        workspace,
+        ffn_topk_idx_scratch,
+        sync_buf,
+        lm_head_fold,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn persistent_decode_launch_range(
+    ordinal: usize,
+    dtype: ScalarType,
+    geom: Qwen36MoePersistentGeom,
+    start_layer: usize,
+    end_layer_exclusive: usize,
+    mode: Qwen36MoePersistentMode,
     position: i32,
     layers_device: &GpuBuffer,
     int4_scales_device: Option<&GpuBuffer>,
@@ -769,6 +828,9 @@ pub fn persistent_decode_launch(
                     dtype.kernel_dtype_code(),
                     ordinal,
                     num_layers as c_int,
+                    start_layer as c_int,
+                    end_layer_exclusive as c_int,
+                    mode.as_ffi(),
                     layers_device.as_ptr() as *const Qwen36MoeDecodeLayerDesc,
                     int4_ptr,
                     geom.hidden,

--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -2039,8 +2039,8 @@ fn decode_text(
         );
         if persistent_decode {
             println!(
-                "  [vmm] sparse MoE residency uses chained decode for router prefetch; \
-                 persistent megakernel disabled for this run"
+                "  [vmm] sparse MoE residency will use segmented persistent decode \
+                 (router prefetch + FFN resume per layer)"
             );
         }
         _moe_expert_residency = Some(manager);
@@ -2105,8 +2105,6 @@ fn decode_text(
             None,
         )?
     };
-    let persistent_decode = persistent_decode && !sparse_moe_requested;
-
     // Phase 6 self-speculative decode: load the multi-token-prediction
     // (MTP) head from the bake when --speculative-decode is set.
     //
@@ -2410,10 +2408,54 @@ fn decode_text(
             .as_ref()
             .map(MoeSparseTelemetrySnapshot::capture);
         let outputs = if let Some(scratch) = persistent_scratch.as_mut() {
-            lm_head_folded = fold.is_some();
-            scratch
-                .run(ordinal, &initial_hidden, position, fold)
-                .with_context(|| format!("persistent decode (step {step}, position {position})"))?
+            if let Some(manager) = _moe_expert_residency.as_mut() {
+                // Sparse VMM needs a host remap point after each layer's
+                // router top-k is known. The segmented persistent path keeps
+                // the persistent phase bodies but skips folded lm_head; the
+                // standalone lm_head launch below consumes final_hidden_bytes.
+                lm_head_folded = false;
+                drop(fold);
+                let mut prefetch = |layer_idx: usize, topk: &[usize]| -> Result<()> {
+                    for &expert_idx in topk {
+                        manager.ensure_resident(
+                            &store,
+                            MoeExpertKey {
+                                layer_idx,
+                                expert_idx,
+                                projection: MoeExpertProjection::GateUp,
+                            },
+                        )?;
+                        manager.ensure_resident(
+                            &store,
+                            MoeExpertKey {
+                                layer_idx,
+                                expert_idx,
+                                projection: MoeExpertProjection::Down,
+                            },
+                        )?;
+                    }
+                    Ok(())
+                };
+                scratch
+                    .run_sparse_with_expert_prefetch(
+                        ordinal,
+                        &initial_hidden,
+                        position,
+                        &mut prefetch,
+                    )
+                    .with_context(|| {
+                        format!(
+                            "segmented persistent sparse decode (step {step}, position {position})"
+                        )
+                    })?
+            } else {
+                lm_head_folded = fold.is_some();
+                scratch
+                    .run(ordinal, &initial_hidden, position, fold)
+                    .with_context(|| {
+                        format!("persistent decode (step {step}, position {position})")
+                    })?
+            }
         } else {
             // Chained path doesn't support the fold; lm_head still
             // launches separately below on gen steps.

--- a/crates/runner/src/qwen36_moe_persistent_decode.rs
+++ b/crates/runner/src/qwen36_moe_persistent_decode.rs
@@ -29,8 +29,9 @@
 use anyhow::{anyhow, Context, Result};
 use gpu_hal::{copy_d2h, copy_h2d, GpuBuffer, GpuError, ScalarType};
 use kernel_ffi::qwen36_moe::{
-    persistent_decode_launch, Qwen36MoeDecodeLayerDesc, Qwen36MoeInt4ScaleDesc,
-    Qwen36MoePersistentGeom, Qwen36MoePersistentLmHeadFold,
+    persistent_decode_launch, persistent_decode_launch_range, Qwen36MoeDecodeLayerDesc,
+    Qwen36MoeInt4ScaleDesc, Qwen36MoePersistentGeom, Qwen36MoePersistentLmHeadFold,
+    Qwen36MoePersistentMode,
 };
 use std::ffi::c_void;
 use std::os::raw::c_int;
@@ -76,8 +77,9 @@ pub struct PersistentScratch {
     /// F32 shared scratch sized for `max(full_attn, linear_attn, ffn)`
     /// workspace footprints.
     pub workspace: GpuBuffer,
-    /// `[top_k]` i32 — only consumed by the FFN phase at stage 1; passed
-    /// to satisfy the kernel signature (its body never derefs at stage 5).
+    /// `[top_k]` i32. The full megakernel keeps this as internal FFN
+    /// scratch; segmented sparse-VMM decode downloads it after router-only
+    /// launches to know which expert pages to remap.
     pub ffn_topk_idx_scratch: GpuBuffer,
     /// 96-byte sync_buf: counters[0..16] + barrier_counter (+64) +
     /// barrier_flag (+68). Bridge zeros it on every launch.
@@ -253,6 +255,126 @@ impl PersistentScratch {
             kernel_linear_attn_us: 0,
             kernel_ffn_us: 0,
         })
+    }
+
+    /// Sparse MoE residency variant. Each layer is split into:
+    ///
+    /// 1. attention/linear-attention + router top-k
+    /// 2. host VMM remap for the routed experts
+    /// 3. FFN completion for that layer
+    ///
+    /// This keeps the persistent phase bodies in use while preserving the
+    /// host-side remap point required by HIP VMM. The folded lm_head phase is
+    /// intentionally not run here; callers keep using the standalone
+    /// `lm_head_launch` path after downloading `final_hidden_bytes`.
+    pub fn run_sparse_with_expert_prefetch<F>(
+        &mut self,
+        ordinal: usize,
+        initial_hidden_bytes: &[u8],
+        position: i32,
+        mut prefetch: F,
+    ) -> Result<DecodeOutputs>
+    where
+        F: FnMut(usize, &[usize]) -> Result<()>,
+    {
+        let hidden_bytes = self.geom.hidden as usize * 2;
+        if initial_hidden_bytes.len() != hidden_bytes {
+            return Err(anyhow!(
+                "initial_hidden_bytes len {} != expected {} (hidden*2 BF16 bytes)",
+                initial_hidden_bytes.len(),
+                hidden_bytes,
+            ));
+        }
+        copy_h2d(
+            ordinal,
+            self.hidden_ping.as_mut_ptr(),
+            initial_hidden_bytes.as_ptr() as *const _,
+            hidden_bytes,
+        )
+        .context("h2d initial_hidden -> hidden_ping")?;
+
+        let t_launch = std::time::Instant::now();
+        for layer_idx in 0..self.num_layers {
+            persistent_decode_launch_range(
+                ordinal,
+                ScalarType::BF16,
+                self.geom,
+                layer_idx,
+                layer_idx + 1,
+                Qwen36MoePersistentMode::RouterOnly,
+                position,
+                &self.layer_descs_dev,
+                self.int4_scales_dev.as_ref(),
+                self.num_layers,
+                &mut self.hidden_ping,
+                &mut self.hidden_pong,
+                &mut self.workspace,
+                &mut self.ffn_topk_idx_scratch,
+                &mut self.sync_buf,
+                None,
+            )
+            .map_err(|e: GpuError| anyhow!(e))
+            .with_context(|| format!("persistent router-only launch (layer {layer_idx})"))?;
+
+            let topk = self
+                .download_topk_indices(ordinal)
+                .with_context(|| format!("download FFN top-k indices (layer {layer_idx})"))?;
+            prefetch(layer_idx, &topk)
+                .with_context(|| format!("prefetch routed experts (layer {layer_idx})"))?;
+
+            persistent_decode_launch_range(
+                ordinal,
+                ScalarType::BF16,
+                self.geom,
+                layer_idx,
+                layer_idx + 1,
+                Qwen36MoePersistentMode::FfnOnly,
+                position,
+                &self.layer_descs_dev,
+                self.int4_scales_dev.as_ref(),
+                self.num_layers,
+                &mut self.hidden_ping,
+                &mut self.hidden_pong,
+                &mut self.workspace,
+                &mut self.ffn_topk_idx_scratch,
+                &mut self.sync_buf,
+                None,
+            )
+            .map_err(|e: GpuError| anyhow!(e))
+            .with_context(|| format!("persistent ffn-only launch (layer {layer_idx})"))?;
+        }
+        let elapsed_us = t_launch.elapsed().as_micros() as u64;
+
+        let mut final_hidden_bytes = vec![0u8; hidden_bytes];
+        copy_d2h(
+            ordinal,
+            final_hidden_bytes.as_mut_ptr() as *mut _,
+            self.hidden_ping.as_ptr(),
+            hidden_bytes,
+        )
+        .context("d2h hidden_ping -> final_hidden_bytes")?;
+
+        Ok(DecodeOutputs {
+            final_hidden_bytes,
+            per_layer_attn_out: Vec::new(),
+            per_layer_ffn_out: Vec::new(),
+            kernel_full_attn_us: elapsed_us,
+            kernel_linear_attn_us: 0,
+            kernel_ffn_us: 0,
+        })
+    }
+
+    fn download_topk_indices(&self, ordinal: usize) -> Result<Vec<usize>> {
+        let top_k = self.geom.top_k as usize;
+        let mut host = vec![0u32; top_k];
+        copy_d2h(
+            ordinal,
+            host.as_mut_ptr() as *mut _,
+            self.ffn_topk_idx_scratch.as_ptr(),
+            top_k * std::mem::size_of::<u32>(),
+        )
+        .context("d2h ffn_topk_idx_scratch")?;
+        Ok(host.into_iter().map(|idx| idx as usize).collect())
     }
 }
 

--- a/crates/runner/tests/qwen36_moe_multilayer_parity.rs
+++ b/crates/runner/tests/qwen36_moe_multilayer_parity.rs
@@ -746,4 +746,21 @@ fn multilayer_persistent_decode_matches_chained() {
         1e-3,
         0.99999,
     );
+
+    // Segmented persistent is the sparse-VMM orchestration: each layer runs
+    // attention + router top-k, returns to the host for remap, then resumes
+    // that layer's FFN. With a no-op remap callback it must match the same
+    // chained reference.
+    restore_linear_attn_state(ordinal, &mut layers, &snapshot)
+        .expect("restore_linear_attn_state before segmented persistent");
+    let segmented_outputs = scratch
+        .run_sparse_with_expert_prefetch(ordinal, &initial_hidden, position, |_layer, _topk| Ok(()))
+        .expect("PersistentScratch::run_sparse_with_expert_prefetch");
+    assert_parity_bf16(
+        "segmented persistent sparse vs chained final_hidden",
+        &segmented_outputs.final_hidden_bytes,
+        &chained.final_hidden_bytes,
+        1e-3,
+        0.99999,
+    );
 }

--- a/kernels/qwen36_moe_bridge.cpp
+++ b/kernels/qwen36_moe_bridge.cpp
@@ -1051,6 +1051,9 @@ extern "C" int qwen36_moe_hip_persistent_decode_launch(
     int           dtype,
     size_t        device_ordinal,
     int           num_layers,
+    int           start_layer,
+    int           end_layer_exclusive,
+    int           mode,
     const qwen36_moe::DecodeLayerDesc* layers,
     const qwen36_moe::Int4ScaleDesc*   int4_scales,    // nullable
     int           hidden,
@@ -1094,6 +1097,19 @@ extern "C" int qwen36_moe_hip_persistent_decode_launch(
     // caller downloads `hidden_ping` for the result.
     if (layers == nullptr) return 133;
     if (hidden <= 0 || num_experts <= 0 || top_k <= 0) return 134;
+    if (mode < 0 || mode > 2) return 140;
+    if (start_layer < 0 || start_layer >= num_layers) return 141;
+    if (mode == 0) {
+        if (end_layer_exclusive <= start_layer ||
+            end_layer_exclusive > num_layers) {
+            return 142;
+        }
+    } else {
+        // Router-only and FFN-only are single-layer segmented sparse-VMM
+        // entry points. The host remaps between the two launches, so folded
+        // lm_head is intentionally available only to the full-step mode.
+        end_layer_exclusive = start_layer + 1;
+    }
     // FFN's concurrent-experts dispatch uses counters[group_id] for Phase G
     // and counters[top_k + group_id] for Phase I — i.e., 2*top_k slots.
     // sync_buf provisions exactly 16 u32 counters (also matches
@@ -1114,6 +1130,7 @@ extern "C" int qwen36_moe_hip_persistent_decode_launch(
     const bool lm_head_complete = (final_norm_w != nullptr) && (lm_head_w != nullptr) &&
                                   (logits_out != nullptr) && (vocab > 0);
     if (lm_head_on && !lm_head_complete) return 139;
+    if (lm_head_on && (mode != 0 || end_layer_exclusive != num_layers)) return 143;
 
     ScopedHipDevice scoped(static_cast<int>(device_ordinal));
 
@@ -1164,7 +1181,8 @@ extern "C" int qwen36_moe_hip_persistent_decode_launch(
             dim3(static_cast<unsigned int>(num_blocks)),
             dim3(block_size),
             lds_bytes, 0,
-            num_layers, layers, int4_scales,
+            num_layers, start_layer, end_layer_exclusive, mode,
+            layers, int4_scales,
             hidden, num_heads, num_kv_heads, head_dim, rotary_dim,
             num_k_heads, num_v_heads, head_k_dim, head_v_dim, conv_kernel_dim,
             num_experts, moe_intermediate, shared_intermediate, top_k,
@@ -1182,7 +1200,8 @@ extern "C" int qwen36_moe_hip_persistent_decode_launch(
             dim3(static_cast<unsigned int>(num_blocks)),
             dim3(block_size),
             lds_bytes, 0,
-            num_layers, layers, int4_scales,
+            num_layers, start_layer, end_layer_exclusive, mode,
+            layers, int4_scales,
             hidden, num_heads, num_kv_heads, head_dim, rotary_dim,
             num_k_heads, num_v_heads, head_k_dim, head_v_dim, conv_kernel_dim,
             num_experts, moe_intermediate, shared_intermediate, top_k,

--- a/kernels/qwen36_moe_persistent/persistent_decode.hip
+++ b/kernels/qwen36_moe_persistent/persistent_decode.hip
@@ -92,6 +92,12 @@ __device__ inline void reset_counters_16(
     grid_barrier(barrier_counter, barrier_flag, num_blocks);
 }
 
+enum PersistentDecodeMode {
+    PERSISTENT_MODE_FULL = 0,
+    PERSISTENT_MODE_ROUTER_ONLY = 1,
+    PERSISTENT_MODE_FFN_ONLY = 2,
+};
+
 // Persistent decode kernel template. Instantiated by the bridge for
 // (T=hip_bfloat16, USE_WMMA={true,false}) at launch time based on
 // `device_supports_wmma_bf16(ordinal)` + dim divisibility.
@@ -106,6 +112,9 @@ __device__ inline void reset_counters_16(
 template <typename T, bool USE_WMMA>
 __global__ void qwen36_moe_persistent_decode_kernel(
     int                                  num_layers,
+    int                                  start_layer,
+    int                                  end_layer_exclusive,
+    int                                  mode,
     const DecodeLayerDesc* __restrict__  layers,
     const Int4ScaleDesc*   __restrict__  int4_scales,           // nullable
     int                                  hidden,
@@ -148,7 +157,45 @@ __global__ void qwen36_moe_persistent_decode_kernel(
     T* in_buf  = hidden_ping;
     T* out_buf = hidden_pong;
 
-    for (int li = 0; li < num_layers; ++li) {
+    if (mode == PERSISTENT_MODE_FFN_ONLY) {
+        const DecodeLayerDesc& d = layers[start_layer];
+        const Int4ScaleDesc* i4 =
+            (int4_scales != nullptr) ? &int4_scales[start_layer] : nullptr;
+        const int i4_gs = (i4 != nullptr) ? i4->group_size : 0;
+
+        qwen36_moe_ffn_step_device<T, USE_WMMA>(
+            /*stage*/ 5,
+            hidden, num_experts,
+            moe_intermediate, shared_intermediate, top_k,
+            rms_norm_eps,
+            hidden_pong,
+            static_cast<const T*>(d.post_attn_norm_w),
+            static_cast<const T*>(d.router_w),
+            static_cast<const T*>(d.experts_gate_up_w),
+            static_cast<const T*>(d.experts_down_w),
+            static_cast<const T*>(d.shared_expert_gate_proj_w),
+            static_cast<const T*>(d.shared_expert_up_proj_w),
+            static_cast<const T*>(d.shared_expert_down_proj_w),
+            static_cast<const T*>(d.shared_expert_gate_w),
+            i4_gs,
+            i4 ? static_cast<const hip_bfloat16*>(i4->experts_gate_up_scale) : nullptr,
+            i4 ? static_cast<const hip_bfloat16*>(i4->experts_gate_up_zero)  : nullptr,
+            i4 ? static_cast<const hip_bfloat16*>(i4->experts_down_scale)    : nullptr,
+            i4 ? static_cast<const hip_bfloat16*>(i4->experts_down_zero)     : nullptr,
+            i4 ? static_cast<const hip_bfloat16*>(i4->shared_expert_gate_proj_scale) : nullptr,
+            i4 ? static_cast<const hip_bfloat16*>(i4->shared_expert_gate_proj_zero)  : nullptr,
+            i4 ? static_cast<const hip_bfloat16*>(i4->shared_expert_up_proj_scale)   : nullptr,
+            i4 ? static_cast<const hip_bfloat16*>(i4->shared_expert_up_proj_zero)    : nullptr,
+            i4 ? static_cast<const hip_bfloat16*>(i4->shared_expert_down_proj_scale) : nullptr,
+            i4 ? static_cast<const hip_bfloat16*>(i4->shared_expert_down_proj_zero)  : nullptr,
+            hidden_ping,
+            ffn_topk_idx_scratch,
+            workspace,
+            counters, barrier_counter, barrier_flag);
+        return;
+    }
+
+    for (int li = start_layer; li < end_layer_exclusive; ++li) {
         const DecodeLayerDesc& d = layers[li];
         const Int4ScaleDesc* i4 =
             (int4_scales != nullptr) ? &int4_scales[li] : nullptr;
@@ -227,8 +274,9 @@ __global__ void qwen36_moe_persistent_decode_kernel(
         out_buf = tmp;
 
         // ---- FFN ----
+        const int ffn_stage = (mode == PERSISTENT_MODE_ROUTER_ONLY) ? 1 : 5;
         qwen36_moe_ffn_step_device<T, USE_WMMA>(
-            /*stage*/ 5,
+            ffn_stage,
             hidden, num_experts,
             moe_intermediate, shared_intermediate, top_k,
             rms_norm_eps,
@@ -256,6 +304,13 @@ __global__ void qwen36_moe_persistent_decode_kernel(
             ffn_topk_idx_scratch,
             workspace,
             counters, barrier_counter, barrier_flag);
+
+        if (mode == PERSISTENT_MODE_ROUTER_ONLY) {
+            // The post-attention hidden stays in hidden_pong. The host can
+            // read ffn_topk_idx_scratch, remap sparse expert pages, then
+            // resume this layer with PERSISTENT_MODE_FFN_ONLY.
+            return;
+        }
 
         // Reset counters before the next layer's attn (which only touches
         // counters[0], so resetting all 16 is over-conservative but still


### PR DESCRIPTION
## Summary
- add segmented Qwen3.6-MoE persistent launch modes for router-only and FFN-only resume
- route sparse MoE VMM residency through persistent phase bodies with a host remap point after router top-k
- extend multilayer parity coverage so segmented sparse persistent decode matches chained decode

## Tests
- cargo check -p runner
- cargo test -p runner qwen36_moe_residency --lib
- SUPERSONIC_QWEN36_MULTILAYER_ORACLE_JSON=/tmp/qwen36_ml.json cargo test -p runner --test qwen36_moe_multilayer_parity multilayer_persistent_decode_matches_chained -- --nocapture
- SUPERSONIC_QWEN36_MULTILAYER_ORACLE_JSON=/tmp/qwen36_ml_int4.json cargo test -p runner --test qwen36_moe_multilayer_parity multilayer_persistent_decode_matches_chained -- --nocapture
- cargo build --release -p runner --bin supersonic