### PR TITLE
Document MoE prefetch policy sweep

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -286,6 +286,26 @@ The sweep helper can also compare previous-token prefetch policies in one run:
 add `--prefetch-rank-sweep none,1,2,4,all` to expand every sparse cap across
 no lookahead, rank-limited lookahead, and full top-k lookahead rows.
 
+**Sparse MoE previous-token prefetch sweep** — measured 2026-05-03 after
+non-evicting prefetch admission landed. Same host/GPU/model/prompt as above,
+cap fixed at `SUPERSONIC_MOE_ISLAND_CAP_EXPERTS=320`, 16 generated tokens,
+no warmup:
+
+| Mode | total ms/tok | tok/s | total resident GiB | prefetch | ranks | page misses | prefetch page misses | prefetch skipped | rank0 resident | rank0 repeat | evicted pages | ids match |
+|---|---:|---:|---:|:---:|---:|---:|---:|---:|---:|---:|---:|:---:|
+| dense | 28.73 | 34.81 | 15.04 | - | - | - | - | - | - | - | - | yes |
+| cap320-none | 108.66 | 9.20 | 1.29 | disabled | 0 | 8357 | 0 | 0 | 52.4% | 52.3% | 7717 | yes |
+| cap320-r1 | 119.62 | 8.36 | 1.29 | previous-token | 1 | 9815 | 0 | 616 | 42.6% | 52.3% | 9175 | yes |
+| cap320-r2 | 131.78 | 7.59 | 1.29 | previous-token | 2 | 11190 | 0 | 2196 | 25.8% | 52.3% | 10550 | yes |
+| cap320-r4 | 140.39 | 7.12 | 1.29 | previous-token | 4 | 12310 | 0 | 5511 | 9.5% | 52.3% | 11670 | yes |
+| cap320-all | 147.75 | 6.77 | 1.29 | previous-token | 8 | 12927 | 0 | 11961 | 0.6% | 52.3% | 12287 | yes |
+
+Non-evicting admission successfully prevents prefetch page misses, but this
+previous-token policy is still a regression on the fox prompt. As ranks
+increase, skipped prefetches and demand page misses rise monotonically. Treat
+previous-token prefetch as diagnostic only; the next useful policy needs a
+stronger admission signal than "same layer's previous token top-k".
+
 Reproduce:
 
 ```bash


### PR DESCRIPTION
## Summary
- add the measured cap320 previous-token prefetch rank sweep after non-evicting admission
- record that previous-token rank policies remain slower than no-prefetch on the fox prompt
- note the next policy needs a stronger admission signal than previous-token top-k reuse

## Validation
- git diff --check
- HIP sweep: python3 tests/gfx1100/bench_qwen36_sparse_caps.py --caps 320 --prefetch-rank-sweep none,1,2,4,all --max-new-tokens 16 --no-warmup --timeout 900 --out-json target/qwen36_sparse_prefetch_cap320_sweep.json --out-md target/qwen36_sparse_prefetch_cap320_sweep.md

## Result
| Mode | total ms/tok | tok/s | total resident GiB | prefetch | ranks | page misses | prefetch page misses | prefetch skipped | rank0 resident | rank0 repeat | evicted pages | ids match |
|---|---:|---:|---:|:---:|---:|---:|---:|---:|---:|---:|---:|:---:|
| dense | 28.73 | 34.81 | 15.04 | - | - | - | - | - | - | - | - | yes |
| cap320-none | 108.66 | 9.20 | 1.29 | disabled | 0 | 8357 | 0 | 0 | 52.4% | 52.3% | 7717 | yes |
| cap320-r1 | 119.62 | 8.36 | 1.29 | previous-token | 1 | 9815 | 0 | 616 | 42.6% | 52.3% | 9175 | yes |
| cap320-r2 | 131.78 | 7.59 | 1.29 | previous-token | 2 | 11190 | 0 | 2196 | 25.8% | 52.3% | 10550 | yes |
| cap320-r4 | 140.39 | 7.12 | 1.29 | previous-token | 4 | 12310 | 0 | 5511 | 9.5% | 52.3% | 11670 | yes |
| cap320-all | 147.75 | 6.77 | 1.29 | previous-token | 8 | 12927 | 0 | 11961 | 0.6% | 52.3% | 12287 | yes |