### PR TITLE
Add transition-aware MoE prefetch admission

### DIFF
--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -42,7 +42,7 @@ use crate::qwen36_moe_speculative::{
 use crate::qwen36_moe_state::{refresh_linear_attn_state, restore_linear_attn_state};
 use crate::qwen36_moe_telemetry::{
     MoeIslandPrefetchMode, MoeRouteTelemetry, MoeSparseTelemetry, MoeSparseTelemetrySnapshot,
-    VirtualKvStats,
+    MoeTransitionPredictor, VirtualKvStats,
 };
 use crate::registry::{FamilyParams, Qwen36MoeKernelParams, RegistryEntry};
 
@@ -1102,35 +1102,63 @@ fn moe_island_prefetch_ranks_from_env_value(
             if raw.is_some() {
                 anyhow::bail!(
                     "SUPERSONIC_MOE_ISLAND_PREFETCH_RANKS requires \
-                     SUPERSONIC_MOE_ISLAND_PREFETCH=previous-token or previous-token-resident"
+                     SUPERSONIC_MOE_ISLAND_PREFETCH=previous-token, \
+                     previous-token-resident, or transition"
                 );
             }
             Ok(0)
         }
-        MoeIslandPrefetchMode::PreviousToken | MoeIslandPrefetchMode::PreviousTokenResidentOnly => {
-            match raw {
-                None | Some("all") => Ok(top_k),
-                Some(value) => {
-                    let ranks = value.parse::<usize>().with_context(|| {
-                        format!(
+        MoeIslandPrefetchMode::PreviousToken
+        | MoeIslandPrefetchMode::PreviousTokenResidentOnly
+        | MoeIslandPrefetchMode::Transition => match raw {
+            None | Some("all") => Ok(top_k),
+            Some(value) => {
+                let ranks = value.parse::<usize>().with_context(|| {
+                    format!(
                         "parse SUPERSONIC_MOE_ISLAND_PREFETCH_RANKS={value:?} as positive integer"
                     )
-                    })?;
-                    if ranks == 0 || ranks > top_k {
-                        anyhow::bail!(
+                })?;
+                if ranks == 0 || ranks > top_k {
+                    anyhow::bail!(
                         "SUPERSONIC_MOE_ISLAND_PREFETCH_RANKS must be in 1..={top_k}; got {ranks}"
                     );
-                    }
-                    Ok(ranks)
                 }
+                Ok(ranks)
             }
-        }
+        },
     }
 }
 
 fn moe_island_prefetch_ranks_from_env(mode: MoeIslandPrefetchMode, top_k: usize) -> Result<usize> {
     let raw = std::env::var("SUPERSONIC_MOE_ISLAND_PREFETCH_RANKS").ok();
     moe_island_prefetch_ranks_from_env_value(raw.as_deref(), mode, top_k)
+}
+
+fn moe_island_prefetch_transition_min_observations_from_env_value(
+    raw: Option<&str>,
+    mode: MoeIslandPrefetchMode,
+) -> Result<u32> {
+    if !mode.transition_weighted() {
+        if raw.is_some() {
+            anyhow::bail!(
+                "SUPERSONIC_MOE_ISLAND_PREFETCH_TRANSITION_MIN_OBS requires \
+                 SUPERSONIC_MOE_ISLAND_PREFETCH=transition"
+            );
+        }
+        return Ok(0);
+    }
+
+    let Some(value) = raw else {
+        return Ok(32);
+    };
+    value.parse::<u32>().with_context(|| {
+        format!("parse SUPERSONIC_MOE_ISLAND_PREFETCH_TRANSITION_MIN_OBS={value:?} as integer")
+    })
+}
+
+fn moe_island_prefetch_transition_min_observations(mode: MoeIslandPrefetchMode) -> Result<u32> {
+    let raw = std::env::var("SUPERSONIC_MOE_ISLAND_PREFETCH_TRANSITION_MIN_OBS").ok();
+    moe_island_prefetch_transition_min_observations_from_env_value(raw.as_deref(), mode)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2130,6 +2158,8 @@ fn decode_text(
     let moe_prefetch_mode = MoeIslandPrefetchMode::from_env()?;
     let moe_prefetch_ranks =
         moe_island_prefetch_ranks_from_env(moe_prefetch_mode, geom.top_k as usize)?;
+    let moe_transition_min_observations =
+        moe_island_prefetch_transition_min_observations(moe_prefetch_mode)?;
     if moe_prefetch_mode != MoeIslandPrefetchMode::Disabled && !sparse_moe_requested {
         anyhow::bail!("SUPERSONIC_MOE_ISLAND_PREFETCH requires SUPERSONIC_MOE_ISLAND_CAP_EXPERTS");
     }
@@ -2207,6 +2237,12 @@ fn decode_text(
                 moe_prefetch_mode.as_str(),
                 geom.top_k
             );
+            if moe_prefetch_mode.transition_weighted() {
+                println!(
+                    "  [vmm] sparse MoE transition predictor warmup \
+                     min_observations={moe_transition_min_observations}"
+                );
+            }
         }
         _moe_expert_residency = Some(manager);
         layers
@@ -2540,6 +2576,12 @@ fn decode_text(
         vec![Vec::new(); geom.num_layers as usize];
     let mut moe_route_telemetry =
         sparse_moe_requested.then(|| MoeRouteTelemetry::new(geom.top_k as usize));
+    let mut moe_transition_predictors = moe_prefetch_mode.transition_weighted().then(|| {
+        vec![
+            MoeTransitionPredictor::new(geom.top_k as usize, moe_transition_min_observations,);
+            geom.num_layers as usize
+        ]
+    });
 
     for step in 0..total_steps {
         // When speculative decode is on, each iteration can commit
@@ -2628,6 +2670,7 @@ fn decode_text(
                         &mut next_moe_topk_by_layer,
                         track_moe_routes,
                         moe_route_telemetry.as_mut(),
+                        moe_transition_predictors.as_deref_mut(),
                         phase,
                         layer_idx,
                         routes,
@@ -2672,6 +2715,7 @@ fn decode_text(
                         &mut next_moe_topk_by_layer,
                         track_moe_routes,
                         moe_route_telemetry.as_mut(),
+                        moe_transition_predictors.as_deref_mut(),
                         phase,
                         layer_idx,
                         routes,
@@ -3506,8 +3550,10 @@ fn decode_first_token(model_dir: &Path, report: &DryRunReport, kv_fp8: bool) -> 
 #[cfg(test)]
 mod tests {
     use super::{
-        moe_island_prefetch_ranks_from_env_value, qwen36_kv_vmm_mode_from_env_value, ExpertRoute,
-        MoeIslandPrefetchMode, MoeRouteTelemetry, Qwen36KvVmmMode,
+        moe_island_prefetch_ranks_from_env_value,
+        moe_island_prefetch_transition_min_observations_from_env_value,
+        qwen36_kv_vmm_mode_from_env_value, ExpertRoute, MoeIslandPrefetchMode, MoeRouteTelemetry,
+        MoeTransitionPredictor, Qwen36KvVmmMode,
     };
     use gpu_hal::Backend;
 
@@ -3578,6 +3624,21 @@ mod tests {
     }
 
     #[test]
+    fn moe_prefetch_mode_env_accepts_transition_aliases() {
+        assert_eq!(
+            MoeIslandPrefetchMode::from_env_value(Some("transition")).unwrap(),
+            MoeIslandPrefetchMode::Transition
+        );
+        assert_eq!(
+            MoeIslandPrefetchMode::from_env_value(Some("transition-weighted")).unwrap(),
+            MoeIslandPrefetchMode::Transition
+        );
+        assert_eq!(MoeIslandPrefetchMode::Transition.as_str(), "transition");
+        assert!(MoeIslandPrefetchMode::Transition.uses_previous_token_routes());
+        assert!(MoeIslandPrefetchMode::Transition.transition_weighted());
+    }
+
+    #[test]
     fn moe_prefetch_ranks_default_to_all_previous_token_routes() {
         assert_eq!(
             moe_island_prefetch_ranks_from_env_value(
@@ -3619,6 +3680,15 @@ mod tests {
             .unwrap(),
             4
         );
+        assert_eq!(
+            moe_island_prefetch_ranks_from_env_value(
+                Some("2"),
+                MoeIslandPrefetchMode::Transition,
+                8,
+            )
+            .unwrap(),
+            2
+        );
     }
 
     #[test]
@@ -3642,10 +3712,84 @@ mod tests {
         .is_err());
         assert!(moe_island_prefetch_ranks_from_env_value(
             Some("9"),
-            MoeIslandPrefetchMode::PreviousToken,
+            MoeIslandPrefetchMode::Transition,
             8,
         )
         .is_err());
+    }
+
+    #[test]
+    fn moe_transition_min_observations_defaults_only_for_transition_mode() {
+        assert_eq!(
+            moe_island_prefetch_transition_min_observations_from_env_value(
+                None,
+                MoeIslandPrefetchMode::Transition,
+            )
+            .unwrap(),
+            32
+        );
+        assert_eq!(
+            moe_island_prefetch_transition_min_observations_from_env_value(
+                Some("4"),
+                MoeIslandPrefetchMode::Transition,
+            )
+            .unwrap(),
+            4
+        );
+        assert_eq!(
+            moe_island_prefetch_transition_min_observations_from_env_value(
+                None,
+                MoeIslandPrefetchMode::PreviousToken,
+            )
+            .unwrap(),
+            0
+        );
+        assert!(
+            moe_island_prefetch_transition_min_observations_from_env_value(
+                Some("4"),
+                MoeIslandPrefetchMode::PreviousToken,
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn moe_transition_predictor_waits_for_warmup_and_scores_repeats() {
+        let mut predictor = MoeTransitionPredictor::new(3, 2);
+        let previous_routes = [10, 20, 30];
+        let routes = [
+            ExpertRoute {
+                rank: 0,
+                expert_idx: 20,
+                weight: 0.5,
+            },
+            ExpertRoute {
+                rank: 1,
+                expert_idx: 99,
+                weight: 0.25,
+            },
+        ];
+
+        predictor.update(&routes, &previous_routes);
+        assert!(predictor.candidates(&previous_routes, 2).is_empty());
+
+        predictor.update(&routes, &previous_routes);
+        assert_eq!(predictor.candidates(&previous_routes, 2), vec![20]);
+
+        let later_routes = [
+            ExpertRoute {
+                rank: 0,
+                expert_idx: 10,
+                weight: 0.5,
+            },
+            ExpertRoute {
+                rank: 1,
+                expert_idx: 20,
+                weight: 0.25,
+            },
+        ];
+        predictor.update(&later_routes, &previous_routes);
+        assert_eq!(predictor.candidates(&previous_routes, 2), vec![20, 10]);
     }
 
     #[test]

--- a/crates/runner/src/qwen36_moe_prefetch.rs
+++ b/crates/runner/src/qwen36_moe_prefetch.rs
@@ -1,9 +1,13 @@
 use anyhow::Result;
+use std::borrow::Cow;
+
 use model_store::BakedStore;
 
 use crate::qwen36_moe_decode::{ExpertPrefetchPhase, ExpertRoute};
 use crate::qwen36_moe_residency::{MoeExpertKey, MoeExpertProjection, MoeExpertResidencyManager};
-use crate::qwen36_moe_telemetry::{MoeIslandPrefetchMode, MoeRouteTelemetry};
+use crate::qwen36_moe_telemetry::{
+    MoeIslandPrefetchMode, MoeRouteTelemetry, MoeTransitionPredictor,
+};
 
 pub(crate) fn handle_moe_expert_prefetch(
     manager: &mut MoeExpertResidencyManager,
@@ -14,6 +18,7 @@ pub(crate) fn handle_moe_expert_prefetch(
     next_topk_by_layer: &mut [Vec<usize>],
     track_routes: bool,
     route_telemetry: Option<&mut MoeRouteTelemetry>,
+    transition_predictors: Option<&mut [MoeTransitionPredictor]>,
     phase: ExpertPrefetchPhase,
     layer_idx: usize,
     routes: &[ExpertRoute],
@@ -26,6 +31,7 @@ pub(crate) fn handle_moe_expert_prefetch(
                 mode,
                 prefetch_ranks,
                 previous_topk_by_layer,
+                transition_predictors,
                 layer_idx,
             )?;
         }
@@ -38,6 +44,7 @@ pub(crate) fn handle_moe_expert_prefetch(
                 next_topk_by_layer,
                 track_routes,
                 route_telemetry,
+                transition_predictors,
                 layer_idx,
                 routes,
             )?;
@@ -52,15 +59,26 @@ fn prefetch_previous_token_routes(
     mode: MoeIslandPrefetchMode,
     prefetch_ranks: usize,
     previous_topk_by_layer: &[Vec<usize>],
+    transition_predictors: Option<&mut [MoeTransitionPredictor]>,
     layer_idx: usize,
 ) -> Result<()> {
-    for &expert_idx in previous_topk_by_layer
+    let previous_routes = previous_topk_by_layer
         .get(layer_idx)
         .map(Vec::as_slice)
-        .unwrap_or(&[])
-        .iter()
-        .take(prefetch_ranks)
-    {
+        .unwrap_or(&[]);
+    let transition_candidates;
+    let candidate_experts: Cow<'_, [usize]> = if mode.transition_weighted() {
+        transition_candidates = transition_predictors
+            .as_ref()
+            .and_then(|predictors| predictors.get(layer_idx))
+            .map(|predictor| predictor.candidates(previous_routes, prefetch_ranks))
+            .unwrap_or_default();
+        Cow::Owned(transition_candidates)
+    } else {
+        Cow::Borrowed(&previous_routes[..previous_routes.len().min(prefetch_ranks)])
+    };
+
+    for &expert_idx in candidate_experts.iter() {
         let gate_up = expert_key(layer_idx, expert_idx, MoeExpertProjection::GateUp);
         let down = expert_key(layer_idx, expert_idx, MoeExpertProjection::Down);
         if mode.resident_only() && !(manager.is_resident(gate_up) && manager.is_resident(down)) {
@@ -79,6 +97,7 @@ fn ensure_demand_routes(
     next_topk_by_layer: &mut [Vec<usize>],
     track_routes: bool,
     route_telemetry: Option<&mut MoeRouteTelemetry>,
+    transition_predictors: Option<&mut [MoeTransitionPredictor]>,
     layer_idx: usize,
     routes: &[ExpertRoute],
 ) -> Result<()> {
@@ -88,6 +107,11 @@ fn ensure_demand_routes(
         .unwrap_or(&[]);
     if let Some(route_telemetry) = route_telemetry {
         route_telemetry.record(manager, layer_idx, routes, previous_routes);
+    }
+    if let Some(predictors) = transition_predictors {
+        if let Some(predictor) = predictors.get_mut(layer_idx) {
+            predictor.update(routes, previous_routes);
+        }
     }
     for route in routes {
         let expert_idx = route.expert_idx;

--- a/crates/runner/src/qwen36_moe_telemetry.rs
+++ b/crates/runner/src/qwen36_moe_telemetry.rs
@@ -12,6 +12,7 @@ pub(crate) enum MoeIslandPrefetchMode {
     Disabled,
     PreviousToken,
     PreviousTokenResidentOnly,
+    Transition,
 }
 
 impl MoeIslandPrefetchMode {
@@ -20,15 +21,23 @@ impl MoeIslandPrefetchMode {
             Self::Disabled => "disabled",
             Self::PreviousToken => "previous-token",
             Self::PreviousTokenResidentOnly => "previous-token-resident",
+            Self::Transition => "transition",
         }
     }
 
     pub(crate) fn uses_previous_token_routes(self) -> bool {
-        matches!(self, Self::PreviousToken | Self::PreviousTokenResidentOnly)
+        matches!(
+            self,
+            Self::PreviousToken | Self::PreviousTokenResidentOnly | Self::Transition
+        )
     }
 
     pub(crate) fn resident_only(self) -> bool {
         matches!(self, Self::PreviousTokenResidentOnly)
+    }
+
+    pub(crate) fn transition_weighted(self) -> bool {
+        matches!(self, Self::Transition)
     }
 
     pub(crate) fn from_env() -> Result<Self> {
@@ -49,13 +58,72 @@ impl MoeIslandPrefetchMode {
             | Some("previous_token_resident")
             | Some("prev-token-resident")
             | Some("resident-previous-token") => Ok(Self::PreviousTokenResidentOnly),
+            Some("transition") | Some("transition-weighted") | Some("transition_weighted") => {
+                Ok(Self::Transition)
+            }
             Some(other) => anyhow::bail!(
                 "SUPERSONIC_MOE_ISLAND_PREFETCH must be unset, 0, off, disabled, \
                  previous-token, previous_token, prev-token, previous-token-resident, \
-                 previous_token_resident, prev-token-resident, or resident-previous-token; \
+                 previous_token_resident, prev-token-resident, resident-previous-token, \
+                 transition, transition-weighted, or transition_weighted; \
                  got {other:?}"
             ),
         }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct MoeTransitionPredictor {
+    top_k: usize,
+    min_observations: u32,
+    observations_by_previous_rank: Vec<u32>,
+    repeated_current_by_previous_rank: Vec<u32>,
+}
+
+impl MoeTransitionPredictor {
+    pub(crate) fn new(top_k: usize, min_observations: u32) -> Self {
+        Self {
+            top_k,
+            min_observations,
+            observations_by_previous_rank: vec![0; top_k],
+            repeated_current_by_previous_rank: vec![0; top_k],
+        }
+    }
+
+    pub(crate) fn update(&mut self, routes: &[ExpertRoute], previous_routes: &[usize]) {
+        for (previous_rank, &expert_idx) in previous_routes.iter().take(self.top_k).enumerate() {
+            self.observations_by_previous_rank[previous_rank] =
+                self.observations_by_previous_rank[previous_rank].saturating_add(1);
+            if routes.iter().any(|route| route.expert_idx == expert_idx) {
+                self.repeated_current_by_previous_rank[previous_rank] =
+                    self.repeated_current_by_previous_rank[previous_rank].saturating_add(1);
+            }
+        }
+    }
+
+    pub(crate) fn candidates(&self, previous_routes: &[usize], limit: usize) -> Vec<usize> {
+        let mut scored = Vec::new();
+        for (previous_rank, &expert_idx) in previous_routes.iter().take(self.top_k).enumerate() {
+            let observations = self.observations_by_previous_rank[previous_rank];
+            if observations < self.min_observations {
+                continue;
+            }
+            let repeats = self.repeated_current_by_previous_rank[previous_rank];
+            if repeats == 0 {
+                continue;
+            }
+            scored.push((repeats, observations, previous_rank, expert_idx));
+        }
+        scored.sort_by(|a, b| {
+            let lhs = (a.0 as u64) * (b.1 as u64);
+            let rhs = (b.0 as u64) * (a.1 as u64);
+            rhs.cmp(&lhs).then_with(|| a.2.cmp(&b.2))
+        });
+        scored
+            .into_iter()
+            .take(limit)
+            .map(|(_, _, _, expert_idx)| expert_idx)
+            .collect()
     }
 }
 

--- a/docs/lowlevel-memory.md
+++ b/docs/lowlevel-memory.md
@@ -118,6 +118,13 @@ Current scope:
   variant: it only refreshes the previous-token expert pair when both routed
   projections are already resident. It never uploads missing pages, so it can
   measure LRU refresh value without changing residency admission.
+- `SUPERSONIC_MOE_ISLAND_PREFETCH=transition` enables online transition-aware
+  admission for sparse MoE islands. Each layer tracks how often a previous-token
+  routed rank is reused by the current token, waits for
+  `SUPERSONIC_MOE_ISLAND_PREFETCH_TRANSITION_MIN_OBS` observations per previous
+  rank (default 32), then prefetches only ranks with observed repeats. Candidate
+  ordering uses repeat probability and still honors
+  `SUPERSONIC_MOE_ISLAND_PREFETCH_RANKS` as the maximum candidate count.
 - `SUPERSONIC_VMM_KV=0` disables the Qwen3.5 and Qwen3.6 KV integrations.
 - `SUPERSONIC_VMM_KV=1` requests KV VMM and logs if the backend cannot support
   it. HIP may auto-enable when unset; CUDA requires this explicit opt-in.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -285,11 +285,12 @@ the miss rate substantially.
 The sweep helper can compare prefetch policies in one run. Use
 `--prefetch-rank-sweep none,1,2,4,all` to expand every sparse cap across no
 lookahead, rank-limited lookahead, and full top-k lookahead rows. Use
-`--prefetch-mode-sweep disabled,previous-token,previous-token-resident`
+`--prefetch-mode-sweep disabled,previous-token,previous-token-resident,transition`
 together with `--prefetch-rank-sweep none,1,all` to compare normal
-previous-token prefetch with resident-only LRU refresh without hand-running
-separate commands. The markdown table includes same-rank repeat, previous-rank
-reuse, and best-transition columns derived from the route transition matrix.
+previous-token prefetch, resident-only LRU refresh, and online transition-aware
+admission without hand-running separate commands. The markdown table includes
+same-rank repeat, previous-rank reuse, and best-transition columns derived from
+the route transition matrix.
 
 **Sparse MoE previous-token prefetch sweep** — measured 2026-05-03 after
 non-evicting prefetch admission landed. Same host/GPU/model/prompt as above,
@@ -314,6 +315,16 @@ but still regresses versus no lookahead, so even refreshing previous-token
 residents perturbs LRU in the wrong direction for this prompt. Treat
 previous-token prefetch as diagnostic only; the next useful policy needs a
 stronger admission signal than "same layer's previous token top-k".
+
+**Sparse MoE transition-prefetch smoke** — measured 2026-05-03 with
+`SUPERSONIC_MOE_ISLAND_CAP_EXPERTS=320`, 8 generated tokens, no warmup, and
+`--prefetch-transition-min-obs 1` to force the online predictor path to admit
+within the short run. IDs matched across all rows. The transition path remained
+non-evicting and recorded zero prefetch page misses, but it regressed this short
+fox prompt (`126.31 ms/tok`) versus no lookahead (`108.63 ms/tok`) and
+previous-token rank-1 (`122.00 ms/tok`). Treat transition prefetch as an
+experimental policy that needs longer prompts and prompt diversity before it can
+be considered for defaults.
 
 Reproduce:
 

--- a/tests/gfx1100/bench_qwen36_sparse_caps.py
+++ b/tests/gfx1100/bench_qwen36_sparse_caps.py
@@ -67,6 +67,8 @@ def parse_prefetch_mode_policy(raw: str) -> tuple[str, str | None]:
         "resident-previous-token",
     }:
         return ("previous-token-resident", "previous-token-resident")
+    if value in {"transition", "transition-weighted"}:
+        return ("transition", "transition")
     raise ValueError(f"unknown prefetch mode {raw!r}")
 
 
@@ -257,6 +259,7 @@ def run_case(
     env.pop("SUPERSONIC_MOE_ISLAND_TELEMETRY_JSON", None)
     env.pop("SUPERSONIC_MOE_ISLAND_PREFETCH", None)
     env.pop("SUPERSONIC_MOE_ISLAND_PREFETCH_RANKS", None)
+    transition_min_obs = env.pop("SUPERSONIC_MOE_ISLAND_PREFETCH_TRANSITION_MIN_OBS", None)
     telemetry_path = tmp / f"{case.label}_telemetry.json"
     if case.cap is not None:
         env["SUPERSONIC_MOE_ISLAND_CAP_EXPERTS"] = str(case.cap)
@@ -265,6 +268,14 @@ def run_case(
             env["SUPERSONIC_MOE_ISLAND_PREFETCH"] = case.prefetch_mode
         if case.prefetch_ranks is not None:
             env["SUPERSONIC_MOE_ISLAND_PREFETCH_RANKS"] = case.prefetch_ranks
+        if case.prefetch_mode == "transition":
+            configured_min_obs = args.prefetch_transition_min_obs
+            if configured_min_obs is None:
+                configured_min_obs = transition_min_obs
+            if configured_min_obs is not None:
+                env["SUPERSONIC_MOE_ISLAND_PREFETCH_TRANSITION_MIN_OBS"] = str(
+                    configured_min_obs
+                )
 
     cmd = [
         str(args.binary),
@@ -386,14 +397,14 @@ def main() -> int:
     parser.add_argument("--no-persistent-decode", action="store_true")
     parser.add_argument(
         "--prefetch",
-        choices=["previous-token", "previous-token-resident"],
+        choices=["previous-token", "previous-token-resident", "transition"],
         help="set SUPERSONIC_MOE_ISLAND_PREFETCH for sparse cap rows",
     )
     parser.add_argument(
         "--prefetch-mode-sweep",
         help=(
             "comma-separated sparse prefetch modes to sweep per cap, e.g. "
-            "disabled,previous-token,previous-token-resident"
+            "disabled,previous-token,previous-token-resident,transition"
         ),
     )
     parser.add_argument(
@@ -406,6 +417,11 @@ def main() -> int:
             "comma-separated sparse prefetch policies to sweep per cap, e.g. "
             "none,1,2,4,all; overrides --prefetch/--prefetch-ranks"
         ),
+    )
+    parser.add_argument(
+        "--prefetch-transition-min-obs",
+        type=int,
+        help="set SUPERSONIC_MOE_ISLAND_PREFETCH_TRANSITION_MIN_OBS for transition rows only",
     )
     parser.add_argument("--out-json", type=Path, default=Path("target/qwen36_sparse_cap_sweep.json"))
     parser.add_argument("--out-md", type=Path, default=Path("target/qwen36_sparse_cap_sweep.md"))
@@ -425,6 +441,8 @@ def main() -> int:
         if ranks is None:
             parser.error("--prefetch-ranks must be a positive integer or all")
         args.prefetch_ranks = ranks
+    if args.prefetch_transition_min_obs is not None and args.prefetch_transition_min_obs < 0:
+        parser.error("--prefetch-transition-min-obs must be >= 0")
     if not args.binary.exists():
         raise FileNotFoundError(args.binary)
     if not args.model_dir.exists():
@@ -483,6 +501,7 @@ def main() -> int:
         "prefetch": args.prefetch,
         "prefetch_mode_sweep": args.prefetch_mode_sweep,
         "prefetch_rank_sweep": args.prefetch_rank_sweep,
+        "prefetch_transition_min_obs": args.prefetch_transition_min_obs,
         "rows": rows,
     }
     args.out_json.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_qwen36_sparse_caps.py
+++ b/tests/test_qwen36_sparse_caps.py
@@ -42,11 +42,15 @@ class Qwen36SparseCapBenchTests(unittest.TestCase):
     def test_parse_prefetch_mode_policies_accepts_aliases_and_dedupes(self):
         parse = bench_qwen36_sparse_caps.parse_prefetch_mode_policies
         self.assertEqual(
-            parse("disabled,previous-token,previous_token,previous-token-resident"),
+            parse(
+                "disabled,previous-token,previous_token,previous-token-resident,"
+                "transition,transition_weighted"
+            ),
             [
                 ("none", None),
                 ("previous-token", "previous-token"),
                 ("previous-token-resident", "previous-token-resident"),
+                ("transition", "transition"),
             ],
         )
         with self.assertRaises(ValueError):
@@ -83,7 +87,7 @@ class Qwen36SparseCapBenchTests(unittest.TestCase):
         self.assert_cases_equal(
             build_cases(
                 [320],
-                "disabled,previous-token,previous-token-resident",
+                "disabled,previous-token,previous-token-resident,transition",
                 "none,1,all",
                 None,
                 None,
@@ -105,6 +109,8 @@ class Qwen36SparseCapBenchTests(unittest.TestCase):
                     "previous-token-resident",
                     "all",
                 ),
+                ("cap320-transition-r1", 320, "transition", "1"),
+                ("cap320-transition-all", 320, "transition", "all"),
             ],
         )
 


### PR DESCRIPTION
## Summary
- add SUPERSONIC_MOE_ISLAND_PREFETCH=transition with a per-layer online transition predictor
- gate transition candidates behind SUPERSONIC_MOE_ISLAND_PREFETCH_TRANSITION_MIN_OBS and keep non-evicting admission
- extend the sparse cap benchmark and docs for transition mode and transition-only warmup tuning

## Validation
- python3 -m py_compile tests/gfx1100/bench_qwen36_sparse_caps.py
- python3 -m unittest tests.test_qwen36_sparse_caps
- cargo test -p runner --bin supersonic moe_prefetch -- --nocapture
- cargo test -p runner --bin supersonic moe_transition -- --nocapture
- cargo check -p runner
- cargo build --release --bin supersonic
- python3 tests/gfx1100/bench_qwen36_sparse_caps.py --caps 320 --prefetch-mode-sweep disabled,previous-token,previous-token-resident,transition --prefetch-rank-sweep none,1 --prefetch-transition-min-obs 1 --max-new-tokens 8 --no-warmup --timeout 900 --out-json target/qwen36_sparse_transition_prefetch_smoke.json --out-md target/qwen36_sparse_transition_prefetch_smoke.md

## HIP smoke result
- IDs matched across dense, disabled sparse, previous-token rank-1, previous-token-resident rank-1, and transition rank-1
- transition rank-1 was functionally live but regressed on the short fox prompt: 126.31 ms/tok vs 108.63 ms/tok disabled sparse