### PR TITLE
Add resident-only MoE prefetch diagnostic

### DIFF
--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -1101,6 +1101,7 @@ fn moe_island_cap_experts_from_env() -> Result<Option<usize>> {
 enum MoeIslandPrefetchMode {
     Disabled,
     PreviousToken,
+    PreviousTokenResidentOnly,
 }
 
 impl MoeIslandPrefetchMode {
@@ -1108,21 +1109,41 @@ impl MoeIslandPrefetchMode {
         match self {
             Self::Disabled => "disabled",
             Self::PreviousToken => "previous-token",
+            Self::PreviousTokenResidentOnly => "previous-token-resident",
         }
     }
 
+    fn uses_previous_token_routes(self) -> bool {
+        matches!(self, Self::PreviousToken | Self::PreviousTokenResidentOnly)
+    }
+
+    fn resident_only(self) -> bool {
+        matches!(self, Self::PreviousTokenResidentOnly)
+    }
+
     fn from_env() -> Result<Self> {
-        match std::env::var("SUPERSONIC_MOE_ISLAND_PREFETCH")
-            .ok()
-            .as_deref()
-        {
+        Self::from_env_value(
+            std::env::var("SUPERSONIC_MOE_ISLAND_PREFETCH")
+                .ok()
+                .as_deref(),
+        )
+    }
+
+    fn from_env_value(raw: Option<&str>) -> Result<Self> {
+        match raw {
             None | Some("0") | Some("off") | Some("disabled") => Ok(Self::Disabled),
             Some("previous-token") | Some("previous_token") | Some("prev-token") => {
                 Ok(Self::PreviousToken)
             }
+            Some("previous-token-resident")
+            | Some("previous_token_resident")
+            | Some("prev-token-resident")
+            | Some("resident-previous-token") => Ok(Self::PreviousTokenResidentOnly),
             Some(other) => Err(anyhow!(
                 "SUPERSONIC_MOE_ISLAND_PREFETCH must be unset, 0, off, disabled, \
-                 previous-token, previous_token, or prev-token; got {other:?}"
+                 previous-token, previous_token, prev-token, previous-token-resident, \
+                 previous_token_resident, prev-token-resident, or resident-previous-token; \
+                 got {other:?}"
             )),
         }
     }
@@ -1138,27 +1159,29 @@ fn moe_island_prefetch_ranks_from_env_value(
             if raw.is_some() {
                 anyhow::bail!(
                     "SUPERSONIC_MOE_ISLAND_PREFETCH_RANKS requires \
-                     SUPERSONIC_MOE_ISLAND_PREFETCH=previous-token"
+                     SUPERSONIC_MOE_ISLAND_PREFETCH=previous-token or previous-token-resident"
                 );
             }
             Ok(0)
         }
-        MoeIslandPrefetchMode::PreviousToken => match raw {
-            None | Some("all") => Ok(top_k),
-            Some(value) => {
-                let ranks = value.parse::<usize>().with_context(|| {
-                    format!(
+        MoeIslandPrefetchMode::PreviousToken | MoeIslandPrefetchMode::PreviousTokenResidentOnly => {
+            match raw {
+                None | Some("all") => Ok(top_k),
+                Some(value) => {
+                    let ranks = value.parse::<usize>().with_context(|| {
+                        format!(
                         "parse SUPERSONIC_MOE_ISLAND_PREFETCH_RANKS={value:?} as positive integer"
                     )
-                })?;
-                if ranks == 0 || ranks > top_k {
-                    anyhow::bail!(
+                    })?;
+                    if ranks == 0 || ranks > top_k {
+                        anyhow::bail!(
                         "SUPERSONIC_MOE_ISLAND_PREFETCH_RANKS must be in 1..={top_k}; got {ranks}"
                     );
+                    }
+                    Ok(ranks)
                 }
-                Ok(ranks)
             }
-        },
+        }
     }
 }
 
@@ -2518,10 +2541,11 @@ fn decode_text(
                  (router prefetch + FFN resume per layer)"
             );
         }
-        if moe_prefetch_mode == MoeIslandPrefetchMode::PreviousToken {
+        if moe_prefetch_mode.uses_previous_token_routes() {
             println!(
-                "  [vmm] sparse MoE previous-token lookahead prefetch active \
+                "  [vmm] sparse MoE {} lookahead prefetch active \
                  (ranks={moe_prefetch_ranks}/{})",
+                moe_prefetch_mode.as_str(),
                 geom.top_k
             );
         }
@@ -2917,8 +2941,8 @@ fn decode_text(
         let moe_telemetry_before = _moe_expert_residency
             .as_ref()
             .map(MoeSparseTelemetrySnapshot::capture);
-        let track_moe_routes = moe_prefetch_mode == MoeIslandPrefetchMode::PreviousToken
-            || moe_route_telemetry.is_some();
+        let track_moe_routes =
+            moe_prefetch_mode.uses_previous_token_routes() || moe_route_telemetry.is_some();
         let mut next_moe_topk_by_layer = if track_moe_routes {
             previous_moe_topk_by_layer.clone()
         } else {
@@ -2938,7 +2962,7 @@ fn decode_text(
                  -> Result<()> {
                     match phase {
                         ExpertPrefetchPhase::Lookahead
-                            if moe_prefetch_mode == MoeIslandPrefetchMode::PreviousToken =>
+                            if moe_prefetch_mode.uses_previous_token_routes() =>
                         {
                             for &expert_idx in previous_moe_topk_by_layer
                                 .get(layer_idx)
@@ -2957,6 +2981,11 @@ fn decode_text(
                                     expert_idx,
                                     projection: MoeExpertProjection::Down,
                                 };
+                                if moe_prefetch_mode.resident_only()
+                                    && !(manager.is_resident(gate_up) && manager.is_resident(down))
+                                {
+                                    continue;
+                                }
                                 manager.prefetch_resident(&store, gate_up)?;
                                 manager.prefetch_resident(&store, down)?;
                             }
@@ -3031,7 +3060,7 @@ fn decode_text(
                  -> Result<()> {
                     match phase {
                         ExpertPrefetchPhase::Lookahead
-                            if moe_prefetch_mode == MoeIslandPrefetchMode::PreviousToken =>
+                            if moe_prefetch_mode.uses_previous_token_routes() =>
                         {
                             for &expert_idx in previous_moe_topk_by_layer
                                 .get(layer_idx)
@@ -3050,6 +3079,11 @@ fn decode_text(
                                     expert_idx,
                                     projection: MoeExpertProjection::Down,
                                 };
+                                if moe_prefetch_mode.resident_only()
+                                    && !(manager.is_resident(gate_up) && manager.is_resident(down))
+                                {
+                                    continue;
+                                }
                                 manager.prefetch_resident(&store, gate_up)?;
                                 manager.prefetch_resident(&store, down)?;
                             }
@@ -3956,6 +3990,43 @@ mod tests {
     }
 
     #[test]
+    fn moe_prefetch_mode_env_accepts_disabled_and_previous_token_aliases() {
+        assert_eq!(
+            MoeIslandPrefetchMode::from_env_value(None).unwrap(),
+            MoeIslandPrefetchMode::Disabled
+        );
+        assert_eq!(
+            MoeIslandPrefetchMode::from_env_value(Some("disabled")).unwrap(),
+            MoeIslandPrefetchMode::Disabled
+        );
+        assert_eq!(
+            MoeIslandPrefetchMode::from_env_value(Some("previous-token")).unwrap(),
+            MoeIslandPrefetchMode::PreviousToken
+        );
+        assert_eq!(
+            MoeIslandPrefetchMode::from_env_value(Some("prev-token")).unwrap(),
+            MoeIslandPrefetchMode::PreviousToken
+        );
+    }
+
+    #[test]
+    fn moe_prefetch_mode_env_accepts_resident_only_aliases() {
+        assert_eq!(
+            MoeIslandPrefetchMode::from_env_value(Some("previous-token-resident")).unwrap(),
+            MoeIslandPrefetchMode::PreviousTokenResidentOnly
+        );
+        assert_eq!(
+            MoeIslandPrefetchMode::from_env_value(Some("previous_token_resident")).unwrap(),
+            MoeIslandPrefetchMode::PreviousTokenResidentOnly
+        );
+        assert_eq!(
+            MoeIslandPrefetchMode::from_env_value(Some("resident-previous-token")).unwrap(),
+            MoeIslandPrefetchMode::PreviousTokenResidentOnly
+        );
+        assert!(MoeIslandPrefetchMode::from_env_value(Some("resident")).is_err());
+    }
+
+    #[test]
     fn moe_prefetch_ranks_default_to_all_previous_token_routes() {
         assert_eq!(
             moe_island_prefetch_ranks_from_env_value(
@@ -3969,7 +4040,7 @@ mod tests {
         assert_eq!(
             moe_island_prefetch_ranks_from_env_value(
                 Some("all"),
-                MoeIslandPrefetchMode::PreviousToken,
+                MoeIslandPrefetchMode::PreviousTokenResidentOnly,
                 8,
             )
             .unwrap(),
@@ -3991,7 +4062,7 @@ mod tests {
         assert_eq!(
             moe_island_prefetch_ranks_from_env_value(
                 Some("4"),
-                MoeIslandPrefetchMode::PreviousToken,
+                MoeIslandPrefetchMode::PreviousTokenResidentOnly,
                 8,
             )
             .unwrap(),

--- a/docs/lowlevel-memory.md
+++ b/docs/lowlevel-memory.md
@@ -112,6 +112,10 @@ Current scope:
   the missing pages, the runtime records `prefetch_skipped` counters and leaves
   resident demand pages untouched. This is a measurement hook for future
   overlapped prefetch work, not a default path.
+- `SUPERSONIC_MOE_ISLAND_PREFETCH=previous-token-resident` is the conservative
+  variant: it only refreshes the previous-token expert pair when both routed
+  projections are already resident. It never uploads missing pages, so it can
+  measure LRU refresh value without changing residency admission.
 - `SUPERSONIC_VMM_KV=0` disables the Qwen3.5 and Qwen3.6 KV integrations.
 - `SUPERSONIC_VMM_KV=1` requests KV VMM and logs if the backend cannot support
   it. HIP may auto-enable when unset; CUDA requires this explicit opt-in.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -285,6 +285,9 @@ the miss rate substantially.
 The sweep helper can also compare previous-token prefetch policies in one run:
 add `--prefetch-rank-sweep none,1,2,4,all` to expand every sparse cap across
 no lookahead, rank-limited lookahead, and full top-k lookahead rows.
+Use `--prefetch previous-token-resident --prefetch-ranks 1` to isolate LRU
+refresh of already resident previous-token routes without uploading missing
+pages.
 
 **Sparse MoE previous-token prefetch sweep** — measured 2026-05-03 after
 non-evicting prefetch admission landed. Same host/GPU/model/prompt as above,
@@ -296,13 +299,17 @@ no warmup:
 | dense | 28.73 | 34.81 | 15.04 | - | - | - | - | - | - | - | - | yes |
 | cap320-none | 108.66 | 9.20 | 1.29 | disabled | 0 | 8357 | 0 | 0 | 52.4% | 52.3% | 7717 | yes |
 | cap320-r1 | 119.62 | 8.36 | 1.29 | previous-token | 1 | 9815 | 0 | 616 | 42.6% | 52.3% | 9175 | yes |
+| cap320-r1-resident | 116.18 | 8.61 | 1.29 | previous-token-resident | 1 | 9752 | 0 | 0 | 43.9% | 52.3% | 9112 | yes |
 | cap320-r2 | 131.78 | 7.59 | 1.29 | previous-token | 2 | 11190 | 0 | 2196 | 25.8% | 52.3% | 10550 | yes |
 | cap320-r4 | 140.39 | 7.12 | 1.29 | previous-token | 4 | 12310 | 0 | 5511 | 9.5% | 52.3% | 11670 | yes |
 | cap320-all | 147.75 | 6.77 | 1.29 | previous-token | 8 | 12927 | 0 | 11961 | 0.6% | 52.3% | 12287 | yes |
 
 Non-evicting admission successfully prevents prefetch page misses, but this
 previous-token policy is still a regression on the fox prompt. As ranks
-increase, skipped prefetches and demand page misses rise monotonically. Treat
+increase, skipped prefetches and demand page misses rise monotonically. The
+resident-only row keeps prefetch page misses and skipped prefetches at zero,
+but still regresses versus no lookahead, so even refreshing previous-token
+residents perturbs LRU in the wrong direction for this prompt. Treat
 previous-token prefetch as diagnostic only; the next useful policy needs a
 stronger admission signal than "same layer's previous token top-k".
 

--- a/tests/gfx1100/bench_qwen36_sparse_caps.py
+++ b/tests/gfx1100/bench_qwen36_sparse_caps.py
@@ -267,7 +267,7 @@ def main() -> int:
     parser.add_argument("--no-persistent-decode", action="store_true")
     parser.add_argument(
         "--prefetch",
-        choices=["previous-token"],
+        choices=["previous-token", "previous-token-resident"],
         help="set SUPERSONIC_MOE_ISLAND_PREFETCH for sparse cap rows",
     )
     parser.add_argument(
@@ -288,7 +288,7 @@ def main() -> int:
     if args.prefetch_rank_sweep and (args.prefetch or args.prefetch_ranks is not None):
         parser.error("--prefetch-rank-sweep cannot be combined with --prefetch/--prefetch-ranks")
     if args.prefetch_ranks is not None and not args.prefetch:
-        parser.error("--prefetch-ranks requires --prefetch previous-token")
+        parser.error("--prefetch-ranks requires --prefetch")
     if args.prefetch_ranks is not None:
         try:
             _, ranks = parse_prefetch_rank_policy(args.prefetch_ranks)


### PR DESCRIPTION
## Summary
- add `SUPERSONIC_MOE_ISLAND_PREFETCH=previous-token-resident` to refresh only previous-token experts whose GateUp and Down projections are already resident
- keep the mode from uploading missing pages, so it isolates LRU refresh effects from admission/page-fill effects
- allow the gfx1100 sparse-cap benchmark helper to run the new prefetch mode and document the measured result

## HIP result
`python3 tests/gfx1100/bench_qwen36_sparse_caps.py --caps 320 --prefetch previous-token-resident --prefetch-ranks 1 --max-new-tokens 16 --no-warmup --timeout 900 --out-json target/qwen36_sparse_prefetch_resident_r1.json --out-md target/qwen36_sparse_prefetch_resident_r1.md`

- dense: 28.25 ms/tok, ids match
- cap320 previous-token-resident r1: 116.18 ms/tok, ids match, prefetch page misses 0, prefetch skipped 0

Same binary/session-style no-prefetch comparison:
- cap320 disabled: 104.94 ms/tok, ids match

Conclusion: resident-only refresh avoids uploads/skips as intended, but still regresses versus no lookahead on the fox prompt. This keeps previous-token prefetch diagnostic-only and points the next policy toward a stronger admission signal.

## Tests
- `cargo fmt --check`
- `git diff --check`
- `python3 -m py_compile tests/gfx1100/bench_qwen36_sparse_caps.py`
- `python3 -m unittest tests.test_qwen36_sparse_caps`
- `cargo check -p runner`
- `cargo test -p runner --bin supersonic moe_prefetch`
- `cargo build --release --bin supersonic`