### PR TITLE
Add MoE route transition telemetry

### DIFF
--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -1305,6 +1305,7 @@ struct MoeRouteTelemetry {
     observations_by_rank: Vec<u64>,
     resident_before_by_rank: Vec<u64>,
     repeated_previous_by_rank: Vec<u64>,
+    repeated_previous_rank_by_current_rank: Vec<Vec<u64>>,
     weight_sum_by_rank: Vec<f64>,
 }
 
@@ -1314,7 +1315,30 @@ impl MoeRouteTelemetry {
             observations_by_rank: vec![0; top_k],
             resident_before_by_rank: vec![0; top_k],
             repeated_previous_by_rank: vec![0; top_k],
+            repeated_previous_rank_by_current_rank: vec![vec![0; top_k]; top_k],
             weight_sum_by_rank: vec![0.0; top_k],
+        }
+    }
+
+    fn record_route_observation(&mut self, route: &ExpertRoute, previous_routes: &[usize]) {
+        if route.rank >= self.observations_by_rank.len() {
+            return;
+        }
+        self.observations_by_rank[route.rank] += 1;
+        self.weight_sum_by_rank[route.rank] += route.weight as f64;
+        if let Some(previous_rank) = previous_routes
+            .iter()
+            .position(|&expert_idx| expert_idx == route.expert_idx)
+        {
+            self.repeated_previous_by_rank[route.rank] += 1;
+            if let Some(row) = self
+                .repeated_previous_rank_by_current_rank
+                .get_mut(route.rank)
+            {
+                if let Some(cell) = row.get_mut(previous_rank) {
+                    *cell += 1;
+                }
+            }
         }
     }
 
@@ -1329,11 +1353,7 @@ impl MoeRouteTelemetry {
             if route.rank >= self.observations_by_rank.len() {
                 continue;
             }
-            self.observations_by_rank[route.rank] += 1;
-            self.weight_sum_by_rank[route.rank] += route.weight as f64;
-            if previous_routes.contains(&route.expert_idx) {
-                self.repeated_previous_by_rank[route.rank] += 1;
-            }
+            self.record_route_observation(route, previous_routes);
             let gate_up = MoeExpertKey {
                 layer_idx,
                 expert_idx: route.expert_idx,
@@ -1367,6 +1387,7 @@ impl MoeRouteTelemetry {
             "observations_by_rank": &self.observations_by_rank,
             "resident_before_by_rank": &self.resident_before_by_rank,
             "repeated_previous_by_rank": &self.repeated_previous_by_rank,
+            "repeated_previous_rank_by_current_rank": &self.repeated_previous_rank_by_current_rank,
             "avg_weight_by_rank": avg_weight_by_rank,
         })
     }
@@ -3955,8 +3976,8 @@ fn decode_first_token(model_dir: &Path, report: &DryRunReport, kv_fp8: bool) -> 
 #[cfg(test)]
 mod tests {
     use super::{
-        moe_island_prefetch_ranks_from_env_value, qwen36_kv_vmm_mode_from_env_value,
-        MoeIslandPrefetchMode, Qwen36KvVmmMode,
+        moe_island_prefetch_ranks_from_env_value, qwen36_kv_vmm_mode_from_env_value, ExpertRoute,
+        MoeIslandPrefetchMode, MoeRouteTelemetry, Qwen36KvVmmMode,
     };
     use gpu_hal::Backend;
 
@@ -4095,5 +4116,49 @@ mod tests {
             8,
         )
         .is_err());
+    }
+
+    #[test]
+    fn moe_route_telemetry_records_previous_rank_transition_matrix() {
+        let mut telemetry = MoeRouteTelemetry::new(3);
+        let previous_routes = [7, 11, 13];
+        telemetry.record_route_observation(
+            &ExpertRoute {
+                rank: 0,
+                expert_idx: 11,
+                weight: 0.5,
+            },
+            &previous_routes,
+        );
+        telemetry.record_route_observation(
+            &ExpertRoute {
+                rank: 1,
+                expert_idx: 7,
+                weight: 0.25,
+            },
+            &previous_routes,
+        );
+        telemetry.record_route_observation(
+            &ExpertRoute {
+                rank: 2,
+                expert_idx: 99,
+                weight: 0.125,
+            },
+            &previous_routes,
+        );
+
+        assert_eq!(telemetry.observations_by_rank, vec![1, 1, 1]);
+        assert_eq!(telemetry.repeated_previous_by_rank, vec![1, 1, 0]);
+        assert_eq!(
+            telemetry.repeated_previous_rank_by_current_rank,
+            vec![vec![0, 1, 0], vec![1, 0, 0], vec![0, 0, 0]]
+        );
+        assert_eq!(
+            telemetry
+                .to_json()
+                .get("repeated_previous_rank_by_current_rank")
+                .unwrap(),
+            &serde_json::json!([[0, 1, 0], [1, 0, 0], [0, 0, 0]])
+        );
     }
 }

--- a/docs/lowlevel-memory.md
+++ b/docs/lowlevel-memory.md
@@ -101,7 +101,8 @@ Current scope:
   fully resident virtual expert slabs to sparse router-prefetched islands with
   at most `N` experts' two routed projections tracked resident at once. Sparse
   telemetry records ordered router rank summaries, including per-rank resident
-  hits before demand loading, previous-token repeats, and average router weight.
+  hits before demand loading, previous-token repeats, previous-rank to
+  current-rank repeat transitions, and average router weight.
 - `SUPERSONIC_MOE_ISLAND_PREFETCH=previous-token` enables experimental
   previous-token routed-expert lookahead for sparse MoE islands. It preloads
   each layer's previous top-k before that layer's router runs. Set

--- a/tests/gfx1100/bench_qwen36_sparse_caps.py
+++ b/tests/gfx1100/bench_qwen36_sparse_caps.py
@@ -125,6 +125,23 @@ def fmt_rank_pct(route_summary: dict[str, Any], key: str, rank: int = 0) -> str:
     return f"{100.0 * float(values[rank]) / float(observations[rank]):.1f}%"
 
 
+def fmt_rank_transition_pct(
+    route_summary: dict[str, Any],
+    current_rank: int = 0,
+    previous_rank: int = 0,
+) -> str:
+    observations = route_summary.get("observations_by_rank") or []
+    matrix = route_summary.get("repeated_previous_rank_by_current_rank") or []
+    if (
+        current_rank >= len(observations)
+        or current_rank >= len(matrix)
+        or previous_rank >= len(matrix[current_rank])
+        or not observations[current_rank]
+    ):
+        return "-"
+    return f"{100.0 * float(matrix[current_rank][previous_rank]) / float(observations[current_rank]):.1f}%"
+
+
 def run_case(
     args: argparse.Namespace,
     label: str,
@@ -220,8 +237,8 @@ def run_case(
 
 def markdown(rows: list[dict[str, Any]]) -> str:
     out = [
-        "| Mode | total ms/tok | tok/s | total resident GiB | MoE resident GiB | KV resident GiB | prefetch | ranks | peak pages | page misses | prefetch page misses | prefetch skipped | rank0 resident | rank0 repeat | evicted pages | ids match |",
-        "|---|---:|---:|---:|---:|---:|:---:|---:|---:|---:|---:|---:|---:|---:|---:|:---:|",
+        "| Mode | total ms/tok | tok/s | total resident GiB | MoE resident GiB | KV resident GiB | prefetch | ranks | peak pages | page misses | prefetch page misses | prefetch skipped | rank0 resident | rank0 repeat | rank0 prev-rank0 repeat | evicted pages | ids match |",
+        "|---|---:|---:|---:|---:|---:|:---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|:---:|",
     ]
     for row in rows:
         residency = row.get("vmm_residency") or {}
@@ -229,7 +246,7 @@ def markdown(rows: list[dict[str, Any]]) -> str:
         stage = row.get("stage") or {}
         ids_match = row.get("generated_ids_match")
         out.append(
-            "| {label} | {ms} | {tok} | {total_gib} | {moe_gib} | {kv_gib} | {prefetch_mode} | {prefetch_ranks} | {peak_pages} | {page_misses} | {prefetch_page_misses} | {prefetch_skipped} | {rank0_resident} | {rank0_repeat} | {evicted_pages} | {ids_match} |".format(
+            "| {label} | {ms} | {tok} | {total_gib} | {moe_gib} | {kv_gib} | {prefetch_mode} | {prefetch_ranks} | {peak_pages} | {page_misses} | {prefetch_page_misses} | {prefetch_skipped} | {rank0_resident} | {rank0_repeat} | {rank0_prev0_repeat} | {evicted_pages} | {ids_match} |".format(
                 label=row["label"],
                 ms=fmt_num(stage.get("total_ms_avg")),
                 tok=fmt_num(row.get("tok_per_s")),
@@ -244,6 +261,7 @@ def markdown(rows: list[dict[str, Any]]) -> str:
                 prefetch_skipped=residency.get("prefetch_skipped", "-"),
                 rank0_resident=fmt_rank_pct(route_summary, "resident_before_by_rank"),
                 rank0_repeat=fmt_rank_pct(route_summary, "repeated_previous_by_rank"),
+                rank0_prev0_repeat=fmt_rank_transition_pct(route_summary),
                 evicted_pages=residency.get("evicted_pages", "-"),
                 ids_match="yes" if ids_match else "NO",
             )

--- a/tests/test_qwen36_sparse_caps.py
+++ b/tests/test_qwen36_sparse_caps.py
@@ -59,6 +59,17 @@ class Qwen36SparseCapBenchTests(unittest.TestCase):
             ],
         )
 
+    def test_fmt_rank_transition_pct_uses_current_rank_denominator(self):
+        fmt = bench_qwen36_sparse_caps.fmt_rank_transition_pct
+        summary = {
+            "observations_by_rank": [10, 5],
+            "repeated_previous_rank_by_current_rank": [[3, 2], [1, 4]],
+        }
+        self.assertEqual(fmt(summary, current_rank=0, previous_rank=0), "30.0%")
+        self.assertEqual(fmt(summary, current_rank=0, previous_rank=1), "20.0%")
+        self.assertEqual(fmt(summary, current_rank=1, previous_rank=1), "80.0%")
+        self.assertEqual(fmt({}, current_rank=0, previous_rank=0), "-")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- extend sparse MoE route telemetry with `repeated_previous_rank_by_current_rank`, a current-rank x previous-rank repeat matrix
- keep the existing per-rank repeat totals, but make it possible to distinguish rank-stable reuse from any-previous-route reuse
- show current rank-0 / previous rank-0 repeat percentage in the gfx1100 sparse-cap benchmark markdown
- document the new telemetry signal

## HIP smoke
`python3 tests/gfx1100/bench_qwen36_sparse_caps.py --caps 320 --max-new-tokens 8 --no-warmup --timeout 900 --out-json target/qwen36_sparse_route_transition_smoke.json --out-md target/qwen36_sparse_route_transition_smoke.md`

- dense: 28.52 ms/tok, ids match
- cap320: 107.41 ms/tok, ids match
- rank0 repeat: 51.9%
- rank0 previous-rank0 repeat: 22.7%

That gap is the useful finding: current rank-0 often repeats some previous expert, but less than half of those repeats were previous rank-0. The next admission policy should use the transition shape instead of assuming same-rank previous-token reuse.

## Tests
- `cargo fmt --check`
- `git diff --check`
- `python3 -m py_compile tests/gfx1100/bench_qwen36_sparse_caps.py`
- `python3 -m unittest tests.test_qwen36_sparse_caps`
- `cargo check -p runner`
- `cargo test -p runner --bin supersonic moe_route_telemetry`
- `cargo build --release --bin supersonic`