### PR TITLE
Add MoE route transition summaries

### DIFF
--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -3797,5 +3797,41 @@ mod tests {
                 .unwrap(),
             &serde_json::json!([[0, 1, 0], [1, 0, 0], [0, 0, 0]])
         );
+        let json = telemetry.to_json();
+        assert_eq!(
+            json.get("repeated_previous_probability_by_current_rank")
+                .unwrap(),
+            &serde_json::json!([1.0, 1.0, 0.0])
+        );
+        assert_eq!(
+            json.get("same_rank_repeat_probability_by_rank").unwrap(),
+            &serde_json::json!([0.0, 0.0, 0.0])
+        );
+        assert_eq!(
+            json.get("repeated_current_by_previous_rank").unwrap(),
+            &serde_json::json!([1, 1, 0])
+        );
+        assert_eq!(
+            json.get("repeated_current_probability_by_previous_rank")
+                .unwrap(),
+            &serde_json::json!([1.0, 1.0, 0.0])
+        );
+        assert_eq!(
+            json.get("best_previous_rank_by_current_rank").unwrap(),
+            &serde_json::json!([1, 0, null])
+        );
+        assert_eq!(
+            json.get("best_current_rank_by_previous_rank").unwrap(),
+            &serde_json::json!([1, 0, null])
+        );
+        assert_eq!(
+            json.get("best_transition").unwrap(),
+            &serde_json::json!({
+                "current_rank": 0,
+                "previous_rank": 1,
+                "count": 1,
+                "probability_by_current_rank": 1.0,
+            })
+        );
     }
 }

--- a/crates/runner/src/qwen36_moe_telemetry.rs
+++ b/crates/runner/src/qwen36_moe_telemetry.rs
@@ -173,6 +173,14 @@ impl MoeRouteTelemetry {
     }
 
     pub(crate) fn to_json(&self) -> serde_json::Value {
+        fn probability(count: u64, observations: u64) -> f64 {
+            if observations == 0 {
+                0.0
+            } else {
+                count as f64 / observations as f64
+            }
+        }
+
         let avg_weight_by_rank: Vec<f64> = self
             .weight_sum_by_rank
             .iter()
@@ -185,11 +193,107 @@ impl MoeRouteTelemetry {
                 }
             })
             .collect();
+        let repeated_previous_probability_by_current_rank: Vec<f64> = self
+            .repeated_previous_by_rank
+            .iter()
+            .zip(&self.observations_by_rank)
+            .map(|(count, observations)| probability(*count, *observations))
+            .collect();
+        let same_rank_repeat_probability_by_rank: Vec<f64> = self
+            .repeated_previous_rank_by_current_rank
+            .iter()
+            .enumerate()
+            .map(|(rank, row)| {
+                probability(
+                    row.get(rank).copied().unwrap_or(0),
+                    self.observations_by_rank.get(rank).copied().unwrap_or(0),
+                )
+            })
+            .collect();
+        let top_k = self.observations_by_rank.len();
+        let mut repeated_current_by_previous_rank = vec![0u64; top_k];
+        let mut best_previous_rank_by_current_rank = vec![None; top_k];
+        let mut best_current_rank_by_previous_rank = vec![None; top_k];
+        let mut best_transition: Option<(usize, usize, u64)> = None;
+        for (current_rank, row) in self
+            .repeated_previous_rank_by_current_rank
+            .iter()
+            .enumerate()
+        {
+            let mut best_previous: Option<(usize, u64)> = None;
+            for (previous_rank, &count) in row.iter().enumerate() {
+                if previous_rank < repeated_current_by_previous_rank.len() {
+                    repeated_current_by_previous_rank[previous_rank] += count;
+                }
+                if count > 0
+                    && best_previous
+                        .map(|(_, best_count)| count > best_count)
+                        .unwrap_or(true)
+                {
+                    best_previous = Some((previous_rank, count));
+                }
+                if count > 0
+                    && best_transition
+                        .map(|(_, _, best_count)| count > best_count)
+                        .unwrap_or(true)
+                {
+                    best_transition = Some((current_rank, previous_rank, count));
+                }
+            }
+            best_previous_rank_by_current_rank[current_rank] =
+                best_previous.map(|(previous_rank, _)| previous_rank);
+        }
+        for previous_rank in 0..top_k {
+            let mut best_current: Option<(usize, u64)> = None;
+            for (current_rank, row) in self
+                .repeated_previous_rank_by_current_rank
+                .iter()
+                .enumerate()
+            {
+                let count = row.get(previous_rank).copied().unwrap_or(0);
+                if count > 0
+                    && best_current
+                        .map(|(_, best_count)| count > best_count)
+                        .unwrap_or(true)
+                {
+                    best_current = Some((current_rank, count));
+                }
+            }
+            best_current_rank_by_previous_rank[previous_rank] =
+                best_current.map(|(current_rank, _)| current_rank);
+        }
+        let repeated_current_probability_by_previous_rank: Vec<f64> =
+            repeated_current_by_previous_rank
+                .iter()
+                .zip(&self.observations_by_rank)
+                .map(|(count, observations)| probability(*count, *observations))
+                .collect();
+        let best_transition_json = best_transition.map(|(current_rank, previous_rank, count)| {
+            serde_json::json!({
+                "current_rank": current_rank,
+                "previous_rank": previous_rank,
+                "count": count,
+                "probability_by_current_rank": probability(
+                    count,
+                    self.observations_by_rank
+                        .get(current_rank)
+                        .copied()
+                        .unwrap_or(0),
+                ),
+            })
+        });
         serde_json::json!({
             "observations_by_rank": &self.observations_by_rank,
             "resident_before_by_rank": &self.resident_before_by_rank,
             "repeated_previous_by_rank": &self.repeated_previous_by_rank,
+            "repeated_previous_probability_by_current_rank": repeated_previous_probability_by_current_rank,
             "repeated_previous_rank_by_current_rank": &self.repeated_previous_rank_by_current_rank,
+            "same_rank_repeat_probability_by_rank": same_rank_repeat_probability_by_rank,
+            "repeated_current_by_previous_rank": repeated_current_by_previous_rank,
+            "repeated_current_probability_by_previous_rank": repeated_current_probability_by_previous_rank,
+            "best_previous_rank_by_current_rank": best_previous_rank_by_current_rank,
+            "best_current_rank_by_previous_rank": best_current_rank_by_previous_rank,
+            "best_transition": best_transition_json,
             "avg_weight_by_rank": avg_weight_by_rank,
         })
     }

--- a/docs/lowlevel-memory.md
+++ b/docs/lowlevel-memory.md
@@ -102,7 +102,8 @@ Current scope:
   at most `N` experts' two routed projections tracked resident at once. Sparse
   telemetry records ordered router rank summaries, including per-rank resident
   hits before demand loading, previous-token repeats, previous-rank to
-  current-rank repeat transitions, and average router weight.
+  current-rank repeat transitions, derived transition probabilities, and
+  average router weight.
 - `SUPERSONIC_MOE_ISLAND_PREFETCH=previous-token` enables experimental
   previous-token routed-expert lookahead for sparse MoE islands. It preloads
   each layer's previous top-k before that layer's router runs. Set

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -288,7 +288,8 @@ lookahead, rank-limited lookahead, and full top-k lookahead rows. Use
 `--prefetch-mode-sweep disabled,previous-token,previous-token-resident`
 together with `--prefetch-rank-sweep none,1,all` to compare normal
 previous-token prefetch with resident-only LRU refresh without hand-running
-separate commands.
+separate commands. The markdown table includes same-rank repeat, previous-rank
+reuse, and best-transition columns derived from the route transition matrix.
 
 **Sparse MoE previous-token prefetch sweep** — measured 2026-05-03 after
 non-evicting prefetch admission landed. Same host/GPU/model/prompt as above,

--- a/tests/gfx1100/bench_qwen36_sparse_caps.py
+++ b/tests/gfx1100/bench_qwen36_sparse_caps.py
@@ -205,6 +205,45 @@ def fmt_rank_transition_pct(
     return f"{100.0 * float(matrix[current_rank][previous_rank]) / float(observations[current_rank]):.1f}%"
 
 
+def fmt_probability_pct(values: list[Any], rank: int = 0) -> str:
+    if rank >= len(values):
+        return "-"
+    return f"{100.0 * float(values[rank]):.1f}%"
+
+
+def fmt_same_rank_repeat_pct(route_summary: dict[str, Any], rank: int = 0) -> str:
+    values = route_summary.get("same_rank_repeat_probability_by_rank") or []
+    if values:
+        return fmt_probability_pct(values, rank)
+    return fmt_rank_transition_pct(route_summary, current_rank=rank, previous_rank=rank)
+
+
+def fmt_previous_rank_reused_pct(route_summary: dict[str, Any], previous_rank: int = 0) -> str:
+    values = route_summary.get("repeated_current_probability_by_previous_rank") or []
+    if values:
+        return fmt_probability_pct(values, previous_rank)
+    observations = route_summary.get("observations_by_rank") or []
+    matrix = route_summary.get("repeated_previous_rank_by_current_rank") or []
+    if previous_rank >= len(observations) or not observations[previous_rank]:
+        return "-"
+    count = sum(
+        row[previous_rank]
+        for row in matrix
+        if previous_rank < len(row)
+    )
+    return f"{100.0 * float(count) / float(observations[previous_rank]):.1f}%"
+
+
+def fmt_best_transition(route_summary: dict[str, Any]) -> str:
+    transition = route_summary.get("best_transition") or {}
+    current_rank = transition.get("current_rank")
+    previous_rank = transition.get("previous_rank")
+    probability = transition.get("probability_by_current_rank")
+    if current_rank is None or previous_rank is None or probability is None:
+        return "-"
+    return f"{previous_rank}->{current_rank} ({100.0 * float(probability):.1f}%)"
+
+
 def run_case(
     args: argparse.Namespace,
     case: BenchCase,
@@ -297,8 +336,8 @@ def run_case(
 
 def markdown(rows: list[dict[str, Any]]) -> str:
     out = [
-        "| Mode | total ms/tok | tok/s | total resident GiB | MoE resident GiB | KV resident GiB | prefetch | ranks | peak pages | page misses | prefetch page misses | prefetch skipped | rank0 resident | rank0 repeat | rank0 prev-rank0 repeat | evicted pages | ids match |",
-        "|---|---:|---:|---:|---:|---:|:---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|:---:|",
+        "| Mode | total ms/tok | tok/s | total resident GiB | MoE resident GiB | KV resident GiB | prefetch | ranks | peak pages | page misses | prefetch page misses | prefetch skipped | rank0 resident | rank0 repeat | rank0 same-rank | prev-rank0 reused | best transition | evicted pages | ids match |",
+        "|---|---:|---:|---:|---:|---:|:---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|:---:|---:|:---:|",
     ]
     for row in rows:
         residency = row.get("vmm_residency") or {}
@@ -306,7 +345,7 @@ def markdown(rows: list[dict[str, Any]]) -> str:
         stage = row.get("stage") or {}
         ids_match = row.get("generated_ids_match")
         out.append(
-            "| {label} | {ms} | {tok} | {total_gib} | {moe_gib} | {kv_gib} | {prefetch_mode} | {prefetch_ranks} | {peak_pages} | {page_misses} | {prefetch_page_misses} | {prefetch_skipped} | {rank0_resident} | {rank0_repeat} | {rank0_prev0_repeat} | {evicted_pages} | {ids_match} |".format(
+            "| {label} | {ms} | {tok} | {total_gib} | {moe_gib} | {kv_gib} | {prefetch_mode} | {prefetch_ranks} | {peak_pages} | {page_misses} | {prefetch_page_misses} | {prefetch_skipped} | {rank0_resident} | {rank0_repeat} | {rank0_same_rank} | {prev_rank0_reused} | {best_transition} | {evicted_pages} | {ids_match} |".format(
                 label=row["label"],
                 ms=fmt_num(stage.get("total_ms_avg")),
                 tok=fmt_num(row.get("tok_per_s")),
@@ -321,7 +360,9 @@ def markdown(rows: list[dict[str, Any]]) -> str:
                 prefetch_skipped=residency.get("prefetch_skipped", "-"),
                 rank0_resident=fmt_rank_pct(route_summary, "resident_before_by_rank"),
                 rank0_repeat=fmt_rank_pct(route_summary, "repeated_previous_by_rank"),
-                rank0_prev0_repeat=fmt_rank_transition_pct(route_summary),
+                rank0_same_rank=fmt_same_rank_repeat_pct(route_summary),
+                prev_rank0_reused=fmt_previous_rank_reused_pct(route_summary),
+                best_transition=fmt_best_transition(route_summary),
                 evicted_pages=residency.get("evicted_pages", "-"),
                 ids_match="yes" if ids_match else "NO",
             )

--- a/tests/test_qwen36_sparse_caps.py
+++ b/tests/test_qwen36_sparse_caps.py
@@ -119,6 +119,45 @@ class Qwen36SparseCapBenchTests(unittest.TestCase):
         self.assertEqual(fmt(summary, current_rank=1, previous_rank=1), "80.0%")
         self.assertEqual(fmt({}, current_rank=0, previous_rank=0), "-")
 
+    def test_transition_summary_formatters_use_derived_fields(self):
+        summary = {
+            "observations_by_rank": [10, 5],
+            "same_rank_repeat_probability_by_rank": [0.3, 0.8],
+            "repeated_current_probability_by_previous_rank": [0.4, 0.6],
+            "best_transition": {
+                "previous_rank": 1,
+                "current_rank": 0,
+                "probability_by_current_rank": 0.2,
+            },
+        }
+        self.assertEqual(
+            bench_qwen36_sparse_caps.fmt_same_rank_repeat_pct(summary, rank=0),
+            "30.0%",
+        )
+        self.assertEqual(
+            bench_qwen36_sparse_caps.fmt_previous_rank_reused_pct(summary, previous_rank=1),
+            "60.0%",
+        )
+        self.assertEqual(
+            bench_qwen36_sparse_caps.fmt_best_transition(summary),
+            "1->0 (20.0%)",
+        )
+
+    def test_transition_summary_formatters_fallback_to_matrix(self):
+        summary = {
+            "observations_by_rank": [10, 5],
+            "repeated_previous_rank_by_current_rank": [[3, 2], [1, 4]],
+        }
+        self.assertEqual(
+            bench_qwen36_sparse_caps.fmt_same_rank_repeat_pct(summary, rank=0),
+            "30.0%",
+        )
+        self.assertEqual(
+            bench_qwen36_sparse_caps.fmt_previous_rank_reused_pct(summary, previous_rank=0),
+            "40.0%",
+        )
+        self.assertEqual(bench_qwen36_sparse_caps.fmt_best_transition({}), "-")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- derive route-transition probabilities from the sparse MoE transition matrix in runtime telemetry JSON
- add same-rank repeat probabilities, previous-rank reuse probabilities, best rank mappings, and the strongest observed transition
- extend the gfx1100 sparse-cap markdown table with rank0 same-rank repeat, previous-rank0 reuse, and best-transition columns
- keep fallback formatting for older telemetry JSON that only has the raw transition matrix
- document the richer transition summaries in the low-level memory and performance notes

This builds on the larger sweep harness from #173: future prefetch/admission PRs can now cite the transition summaries directly instead of re-parsing the raw matrix manually.

## HIP smoke
`python3 tests/gfx1100/bench_qwen36_sparse_caps.py --caps 320 --prefetch-mode-sweep disabled,previous-token,previous-token-resident --prefetch-rank-sweep none,1 --max-new-tokens 8 --no-warmup --timeout 900 --out-json target/qwen36_sparse_transition_summary_smoke.json --out-md target/qwen36_sparse_transition_summary_smoke.md`

- dense: 28.50 ms/tok, ids match
- cap320 disabled: 107.61 ms/tok, ids match
- cap320 previous-token r1: 121.02 ms/tok, ids match
- cap320 previous-token-resident r1: 120.28 ms/tok, ids match
- cap320 disabled transition summaries: rank0 repeat 51.9%, rank0 same-rank 22.7%, previous-rank0 reused 52.5%, best transition 0->0 at 22.7%

## Tests
- `cargo fmt --check`
- `git diff --check`
- `python3 -m py_compile tests/gfx1100/bench_qwen36_sparse_caps.py`
- `python3 -m unittest tests.test_qwen36_sparse_caps tests.test_qwen36_verify_suite`
- `cargo check -p runner`
- `cargo test -p runner --bin supersonic moe_route_telemetry`
- `cargo build --release --bin supersonic`