### PR TITLE
[codex] deduplicate runner tensor byte helpers

### DIFF
--- a/crates/runner/src/bin/gemma4_batched_divergent_test.rs
+++ b/crates/runner/src/bin/gemma4_batched_divergent_test.rs
@@ -39,6 +39,8 @@ use clap::Parser;
 mod gemma4_engine;
 #[path = "../gemma4_int4_engine.rs"]
 mod gemma4_int4_engine;
+#[path = "../tensor_bytes.rs"]
+mod tensor_bytes;
 use gemma4_engine::Gemma4Engine;
 use gemma4_int4_engine::Gemma4Int4Engine;
 

--- a/crates/runner/src/bin/gemma4_corpus_test.rs
+++ b/crates/runner/src/bin/gemma4_corpus_test.rs
@@ -32,6 +32,8 @@ use serde::Deserialize;
 mod gemma4_engine;
 #[path = "../gemma4_int4_engine.rs"]
 mod gemma4_int4_engine;
+#[path = "../tensor_bytes.rs"]
+mod tensor_bytes;
 use gemma4_engine::Gemma4Engine;
 use gemma4_int4_engine::Gemma4Int4Engine;
 

--- a/crates/runner/src/bin/gemma4_fused_int4_validate.rs
+++ b/crates/runner/src/bin/gemma4_fused_int4_validate.rs
@@ -28,6 +28,8 @@ use tokenizers::Tokenizer;
 
 #[path = "../gemma4_int4_engine.rs"]
 mod gemma4_int4_engine;
+#[path = "../tensor_bytes.rs"]
+mod tensor_bytes;
 use gemma4_int4_engine::{int4_bake_ok, Gemma4Int4Engine};
 
 #[derive(Parser, Debug)]

--- a/crates/runner/src/bin/gemma4_int4_layer_diag.rs
+++ b/crates/runner/src/bin/gemma4_int4_layer_diag.rs
@@ -38,6 +38,8 @@ use tokenizers::Tokenizer;
 mod gemma4_engine;
 #[path = "../gemma4_int4_engine.rs"]
 mod gemma4_int4_engine;
+#[path = "../tensor_bytes.rs"]
+mod tensor_bytes;
 use gemma4_engine::Gemma4Engine;
 use gemma4_int4_engine::{int4_bake_ok, Gemma4Int4Engine};
 

--- a/crates/runner/src/gemma4_engine.rs
+++ b/crates/runner/src/gemma4_engine.rs
@@ -29,20 +29,7 @@ use kernel_ffi::gemma4::{
 use memmap2::Mmap;
 use safetensors::SafeTensors;
 
-fn bf16_bytes_to_f32(bytes: &[u8]) -> Vec<f32> {
-    bytes
-        .chunks_exact(2)
-        .map(|c| bf16::from_bits(u16::from_le_bytes([c[0], c[1]])).to_f32())
-        .collect()
-}
-
-fn f32_to_bf16_bytes(vals: &[f32]) -> Vec<u8> {
-    let mut out = Vec::with_capacity(vals.len() * 2);
-    for &v in vals {
-        out.extend_from_slice(&bf16::from_f32(v).to_bits().to_le_bytes());
-    }
-    out
-}
+use crate::tensor_bytes::{bf16_bytes_to_f32, f32_to_bf16_bytes};
 
 fn upload_bf16(device: usize, shape: &[usize], host: &[f32]) -> Result<GpuBuffer> {
     let bytes = f32_to_bf16_bytes(host);

--- a/crates/runner/src/gemma4_int4_engine.rs
+++ b/crates/runner/src/gemma4_int4_engine.rs
@@ -28,20 +28,7 @@ use kernel_ffi::gemma4 as g4;
 use kernel_ffi::gemma4::{Gemma4BatchSeqDesc, Gemma4DecodeLayerDesc, Gemma4Int4ScaleDesc};
 use model_store::BakedStore;
 
-fn bf16_bytes_to_f32(bytes: &[u8]) -> Vec<f32> {
-    bytes
-        .chunks_exact(2)
-        .map(|c| bf16::from_bits(u16::from_le_bytes([c[0], c[1]])).to_f32())
-        .collect()
-}
-
-fn f32_to_bf16_bytes(vals: &[f32]) -> Vec<u8> {
-    let mut out = Vec::with_capacity(vals.len() * 2);
-    for &v in vals {
-        out.extend_from_slice(&bf16::from_f32(v).to_bits().to_le_bytes());
-    }
-    out
-}
+use crate::tensor_bytes::{bf16_bytes_to_f32, f32_to_bf16_bytes};
 
 fn upload_bf16(device: usize, shape: &[usize], host: &[f32]) -> Result<GpuBuffer> {
     let bytes = f32_to_bf16_bytes(host);

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -2485,7 +2485,7 @@ fn trace_persistent_full_attn_layer(
         ordinal,
         gpu_hal::ScalarType::BF16,
         &[1, q_dim],
-        &f32_to_bf16_bytes(native_gated_f32.iter().copied()),
+        &f32_to_bf16_bytes(&native_gated_f32),
     )
     .map_err(|e| anyhow::anyhow!("trace native gated H2D: {e}"))?;
     let mut native_o_proj_gpu = gpu_hal::GpuBuffer::zeros(

--- a/crates/runner/src/prefill_engine.rs
+++ b/crates/runner/src/prefill_engine.rs
@@ -14,6 +14,10 @@ use qwen35::rotary::RotaryTables;
 use qwen35::state::{kv_fp8_bf16_sidecar_enabled, kv_fp8_bf16_sidecar_window_tokens, ModelState};
 use qwen35::weights::Qwen35Weights;
 
+use crate::tensor_bytes::{
+    bf16_bytes_to_f32 as decode_bf16_le, f32_bytes_to_f32 as decode_f32_le,
+    f32_to_bf16_bytes as encode_bf16_le, f32_to_f32_bytes as encode_f32_le,
+};
 use kernel_ffi::prefill_ffi;
 
 /// D2D copy that stays correctly sequenced with pending GPU work when an
@@ -37,42 +41,12 @@ fn copy_d2d_batched(
     }
 }
 
-fn decode_bf16_le(bytes: &[u8]) -> Vec<f32> {
-    bytes
-        .chunks_exact(2)
-        .map(|chunk| bf16::from_le_bytes([chunk[0], chunk[1]]).to_f32())
-        .collect()
-}
-
-fn encode_bf16_le(values: &[f32]) -> Vec<u8> {
-    let mut out = Vec::with_capacity(values.len() * 2);
-    for &v in values {
-        out.extend_from_slice(&bf16::from_f32(v).to_le_bytes());
-    }
-    out
-}
-
-fn encode_f32_le(values: &[f32]) -> Vec<u8> {
-    let mut out = Vec::with_capacity(values.len() * 4);
-    for &v in values {
-        out.extend_from_slice(&v.to_le_bytes());
-    }
-    out
-}
-
 fn encode_u32_le(values: &[usize]) -> Vec<u8> {
     let mut out = Vec::with_capacity(values.len() * 4);
     for &v in values {
         out.extend_from_slice(&(v as u32).to_le_bytes());
     }
     out
-}
-
-fn decode_f32_le(bytes: &[u8]) -> Vec<f32> {
-    bytes
-        .chunks_exact(4)
-        .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
-        .collect()
 }
 
 fn detect_outlier_cols(lhs_bf16: &[f32], rows: usize, cols: usize, threshold: f32) -> Vec<usize> {

--- a/crates/runner/src/qwen35_runtime.rs
+++ b/crates/runner/src/qwen35_runtime.rs
@@ -762,21 +762,21 @@ pub(crate) fn trace_qwen35_oracle_prefill_layer(
                 ordinal,
                 gpu_hal::ScalarType::BF16,
                 &[num_heads, 1, head_dim],
-                &f32_to_bf16_bytes(q_rope_host.iter().copied()),
+                &f32_to_bf16_bytes(&q_rope_host),
             )
             .map_err(|e| anyhow::anyhow!("trace direct attn q H2D: {e}"))?;
             let k_gpu = gpu_hal::GpuBuffer::from_host_bytes(
                 ordinal,
                 gpu_hal::ScalarType::BF16,
                 &[num_kv_heads, kv_len, head_dim],
-                &f32_to_bf16_bytes(full_k.iter().copied()),
+                &f32_to_bf16_bytes(&full_k),
             )
             .map_err(|e| anyhow::anyhow!("trace direct attn k H2D: {e}"))?;
             let v_gpu = gpu_hal::GpuBuffer::from_host_bytes(
                 ordinal,
                 gpu_hal::ScalarType::BF16,
                 &[num_kv_heads, kv_len, head_dim],
-                &f32_to_bf16_bytes(full_v.iter().copied()),
+                &f32_to_bf16_bytes(&full_v),
             )
             .map_err(|e| anyhow::anyhow!("trace direct attn v H2D: {e}"))?;
             let mut out_gpu = gpu_hal::GpuBuffer::zeros(

--- a/crates/runner/src/qwen36_moe_decode.rs
+++ b/crates/runner/src/qwen36_moe_decode.rs
@@ -37,6 +37,8 @@ use kernel_ffi::qwen36_moe::{
     Qwen36MoeLinearStepParams, Qwen36MoeLinearStepWeights,
 };
 
+use crate::tensor_bytes;
+
 /// Hybrid pattern: every 4th layer is full attention. Indices 3, 7, 11, ...
 /// are full; everything else is linear. Matches Qwen3.6-MoE 35B-A3B.
 pub const HYBRID_FULL_ATTN_STRIDE: i32 = 4;
@@ -1247,13 +1249,7 @@ fn download_topk_routes(
 /// BF16 as raw int16 → bytes; this is the inverse.
 pub fn bf16_bytes_to_f32(bytes: &[u8]) -> Vec<f32> {
     assert!(bytes.len() % 2 == 0, "BF16 bytes must be even");
-    bytes
-        .chunks_exact(2)
-        .map(|c| {
-            let bits = u32::from(c[0]) | (u32::from(c[1]) << 8);
-            f32::from_bits(bits << 16)
-        })
-        .collect()
+    tensor_bytes::bf16_bytes_to_f32(bytes)
 }
 
 /// Round an F32 to BF16 (RNE), returning the 16 raw bits. Matches PyTorch's
@@ -1273,13 +1269,7 @@ pub fn f32_to_bf16_bits(x: f32) -> u16 {
 
 /// Encode a slice of F32 values to BF16 little-endian bytes (RNE).
 pub fn f32_to_bf16_bytes(vals: &[f32]) -> Vec<u8> {
-    let mut out = Vec::with_capacity(vals.len() * 2);
-    for &v in vals {
-        let bits = f32_to_bf16_bits(v);
-        out.push((bits & 0xFF) as u8);
-        out.push((bits >> 8) as u8);
-    }
-    out
+    tensor_bytes::f32_to_bf16_bytes(vals)
 }
 
 /// Apply RMSnorm + lm_head GEMV on the host. Mirrors the multi-layer

--- a/crates/runner/src/tensor_bytes.rs
+++ b/crates/runner/src/tensor_bytes.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 pub fn bf16_bytes_to_f32(bytes: &[u8]) -> Vec<f32> {
     bytes
         .chunks_exact(2)
@@ -12,9 +14,18 @@ pub fn f32_bytes_to_f32(bytes: &[u8]) -> Vec<f32> {
         .collect()
 }
 
-pub fn f32_to_bf16_bytes(values: impl IntoIterator<Item = f32>) -> Vec<u8> {
-    values
-        .into_iter()
-        .flat_map(|value| half::bf16::from_f32(value).to_le_bytes())
-        .collect()
+pub fn f32_to_bf16_bytes(values: &[f32]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(values.len() * 2);
+    for &value in values {
+        out.extend_from_slice(&half::bf16::from_f32(value).to_le_bytes());
+    }
+    out
+}
+
+pub fn f32_to_f32_bytes(values: &[f32]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(values.len() * 4);
+    for &value in values {
+        out.extend_from_slice(&value.to_le_bytes());
+    }
+    out
 }


### PR DESCRIPTION
## Summary

Centralizes common BF16/F32 byte conversion helpers through `runner::tensor_bytes` and updates core runner modules to use them instead of local copies.

Covered in this PR:

- Gemma 4 BF16 and INT4 engines
- Qwen3.5 runtime/main debug call sites
- native prefill engine
- Qwen3.6 public converter wrappers, preserving the existing public function names
- Gemma path-style diagnostic bins that include engine files directly

## Impact

This removes duplicated byte conversion code from core runtime paths and keeps the shared helper available for future cleanup. Remaining duplicates in diagnostic bins, `decode_engine`, `llama31_engine`, and `bughunt` are intentionally left for a later sweep to keep this PR small.

## Validation

- `cargo fmt`
- `cargo check -p runner --bin supersonic --quiet`
- `cargo test -p runner --bin supersonic --quiet`
- `cargo check -p runner --all-targets --quiet`
- `cargo test --workspace --no-fail-fast`