### PR TITLE
Add Qwen3.6 rolling KV-FP8 sidecar window

### DIFF
--- a/crates/kernel-ffi/src/qwen36_moe.rs
+++ b/crates/kernel-ffi/src/qwen36_moe.rs
@@ -114,17 +114,22 @@ pub struct Qwen36MoeDecodeLayerDesc {
 
     // --- KV-FP8 sidecar (read iff is_full_attention == 1 AND
     // matching kv_fp8_descs[layer].kv_scale_k != null) ---------------
-    /// BF16 sidecar buffer `[num_kv_heads, window, head_dim]`. Null when
-    /// the sidecar is disabled. The kernel reads from the sidecar (instead
-    /// of dequantising FP8) when `t >= kv_shadow_start`.
+    /// BF16 sidecar buffer `[num_kv_heads, kv_shadow_window, head_dim]`.
+    /// Null when the sidecar is disabled. The kernel reads from the sidecar
+    /// (instead of dequantising FP8) for positions covered by the rolling
+    /// sidecar window.
     pub kv_shadow_k: *mut c_void,
-    /// BF16 sidecar buffer `[num_kv_heads, window, head_dim]`. Paired with
-    /// [`Self::kv_shadow_k`]; null under the same conditions.
+    /// BF16 sidecar buffer `[num_kv_heads, kv_shadow_window, head_dim]`.
+    /// Paired with [`Self::kv_shadow_k`]; null under the same conditions.
     pub kv_shadow_v: *mut c_void,
-    /// First absolute KV position covered by the sidecar. `-1` when the
-    /// sidecar is disabled (or no positions are covered yet); the kernel
-    /// reads `t >= kv_shadow_start && kv_shadow_start >= 0` to decide.
+    /// Earliest absolute KV position the sidecar may cover. `-1` when the
+    /// sidecar is disabled. Runtime coverage is
+    /// `max(kv_shadow_start, position + 1 - kv_shadow_window)..=position`.
     pub kv_shadow_start: c_int,
+    /// Number of recent KV positions physically stored in the BF16 sidecar.
+    /// Zero when the sidecar is disabled. The kernel uses modulo indexing so
+    /// the descriptor can remain fixed across decode steps.
+    pub kv_shadow_window: c_int,
 }
 
 unsafe impl Send for Qwen36MoeDecodeLayerDesc {}

--- a/crates/qwen36_moe/src/state.rs
+++ b/crates/qwen36_moe/src/state.rs
@@ -24,9 +24,8 @@ pub struct StateLayout {
     /// Bytes per (head, position) element for the BF16 sidecar. 2 when
     /// kv_fp8 is on AND a sidecar window is configured, 0 otherwise.
     pub kv_fp8_sidecar_bytes_per_token: u64,
-    /// Number of positions covered by the BF16 sidecar (per layer per
-    /// kv_head). 0 when the sidecar is disabled. v1 forces this to
-    /// equal `context_tokens` when the sidecar is on.
+    /// Number of recent positions covered by the rolling BF16 sidecar
+    /// (per layer per kv_head). 0 when the sidecar is disabled.
     pub kv_fp8_sidecar_window: u64,
 }
 

--- a/crates/runner/src/qwen36_moe_decode.rs
+++ b/crates/runner/src/qwen36_moe_decode.rs
@@ -135,6 +135,9 @@ pub enum AttnLayerBuffers {
 ///     parity-sensitive recent reads.
 ///   - `kv_shadow_start` is the first absolute position covered by the
 ///     sidecar (`-1` when the sidecar is disabled).
+///   - `kv_shadow_window` is the sidecar's rolling capacity in positions
+///     (`0` when disabled). The kernel computes the active start from the
+///     current decode position, so descriptors do not need per-step updates.
 ///
 /// Exactly one of `k` / `virtual_kv_cache_k` is `Some` (same for V).
 /// `virtual_kv_cache_k` is `Some` when `SUPERSONIC_VMM_KV=1` was set
@@ -155,6 +158,8 @@ pub struct FullAttnKvCache {
     /// First absolute KV position covered by the sidecar (`-1` when
     /// the sidecar is disabled).
     pub kv_shadow_start: i32,
+    /// Rolling sidecar capacity in positions (`0` when disabled).
+    pub kv_shadow_window: i32,
     /// `Some` when `SUPERSONIC_VMM_KV=1` was set at allocation time AND
     /// the backend supports VMM. Mutually exclusive with `k` (exactly
     /// one is `Some`).

--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -167,12 +167,13 @@ pub fn run_qwen36_moe_dry_run(
     let int4_projected_bytes = checkpoint.project_int4_total_bytes(&config.text_config, 128);
 
     // The sidecar window is consulted only when --kv-fp8 is on AND the
-    // env-var helper is enabled. v1 forces the runtime allocation to
-    // window=kv_max_t (matches the kernel hard-coding); the env helper
-    // would only matter for VRAM accounting if the kernel grew a
-    // kv_shadow_window arg later.
+    // env-var helper is enabled. The persistent kernel treats it as a
+    // rolling recent-token window.
     let sidecar_window = if kv_fp8 && qwen35::state::kv_fp8_bf16_sidecar_enabled() {
-        Some(qwen35::state::kv_fp8_bf16_sidecar_window_tokens().unwrap_or(context_size))
+        let window = qwen35::state::kv_fp8_bf16_sidecar_window_tokens()
+            .unwrap_or(context_size)
+            .min(context_size);
+        (window > 0).then_some(window)
     } else {
         None
     };
@@ -1476,25 +1477,31 @@ fn load_layer_buffers(
                     .with_context(|| format!("alloc kv_cache_v (layer {layer_idx})"))?;
                 (Some(k), Some(v), None, None, None, None, None)
             };
-            let (kv_shadow_k, kv_shadow_v) = if kv_fp8
-                && qwen35::state::kv_fp8_bf16_sidecar_enabled()
-            {
-                // Window is hard-coded to kv_max_t in v1 (matches the
-                // kernel's stride). The env-var window helper is consulted
-                // by Task 11 only for VRAM accounting; the actual buffer
-                // size always equals kv_max_t until the kernel grows a
-                // kv_shadow_window arg.
-                let window = kv_max_t;
-                let sk =
-                    GpuBuffer::zeros(ordinal, ScalarType::BF16, &[num_kv_heads, window, head_dim])
+            let (kv_shadow_k, kv_shadow_v, kv_shadow_window) =
+                if kv_fp8 && qwen35::state::kv_fp8_bf16_sidecar_enabled() {
+                    let window = qwen35::state::kv_fp8_bf16_sidecar_window_tokens()
+                        .unwrap_or(kv_max_t)
+                        .min(kv_max_t);
+                    if window == 0 {
+                        (None, None, 0)
+                    } else {
+                        let sk = GpuBuffer::zeros(
+                            ordinal,
+                            ScalarType::BF16,
+                            &[num_kv_heads, window, head_dim],
+                        )
                         .with_context(|| format!("alloc kv_shadow_k (layer {layer_idx})"))?;
-                let sv =
-                    GpuBuffer::zeros(ordinal, ScalarType::BF16, &[num_kv_heads, window, head_dim])
+                        let sv = GpuBuffer::zeros(
+                            ordinal,
+                            ScalarType::BF16,
+                            &[num_kv_heads, window, head_dim],
+                        )
                         .with_context(|| format!("alloc kv_shadow_v (layer {layer_idx})"))?;
-                (Some(sk), Some(sv))
-            } else {
-                (None, None)
-            };
+                        (Some(sk), Some(sv), window as i32)
+                    }
+                } else {
+                    (None, None, 0)
+                };
             Some(FullAttnKvCache {
                 k,
                 v,
@@ -1504,6 +1511,7 @@ fn load_layer_buffers(
                 kv_shadow_k,
                 kv_shadow_v,
                 kv_shadow_start: -1,
+                kv_shadow_window,
                 virtual_kv_cache_k,
                 virtual_kv_cache_v,
                 virtual_kv_max_t,
@@ -1929,6 +1937,7 @@ fn load_mtp_buffers(
             kv_shadow_k: None,
             kv_shadow_v: None,
             kv_shadow_start: -1,
+            kv_shadow_window: 0,
             virtual_kv_cache_k: None,
             virtual_kv_cache_v: None,
             virtual_kv_max_t: None,
@@ -2761,12 +2770,10 @@ fn decode_text(
         let t_chain_step = t1.elapsed();
         position += 1;
 
-        // (KV-FP8 sidecar shadow cursor is set at desc-build time in
-        // build_layer_descs — see qwen36_moe_persistent_decode.rs. v1
-        // forces the sidecar window equal to kv_max_t, so the cursor
-        // is `0` from step 0 onward and the descs never need re-upload.
-        // A future windowed-mode kernel would need decode-time updates
-        // to the device-side desc; flag for that work then.)
+        // KV-FP8 sidecar descriptors stay fixed across decode. The
+        // persistent kernel computes the rolling covered range from
+        // `position` and `kv_shadow_window`, so no descriptor re-upload is
+        // needed when old sidecar slots roll over.
 
         // Prefill steps: feed the next prompt token without computing logits.
         if step + 1 < prompt_ids.len() {

--- a/crates/runner/src/qwen36_moe_persistent_decode.rs
+++ b/crates/runner/src/qwen36_moe_persistent_decode.rs
@@ -433,16 +433,16 @@ pub fn build_layer_descs(layers: &mut [LayerBuffers]) -> Vec<Qwen36MoeDecodeLaye
                         .as_mut()
                         .map(|b| b.as_mut_ptr())
                         .unwrap_or(std::ptr::null_mut());
-                    // Sidecar window is forced equal to kv_max_t in v1 —
-                    // every position is covered, so the kernel guard
-                    // `t >= kv_shadow_start && kv_shadow_start >= 0`
-                    // resolves to "always read sidecar" once any sidecar
-                    // buffer is allocated. Set start = 0 from the get-go;
-                    // the descs are uploaded once and never re-uploaded.
-                    // (`c.kv_shadow_start` is left at -1 in the host
-                    // struct for v1 — it's only meaningful if a future
-                    // windowed-mode lands and the kernel grows a
-                    // kv_shadow_window arg.)
+                    d.kv_shadow_window = if c.kv_shadow_k.is_some() {
+                        c.kv_shadow_window
+                    } else {
+                        0
+                    };
+                    // The descriptor is uploaded once. For rolling windows
+                    // the kernel derives the active start each step from
+                    // `position + 1 - kv_shadow_window`, with this field as
+                    // a lower bound. A zero start preserves the previous
+                    // full-sidecar behavior when window == kv_max_t.
                     d.kv_shadow_start = if c.kv_shadow_k.is_some() { 0 } else { -1 };
                 }
             }

--- a/crates/runner/tests/qwen36_moe_kv_fp8_sidecar_window_smoke.rs
+++ b/crates/runner/tests/qwen36_moe_kv_fp8_sidecar_window_smoke.rs
@@ -1,0 +1,117 @@
+//! Rolling BF16 sidecar window smoke for Qwen3.6-35B-A3B KV-FP8.
+//!
+//! Runs the same prompt twice with a tiny sidecar window: dense FP8 KV and
+//! VMM-backed FP8 KV. Last-step logits must be bit-exact because the window
+//! changes quantization/read policy equally in both runs; VMM changes only
+//! the cache backing.
+//!
+//! Skipped silently when:
+//!  - HIP backend is not compiled
+//!  - SUPERSONIC_QWEN36_35B_A3B_DIR is unset or missing
+//!  - HIP VMM is unsupported on the live device
+//!  - SUPERSONIC_QWEN36_KV_FP8_SIDECAR_WINDOW_SMOKE=0
+
+use gpu_hal::Backend;
+use std::process::Command;
+
+struct RunResult {
+    logits: Vec<f32>,
+    combined_output: String,
+}
+
+fn run_supersonic_capture_logits(
+    args: &[&str],
+    extra_env: &[(&str, &str)],
+) -> anyhow::Result<RunResult> {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_supersonic"));
+    cmd.args(args);
+    cmd.arg("--dump-last-logits");
+    for (k, v) in extra_env {
+        cmd.env(k, v);
+    }
+    let out = cmd.output()?;
+    if !out.status.success() {
+        anyhow::bail!(
+            "supersonic exited {}: stderr=\n{}",
+            out.status,
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    let stdout = String::from_utf8(out.stdout)?;
+    let stderr = String::from_utf8(out.stderr)?;
+    let line = stdout
+        .lines()
+        .find(|l| l.starts_with("LAST_LOGITS:"))
+        .ok_or_else(|| anyhow::anyhow!("LAST_LOGITS line not found in stdout"))?;
+    let csv = &line["LAST_LOGITS:".len()..];
+    let logits = csv
+        .trim()
+        .split(',')
+        .map(|s| s.trim().parse::<f32>().map_err(Into::into))
+        .collect::<anyhow::Result<Vec<f32>>>()?;
+    Ok(RunResult {
+        logits,
+        combined_output: format!("{stdout}\n{stderr}"),
+    })
+}
+
+#[test]
+fn qwen36_moe_kv_fp8_rolling_sidecar_window_vmm_bit_exact() {
+    if !gpu_hal::is_backend_compiled(Backend::Hip) {
+        eprintln!("skipped: HIP backend not compiled");
+        return;
+    }
+    if std::env::var("SUPERSONIC_QWEN36_KV_FP8_SIDECAR_WINDOW_SMOKE").as_deref() == Ok("0") {
+        eprintln!("skipped: SUPERSONIC_QWEN36_KV_FP8_SIDECAR_WINDOW_SMOKE=0");
+        return;
+    }
+    let model_dir = match std::env::var("SUPERSONIC_QWEN36_35B_A3B_DIR") {
+        Ok(d) if std::path::Path::new(&d).exists() => d,
+        _ => {
+            eprintln!("skipped: SUPERSONIC_QWEN36_35B_A3B_DIR unset or missing");
+            return;
+        }
+    };
+    if !gpu_hal::vmm_is_supported(Backend::Hip, 0) {
+        eprintln!("skipped: VMM not supported on this device");
+        return;
+    }
+
+    let args = vec![
+        "--model",
+        "qwen3.6-35b-a3b",
+        "--model-dir",
+        model_dir.as_str(),
+        "--int4",
+        "--kv-fp8",
+        "--prompt",
+        "A rolling sidecar window keeps only the most recent cache entries",
+        "--max-new-tokens",
+        "8",
+    ];
+    let common_env = [("SUPERSONIC_DEBUG_KV_FP8_BF16_SIDECAR_WINDOW", "2")];
+
+    let dense = run_supersonic_capture_logits(&args, &[common_env[0], ("SUPERSONIC_VMM_KV", "0")])
+        .expect("dense decode");
+    let vmm = run_supersonic_capture_logits(&args, &[common_env[0], ("SUPERSONIC_VMM_KV", "1")])
+        .expect("vmm decode");
+
+    assert!(
+        vmm.combined_output
+            .contains("[vmm] Qwen3.6-MoE FP8 KV active"),
+        "VMM run did not report Qwen3.6 FP8 KV VMM activation:\n{}",
+        vmm.combined_output
+    );
+    assert_eq!(
+        dense.logits.len(),
+        vmm.logits.len(),
+        "logits length mismatch"
+    );
+    for (i, (a, b)) in dense.logits.iter().zip(&vmm.logits).enumerate() {
+        assert_eq!(
+            a.to_bits(),
+            b.to_bits(),
+            "rolling sidecar window logits diverged at index {i}: dense={a} vmm={b}",
+        );
+    }
+}

--- a/crates/runner/tests/qwen36_moe_linear_state.rs
+++ b/crates/runner/tests/qwen36_moe_linear_state.rs
@@ -120,6 +120,7 @@ fn make_full_layer(ordinal: usize) -> Result<LayerBuffers> {
                 kv_shadow_k: None,
                 kv_shadow_v: None,
                 kv_shadow_start: -1,
+                kv_shadow_window: 0,
                 virtual_kv_cache_k: None,
                 virtual_kv_cache_v: None,
                 virtual_kv_max_t: None,

--- a/crates/runner/tests/qwen36_moe_mtp_parity.rs
+++ b/crates/runner/tests/qwen36_moe_mtp_parity.rs
@@ -155,6 +155,7 @@ fn load_mtp_buffers_from_bake(
             kv_shadow_k: None,
             kv_shadow_v: None,
             kv_shadow_start: -1,
+            kv_shadow_window: 0,
             virtual_kv_cache_k: None,
             virtual_kv_cache_v: None,
             virtual_kv_max_t: None,

--- a/docs/lowlevel-memory.md
+++ b/docs/lowlevel-memory.md
@@ -39,8 +39,8 @@ Current scope:
   disabled — enabling it is a separate effort.
 - Qwen3.6-MoE full-attention KV reserves BF16 or U8 K/V VMM allocations
   (full logical capacity mapped up front) per full-attn layer. FP8 scale
-  buffers (F32 [num_kv_heads, max_T]) and the optional BF16 sidecar
-  ([num_kv_heads, kv_max_t, head_dim]) stay as dense `GpuBuffer` for v1.
+  buffers (F32 [num_kv_heads, max_T]) and the optional rolling BF16 sidecar
+  ([num_kv_heads, sidecar_window, head_dim]) stay as dense `GpuBuffer`.
   See Tasks 9–11 of `docs/superpowers/plans/2026-05-03-qwen36-moe-fp8-kv-fp8.md`.
 - Baked tensors can now be loaded into `VirtualArena` allocations through
   `model-store::BakedStore::load_to_virtual_arena`. `BakedStore` also exposes
@@ -155,6 +155,10 @@ on CUDA devices with `SUPERSONIC_VMM_KV=1`:
 - Qwen3.6-MoE FP8-KV VMM backing parity:
   `SUPERSONIC_QWEN36_35B_A3B_DIR=/mnt/data/models/Qwen3.6-35B-A3B cargo test --release -p runner --test qwen36_moe_kv_fp8_vmm_smoke -- --nocapture`
   runs the same backing-equivalence check with `--kv-fp8`.
+- Qwen3.6-MoE FP8-KV rolling BF16 sidecar window parity:
+  `SUPERSONIC_QWEN36_35B_A3B_DIR=/mnt/data/models/Qwen3.6-35B-A3B cargo test --release -p runner --test qwen36_moe_kv_fp8_sidecar_window_smoke -- --nocapture`
+  forces `SUPERSONIC_DEBUG_KV_FP8_BF16_SIDECAR_WINDOW=2` inside the test and
+  compares dense FP8 KV with VMM-backed FP8 KV bit-exactly.
 - Qwen3.5 virtual KV e2e with eviction and restore-to-VMM:
   `SUPERSONIC_VMM_KV=1 SUPERSONIC_VMM_KV_EVICT_AFTER_PREFILL=1 SUPERSONIC_VMM_KV_RESTORE_TO_VMM=1 ... --validate`
   passed and kept stable VMM pointers through decode.

--- a/kernels/qwen36_moe.hip
+++ b/kernels/qwen36_moe.hip
@@ -115,9 +115,10 @@ struct DecodeLayerDesc {
 
     // --- KV-FP8 sidecar (read iff is_full_attention == 1 AND
     // matching kv_fp8_descs[layer].kv_scale_k != null) ---------------
-    void* kv_shadow_k;       // BF16 [num_kv_heads, window, head_dim]
-    void* kv_shadow_v;       // BF16 [num_kv_heads, window, head_dim]
-    int   kv_shadow_start;   // first KV position covered by the sidecar; -1 = disabled
+    void* kv_shadow_k;       // BF16 [num_kv_heads, kv_shadow_window, head_dim]
+    void* kv_shadow_v;       // BF16 [num_kv_heads, kv_shadow_window, head_dim]
+    int   kv_shadow_start;   // earliest KV position the sidecar may cover; -1 = disabled
+    int   kv_shadow_window;  // rolling BF16 sidecar capacity in positions; 0 = disabled
 };
 
 // -- Int4 scale/zero parallel struct (mirror of Rust Qwen36MoeInt4ScaleDesc) -
@@ -364,7 +365,7 @@ __global__ void qwen36_moe_attn_step_kernel(
         kv_cache_k, kv_cache_v,
         /*kv_scale_k*/ nullptr, /*kv_scale_v*/ nullptr,
         /*kv_shadow_k*/ nullptr, /*kv_shadow_v*/ nullptr,
-        /*kv_shadow_start*/ -1,
+        /*kv_shadow_start*/ -1, /*kv_shadow_window*/ 0,
         kv_max_t,
         counters, barrier_counter, barrier_flag);
 }

--- a/kernels/qwen36_moe_bridge.cpp
+++ b/kernels/qwen36_moe_bridge.cpp
@@ -1166,6 +1166,20 @@ extern "C" int qwen36_moe_hip_persistent_decode_launch(
                     li, d.kv_shadow_k, d.kv_shadow_v);
                 return 142;
             }
+            if (full && both && d.kv_shadow_k != nullptr && d.kv_shadow_window <= 0) {
+                fprintf(stderr,
+                    "[qwen36_moe] KV-FP8 layer %d: kv_shadow_window must be > 0 "
+                    "when kv_shadow_k/v are set (got %d)\n",
+                    li, d.kv_shadow_window);
+                return 144;
+            }
+            if ((!full || none || d.kv_shadow_k == nullptr) && d.kv_shadow_window != 0) {
+                fprintf(stderr,
+                    "[qwen36_moe] KV-FP8 layer %d: kv_shadow_window must be 0 "
+                    "when the BF16 sidecar is disabled (got %d)\n",
+                    li, d.kv_shadow_window);
+                return 145;
+            }
         }
     }
 

--- a/kernels/qwen36_moe_persistent/full_attn_phase.cuh
+++ b/kernels/qwen36_moe_persistent/full_attn_phase.cuh
@@ -98,10 +98,13 @@ __device__ inline void qwen36_moe_attn_step_device(
     float* __restrict__            kv_scale_k,
     float* __restrict__            kv_scale_v,
     // BF16 sidecar (optional; requires KV-FP8 to be active). When null
-    // the kernel always dequantises from FP8.
+    // or window==0 the kernel always dequantises from FP8. When enabled,
+    // the sidecar is a rolling circular buffer of the most recent
+    // kv_shadow_window positions.
     void* __restrict__             kv_shadow_k,
     void* __restrict__             kv_shadow_v,
     int                            kv_shadow_start,
+    int                            kv_shadow_window,
     int                            kv_max_t,
     unsigned int* __restrict__     counters,
     unsigned int* __restrict__     barrier_counter,
@@ -803,11 +806,11 @@ __device__ inline void qwen36_moe_attn_step_device(
                     // sidecar is configured to cover this position.
                     const bool sidecar_active =
                         (kv_shadow_k != nullptr && kv_shadow_v != nullptr &&
-                         kv_shadow_start >= 0 && eff_cache_pos >= kv_shadow_start);
+                         kv_shadow_start >= 0 && kv_shadow_window > 0);
                     T* shadow_k = sidecar_active ? static_cast<T*>(kv_shadow_k) : nullptr;
                     T* shadow_v = sidecar_active ? static_cast<T*>(kv_shadow_v) : nullptr;
                     const int shadow_slot =
-                        sidecar_active ? (eff_cache_pos - kv_shadow_start) : 0;
+                        sidecar_active ? (eff_cache_pos % kv_shadow_window) : 0;
 
                     for (int i = tid; i < d; i += block_size) {
                         const float kv = workspace[OFF_K_ROT + h_kv * d + i];
@@ -815,12 +818,10 @@ __device__ inline void qwen36_moe_attn_step_device(
                         fp8_k[slot_base + h_kv * d + i] = float_to_fp8_e4m3(kv * inv_k);
                         fp8_v[slot_base + h_kv * d + i] = float_to_fp8_e4m3(vv * inv_v);
                         if (sidecar_active) {
-                            // Sidecar window is forced equal to kv_max_t in v1
-                            // (full sidecar). If a future change shrinks the
-                            // window, add a kv_shadow_window kernel arg and
-                            // replace kv_max_t in the offset below.
-                            shadow_k[h_kv * kv_max_t * d + shadow_slot * d + i] = static_cast<T>(kv);
-                            shadow_v[h_kv * kv_max_t * d + shadow_slot * d + i] = static_cast<T>(vv);
+                            shadow_k[h_kv * kv_shadow_window * d + shadow_slot * d + i] =
+                                static_cast<T>(kv);
+                            shadow_v[h_kv * kv_shadow_window * d + shadow_slot * d + i] =
+                                static_cast<T>(vv);
                         }
                     }
                     __syncthreads();
@@ -888,14 +889,26 @@ __device__ inline void qwen36_moe_attn_step_device(
             // null), so checking only kv_shadow_k here is sufficient and
             // matches the kv_shadow_v check on the V read side.
             const bool sidecar_active =
-                (kv_shadow_k != nullptr && kv_shadow_start >= 0);
+                (kv_shadow_k != nullptr && kv_shadow_start >= 0 && kv_shadow_window > 0);
+            const int rolling_shadow_start =
+                sidecar_active
+                    ? ((eff_cache_pos + 1 > kv_shadow_window)
+                        ? (eff_cache_pos + 1 - kv_shadow_window)
+                        : 0)
+                    : 0;
+            const int shadow_start =
+                sidecar_active
+                    ? ((rolling_shadow_start > kv_shadow_start)
+                        ? rolling_shadow_start
+                        : kv_shadow_start)
+                    : 0;
             const T* shadow_k = sidecar_active ? static_cast<const T*>(kv_shadow_k) : nullptr;
             const uint8_t* fp8_ck = use_fp8_kv ? reinterpret_cast<const uint8_t*>(kv_cache_k) : nullptr;
             const float* sk_buf = use_fp8_kv ? kv_scale_k : nullptr;
 
             for (int t = 0; t < kv_len; t++) {
                 float partial = 0.0f;
-                const bool use_sidecar = sidecar_active && (t >= kv_shadow_start);
+                const bool use_sidecar = sidecar_active && (t >= shadow_start);
                 const float scale_k_t =
                     (use_fp8_kv && !use_sidecar) ? sk_buf[h_kv * kv_max_t + t] : 0.f;
                 for (int i = tid; i < d; i += block_size) {
@@ -904,15 +917,9 @@ __device__ inline void qwen36_moe_attn_step_device(
                     if (!use_fp8_kv) {
                         k = static_cast<float>(kv_cache_k[t * Hkv * d + h_kv * d + i]);
                     } else if (use_sidecar) {
-                        // Sidecar window is forced equal to kv_max_t in v1
-                        // (full sidecar). If a future change shrinks the
-                        // window, add a kv_shadow_window kernel arg and
-                        // replace kv_max_t in the offset below — must
-                        // stay in sync with the write site at line 822
-                        // and the V read site below.
-                        const int shadow_slot = t - kv_shadow_start;
+                        const int shadow_slot = t % kv_shadow_window;
                         k = static_cast<float>(
-                            shadow_k[h_kv * kv_max_t * d + shadow_slot * d + i]);
+                            shadow_k[h_kv * kv_shadow_window * d + shadow_slot * d + i]);
                     } else {
                         const uint8_t byte =
                             fp8_ck[t * Hkv * d + h_kv * d + i];
@@ -957,7 +964,19 @@ __device__ inline void qwen36_moe_attn_step_device(
             const float inv_sum = 1.0f / exp_sum;
             const bool use_fp8_kv_v = (kv_scale_v != nullptr);
             const bool sidecar_active_v =
-                (kv_shadow_v != nullptr && kv_shadow_start >= 0);
+                (kv_shadow_v != nullptr && kv_shadow_start >= 0 && kv_shadow_window > 0);
+            const int rolling_shadow_start_v =
+                sidecar_active_v
+                    ? ((eff_cache_pos + 1 > kv_shadow_window)
+                        ? (eff_cache_pos + 1 - kv_shadow_window)
+                        : 0)
+                    : 0;
+            const int shadow_start_v =
+                sidecar_active_v
+                    ? ((rolling_shadow_start_v > kv_shadow_start)
+                        ? rolling_shadow_start_v
+                        : kv_shadow_start)
+                    : 0;
             const T* shadow_v = sidecar_active_v ? static_cast<const T*>(kv_shadow_v) : nullptr;
             const uint8_t* fp8_cv =
                 use_fp8_kv_v ? reinterpret_cast<const uint8_t*>(kv_cache_v) : nullptr;
@@ -967,19 +986,14 @@ __device__ inline void qwen36_moe_attn_step_device(
                 float acc = 0.0f;
                 for (int t = 0; t < kv_len; t++) {
                     const float w = workspace[score_base + t] * inv_sum;
-                    const bool use_sidecar = sidecar_active_v && (t >= kv_shadow_start);
+                    const bool use_sidecar = sidecar_active_v && (t >= shadow_start_v);
                     float v;
                     if (!use_fp8_kv_v) {
                         v = static_cast<float>(kv_cache_v[t * Hkv * d + h_kv * d + i]);
                     } else if (use_sidecar) {
-                        // Sidecar window is forced equal to kv_max_t in v1
-                        // (full sidecar). If a future change shrinks the
-                        // window, see the K-side comment for the
-                        // kv_shadow_window arg threading — all three
-                        // sidecar offset sites must stay in sync.
-                        const int shadow_slot = t - kv_shadow_start;
+                        const int shadow_slot = t % kv_shadow_window;
                         v = static_cast<float>(
-                            shadow_v[h_kv * kv_max_t * d + shadow_slot * d + i]);
+                            shadow_v[h_kv * kv_shadow_window * d + shadow_slot * d + i]);
                     } else {
                         const float scale_v_t = sv_buf[h_kv * kv_max_t + t];
                         const uint8_t byte = fp8_cv[t * Hkv * d + h_kv * d + i];

--- a/kernels/qwen36_moe_persistent/persistent_decode.hip
+++ b/kernels/qwen36_moe_persistent/persistent_decode.hip
@@ -239,6 +239,7 @@ __global__ void qwen36_moe_persistent_decode_kernel(
                 /* kv_shadow_k */ d.kv_shadow_k,
                 /* kv_shadow_v */ d.kv_shadow_v,
                 /* kv_shadow_start */ d.kv_shadow_start,
+                /* kv_shadow_window */ d.kv_shadow_window,
                 d.kv_max_t,
                 counters, barrier_counter, barrier_flag);
         } else {


### PR DESCRIPTION
## Summary
- thread kv_shadow_window through the Qwen3.6 persistent descriptor, bridge validation, and HIP attention path without increasing the descriptor size
- allocate the Qwen3.6 KV-FP8 BF16 sidecar as a rolling circular window controlled by SUPERSONIC_DEBUG_KV_FP8_BF16_SIDECAR_WINDOW
- update docs/state comments and add a dense-vs-VMM HIP smoke for a tiny rolling sidecar window

## Tests
- cargo fmt --check
- git diff --check
- cargo check -p kernel-ffi
- cargo test -p kernel-ffi descriptor_layout_offsets_documented -- --nocapture
- cargo check -p runner
- cargo test -p runner --test qwen36_moe_kv_fp8_sidecar_window_smoke -- --list
- SUPERSONIC_QWEN36_35B_A3B_DIR=/mnt/data/models/Qwen3.6-35B-A3B cargo test --release -p runner --test qwen36_moe_kv_fp8_sidecar_window_smoke -- --nocapture
- SUPERSONIC_QWEN36_35B_A3B_DIR=/mnt/data/models/Qwen3.6-35B-A3B cargo test --release -p runner --test qwen36_moe_kv_fp8_vmm_smoke -- --nocapture
- SUPERSONIC_QWEN36_35B_A3B_DIR=/mnt/data/models/Qwen3.6-35B-A3B cargo test --release -p runner --test qwen36_moe_bf16_kv_vmm_smoke -- --nocapture

Note: running the FP8 and BF16 35B VMM smokes concurrently overcommitted the 24 GiB GPU and caused the BF16 dense setup to OOM; the BF16 smoke passed when rerun alone.