### PR TITLE
specprefill: reject --specprefill-draft-dir + --kv-fp8 upfront (was cryptic runtime error)

### DIFF
--- a/crates/runner/src/policy.rs
+++ b/crates/runner/src/policy.rs
@@ -114,6 +114,16 @@ pub(crate) fn validate_specprefill_flags(
         if cli.dflash {
             anyhow::bail!("--specprefill-* and --dflash cannot be combined");
         }
+        if cli.kv_fp8 {
+            anyhow::bail!(
+                "--specprefill-draft-dir cannot be combined with --kv-fp8 today: the \
+                 BF16 step-copy fallback used by the speculator's lookahead decode \
+                 (`kernel_ffi::certified_kv::copy_step_bf16`, added in PR #177) requires \
+                 BF16 destination buffers, but --kv-fp8 makes the K/V cache U8. The combo \
+                 trips a runtime error several seconds into decode. Tracked as a Phase D \
+                 follow-up: extend the per-head D2D fallback to BF16→FP8 quantise on the fly."
+            );
+        }
         if let Some(keep) = cli.specprefill_keep_ratio {
             if !(0.05..=1.0).contains(&keep) {
                 anyhow::bail!("--specprefill-keep-ratio must be in [0.05, 1.0] (got {keep})");

--- a/docs/feature-compatibility.md
+++ b/docs/feature-compatibility.md
@@ -195,11 +195,13 @@ combo (or one feature implicitly requires the other to be off).
 ⁴ Dash means "no validated combo exists today" — the underlying
   features apply to disjoint model families (e.g. SpecPrefill is
   Qwen3.5-9B; MoE prefetch is Qwen3.6-MoE).
-⁵ SpecPrefill + KV-FP8 trips a runtime error on the first decode step:
-  the BF16 step-copy fallback added in PR #177 to unblock SpecPrefill
-  on HIP requires BF16 dst buffers, but --kv-fp8 makes them U8 (FP8).
-  Validation should reject the combo until the fallback grows an
-  FP8-quantising path.
+⁵ SpecPrefill + KV-FP8 is rejected upfront by `validate_specprefill_flags`
+  (since 2026-05-04). The underlying issue: the BF16 step-copy fallback
+  added in PR #177 to unblock SpecPrefill on HIP requires BF16 dst
+  buffers, but `--kv-fp8` makes them U8 (FP8). Lifting the gate is a
+  Phase D follow-up — the per-head D2D fallback in
+  `kernel_ffi::certified_kv::copy_step_bf16` (non-CUDA branch) needs
+  a BF16→FP8 quantise-on-the-fly path.
 
 ## Picker recipes — "I want to ..."
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -737,7 +737,7 @@ in.
 | VMM | qwen3.6-35b-a3b INT4 + 8192-token context, gfx1100 | OOM (24 GiB exceeded) | runs | enables the workload | tests/gfx1100/bench_qwen36_sparse_caps.py |
 | SpecPrefill (keep=0.50) | qwen3.5-9b BF16 + 1353-token prompt, gfx1100 | 5057 ms TTFT | 5729 ms speculator + 2010 ms target prefill = 7739 ms TTFT | **1.53× SLOWER**² | manual run, 2026-05-03 |
 | SpecPrefill (keep=0.30) | qwen3.5-9b BF16 + 1353-token prompt, gfx1100 | 5057 ms TTFT | 5743 ms speculator + 1301 ms target prefill = 7044 ms TTFT | **1.39× SLOWER**² | manual run, 2026-05-03 |
-| SpecPrefill + KV-FP8 | qwen3.5-9b BF16 + KV-FP8 + 1353-token prompt | — | runtime error³ | **BROKEN** | manual run, 2026-05-03 |
+| SpecPrefill + KV-FP8 | qwen3.5-9b BF16 + KV-FP8 + 1353-token prompt | — | rejected by validation³ | **REJECTED** | n/a (CLI guard since 2026-05-04) |
 | DFlash (B=3) | qwen3.5-9b INT4 greedy decode, gfx1100 | ~32 ms/step | ~12 ms/step (effective; 2.5-3× speedup) | 2.5-3× FASTER | docs/dflash.md M4.3 numbers |
 | MoE prefetch | qwen3.6-35b-a3b INT4 decode, gfx1100 | included | (default-on) | — | the 28.3 ms/step row above already includes prefetch — the persistent megakernel default path uses it. A/B vs no-prefetch needs `--no-persistent-decode` which falls back to a different decode path entirely. |
 | Certified KV (shadow-validate) | llama3.1-8b INT8 + 1024-token prompt, sm86 | TBM ms/step | TBM ms/step | TBM | (script TBM, sm86-only — not measurable on a HIP-only dev box) |
@@ -757,11 +757,12 @@ in.
   a Phase D follow-up. See `project_specprefill_phase_d_followups.md` in
   memory for the fix path.
 
-³ SpecPrefill + KV-FP8 combo trips a runtime error on the first decode
-  step: `certified KV BF16 step copy expects BF16 buffers, got src BF16/BF16
-  dst U8/U8`. The PR #177 fallback assumes BF16 dst; FP8 (U8) destination
-  isn't handled. Validation should reject the combo until the fallback
-  grows an FP8-quantising path.
+³ SpecPrefill + KV-FP8 is rejected upfront by `validate_specprefill_flags`
+  (since 2026-05-04). The underlying issue: the BF16 step-copy fallback
+  added in PR #177 assumes BF16 destination buffers; `--kv-fp8` makes the
+  K/V cache U8 (FP8). Lifting the gate is a Phase D follow-up — the
+  per-head D2D fallback in `kernel_ffi::certified_kv::copy_step_bf16`
+  (non-CUDA branch) needs a BF16→FP8 quantise-on-the-fly path.
 
 The DFlash numbers are pulled from [dflash.md](dflash.md)'s M4.3
 single-pass fused-verify section. The KV-FP8 number is the gfx1100


### PR DESCRIPTION
## Summary

Today combining `--specprefill-draft-dir` with `--kv-fp8` trips a runtime error several seconds into decode (after the 0.8B speculator + target prefill have run):

\`\`\`
Error: layer 3 cache KV step write: invalid argument:
  certified KV BF16 step copy expects BF16 buffers,
  got src BF16/BF16 dst U8/U8
\`\`\`

The BF16 step-copy fallback added in PR #177 to unblock SpecPrefill on HIP requires BF16 destination buffers, but `--kv-fp8` makes the K/V cache U8 (FP8). The fallback's non-CUDA branch doesn't have a BF16→FP8 quantising path.

Adds a guard in `validate_specprefill_flags` so the CLI rejects the combo upfront with a clear actionable message instead of letting users wait seconds for a cryptic deep-decode error. The guard sits next to the existing `--specprefill-* + --dflash` mutual-exclusion check.

The real fix (extending `copy_step_bf16`'s per-head D2D fallback to BF16→FP8 quantise on the fly) is a Phase D follow-up tracked in memory; this PR is the cheap upfront-gate that closes the user-facing UX issue.

## Files changed

- `crates/runner/src/policy.rs`: 9-line guard added inside the existing `validate_specprefill_flags` check.
- `docs/feature-compatibility.md`: footnote ⁵ updated from "should reject" to "rejected upfront (since 2026-05-04)".
- `docs/performance.md`: Runtime feature impact row for SpecPrefill + KV-FP8 changes from "BROKEN" → "REJECTED"; footnote ³ updated to match.

## Smoke verification

\`\`\`
$ supersonic --backend hip --model qwen3.5-9b --model-dir /mnt/data/models/Qwen3.5-9B \
    --specprefill-draft-dir /mnt/data/models/Qwen3.5-0.8B \
    --kv-fp8 --prompt test --max-new-tokens 1
Error: --specprefill-draft-dir cannot be combined with --kv-fp8 today: the
  BF16 step-copy fallback used by the speculator's lookahead decode
  (\`kernel_ffi::certified_kv::copy_step_bf16\`, added in PR #177) requires
  BF16 destination buffers, but --kv-fp8 makes the K/V cache U8. The combo
  trips a runtime error several seconds into decode. Tracked as a Phase D
  follow-up: extend the per-head D2D fallback to BF16→FP8 quantise on the fly.
\`\`\`

Dense path with `--kv-fp8` alone (no `--specprefill-draft-dir`) is unaffected — verified against Qwen3.5-9B + KV-FP8 + 1-token decode.

## Test plan

- [x] Build clean (`cargo build --release --bin supersonic`).
- [x] Smoke: `--specprefill-draft-dir + --kv-fp8` rejects upfront with the new error.
- [x] Smoke: `--kv-fp8` alone (dense path) still works.
- [ ] Codex review bot P1/P2 issues addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)