### PR TITLE
Make sparse MoE prefetch non-evicting

### DIFF
--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -1418,6 +1418,8 @@ impl MoeSparseTelemetry {
                 "prefetch_misses": after.stats.prefetch_misses.saturating_sub(before.stats.prefetch_misses),
                 "prefetch_page_hits": after.stats.prefetch_page_hits.saturating_sub(before.stats.prefetch_page_hits),
                 "prefetch_page_misses": after.stats.prefetch_page_misses.saturating_sub(before.stats.prefetch_page_misses),
+                "prefetch_skipped": after.stats.prefetch_skipped.saturating_sub(before.stats.prefetch_skipped),
+                "prefetch_skipped_pages": after.stats.prefetch_skipped_pages.saturating_sub(before.stats.prefetch_skipped_pages),
                 "prefetch_uploaded_bytes": after.stats.prefetch_uploaded_bytes.saturating_sub(before.stats.prefetch_uploaded_bytes),
             },
             "resident": {
@@ -1442,6 +1444,8 @@ impl MoeSparseTelemetry {
                 "prefetch_misses": after.stats.prefetch_misses,
                 "prefetch_page_hits": after.stats.prefetch_page_hits,
                 "prefetch_page_misses": after.stats.prefetch_page_misses,
+                "prefetch_skipped": after.stats.prefetch_skipped,
+                "prefetch_skipped_pages": after.stats.prefetch_skipped_pages,
                 "prefetch_uploaded_bytes": after.stats.prefetch_uploaded_bytes,
             }
         }));
@@ -1514,6 +1518,8 @@ impl MoeSparseTelemetry {
                 "prefetch_misses": final_snapshot.stats.prefetch_misses,
                 "prefetch_page_hits": final_snapshot.stats.prefetch_page_hits,
                 "prefetch_page_misses": final_snapshot.stats.prefetch_page_misses,
+                "prefetch_skipped": final_snapshot.stats.prefetch_skipped,
+                "prefetch_skipped_pages": final_snapshot.stats.prefetch_skipped_pages,
                 "prefetch_uploaded_bytes": final_snapshot.stats.prefetch_uploaded_bytes,
                 "route_summary": route_telemetry.map(MoeRouteTelemetry::to_json),
             },
@@ -3597,6 +3603,7 @@ fn decode_text(
                  hits={} misses={} page_hits={} page_misses={} evicted_slices={} evicted_pages={} \
                  prefetch_requests={} prefetch_hits={} prefetch_misses={} \
                  prefetch_page_hits={} prefetch_page_misses={} \
+                 prefetch_skipped={} prefetch_skipped_pages={} \
                  uploaded={:.2}MiB unmapped={:.2}MiB \
                  resident={:.2}MiB peak_resident={:.2}MiB reserved={:.2}MiB \
                  kv_resident={:.2}MiB total_vmm_resident={:.2}MiB total_vmm_reserved={:.2}MiB",
@@ -3616,6 +3623,8 @@ fn decode_text(
                 residency.prefetch_misses,
                 residency.prefetch_page_hits,
                 residency.prefetch_page_misses,
+                residency.prefetch_skipped,
+                residency.prefetch_skipped_pages,
                 residency.uploaded_bytes as f64 / MIB,
                 residency.unmapped_bytes as f64 / MIB,
                 arena.resident_bytes as f64 / MIB,
@@ -3637,7 +3646,8 @@ fn decode_text(
                  page_backed_slices={} hits={} misses={} page_hits={} page_misses={} \
                  evicted_slices={} evicted_pages={} prefetch_requests={} \
                  prefetch_hits={} prefetch_misses={} prefetch_page_hits={} \
-                 prefetch_page_misses={} uploaded={:.2}MiB unmapped={:.2}MiB \
+                 prefetch_page_misses={} prefetch_skipped={} prefetch_skipped_pages={} \
+                 uploaded={:.2}MiB unmapped={:.2}MiB \
                  resident={:.2}MiB reserved={:.2}MiB kv_resident={:.2}MiB \
                  total_vmm_resident={:.2}MiB total_vmm_reserved={:.2}MiB",
                 residency.resident_slices,
@@ -3654,6 +3664,8 @@ fn decode_text(
                 residency.prefetch_misses,
                 residency.prefetch_page_hits,
                 residency.prefetch_page_misses,
+                residency.prefetch_skipped,
+                residency.prefetch_skipped_pages,
                 residency.uploaded_bytes as f64 / MIB,
                 residency.unmapped_bytes as f64 / MIB,
                 arena.resident_bytes as f64 / MIB,

--- a/crates/runner/src/qwen36_moe_residency.rs
+++ b/crates/runner/src/qwen36_moe_residency.rs
@@ -66,6 +66,8 @@ pub struct MoeExpertResidencyStats {
     pub prefetch_misses: u64,
     pub prefetch_page_hits: u64,
     pub prefetch_page_misses: u64,
+    pub prefetch_skipped: u64,
+    pub prefetch_skipped_pages: u64,
     pub prefetch_uploaded_bytes: usize,
 }
 
@@ -144,6 +146,8 @@ pub struct MoeExpertResidencyManager {
     prefetch_misses: u64,
     prefetch_page_hits: u64,
     prefetch_page_misses: u64,
+    prefetch_skipped: u64,
+    prefetch_skipped_pages: u64,
     prefetch_uploaded_bytes: usize,
 }
 
@@ -176,6 +180,8 @@ impl MoeExpertResidencyManager {
             prefetch_misses: 0,
             prefetch_page_hits: 0,
             prefetch_page_misses: 0,
+            prefetch_skipped: 0,
+            prefetch_skipped_pages: 0,
             prefetch_uploaded_bytes: 0,
         }
     }
@@ -208,6 +214,8 @@ impl MoeExpertResidencyManager {
             prefetch_misses: self.prefetch_misses,
             prefetch_page_hits: self.prefetch_page_hits,
             prefetch_page_misses: self.prefetch_page_misses,
+            prefetch_skipped: self.prefetch_skipped,
+            prefetch_skipped_pages: self.prefetch_skipped_pages,
             prefetch_uploaded_bytes: self.prefetch_uploaded_bytes,
         }
     }
@@ -446,6 +454,17 @@ impl MoeExpertResidencyManager {
             }
         }
 
+        if kind == ResidencyAccessKind::Prefetch {
+            let free_pages = self
+                .config
+                .max_resident_pages
+                .saturating_sub(self.resident_pages.len());
+            if missing_pages.len() > free_pages {
+                self.prefetch_skipped += 1;
+                self.prefetch_skipped_pages += missing_pages.len() as u64;
+                return Ok(());
+            }
+        }
         self.page_misses += missing_pages.len() as u64;
         if kind == ResidencyAccessKind::Prefetch {
             self.prefetch_page_misses += missing_pages.len() as u64;
@@ -921,6 +940,70 @@ mod tests {
                 .expect("read expert 1");
             assert!(bytes.iter().all(|b| *b == 2));
         });
+    }
+
+    #[test]
+    fn prefetch_does_not_evict_when_page_budget_is_full() {
+        with_supported_vmm_backend(
+            "prefetch_does_not_evict_when_page_budget_is_full",
+            |_backend| {
+                let probe_tmp = synthetic_store(1, 4096);
+                let probe_store = BakedStore::open(probe_tmp.path()).expect("open probe store");
+                let mut probe =
+                    MoeExpertResidencyManager::new(0, MoeExpertResidencyConfig::new(1).unwrap());
+                probe
+                    .register_tensor(
+                        &probe_store,
+                        0,
+                        MoeExpertProjection::GateUp,
+                        "model.layers.0.mlp.experts.gate_up_proj",
+                        1,
+                    )
+                    .expect("register probe tensor");
+                let expert_bytes = probe.tensors[0].page_bytes;
+
+                let tmp = synthetic_store(2, expert_bytes);
+                let store = BakedStore::open(tmp.path()).expect("open synthetic store");
+                let mut manager =
+                    MoeExpertResidencyManager::new(0, MoeExpertResidencyConfig::new(1).unwrap());
+                manager
+                    .register_tensor(
+                        &store,
+                        0,
+                        MoeExpertProjection::GateUp,
+                        "model.layers.0.mlp.experts.gate_up_proj",
+                        2,
+                    )
+                    .expect("register tensor");
+
+                let e0 = MoeExpertKey {
+                    layer_idx: 0,
+                    expert_idx: 0,
+                    projection: MoeExpertProjection::GateUp,
+                };
+                let e1 = MoeExpertKey {
+                    layer_idx: 0,
+                    expert_idx: 1,
+                    projection: MoeExpertProjection::GateUp,
+                };
+
+                manager.ensure_resident(&store, e0).expect("load expert 0");
+                manager
+                    .prefetch_resident(&store, e1)
+                    .expect("prefetch expert 1");
+
+                assert!(manager.is_resident(e0));
+                assert!(!manager.is_resident(e1));
+                assert_eq!(manager.stats().resident_pages, 1);
+                assert_eq!(manager.stats().evicted_pages, 0);
+                assert_eq!(manager.stats().page_misses, 1);
+                assert_eq!(manager.stats().prefetch_requests, 1);
+                assert_eq!(manager.stats().prefetch_misses, 1);
+                assert_eq!(manager.stats().prefetch_page_misses, 0);
+                assert_eq!(manager.stats().prefetch_skipped, 1);
+                assert_eq!(manager.stats().prefetch_skipped_pages, 1);
+            },
+        );
     }
 
     #[test]

--- a/docs/lowlevel-memory.md
+++ b/docs/lowlevel-memory.md
@@ -108,8 +108,10 @@ Current scope:
   `SUPERSONIC_MOE_ISLAND_PREFETCH_RANKS=N` to prefetch only the first N ordered
   router ranks, for example N=1 for rank-0-only lookahead. Sparse telemetry
   records the effective prefetch rank count plus prefetch hit/miss/page
-  counters. This is a measurement hook for future overlapped prefetch work, not
-  a default path.
+  counters. Prefetch is non-evicting: if the sparse page budget has no room for
+  the missing pages, the runtime records `prefetch_skipped` counters and leaves
+  resident demand pages untouched. This is a measurement hook for future
+  overlapped prefetch work, not a default path.
 - `SUPERSONIC_VMM_KV=0` disables the Qwen3.5 and Qwen3.6 KV integrations.
 - `SUPERSONIC_VMM_KV=1` requests KV VMM and logs if the backend cannot support
   it. HIP may auto-enable when unset; CUDA requires this explicit opt-in.

--- a/oracle/qwen36_verify_suite.py
+++ b/oracle/qwen36_verify_suite.py
@@ -352,6 +352,8 @@ def load_vmm_residency(path: Path) -> dict[str, Any]:
         "prefetch_misses",
         "prefetch_page_hits",
         "prefetch_page_misses",
+        "prefetch_skipped",
+        "prefetch_skipped_pages",
         "prefetch_uploaded_bytes",
         "route_summary",
     ]

--- a/tests/gfx1100/bench_qwen36_sparse_caps.py
+++ b/tests/gfx1100/bench_qwen36_sparse_caps.py
@@ -220,8 +220,8 @@ def run_case(
 
 def markdown(rows: list[dict[str, Any]]) -> str:
     out = [
-        "| Mode | total ms/tok | tok/s | total resident GiB | MoE resident GiB | KV resident GiB | prefetch | ranks | peak pages | page misses | prefetch page misses | rank0 resident | rank0 repeat | evicted pages | ids match |",
-        "|---|---:|---:|---:|---:|---:|:---:|---:|---:|---:|---:|---:|---:|---:|:---:|",
+        "| Mode | total ms/tok | tok/s | total resident GiB | MoE resident GiB | KV resident GiB | prefetch | ranks | peak pages | page misses | prefetch page misses | prefetch skipped | rank0 resident | rank0 repeat | evicted pages | ids match |",
+        "|---|---:|---:|---:|---:|---:|:---:|---:|---:|---:|---:|---:|---:|---:|---:|:---:|",
     ]
     for row in rows:
         residency = row.get("vmm_residency") or {}
@@ -229,7 +229,7 @@ def markdown(rows: list[dict[str, Any]]) -> str:
         stage = row.get("stage") or {}
         ids_match = row.get("generated_ids_match")
         out.append(
-            "| {label} | {ms} | {tok} | {total_gib} | {moe_gib} | {kv_gib} | {prefetch_mode} | {prefetch_ranks} | {peak_pages} | {page_misses} | {prefetch_page_misses} | {rank0_resident} | {rank0_repeat} | {evicted_pages} | {ids_match} |".format(
+            "| {label} | {ms} | {tok} | {total_gib} | {moe_gib} | {kv_gib} | {prefetch_mode} | {prefetch_ranks} | {peak_pages} | {page_misses} | {prefetch_page_misses} | {prefetch_skipped} | {rank0_resident} | {rank0_repeat} | {evicted_pages} | {ids_match} |".format(
                 label=row["label"],
                 ms=fmt_num(stage.get("total_ms_avg")),
                 tok=fmt_num(row.get("tok_per_s")),
@@ -241,6 +241,7 @@ def markdown(rows: list[dict[str, Any]]) -> str:
                 peak_pages=residency.get("peak_resident_pages", "-"),
                 page_misses=residency.get("page_misses", "-"),
                 prefetch_page_misses=residency.get("prefetch_page_misses", "-"),
+                prefetch_skipped=residency.get("prefetch_skipped", "-"),
                 rank0_resident=fmt_rank_pct(route_summary, "resident_before_by_rank"),
                 rank0_repeat=fmt_rank_pct(route_summary, "repeated_previous_by_rank"),
                 evicted_pages=residency.get("evicted_pages", "-"),

--- a/tests/test_qwen36_verify_suite.py
+++ b/tests/test_qwen36_verify_suite.py
@@ -212,6 +212,8 @@ class Qwen36VerifySuiteTests(unittest.TestCase):
                     "moe_resident_bytes": 10,
                     "kv_resident_bytes": 3,
                     "total_vmm_resident_bytes": 13,
+                    "prefetch_skipped": 4,
+                    "prefetch_skipped_pages": 9,
                     "route_summary": {
                         "observations_by_rank": [2],
                         "resident_before_by_rank": [1],
@@ -227,6 +229,8 @@ class Qwen36VerifySuiteTests(unittest.TestCase):
                     "moe_resident_bytes": 10,
                     "kv_resident_bytes": 3,
                     "total_vmm_resident_bytes": 13,
+                    "prefetch_skipped": 4,
+                    "prefetch_skipped_pages": 9,
                     "route_summary": {
                         "observations_by_rank": [2],
                         "resident_before_by_rank": [1],


### PR DESCRIPTION
## Summary
- make sparse MoE previous-token prefetch admission non-evicting: prefetch now skips missing pages when the sparse page budget is full instead of evicting demand-resident pages
- add prefetch_skipped and prefetch_skipped_pages counters to residency stats, sparse telemetry JSON, CLI output, and benchmark markdown
- keep demand loads unchanged: they can still evict LRU pages to satisfy the router's actual top-k
- document the non-evicting prefetch behavior

## Validation
- cargo fmt --check
- git diff --check
- python3 -m py_compile tests/gfx1100/bench_qwen36_sparse_caps.py oracle/qwen36_verify_suite.py
- python3 -m unittest tests.test_qwen36_verify_suite tests.test_qwen36_sparse_caps
- cargo check -p runner
- cargo test -p runner qwen36_moe_residency --lib
- cargo build --release --bin supersonic
- HIP script smoke: python3 tests/gfx1100/bench_qwen36_sparse_caps.py --caps 320 --prefetch-rank-sweep none,1 --max-new-tokens 2 --no-warmup --timeout 600 --out-json target/qwen36_sparse_prefetch_admission_smoke.json --out-md target/qwen36_sparse_prefetch_admission_smoke.md

## HIP script smoke result
| Mode | total ms/tok | tok/s | total resident GiB | MoE resident GiB | KV resident GiB | prefetch | ranks | peak pages | page misses | prefetch page misses | prefetch skipped | rank0 resident | rank0 repeat | evicted pages | ids match |
|---|---:|---:|---:|---:|---:|:---:|---:|---:|---:|---:|---:|---:|---:|---:|:---:|
| dense | 30.09 | 33.23 | 15.04 | 15.00 | 0.04 | - | - | - | - | - | - | - | - | - | yes |
| cap320-none | 110.63 | 9.04 | 1.29 | 1.25 | 0.04 | disabled | 0 | 640 | 2981 | 0 | 0 | 46.8% | 46.8% | 2341 | yes |
| cap320-r1 | 127.25 | 7.86 | 1.29 | 1.25 | 0.04 | previous-token | 1 | 640 | 3469 | 0 | 223 | 36.4% | 46.8% | 2829 | yes |

Compared with the previous rank-1 smoke, this removes prefetch page misses and reduces eviction pressure. Rank-1 prefetch is still slower than no-prefetch on this tiny prompt, but it no longer self-sabotages by evicting resident demand pages.