### PR TITLE
[codex] split qwen36 moe prefetch orchestration

### DIFF
--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -17,6 +17,7 @@ mod qwen36_moe_decode;
 mod qwen36_moe_engine;
 mod qwen36_moe_mtp;
 mod qwen36_moe_persistent_decode;
+mod qwen36_moe_prefetch;
 mod qwen36_moe_residency;
 mod qwen36_moe_speculative;
 mod qwen36_moe_state;

--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -32,8 +32,9 @@ use crate::qwen36_moe_decode::{
     FullAttnInt4Sidecars, FullAttnKvCache, LayerBuffers, LinearAttnInt4Sidecars, MtpLayerBuffers,
     MultiLayerGeom, ResidentWeight, XorshiftRng,
 };
+use crate::qwen36_moe_prefetch::handle_moe_expert_prefetch;
 use crate::qwen36_moe_residency::{
-    MoeExpertKey, MoeExpertProjection, MoeExpertResidencyConfig, MoeExpertResidencyManager,
+    MoeExpertProjection, MoeExpertResidencyConfig, MoeExpertResidencyManager,
 };
 use crate::qwen36_moe_speculative::{
     run_speculative_decode_step, run_speculative_decode_step_batched,
@@ -2618,73 +2619,19 @@ fn decode_text(
                                     layer_idx: usize,
                                     routes: &[ExpertRoute]|
                  -> Result<()> {
-                    match phase {
-                        ExpertPrefetchPhase::Lookahead
-                            if moe_prefetch_mode.uses_previous_token_routes() =>
-                        {
-                            for &expert_idx in previous_moe_topk_by_layer
-                                .get(layer_idx)
-                                .map(Vec::as_slice)
-                                .unwrap_or(&[])
-                                .iter()
-                                .take(moe_prefetch_ranks)
-                            {
-                                let gate_up = MoeExpertKey {
-                                    layer_idx,
-                                    expert_idx,
-                                    projection: MoeExpertProjection::GateUp,
-                                };
-                                let down = MoeExpertKey {
-                                    layer_idx,
-                                    expert_idx,
-                                    projection: MoeExpertProjection::Down,
-                                };
-                                if moe_prefetch_mode.resident_only()
-                                    && !(manager.is_resident(gate_up) && manager.is_resident(down))
-                                {
-                                    continue;
-                                }
-                                manager.prefetch_resident(&store, gate_up)?;
-                                manager.prefetch_resident(&store, down)?;
-                            }
-                        }
-                        ExpertPrefetchPhase::Lookahead => {}
-                        ExpertPrefetchPhase::Demand => {
-                            if let Some(route_telemetry) = moe_route_telemetry.as_mut() {
-                                route_telemetry.record(
-                                    manager,
-                                    layer_idx,
-                                    routes,
-                                    previous_moe_topk_by_layer
-                                        .get(layer_idx)
-                                        .map(Vec::as_slice)
-                                        .unwrap_or(&[]),
-                                );
-                            }
-                            for route in routes {
-                                let expert_idx = route.expert_idx;
-                                let gate_up = MoeExpertKey {
-                                    layer_idx,
-                                    expert_idx,
-                                    projection: MoeExpertProjection::GateUp,
-                                };
-                                let down = MoeExpertKey {
-                                    layer_idx,
-                                    expert_idx,
-                                    projection: MoeExpertProjection::Down,
-                                };
-                                manager.ensure_resident(&store, gate_up)?;
-                                manager.ensure_resident(&store, down)?;
-                            }
-                            if track_moe_routes {
-                                if let Some(slot) = next_moe_topk_by_layer.get_mut(layer_idx) {
-                                    slot.clear();
-                                    slot.extend(routes.iter().map(|route| route.expert_idx));
-                                }
-                            }
-                        }
-                    }
-                    Ok(())
+                    handle_moe_expert_prefetch(
+                        manager,
+                        &store,
+                        moe_prefetch_mode,
+                        moe_prefetch_ranks,
+                        &previous_moe_topk_by_layer,
+                        &mut next_moe_topk_by_layer,
+                        track_moe_routes,
+                        moe_route_telemetry.as_mut(),
+                        phase,
+                        layer_idx,
+                        routes,
+                    )
                 };
                 scratch
                     .run_sparse_with_expert_prefetch(
@@ -2716,73 +2663,19 @@ fn decode_text(
                                     layer_idx: usize,
                                     routes: &[ExpertRoute]|
                  -> Result<()> {
-                    match phase {
-                        ExpertPrefetchPhase::Lookahead
-                            if moe_prefetch_mode.uses_previous_token_routes() =>
-                        {
-                            for &expert_idx in previous_moe_topk_by_layer
-                                .get(layer_idx)
-                                .map(Vec::as_slice)
-                                .unwrap_or(&[])
-                                .iter()
-                                .take(moe_prefetch_ranks)
-                            {
-                                let gate_up = MoeExpertKey {
-                                    layer_idx,
-                                    expert_idx,
-                                    projection: MoeExpertProjection::GateUp,
-                                };
-                                let down = MoeExpertKey {
-                                    layer_idx,
-                                    expert_idx,
-                                    projection: MoeExpertProjection::Down,
-                                };
-                                if moe_prefetch_mode.resident_only()
-                                    && !(manager.is_resident(gate_up) && manager.is_resident(down))
-                                {
-                                    continue;
-                                }
-                                manager.prefetch_resident(&store, gate_up)?;
-                                manager.prefetch_resident(&store, down)?;
-                            }
-                        }
-                        ExpertPrefetchPhase::Lookahead => {}
-                        ExpertPrefetchPhase::Demand => {
-                            if let Some(route_telemetry) = moe_route_telemetry.as_mut() {
-                                route_telemetry.record(
-                                    manager,
-                                    layer_idx,
-                                    routes,
-                                    previous_moe_topk_by_layer
-                                        .get(layer_idx)
-                                        .map(Vec::as_slice)
-                                        .unwrap_or(&[]),
-                                );
-                            }
-                            for route in routes {
-                                let expert_idx = route.expert_idx;
-                                let gate_up = MoeExpertKey {
-                                    layer_idx,
-                                    expert_idx,
-                                    projection: MoeExpertProjection::GateUp,
-                                };
-                                let down = MoeExpertKey {
-                                    layer_idx,
-                                    expert_idx,
-                                    projection: MoeExpertProjection::Down,
-                                };
-                                manager.ensure_resident(&store, gate_up)?;
-                                manager.ensure_resident(&store, down)?;
-                            }
-                            if track_moe_routes {
-                                if let Some(slot) = next_moe_topk_by_layer.get_mut(layer_idx) {
-                                    slot.clear();
-                                    slot.extend(routes.iter().map(|route| route.expert_idx));
-                                }
-                            }
-                        }
-                    }
-                    Ok(())
+                    handle_moe_expert_prefetch(
+                        manager,
+                        &store,
+                        moe_prefetch_mode,
+                        moe_prefetch_ranks,
+                        &previous_moe_topk_by_layer,
+                        &mut next_moe_topk_by_layer,
+                        track_moe_routes,
+                        moe_route_telemetry.as_mut(),
+                        phase,
+                        layer_idx,
+                        routes,
+                    )
                 };
                 run_chained_decode_fast_with_expert_prefetch(
                     ordinal,

--- a/crates/runner/src/qwen36_moe_prefetch.rs
+++ b/crates/runner/src/qwen36_moe_prefetch.rs
@@ -1,0 +1,118 @@
+use anyhow::Result;
+use model_store::BakedStore;
+
+use crate::qwen36_moe_decode::{ExpertPrefetchPhase, ExpertRoute};
+use crate::qwen36_moe_residency::{MoeExpertKey, MoeExpertProjection, MoeExpertResidencyManager};
+use crate::qwen36_moe_telemetry::{MoeIslandPrefetchMode, MoeRouteTelemetry};
+
+pub(crate) fn handle_moe_expert_prefetch(
+    manager: &mut MoeExpertResidencyManager,
+    store: &BakedStore,
+    mode: MoeIslandPrefetchMode,
+    prefetch_ranks: usize,
+    previous_topk_by_layer: &[Vec<usize>],
+    next_topk_by_layer: &mut [Vec<usize>],
+    track_routes: bool,
+    route_telemetry: Option<&mut MoeRouteTelemetry>,
+    phase: ExpertPrefetchPhase,
+    layer_idx: usize,
+    routes: &[ExpertRoute],
+) -> Result<()> {
+    match phase {
+        ExpertPrefetchPhase::Lookahead if mode.uses_previous_token_routes() => {
+            prefetch_previous_token_routes(
+                manager,
+                store,
+                mode,
+                prefetch_ranks,
+                previous_topk_by_layer,
+                layer_idx,
+            )?;
+        }
+        ExpertPrefetchPhase::Lookahead => {}
+        ExpertPrefetchPhase::Demand => {
+            ensure_demand_routes(
+                manager,
+                store,
+                previous_topk_by_layer,
+                next_topk_by_layer,
+                track_routes,
+                route_telemetry,
+                layer_idx,
+                routes,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn prefetch_previous_token_routes(
+    manager: &mut MoeExpertResidencyManager,
+    store: &BakedStore,
+    mode: MoeIslandPrefetchMode,
+    prefetch_ranks: usize,
+    previous_topk_by_layer: &[Vec<usize>],
+    layer_idx: usize,
+) -> Result<()> {
+    for &expert_idx in previous_topk_by_layer
+        .get(layer_idx)
+        .map(Vec::as_slice)
+        .unwrap_or(&[])
+        .iter()
+        .take(prefetch_ranks)
+    {
+        let gate_up = expert_key(layer_idx, expert_idx, MoeExpertProjection::GateUp);
+        let down = expert_key(layer_idx, expert_idx, MoeExpertProjection::Down);
+        if mode.resident_only() && !(manager.is_resident(gate_up) && manager.is_resident(down)) {
+            continue;
+        }
+        manager.prefetch_resident(store, gate_up)?;
+        manager.prefetch_resident(store, down)?;
+    }
+    Ok(())
+}
+
+fn ensure_demand_routes(
+    manager: &mut MoeExpertResidencyManager,
+    store: &BakedStore,
+    previous_topk_by_layer: &[Vec<usize>],
+    next_topk_by_layer: &mut [Vec<usize>],
+    track_routes: bool,
+    route_telemetry: Option<&mut MoeRouteTelemetry>,
+    layer_idx: usize,
+    routes: &[ExpertRoute],
+) -> Result<()> {
+    let previous_routes = previous_topk_by_layer
+        .get(layer_idx)
+        .map(Vec::as_slice)
+        .unwrap_or(&[]);
+    if let Some(route_telemetry) = route_telemetry {
+        route_telemetry.record(manager, layer_idx, routes, previous_routes);
+    }
+    for route in routes {
+        let expert_idx = route.expert_idx;
+        let gate_up = expert_key(layer_idx, expert_idx, MoeExpertProjection::GateUp);
+        let down = expert_key(layer_idx, expert_idx, MoeExpertProjection::Down);
+        manager.ensure_resident(store, gate_up)?;
+        manager.ensure_resident(store, down)?;
+    }
+    if track_routes {
+        if let Some(slot) = next_topk_by_layer.get_mut(layer_idx) {
+            slot.clear();
+            slot.extend(routes.iter().map(|route| route.expert_idx));
+        }
+    }
+    Ok(())
+}
+
+fn expert_key(
+    layer_idx: usize,
+    expert_idx: usize,
+    projection: MoeExpertProjection,
+) -> MoeExpertKey {
+    MoeExpertKey {
+        layer_idx,
+        expert_idx,
+        projection,
+    }
+}


### PR DESCRIPTION
## Summary

- Move the duplicated Qwen3.6 MoE expert prefetch/routing logic into `qwen36_moe_prefetch.rs`.
- Reuse the same handler from both the segmented persistent path and chained decode path.
- Preserve resident-only lookahead prefetch, demand residency, route telemetry, and next-token route tracking behavior.

## Impact

This is a cleanup-only refactor that keeps decode behavior unchanged while making `qwen36_moe_engine.rs` smaller and reducing duplicated prefetch policy logic.

## Validation

- `cargo fmt`
- `cargo check -p runner --bin supersonic --quiet`
- `cargo test -p runner --bin supersonic --quiet`
- `cargo check -p runner --all-targets --quiet`
- `cargo test --workspace --no-fail-fast`
