### PR TITLE
Fix float_to_fp8_e4m3 saturation comment exponent math (#150)

### DIFF
--- a/kernels/full_attention_4b.hip
+++ b/kernels/full_attention_4b.hip
@@ -206,7 +206,7 @@ __device__ inline uint8_t float_to_fp8_e4m3(float val) {
     uint8_t sign = 0;
     if (val < 0.0f) { sign = 0x80; val = -val; }
     // Clamp to max representable E4M3 value
-    if (val >= 448.0f) return sign | 0x7E;  // max normal: exp=14, mantissa=6 → 2^7*(1+6/8)=448
+    if (val >= 448.0f) return sign | 0x7E;  // max normal: stored-exp=15, mantissa=6 → 2^8*(1+6/8)=448
     if (val < 1.52587890625e-2f * 0.125f) return sign;  // too small → ±0
     // Subnormal range: val < 2^(-6) = 0.015625
     if (val < 0.015625f) {

--- a/kernels/full_attention_4b_cuda.cuh
+++ b/kernels/full_attention_4b_cuda.cuh
@@ -220,7 +220,7 @@ __device__ inline uint8_t float_to_fp8_e4m3(float val) {
     uint8_t sign = 0;
     if (val < 0.0f) { sign = 0x80; val = -val; }
     // Clamp to max representable E4M3 value
-    if (val >= 448.0f) return sign | 0x7E;  // max normal: exp=14, mantissa=6 → 2^7*(1+6/8)=448
+    if (val >= 448.0f) return sign | 0x7E;  // max normal: stored-exp=15, mantissa=6 → 2^8*(1+6/8)=448
     if (val < 1.52587890625e-2f * 0.125f) return sign;  // too small → ±0
     // Subnormal range: val < 2^(-6) = 0.015625
     if (val < 0.015625f) {

--- a/kernels/phi4.hip
+++ b/kernels/phi4.hip
@@ -153,7 +153,7 @@ __device__ inline uint8_t float_to_fp8_e4m3(float val) {
     uint8_t sign = 0;
     if (val < 0.0f) { sign = 0x80; val = -val; }
     // Clamp to max representable E4M3 value
-    if (val >= 448.0f) return sign | 0x7E;  // max normal: exp=14, mantissa=6 → 2^7*(1+6/8)=448
+    if (val >= 448.0f) return sign | 0x7E;  // max normal: stored-exp=15, mantissa=6 → 2^8*(1+6/8)=448
     if (val < 1.52587890625e-2f * 0.125f) return sign;  // too small → ±0
     // Subnormal range: val < 2^(-6) = 0.015625
     if (val < 0.015625f) {

--- a/kernels/phi4_cuda.cuh
+++ b/kernels/phi4_cuda.cuh
@@ -160,7 +160,7 @@ __device__ inline uint8_t float_to_fp8_e4m3(float val) {
     uint8_t sign = 0;
     if (val < 0.0f) { sign = 0x80; val = -val; }
     // Clamp to max representable E4M3 value
-    if (val >= 448.0f) return sign | 0x7E;  // max normal: exp=14, mantissa=6 → 2^7*(1+6/8)=448
+    if (val >= 448.0f) return sign | 0x7E;  // max normal: stored-exp=15, mantissa=6 → 2^8*(1+6/8)=448
     if (val < 1.52587890625e-2f * 0.125f) return sign;  // too small → ±0
     // Subnormal range: val < 2^(-6) = 0.015625
     if (val < 0.015625f) {

--- a/kernels/qwen36_moe_persistent/helpers.cuh
+++ b/kernels/qwen36_moe_persistent/helpers.cuh
@@ -320,7 +320,7 @@ __device__ inline uint8_t float_to_fp8_e4m3(float val) {
     uint8_t sign = 0;
     if (val < 0.0f) { sign = 0x80; val = -val; }
     // Clamp to max representable E4M3 value
-    if (val >= 448.0f) return sign | 0x7E;  // max normal: exp=14, mantissa=6 → 2^7*(1+6/8)=448
+    if (val >= 448.0f) return sign | 0x7E;  // max normal: stored-exp=15, mantissa=6 → 2^8*(1+6/8)=448
     if (val < 1.52587890625e-2f * 0.125f) return sign;  // too small → ±0
     // Subnormal range: val < 2^(-6) = 0.015625
     if (val < 0.015625f) {


### PR DESCRIPTION
## Summary
- Byte `0x7E` decodes as `stored_exp=15, mantissa=6`, giving `2^(15-7) × 1.75 = 256 × 1.75 = 448`. The comment said `exp=14` and `2^7 × 1.75`, which is wrong arithmetic.
- Implementation has always produced the correct FP8 byte; this changes only the trailing comment.
- Fixed in all five files where the buggy comment was duplicated (`full_attention_4b.{hip,cuh}`, `phi4.{hip,cuh}`, `qwen36_moe_persistent/helpers.cuh`) per the issue's request to keep them in one commit.

Closes #150.

Targeted at `feature/qwen36-fp8` because `helpers.cuh` only exists on this branch — keeping all five fixes in one commit per the issue's instruction.

## Test plan
- [x] `git diff` shows comment-only edits, identical text across all five files
- [ ] Branch still builds (no kernel logic changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)