### PR TITLE
[codex] split qwen36 moe speculative verify helpers

### DIFF
--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -34,6 +34,7 @@ mod qwen36_moe_prefetch;
 mod qwen36_moe_prompt;
 mod qwen36_moe_residency;
 mod qwen36_moe_session;
+mod qwen36_moe_spec_verify;
 mod qwen36_moe_speculative;
 mod qwen36_moe_state;
 mod qwen36_moe_telemetry;

--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -37,12 +37,13 @@ use crate::qwen36_moe_prompt::{
 };
 use crate::qwen36_moe_session::{prepare_decode_session, Qwen36DecodeSession};
 use crate::qwen36_moe_spec_verify::{
-    run_batched_lm_head_top1, run_spec_chain_step, Qwen36BatchedLmHeadTop1, Qwen36SpecChainStep,
+    restore_and_replay_accepted_prefix, run_batched_lm_head_top1, run_spec_chain_step,
+    Qwen36BatchedLmHeadTop1, Qwen36SpecChainStep, Qwen36SpecReplayAccepted,
 };
 use crate::qwen36_moe_speculative::{
     run_speculative_decode_step, run_speculative_decode_step_batched,
 };
-use crate::qwen36_moe_state::{refresh_linear_attn_state, restore_linear_attn_state};
+use crate::qwen36_moe_state::refresh_linear_attn_state;
 use crate::qwen36_moe_telemetry::{print_and_write_moe_residency_summary, MoeRouteRuntime};
 use crate::qwen36_moe_timing::{Qwen36StageTimingTotals, SamplingParams};
 use crate::qwen36_moe_vmm::{
@@ -500,33 +501,22 @@ fn decode_text(
                 // drafts[K-1], one more chain's worth advances naturally
                 // when next iter feeds the bonus token).
                 if r.n_accepted < dynamic_k {
-                    restore_linear_attn_state(ordinal, &mut layers, snapshot)
-                        .context("restore linear-attn state after partial-accept")?;
                     // Replay (j+1) chains: first_token at the current
                     // position, then the j accepted drafts at the
                     // following positions.
                     let replay = loop_state.speculative_replay_inputs(next_token, &r);
-                    for &(pos, input) in &replay {
-                        run_spec_chain_step(Qwen36SpecChainStep {
-                            ordinal,
-                            geom: &geom,
-                            store: &store,
-                            weight_prefix,
-                            layers: &mut layers,
-                            persistent_scratch: persistent_scratch.as_mut(),
-                            stage_timings: &mut stage_timings,
-                            position: pos,
-                            input,
-                            emit_stage_timings,
-                        })?;
-                        // Per-kernel-class breakdown for replay chains
-                        // contributes to the same accumulators as the
-                        // verify chains so `--emit-stage-timings` reports
-                        // honest full-attn/linear-attn/ffn averages on
-                        // partial-accept iters. Without this the reported
-                        // chain breakdown undercounts actual work as the
-                        // accept rate falls.
-                    }
+                    restore_and_replay_accepted_prefix(Qwen36SpecReplayAccepted {
+                        ordinal,
+                        geom: &geom,
+                        store: &store,
+                        weight_prefix,
+                        layers: &mut layers,
+                        snapshot,
+                        persistent_scratch: persistent_scratch.as_mut(),
+                        stage_timings: &mut stage_timings,
+                        replay_inputs: &replay,
+                        emit_stage_timings,
+                    })?;
                 }
                 r
             } else {

--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -18,7 +18,7 @@ use model_store::BakedStore;
 
 use crate::qwen36_moe_bake::{ensure_qwen36_bake, select_decode_bake};
 use crate::qwen36_moe_chain::{run_chain_step, Qwen36ChainStep};
-use crate::qwen36_moe_decode::{argmax_bf16_logits, run_chained_decode_fast, XorshiftRng};
+use crate::qwen36_moe_decode::{argmax_bf16_logits, XorshiftRng};
 use crate::qwen36_moe_dry_run::{print_report, run_qwen36_moe_dry_run, DryRunReport};
 use crate::qwen36_moe_generation::{run_generation_step, Qwen36GenerationStep};
 use crate::qwen36_moe_geom::build_multi_layer_geom;
@@ -36,6 +36,7 @@ use crate::qwen36_moe_prompt::{
     prepare_prompt, print_prompt_summary, validate_speculative_sampling,
 };
 use crate::qwen36_moe_session::{prepare_decode_session, Qwen36DecodeSession};
+use crate::qwen36_moe_spec_verify::{run_spec_chain_step, Qwen36SpecChainStep};
 use crate::qwen36_moe_speculative::{
     run_speculative_decode_step, run_speculative_decode_step_batched,
 };
@@ -464,30 +465,18 @@ fn decode_text(
                         // K+1 sequential chains, accumulate final_hiddens.
                         let mut final_hiddens: Vec<Vec<u8>> = Vec::with_capacity(n);
                         for &(pos, input) in inputs {
-                            let t_embed_start = std::time::Instant::now();
-                            let initial_hidden = lookup_embed_row(
-                                &store,
+                            let chain_outputs = run_spec_chain_step(Qwen36SpecChainStep {
+                                ordinal,
+                                geom: &geom,
+                                store: &store,
                                 weight_prefix,
-                                input as usize,
-                                geom.hidden as usize,
-                            )?;
-                            stage_timings.record_embed(t_embed_start.elapsed());
-
-                            let t_chain_start = std::time::Instant::now();
-                            let chain_outputs = if let Some(scratch) = persistent_scratch.as_mut() {
-                                scratch.run(ordinal, &initial_hidden, pos, None)?
-                            } else {
-                                run_chained_decode_fast(
-                                    ordinal,
-                                    &geom,
-                                    &mut layers,
-                                    &initial_hidden,
-                                    pos,
-                                    emit_stage_timings,
-                                )?
-                            };
-                            stage_timings.record_chain(t_chain_start.elapsed(), &chain_outputs);
-                            stage_timings.count_generation_step();
+                                layers: &mut layers,
+                                persistent_scratch: persistent_scratch.as_mut(),
+                                stage_timings: &mut stage_timings,
+                                position: pos,
+                                input,
+                                emit_stage_timings,
+                            })?;
                             final_hiddens.push(chain_outputs.final_hidden_bytes);
                         }
 
@@ -550,28 +539,18 @@ fn decode_text(
                     // following positions.
                     let replay = loop_state.speculative_replay_inputs(next_token, &r);
                     for &(pos, input) in &replay {
-                        let t_embed_start = std::time::Instant::now();
-                        let initial_hidden = lookup_embed_row(
-                            &store,
+                        run_spec_chain_step(Qwen36SpecChainStep {
+                            ordinal,
+                            geom: &geom,
+                            store: &store,
                             weight_prefix,
-                            input as usize,
-                            geom.hidden as usize,
-                        )?;
-                        stage_timings.record_embed(t_embed_start.elapsed());
-                        let t_chain_start = std::time::Instant::now();
-                        let replay_outputs = if let Some(scratch) = persistent_scratch.as_mut() {
-                            scratch.run(ordinal, &initial_hidden, pos, None)?
-                        } else {
-                            run_chained_decode_fast(
-                                ordinal,
-                                &geom,
-                                &mut layers,
-                                &initial_hidden,
-                                pos,
-                                emit_stage_timings,
-                            )?
-                        };
-                        stage_timings.record_chain(t_chain_start.elapsed(), &replay_outputs);
+                            layers: &mut layers,
+                            persistent_scratch: persistent_scratch.as_mut(),
+                            stage_timings: &mut stage_timings,
+                            position: pos,
+                            input,
+                            emit_stage_timings,
+                        })?;
                         // Per-kernel-class breakdown for replay chains
                         // contributes to the same accumulators as the
                         // verify chains so `--emit-stage-timings` reports
@@ -579,7 +558,6 @@ fn decode_text(
                         // partial-accept iters. Without this the reported
                         // chain breakdown undercounts actual work as the
                         // accept rate falls.
-                        stage_timings.count_generation_step();
                     }
                 }
                 r
@@ -597,34 +575,18 @@ fn decode_text(
                     loop_state.position,
                     dynamic_k,
                     |pos, input| -> anyhow::Result<(u32, Vec<u8>)> {
-                        // Embed lookup is its own stage in the timing
-                        // breakdown — bundling it into `t_chain` (as the
-                        // first cut of this closure did) systematically
-                        // inflates `chain_ms_avg` and deflates
-                        // `embed_ms_avg` as the MTP accept rate rises.
-                        let t_embed_start = std::time::Instant::now();
-                        let initial_hidden = lookup_embed_row(
-                            &store,
+                        let outputs = run_spec_chain_step(Qwen36SpecChainStep {
+                            ordinal,
+                            geom: &geom,
+                            store: &store,
                             weight_prefix,
-                            input as usize,
-                            geom.hidden as usize,
-                        )?;
-                        stage_timings.record_embed(t_embed_start.elapsed());
-
-                        let t_chain_start = std::time::Instant::now();
-                        let outputs = if let Some(scratch) = persistent_scratch.as_mut() {
-                            scratch.run(ordinal, &initial_hidden, pos, None)?
-                        } else {
-                            run_chained_decode_fast(
-                                ordinal,
-                                &geom,
-                                &mut layers,
-                                &initial_hidden,
-                                pos,
-                                emit_stage_timings,
-                            )?
-                        };
-                        stage_timings.record_chain(t_chain_start.elapsed(), &outputs);
+                            layers: &mut layers,
+                            persistent_scratch: persistent_scratch.as_mut(),
+                            stage_timings: &mut stage_timings,
+                            position: pos,
+                            input,
+                            emit_stage_timings,
+                        })?;
 
                         let t_lm_head_start = std::time::Instant::now();
                         let logits_bytes = launch_lm_head_from_final_hidden_bytes(
@@ -641,15 +603,6 @@ fn decode_text(
                         )
                         .context("spec verify GPU lm_head")?;
                         stage_timings.record_lm_head(t_lm_head_start.elapsed());
-                        // Each verify base step counts as one decode step
-                        // for the per-token average — emitted_tokens.len()
-                        // tokens are committed per spec call, and
-                        // closure-call-count == emitted_tokens.len() in
-                        // both the partial-accept and full-accept (with
-                        // bonus) cases. Bumping here is equivalent to
-                        // "one closure call = one decode step worth of
-                        // base work."
-                        stage_timings.count_generation_step();
                         Ok((
                             argmax_bf16_logits(&logits_bytes),
                             outputs.final_hidden_bytes,

--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -36,7 +36,9 @@ use crate::qwen36_moe_prompt::{
     prepare_prompt, print_prompt_summary, validate_speculative_sampling,
 };
 use crate::qwen36_moe_session::{prepare_decode_session, Qwen36DecodeSession};
-use crate::qwen36_moe_spec_verify::{run_spec_chain_step, Qwen36SpecChainStep};
+use crate::qwen36_moe_spec_verify::{
+    run_batched_lm_head_top1, run_spec_chain_step, Qwen36BatchedLmHeadTop1, Qwen36SpecChainStep,
+};
 use crate::qwen36_moe_speculative::{
     run_speculative_decode_step, run_speculative_decode_step_batched,
 };
@@ -460,8 +462,6 @@ fn decode_text(
                         if n == 0 {
                             return Ok(Vec::new());
                         }
-                        let hidden = geom.hidden as usize;
-
                         // K+1 sequential chains, accumulate final_hiddens.
                         let mut final_hiddens: Vec<Vec<u8>> = Vec::with_capacity(n);
                         for &(pos, input) in inputs {
@@ -480,46 +480,14 @@ fn decode_text(
                             final_hiddens.push(chain_outputs.final_hidden_bytes);
                         }
 
-                        // ONE batched lm_head over [n, hidden].
-                        let t_lm_head_start = std::time::Instant::now();
-                        let mut concat = Vec::with_capacity(n * hidden * 2);
-                        for fh in &final_hiddens {
-                            concat.extend_from_slice(fh);
-                        }
-                        let fh_buf = gpu_hal::GpuBuffer::from_host_bytes(
+                        run_batched_lm_head_top1(Qwen36BatchedLmHeadTop1 {
                             ordinal,
-                            gpu_hal::ScalarType::BF16,
-                            &[n, hidden],
-                            &concat,
-                        )?;
-                        let mut logits_buf_b = gpu_hal::GpuBuffer::zeros(
-                            ordinal,
-                            gpu_hal::ScalarType::BF16,
-                            &[n, geom.vocab as usize],
-                        )?;
-                        kernel_ffi::qwen36_moe::lm_head_batched_launch(
-                            ordinal,
-                            n as i32,
-                            geom.hidden,
-                            geom.vocab,
-                            geom.rms_norm_eps,
-                            &fh_buf,
-                            &final_norm_w_buf,
-                            &lm_head_w_buf,
-                            &mut logits_buf_b,
-                            None,
-                        )?;
-                        let logits_bytes =
-                            logits_buf_b.to_host_bytes().context("d2h batched logits")?;
-                        stage_timings.record_lm_head(t_lm_head_start.elapsed());
-
-                        let row_bytes = geom.vocab as usize * 2;
-                        let mut results: Vec<(u32, Vec<u8>)> = Vec::with_capacity(n);
-                        for (i, fh) in final_hiddens.into_iter().enumerate() {
-                            let row = &logits_bytes[i * row_bytes..(i + 1) * row_bytes];
-                            results.push((argmax_bf16_logits(row), fh));
-                        }
-                        Ok(results)
+                            geom: &geom,
+                            final_norm_w: &final_norm_w_buf,
+                            lm_head_w: &lm_head_w_buf,
+                            stage_timings: &mut stage_timings,
+                            final_hiddens,
+                        })
                     },
                 )
                 .context("batched speculative decode step")?;

--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -420,8 +420,7 @@ fn decode_text(
             // available draft count is `headroom - 1`. If headroom <=
             // 1 we can still emit 1 token via the K=0 fallback; if
             // headroom == 0 we already broke out above.
-            let headroom = loop_state.remaining_generation_slots();
-            let dynamic_k = QWEN36_NUM_SPECULATIVE_TOKENS.min(headroom.saturating_sub(1));
+            let dynamic_k = loop_state.speculative_draft_count(QWEN36_NUM_SPECULATIVE_TOKENS);
             let h_base = outputs.final_hidden_bytes.clone();
             // P2: thread spec-verify timings into the engine-level
             // accumulators so `--emit-stage-timings` reports honest
@@ -549,11 +548,7 @@ fn decode_text(
                     // Replay (j+1) chains: first_token at the current
                     // position, then the j accepted drafts at the
                     // following positions.
-                    let mut replay: Vec<(i32, u32)> = Vec::with_capacity(r.n_accepted + 1);
-                    replay.push((loop_state.position, next_token));
-                    for (i, &tok) in r.emitted_tokens.iter().take(r.n_accepted).enumerate() {
-                        replay.push((loop_state.position + 1 + i as i32, tok));
-                    }
+                    let replay = loop_state.speculative_replay_inputs(next_token, &r);
                     for &(pos, input) in &replay {
                         let t_embed_start = std::time::Instant::now();
                         let initial_hidden = lookup_embed_row(

--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -18,12 +18,11 @@ use model_store::BakedStore;
 
 use crate::qwen36_moe_bake::{ensure_qwen36_bake, select_decode_bake};
 use crate::qwen36_moe_chain::{run_chain_step, Qwen36ChainStep};
-use crate::qwen36_moe_decode::{argmax_bf16_logits, XorshiftRng};
+use crate::qwen36_moe_decode::XorshiftRng;
 use crate::qwen36_moe_dry_run::{print_report, run_qwen36_moe_dry_run, DryRunReport};
 use crate::qwen36_moe_generation::{run_generation_step, Qwen36GenerationStep};
 use crate::qwen36_moe_geom::build_multi_layer_geom;
 use crate::qwen36_moe_host::lookup_embed_row;
-use crate::qwen36_moe_lm_head::{launch_lm_head_from_final_hidden_bytes, LmHeadBuffers};
 use crate::qwen36_moe_loop::Qwen36DecodeLoopState;
 use crate::qwen36_moe_output::{
     print_decode_stream_start, print_generation_summary, print_last_logits_if_requested,
@@ -37,8 +36,9 @@ use crate::qwen36_moe_prompt::{
 };
 use crate::qwen36_moe_session::{prepare_decode_session, Qwen36DecodeSession};
 use crate::qwen36_moe_spec_verify::{
-    restore_and_replay_accepted_prefix, run_batched_lm_head_top1, run_spec_chain_step,
-    Qwen36BatchedLmHeadTop1, Qwen36SpecChainStep, Qwen36SpecReplayAccepted,
+    restore_and_replay_accepted_prefix, run_batched_lm_head_top1, run_single_lm_head_top1,
+    run_spec_chain_step, Qwen36BatchedLmHeadTop1, Qwen36SingleLmHeadTop1, Qwen36SpecChainStep,
+    Qwen36SpecReplayAccepted,
 };
 use crate::qwen36_moe_speculative::{
     run_speculative_decode_step, run_speculative_decode_step_batched,
@@ -546,25 +546,18 @@ fn decode_text(
                             emit_stage_timings,
                         })?;
 
-                        let t_lm_head_start = std::time::Instant::now();
-                        let logits_bytes = launch_lm_head_from_final_hidden_bytes(
+                        let top1 = run_single_lm_head_top1(Qwen36SingleLmHeadTop1 {
                             ordinal,
-                            &geom,
-                            &outputs.final_hidden_bytes,
-                            LmHeadBuffers {
-                                final_norm_w: &final_norm_w_buf,
-                                lm_head_w: &lm_head_w_buf,
-                                final_hidden: &mut final_hidden_buf,
-                                logits: &mut logits_buf,
-                                counter: &mut counter_buf,
-                            },
-                        )
-                        .context("spec verify GPU lm_head")?;
-                        stage_timings.record_lm_head(t_lm_head_start.elapsed());
-                        Ok((
-                            argmax_bf16_logits(&logits_bytes),
-                            outputs.final_hidden_bytes,
-                        ))
+                            geom: &geom,
+                            final_norm_w: &final_norm_w_buf,
+                            lm_head_w: &lm_head_w_buf,
+                            final_hidden: &mut final_hidden_buf,
+                            logits: &mut logits_buf,
+                            counter: &mut counter_buf,
+                            stage_timings: &mut stage_timings,
+                            final_hidden_bytes: &outputs.final_hidden_bytes,
+                        })?;
+                        Ok((top1, outputs.final_hidden_bytes))
                     },
                 )
                 .context("speculative decode step")?

--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -26,8 +26,8 @@ use crate::qwen36_moe_host::lookup_embed_row;
 use crate::qwen36_moe_lm_head::{launch_lm_head_from_final_hidden_bytes, LmHeadBuffers};
 use crate::qwen36_moe_loop::Qwen36DecodeLoopState;
 use crate::qwen36_moe_output::{
-    print_decode_stream_start, print_decoded_token, print_generation_summary,
-    print_last_logits_if_requested, print_sampling_summary,
+    print_decode_stream_start, print_generation_summary, print_last_logits_if_requested,
+    print_sampling_summary,
 };
 use crate::qwen36_moe_policy::{
     resolve_context_size, validate_decode_backend, validate_persistent_kv_fp8_flags,
@@ -154,8 +154,6 @@ fn decode_text(
     kv_fp8: bool,
     dump_last_logits: bool,
 ) -> Result<()> {
-    use std::io::Write as _;
-
     validate_speculative_sampling(speculative_decode, sampling)?;
 
     let weight_prefix = report.kernel_params.weight_prefix;
@@ -666,30 +664,9 @@ fn decode_text(
                 .context("speculative decode step")?
             };
 
-            // Append emitted tokens. Honour `max_new` and EOS by
-            // breaking out cleanly mid-emission.
-            let mut hit_stop = false;
-            for tok in result.emitted_tokens.iter().copied() {
-                if loop_state.reached_max_new() {
-                    hit_stop = true;
-                    break;
-                }
-                loop_state.generated_ids.push(tok);
-                print_decoded_token(tokenizer.as_ref(), tok);
-                if Some(tok) == eos_id {
-                    hit_stop = true;
-                    break;
-                }
-            }
-            std::io::stdout().flush().ok();
-            loop_state.position += result.emitted_tokens.len() as i32;
-            if hit_stop {
+            if loop_state.append_speculative_emissions(&result, tokenizer.as_ref(), eos_id) {
                 break;
             }
-            loop_state.current_token = *result
-                .emitted_tokens
-                .last()
-                .expect("speculative step must emit at least one token (K=0 fallback ensured)");
         }
     }
 

--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -36,9 +36,9 @@ use crate::qwen36_moe_prompt::{
 };
 use crate::qwen36_moe_session::{prepare_decode_session, Qwen36DecodeSession};
 use crate::qwen36_moe_spec_verify::{
-    restore_and_replay_accepted_prefix, run_batched_lm_head_top1, run_single_lm_head_top1,
-    run_spec_chain_step, Qwen36BatchedLmHeadTop1, Qwen36SingleLmHeadTop1, Qwen36SpecChainStep,
-    Qwen36SpecReplayAccepted,
+    restore_and_replay_accepted_prefix, run_batched_spec_verify_inputs, run_single_lm_head_top1,
+    run_spec_chain_step, Qwen36BatchedSpecVerifyInputs, Qwen36SingleLmHeadTop1,
+    Qwen36SpecChainStep, Qwen36SpecReplayAccepted,
 };
 use crate::qwen36_moe_speculative::{
     run_speculative_decode_step, run_speculative_decode_step_batched,
@@ -459,35 +459,18 @@ fn decode_text(
                     loop_state.position,
                     dynamic_k,
                     |inputs| -> anyhow::Result<Vec<(u32, Vec<u8>)>> {
-                        let n = inputs.len();
-                        if n == 0 {
-                            return Ok(Vec::new());
-                        }
-                        // K+1 sequential chains, accumulate final_hiddens.
-                        let mut final_hiddens: Vec<Vec<u8>> = Vec::with_capacity(n);
-                        for &(pos, input) in inputs {
-                            let chain_outputs = run_spec_chain_step(Qwen36SpecChainStep {
-                                ordinal,
-                                geom: &geom,
-                                store: &store,
-                                weight_prefix,
-                                layers: &mut layers,
-                                persistent_scratch: persistent_scratch.as_mut(),
-                                stage_timings: &mut stage_timings,
-                                position: pos,
-                                input,
-                                emit_stage_timings,
-                            })?;
-                            final_hiddens.push(chain_outputs.final_hidden_bytes);
-                        }
-
-                        run_batched_lm_head_top1(Qwen36BatchedLmHeadTop1 {
+                        run_batched_spec_verify_inputs(Qwen36BatchedSpecVerifyInputs {
                             ordinal,
                             geom: &geom,
+                            store: &store,
+                            weight_prefix,
+                            layers: &mut layers,
+                            persistent_scratch: persistent_scratch.as_mut(),
                             final_norm_w: &final_norm_w_buf,
                             lm_head_w: &lm_head_w_buf,
                             stage_timings: &mut stage_timings,
-                            final_hiddens,
+                            inputs,
+                            emit_stage_timings,
                         })
                     },
                 )

--- a/crates/runner/src/qwen36_moe_loop.rs
+++ b/crates/runner/src/qwen36_moe_loop.rs
@@ -1,3 +1,8 @@
+use std::io::Write as _;
+
+use crate::qwen36_moe_output::print_decoded_token;
+use crate::qwen36_moe_speculative::SpeculativeStepResult;
+
 pub struct Qwen36DecodeLoopState {
     pub generated_ids: Vec<u32>,
     pub last_logits_bytes: Vec<u8>,
@@ -30,5 +35,35 @@ impl Qwen36DecodeLoopState {
     pub fn record_last_logits(&mut self, logits: &[u8]) {
         self.last_logits_bytes.clear();
         self.last_logits_bytes.extend_from_slice(logits);
+    }
+
+    pub fn append_speculative_emissions(
+        &mut self,
+        result: &SpeculativeStepResult,
+        tokenizer: Option<&tokenizers::Tokenizer>,
+        eos_id: Option<u32>,
+    ) -> bool {
+        let mut hit_stop = false;
+        for tok in result.emitted_tokens.iter().copied() {
+            if self.reached_max_new() {
+                hit_stop = true;
+                break;
+            }
+            self.generated_ids.push(tok);
+            print_decoded_token(tokenizer, tok);
+            if Some(tok) == eos_id {
+                hit_stop = true;
+                break;
+            }
+        }
+        std::io::stdout().flush().ok();
+        self.position += result.emitted_tokens.len() as i32;
+        if !hit_stop {
+            self.current_token = *result
+                .emitted_tokens
+                .last()
+                .expect("speculative step must emit at least one token (K=0 fallback ensured)");
+        }
+        hit_stop
     }
 }

--- a/crates/runner/src/qwen36_moe_loop.rs
+++ b/crates/runner/src/qwen36_moe_loop.rs
@@ -32,6 +32,28 @@ impl Qwen36DecodeLoopState {
         self.max_new.saturating_sub(self.generated_ids.len())
     }
 
+    pub fn speculative_draft_count(&self, max_drafts: usize) -> usize {
+        max_drafts.min(self.remaining_generation_slots().saturating_sub(1))
+    }
+
+    pub fn speculative_replay_inputs(
+        &self,
+        first_token: u32,
+        result: &SpeculativeStepResult,
+    ) -> Vec<(i32, u32)> {
+        let mut replay = Vec::with_capacity(result.n_accepted + 1);
+        replay.push((self.position, first_token));
+        for (i, &tok) in result
+            .emitted_tokens
+            .iter()
+            .take(result.n_accepted)
+            .enumerate()
+        {
+            replay.push((self.position + 1 + i as i32, tok));
+        }
+        replay
+    }
+
     pub fn record_last_logits(&mut self, logits: &[u8]) {
         self.last_logits_bytes.clear();
         self.last_logits_bytes.extend_from_slice(logits);

--- a/crates/runner/src/qwen36_moe_spec_verify.rs
+++ b/crates/runner/src/qwen36_moe_spec_verify.rs
@@ -7,6 +7,7 @@ use crate::qwen36_moe_decode::{
 };
 use crate::qwen36_moe_host::lookup_embed_row;
 use crate::qwen36_moe_persistent_decode::PersistentScratch;
+use crate::qwen36_moe_state::{restore_linear_attn_state, LinearAttnSnapshot};
 use crate::qwen36_moe_timing::Qwen36StageTimingTotals;
 
 pub(crate) struct Qwen36SpecChainStep<'a> {
@@ -55,6 +56,41 @@ pub(crate) fn run_spec_chain_step(args: Qwen36SpecChainStep<'_>) -> Result<Decod
         .record_chain(t_chain_start.elapsed(), &outputs);
     args.stage_timings.count_generation_step();
     Ok(outputs)
+}
+
+pub(crate) struct Qwen36SpecReplayAccepted<'a> {
+    pub(crate) ordinal: usize,
+    pub(crate) geom: &'a MultiLayerGeom,
+    pub(crate) store: &'a BakedStore,
+    pub(crate) weight_prefix: &'a str,
+    pub(crate) layers: &'a mut [LayerBuffers],
+    pub(crate) snapshot: &'a LinearAttnSnapshot,
+    pub(crate) persistent_scratch: Option<&'a mut PersistentScratch>,
+    pub(crate) stage_timings: &'a mut Qwen36StageTimingTotals,
+    pub(crate) replay_inputs: &'a [(i32, u32)],
+    pub(crate) emit_stage_timings: bool,
+}
+
+pub(crate) fn restore_and_replay_accepted_prefix(
+    mut args: Qwen36SpecReplayAccepted<'_>,
+) -> Result<()> {
+    restore_linear_attn_state(args.ordinal, args.layers, args.snapshot)
+        .context("restore linear-attn state after partial-accept")?;
+    for &(position, input) in args.replay_inputs {
+        run_spec_chain_step(Qwen36SpecChainStep {
+            ordinal: args.ordinal,
+            geom: args.geom,
+            store: args.store,
+            weight_prefix: args.weight_prefix,
+            layers: args.layers,
+            persistent_scratch: args.persistent_scratch.as_deref_mut(),
+            stage_timings: args.stage_timings,
+            position,
+            input,
+            emit_stage_timings: args.emit_stage_timings,
+        })?;
+    }
+    Ok(())
 }
 
 pub(crate) struct Qwen36BatchedLmHeadTop1<'a> {

--- a/crates/runner/src/qwen36_moe_spec_verify.rs
+++ b/crates/runner/src/qwen36_moe_spec_verify.rs
@@ -1,8 +1,9 @@
 use anyhow::{Context, Result};
+use gpu_hal::{GpuBuffer, ScalarType};
 use model_store::BakedStore;
 
 use crate::qwen36_moe_decode::{
-    run_chained_decode_fast, DecodeOutputs, LayerBuffers, MultiLayerGeom,
+    argmax_bf16_logits, run_chained_decode_fast, DecodeOutputs, LayerBuffers, MultiLayerGeom,
 };
 use crate::qwen36_moe_host::lookup_embed_row;
 use crate::qwen36_moe_persistent_decode::PersistentScratch;
@@ -54,4 +55,57 @@ pub(crate) fn run_spec_chain_step(args: Qwen36SpecChainStep<'_>) -> Result<Decod
         .record_chain(t_chain_start.elapsed(), &outputs);
     args.stage_timings.count_generation_step();
     Ok(outputs)
+}
+
+pub(crate) struct Qwen36BatchedLmHeadTop1<'a> {
+    pub(crate) ordinal: usize,
+    pub(crate) geom: &'a MultiLayerGeom,
+    pub(crate) final_norm_w: &'a GpuBuffer,
+    pub(crate) lm_head_w: &'a GpuBuffer,
+    pub(crate) stage_timings: &'a mut Qwen36StageTimingTotals,
+    pub(crate) final_hiddens: Vec<Vec<u8>>,
+}
+
+pub(crate) fn run_batched_lm_head_top1(
+    args: Qwen36BatchedLmHeadTop1<'_>,
+) -> Result<Vec<(u32, Vec<u8>)>> {
+    let n = args.final_hiddens.len();
+    if n == 0 {
+        return Ok(Vec::new());
+    }
+
+    let hidden = args.geom.hidden as usize;
+    let t_lm_head_start = std::time::Instant::now();
+    let mut concat = Vec::with_capacity(n * hidden * 2);
+    for fh in &args.final_hiddens {
+        concat.extend_from_slice(fh);
+    }
+    let fh_buf = GpuBuffer::from_host_bytes(args.ordinal, ScalarType::BF16, &[n, hidden], &concat)?;
+    let mut logits_buf = GpuBuffer::zeros(
+        args.ordinal,
+        ScalarType::BF16,
+        &[n, args.geom.vocab as usize],
+    )?;
+    kernel_ffi::qwen36_moe::lm_head_batched_launch(
+        args.ordinal,
+        n as i32,
+        args.geom.hidden,
+        args.geom.vocab,
+        args.geom.rms_norm_eps,
+        &fh_buf,
+        args.final_norm_w,
+        args.lm_head_w,
+        &mut logits_buf,
+        None,
+    )?;
+    let logits_bytes = logits_buf.to_host_bytes().context("d2h batched logits")?;
+    args.stage_timings.record_lm_head(t_lm_head_start.elapsed());
+
+    let row_bytes = args.geom.vocab as usize * 2;
+    let mut results = Vec::with_capacity(n);
+    for (i, fh) in args.final_hiddens.into_iter().enumerate() {
+        let row = &logits_bytes[i * row_bytes..(i + 1) * row_bytes];
+        results.push((argmax_bf16_logits(row), fh));
+    }
+    Ok(results)
 }

--- a/crates/runner/src/qwen36_moe_spec_verify.rs
+++ b/crates/runner/src/qwen36_moe_spec_verify.rs
@@ -1,0 +1,57 @@
+use anyhow::{Context, Result};
+use model_store::BakedStore;
+
+use crate::qwen36_moe_decode::{
+    run_chained_decode_fast, DecodeOutputs, LayerBuffers, MultiLayerGeom,
+};
+use crate::qwen36_moe_host::lookup_embed_row;
+use crate::qwen36_moe_persistent_decode::PersistentScratch;
+use crate::qwen36_moe_timing::Qwen36StageTimingTotals;
+
+pub(crate) struct Qwen36SpecChainStep<'a> {
+    pub(crate) ordinal: usize,
+    pub(crate) geom: &'a MultiLayerGeom,
+    pub(crate) store: &'a BakedStore,
+    pub(crate) weight_prefix: &'a str,
+    pub(crate) layers: &'a mut [LayerBuffers],
+    pub(crate) persistent_scratch: Option<&'a mut PersistentScratch>,
+    pub(crate) stage_timings: &'a mut Qwen36StageTimingTotals,
+    pub(crate) position: i32,
+    pub(crate) input: u32,
+    pub(crate) emit_stage_timings: bool,
+}
+
+pub(crate) fn run_spec_chain_step(args: Qwen36SpecChainStep<'_>) -> Result<DecodeOutputs> {
+    let t_embed_start = std::time::Instant::now();
+    let initial_hidden = lookup_embed_row(
+        args.store,
+        args.weight_prefix,
+        args.input as usize,
+        args.geom.hidden as usize,
+    )
+    .with_context(|| {
+        format!(
+            "spec verify embed lookup token {} at position {}",
+            args.input, args.position
+        )
+    })?;
+    args.stage_timings.record_embed(t_embed_start.elapsed());
+
+    let t_chain_start = std::time::Instant::now();
+    let outputs = if let Some(scratch) = args.persistent_scratch {
+        scratch.run(args.ordinal, &initial_hidden, args.position, None)?
+    } else {
+        run_chained_decode_fast(
+            args.ordinal,
+            args.geom,
+            args.layers,
+            &initial_hidden,
+            args.position,
+            args.emit_stage_timings,
+        )?
+    };
+    args.stage_timings
+        .record_chain(t_chain_start.elapsed(), &outputs);
+    args.stage_timings.count_generation_step();
+    Ok(outputs)
+}

--- a/crates/runner/src/qwen36_moe_spec_verify.rs
+++ b/crates/runner/src/qwen36_moe_spec_verify.rs
@@ -6,6 +6,7 @@ use crate::qwen36_moe_decode::{
     argmax_bf16_logits, run_chained_decode_fast, DecodeOutputs, LayerBuffers, MultiLayerGeom,
 };
 use crate::qwen36_moe_host::lookup_embed_row;
+use crate::qwen36_moe_lm_head::{launch_lm_head_from_final_hidden_bytes, LmHeadBuffers};
 use crate::qwen36_moe_persistent_decode::PersistentScratch;
 use crate::qwen36_moe_state::{restore_linear_attn_state, LinearAttnSnapshot};
 use crate::qwen36_moe_timing::Qwen36StageTimingTotals;
@@ -91,6 +92,37 @@ pub(crate) fn restore_and_replay_accepted_prefix(
         })?;
     }
     Ok(())
+}
+
+pub(crate) struct Qwen36SingleLmHeadTop1<'a> {
+    pub(crate) ordinal: usize,
+    pub(crate) geom: &'a MultiLayerGeom,
+    pub(crate) final_norm_w: &'a GpuBuffer,
+    pub(crate) lm_head_w: &'a GpuBuffer,
+    pub(crate) final_hidden: &'a mut GpuBuffer,
+    pub(crate) logits: &'a mut GpuBuffer,
+    pub(crate) counter: &'a mut GpuBuffer,
+    pub(crate) stage_timings: &'a mut Qwen36StageTimingTotals,
+    pub(crate) final_hidden_bytes: &'a [u8],
+}
+
+pub(crate) fn run_single_lm_head_top1(args: Qwen36SingleLmHeadTop1<'_>) -> Result<u32> {
+    let t_lm_head_start = std::time::Instant::now();
+    let logits_bytes = launch_lm_head_from_final_hidden_bytes(
+        args.ordinal,
+        args.geom,
+        args.final_hidden_bytes,
+        LmHeadBuffers {
+            final_norm_w: args.final_norm_w,
+            lm_head_w: args.lm_head_w,
+            final_hidden: args.final_hidden,
+            logits: args.logits,
+            counter: args.counter,
+        },
+    )
+    .context("spec verify GPU lm_head")?;
+    args.stage_timings.record_lm_head(t_lm_head_start.elapsed());
+    Ok(argmax_bf16_logits(&logits_bytes))
 }
 
 pub(crate) struct Qwen36BatchedLmHeadTop1<'a> {

--- a/crates/runner/src/qwen36_moe_spec_verify.rs
+++ b/crates/runner/src/qwen36_moe_spec_verify.rs
@@ -94,6 +94,54 @@ pub(crate) fn restore_and_replay_accepted_prefix(
     Ok(())
 }
 
+pub(crate) struct Qwen36BatchedSpecVerifyInputs<'a> {
+    pub(crate) ordinal: usize,
+    pub(crate) geom: &'a MultiLayerGeom,
+    pub(crate) store: &'a BakedStore,
+    pub(crate) weight_prefix: &'a str,
+    pub(crate) layers: &'a mut [LayerBuffers],
+    pub(crate) persistent_scratch: Option<&'a mut PersistentScratch>,
+    pub(crate) final_norm_w: &'a GpuBuffer,
+    pub(crate) lm_head_w: &'a GpuBuffer,
+    pub(crate) stage_timings: &'a mut Qwen36StageTimingTotals,
+    pub(crate) inputs: &'a [(i32, u32)],
+    pub(crate) emit_stage_timings: bool,
+}
+
+pub(crate) fn run_batched_spec_verify_inputs(
+    mut args: Qwen36BatchedSpecVerifyInputs<'_>,
+) -> Result<Vec<(u32, Vec<u8>)>> {
+    if args.inputs.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut final_hiddens = Vec::with_capacity(args.inputs.len());
+    for &(position, input) in args.inputs {
+        let chain_outputs = run_spec_chain_step(Qwen36SpecChainStep {
+            ordinal: args.ordinal,
+            geom: args.geom,
+            store: args.store,
+            weight_prefix: args.weight_prefix,
+            layers: args.layers,
+            persistent_scratch: args.persistent_scratch.as_deref_mut(),
+            stage_timings: args.stage_timings,
+            position,
+            input,
+            emit_stage_timings: args.emit_stage_timings,
+        })?;
+        final_hiddens.push(chain_outputs.final_hidden_bytes);
+    }
+
+    run_batched_lm_head_top1(Qwen36BatchedLmHeadTop1 {
+        ordinal: args.ordinal,
+        geom: args.geom,
+        final_norm_w: args.final_norm_w,
+        lm_head_w: args.lm_head_w,
+        stage_timings: args.stage_timings,
+        final_hiddens,
+    })
+}
+
 pub(crate) struct Qwen36SingleLmHeadTop1<'a> {
     pub(crate) ordinal: usize,
     pub(crate) geom: &'a MultiLayerGeom,


### PR DESCRIPTION
## Summary

- split Qwen3.6-MoE speculative emission bookkeeping into loop-state helpers
- move speculative verify chain, lm-head/top-1, and partial replay helpers into `qwen36_moe_spec_verify`
- keep `qwen36_moe_engine` focused on decode-loop orchestration, reducing it to 569 lines
- merge latest `origin/main` before opening the PR

## Validation

- `cargo check -p runner --all-targets --quiet`
- `cargo test -p runner --bin supersonic --quiet`
- `git diff --check`
- `cargo test --workspace --no-fail-fast`

Known baseline warnings remain from `gpu-hal`, `prefill_engine`, and `specprefill`.
