### PR TITLE
Add rank-limited MoE prefetch policy

### DIFF
--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -1128,6 +1128,45 @@ impl MoeIslandPrefetchMode {
     }
 }
 
+fn moe_island_prefetch_ranks_from_env_value(
+    raw: Option<&str>,
+    mode: MoeIslandPrefetchMode,
+    top_k: usize,
+) -> Result<usize> {
+    match mode {
+        MoeIslandPrefetchMode::Disabled => {
+            if raw.is_some() {
+                anyhow::bail!(
+                    "SUPERSONIC_MOE_ISLAND_PREFETCH_RANKS requires \
+                     SUPERSONIC_MOE_ISLAND_PREFETCH=previous-token"
+                );
+            }
+            Ok(0)
+        }
+        MoeIslandPrefetchMode::PreviousToken => match raw {
+            None | Some("all") => Ok(top_k),
+            Some(value) => {
+                let ranks = value.parse::<usize>().with_context(|| {
+                    format!(
+                        "parse SUPERSONIC_MOE_ISLAND_PREFETCH_RANKS={value:?} as positive integer"
+                    )
+                })?;
+                if ranks == 0 || ranks > top_k {
+                    anyhow::bail!(
+                        "SUPERSONIC_MOE_ISLAND_PREFETCH_RANKS must be in 1..={top_k}; got {ranks}"
+                    );
+                }
+                Ok(ranks)
+            }
+        },
+    }
+}
+
+fn moe_island_prefetch_ranks_from_env(mode: MoeIslandPrefetchMode, top_k: usize) -> Result<usize> {
+    let raw = std::env::var("SUPERSONIC_MOE_ISLAND_PREFETCH_RANKS").ok();
+    moe_island_prefetch_ranks_from_env_value(raw.as_deref(), mode, top_k)
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Qwen36KvVmmMode {
     Auto,
@@ -1229,6 +1268,7 @@ struct MoeSparseTelemetry {
     dump_path: Option<PathBuf>,
     decode_path: &'static str,
     prefetch_mode: MoeIslandPrefetchMode,
+    prefetch_ranks: usize,
     steps: Vec<serde_json::Value>,
     peak_resident_slices: usize,
     peak_resident_pages: usize,
@@ -1314,6 +1354,7 @@ impl MoeSparseTelemetry {
         active: bool,
         persistent_decode: bool,
         prefetch_mode: MoeIslandPrefetchMode,
+        prefetch_ranks: usize,
     ) -> Result<Option<Self>> {
         if !active {
             return Ok(None);
@@ -1327,6 +1368,7 @@ impl MoeSparseTelemetry {
                 "chained"
             },
             prefetch_mode,
+            prefetch_ranks,
             steps: Vec::new(),
             peak_resident_slices: 0,
             peak_resident_pages: 0,
@@ -1430,6 +1472,7 @@ impl MoeSparseTelemetry {
             "summary": {
                 "decode_path": self.decode_path,
                 "prefetch_mode": self.prefetch_mode.as_str(),
+                "prefetch_ranks": self.prefetch_ranks,
                 "registered_tensors": final_snapshot.stats.registered_tensors,
                 "max_resident_pages": manager.max_resident_pages(),
                 "final_resident_slices": final_snapshot.stats.resident_slices,
@@ -2397,11 +2440,17 @@ fn decode_text(
     let mut _moe_expert_residency = None;
     let sparse_moe_requested = moe_island_cap_experts.is_some();
     let moe_prefetch_mode = MoeIslandPrefetchMode::from_env()?;
+    let moe_prefetch_ranks =
+        moe_island_prefetch_ranks_from_env(moe_prefetch_mode, geom.top_k as usize)?;
     if moe_prefetch_mode != MoeIslandPrefetchMode::Disabled && !sparse_moe_requested {
         anyhow::bail!("SUPERSONIC_MOE_ISLAND_PREFETCH requires SUPERSONIC_MOE_ISLAND_CAP_EXPERTS");
     }
-    let mut moe_sparse_telemetry =
-        MoeSparseTelemetry::from_env(sparse_moe_requested, persistent_decode, moe_prefetch_mode)?;
+    let mut moe_sparse_telemetry = MoeSparseTelemetry::from_env(
+        sparse_moe_requested,
+        persistent_decode,
+        moe_prefetch_mode,
+        moe_prefetch_ranks,
+    )?;
     if let Some(path) = moe_sparse_telemetry
         .as_ref()
         .and_then(|telemetry| telemetry.dump_path.as_ref())
@@ -2464,7 +2513,11 @@ fn decode_text(
             );
         }
         if moe_prefetch_mode == MoeIslandPrefetchMode::PreviousToken {
-            println!("  [vmm] sparse MoE previous-token lookahead prefetch active");
+            println!(
+                "  [vmm] sparse MoE previous-token lookahead prefetch active \
+                 (ranks={moe_prefetch_ranks}/{})",
+                geom.top_k
+            );
         }
         _moe_expert_residency = Some(manager);
         layers
@@ -2885,6 +2938,8 @@ fn decode_text(
                                 .get(layer_idx)
                                 .map(Vec::as_slice)
                                 .unwrap_or(&[])
+                                .iter()
+                                .take(moe_prefetch_ranks)
                             {
                                 let gate_up = MoeExpertKey {
                                     layer_idx,
@@ -2976,6 +3031,8 @@ fn decode_text(
                                 .get(layer_idx)
                                 .map(Vec::as_slice)
                                 .unwrap_or(&[])
+                                .iter()
+                                .take(moe_prefetch_ranks)
                             {
                                 let gate_up = MoeExpertKey {
                                     layer_idx,
@@ -3851,7 +3908,10 @@ fn decode_first_token(model_dir: &Path, report: &DryRunReport, kv_fp8: bool) -> 
 
 #[cfg(test)]
 mod tests {
-    use super::{qwen36_kv_vmm_mode_from_env_value, Qwen36KvVmmMode};
+    use super::{
+        moe_island_prefetch_ranks_from_env_value, qwen36_kv_vmm_mode_from_env_value,
+        MoeIslandPrefetchMode, Qwen36KvVmmMode,
+    };
     use gpu_hal::Backend;
 
     #[test]
@@ -3881,5 +3941,76 @@ mod tests {
             Qwen36KvVmmMode::Force
         );
         assert!(qwen36_kv_vmm_mode_from_env_value(Some("yes"), Backend::Hip).is_err());
+    }
+
+    #[test]
+    fn moe_prefetch_ranks_default_to_all_previous_token_routes() {
+        assert_eq!(
+            moe_island_prefetch_ranks_from_env_value(
+                None,
+                MoeIslandPrefetchMode::PreviousToken,
+                8,
+            )
+            .unwrap(),
+            8
+        );
+        assert_eq!(
+            moe_island_prefetch_ranks_from_env_value(
+                Some("all"),
+                MoeIslandPrefetchMode::PreviousToken,
+                8,
+            )
+            .unwrap(),
+            8
+        );
+    }
+
+    #[test]
+    fn moe_prefetch_ranks_accept_rank_limited_previous_token_routes() {
+        assert_eq!(
+            moe_island_prefetch_ranks_from_env_value(
+                Some("1"),
+                MoeIslandPrefetchMode::PreviousToken,
+                8,
+            )
+            .unwrap(),
+            1
+        );
+        assert_eq!(
+            moe_island_prefetch_ranks_from_env_value(
+                Some("4"),
+                MoeIslandPrefetchMode::PreviousToken,
+                8,
+            )
+            .unwrap(),
+            4
+        );
+    }
+
+    #[test]
+    fn moe_prefetch_ranks_reject_disabled_or_out_of_range_values() {
+        assert_eq!(
+            moe_island_prefetch_ranks_from_env_value(None, MoeIslandPrefetchMode::Disabled, 8)
+                .unwrap(),
+            0
+        );
+        assert!(moe_island_prefetch_ranks_from_env_value(
+            Some("1"),
+            MoeIslandPrefetchMode::Disabled,
+            8,
+        )
+        .is_err());
+        assert!(moe_island_prefetch_ranks_from_env_value(
+            Some("0"),
+            MoeIslandPrefetchMode::PreviousToken,
+            8,
+        )
+        .is_err());
+        assert!(moe_island_prefetch_ranks_from_env_value(
+            Some("9"),
+            MoeIslandPrefetchMode::PreviousToken,
+            8,
+        )
+        .is_err());
     }
 }

--- a/docs/lowlevel-memory.md
+++ b/docs/lowlevel-memory.md
@@ -104,9 +104,12 @@ Current scope:
   hits before demand loading, previous-token repeats, and average router weight.
 - `SUPERSONIC_MOE_ISLAND_PREFETCH=previous-token` enables experimental
   previous-token routed-expert lookahead for sparse MoE islands. It preloads
-  each layer's previous top-k before that layer's router runs, then records
-  prefetch hit/miss/page counters in the sparse telemetry JSON. This is a
-  measurement hook for future overlapped prefetch work, not a default path.
+  each layer's previous top-k before that layer's router runs. Set
+  `SUPERSONIC_MOE_ISLAND_PREFETCH_RANKS=N` to prefetch only the first N ordered
+  router ranks, for example N=1 for rank-0-only lookahead. Sparse telemetry
+  records the effective prefetch rank count plus prefetch hit/miss/page
+  counters. This is a measurement hook for future overlapped prefetch work, not
+  a default path.
 - `SUPERSONIC_VMM_KV=0` disables the Qwen3.5 and Qwen3.6 KV integrations.
 - `SUPERSONIC_VMM_KV=1` requests KV VMM and logs if the backend cannot support
   it. HIP may auto-enable when unset; CUDA requires this explicit opt-in.

--- a/oracle/qwen36_verify_suite.py
+++ b/oracle/qwen36_verify_suite.py
@@ -334,6 +334,7 @@ def load_vmm_residency(path: Path) -> dict[str, Any]:
     keys = [
         "decode_path",
         "prefetch_mode",
+        "prefetch_ranks",
         "max_resident_pages",
         "final_resident_pages",
         "peak_resident_pages",

--- a/tests/gfx1100/bench_qwen36_sparse_caps.py
+++ b/tests/gfx1100/bench_qwen36_sparse_caps.py
@@ -96,12 +96,15 @@ def run_case(
     env.pop("SUPERSONIC_MOE_ISLAND_CAP_EXPERTS", None)
     env.pop("SUPERSONIC_MOE_ISLAND_TELEMETRY_JSON", None)
     env.pop("SUPERSONIC_MOE_ISLAND_PREFETCH", None)
+    env.pop("SUPERSONIC_MOE_ISLAND_PREFETCH_RANKS", None)
     telemetry_path = tmp / f"{label}_telemetry.json"
     if cap is not None:
         env["SUPERSONIC_MOE_ISLAND_CAP_EXPERTS"] = str(cap)
         env["SUPERSONIC_MOE_ISLAND_TELEMETRY_JSON"] = str(telemetry_path)
         if args.prefetch:
             env["SUPERSONIC_MOE_ISLAND_PREFETCH"] = args.prefetch
+        if args.prefetch_ranks is not None:
+            env["SUPERSONIC_MOE_ISLAND_PREFETCH_RANKS"] = str(args.prefetch_ranks)
 
     cmd = [
         str(args.binary),
@@ -171,8 +174,8 @@ def run_case(
 
 def markdown(rows: list[dict[str, Any]]) -> str:
     out = [
-        "| Mode | total ms/tok | tok/s | total resident GiB | MoE resident GiB | KV resident GiB | peak pages | page misses | prefetch page misses | rank0 resident | rank0 repeat | evicted pages | ids match |",
-        "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|:---:|",
+        "| Mode | total ms/tok | tok/s | total resident GiB | MoE resident GiB | KV resident GiB | prefetch ranks | peak pages | page misses | prefetch page misses | rank0 resident | rank0 repeat | evicted pages | ids match |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|:---:|",
     ]
     for row in rows:
         residency = row.get("vmm_residency") or {}
@@ -180,13 +183,14 @@ def markdown(rows: list[dict[str, Any]]) -> str:
         stage = row.get("stage") or {}
         ids_match = row.get("generated_ids_match")
         out.append(
-            "| {label} | {ms} | {tok} | {total_gib} | {moe_gib} | {kv_gib} | {peak_pages} | {page_misses} | {prefetch_page_misses} | {rank0_resident} | {rank0_repeat} | {evicted_pages} | {ids_match} |".format(
+            "| {label} | {ms} | {tok} | {total_gib} | {moe_gib} | {kv_gib} | {prefetch_ranks} | {peak_pages} | {page_misses} | {prefetch_page_misses} | {rank0_resident} | {rank0_repeat} | {evicted_pages} | {ids_match} |".format(
                 label=row["label"],
                 ms=fmt_num(stage.get("total_ms_avg")),
                 tok=fmt_num(row.get("tok_per_s")),
                 total_gib=fmt_gib(residency.get("total_vmm_resident_bytes")),
                 moe_gib=fmt_gib(residency.get("moe_resident_bytes")),
                 kv_gib=fmt_gib(residency.get("kv_resident_bytes")),
+                prefetch_ranks=residency.get("prefetch_ranks", "-"),
                 peak_pages=residency.get("peak_resident_pages", "-"),
                 page_misses=residency.get("page_misses", "-"),
                 prefetch_page_misses=residency.get("prefetch_page_misses", "-"),
@@ -218,10 +222,17 @@ def main() -> int:
         choices=["previous-token"],
         help="set SUPERSONIC_MOE_ISLAND_PREFETCH for sparse cap rows",
     )
+    parser.add_argument(
+        "--prefetch-ranks",
+        type=int,
+        help="set SUPERSONIC_MOE_ISLAND_PREFETCH_RANKS for sparse cap rows",
+    )
     parser.add_argument("--out-json", type=Path, default=Path("target/qwen36_sparse_cap_sweep.json"))
     parser.add_argument("--out-md", type=Path, default=Path("target/qwen36_sparse_cap_sweep.md"))
     args = parser.parse_args()
 
+    if args.prefetch_ranks is not None and not args.prefetch:
+        parser.error("--prefetch-ranks requires --prefetch previous-token")
     if not args.binary.exists():
         raise FileNotFoundError(args.binary)
     if not args.model_dir.exists():

--- a/tests/test_qwen36_verify_suite.py
+++ b/tests/test_qwen36_verify_suite.py
@@ -208,6 +208,7 @@ class Qwen36VerifySuiteTests(unittest.TestCase):
             path.write_text(json.dumps({
                 "summary": {
                     "decode_path": "segmented_persistent",
+                    "prefetch_ranks": 1,
                     "moe_resident_bytes": 10,
                     "kv_resident_bytes": 3,
                     "total_vmm_resident_bytes": 13,
@@ -222,6 +223,7 @@ class Qwen36VerifySuiteTests(unittest.TestCase):
                 load_vmm_residency(path),
                 {
                     "decode_path": "segmented_persistent",
+                    "prefetch_ranks": 1,
                     "moe_resident_bytes": 10,
                     "kv_resident_bytes": 3,
                     "total_vmm_resident_bytes": 13,


### PR DESCRIPTION
## Summary
- add SUPERSONIC_MOE_ISLAND_PREFETCH_RANKS for previous-token sparse MoE lookahead
- include the effective prefetch rank count in sparse VMM telemetry and verify-suite summaries
- extend the gfx1100 sparse cap sweep with --prefetch-ranks and a markdown prefetch-ranks column

## Notes
The default previous-token policy remains unchanged: when SUPERSONIC_MOE_ISLAND_PREFETCH=previous-token is set and ranks are unset, all top-k routes are prefetched. Setting SUPERSONIC_MOE_ISLAND_PREFETCH_RANKS=1 enables rank-0-only lookahead for measuring whether the strongest route reuse is worth preloading without touching all top-k experts.

## Validation
- cargo fmt --check
- git diff --check
- python3 -m py_compile tests/gfx1100/bench_qwen36_sparse_caps.py oracle/qwen36_verify_suite.py
- python3 -m unittest tests.test_qwen36_verify_suite
- cargo check -p runner
- cargo test -p runner qwen36_moe_residency --lib
- cargo test -p runner --bin supersonic moe_prefetch_ranks
- HIP smoke: Qwen3.6-35B-A3B INT4 sparse MoE VMM, cap=320, previous-token prefetch ranks=1, generated ids [279, 15217]

## HIP smoke counters
- prefetch_mode: previous-token
- prefetch_ranks: 1
- prefetch_requests: 480
- prefetch_hits: 82
- prefetch_misses: 398
- prefetch_page_misses: 398
- rank0 repeat: 46.8%
- rank0 resident-before-demand: 23.9%

The rank-1 smoke is slower on this tiny prompt, so this PR keeps the policy explicit and measurable rather than changing defaults.