### PR TITLE
Extend Qwen3.6 KV VMM to BF16

### DIFF
--- a/crates/qwen36_moe/src/state.rs
+++ b/crates/qwen36_moe/src/state.rs
@@ -65,12 +65,10 @@ impl StateAccount {
         // Per-layer KV bytes:
         //   FP8 path: 2 (K+V) * kv_heads * head_dim * 1 byte (FP8 E4M3)
         //   BF16 path: 2 (K+V) * kv_heads * head_dim * 2 bytes (BF16)
-        let kv_bytes_per_layer_per_token =
-            2 * kv_heads * head_dim * layout.kv_dtype_bytes;
+        let kv_bytes_per_layer_per_token = 2 * kv_heads * head_dim * layout.kv_dtype_bytes;
         // Per-layer scale bytes (FP8 only): 2 (K+V) * kv_heads * 4 bytes
         // F32 per (head, position). Independent of head_dim.
-        let kv_scale_bytes_per_layer_per_token =
-            2 * kv_heads * layout.kv_fp8_scale_bytes_per_token;
+        let kv_scale_bytes_per_layer_per_token = 2 * kv_heads * layout.kv_fp8_scale_bytes_per_token;
         // Per-layer BF16 sidecar bytes (FP8 + sidecar enabled only):
         // 2 (K+V) * kv_heads * head_dim * 2 bytes per scalar element
         // (BF16 dtype), total across the configured window. head_dim is a
@@ -201,21 +199,13 @@ mod tests {
     #[test]
     fn fp8_kv_sizes_relative_to_bf16() {
         let cfg = config_35b_a3b();
-        let bf16 = StateAccount::from_config(
-            &cfg,
-            StateLayout::new(4096, 1, false, None),
-        )
-        .full_kv_bytes;
-        let fp8_no_sidecar = StateAccount::from_config(
-            &cfg,
-            StateLayout::new(4096, 1, true, None),
-        )
-        .full_kv_bytes;
-        let fp8_with_sidecar = StateAccount::from_config(
-            &cfg,
-            StateLayout::new(4096, 1, true, Some(4096)),
-        )
-        .full_kv_bytes;
+        let bf16 =
+            StateAccount::from_config(&cfg, StateLayout::new(4096, 1, false, None)).full_kv_bytes;
+        let fp8_no_sidecar =
+            StateAccount::from_config(&cfg, StateLayout::new(4096, 1, true, None)).full_kv_bytes;
+        let fp8_with_sidecar =
+            StateAccount::from_config(&cfg, StateLayout::new(4096, 1, true, Some(4096)))
+                .full_kv_bytes;
         // FP8 cache (no sidecar): half the cache plus a small per-token scale.
         // Strictly less than BF16, but greater than half.
         assert!(fp8_no_sidecar < bf16);

--- a/crates/runner/src/qwen36_moe_decode.rs
+++ b/crates/runner/src/qwen36_moe_decode.rs
@@ -137,8 +137,8 @@ pub enum AttnLayerBuffers {
 ///     sidecar (`-1` when the sidecar is disabled).
 ///
 /// Exactly one of `k` / `virtual_kv_cache_k` is `Some` (same for V).
-/// `virtual_kv_cache_k` is only `Some` when KV-FP8 is on AND
-/// `SUPERSONIC_VMM_KV=1` was set AND the backend supports VMM.
+/// `virtual_kv_cache_k` is `Some` when `SUPERSONIC_VMM_KV=1` was set
+/// and the backend supports VMM. It can back either BF16 KV or FP8 KV.
 pub struct FullAttnKvCache {
     /// `Some` when VMM-backed KV is OFF (the default). `None` when
     /// `virtual_kv_cache_k` is `Some` (VMM-backed). Exactly one of
@@ -156,8 +156,8 @@ pub struct FullAttnKvCache {
     /// the sidecar is disabled).
     pub kv_shadow_start: i32,
     /// `Some` when `SUPERSONIC_VMM_KV=1` was set at allocation time AND
-    /// the backend supports VMM AND `kv_fp8` is on. Mutually exclusive
-    /// with `k` (exactly one is `Some`).
+    /// the backend supports VMM. Mutually exclusive with `k` (exactly
+    /// one is `Some`).
     pub virtual_kv_cache_k: Option<gpu_hal::VirtualBuffer>,
     pub virtual_kv_cache_v: Option<gpu_hal::VirtualBuffer>,
     /// The VMM reservation's logical max_T (matches `kv_max_t` above).

--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -130,6 +130,16 @@ pub struct VirtualBakeProbe {
     pub failed_tensors: Vec<String>,
 }
 
+#[derive(Debug, Clone, Copy, Default)]
+struct VirtualKvStats {
+    layers: usize,
+    logical_bytes: usize,
+    reserved_bytes: usize,
+    resident_bytes: usize,
+    logical_resident_bytes: usize,
+    mappings: usize,
+}
+
 pub fn run_qwen36_moe_dry_run(
     model_dir: &Path,
     entry: &RegistryEntry,
@@ -161,11 +171,8 @@ pub fn run_qwen36_moe_dry_run(
     // window=kv_max_t (matches the kernel hard-coding); the env helper
     // would only matter for VRAM accounting if the kernel grew a
     // kv_shadow_window arg later.
-    let sidecar_window = if kv_fp8
-        && qwen35::state::kv_fp8_bf16_sidecar_enabled()
-    {
-        Some(qwen35::state::kv_fp8_bf16_sidecar_window_tokens()
-            .unwrap_or(context_size))
+    let sidecar_window = if kv_fp8 && qwen35::state::kv_fp8_bf16_sidecar_enabled() {
+        Some(qwen35::state::kv_fp8_bf16_sidecar_window_tokens().unwrap_or(context_size))
     } else {
         None
     };
@@ -1089,6 +1096,63 @@ fn moe_island_cap_experts_from_env() -> Result<Option<usize>> {
     Ok(Some(cap))
 }
 
+fn qwen36_kv_vmm_requested_from_env() -> Result<bool> {
+    match std::env::var("SUPERSONIC_VMM_KV").ok().as_deref() {
+        None | Some("0") => Ok(false),
+        Some("1") => Ok(true),
+        Some(other) => Err(anyhow!(
+            "SUPERSONIC_VMM_KV must be unset, 0, or 1 for Qwen3.6-MoE; got {other:?}"
+        )),
+    }
+}
+
+fn should_use_qwen36_kv_vmm(backend: Backend, ordinal: usize) -> Result<bool> {
+    if !qwen36_kv_vmm_requested_from_env()? {
+        return Ok(false);
+    }
+    if !gpu_hal::vmm_is_supported(backend, ordinal) {
+        eprintln!(
+            "[vmm] SUPERSONIC_VMM_KV=1 requested for Qwen3.6-MoE but backend={backend} \
+             device {ordinal} does not support VMM; using dense KV buffers"
+        );
+        return Ok(false);
+    }
+    Ok(true)
+}
+
+fn virtual_kv_stats_for_layers(layers: &[LayerBuffers]) -> VirtualKvStats {
+    let mut out = VirtualKvStats::default();
+    for layer in layers {
+        let AttnLayerBuffers::Full {
+            kv_cache: Some(cache),
+            ..
+        } = &layer.attn
+        else {
+            continue;
+        };
+        let mut layer_has_virtual_kv = false;
+        for buffer in [
+            cache.virtual_kv_cache_k.as_ref(),
+            cache.virtual_kv_cache_v.as_ref(),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            let stats = buffer.stats();
+            out.logical_bytes += stats.logical_bytes;
+            out.reserved_bytes += stats.reserved_bytes;
+            out.resident_bytes += stats.resident_bytes;
+            out.logical_resident_bytes += stats.logical_resident_bytes;
+            out.mappings += stats.mapping_count;
+            layer_has_virtual_kv = true;
+        }
+        if layer_has_virtual_kv {
+            out.layers += 1;
+        }
+    }
+    out
+}
+
 #[derive(Debug, Clone, Copy)]
 struct MoeSparseTelemetrySnapshot {
     stats: crate::qwen36_moe_residency::MoeExpertResidencyStats,
@@ -1263,6 +1327,10 @@ fn load_layer_buffers(
     // sidecar (gated by `qwen35::state::kv_fp8_bf16_sidecar_*` env
     // helpers).
     kv_fp8: bool,
+    // When true, full-attention K/V caches use VMM reservations for
+    // their main K/V storage. Applies to BF16 and FP8 KV; FP8 scale
+    // and sidecar buffers stay dense.
+    kv_vmm: bool,
     mut expert_arena: Option<&mut VirtualArena>,
     mut expert_residency: Option<&mut MoeExpertResidencyManager>,
 ) -> Result<LayerBuffers> {
@@ -1332,37 +1400,40 @@ fn load_layer_buffers(
         // FP8 path: same shape but U8 (FP8 E4M3 bytes) plus F32 scales
         // [num_kv_heads, kv_max_t] for K and V, plus optional BF16 sidecar
         // [num_kv_heads, sidecar_window, head_dim] when enabled.
-        // VMM-FP8 path (SUPERSONIC_VMM_KV=1): same as FP8 but K/V are
-        // VirtualBuffer reservations with a mapped prefix; dense k/v are None.
+        // VMM path (SUPERSONIC_VMM_KV=1): K/V are VirtualBuffer
+        // reservations with a mapped prefix; dense k/v are None. FP8 scale
+        // and sidecar buffers remain regular dense GpuBuffers.
         let kv_dim = (geom.num_kv_heads as usize) * (geom.head_dim as usize);
         let kv_cache = if kv_max_t > 0 {
             let num_kv_heads = geom.num_kv_heads as usize;
             let head_dim = geom.head_dim as usize;
 
-            let want_vmm = std::env::var_os("SUPERSONIC_VMM_KV")
-                .and_then(|v| v.into_string().ok())
-                .map(|v| v == "1")
-                .unwrap_or(false);
-            let vmm_active = kv_fp8
-                && want_vmm
-                && gpu_hal::vmm_is_supported(gpu_hal::current_backend(), ordinal);
-
-            let (k, v, virtual_kv_cache_k, virtual_kv_cache_v, virtual_kv_max_t,
-                 kv_scale_k, kv_scale_v) = if vmm_active {
+            let (
+                k,
+                v,
+                virtual_kv_cache_k,
+                virtual_kv_cache_v,
+                virtual_kv_max_t,
+                kv_scale_k,
+                kv_scale_v,
+            ) = if kv_vmm {
                 // VMM-backed: reserve full logical capacity AND map all of
-                // it up front. We don't evict KV-FP8 in v1 (CpuBackup is off
-                // — VirtualBacking::Discard), and the kernel writes K/V at
-                // arbitrary `eff_cache_pos` between 0 and kv_max_t-1, so any
-                // unmapped page would page-fault mid-launch. The benefit of
-                // lazy mapping was VRAM pressure relief — but at typical
-                // sizes (e.g. ~128 MiB per K-cache, 2.56 GiB across 10
-                // full-attn layers for max_t=262144) the savings don't
-                // justify decode-time map_range_bytes calls. Map the full
-                // logical bytes once at construction.
-                let map_full_bytes = kv_max_t * kv_dim;
+                // it up front. We don't evict Qwen3.6 KV in v1 (CpuBackup is
+                // off — VirtualBacking::Discard), and the kernel writes K/V
+                // at arbitrary `eff_cache_pos` between 0 and kv_max_t-1, so
+                // any unmapped page would page-fault mid-launch. The benefit
+                // here is stable VA and shared VMM descriptor plumbing, not
+                // decode-time KV paging yet.
+                let kv_dtype = if kv_fp8 {
+                    ScalarType::U8
+                } else {
+                    ScalarType::BF16
+                };
+                let kv_dtype_bytes = if kv_fp8 { 1 } else { 2 };
+                let map_full_bytes = kv_max_t * kv_dim * kv_dtype_bytes;
                 let vk = gpu_hal::VirtualBuffer::reserve_and_map_prefix(
                     ordinal,
-                    ScalarType::U8,
+                    kv_dtype,
                     &[kv_max_t, kv_dim],
                     map_full_bytes,
                     gpu_hal::VirtualBacking::Discard,
@@ -1370,17 +1441,22 @@ fn load_layer_buffers(
                 .with_context(|| format!("vmm reserve kv_cache_k (layer {layer_idx})"))?;
                 let vv = gpu_hal::VirtualBuffer::reserve_and_map_prefix(
                     ordinal,
-                    ScalarType::U8,
+                    kv_dtype,
                     &[kv_max_t, kv_dim],
                     map_full_bytes,
                     gpu_hal::VirtualBacking::Discard,
                 )
                 .with_context(|| format!("vmm reserve kv_cache_v (layer {layer_idx})"))?;
-                let sk = GpuBuffer::zeros(ordinal, ScalarType::F32, &[num_kv_heads, kv_max_t])
-                    .with_context(|| format!("alloc kv_scale_k (layer {layer_idx})"))?;
-                let sv = GpuBuffer::zeros(ordinal, ScalarType::F32, &[num_kv_heads, kv_max_t])
-                    .with_context(|| format!("alloc kv_scale_v (layer {layer_idx})"))?;
-                (None, None, Some(vk), Some(vv), Some(kv_max_t), Some(sk), Some(sv))
+                let (sk, sv) = if kv_fp8 {
+                    let sk = GpuBuffer::zeros(ordinal, ScalarType::F32, &[num_kv_heads, kv_max_t])
+                        .with_context(|| format!("alloc kv_scale_k (layer {layer_idx})"))?;
+                    let sv = GpuBuffer::zeros(ordinal, ScalarType::F32, &[num_kv_heads, kv_max_t])
+                        .with_context(|| format!("alloc kv_scale_v (layer {layer_idx})"))?;
+                    (Some(sk), Some(sv))
+                } else {
+                    (None, None)
+                };
+                (None, None, Some(vk), Some(vv), Some(kv_max_t), sk, sv)
             } else if kv_fp8 {
                 // dense FP8 path
                 let k = GpuBuffer::zeros(ordinal, ScalarType::U8, &[kv_max_t, kv_dim])
@@ -1409,18 +1485,12 @@ fn load_layer_buffers(
                 // size always equals kv_max_t until the kernel grows a
                 // kv_shadow_window arg.
                 let window = kv_max_t;
-                let sk = GpuBuffer::zeros(
-                    ordinal,
-                    ScalarType::BF16,
-                    &[num_kv_heads, window, head_dim],
-                )
-                .with_context(|| format!("alloc kv_shadow_k (layer {layer_idx})"))?;
-                let sv = GpuBuffer::zeros(
-                    ordinal,
-                    ScalarType::BF16,
-                    &[num_kv_heads, window, head_dim],
-                )
-                .with_context(|| format!("alloc kv_shadow_v (layer {layer_idx})"))?;
+                let sk =
+                    GpuBuffer::zeros(ordinal, ScalarType::BF16, &[num_kv_heads, window, head_dim])
+                        .with_context(|| format!("alloc kv_shadow_k (layer {layer_idx})"))?;
+                let sv =
+                    GpuBuffer::zeros(ordinal, ScalarType::BF16, &[num_kv_heads, window, head_dim])
+                        .with_context(|| format!("alloc kv_shadow_v (layer {layer_idx})"))?;
                 (Some(sk), Some(sv))
             } else {
                 (None, None)
@@ -1726,6 +1796,7 @@ fn load_all_layer_buffers(
     weight_mode: Qwen36WeightMode,
     kv_max_t: usize,
     kv_fp8: bool,
+    kv_vmm: bool,
     mut expert_arena: Option<&mut VirtualArena>,
     mut expert_residency: Option<&mut MoeExpertResidencyManager>,
 ) -> Result<Vec<LayerBuffers>> {
@@ -1741,6 +1812,7 @@ fn load_all_layer_buffers(
             weight_mode,
             kv_max_t,
             kv_fp8,
+            kv_vmm,
             expert_arena.as_deref_mut(),
             expert_residency.as_deref_mut(),
         )
@@ -2141,6 +2213,7 @@ fn decode_text(
             path.display()
         );
     }
+    let kv_vmm = should_use_qwen36_kv_vmm(backend, ordinal)?;
     let mut layers = if let Some(cap_experts) = moe_island_cap_experts {
         if cap_experts < geom.top_k as usize {
             anyhow::bail!(
@@ -2163,6 +2236,7 @@ fn decode_text(
             weight_mode,
             kv_max_t,
             kv_fp8,
+            kv_vmm,
             None,
             Some(&mut manager),
         )
@@ -2204,6 +2278,7 @@ fn decode_text(
             weight_mode,
             kv_max_t,
             kv_fp8,
+            kv_vmm,
             Some(&mut arena),
             None,
         ) {
@@ -2236,6 +2311,7 @@ fn decode_text(
                     weight_mode,
                     kv_max_t,
                     kv_fp8,
+                    kv_vmm,
                     None,
                     None,
                 )?
@@ -2252,10 +2328,27 @@ fn decode_text(
             weight_mode,
             kv_max_t,
             kv_fp8,
+            kv_vmm,
             None,
             None,
         )?
     };
+    let virtual_kv_stats = virtual_kv_stats_for_layers(&layers);
+    if virtual_kv_stats.layers > 0 {
+        println!(
+            "  [vmm] Qwen3.6-MoE {} KV active on backend={} device {ordinal}: \
+             layers={} mappings={} logical={:.2}MiB logical_resident={:.2}MiB \
+             resident={:.2}MiB reserved={:.2}MiB",
+            if kv_fp8 { "FP8" } else { "BF16" },
+            backend,
+            virtual_kv_stats.layers,
+            virtual_kv_stats.mappings,
+            virtual_kv_stats.logical_bytes as f64 / MIB,
+            virtual_kv_stats.logical_resident_bytes as f64 / MIB,
+            virtual_kv_stats.resident_bytes as f64 / MIB,
+            virtual_kv_stats.reserved_bytes as f64 / MIB,
+        );
+    }
     // Phase 6 self-speculative decode: load the multi-token-prediction
     // (MTP) head from the bake when --speculative-decode is set.
     //
@@ -3334,6 +3427,7 @@ fn decode_first_token(model_dir: &Path, report: &DryRunReport, kv_fp8: bool) -> 
             weight_mode,
             0, // legacy single-token path: no KV cache, kv_len=1 fast path.
             kv_fp8,
+            false,
             None,
             None,
         )

--- a/crates/runner/src/qwen36_moe_persistent_decode.rs
+++ b/crates/runner/src/qwen36_moe_persistent_decode.rs
@@ -423,10 +423,14 @@ pub fn build_layer_descs(layers: &mut [LayerBuffers]) -> Vec<Qwen36MoeDecodeLaye
                     d.kv_cache_k = c.k_device_ptr();
                     d.kv_cache_v = c.v_device_ptr();
                     d.kv_max_t = c.kv_max_t;
-                    d.kv_shadow_k = c.kv_shadow_k.as_mut()
+                    d.kv_shadow_k = c
+                        .kv_shadow_k
+                        .as_mut()
                         .map(|b| b.as_mut_ptr())
                         .unwrap_or(std::ptr::null_mut());
-                    d.kv_shadow_v = c.kv_shadow_v.as_mut()
+                    d.kv_shadow_v = c
+                        .kv_shadow_v
+                        .as_mut()
                         .map(|b| b.as_mut_ptr())
                         .unwrap_or(std::ptr::null_mut());
                     // Sidecar window is forced equal to kv_max_t in v1 —
@@ -439,11 +443,7 @@ pub fn build_layer_descs(layers: &mut [LayerBuffers]) -> Vec<Qwen36MoeDecodeLaye
                     // struct for v1 — it's only meaningful if a future
                     // windowed-mode lands and the kernel grows a
                     // kv_shadow_window arg.)
-                    d.kv_shadow_start = if c.kv_shadow_k.is_some() {
-                        0
-                    } else {
-                        -1
-                    };
+                    d.kv_shadow_start = if c.kv_shadow_k.is_some() { 0 } else { -1 };
                 }
             }
             AttnLayerBuffers::Linear {
@@ -550,9 +550,7 @@ pub fn build_int4_descs(layers: &[LayerBuffers]) -> Option<Vec<Qwen36MoeInt4Scal
 /// without KV-FP8). Linear-attn layers emit a zeroed descriptor
 /// (null scale pointers); the kernel checks `is_full_attention != 0`
 /// before dereferencing them.
-pub fn build_kv_fp8_descs(
-    layers: &mut [LayerBuffers],
-) -> Option<Vec<Qwen36MoeKVCacheFp8Desc>> {
+pub fn build_kv_fp8_descs(layers: &mut [LayerBuffers]) -> Option<Vec<Qwen36MoeKVCacheFp8Desc>> {
     let any_fp8 = layers.iter().any(|l| match &l.attn {
         AttnLayerBuffers::Full {
             kv_cache: Some(c), ..

--- a/crates/runner/tests/qwen36_moe_bf16_kv_vmm_smoke.rs
+++ b/crates/runner/tests/qwen36_moe_bf16_kv_vmm_smoke.rs
@@ -1,17 +1,14 @@
-//! VMM-backed vs dense FP8 KV bit-exact smoke for Qwen3.6-35B-A3B
-//! (--int4 weights + --kv-fp8, gfx1100).
+//! VMM-backed vs dense BF16 KV bit-exact smoke for Qwen3.6-35B-A3B.
 //!
-//! Same prompt, same args, run twice via the supersonic binary — once
+//! Same prompt, same args, run twice via the supersonic binary: once
 //! with SUPERSONIC_VMM_KV=1, once with SUPERSONIC_VMM_KV=0. Last-step
-//! logits must be bit-exact (not just cossim ≥ 0.999): VMM-backed KV
-//! is a different *backing*, not a different *quantisation*, so kernel
-//! reads should be identical to the byte.
+//! logits must be bit-exact because VMM changes only the cache backing.
 //!
 //! Skipped silently when:
-//!  - HIP backend not compiled
-//!  - SUPERSONIC_QWEN36_35B_A3B_DIR unset or path missing
-//!  - HIP backend doesn't support VMM on the live device
-//!  - SUPERSONIC_QWEN36_KV_FP8_VMM_SMOKE=0
+//!  - HIP backend is not compiled
+//!  - SUPERSONIC_QWEN36_35B_A3B_DIR is unset or missing
+//!  - HIP VMM is unsupported on the live device
+//!  - SUPERSONIC_QWEN36_BF16_KV_VMM_SMOKE=0
 
 use gpu_hal::Backend;
 use std::process::Command;
@@ -58,13 +55,13 @@ fn run_supersonic_capture_logits(
 }
 
 #[test]
-fn qwen36_moe_kv_fp8_vmm_dense_bit_exact() {
+fn qwen36_moe_bf16_kv_vmm_dense_bit_exact() {
     if !gpu_hal::is_backend_compiled(Backend::Hip) {
         eprintln!("skipped: HIP backend not compiled");
         return;
     }
-    if std::env::var("SUPERSONIC_QWEN36_KV_FP8_VMM_SMOKE").as_deref() == Ok("0") {
-        eprintln!("skipped: SUPERSONIC_QWEN36_KV_FP8_VMM_SMOKE=0");
+    if std::env::var("SUPERSONIC_QWEN36_BF16_KV_VMM_SMOKE").as_deref() == Ok("0") {
+        eprintln!("skipped: SUPERSONIC_QWEN36_BF16_KV_VMM_SMOKE=0");
         return;
     }
     let model_dir = match std::env::var("SUPERSONIC_QWEN36_35B_A3B_DIR") {
@@ -85,9 +82,8 @@ fn qwen36_moe_kv_fp8_vmm_dense_bit_exact() {
         "--model-dir",
         model_dir.as_str(),
         "--int4",
-        "--kv-fp8",
         "--prompt",
-        "Hello, world.",
+        "The stable virtual address for the key value cache is",
         "--max-new-tokens",
         "8",
     ];
@@ -99,8 +95,8 @@ fn qwen36_moe_kv_fp8_vmm_dense_bit_exact() {
 
     assert!(
         vmm.combined_output
-            .contains("[vmm] Qwen3.6-MoE FP8 KV active"),
-        "VMM run did not report Qwen3.6 FP8 KV VMM activation:\n{}",
+            .contains("[vmm] Qwen3.6-MoE BF16 KV active"),
+        "VMM run did not report Qwen3.6 BF16 KV VMM activation:\n{}",
         vmm.combined_output
     );
     assert_eq!(
@@ -112,7 +108,7 @@ fn qwen36_moe_kv_fp8_vmm_dense_bit_exact() {
         assert_eq!(
             a.to_bits(),
             b.to_bits(),
-            "VMM-backed KV-FP8 logits diverged at index {i}: dense={a} vmm={b}",
+            "VMM-backed BF16 KV logits diverged at index {i}: dense={a} vmm={b}",
         );
     }
 }

--- a/crates/runner/tests/qwen36_moe_fp8_weights_smoke.rs
+++ b/crates/runner/tests/qwen36_moe_fp8_weights_smoke.rs
@@ -69,11 +69,15 @@ fn qwen36_moe_fp8_weights_kv_fp8_gfx942() {
     };
 
     let common = vec![
-        "--model", "qwen3.6-35b-a3b",
-        "--model-dir", model_dir.as_str(),
+        "--model",
+        "qwen3.6-35b-a3b",
+        "--model-dir",
+        model_dir.as_str(),
         "--kv-fp8",
-        "--prompt", "When the cooperative kernel grids meet,",
-        "--max-new-tokens", "16",
+        "--prompt",
+        "When the cooperative kernel grids meet,",
+        "--max-new-tokens",
+        "16",
     ];
     let mut int4 = common.clone();
     int4.push("--int4");

--- a/crates/runner/tests/qwen36_moe_kv_fp8_parity.rs
+++ b/crates/runner/tests/qwen36_moe_kv_fp8_parity.rs
@@ -70,12 +70,10 @@ fn qwen36_moe_kv_fp8_vs_bf16_self_parity() {
         "16",
     ];
 
-    let bf16_kv: Vec<f32> =
-        run_supersonic_capture_logits(&common, &[]).expect("BF16-KV decode");
+    let bf16_kv: Vec<f32> = run_supersonic_capture_logits(&common, &[]).expect("BF16-KV decode");
     let mut fp8_args = common.clone();
     fp8_args.push("--kv-fp8");
-    let fp8_kv: Vec<f32> =
-        run_supersonic_capture_logits(&fp8_args, &[]).expect("FP8-KV decode");
+    let fp8_kv: Vec<f32> = run_supersonic_capture_logits(&fp8_args, &[]).expect("FP8-KV decode");
 
     assert_eq!(
         bf16_kv.len(),
@@ -101,8 +99,5 @@ fn qwen36_moe_kv_fp8_vs_bf16_self_parity() {
         .sqrt();
     let cossim = dot / (na * nb);
     eprintln!("[kv-fp8 self-parity] cossim = {:.6}", cossim);
-    assert!(
-        cossim >= 0.999,
-        "KV-FP8 vs BF16-KV cossim {cossim} < 0.999"
-    );
+    assert!(cossim >= 0.999, "KV-FP8 vs BF16-KV cossim {cossim} < 0.999");
 }

--- a/docs/lowlevel-memory.md
+++ b/docs/lowlevel-memory.md
@@ -32,13 +32,14 @@ Current scope:
 
 - Decode-active VMM is enabled internally for Qwen3.5 BF16 dense KV, for
   Qwen3.6-MoE INT4 routed expert slabs when the VMM expert mode is active,
-  and for Qwen3.6-MoE FP8 KV (opt-in via `SUPERSONIC_VMM_KV=1`).
+  and for Qwen3.6-MoE full-attention KV (BF16 or FP8, opt-in via
+  `SUPERSONIC_VMM_KV=1`).
 - Disabled for certified-KV, batch decode, Qwen3.5 4B/component decode,
   DFlash cloned states, Gemma4, and Llama3.1. Qwen3.5 KV-FP8 also remains
   disabled — enabling it is a separate effort.
-- Qwen3.6-MoE FP8 KV reserves U8 K/V VMM allocations (full logical
-  capacity, mapped prefix at kv_chunk_size=256) per full-attn layer.
-  Scale buffers (F32 [num_kv_heads, max_T]) and the optional BF16 sidecar
+- Qwen3.6-MoE full-attention KV reserves BF16 or U8 K/V VMM allocations
+  (full logical capacity mapped up front) per full-attn layer. FP8 scale
+  buffers (F32 [num_kv_heads, max_T]) and the optional BF16 sidecar
   ([num_kv_heads, kv_max_t, head_dim]) stay as dense `GpuBuffer` for v1.
   See Tasks 9–11 of `docs/superpowers/plans/2026-05-03-qwen36-moe-fp8-kv-fp8.md`.
 - Baked tensors can now be loaded into `VirtualArena` allocations through
@@ -147,6 +148,13 @@ on CUDA devices with `SUPERSONIC_VMM_KV=1`:
   `SUPERSONIC_TEST_QWEN36_MOE_SPARSE_CAP_EXPERTS=8` for the smallest
   top-k-sized residency window, or with a larger value when investigating HIP
   live-mapping limits.
+- Qwen3.6-MoE BF16-KV VMM backing parity:
+  `SUPERSONIC_QWEN36_35B_A3B_DIR=/mnt/data/models/Qwen3.6-35B-A3B cargo test --release -p runner --test qwen36_moe_bf16_kv_vmm_smoke -- --nocapture`
+  compares `SUPERSONIC_VMM_KV=0` and `SUPERSONIC_VMM_KV=1` last-step logits
+  bit-exactly with INT4 weights and BF16 KV.
+- Qwen3.6-MoE FP8-KV VMM backing parity:
+  `SUPERSONIC_QWEN36_35B_A3B_DIR=/mnt/data/models/Qwen3.6-35B-A3B cargo test --release -p runner --test qwen36_moe_kv_fp8_vmm_smoke -- --nocapture`
+  runs the same backing-equivalence check with `--kv-fp8`.
 - Qwen3.5 virtual KV e2e with eviction and restore-to-VMM:
   `SUPERSONIC_VMM_KV=1 SUPERSONIC_VMM_KV_EVICT_AFTER_PREFILL=1 SUPERSONIC_VMM_KV_RESTORE_TO_VMM=1 ... --validate`
   passed and kept stable VMM pointers through decode.


### PR DESCRIPTION
## Summary
- generalize Qwen3.6 full-attention virtual KV backing so SUPERSONIC_VMM_KV=1 works for BF16 KV as well as FP8 KV
- report Qwen3.6 virtual KV activation/residency stats for BF16 and FP8 modes
- add a BF16 dense-vs-VMM bit-exact HIP smoke and tighten the FP8 VMM smoke to assert activation
- update low-level memory docs and apply cargo fmt cleanup needed after #154

## Tests
- cargo fmt --check
- cargo check -p runner
- SUPERSONIC_QWEN36_35B_A3B_DIR=/mnt/data/models/Qwen3.6-35B-A3B cargo test --release -p runner --test qwen36_moe_bf16_kv_vmm_smoke -- --nocapture
- SUPERSONIC_QWEN36_35B_A3B_DIR=/mnt/data/models/Qwen3.6-35B-A3B cargo test --release -p runner --test qwen36_moe_kv_fp8_vmm_smoke -- --nocapture