### PR TITLE
Add MoE island prefetch telemetry hook

### DIFF
--- a/crates/runner/src/qwen36_moe_decode.rs
+++ b/crates/runner/src/qwen36_moe_decode.rs
@@ -633,7 +633,14 @@ pub fn run_chained_decode_fast(
     )
 }
 
-pub type ExpertPrefetchCallback<'a> = dyn FnMut(usize, &[usize]) -> Result<()> + 'a;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExpertPrefetchPhase {
+    Lookahead,
+    Demand,
+}
+
+pub type ExpertPrefetchCallback<'a> =
+    dyn FnMut(ExpertPrefetchPhase, usize, &[usize]) -> Result<()> + 'a;
 
 /// Production chained decode with a host-side hook between router top-k and
 /// routed expert GEMVs. The hook is intended for sparse VMM MoE residency:
@@ -1087,6 +1094,9 @@ fn run_chained_decode_impl(
             None => Qwen36MoeFfnStepInt4::disabled(),
         };
         if let Some(prefetch) = expert_prefetch.as_mut() {
+            prefetch(ExpertPrefetchPhase::Lookahead, layer_idx, &[]).with_context(|| {
+                format!("lookahead prefetch routed experts (layer {layer_idx})")
+            })?;
             let params_stage1 = Qwen36MoeFfnStepParams {
                 stage: 1,
                 ..params_stage5
@@ -1112,7 +1122,7 @@ fn run_chained_decode_impl(
 
             let topk = download_topk_indices(&ffn_output_idx, geom.top_k as usize)
                 .with_context(|| format!("download FFN top-k indices (layer {layer_idx})"))?;
-            prefetch(layer_idx, &topk)
+            prefetch(ExpertPrefetchPhase::Demand, layer_idx, &topk)
                 .with_context(|| format!("prefetch routed experts (layer {layer_idx})"))?;
             reset_sync_buf(ordinal, &mut sync_buf)
                 .context("reset sync_buf (ffn after prefetch)")?;

--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -28,9 +28,9 @@ use qwen36_moe::weights::{
 use crate::qwen36_moe_decode::{
     argmax_bf16_logits, dequant_int4_to_bf16_bytes, host_final_norm_lm_head, run_chained_decode,
     run_chained_decode_fast, run_chained_decode_fast_with_expert_prefetch, sample_bf16_logits,
-    AttnLayerBuffers, FfnInt4Sidecars, FfnLayerBuffers, FullAttnInt4Sidecars, FullAttnKvCache,
-    LayerBuffers, LinearAttnInt4Sidecars, MtpLayerBuffers, MultiLayerGeom, ResidentWeight,
-    XorshiftRng,
+    AttnLayerBuffers, ExpertPrefetchPhase, FfnInt4Sidecars, FfnLayerBuffers, FullAttnInt4Sidecars,
+    FullAttnKvCache, LayerBuffers, LinearAttnInt4Sidecars, MtpLayerBuffers, MultiLayerGeom,
+    ResidentWeight, XorshiftRng,
 };
 use crate::qwen36_moe_residency::{
     MoeExpertKey, MoeExpertProjection, MoeExpertResidencyConfig, MoeExpertResidencyManager,
@@ -1098,6 +1098,37 @@ fn moe_island_cap_experts_from_env() -> Result<Option<usize>> {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MoeIslandPrefetchMode {
+    Disabled,
+    PreviousToken,
+}
+
+impl MoeIslandPrefetchMode {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Disabled => "disabled",
+            Self::PreviousToken => "previous-token",
+        }
+    }
+
+    fn from_env() -> Result<Self> {
+        match std::env::var("SUPERSONIC_MOE_ISLAND_PREFETCH")
+            .ok()
+            .as_deref()
+        {
+            None | Some("0") | Some("off") | Some("disabled") => Ok(Self::Disabled),
+            Some("previous-token") | Some("previous_token") | Some("prev-token") => {
+                Ok(Self::PreviousToken)
+            }
+            Some(other) => Err(anyhow!(
+                "SUPERSONIC_MOE_ISLAND_PREFETCH must be unset, 0, off, disabled, \
+                 previous-token, previous_token, or prev-token; got {other:?}"
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Qwen36KvVmmMode {
     Auto,
     Disabled,
@@ -1197,6 +1228,7 @@ impl MoeSparseTelemetrySnapshot {
 struct MoeSparseTelemetry {
     dump_path: Option<PathBuf>,
     decode_path: &'static str,
+    prefetch_mode: MoeIslandPrefetchMode,
     steps: Vec<serde_json::Value>,
     peak_resident_slices: usize,
     peak_resident_pages: usize,
@@ -1206,7 +1238,11 @@ struct MoeSparseTelemetry {
 }
 
 impl MoeSparseTelemetry {
-    fn from_env(active: bool, persistent_decode: bool) -> Result<Option<Self>> {
+    fn from_env(
+        active: bool,
+        persistent_decode: bool,
+        prefetch_mode: MoeIslandPrefetchMode,
+    ) -> Result<Option<Self>> {
         if !active {
             return Ok(None);
         }
@@ -1218,6 +1254,7 @@ impl MoeSparseTelemetry {
             } else {
                 "chained"
             },
+            prefetch_mode,
             steps: Vec::new(),
             peak_resident_slices: 0,
             peak_resident_pages: 0,
@@ -1262,6 +1299,12 @@ impl MoeSparseTelemetry {
                 "evicted_pages": after.stats.evicted_pages.saturating_sub(before.stats.evicted_pages),
                 "uploaded_bytes": after.stats.uploaded_bytes.saturating_sub(before.stats.uploaded_bytes),
                 "unmapped_bytes": after.stats.unmapped_bytes.saturating_sub(before.stats.unmapped_bytes),
+                "prefetch_requests": after.stats.prefetch_requests.saturating_sub(before.stats.prefetch_requests),
+                "prefetch_hits": after.stats.prefetch_hits.saturating_sub(before.stats.prefetch_hits),
+                "prefetch_misses": after.stats.prefetch_misses.saturating_sub(before.stats.prefetch_misses),
+                "prefetch_page_hits": after.stats.prefetch_page_hits.saturating_sub(before.stats.prefetch_page_hits),
+                "prefetch_page_misses": after.stats.prefetch_page_misses.saturating_sub(before.stats.prefetch_page_misses),
+                "prefetch_uploaded_bytes": after.stats.prefetch_uploaded_bytes.saturating_sub(before.stats.prefetch_uploaded_bytes),
             },
             "resident": {
                 "slices": after.stats.resident_slices,
@@ -1280,6 +1323,12 @@ impl MoeSparseTelemetry {
                 "evicted_pages": after.stats.evicted_pages,
                 "uploaded_bytes": after.stats.uploaded_bytes,
                 "unmapped_bytes": after.stats.unmapped_bytes,
+                "prefetch_requests": after.stats.prefetch_requests,
+                "prefetch_hits": after.stats.prefetch_hits,
+                "prefetch_misses": after.stats.prefetch_misses,
+                "prefetch_page_hits": after.stats.prefetch_page_hits,
+                "prefetch_page_misses": after.stats.prefetch_page_misses,
+                "prefetch_uploaded_bytes": after.stats.prefetch_uploaded_bytes,
             }
         }));
     }
@@ -1307,6 +1356,7 @@ impl MoeSparseTelemetry {
             "schema": "supersonic-qwen36-moe-sparse-vmm-telemetry-v1",
             "summary": {
                 "decode_path": self.decode_path,
+                "prefetch_mode": self.prefetch_mode.as_str(),
                 "registered_tensors": final_snapshot.stats.registered_tensors,
                 "max_resident_pages": manager.max_resident_pages(),
                 "final_resident_slices": final_snapshot.stats.resident_slices,
@@ -1343,6 +1393,12 @@ impl MoeSparseTelemetry {
                 "evicted_pages": final_snapshot.stats.evicted_pages,
                 "uploaded_bytes": final_snapshot.stats.uploaded_bytes,
                 "unmapped_bytes": final_snapshot.stats.unmapped_bytes,
+                "prefetch_requests": final_snapshot.stats.prefetch_requests,
+                "prefetch_hits": final_snapshot.stats.prefetch_hits,
+                "prefetch_misses": final_snapshot.stats.prefetch_misses,
+                "prefetch_page_hits": final_snapshot.stats.prefetch_page_hits,
+                "prefetch_page_misses": final_snapshot.stats.prefetch_page_misses,
+                "prefetch_uploaded_bytes": final_snapshot.stats.prefetch_uploaded_bytes,
             },
             "generated_ids": generated_ids,
             "steps": self.steps,
@@ -2266,8 +2322,12 @@ fn decode_text(
     let mut _moe_expert_arena = None;
     let mut _moe_expert_residency = None;
     let sparse_moe_requested = moe_island_cap_experts.is_some();
+    let moe_prefetch_mode = MoeIslandPrefetchMode::from_env()?;
+    if moe_prefetch_mode != MoeIslandPrefetchMode::Disabled && !sparse_moe_requested {
+        anyhow::bail!("SUPERSONIC_MOE_ISLAND_PREFETCH requires SUPERSONIC_MOE_ISLAND_CAP_EXPERTS");
+    }
     let mut moe_sparse_telemetry =
-        MoeSparseTelemetry::from_env(sparse_moe_requested, persistent_decode)?;
+        MoeSparseTelemetry::from_env(sparse_moe_requested, persistent_decode, moe_prefetch_mode)?;
     if let Some(path) = moe_sparse_telemetry
         .as_ref()
         .and_then(|telemetry| telemetry.dump_path.as_ref())
@@ -2328,6 +2388,9 @@ fn decode_text(
                 "  [vmm] sparse MoE residency will use segmented persistent decode \
                  (router prefetch + FFN resume per layer)"
             );
+        }
+        if moe_prefetch_mode == MoeIslandPrefetchMode::PreviousToken {
+            println!("  [vmm] sparse MoE previous-token lookahead prefetch active");
         }
         _moe_expert_residency = Some(manager);
         layers
@@ -2657,6 +2720,8 @@ fn decode_text(
     let mut t_chain_full_attn_us: u64 = 0;
     let mut t_chain_linear_attn_us: u64 = 0;
     let mut t_chain_ffn_us: u64 = 0;
+    let mut previous_moe_topk_by_layer: Vec<Vec<usize>> =
+        vec![Vec::new(); geom.num_layers as usize];
 
     for step in 0..total_steps {
         // When speculative decode is on, each iteration can commit
@@ -2717,6 +2782,12 @@ fn decode_text(
         let moe_telemetry_before = _moe_expert_residency
             .as_ref()
             .map(MoeSparseTelemetrySnapshot::capture);
+        let mut next_moe_topk_by_layer =
+            if moe_prefetch_mode == MoeIslandPrefetchMode::PreviousToken {
+                previous_moe_topk_by_layer.clone()
+            } else {
+                Vec::new()
+            };
         let outputs = if let Some(scratch) = persistent_scratch.as_mut() {
             if let Some(manager) = _moe_expert_residency.as_mut() {
                 // Sparse VMM needs a host remap point after each layer's
@@ -2725,27 +2796,52 @@ fn decode_text(
                 // standalone lm_head launch below consumes final_hidden_bytes.
                 lm_head_folded = false;
                 drop(fold);
-                let mut prefetch = |layer_idx: usize, topk: &[usize]| -> Result<()> {
-                    for &expert_idx in topk {
-                        manager.ensure_resident(
-                            &store,
-                            MoeExpertKey {
+                let mut prefetch =
+                    |phase: ExpertPrefetchPhase, layer_idx: usize, topk: &[usize]| -> Result<()> {
+                        let experts = match phase {
+                            ExpertPrefetchPhase::Lookahead
+                                if moe_prefetch_mode == MoeIslandPrefetchMode::PreviousToken =>
+                            {
+                                previous_moe_topk_by_layer
+                                    .get(layer_idx)
+                                    .map(Vec::as_slice)
+                                    .unwrap_or(&[])
+                            }
+                            ExpertPrefetchPhase::Lookahead => &[],
+                            ExpertPrefetchPhase::Demand => topk,
+                        };
+                        for &expert_idx in experts {
+                            let gate_up = MoeExpertKey {
                                 layer_idx,
                                 expert_idx,
                                 projection: MoeExpertProjection::GateUp,
-                            },
-                        )?;
-                        manager.ensure_resident(
-                            &store,
-                            MoeExpertKey {
+                            };
+                            let down = MoeExpertKey {
                                 layer_idx,
                                 expert_idx,
                                 projection: MoeExpertProjection::Down,
-                            },
-                        )?;
-                    }
-                    Ok(())
-                };
+                            };
+                            match phase {
+                                ExpertPrefetchPhase::Lookahead => {
+                                    manager.prefetch_resident(&store, gate_up)?;
+                                    manager.prefetch_resident(&store, down)?;
+                                }
+                                ExpertPrefetchPhase::Demand => {
+                                    manager.ensure_resident(&store, gate_up)?;
+                                    manager.ensure_resident(&store, down)?;
+                                }
+                            }
+                        }
+                        if phase == ExpertPrefetchPhase::Demand
+                            && moe_prefetch_mode == MoeIslandPrefetchMode::PreviousToken
+                        {
+                            if let Some(slot) = next_moe_topk_by_layer.get_mut(layer_idx) {
+                                slot.clear();
+                                slot.extend_from_slice(topk);
+                            }
+                        }
+                        Ok(())
+                    };
                 scratch
                     .run_sparse_with_expert_prefetch(
                         ordinal,
@@ -2772,27 +2868,52 @@ fn decode_text(
             lm_head_folded = false;
             drop(fold);
             if let Some(manager) = _moe_expert_residency.as_mut() {
-                let mut prefetch = |layer_idx: usize, topk: &[usize]| -> Result<()> {
-                    for &expert_idx in topk {
-                        manager.ensure_resident(
-                            &store,
-                            MoeExpertKey {
+                let mut prefetch =
+                    |phase: ExpertPrefetchPhase, layer_idx: usize, topk: &[usize]| -> Result<()> {
+                        let experts = match phase {
+                            ExpertPrefetchPhase::Lookahead
+                                if moe_prefetch_mode == MoeIslandPrefetchMode::PreviousToken =>
+                            {
+                                previous_moe_topk_by_layer
+                                    .get(layer_idx)
+                                    .map(Vec::as_slice)
+                                    .unwrap_or(&[])
+                            }
+                            ExpertPrefetchPhase::Lookahead => &[],
+                            ExpertPrefetchPhase::Demand => topk,
+                        };
+                        for &expert_idx in experts {
+                            let gate_up = MoeExpertKey {
                                 layer_idx,
                                 expert_idx,
                                 projection: MoeExpertProjection::GateUp,
-                            },
-                        )?;
-                        manager.ensure_resident(
-                            &store,
-                            MoeExpertKey {
+                            };
+                            let down = MoeExpertKey {
                                 layer_idx,
                                 expert_idx,
                                 projection: MoeExpertProjection::Down,
-                            },
-                        )?;
-                    }
-                    Ok(())
-                };
+                            };
+                            match phase {
+                                ExpertPrefetchPhase::Lookahead => {
+                                    manager.prefetch_resident(&store, gate_up)?;
+                                    manager.prefetch_resident(&store, down)?;
+                                }
+                                ExpertPrefetchPhase::Demand => {
+                                    manager.ensure_resident(&store, gate_up)?;
+                                    manager.ensure_resident(&store, down)?;
+                                }
+                            }
+                        }
+                        if phase == ExpertPrefetchPhase::Demand
+                            && moe_prefetch_mode == MoeIslandPrefetchMode::PreviousToken
+                        {
+                            if let Some(slot) = next_moe_topk_by_layer.get_mut(layer_idx) {
+                                slot.clear();
+                                slot.extend_from_slice(topk);
+                            }
+                        }
+                        Ok(())
+                    };
                 run_chained_decode_fast_with_expert_prefetch(
                     ordinal,
                     &geom,
@@ -2814,6 +2935,9 @@ fn decode_text(
             }
             .with_context(|| format!("chained decode (step {step}, position {position})"))?
         };
+        if moe_prefetch_mode == MoeIslandPrefetchMode::PreviousToken {
+            previous_moe_topk_by_layer = next_moe_topk_by_layer;
+        }
         if let (Some(telemetry), Some(before), Some(manager)) = (
             moe_sparse_telemetry.as_mut(),
             moe_telemetry_before,
@@ -3299,6 +3423,8 @@ fn decode_text(
                 "  [vmm] MoE island residency: resident_slices={} peak_slices={} \
                  resident_pages={} peak_pages={} page_backed_slices={} \
                  hits={} misses={} page_hits={} page_misses={} evicted_slices={} evicted_pages={} \
+                 prefetch_requests={} prefetch_hits={} prefetch_misses={} \
+                 prefetch_page_hits={} prefetch_page_misses={} \
                  uploaded={:.2}MiB unmapped={:.2}MiB \
                  resident={:.2}MiB peak_resident={:.2}MiB reserved={:.2}MiB \
                  kv_resident={:.2}MiB total_vmm_resident={:.2}MiB total_vmm_reserved={:.2}MiB",
@@ -3313,6 +3439,11 @@ fn decode_text(
                 residency.page_misses,
                 residency.evicted_slices,
                 residency.evicted_pages,
+                residency.prefetch_requests,
+                residency.prefetch_hits,
+                residency.prefetch_misses,
+                residency.prefetch_page_hits,
+                residency.prefetch_page_misses,
                 residency.uploaded_bytes as f64 / MIB,
                 residency.unmapped_bytes as f64 / MIB,
                 arena.resident_bytes as f64 / MIB,
@@ -3327,7 +3458,9 @@ fn decode_text(
             println!(
                 "  [vmm] MoE island residency: resident_slices={} resident_pages={} \
                  page_backed_slices={} hits={} misses={} page_hits={} page_misses={} \
-                 evicted_slices={} evicted_pages={} uploaded={:.2}MiB unmapped={:.2}MiB \
+                 evicted_slices={} evicted_pages={} prefetch_requests={} \
+                 prefetch_hits={} prefetch_misses={} prefetch_page_hits={} \
+                 prefetch_page_misses={} uploaded={:.2}MiB unmapped={:.2}MiB \
                  resident={:.2}MiB reserved={:.2}MiB kv_resident={:.2}MiB \
                  total_vmm_resident={:.2}MiB total_vmm_reserved={:.2}MiB",
                 residency.resident_slices,
@@ -3339,6 +3472,11 @@ fn decode_text(
                 residency.page_misses,
                 residency.evicted_slices,
                 residency.evicted_pages,
+                residency.prefetch_requests,
+                residency.prefetch_hits,
+                residency.prefetch_misses,
+                residency.prefetch_page_hits,
+                residency.prefetch_page_misses,
                 residency.uploaded_bytes as f64 / MIB,
                 residency.unmapped_bytes as f64 / MIB,
                 arena.resident_bytes as f64 / MIB,

--- a/crates/runner/src/qwen36_moe_persistent_decode.rs
+++ b/crates/runner/src/qwen36_moe_persistent_decode.rs
@@ -48,7 +48,7 @@ pub struct LmHeadFold<'a> {
 
 use crate::qwen36_moe_decode::{
     ffn_workspace_floats, full_attn_workspace_floats, linear_attn_workspace_floats,
-    AttnLayerBuffers, DecodeOutputs, LayerBuffers, MultiLayerGeom,
+    AttnLayerBuffers, DecodeOutputs, ExpertPrefetchPhase, LayerBuffers, MultiLayerGeom,
 };
 
 /// Pre-allocated scratch + cached descriptor arrays for the persistent
@@ -286,7 +286,7 @@ impl PersistentScratch {
         mut prefetch: F,
     ) -> Result<DecodeOutputs>
     where
-        F: FnMut(usize, &[usize]) -> Result<()>,
+        F: FnMut(ExpertPrefetchPhase, usize, &[usize]) -> Result<()>,
     {
         let hidden_bytes = self.geom.hidden as usize * 2;
         if initial_hidden_bytes.len() != hidden_bytes {
@@ -306,6 +306,9 @@ impl PersistentScratch {
 
         let t_launch = std::time::Instant::now();
         for layer_idx in 0..self.num_layers {
+            prefetch(ExpertPrefetchPhase::Lookahead, layer_idx, &[]).with_context(|| {
+                format!("lookahead prefetch routed experts (layer {layer_idx})")
+            })?;
             persistent_decode_launch_range(
                 ordinal,
                 ScalarType::BF16,
@@ -331,7 +334,7 @@ impl PersistentScratch {
             let topk = self
                 .download_topk_indices(ordinal)
                 .with_context(|| format!("download FFN top-k indices (layer {layer_idx})"))?;
-            prefetch(layer_idx, &topk)
+            prefetch(ExpertPrefetchPhase::Demand, layer_idx, &topk)
                 .with_context(|| format!("prefetch routed experts (layer {layer_idx})"))?;
 
             persistent_decode_launch_range(

--- a/crates/runner/src/qwen36_moe_residency.rs
+++ b/crates/runner/src/qwen36_moe_residency.rs
@@ -61,6 +61,12 @@ pub struct MoeExpertResidencyStats {
     pub evicted_pages: u64,
     pub uploaded_bytes: usize,
     pub unmapped_bytes: usize,
+    pub prefetch_requests: u64,
+    pub prefetch_hits: u64,
+    pub prefetch_misses: u64,
+    pub prefetch_page_hits: u64,
+    pub prefetch_page_misses: u64,
+    pub prefetch_uploaded_bytes: usize,
 }
 
 #[derive(Debug, Clone)]
@@ -133,6 +139,18 @@ pub struct MoeExpertResidencyManager {
     evicted_pages: u64,
     uploaded_bytes: usize,
     unmapped_bytes: usize,
+    prefetch_requests: u64,
+    prefetch_hits: u64,
+    prefetch_misses: u64,
+    prefetch_page_hits: u64,
+    prefetch_page_misses: u64,
+    prefetch_uploaded_bytes: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ResidencyAccessKind {
+    Demand,
+    Prefetch,
 }
 
 impl MoeExpertResidencyManager {
@@ -153,6 +171,12 @@ impl MoeExpertResidencyManager {
             evicted_pages: 0,
             uploaded_bytes: 0,
             unmapped_bytes: 0,
+            prefetch_requests: 0,
+            prefetch_hits: 0,
+            prefetch_misses: 0,
+            prefetch_page_hits: 0,
+            prefetch_page_misses: 0,
+            prefetch_uploaded_bytes: 0,
         }
     }
 
@@ -179,6 +203,12 @@ impl MoeExpertResidencyManager {
             evicted_pages: self.evicted_pages,
             uploaded_bytes: self.uploaded_bytes,
             unmapped_bytes: self.unmapped_bytes,
+            prefetch_requests: self.prefetch_requests,
+            prefetch_hits: self.prefetch_hits,
+            prefetch_misses: self.prefetch_misses,
+            prefetch_page_hits: self.prefetch_page_hits,
+            prefetch_page_misses: self.prefetch_page_misses,
+            prefetch_uploaded_bytes: self.prefetch_uploaded_bytes,
         }
     }
 
@@ -301,6 +331,22 @@ impl MoeExpertResidencyManager {
     }
 
     pub fn ensure_resident(&mut self, store: &BakedStore, key: MoeExpertKey) -> Result<()> {
+        self.ensure_resident_with_kind(store, key, ResidencyAccessKind::Demand)
+    }
+
+    pub fn prefetch_resident(&mut self, store: &BakedStore, key: MoeExpertKey) -> Result<()> {
+        self.ensure_resident_with_kind(store, key, ResidencyAccessKind::Prefetch)
+    }
+
+    fn ensure_resident_with_kind(
+        &mut self,
+        store: &BakedStore,
+        key: MoeExpertKey,
+        kind: ResidencyAccessKind,
+    ) -> Result<()> {
+        if kind == ResidencyAccessKind::Prefetch {
+            self.prefetch_requests += 1;
+        }
         let tensor_idx = self.tensor_idx(key.layer_idx, key.projection)?;
         let (name, allocation_id, logical_offset, logical_len, pages) = {
             let tensor = &self.tensors[tensor_idx];
@@ -359,8 +405,14 @@ impl MoeExpertResidencyManager {
             });
             if all_pages_resident {
                 self.hits += 1;
+                if kind == ResidencyAccessKind::Prefetch {
+                    self.prefetch_hits += 1;
+                }
                 for span in &pages {
                     self.page_hits += 1;
+                    if kind == ResidencyAccessKind::Prefetch {
+                        self.prefetch_page_hits += 1;
+                    }
                     if let Some(page) = self.resident_pages.get_mut(&ResidentPageKey {
                         tensor_idx,
                         page_offset: span.offset,
@@ -374,6 +426,9 @@ impl MoeExpertResidencyManager {
         }
 
         self.misses += 1;
+        if kind == ResidencyAccessKind::Prefetch {
+            self.prefetch_misses += 1;
+        }
         let mut missing_pages = Vec::new();
         for span in &pages {
             let page_key = ResidentPageKey {
@@ -383,12 +438,18 @@ impl MoeExpertResidencyManager {
             if let Some(page) = self.resident_pages.get_mut(&page_key) {
                 page.last_used = self.clock;
                 self.page_hits += 1;
+                if kind == ResidencyAccessKind::Prefetch {
+                    self.prefetch_page_hits += 1;
+                }
             } else {
                 missing_pages.push(*span);
             }
         }
 
         self.page_misses += missing_pages.len() as u64;
+        if kind == ResidencyAccessKind::Prefetch {
+            self.prefetch_page_misses += missing_pages.len() as u64;
+        }
         for span in missing_pages {
             while self.resident_pages.len() >= self.config.max_resident_pages {
                 self.evict_lru_page()?;
@@ -409,6 +470,9 @@ impl MoeExpertResidencyManager {
                     )
                 })?;
             self.uploaded_bytes += span.copy_len;
+            if kind == ResidencyAccessKind::Prefetch {
+                self.prefetch_uploaded_bytes += span.copy_len;
+            }
             self.resident_pages.insert(
                 ResidentPageKey {
                     tensor_idx,

--- a/crates/runner/tests/qwen36_moe_multilayer_parity.rs
+++ b/crates/runner/tests/qwen36_moe_multilayer_parity.rs
@@ -754,7 +754,12 @@ fn multilayer_persistent_decode_matches_chained() {
     restore_linear_attn_state(ordinal, &mut layers, &snapshot)
         .expect("restore_linear_attn_state before segmented persistent");
     let segmented_outputs = scratch
-        .run_sparse_with_expert_prefetch(ordinal, &initial_hidden, position, |_layer, _topk| Ok(()))
+        .run_sparse_with_expert_prefetch(
+            ordinal,
+            &initial_hidden,
+            position,
+            |_phase, _layer, _topk| Ok(()),
+        )
         .expect("PersistentScratch::run_sparse_with_expert_prefetch");
     assert_parity_bf16(
         "segmented persistent sparse vs chained final_hidden",

--- a/docs/lowlevel-memory.md
+++ b/docs/lowlevel-memory.md
@@ -100,6 +100,11 @@ Current scope:
 - `SUPERSONIC_MOE_ISLAND_CAP_EXPERTS=N` switches Qwen3.6-MoE INT4 decode from
   fully resident virtual expert slabs to sparse router-prefetched islands with
   at most `N` experts' two routed projections tracked resident at once.
+- `SUPERSONIC_MOE_ISLAND_PREFETCH=previous-token` enables experimental
+  previous-token routed-expert lookahead for sparse MoE islands. It preloads
+  each layer's previous top-k before that layer's router runs, then records
+  prefetch hit/miss/page counters in the sparse telemetry JSON. This is a
+  measurement hook for future overlapped prefetch work, not a default path.
 - `SUPERSONIC_VMM_KV=0` disables the Qwen3.5 and Qwen3.6 KV integrations.
 - `SUPERSONIC_VMM_KV=1` requests KV VMM and logs if the backend cannot support
   it. HIP may auto-enable when unset; CUDA requires this explicit opt-in.

--- a/oracle/qwen36_verify_suite.py
+++ b/oracle/qwen36_verify_suite.py
@@ -333,6 +333,7 @@ def load_vmm_residency(path: Path) -> dict[str, Any]:
     summary = payload.get("summary") or {}
     keys = [
         "decode_path",
+        "prefetch_mode",
         "max_resident_pages",
         "final_resident_pages",
         "peak_resident_pages",
@@ -345,6 +346,12 @@ def load_vmm_residency(path: Path) -> dict[str, Any]:
         "total_vmm_resident_bytes",
         "total_vmm_reserved_bytes",
         "total_vmm_logical_resident_bytes",
+        "prefetch_requests",
+        "prefetch_hits",
+        "prefetch_misses",
+        "prefetch_page_hits",
+        "prefetch_page_misses",
+        "prefetch_uploaded_bytes",
     ]
     return {k: summary[k] for k in keys if k in summary}
 

--- a/tests/gfx1100/bench_qwen36_sparse_caps.py
+++ b/tests/gfx1100/bench_qwen36_sparse_caps.py
@@ -87,10 +87,13 @@ def run_case(
     env["SUPERSONIC_VMM_MOE_ISLANDS"] = "1"
     env.pop("SUPERSONIC_MOE_ISLAND_CAP_EXPERTS", None)
     env.pop("SUPERSONIC_MOE_ISLAND_TELEMETRY_JSON", None)
+    env.pop("SUPERSONIC_MOE_ISLAND_PREFETCH", None)
     telemetry_path = tmp / f"{label}_telemetry.json"
     if cap is not None:
         env["SUPERSONIC_MOE_ISLAND_CAP_EXPERTS"] = str(cap)
         env["SUPERSONIC_MOE_ISLAND_TELEMETRY_JSON"] = str(telemetry_path)
+        if args.prefetch:
+            env["SUPERSONIC_MOE_ISLAND_PREFETCH"] = args.prefetch
 
     cmd = [
         str(args.binary),
@@ -160,15 +163,15 @@ def run_case(
 
 def markdown(rows: list[dict[str, Any]]) -> str:
     out = [
-        "| Mode | total ms/tok | tok/s | total resident GiB | MoE resident GiB | KV resident GiB | peak pages | page misses | evicted pages | ids match |",
-        "|---|---:|---:|---:|---:|---:|---:|---:|---:|:---:|",
+        "| Mode | total ms/tok | tok/s | total resident GiB | MoE resident GiB | KV resident GiB | peak pages | page misses | prefetch page misses | evicted pages | ids match |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:---:|",
     ]
     for row in rows:
         residency = row.get("vmm_residency") or {}
         stage = row.get("stage") or {}
         ids_match = row.get("generated_ids_match")
         out.append(
-            "| {label} | {ms} | {tok} | {total_gib} | {moe_gib} | {kv_gib} | {peak_pages} | {page_misses} | {evicted_pages} | {ids_match} |".format(
+            "| {label} | {ms} | {tok} | {total_gib} | {moe_gib} | {kv_gib} | {peak_pages} | {page_misses} | {prefetch_page_misses} | {evicted_pages} | {ids_match} |".format(
                 label=row["label"],
                 ms=fmt_num(stage.get("total_ms_avg")),
                 tok=fmt_num(row.get("tok_per_s")),
@@ -177,6 +180,7 @@ def markdown(rows: list[dict[str, Any]]) -> str:
                 kv_gib=fmt_gib(residency.get("kv_resident_bytes")),
                 peak_pages=residency.get("peak_resident_pages", "-"),
                 page_misses=residency.get("page_misses", "-"),
+                prefetch_page_misses=residency.get("prefetch_page_misses", "-"),
                 evicted_pages=residency.get("evicted_pages", "-"),
                 ids_match="yes" if ids_match else "NO",
             )
@@ -198,6 +202,11 @@ def main() -> int:
     parser.add_argument("--timeout", type=int, default=600)
     parser.add_argument("--no-warmup", action="store_true")
     parser.add_argument("--no-persistent-decode", action="store_true")
+    parser.add_argument(
+        "--prefetch",
+        choices=["previous-token"],
+        help="set SUPERSONIC_MOE_ISLAND_PREFETCH for sparse cap rows",
+    )
     parser.add_argument("--out-json", type=Path, default=Path("target/qwen36_sparse_cap_sweep.json"))
     parser.add_argument("--out-md", type=Path, default=Path("target/qwen36_sparse_cap_sweep.md"))
     args = parser.parse_args()


### PR DESCRIPTION
## Summary
- add a phase-aware routed-expert callback so sparse MoE VMM can distinguish lookahead prefetch from demand residency
- add an experimental `SUPERSONIC_MOE_ISLAND_PREFETCH=previous-token` mode behind the existing sparse cap path
- surface prefetch request/hit/miss/page/upload counters in telemetry, CLI output, verify summaries, and the sparse-cap benchmark script

## HIP notes
Shared experts remain resident in the normal weight path; this hook only targets routed experts managed by the sparse MoE VMM island residency manager. The previous-token predictor is intentionally disabled by default. On a short gfx1100 smoke it was useful as instrumentation but not a win: cap 320 without lookahead uploaded ~10.2 GiB and averaged ~107 ms/token chain time; previous-token lookahead uploaded ~24.8 GiB and averaged ~317 ms/token, with only 32 prefetch hits. That makes the next real target an overlapped/double-buffered prefetch policy with a better source of future expert IDs, not enabling this predictor by default.

## Tests
- `cargo fmt`
- `python3 -m py_compile tests/gfx1100/bench_qwen36_sparse_caps.py oracle/qwen36_verify_suite.py`
- `cargo test -p runner qwen36_moe_residency --lib`
- `cargo test -p runner --test qwen36_moe_sparse_vmm_smoke -- --list`
- `cargo check -p runner`
- `git diff --check`
- HIP smoke: `SUPERSONIC_BACKENDS=hip SUPERSONIC_VMM_MOE_ISLANDS=1 SUPERSONIC_MOE_ISLAND_CAP_EXPERTS=320 SUPERSONIC_MOE_ISLAND_PREFETCH=previous-token ... --max-new-tokens 2`