### PR TITLE
Default Qwen3.6 KV VMM on HIP

### DIFF
--- a/crates/runner/src/qwen36_moe_decode.rs
+++ b/crates/runner/src/qwen36_moe_decode.rs
@@ -140,12 +140,13 @@ pub enum AttnLayerBuffers {
 ///     current decode position, so descriptors do not need per-step updates.
 ///
 /// Exactly one of `k` / `virtual_kv_cache_k` is `Some` (same for V).
-/// `virtual_kv_cache_k` is `Some` when `SUPERSONIC_VMM_KV=1` was set
-/// and the backend supports VMM. It can back either BF16 KV or FP8 KV.
+/// `virtual_kv_cache_k` is `Some` when Qwen3.6 KV VMM was selected
+/// (default on HIP when supported, or forced with `SUPERSONIC_VMM_KV=1`).
+/// It can back either BF16 KV or FP8 KV.
 pub struct FullAttnKvCache {
-    /// `Some` when VMM-backed KV is OFF (the default). `None` when
-    /// `virtual_kv_cache_k` is `Some` (VMM-backed). Exactly one of
-    /// `k` / `virtual_kv_cache_k` is `Some`. Same for V.
+    /// `Some` when dense KV backing was selected. `None` when
+    /// `virtual_kv_cache_k` is `Some` (VMM-backed). Exactly one of `k` /
+    /// `virtual_kv_cache_k` is `Some`. Same for V.
     pub k: Option<GpuBuffer>,
     pub v: Option<GpuBuffer>,
     pub kv_max_t: i32,
@@ -160,9 +161,9 @@ pub struct FullAttnKvCache {
     pub kv_shadow_start: i32,
     /// Rolling sidecar capacity in positions (`0` when disabled).
     pub kv_shadow_window: i32,
-    /// `Some` when `SUPERSONIC_VMM_KV=1` was set at allocation time AND
-    /// the backend supports VMM. Mutually exclusive with `k` (exactly
-    /// one is `Some`).
+    /// `Some` when Qwen3.6 KV VMM was selected at allocation time AND the
+    /// backend supports VMM. Mutually exclusive with `k` (exactly one is
+    /// `Some`).
     pub virtual_kv_cache_k: Option<gpu_hal::VirtualBuffer>,
     pub virtual_kv_cache_v: Option<gpu_hal::VirtualBuffer>,
     /// The VMM reservation's logical max_T (matches `kv_max_t` above).

--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -1097,10 +1097,22 @@ fn moe_island_cap_experts_from_env() -> Result<Option<usize>> {
     Ok(Some(cap))
 }
 
-fn qwen36_kv_vmm_requested_from_env() -> Result<bool> {
-    match std::env::var("SUPERSONIC_VMM_KV").ok().as_deref() {
-        None | Some("0") => Ok(false),
-        Some("1") => Ok(true),
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Qwen36KvVmmMode {
+    Auto,
+    Disabled,
+    Force,
+}
+
+fn qwen36_kv_vmm_mode_from_env_value(
+    raw: Option<&str>,
+    backend: Backend,
+) -> Result<Qwen36KvVmmMode> {
+    match raw {
+        None if backend == Backend::Hip => Ok(Qwen36KvVmmMode::Auto),
+        None => Ok(Qwen36KvVmmMode::Disabled),
+        Some("0") => Ok(Qwen36KvVmmMode::Disabled),
+        Some("1") => Ok(Qwen36KvVmmMode::Force),
         Some(other) => Err(anyhow!(
             "SUPERSONIC_VMM_KV must be unset, 0, or 1 for Qwen3.6-MoE; got {other:?}"
         )),
@@ -1108,17 +1120,29 @@ fn qwen36_kv_vmm_requested_from_env() -> Result<bool> {
 }
 
 fn should_use_qwen36_kv_vmm(backend: Backend, ordinal: usize) -> Result<bool> {
-    if !qwen36_kv_vmm_requested_from_env()? {
-        return Ok(false);
-    }
+    let mode = qwen36_kv_vmm_mode_from_env_value(
+        std::env::var("SUPERSONIC_VMM_KV").ok().as_deref(),
+        backend,
+    )?;
+    let requested = match mode {
+        Qwen36KvVmmMode::Disabled => return Ok(false),
+        Qwen36KvVmmMode::Auto | Qwen36KvVmmMode::Force => true,
+    };
     if !gpu_hal::vmm_is_supported(backend, ordinal) {
-        eprintln!(
-            "[vmm] SUPERSONIC_VMM_KV=1 requested for Qwen3.6-MoE but backend={backend} \
-             device {ordinal} does not support VMM; using dense KV buffers"
-        );
+        if mode == Qwen36KvVmmMode::Force {
+            eprintln!(
+                "[vmm] SUPERSONIC_VMM_KV=1 requested for Qwen3.6-MoE but backend={backend} \
+                 device {ordinal} does not support VMM; using dense KV buffers"
+            );
+        } else {
+            eprintln!(
+                "[vmm] Qwen3.6-MoE HIP KV VMM auto-enable skipped because backend={backend} \
+                 device {ordinal} does not support VMM; using dense KV buffers"
+            );
+        }
         return Ok(false);
     }
-    Ok(true)
+    Ok(requested)
 }
 
 fn virtual_kv_stats_for_layers(layers: &[LayerBuffers]) -> VirtualKvStats {
@@ -1401,9 +1425,10 @@ fn load_layer_buffers(
         // FP8 path: same shape but U8 (FP8 E4M3 bytes) plus F32 scales
         // [num_kv_heads, kv_max_t] for K and V, plus optional BF16 sidecar
         // [num_kv_heads, sidecar_window, head_dim] when enabled.
-        // VMM path (SUPERSONIC_VMM_KV=1): K/V are VirtualBuffer
-        // reservations with a mapped prefix; dense k/v are None. FP8 scale
-        // and sidecar buffers remain regular dense GpuBuffers.
+        // VMM path (default on HIP when supported, or
+        // SUPERSONIC_VMM_KV=1): K/V are VirtualBuffer reservations with a
+        // mapped prefix; dense k/v are None. FP8 scale and sidecar buffers
+        // remain regular dense GpuBuffers.
         let kv_dim = (geom.num_kv_heads as usize) * (geom.head_dim as usize);
         let kv_cache = if kv_max_t > 0 {
             let num_kv_heads = geom.num_kv_heads as usize;
@@ -3524,4 +3549,39 @@ fn decode_first_token(model_dir: &Path, report: &DryRunReport, kv_fp8: bool) -> 
         geom.rms_norm_eps,
     );
     Ok(argmax_bf16_logits(&logits))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{qwen36_kv_vmm_mode_from_env_value, Qwen36KvVmmMode};
+    use gpu_hal::Backend;
+
+    #[test]
+    fn qwen36_kv_vmm_defaults_to_auto_on_hip_only() {
+        assert_eq!(
+            qwen36_kv_vmm_mode_from_env_value(None, Backend::Hip).unwrap(),
+            Qwen36KvVmmMode::Auto
+        );
+        assert_eq!(
+            qwen36_kv_vmm_mode_from_env_value(None, Backend::Cuda).unwrap(),
+            Qwen36KvVmmMode::Disabled
+        );
+        assert_eq!(
+            qwen36_kv_vmm_mode_from_env_value(None, Backend::Metal).unwrap(),
+            Qwen36KvVmmMode::Disabled
+        );
+    }
+
+    #[test]
+    fn qwen36_kv_vmm_env_override_is_explicit() {
+        assert_eq!(
+            qwen36_kv_vmm_mode_from_env_value(Some("0"), Backend::Hip).unwrap(),
+            Qwen36KvVmmMode::Disabled
+        );
+        assert_eq!(
+            qwen36_kv_vmm_mode_from_env_value(Some("1"), Backend::Cuda).unwrap(),
+            Qwen36KvVmmMode::Force
+        );
+        assert!(qwen36_kv_vmm_mode_from_env_value(Some("yes"), Backend::Hip).is_err());
+    }
 }

--- a/crates/runner/tests/qwen36_moe_bf16_kv_vmm_smoke.rs
+++ b/crates/runner/tests/qwen36_moe_bf16_kv_vmm_smoke.rs
@@ -1,8 +1,9 @@
 //! VMM-backed vs dense BF16 KV bit-exact smoke for Qwen3.6-35B-A3B.
 //!
-//! Same prompt, same args, run twice via the supersonic binary: once
-//! with SUPERSONIC_VMM_KV=1, once with SUPERSONIC_VMM_KV=0. Last-step
-//! logits must be bit-exact because VMM changes only the cache backing.
+//! Same prompt, same args, run via the supersonic binary with dense KV
+//! (`SUPERSONIC_VMM_KV=0`), forced VMM (`SUPERSONIC_VMM_KV=1`), and HIP
+//! default VMM (`SUPERSONIC_VMM_KV` unset). Last-step logits must be
+//! bit-exact because VMM changes only the cache backing.
 //!
 //! Skipped silently when:
 //!  - HIP backend is not compiled
@@ -25,6 +26,7 @@ fn run_supersonic_capture_logits(
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_supersonic"));
     cmd.args(args);
     cmd.arg("--dump-last-logits");
+    cmd.env_remove("SUPERSONIC_VMM_KV");
     for (k, v) in extra_env {
         cmd.env(k, v);
     }
@@ -92,6 +94,7 @@ fn qwen36_moe_bf16_kv_vmm_dense_bit_exact() {
         run_supersonic_capture_logits(&args, &[("SUPERSONIC_VMM_KV", "0")]).expect("dense decode");
     let vmm =
         run_supersonic_capture_logits(&args, &[("SUPERSONIC_VMM_KV", "1")]).expect("vmm decode");
+    let auto_vmm = run_supersonic_capture_logits(&args, &[]).expect("auto vmm decode");
 
     assert!(
         vmm.combined_output
@@ -99,16 +102,35 @@ fn qwen36_moe_bf16_kv_vmm_dense_bit_exact() {
         "VMM run did not report Qwen3.6 BF16 KV VMM activation:\n{}",
         vmm.combined_output
     );
+    assert!(
+        auto_vmm
+            .combined_output
+            .contains("[vmm] Qwen3.6-MoE BF16 KV active"),
+        "unset-env HIP run did not auto-enable Qwen3.6 BF16 KV VMM:\n{}",
+        auto_vmm.combined_output
+    );
     assert_eq!(
         dense.logits.len(),
         vmm.logits.len(),
         "logits length mismatch"
+    );
+    assert_eq!(
+        dense.logits.len(),
+        auto_vmm.logits.len(),
+        "auto-vmm logits length mismatch"
     );
     for (i, (a, b)) in dense.logits.iter().zip(&vmm.logits).enumerate() {
         assert_eq!(
             a.to_bits(),
             b.to_bits(),
             "VMM-backed BF16 KV logits diverged at index {i}: dense={a} vmm={b}",
+        );
+    }
+    for (i, (a, b)) in dense.logits.iter().zip(&auto_vmm.logits).enumerate() {
+        assert_eq!(
+            a.to_bits(),
+            b.to_bits(),
+            "auto VMM-backed BF16 KV logits diverged at index {i}: dense={a} auto_vmm={b}",
         );
     }
 }

--- a/crates/runner/tests/qwen36_moe_kv_fp8_sidecar_window_smoke.rs
+++ b/crates/runner/tests/qwen36_moe_kv_fp8_sidecar_window_smoke.rs
@@ -26,6 +26,7 @@ fn run_supersonic_capture_logits(
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_supersonic"));
     cmd.args(args);
     cmd.arg("--dump-last-logits");
+    cmd.env_remove("SUPERSONIC_VMM_KV");
     for (k, v) in extra_env {
         cmd.env(k, v);
     }

--- a/crates/runner/tests/qwen36_moe_kv_fp8_vmm_smoke.rs
+++ b/crates/runner/tests/qwen36_moe_kv_fp8_vmm_smoke.rs
@@ -28,6 +28,7 @@ fn run_supersonic_capture_logits(
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_supersonic"));
     cmd.args(args);
     cmd.arg("--dump-last-logits");
+    cmd.env_remove("SUPERSONIC_VMM_KV");
     for (k, v) in extra_env {
         cmd.env(k, v);
     }

--- a/docs/lowlevel-memory.md
+++ b/docs/lowlevel-memory.md
@@ -32,8 +32,8 @@ Current scope:
 
 - Decode-active VMM is enabled internally for Qwen3.5 BF16 dense KV, for
   Qwen3.6-MoE INT4 routed expert slabs when the VMM expert mode is active,
-  and for Qwen3.6-MoE full-attention KV (BF16 or FP8, opt-in via
-  `SUPERSONIC_VMM_KV=1`).
+  and for Qwen3.6-MoE full-attention KV (BF16 or FP8; default on HIP when
+  VMM is supported, opt-in on CUDA via `SUPERSONIC_VMM_KV=1`).
 - Disabled for certified-KV, batch decode, Qwen3.5 4B/component decode,
   DFlash cloned states, Gemma4, and Llama3.1. Qwen3.5 KV-FP8 also remains
   disabled — enabling it is a separate effort.
@@ -98,9 +98,9 @@ Current scope:
 - `SUPERSONIC_MOE_ISLAND_CAP_EXPERTS=N` switches Qwen3.6-MoE INT4 decode from
   fully resident virtual expert slabs to sparse router-prefetched islands with
   at most `N` experts' two routed projections tracked resident at once.
-- `SUPERSONIC_VMM_KV=0` disables the Qwen3.5 integration.
-- `SUPERSONIC_VMM_KV=1` requests it and logs if the backend cannot support it.
-  HIP may auto-enable when unset; CUDA requires this explicit opt-in.
+- `SUPERSONIC_VMM_KV=0` disables the Qwen3.5 and Qwen3.6 KV integrations.
+- `SUPERSONIC_VMM_KV=1` requests KV VMM and logs if the backend cannot support
+  it. HIP may auto-enable when unset; CUDA requires this explicit opt-in.
 - `SUPERSONIC_VMM_KV_EVICT_AFTER_PREFILL=1` backs virtual KV to host RAM after
   prefill, unmaps the device pages, reports zero resident bytes, then restores
   decode state before decode. By default this uses a compact logical-prefix

--- a/docs/superpowers/specs/2026-05-03-qwen36-moe-fp8-kv-fp8-design.md
+++ b/docs/superpowers/specs/2026-05-03-qwen36-moe-fp8-kv-fp8-design.md
@@ -146,8 +146,9 @@ Following `crates/qwen35/src/state.rs` and `qwen35_vmm_smoke.rs`:
   as decode advances.
 - Scale buffers and BF16 sidecars stay as dense `GpuBuffer`s for v1
   (small footprint, no growth pattern, no eviction value).
-- Gate path on `SUPERSONIC_VMM_KV` env var, default 0 for v1; flip
-  default to 1 once the KV-FP8 path is green on gfx1100 + gfx942 in CI.
+- Gate path on `SUPERSONIC_VMM_KV` env var. HIP auto-enables when the
+  variable is unset and VMM support probes successfully; `0` disables and
+  `1` forces/request on any backend. CUDA still requires the explicit opt-in.
 - `lowlevel-memory.md` is updated to remove "FP8-KV disabled" from the
   Qwen3.6-MoE row.
 


### PR DESCRIPTION
## Summary
- make Qwen3.6 full-attention KV VMM auto-enable on HIP when VMM support probes successfully
- keep SUPERSONIC_VMM_KV=0 as an escape hatch and SUPERSONIC_VMM_KV=1 as the explicit request path for CUDA/other backends
- update Qwen3.6 KV VMM docs and smoke isolation so tests remove inherited SUPERSONIC_VMM_KV before each case
- extend the BF16 KV VMM smoke to verify dense, forced VMM, and unset-env HIP auto VMM are bit-exact

## Tests
- cargo fmt --check
- git diff --check
- cargo test -p runner qwen36_kv_vmm -- --nocapture
- cargo test -p runner --test qwen36_moe_bf16_kv_vmm_smoke -- --list
- SUPERSONIC_QWEN36_35B_A3B_DIR=/mnt/data/models/Qwen3.6-35B-A3B cargo test --release -p runner --test qwen36_moe_bf16_kv_vmm_smoke -- --nocapture