### PR TITLE
Add Qwen3.6 VMM resident VRAM telemetry

### DIFF
--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -1284,11 +1284,25 @@ impl MoeSparseTelemetry {
         }));
     }
 
-    fn write_json(&self, manager: &MoeExpertResidencyManager, generated_ids: &[u32]) -> Result<()> {
+    fn write_json(
+        &self,
+        manager: &MoeExpertResidencyManager,
+        virtual_kv_stats: VirtualKvStats,
+        generated_ids: &[u32],
+    ) -> Result<()> {
         let Some(path) = self.dump_path.as_ref() else {
             return Ok(());
         };
         let final_snapshot = MoeSparseTelemetrySnapshot::capture(manager);
+        let total_vmm_logical_bytes =
+            final_snapshot.arena.logical_bytes + virtual_kv_stats.logical_bytes;
+        let total_vmm_logical_resident_bytes =
+            final_snapshot.arena.logical_resident_bytes + virtual_kv_stats.logical_resident_bytes;
+        let total_vmm_resident_bytes =
+            final_snapshot.arena.resident_bytes + virtual_kv_stats.resident_bytes;
+        let total_vmm_reserved_bytes =
+            final_snapshot.arena.reserved_bytes + virtual_kv_stats.reserved_bytes;
+        let total_vmm_mappings = final_snapshot.arena.mapping_count + virtual_kv_stats.mappings;
         let payload = serde_json::json!({
             "schema": "supersonic-qwen36-moe-sparse-vmm-telemetry-v1",
             "summary": {
@@ -1305,6 +1319,22 @@ impl MoeSparseTelemetry {
                 "peak_logical_resident_bytes": self.peak_logical_resident_bytes,
                 "reserved_bytes": final_snapshot.arena.reserved_bytes,
                 "logical_bytes": final_snapshot.arena.logical_bytes,
+                "moe_logical_bytes": final_snapshot.arena.logical_bytes,
+                "moe_logical_resident_bytes": final_snapshot.arena.logical_resident_bytes,
+                "moe_resident_bytes": final_snapshot.arena.resident_bytes,
+                "moe_reserved_bytes": final_snapshot.arena.reserved_bytes,
+                "moe_mappings": final_snapshot.arena.mapping_count,
+                "kv_layers": virtual_kv_stats.layers,
+                "kv_mappings": virtual_kv_stats.mappings,
+                "kv_logical_bytes": virtual_kv_stats.logical_bytes,
+                "kv_logical_resident_bytes": virtual_kv_stats.logical_resident_bytes,
+                "kv_resident_bytes": virtual_kv_stats.resident_bytes,
+                "kv_reserved_bytes": virtual_kv_stats.reserved_bytes,
+                "total_vmm_logical_bytes": total_vmm_logical_bytes,
+                "total_vmm_logical_resident_bytes": total_vmm_logical_resident_bytes,
+                "total_vmm_resident_bytes": total_vmm_resident_bytes,
+                "total_vmm_reserved_bytes": total_vmm_reserved_bytes,
+                "total_vmm_mappings": total_vmm_mappings,
                 "hits": final_snapshot.stats.hits,
                 "misses": final_snapshot.stats.misses,
                 "page_hits": final_snapshot.stats.page_hits,
@@ -3262,13 +3292,16 @@ fn decode_text(
     if let Some(manager) = _moe_expert_residency.as_ref() {
         let residency = manager.stats();
         let arena = manager.arena().stats();
+        let total_resident_bytes = arena.resident_bytes + virtual_kv_stats.resident_bytes;
+        let total_reserved_bytes = arena.reserved_bytes + virtual_kv_stats.reserved_bytes;
         if let Some(telemetry) = moe_sparse_telemetry.as_ref() {
             println!(
                 "  [vmm] MoE island residency: resident_slices={} peak_slices={} \
                  resident_pages={} peak_pages={} page_backed_slices={} \
                  hits={} misses={} page_hits={} page_misses={} evicted_slices={} evicted_pages={} \
                  uploaded={:.2}MiB unmapped={:.2}MiB \
-                 resident={:.2}MiB peak_resident={:.2}MiB reserved={:.2}MiB",
+                 resident={:.2}MiB peak_resident={:.2}MiB reserved={:.2}MiB \
+                 kv_resident={:.2}MiB total_vmm_resident={:.2}MiB total_vmm_reserved={:.2}MiB",
                 residency.resident_slices,
                 telemetry.peak_resident_slices,
                 residency.resident_pages,
@@ -3285,14 +3318,18 @@ fn decode_text(
                 arena.resident_bytes as f64 / MIB,
                 telemetry.peak_resident_bytes as f64 / MIB,
                 arena.reserved_bytes as f64 / MIB,
+                virtual_kv_stats.resident_bytes as f64 / MIB,
+                total_resident_bytes as f64 / MIB,
+                total_reserved_bytes as f64 / MIB,
             );
-            telemetry.write_json(manager, &generated_ids)?;
+            telemetry.write_json(manager, virtual_kv_stats, &generated_ids)?;
         } else {
             println!(
                 "  [vmm] MoE island residency: resident_slices={} resident_pages={} \
                  page_backed_slices={} hits={} misses={} page_hits={} page_misses={} \
                  evicted_slices={} evicted_pages={} uploaded={:.2}MiB unmapped={:.2}MiB \
-                 resident={:.2}MiB reserved={:.2}MiB",
+                 resident={:.2}MiB reserved={:.2}MiB kv_resident={:.2}MiB \
+                 total_vmm_resident={:.2}MiB total_vmm_reserved={:.2}MiB",
                 residency.resident_slices,
                 residency.resident_pages,
                 residency.page_backed_slices,
@@ -3306,6 +3343,9 @@ fn decode_text(
                 residency.unmapped_bytes as f64 / MIB,
                 arena.resident_bytes as f64 / MIB,
                 arena.reserved_bytes as f64 / MIB,
+                virtual_kv_stats.resident_bytes as f64 / MIB,
+                total_resident_bytes as f64 / MIB,
+                total_reserved_bytes as f64 / MIB,
             );
         }
     }

--- a/crates/runner/tests/qwen36_moe_sparse_vmm_smoke.rs
+++ b/crates/runner/tests/qwen36_moe_sparse_vmm_smoke.rs
@@ -56,6 +56,7 @@ fn run_qwen36_moe(
         .env("SUPERSONIC_VMM_MOE_ISLANDS", "1")
         .env_remove("SUPERSONIC_MOE_ISLAND_CAP_EXPERTS")
         .env_remove("SUPERSONIC_MOE_ISLAND_TELEMETRY_JSON")
+        .env_remove("SUPERSONIC_VMM_KV")
         .args([
             "--backend",
             "hip",
@@ -171,6 +172,30 @@ fn qwen36_moe_sparse_vmm_matches_dense_virtual_slabs() {
         summary["peak_resident_bytes"].as_u64().unwrap()
             < summary["reserved_bytes"].as_u64().unwrap(),
         "sparse resident bytes should stay below full VA reservation: {summary:?}"
+    );
+    let moe_resident = summary["moe_resident_bytes"]
+        .as_u64()
+        .expect("sparse telemetry summary should report MoE resident bytes");
+    let kv_resident = summary["kv_resident_bytes"]
+        .as_u64()
+        .expect("sparse telemetry summary should report KV resident bytes");
+    let total_resident = summary["total_vmm_resident_bytes"]
+        .as_u64()
+        .expect("sparse telemetry summary should report total VMM resident bytes");
+    assert!(
+        summary["kv_layers"].as_u64().unwrap() > 0 && kv_resident > 0,
+        "HIP sparse smoke should exercise Qwen3.6 KV VMM accounting: {summary:?}"
+    );
+    assert_eq!(
+        total_resident,
+        moe_resident + kv_resident,
+        "total VMM resident bytes should include MoE and KV residents: {summary:?}"
+    );
+    assert_eq!(
+        summary["total_vmm_reserved_bytes"].as_u64().unwrap(),
+        summary["moe_reserved_bytes"].as_u64().unwrap()
+            + summary["kv_reserved_bytes"].as_u64().unwrap(),
+        "total VMM reserved bytes should include MoE and KV reservations: {summary:?}"
     );
     assert!(
         summary["misses"].as_u64().unwrap() > 0 && summary["uploaded_bytes"].as_u64().unwrap() > 0,

--- a/docs/lowlevel-memory.md
+++ b/docs/lowlevel-memory.md
@@ -75,9 +75,11 @@ Current scope:
   MoE residency telemetry for Qwen3.6-MoE runs: per-forward hits, misses,
   uploads, evictions, resident slices, resident pages, page-backed slice count,
   resident physical bytes, the active sparse decode path
-  (`segmented_persistent` or `chained`), plus summary peaks. This is intended
-  for tuning `SUPERSONIC_MOE_ISLAND_CAP_EXPERTS` against real prompts instead
-  of relying on one-token smoke numbers.
+  (`segmented_persistent` or `chained`), plus summary peaks. The summary also
+  reports MoE-only, KV-only, and total VMM logical/resident/reserved bytes so
+  benchmark scripts can measure resident VRAM without scraping stderr. This is
+  intended for tuning `SUPERSONIC_MOE_ISLAND_CAP_EXPERTS` against real prompts
+  instead of relying on one-token smoke numbers.
 - On the HIP/gfx1100 validation machine, page-budgeted sparse MoE passed the
   two-token Qwen3.6-MoE smoke at the default 256-expert cap, the smallest
   top-k-sized 8-expert cap, and a 320-expert cap (`640` resident VMM pages).

--- a/docs/qwen36-verification-suite.md
+++ b/docs/qwen36-verification-suite.md
@@ -69,6 +69,17 @@ OUT=target/qwen36_verify_results.json \
 tests/gfx942/run_qwen36_verify_suite.sh
 ```
 
+To include sparse INT4 MoE island resident VRAM accounting in the result JSON,
+set an expert cap. The wrapper passes this to
+`--moe-island-cap-experts`, which enables the runner's sparse VMM telemetry
+for INT4 rows and records `vmm_total_resident_bytes_*`,
+`vmm_moe_resident_bytes_mean`, and `vmm_kv_resident_bytes_mean` in each
+summary cell:
+
+```bash
+MOE_ISLAND_CAP_EXPERTS=256 MODES=int4 tests/gfx942/run_qwen36_verify_suite.sh
+```
+
 For a real PG-19 run:
 
 ```bash
@@ -97,9 +108,10 @@ MODES=fp8,int4 FAMILIES=pg19,ruler tests/gfx942/run_qwen36_verify_long_context.s
 The output JSON has:
 
 - `summary`: per case and mode, including deterministic flags for logits,
-  hidden state, and generated ids.
+  hidden state, generated ids, timing means, and optional VMM resident VRAM
+  means/maxes when sparse INT4 telemetry is enabled.
 - `runs`: per subprocess run, including dump hashes, generated ids, vector
-  stats, timing, and stdout/stderr tails.
+  stats, timing, optional `vmm_residency`, and stdout/stderr tails.
 - `failures`: the exact gate failures that caused a non-zero exit.
 
 FP8 and INT4 now pass the repeatability gate through 2K context, so FP8 is the

--- a/oracle/qwen36_verify_suite.py
+++ b/oracle/qwen36_verify_suite.py
@@ -328,6 +328,27 @@ def parse_stage_timings(output: str) -> dict[str, float]:
     return out
 
 
+def load_vmm_residency(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text())
+    summary = payload.get("summary") or {}
+    keys = [
+        "decode_path",
+        "max_resident_pages",
+        "final_resident_pages",
+        "peak_resident_pages",
+        "peak_resident_bytes",
+        "moe_resident_bytes",
+        "moe_reserved_bytes",
+        "kv_layers",
+        "kv_resident_bytes",
+        "kv_reserved_bytes",
+        "total_vmm_resident_bytes",
+        "total_vmm_reserved_bytes",
+        "total_vmm_logical_resident_bytes",
+    ]
+    return {k: summary[k] for k in keys if k in summary}
+
+
 def run_once(
     args: argparse.Namespace,
     case: Case,
@@ -341,10 +362,17 @@ def run_once(
     # bit-identity check below diff's their SHA256s.
     logits = tmp / f"{case.case_id}_{mode}_{decode_path}_{repeat_idx}_logits.bin"
     hidden = tmp / f"{case.case_id}_{mode}_{decode_path}_{repeat_idx}_hidden.bin"
+    vmm_telemetry = tmp / f"{case.case_id}_{mode}_{decode_path}_{repeat_idx}_vmm.json"
     env = os.environ.copy()
     env["SUPERSONIC_QWEN36_DUMP_LOGITS"] = str(logits)
     env["SUPERSONIC_QWEN36_DUMP_FINAL_HIDDEN"] = str(hidden)
     env.setdefault("SUPERSONIC_BACKENDS", args.backend)
+    moe_island_cap = getattr(args, "moe_island_cap_experts", None)
+    collect_vmm_telemetry = moe_island_cap is not None and mode == "int4"
+    if collect_vmm_telemetry:
+        env["SUPERSONIC_VMM_MOE_ISLANDS"] = "1"
+        env["SUPERSONIC_MOE_ISLAND_CAP_EXPERTS"] = str(moe_island_cap)
+        env["SUPERSONIC_MOE_ISLAND_TELEMETRY_JSON"] = str(vmm_telemetry)
 
     cmd = [
         str(args.binary),
@@ -400,6 +428,7 @@ def run_once(
             "wall_seconds": wall,
             "generated_ids": parse_generated_ids(output),
             "stage": parse_stage_timings(output),
+            "vmm_residency": load_vmm_residency(vmm_telemetry) if vmm_telemetry.exists() else None,
             "stdout_tail": stdout[-1200:],
             "stderr_tail": stderr[-1200:],
             "error": f"supersonic timed out after {args.timeout}s",
@@ -414,6 +443,7 @@ def run_once(
         "wall_seconds": wall,
         "generated_ids": parse_generated_ids(output),
         "stage": parse_stage_timings(output),
+        "vmm_residency": load_vmm_residency(vmm_telemetry) if vmm_telemetry.exists() else None,
         "stdout_tail": proc.stdout[-1200:],
         "stderr_tail": proc.stderr[-1200:],
     }
@@ -452,6 +482,29 @@ def _stage_mean(rows: list[dict[str, Any]], key: str) -> float | None:
     return statistics.mean(vals) if vals else None
 
 
+def _vmm_values(rows: list[dict[str, Any]], key: str) -> list[float]:
+    vals: list[float] = []
+    for row in rows:
+        residency = row.get("vmm_residency")
+        if not isinstance(residency, dict) or key not in residency:
+            continue
+        try:
+            vals.append(float(residency[key]))
+        except (TypeError, ValueError):
+            pass
+    return vals
+
+
+def _vmm_mean(rows: list[dict[str, Any]], key: str) -> float | None:
+    vals = _vmm_values(rows, key)
+    return statistics.mean(vals) if vals else None
+
+
+def _vmm_max(rows: list[dict[str, Any]], key: str) -> float | None:
+    vals = _vmm_values(rows, key)
+    return max(vals) if vals else None
+
+
 def summarize_case(case: Case, runs: list[dict[str, Any]]) -> dict[str, Any]:
     # Two-axis grouping: cell = (mode × decode_path). Each cell gets its
     # own determinism + perf stats. The `chained_vs_persistent` block
@@ -488,6 +541,11 @@ def summarize_case(case: Case, runs: list[dict[str, Any]]) -> dict[str, Any]:
             "wall_seconds_mean": statistics.mean(wall) if wall else None,
             "chain_ms_avg_mean": _stage_mean(ok_rows, "chain_ms_avg"),
             "total_ms_avg_mean": _stage_mean(ok_rows, "total_ms_avg"),
+            "vmm_total_resident_bytes_mean": _vmm_mean(ok_rows, "total_vmm_resident_bytes"),
+            "vmm_total_resident_bytes_max": _vmm_max(ok_rows, "total_vmm_resident_bytes"),
+            "vmm_total_reserved_bytes_mean": _vmm_mean(ok_rows, "total_vmm_reserved_bytes"),
+            "vmm_moe_resident_bytes_mean": _vmm_mean(ok_rows, "moe_resident_bytes"),
+            "vmm_kv_resident_bytes_mean": _vmm_mean(ok_rows, "kv_resident_bytes"),
             "errors": [r.get("error") for r in rows if r.get("error") or r.get("returncode") != 0],
         }
         summary["modes"][cell] = cell_summary
@@ -634,6 +692,14 @@ def main() -> int:
     parser.add_argument("--out", type=Path, default=Path("qwen36_verify_results.json"))
     parser.add_argument("--tmp-dir", type=Path)
     parser.add_argument("--emit-stage-timings", action="store_true")
+    parser.add_argument(
+        "--moe-island-cap-experts",
+        type=int,
+        help=(
+            "enable sparse INT4 MoE island residency with the given expert cap "
+            "and fold the runner's VMM telemetry JSON into each run/summary"
+        ),
+    )
     parser.add_argument("--fail-on-nondeterminism", action="store_true", default=True)
     parser.add_argument("--no-fail-on-nondeterminism", dest="fail_on_nondeterminism", action="store_false")
     parser.add_argument("--continue-on-error", action="store_true")
@@ -700,7 +766,8 @@ def main() -> int:
                             f"  {cell_label:<18} repeat={repeat_idx} {status} "
                             f"ids={row.get('generated_ids')} "
                             f"logits={str(row.get('logits_sha256', ''))[:12]} "
-                            f"zero={(row.get('logits_stats') or {}).get('all_zero')}",
+                            f"zero={(row.get('logits_stats') or {}).get('all_zero')} "
+                            f"vmm_resident={((row.get('vmm_residency') or {}).get('total_vmm_resident_bytes'))}",
                             flush=True,
                         )
                         if status != "ok" and not args.continue_on_error:
@@ -708,10 +775,12 @@ def main() -> int:
             case_summary = summarize_case(case, case_runs)
             summary.append(case_summary)
             for cell, row in case_summary["modes"].items():
+                vmm_resident = row.get("vmm_total_resident_bytes_mean")
                 print(
                     f"  summary {cell:<18} logits_det={row['deterministic_logits']} "
                     f"hidden_det={row['deterministic_hidden']} ids_det={row['deterministic_generated_ids']} "
-                    f"all_zero={row['any_all_zero_logits']}",
+                    f"all_zero={row['any_all_zero_logits']} "
+                    f"vmm_resident_mean={vmm_resident}",
                     flush=True,
                 )
             cvp = case_summary.get("chained_vs_persistent")
@@ -744,6 +813,7 @@ def main() -> int:
             "decode_paths": decode_paths,
             "repeats": args.repeats,
             "max_new_tokens": args.max_new_tokens,
+            "moe_island_cap_experts": args.moe_island_cap_experts,
             "summary": summary,
             "runs": all_runs,
         }

--- a/tests/gfx942/run_qwen36_verify_suite.sh
+++ b/tests/gfx942/run_qwen36_verify_suite.sh
@@ -11,6 +11,7 @@ REPEATS="${REPEATS:-3}"
 TIMEOUT="${TIMEOUT:-900}"
 PG19_SOURCE="${PG19_SOURCE:-synthetic}"
 OUT="${OUT:-target/qwen36_verify_results.json}"
+MOE_ISLAND_CAP_EXPERTS="${MOE_ISLAND_CAP_EXPERTS:-}"
 if [[ -z "${PYTHON_BIN:-}" ]]; then
   if [[ -x ".venv-verify/bin/python" ]]; then
     PYTHON_BIN=".venv-verify/bin/python"
@@ -20,6 +21,11 @@ if [[ -z "${PYTHON_BIN:-}" ]]; then
 fi
 
 cargo build --release --bin supersonic
+
+extra_args=()
+if [[ -n "${MOE_ISLAND_CAP_EXPERTS}" ]]; then
+  extra_args+=(--moe-island-cap-experts "${MOE_ISLAND_CAP_EXPERTS}")
+fi
 
 "${PYTHON_BIN}" oracle/qwen36_verify_suite.py \
   --binary "${BINARY}" \
@@ -33,4 +39,5 @@ cargo build --release --bin supersonic
   --timeout "${TIMEOUT}" \
   --pg19-source "${PG19_SOURCE}" \
   --emit-stage-timings \
-  --out "${OUT}"
+  --out "${OUT}" \
+  "${extra_args[@]}"

--- a/tests/test_qwen36_verify_suite.py
+++ b/tests/test_qwen36_verify_suite.py
@@ -9,6 +9,7 @@ from oracle.qwen36_verify_suite import (
     Case,
     build_ruler_cases,
     evaluate_failures,
+    load_vmm_residency,
     parse_contexts,
     parse_generated_ids,
     run_once,
@@ -145,6 +146,7 @@ class Qwen36VerifySuiteTests(unittest.TestCase):
         self.assertTrue(cvp["hidden_bit_identical"])
         self.assertTrue(cvp["generated_ids_match"])
         self.assertAlmostEqual(cvp["chain_speedup_pct"], 10.0, places=4)
+        self.assertIsNone(summary["modes"]["int4/chained"]["vmm_total_resident_bytes_mean"])
 
         # Divergent hashes should fail the bit-identity gate.
         runs[1]["logits_sha256"] = "BBB"
@@ -159,6 +161,68 @@ class Qwen36VerifySuiteTests(unittest.TestCase):
             any("chained vs persistent logits diverged" in f for f in failures),
             f"expected divergence failure, got: {failures}",
         )
+
+    def test_summary_rolls_up_vmm_residency(self):
+        case = Case("vmm", "pg19", 512, "prompt", [], 511)
+        common = {
+            "mode": "int4",
+            "decode_path": "persistent",
+            "returncode": 0,
+            "generated_ids": [1],
+            "logits_sha256": "a",
+            "hidden_sha256": "h",
+            "logits_stats": {"all_zero": False},
+            "wall_seconds": 1.0,
+        }
+        runs = [
+            {
+                "repeat_idx": 0,
+                "vmm_residency": {
+                    "moe_resident_bytes": 10,
+                    "kv_resident_bytes": 3,
+                    "total_vmm_resident_bytes": 13,
+                    "total_vmm_reserved_bytes": 100,
+                },
+                **common,
+            },
+            {
+                "repeat_idx": 1,
+                "vmm_residency": {
+                    "moe_resident_bytes": 20,
+                    "kv_resident_bytes": 3,
+                    "total_vmm_resident_bytes": 23,
+                    "total_vmm_reserved_bytes": 100,
+                },
+                **common,
+            },
+        ]
+        cell = summarize_case(case, runs)["modes"]["int4/persistent"]
+        self.assertEqual(cell["vmm_total_resident_bytes_mean"], 18)
+        self.assertEqual(cell["vmm_total_resident_bytes_max"], 23)
+        self.assertEqual(cell["vmm_moe_resident_bytes_mean"], 15)
+        self.assertEqual(cell["vmm_kv_resident_bytes_mean"], 3)
+
+    def test_load_vmm_residency_keeps_report_fields(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "vmm.json"
+            path.write_text(json.dumps({
+                "summary": {
+                    "decode_path": "segmented_persistent",
+                    "moe_resident_bytes": 10,
+                    "kv_resident_bytes": 3,
+                    "total_vmm_resident_bytes": 13,
+                    "unrelated": "ignored",
+                }
+            }))
+            self.assertEqual(
+                load_vmm_residency(path),
+                {
+                    "decode_path": "segmented_persistent",
+                    "moe_resident_bytes": 10,
+                    "kv_resident_bytes": 3,
+                    "total_vmm_resident_bytes": 13,
+                },
+            )
 
     def test_run_once_records_timeout_as_failed_row(self):
         def fake_run(*args, **kwargs):
@@ -192,6 +256,60 @@ class Qwen36VerifySuiteTests(unittest.TestCase):
         self.assertEqual(row["returncode"], None)
         self.assertEqual(row["generated_ids"], [7])
         self.assertIn("timed out", row["error"])
+
+    def test_run_once_captures_sparse_vmm_telemetry_for_int4(self):
+        def fake_run(*args, **kwargs):
+            del args
+            telemetry_path = Path(kwargs["env"]["SUPERSONIC_MOE_ISLAND_TELEMETRY_JSON"])
+            self.assertEqual(kwargs["env"]["SUPERSONIC_VMM_MOE_ISLANDS"], "1")
+            self.assertEqual(kwargs["env"]["SUPERSONIC_MOE_ISLAND_CAP_EXPERTS"], "8")
+            telemetry_path.write_text(json.dumps({
+                "summary": {
+                    "moe_resident_bytes": 10,
+                    "kv_resident_bytes": 3,
+                    "total_vmm_resident_bytes": 13,
+                    "total_vmm_reserved_bytes": 100,
+                }
+            }))
+            Path(kwargs["env"]["SUPERSONIC_QWEN36_DUMP_LOGITS"]).write_bytes(b"\0\0")
+            Path(kwargs["env"]["SUPERSONIC_QWEN36_DUMP_FINAL_HIDDEN"]).write_bytes(b"\0\0")
+            argv = kwargs.get("args") or []
+            del argv
+            completed = subprocess.CompletedProcess(
+                args=["supersonic"],
+                returncode=0,
+                stdout="Generated ids: [7]\n",
+                stderr="",
+            )
+            return completed
+
+        old_run = verify_suite.subprocess.run
+        old_sha = verify_suite.sha256_file
+        old_stats = verify_suite.vector_stats
+        verify_suite.subprocess.run = fake_run
+        verify_suite.sha256_file = lambda path: f"sha:{Path(path).name}"
+        verify_suite.vector_stats = lambda path: {"all_zero": False}
+        try:
+            with tempfile.TemporaryDirectory() as td:
+                args = Namespace(
+                    binary=Path("target/release/supersonic"),
+                    backend="hip",
+                    model_dir=Path("/tmp/model"),
+                    max_new_tokens=1,
+                    seed=42,
+                    timeout=3,
+                    emit_stage_timings=False,
+                    moe_island_cap_experts=8,
+                )
+                case = Case("c_vmm", "pg19", 8, "hello", [], 7)
+                row = run_once(args, case, "int4", "persistent", 0, Path(td))
+        finally:
+            verify_suite.subprocess.run = old_run
+            verify_suite.sha256_file = old_sha
+            verify_suite.vector_stats = old_stats
+
+        self.assertEqual(row["returncode"], 0)
+        self.assertEqual(row["vmm_residency"]["total_vmm_resident_bytes"], 13)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add MoE-only, KV-only, and total VMM resident/reserved/logical bytes to Qwen3.6 sparse MoE telemetry JSON
- include KV and total VMM resident/reserved bytes in the final CLI residency line
- extend the HIP sparse VMM smoke test to assert KV and total VMM accounting

## Tests
- cargo fmt
- cargo check -p runner
- cargo test -p runner --test qwen36_moe_sparse_vmm_smoke -- --list
- SUPERSONIC_TEST_QWEN36_MOE_MODEL_DIR=/mnt/data/models/Qwen3.6-35B-A3B cargo test --release -p runner --test qwen36_moe_sparse_vmm_smoke -- --ignored --nocapture