### PR TITLE
Add MoE route rank telemetry

### DIFF
--- a/crates/runner/src/qwen36_moe_decode.rs
+++ b/crates/runner/src/qwen36_moe_decode.rs
@@ -639,8 +639,15 @@ pub enum ExpertPrefetchPhase {
     Demand,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct ExpertRoute {
+    pub rank: usize,
+    pub expert_idx: usize,
+    pub weight: f32,
+}
+
 pub type ExpertPrefetchCallback<'a> =
-    dyn FnMut(ExpertPrefetchPhase, usize, &[usize]) -> Result<()> + 'a;
+    dyn FnMut(ExpertPrefetchPhase, usize, &[ExpertRoute]) -> Result<()> + 'a;
 
 /// Production chained decode with a host-side hook between router top-k and
 /// routed expert GEMVs. The hook is intended for sparse VMM MoE residency:
@@ -1120,9 +1127,9 @@ fn run_chained_decode_impl(
             }
             t_ffn += t_router.elapsed();
 
-            let topk = download_topk_indices(&ffn_output_idx, geom.top_k as usize)
-                .with_context(|| format!("download FFN top-k indices (layer {layer_idx})"))?;
-            prefetch(ExpertPrefetchPhase::Demand, layer_idx, &topk)
+            let routes = download_topk_routes(&ffn_output_idx, &ffn_output, geom.top_k as usize)
+                .with_context(|| format!("download FFN top-k routes (layer {layer_idx})"))?;
+            prefetch(ExpertPrefetchPhase::Demand, layer_idx, &routes)
                 .with_context(|| format!("prefetch routed experts (layer {layer_idx})"))?;
             reset_sync_buf(ordinal, &mut sync_buf)
                 .context("reset sync_buf (ffn after prefetch)")?;
@@ -1199,6 +1206,34 @@ fn download_topk_indices(buf: &GpuBuffer, top_k: usize) -> Result<Vec<usize>> {
         .map(|chunk| {
             let raw = u32::from_ne_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
             raw as usize
+        })
+        .collect())
+}
+
+fn download_topk_routes(
+    idx_buf: &GpuBuffer,
+    weight_buf: &GpuBuffer,
+    top_k: usize,
+) -> Result<Vec<ExpertRoute>> {
+    let idx = download_topk_indices(idx_buf, top_k)?;
+    let needed = top_k * std::mem::size_of::<u16>();
+    let mut weight_bytes = vec![0u8; needed];
+    copy_d2h(
+        weight_buf.device_ordinal(),
+        weight_bytes.as_mut_ptr() as *mut _,
+        weight_buf.as_ptr(),
+        needed,
+    )
+    .context("d2h top-k route weights")?;
+    let weights = bf16_bytes_to_f32(&weight_bytes);
+    Ok(idx
+        .into_iter()
+        .zip(weights)
+        .enumerate()
+        .map(|(rank, (expert_idx, weight))| ExpertRoute {
+            rank,
+            expert_idx,
+            weight,
         })
         .collect())
 }

--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -28,9 +28,9 @@ use qwen36_moe::weights::{
 use crate::qwen36_moe_decode::{
     argmax_bf16_logits, dequant_int4_to_bf16_bytes, host_final_norm_lm_head, run_chained_decode,
     run_chained_decode_fast, run_chained_decode_fast_with_expert_prefetch, sample_bf16_logits,
-    AttnLayerBuffers, ExpertPrefetchPhase, FfnInt4Sidecars, FfnLayerBuffers, FullAttnInt4Sidecars,
-    FullAttnKvCache, LayerBuffers, LinearAttnInt4Sidecars, MtpLayerBuffers, MultiLayerGeom,
-    ResidentWeight, XorshiftRng,
+    AttnLayerBuffers, ExpertPrefetchPhase, ExpertRoute, FfnInt4Sidecars, FfnLayerBuffers,
+    FullAttnInt4Sidecars, FullAttnKvCache, LayerBuffers, LinearAttnInt4Sidecars, MtpLayerBuffers,
+    MultiLayerGeom, ResidentWeight, XorshiftRng,
 };
 use crate::qwen36_moe_residency::{
     MoeExpertKey, MoeExpertProjection, MoeExpertResidencyConfig, MoeExpertResidencyManager,
@@ -1237,6 +1237,78 @@ struct MoeSparseTelemetry {
     peak_logical_resident_bytes: usize,
 }
 
+#[derive(Debug, Clone)]
+struct MoeRouteTelemetry {
+    observations_by_rank: Vec<u64>,
+    resident_before_by_rank: Vec<u64>,
+    repeated_previous_by_rank: Vec<u64>,
+    weight_sum_by_rank: Vec<f64>,
+}
+
+impl MoeRouteTelemetry {
+    fn new(top_k: usize) -> Self {
+        Self {
+            observations_by_rank: vec![0; top_k],
+            resident_before_by_rank: vec![0; top_k],
+            repeated_previous_by_rank: vec![0; top_k],
+            weight_sum_by_rank: vec![0.0; top_k],
+        }
+    }
+
+    fn record(
+        &mut self,
+        manager: &MoeExpertResidencyManager,
+        layer_idx: usize,
+        routes: &[ExpertRoute],
+        previous_routes: &[usize],
+    ) {
+        for route in routes {
+            if route.rank >= self.observations_by_rank.len() {
+                continue;
+            }
+            self.observations_by_rank[route.rank] += 1;
+            self.weight_sum_by_rank[route.rank] += route.weight as f64;
+            if previous_routes.contains(&route.expert_idx) {
+                self.repeated_previous_by_rank[route.rank] += 1;
+            }
+            let gate_up = MoeExpertKey {
+                layer_idx,
+                expert_idx: route.expert_idx,
+                projection: MoeExpertProjection::GateUp,
+            };
+            let down = MoeExpertKey {
+                layer_idx,
+                expert_idx: route.expert_idx,
+                projection: MoeExpertProjection::Down,
+            };
+            if manager.is_resident(gate_up) && manager.is_resident(down) {
+                self.resident_before_by_rank[route.rank] += 1;
+            }
+        }
+    }
+
+    fn to_json(&self) -> serde_json::Value {
+        let avg_weight_by_rank: Vec<f64> = self
+            .weight_sum_by_rank
+            .iter()
+            .zip(&self.observations_by_rank)
+            .map(|(sum, count)| {
+                if *count == 0 {
+                    0.0
+                } else {
+                    sum / *count as f64
+                }
+            })
+            .collect();
+        serde_json::json!({
+            "observations_by_rank": &self.observations_by_rank,
+            "resident_before_by_rank": &self.resident_before_by_rank,
+            "repeated_previous_by_rank": &self.repeated_previous_by_rank,
+            "avg_weight_by_rank": avg_weight_by_rank,
+        })
+    }
+}
+
 impl MoeSparseTelemetry {
     fn from_env(
         active: bool,
@@ -1338,6 +1410,7 @@ impl MoeSparseTelemetry {
         manager: &MoeExpertResidencyManager,
         virtual_kv_stats: VirtualKvStats,
         generated_ids: &[u32],
+        route_telemetry: Option<&MoeRouteTelemetry>,
     ) -> Result<()> {
         let Some(path) = self.dump_path.as_ref() else {
             return Ok(());
@@ -1399,6 +1472,7 @@ impl MoeSparseTelemetry {
                 "prefetch_page_hits": final_snapshot.stats.prefetch_page_hits,
                 "prefetch_page_misses": final_snapshot.stats.prefetch_page_misses,
                 "prefetch_uploaded_bytes": final_snapshot.stats.prefetch_uploaded_bytes,
+                "route_summary": route_telemetry.map(MoeRouteTelemetry::to_json),
             },
             "generated_ids": generated_ids,
             "steps": self.steps,
@@ -2722,6 +2796,8 @@ fn decode_text(
     let mut t_chain_ffn_us: u64 = 0;
     let mut previous_moe_topk_by_layer: Vec<Vec<usize>> =
         vec![Vec::new(); geom.num_layers as usize];
+    let mut moe_route_telemetry =
+        sparse_moe_requested.then(|| MoeRouteTelemetry::new(geom.top_k as usize));
 
     for step in 0..total_steps {
         // When speculative decode is on, each iteration can commit
@@ -2782,12 +2858,13 @@ fn decode_text(
         let moe_telemetry_before = _moe_expert_residency
             .as_ref()
             .map(MoeSparseTelemetrySnapshot::capture);
-        let mut next_moe_topk_by_layer =
-            if moe_prefetch_mode == MoeIslandPrefetchMode::PreviousToken {
-                previous_moe_topk_by_layer.clone()
-            } else {
-                Vec::new()
-            };
+        let track_moe_routes = moe_prefetch_mode == MoeIslandPrefetchMode::PreviousToken
+            || moe_route_telemetry.is_some();
+        let mut next_moe_topk_by_layer = if track_moe_routes {
+            previous_moe_topk_by_layer.clone()
+        } else {
+            Vec::new()
+        };
         let outputs = if let Some(scratch) = persistent_scratch.as_mut() {
             if let Some(manager) = _moe_expert_residency.as_mut() {
                 // Sparse VMM needs a host remap point after each layer's
@@ -2796,52 +2873,71 @@ fn decode_text(
                 // standalone lm_head launch below consumes final_hidden_bytes.
                 lm_head_folded = false;
                 drop(fold);
-                let mut prefetch =
-                    |phase: ExpertPrefetchPhase, layer_idx: usize, topk: &[usize]| -> Result<()> {
-                        let experts = match phase {
-                            ExpertPrefetchPhase::Lookahead
-                                if moe_prefetch_mode == MoeIslandPrefetchMode::PreviousToken =>
-                            {
-                                previous_moe_topk_by_layer
-                                    .get(layer_idx)
-                                    .map(Vec::as_slice)
-                                    .unwrap_or(&[])
-                            }
-                            ExpertPrefetchPhase::Lookahead => &[],
-                            ExpertPrefetchPhase::Demand => topk,
-                        };
-                        for &expert_idx in experts {
-                            let gate_up = MoeExpertKey {
-                                layer_idx,
-                                expert_idx,
-                                projection: MoeExpertProjection::GateUp,
-                            };
-                            let down = MoeExpertKey {
-                                layer_idx,
-                                expert_idx,
-                                projection: MoeExpertProjection::Down,
-                            };
-                            match phase {
-                                ExpertPrefetchPhase::Lookahead => {
-                                    manager.prefetch_resident(&store, gate_up)?;
-                                    manager.prefetch_resident(&store, down)?;
-                                }
-                                ExpertPrefetchPhase::Demand => {
-                                    manager.ensure_resident(&store, gate_up)?;
-                                    manager.ensure_resident(&store, down)?;
-                                }
-                            }
-                        }
-                        if phase == ExpertPrefetchPhase::Demand
-                            && moe_prefetch_mode == MoeIslandPrefetchMode::PreviousToken
+                let mut prefetch = |phase: ExpertPrefetchPhase,
+                                    layer_idx: usize,
+                                    routes: &[ExpertRoute]|
+                 -> Result<()> {
+                    match phase {
+                        ExpertPrefetchPhase::Lookahead
+                            if moe_prefetch_mode == MoeIslandPrefetchMode::PreviousToken =>
                         {
-                            if let Some(slot) = next_moe_topk_by_layer.get_mut(layer_idx) {
-                                slot.clear();
-                                slot.extend_from_slice(topk);
+                            for &expert_idx in previous_moe_topk_by_layer
+                                .get(layer_idx)
+                                .map(Vec::as_slice)
+                                .unwrap_or(&[])
+                            {
+                                let gate_up = MoeExpertKey {
+                                    layer_idx,
+                                    expert_idx,
+                                    projection: MoeExpertProjection::GateUp,
+                                };
+                                let down = MoeExpertKey {
+                                    layer_idx,
+                                    expert_idx,
+                                    projection: MoeExpertProjection::Down,
+                                };
+                                manager.prefetch_resident(&store, gate_up)?;
+                                manager.prefetch_resident(&store, down)?;
                             }
                         }
-                        Ok(())
-                    };
+                        ExpertPrefetchPhase::Lookahead => {}
+                        ExpertPrefetchPhase::Demand => {
+                            if let Some(route_telemetry) = moe_route_telemetry.as_mut() {
+                                route_telemetry.record(
+                                    manager,
+                                    layer_idx,
+                                    routes,
+                                    previous_moe_topk_by_layer
+                                        .get(layer_idx)
+                                        .map(Vec::as_slice)
+                                        .unwrap_or(&[]),
+                                );
+                            }
+                            for route in routes {
+                                let expert_idx = route.expert_idx;
+                                let gate_up = MoeExpertKey {
+                                    layer_idx,
+                                    expert_idx,
+                                    projection: MoeExpertProjection::GateUp,
+                                };
+                                let down = MoeExpertKey {
+                                    layer_idx,
+                                    expert_idx,
+                                    projection: MoeExpertProjection::Down,
+                                };
+                                manager.ensure_resident(&store, gate_up)?;
+                                manager.ensure_resident(&store, down)?;
+                            }
+                            if track_moe_routes {
+                                if let Some(slot) = next_moe_topk_by_layer.get_mut(layer_idx) {
+                                    slot.clear();
+                                    slot.extend(routes.iter().map(|route| route.expert_idx));
+                                }
+                            }
+                        }
+                    }
+                    Ok(())
+                };
                 scratch
                     .run_sparse_with_expert_prefetch(
                         ordinal,
@@ -2868,52 +2964,71 @@ fn decode_text(
             lm_head_folded = false;
             drop(fold);
             if let Some(manager) = _moe_expert_residency.as_mut() {
-                let mut prefetch =
-                    |phase: ExpertPrefetchPhase, layer_idx: usize, topk: &[usize]| -> Result<()> {
-                        let experts = match phase {
-                            ExpertPrefetchPhase::Lookahead
-                                if moe_prefetch_mode == MoeIslandPrefetchMode::PreviousToken =>
-                            {
-                                previous_moe_topk_by_layer
-                                    .get(layer_idx)
-                                    .map(Vec::as_slice)
-                                    .unwrap_or(&[])
-                            }
-                            ExpertPrefetchPhase::Lookahead => &[],
-                            ExpertPrefetchPhase::Demand => topk,
-                        };
-                        for &expert_idx in experts {
-                            let gate_up = MoeExpertKey {
-                                layer_idx,
-                                expert_idx,
-                                projection: MoeExpertProjection::GateUp,
-                            };
-                            let down = MoeExpertKey {
-                                layer_idx,
-                                expert_idx,
-                                projection: MoeExpertProjection::Down,
-                            };
-                            match phase {
-                                ExpertPrefetchPhase::Lookahead => {
-                                    manager.prefetch_resident(&store, gate_up)?;
-                                    manager.prefetch_resident(&store, down)?;
-                                }
-                                ExpertPrefetchPhase::Demand => {
-                                    manager.ensure_resident(&store, gate_up)?;
-                                    manager.ensure_resident(&store, down)?;
-                                }
-                            }
-                        }
-                        if phase == ExpertPrefetchPhase::Demand
-                            && moe_prefetch_mode == MoeIslandPrefetchMode::PreviousToken
+                let mut prefetch = |phase: ExpertPrefetchPhase,
+                                    layer_idx: usize,
+                                    routes: &[ExpertRoute]|
+                 -> Result<()> {
+                    match phase {
+                        ExpertPrefetchPhase::Lookahead
+                            if moe_prefetch_mode == MoeIslandPrefetchMode::PreviousToken =>
                         {
-                            if let Some(slot) = next_moe_topk_by_layer.get_mut(layer_idx) {
-                                slot.clear();
-                                slot.extend_from_slice(topk);
+                            for &expert_idx in previous_moe_topk_by_layer
+                                .get(layer_idx)
+                                .map(Vec::as_slice)
+                                .unwrap_or(&[])
+                            {
+                                let gate_up = MoeExpertKey {
+                                    layer_idx,
+                                    expert_idx,
+                                    projection: MoeExpertProjection::GateUp,
+                                };
+                                let down = MoeExpertKey {
+                                    layer_idx,
+                                    expert_idx,
+                                    projection: MoeExpertProjection::Down,
+                                };
+                                manager.prefetch_resident(&store, gate_up)?;
+                                manager.prefetch_resident(&store, down)?;
                             }
                         }
-                        Ok(())
-                    };
+                        ExpertPrefetchPhase::Lookahead => {}
+                        ExpertPrefetchPhase::Demand => {
+                            if let Some(route_telemetry) = moe_route_telemetry.as_mut() {
+                                route_telemetry.record(
+                                    manager,
+                                    layer_idx,
+                                    routes,
+                                    previous_moe_topk_by_layer
+                                        .get(layer_idx)
+                                        .map(Vec::as_slice)
+                                        .unwrap_or(&[]),
+                                );
+                            }
+                            for route in routes {
+                                let expert_idx = route.expert_idx;
+                                let gate_up = MoeExpertKey {
+                                    layer_idx,
+                                    expert_idx,
+                                    projection: MoeExpertProjection::GateUp,
+                                };
+                                let down = MoeExpertKey {
+                                    layer_idx,
+                                    expert_idx,
+                                    projection: MoeExpertProjection::Down,
+                                };
+                                manager.ensure_resident(&store, gate_up)?;
+                                manager.ensure_resident(&store, down)?;
+                            }
+                            if track_moe_routes {
+                                if let Some(slot) = next_moe_topk_by_layer.get_mut(layer_idx) {
+                                    slot.clear();
+                                    slot.extend(routes.iter().map(|route| route.expert_idx));
+                                }
+                            }
+                        }
+                    }
+                    Ok(())
+                };
                 run_chained_decode_fast_with_expert_prefetch(
                     ordinal,
                     &geom,
@@ -2935,7 +3050,7 @@ fn decode_text(
             }
             .with_context(|| format!("chained decode (step {step}, position {position})"))?
         };
-        if moe_prefetch_mode == MoeIslandPrefetchMode::PreviousToken {
+        if track_moe_routes {
             previous_moe_topk_by_layer = next_moe_topk_by_layer;
         }
         if let (Some(telemetry), Some(before), Some(manager)) = (
@@ -3453,7 +3568,12 @@ fn decode_text(
                 total_resident_bytes as f64 / MIB,
                 total_reserved_bytes as f64 / MIB,
             );
-            telemetry.write_json(manager, virtual_kv_stats, &generated_ids)?;
+            telemetry.write_json(
+                manager,
+                virtual_kv_stats,
+                &generated_ids,
+                moe_route_telemetry.as_ref(),
+            )?;
         } else {
             println!(
                 "  [vmm] MoE island residency: resident_slices={} resident_pages={} \

--- a/crates/runner/src/qwen36_moe_persistent_decode.rs
+++ b/crates/runner/src/qwen36_moe_persistent_decode.rs
@@ -47,8 +47,9 @@ pub struct LmHeadFold<'a> {
 }
 
 use crate::qwen36_moe_decode::{
-    ffn_workspace_floats, full_attn_workspace_floats, linear_attn_workspace_floats,
-    AttnLayerBuffers, DecodeOutputs, ExpertPrefetchPhase, LayerBuffers, MultiLayerGeom,
+    bf16_bytes_to_f32, ffn_workspace_floats, full_attn_workspace_floats,
+    linear_attn_workspace_floats, AttnLayerBuffers, DecodeOutputs, ExpertPrefetchPhase,
+    ExpertRoute, LayerBuffers, MultiLayerGeom,
 };
 
 /// Pre-allocated scratch + cached descriptor arrays for the persistent
@@ -286,7 +287,7 @@ impl PersistentScratch {
         mut prefetch: F,
     ) -> Result<DecodeOutputs>
     where
-        F: FnMut(ExpertPrefetchPhase, usize, &[usize]) -> Result<()>,
+        F: FnMut(ExpertPrefetchPhase, usize, &[ExpertRoute]) -> Result<()>,
     {
         let hidden_bytes = self.geom.hidden as usize * 2;
         if initial_hidden_bytes.len() != hidden_bytes {
@@ -331,10 +332,10 @@ impl PersistentScratch {
             .map_err(|e: GpuError| anyhow!(e))
             .with_context(|| format!("persistent router-only launch (layer {layer_idx})"))?;
 
-            let topk = self
-                .download_topk_indices(ordinal)
-                .with_context(|| format!("download FFN top-k indices (layer {layer_idx})"))?;
-            prefetch(ExpertPrefetchPhase::Demand, layer_idx, &topk)
+            let routes = self
+                .download_topk_routes(ordinal)
+                .with_context(|| format!("download FFN top-k routes (layer {layer_idx})"))?;
+            prefetch(ExpertPrefetchPhase::Demand, layer_idx, &routes)
                 .with_context(|| format!("prefetch routed experts (layer {layer_idx})"))?;
 
             persistent_decode_launch_range(
@@ -391,6 +392,30 @@ impl PersistentScratch {
         )
         .context("d2h ffn_topk_idx_scratch")?;
         Ok(host.into_iter().map(|idx| idx as usize).collect())
+    }
+
+    fn download_topk_routes(&self, ordinal: usize) -> Result<Vec<ExpertRoute>> {
+        let top_k = self.geom.top_k as usize;
+        let idx = self.download_topk_indices(ordinal)?;
+        let mut weight_bytes = vec![0u8; top_k * std::mem::size_of::<u16>()];
+        copy_d2h(
+            ordinal,
+            weight_bytes.as_mut_ptr() as *mut _,
+            self.hidden_ping.as_ptr(),
+            weight_bytes.len(),
+        )
+        .context("d2h ffn top-k route weights")?;
+        let weights = bf16_bytes_to_f32(&weight_bytes);
+        Ok(idx
+            .into_iter()
+            .zip(weights)
+            .enumerate()
+            .map(|(rank, (expert_idx, weight))| ExpertRoute {
+                rank,
+                expert_idx,
+                weight,
+            })
+            .collect())
     }
 }
 

--- a/docs/lowlevel-memory.md
+++ b/docs/lowlevel-memory.md
@@ -99,7 +99,9 @@ Current scope:
   loading a hard error.
 - `SUPERSONIC_MOE_ISLAND_CAP_EXPERTS=N` switches Qwen3.6-MoE INT4 decode from
   fully resident virtual expert slabs to sparse router-prefetched islands with
-  at most `N` experts' two routed projections tracked resident at once.
+  at most `N` experts' two routed projections tracked resident at once. Sparse
+  telemetry records ordered router rank summaries, including per-rank resident
+  hits before demand loading, previous-token repeats, and average router weight.
 - `SUPERSONIC_MOE_ISLAND_PREFETCH=previous-token` enables experimental
   previous-token routed-expert lookahead for sparse MoE islands. It preloads
   each layer's previous top-k before that layer's router runs, then records

--- a/oracle/qwen36_verify_suite.py
+++ b/oracle/qwen36_verify_suite.py
@@ -352,6 +352,7 @@ def load_vmm_residency(path: Path) -> dict[str, Any]:
         "prefetch_page_hits",
         "prefetch_page_misses",
         "prefetch_uploaded_bytes",
+        "route_summary",
     ]
     return {k: summary[k] for k in keys if k in summary}
 

--- a/tests/gfx1100/bench_qwen36_sparse_caps.py
+++ b/tests/gfx1100/bench_qwen36_sparse_caps.py
@@ -75,6 +75,14 @@ def fmt_num(value: float | int | None, digits: int = 2) -> str:
     return f"{float(value):.{digits}f}"
 
 
+def fmt_rank_pct(route_summary: dict[str, Any], key: str, rank: int = 0) -> str:
+    observations = route_summary.get("observations_by_rank") or []
+    values = route_summary.get(key) or []
+    if rank >= len(observations) or rank >= len(values) or not observations[rank]:
+        return "-"
+    return f"{100.0 * float(values[rank]) / float(observations[rank]):.1f}%"
+
+
 def run_case(
     args: argparse.Namespace,
     label: str,
@@ -163,15 +171,16 @@ def run_case(
 
 def markdown(rows: list[dict[str, Any]]) -> str:
     out = [
-        "| Mode | total ms/tok | tok/s | total resident GiB | MoE resident GiB | KV resident GiB | peak pages | page misses | prefetch page misses | evicted pages | ids match |",
-        "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:---:|",
+        "| Mode | total ms/tok | tok/s | total resident GiB | MoE resident GiB | KV resident GiB | peak pages | page misses | prefetch page misses | rank0 resident | rank0 repeat | evicted pages | ids match |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|:---:|",
     ]
     for row in rows:
         residency = row.get("vmm_residency") or {}
+        route_summary = residency.get("route_summary") or {}
         stage = row.get("stage") or {}
         ids_match = row.get("generated_ids_match")
         out.append(
-            "| {label} | {ms} | {tok} | {total_gib} | {moe_gib} | {kv_gib} | {peak_pages} | {page_misses} | {prefetch_page_misses} | {evicted_pages} | {ids_match} |".format(
+            "| {label} | {ms} | {tok} | {total_gib} | {moe_gib} | {kv_gib} | {peak_pages} | {page_misses} | {prefetch_page_misses} | {rank0_resident} | {rank0_repeat} | {evicted_pages} | {ids_match} |".format(
                 label=row["label"],
                 ms=fmt_num(stage.get("total_ms_avg")),
                 tok=fmt_num(row.get("tok_per_s")),
@@ -181,6 +190,8 @@ def markdown(rows: list[dict[str, Any]]) -> str:
                 peak_pages=residency.get("peak_resident_pages", "-"),
                 page_misses=residency.get("page_misses", "-"),
                 prefetch_page_misses=residency.get("prefetch_page_misses", "-"),
+                rank0_resident=fmt_rank_pct(route_summary, "resident_before_by_rank"),
+                rank0_repeat=fmt_rank_pct(route_summary, "repeated_previous_by_rank"),
                 evicted_pages=residency.get("evicted_pages", "-"),
                 ids_match="yes" if ids_match else "NO",
             )

--- a/tests/test_qwen36_verify_suite.py
+++ b/tests/test_qwen36_verify_suite.py
@@ -211,6 +211,10 @@ class Qwen36VerifySuiteTests(unittest.TestCase):
                     "moe_resident_bytes": 10,
                     "kv_resident_bytes": 3,
                     "total_vmm_resident_bytes": 13,
+                    "route_summary": {
+                        "observations_by_rank": [2],
+                        "resident_before_by_rank": [1],
+                    },
                     "unrelated": "ignored",
                 }
             }))
@@ -221,6 +225,10 @@ class Qwen36VerifySuiteTests(unittest.TestCase):
                     "moe_resident_bytes": 10,
                     "kv_resident_bytes": 3,
                     "total_vmm_resident_bytes": 13,
+                    "route_summary": {
+                        "observations_by_rank": [2],
+                        "resident_before_by_rank": [1],
+                    },
                 },
             )
 


### PR DESCRIPTION
## Summary
- carry ordered MoE router routes through the sparse expert prefetch callback, including rank, expert index, and BF16 router weight
- record sparse VMM route summaries in telemetry JSON: observations by rank, resident-before-demand hits, previous-token repeats, and average route weight
- surface rank-0 residency/repeat percentages in the sparse cap benchmark markdown and keep the verify-suite loader aware of the new field

## Validation
- cargo fmt --check
- git diff --check
- python3 -m py_compile tests/gfx1100/bench_qwen36_sparse_caps.py oracle/qwen36_verify_suite.py
- python3 -m unittest tests.test_qwen36_verify_suite
- cargo check -p runner
- cargo test -p runner qwen36_moe_residency --lib
- HIP smoke: Qwen3.6-35B-A3B INT4 sparse MoE VMM, cap=320, 6 prompt + 2 generated tokens -> generated ids [279, 15217]

## HIP smoke route summary
- observations_by_rank: [280, 280, 280, 280, 280, 280, 280, 280]
- resident_before_by_rank: [131, 115, 98, 78, 65, 67, 57, 46]
- repeated_previous_by_rank: [131, 113, 98, 77, 63, 67, 54, 46]
- avg_weight_by_rank: [0.29877, 0.16111, 0.12226, 0.10114, 0.08970, 0.08121, 0.07541, 0.07041]