### PR TITLE
[codex] split qwen36 moe speculative verify orchestration

### DIFF
--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -476,18 +476,9 @@ fn decode_text(
                 )
                 .context("batched speculative decode step")?;
 
-                // State mgmt: on partial-accept, restore + replay the
-                // accepted prefix to advance linear-attn state correctly.
-                // Full-accept (n_accepted == dynamic_k) needs no fixup —
-                // K+1 chains advanced state through K+1 inputs which is
-                // exactly what we committed (drafts + bonus's input was
-                // drafts[K-1], one more chain's worth advances naturally
-                // when next iter feeds the bonus token).
-                if r.n_accepted < dynamic_k {
-                    // Replay (j+1) chains: first_token at the current
-                    // position, then the j accepted drafts at the
-                    // following positions.
-                    let replay = loop_state.speculative_replay_inputs(next_token, &r);
+                if let Some(replay) =
+                    loop_state.partial_accept_replay_inputs(next_token, &r, dynamic_k)
+                {
                     restore_and_replay_accepted_prefix(Qwen36SpecReplayAccepted {
                         ordinal,
                         geom: &geom,

--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -36,9 +36,9 @@ use crate::qwen36_moe_prompt::{
 };
 use crate::qwen36_moe_session::{prepare_decode_session, Qwen36DecodeSession};
 use crate::qwen36_moe_spec_verify::{
-    restore_and_replay_accepted_prefix, run_batched_spec_verify_inputs, run_single_lm_head_top1,
-    run_spec_chain_step, Qwen36BatchedSpecVerifyInputs, Qwen36SingleLmHeadTop1,
-    Qwen36SpecChainStep, Qwen36SpecReplayAccepted,
+    restore_and_replay_accepted_prefix, run_batched_spec_verify_inputs,
+    run_sequential_spec_verify_input, Qwen36BatchedSpecVerifyInputs,
+    Qwen36SequentialSpecVerifyInput, Qwen36SpecReplayAccepted,
 };
 use crate::qwen36_moe_speculative::{
     run_speculative_decode_step, run_speculative_decode_step_batched,
@@ -515,32 +515,24 @@ fn decode_text(
                     next_token,
                     loop_state.position,
                     dynamic_k,
-                    |pos, input| -> anyhow::Result<(u32, Vec<u8>)> {
-                        let outputs = run_spec_chain_step(Qwen36SpecChainStep {
+                    |position, input| -> anyhow::Result<(u32, Vec<u8>)> {
+                        run_sequential_spec_verify_input(Qwen36SequentialSpecVerifyInput {
                             ordinal,
                             geom: &geom,
                             store: &store,
                             weight_prefix,
                             layers: &mut layers,
                             persistent_scratch: persistent_scratch.as_mut(),
-                            stage_timings: &mut stage_timings,
-                            position: pos,
-                            input,
-                            emit_stage_timings,
-                        })?;
-
-                        let top1 = run_single_lm_head_top1(Qwen36SingleLmHeadTop1 {
-                            ordinal,
-                            geom: &geom,
                             final_norm_w: &final_norm_w_buf,
                             lm_head_w: &lm_head_w_buf,
                             final_hidden: &mut final_hidden_buf,
                             logits: &mut logits_buf,
                             counter: &mut counter_buf,
                             stage_timings: &mut stage_timings,
-                            final_hidden_bytes: &outputs.final_hidden_bytes,
-                        })?;
-                        Ok((top1, outputs.final_hidden_bytes))
+                            position,
+                            input,
+                            emit_stage_timings,
+                        })
                     },
                 )
                 .context("speculative decode step")?

--- a/crates/runner/src/qwen36_moe_engine.rs
+++ b/crates/runner/src/qwen36_moe_engine.rs
@@ -35,15 +35,7 @@ use crate::qwen36_moe_prompt::{
     prepare_prompt, print_prompt_summary, validate_speculative_sampling,
 };
 use crate::qwen36_moe_session::{prepare_decode_session, Qwen36DecodeSession};
-use crate::qwen36_moe_spec_verify::{
-    restore_and_replay_accepted_prefix, run_batched_spec_verify_inputs,
-    run_sequential_spec_verify_input, Qwen36BatchedSpecVerifyInputs,
-    Qwen36SequentialSpecVerifyInput, Qwen36SpecReplayAccepted,
-};
-use crate::qwen36_moe_speculative::{
-    run_speculative_decode_step, run_speculative_decode_step_batched,
-};
-use crate::qwen36_moe_state::refresh_linear_attn_state;
+use crate::qwen36_moe_spec_verify::{run_speculative_extension, Qwen36SpeculativeExtension};
 use crate::qwen36_moe_telemetry::{print_and_write_moe_residency_summary, MoeRouteRuntime};
 use crate::qwen36_moe_timing::{Qwen36StageTimingTotals, SamplingParams};
 use crate::qwen36_moe_vmm::{
@@ -51,8 +43,6 @@ use crate::qwen36_moe_vmm::{
     print_virtual_kv_stats_if_active, should_use_qwen36_kv_vmm, virtual_kv_stats_for_layers,
 };
 use crate::registry::RegistryEntry;
-
-const QWEN36_NUM_SPECULATIVE_TOKENS: usize = 3;
 
 pub fn run(cli: &crate::Cli, entry: &RegistryEntry, total_vram: u64) -> Result<()> {
     ensure_qwen36_bake(cli, entry)?;
@@ -396,18 +386,6 @@ fn decode_text(
         }
         loop_state.current_token = next_token;
 
-        // Phase 6.3d: speculative extension. After the regular sample,
-        // try to commit additional tokens via MTP draft chain +
-        // sequential base verification. The closure wraps one base
-        // decode step (embed → chain → lm_head → host argmax). Honors
-        // `max_new` and EOS by truncating emitted tokens; the
-        // outer-loop counter advances normally because each iteration
-        // still runs at least one base step.
-        //
-        // Sequential verify gives no amortized speedup vs plain greedy
-        // (each accepted draft costs one base step to produce the next
-        // prediction). Phase 6.4's batched verification is what lifts
-        // tok/s. This wiring is the correctness foundation.
         if let (Some(mtp), Some(fwd_scratch), Some(chain_scratch), Some(embed_w)) = (
             mtp_buffers.as_mut(),
             mtp_forward_scratch.as_mut(),
@@ -417,117 +395,33 @@ fn decode_text(
             if loop_state.reached_max_new() {
                 break;
             }
-            // Cap K to the remaining max_new headroom so the verify
-            // loop never writes cache slots beyond what we'll
-            // actually commit to `generated_ids`. Spec emits up to
-            // K+1 tokens (K accepted + 1 corrected/bonus), so the
-            // available draft count is `headroom - 1`. If headroom <=
-            // 1 we can still emit 1 token via the K=0 fallback; if
-            // headroom == 0 we already broke out above.
-            let dynamic_k = loop_state.speculative_draft_count(QWEN36_NUM_SPECULATIVE_TOKENS);
+
             let h_base = outputs.final_hidden_bytes.clone();
-            // P2: thread spec-verify timings into the engine-level
-            // accumulators so `--emit-stage-timings` reports honest
-            // per-token costs under speculative decode. Without these
-            // captures, every base step inside the verify loop would
-            // be invisible to `gen_steps` / `t_chain` / `t_lm_head`,
-            // making the speculative path look ~K+1× faster than it
-            // really is on stage-timings dashboards.
-            //
-            // Phase 6.4c.2: route through the BATCHED driver when
-            // `--batched-spec-verify` is set. The batched closure runs
-            // K+1 chains sequentially (state mutates through them),
-            // accumulates K+1 final_hidden bytes, runs ONE batched
-            // lm_head over [K+1, hidden], does K+1 host argmaxes. On
-            // partial-accept the engine restores linear-attn state
-            // from the pre-spec snapshot then replays the accepted
-            // prefix sequentially to advance state correctly.
-            let result = if let Some(snapshot) = linear_attn_snapshot.as_mut() {
-                refresh_linear_attn_state(ordinal, &layers, snapshot)
-                    .context("refresh linear-attn snapshot before batched verify")?;
-
-                let r = run_speculative_decode_step_batched(
-                    ordinal,
-                    &geom,
-                    mtp,
-                    fwd_scratch,
-                    chain_scratch,
-                    embed_w,
-                    &lm_head_w_buf,
-                    &h_base,
-                    next_token,
-                    loop_state.position,
-                    dynamic_k,
-                    |inputs| -> anyhow::Result<Vec<(u32, Vec<u8>)>> {
-                        run_batched_spec_verify_inputs(Qwen36BatchedSpecVerifyInputs {
-                            ordinal,
-                            geom: &geom,
-                            store: &store,
-                            weight_prefix,
-                            layers: &mut layers,
-                            persistent_scratch: persistent_scratch.as_mut(),
-                            final_norm_w: &final_norm_w_buf,
-                            lm_head_w: &lm_head_w_buf,
-                            stage_timings: &mut stage_timings,
-                            inputs,
-                            emit_stage_timings,
-                        })
-                    },
-                )
-                .context("batched speculative decode step")?;
-
-                if let Some(replay) =
-                    loop_state.partial_accept_replay_inputs(next_token, &r, dynamic_k)
-                {
-                    restore_and_replay_accepted_prefix(Qwen36SpecReplayAccepted {
-                        ordinal,
-                        geom: &geom,
-                        store: &store,
-                        weight_prefix,
-                        layers: &mut layers,
-                        snapshot,
-                        persistent_scratch: persistent_scratch.as_mut(),
-                        stage_timings: &mut stage_timings,
-                        replay_inputs: &replay,
-                        emit_stage_timings,
-                    })?;
-                }
-                r
-            } else {
-                run_speculative_decode_step(
-                    ordinal,
-                    &geom,
-                    mtp,
-                    fwd_scratch,
-                    chain_scratch,
-                    embed_w,
-                    &lm_head_w_buf,
-                    &h_base,
-                    next_token,
-                    loop_state.position,
-                    dynamic_k,
-                    |position, input| -> anyhow::Result<(u32, Vec<u8>)> {
-                        run_sequential_spec_verify_input(Qwen36SequentialSpecVerifyInput {
-                            ordinal,
-                            geom: &geom,
-                            store: &store,
-                            weight_prefix,
-                            layers: &mut layers,
-                            persistent_scratch: persistent_scratch.as_mut(),
-                            final_norm_w: &final_norm_w_buf,
-                            lm_head_w: &lm_head_w_buf,
-                            final_hidden: &mut final_hidden_buf,
-                            logits: &mut logits_buf,
-                            counter: &mut counter_buf,
-                            stage_timings: &mut stage_timings,
-                            position,
-                            input,
-                            emit_stage_timings,
-                        })
-                    },
-                )
-                .context("speculative decode step")?
-            };
+            // Runs either batched or sequential speculative verify depending on
+            // whether session setup allocated a linear-attn snapshot.
+            let result = run_speculative_extension(Qwen36SpeculativeExtension {
+                ordinal,
+                geom: &geom,
+                store: &store,
+                weight_prefix,
+                layers: &mut layers,
+                persistent_scratch: persistent_scratch.as_mut(),
+                mtp,
+                forward_scratch: fwd_scratch,
+                chain_scratch,
+                embed_w,
+                final_norm_w: &final_norm_w_buf,
+                lm_head_w: &lm_head_w_buf,
+                final_hidden: &mut final_hidden_buf,
+                logits: &mut logits_buf,
+                counter: &mut counter_buf,
+                linear_attn_snapshot: linear_attn_snapshot.as_mut(),
+                loop_state: &loop_state,
+                h_base_in: &h_base,
+                first_token: next_token,
+                stage_timings: &mut stage_timings,
+                emit_stage_timings,
+            })?;
 
             if loop_state.append_speculative_emissions(&result, tokenizer.as_ref(), eos_id) {
                 break;

--- a/crates/runner/src/qwen36_moe_loop.rs
+++ b/crates/runner/src/qwen36_moe_loop.rs
@@ -54,6 +54,16 @@ impl Qwen36DecodeLoopState {
         replay
     }
 
+    pub fn partial_accept_replay_inputs(
+        &self,
+        first_token: u32,
+        result: &SpeculativeStepResult,
+        draft_count: usize,
+    ) -> Option<Vec<(i32, u32)>> {
+        (result.n_accepted < draft_count)
+            .then(|| self.speculative_replay_inputs(first_token, result))
+    }
+
     pub fn record_last_logits(&mut self, logits: &[u8]) {
         self.last_logits_bytes.clear();
         self.last_logits_bytes.extend_from_slice(logits);

--- a/crates/runner/src/qwen36_moe_spec_verify.rs
+++ b/crates/runner/src/qwen36_moe_spec_verify.rs
@@ -173,6 +173,54 @@ pub(crate) fn run_single_lm_head_top1(args: Qwen36SingleLmHeadTop1<'_>) -> Resul
     Ok(argmax_bf16_logits(&logits_bytes))
 }
 
+pub(crate) struct Qwen36SequentialSpecVerifyInput<'a> {
+    pub(crate) ordinal: usize,
+    pub(crate) geom: &'a MultiLayerGeom,
+    pub(crate) store: &'a BakedStore,
+    pub(crate) weight_prefix: &'a str,
+    pub(crate) layers: &'a mut [LayerBuffers],
+    pub(crate) persistent_scratch: Option<&'a mut PersistentScratch>,
+    pub(crate) final_norm_w: &'a GpuBuffer,
+    pub(crate) lm_head_w: &'a GpuBuffer,
+    pub(crate) final_hidden: &'a mut GpuBuffer,
+    pub(crate) logits: &'a mut GpuBuffer,
+    pub(crate) counter: &'a mut GpuBuffer,
+    pub(crate) stage_timings: &'a mut Qwen36StageTimingTotals,
+    pub(crate) position: i32,
+    pub(crate) input: u32,
+    pub(crate) emit_stage_timings: bool,
+}
+
+pub(crate) fn run_sequential_spec_verify_input(
+    args: Qwen36SequentialSpecVerifyInput<'_>,
+) -> Result<(u32, Vec<u8>)> {
+    let outputs = run_spec_chain_step(Qwen36SpecChainStep {
+        ordinal: args.ordinal,
+        geom: args.geom,
+        store: args.store,
+        weight_prefix: args.weight_prefix,
+        layers: args.layers,
+        persistent_scratch: args.persistent_scratch,
+        stage_timings: args.stage_timings,
+        position: args.position,
+        input: args.input,
+        emit_stage_timings: args.emit_stage_timings,
+    })?;
+
+    let top1 = run_single_lm_head_top1(Qwen36SingleLmHeadTop1 {
+        ordinal: args.ordinal,
+        geom: args.geom,
+        final_norm_w: args.final_norm_w,
+        lm_head_w: args.lm_head_w,
+        final_hidden: args.final_hidden,
+        logits: args.logits,
+        counter: args.counter,
+        stage_timings: args.stage_timings,
+        final_hidden_bytes: &outputs.final_hidden_bytes,
+    })?;
+    Ok((top1, outputs.final_hidden_bytes))
+}
+
 pub(crate) struct Qwen36BatchedLmHeadTop1<'a> {
     pub(crate) ordinal: usize,
     pub(crate) geom: &'a MultiLayerGeom,

--- a/crates/runner/src/qwen36_moe_spec_verify.rs
+++ b/crates/runner/src/qwen36_moe_spec_verify.rs
@@ -3,13 +3,23 @@ use gpu_hal::{GpuBuffer, ScalarType};
 use model_store::BakedStore;
 
 use crate::qwen36_moe_decode::{
-    argmax_bf16_logits, run_chained_decode_fast, DecodeOutputs, LayerBuffers, MultiLayerGeom,
+    argmax_bf16_logits, run_chained_decode_fast, DecodeOutputs, LayerBuffers, MtpLayerBuffers,
+    MultiLayerGeom,
 };
 use crate::qwen36_moe_host::lookup_embed_row;
 use crate::qwen36_moe_lm_head::{launch_lm_head_from_final_hidden_bytes, LmHeadBuffers};
+use crate::qwen36_moe_loop::Qwen36DecodeLoopState;
+use crate::qwen36_moe_mtp::{MtpChainScratch, MtpForwardScratch};
 use crate::qwen36_moe_persistent_decode::PersistentScratch;
-use crate::qwen36_moe_state::{restore_linear_attn_state, LinearAttnSnapshot};
+use crate::qwen36_moe_speculative::{
+    run_speculative_decode_step, run_speculative_decode_step_batched, SpeculativeStepResult,
+};
+use crate::qwen36_moe_state::{
+    refresh_linear_attn_state, restore_linear_attn_state, LinearAttnSnapshot,
+};
 use crate::qwen36_moe_timing::Qwen36StageTimingTotals;
+
+const QWEN36_NUM_SPECULATIVE_TOKENS: usize = 3;
 
 pub(crate) struct Qwen36SpecChainStep<'a> {
     pub(crate) ordinal: usize,
@@ -219,6 +229,126 @@ pub(crate) fn run_sequential_spec_verify_input(
         final_hidden_bytes: &outputs.final_hidden_bytes,
     })?;
     Ok((top1, outputs.final_hidden_bytes))
+}
+
+pub(crate) struct Qwen36SpeculativeExtension<'a> {
+    pub(crate) ordinal: usize,
+    pub(crate) geom: &'a MultiLayerGeom,
+    pub(crate) store: &'a BakedStore,
+    pub(crate) weight_prefix: &'a str,
+    pub(crate) layers: &'a mut [LayerBuffers],
+    pub(crate) persistent_scratch: Option<&'a mut PersistentScratch>,
+    pub(crate) mtp: &'a mut MtpLayerBuffers,
+    pub(crate) forward_scratch: &'a mut MtpForwardScratch,
+    pub(crate) chain_scratch: &'a mut MtpChainScratch,
+    pub(crate) embed_w: &'a GpuBuffer,
+    pub(crate) final_norm_w: &'a GpuBuffer,
+    pub(crate) lm_head_w: &'a GpuBuffer,
+    pub(crate) final_hidden: &'a mut GpuBuffer,
+    pub(crate) logits: &'a mut GpuBuffer,
+    pub(crate) counter: &'a mut GpuBuffer,
+    pub(crate) linear_attn_snapshot: Option<&'a mut LinearAttnSnapshot>,
+    pub(crate) loop_state: &'a Qwen36DecodeLoopState,
+    pub(crate) h_base_in: &'a [u8],
+    pub(crate) first_token: u32,
+    pub(crate) stage_timings: &'a mut Qwen36StageTimingTotals,
+    pub(crate) emit_stage_timings: bool,
+}
+
+pub(crate) fn run_speculative_extension(
+    mut args: Qwen36SpeculativeExtension<'_>,
+) -> Result<SpeculativeStepResult> {
+    let dynamic_k = args
+        .loop_state
+        .speculative_draft_count(QWEN36_NUM_SPECULATIVE_TOKENS);
+
+    if let Some(snapshot) = args.linear_attn_snapshot.as_deref_mut() {
+        refresh_linear_attn_state(args.ordinal, args.layers, snapshot)
+            .context("refresh linear-attn snapshot before batched verify")?;
+
+        let result = run_speculative_decode_step_batched(
+            args.ordinal,
+            args.geom,
+            args.mtp,
+            args.forward_scratch,
+            args.chain_scratch,
+            args.embed_w,
+            args.lm_head_w,
+            args.h_base_in,
+            args.first_token,
+            args.loop_state.position,
+            dynamic_k,
+            |inputs| -> Result<Vec<(u32, Vec<u8>)>> {
+                run_batched_spec_verify_inputs(Qwen36BatchedSpecVerifyInputs {
+                    ordinal: args.ordinal,
+                    geom: args.geom,
+                    store: args.store,
+                    weight_prefix: args.weight_prefix,
+                    layers: args.layers,
+                    persistent_scratch: args.persistent_scratch.as_deref_mut(),
+                    final_norm_w: args.final_norm_w,
+                    lm_head_w: args.lm_head_w,
+                    stage_timings: args.stage_timings,
+                    inputs,
+                    emit_stage_timings: args.emit_stage_timings,
+                })
+            },
+        )
+        .context("batched speculative decode step")?;
+
+        if let Some(replay) =
+            args.loop_state
+                .partial_accept_replay_inputs(args.first_token, &result, dynamic_k)
+        {
+            restore_and_replay_accepted_prefix(Qwen36SpecReplayAccepted {
+                ordinal: args.ordinal,
+                geom: args.geom,
+                store: args.store,
+                weight_prefix: args.weight_prefix,
+                layers: args.layers,
+                snapshot,
+                persistent_scratch: args.persistent_scratch.as_deref_mut(),
+                stage_timings: args.stage_timings,
+                replay_inputs: &replay,
+                emit_stage_timings: args.emit_stage_timings,
+            })?;
+        }
+        Ok(result)
+    } else {
+        run_speculative_decode_step(
+            args.ordinal,
+            args.geom,
+            args.mtp,
+            args.forward_scratch,
+            args.chain_scratch,
+            args.embed_w,
+            args.lm_head_w,
+            args.h_base_in,
+            args.first_token,
+            args.loop_state.position,
+            dynamic_k,
+            |position, input| -> Result<(u32, Vec<u8>)> {
+                run_sequential_spec_verify_input(Qwen36SequentialSpecVerifyInput {
+                    ordinal: args.ordinal,
+                    geom: args.geom,
+                    store: args.store,
+                    weight_prefix: args.weight_prefix,
+                    layers: args.layers,
+                    persistent_scratch: args.persistent_scratch.as_deref_mut(),
+                    final_norm_w: args.final_norm_w,
+                    lm_head_w: args.lm_head_w,
+                    final_hidden: args.final_hidden,
+                    logits: args.logits,
+                    counter: args.counter,
+                    stage_timings: args.stage_timings,
+                    position,
+                    input,
+                    emit_stage_timings: args.emit_stage_timings,
+                })
+            },
+        )
+        .context("speculative decode step")
+    }
 }
 
 pub(crate) struct Qwen36BatchedLmHeadTop1<'a> {


### PR DESCRIPTION
## Summary
- move Qwen3.6-MoE sequential speculative verify input handling out of the engine
- centralize partial-accept replay input construction on Qwen36DecodeLoopState
- extract speculative extension dispatch into qwen36_moe_spec_verify so the engine delegates batched/sequential verify orchestration

## Impact
This keeps qwen36_moe_engine.rs focused on the decode loop while the speculative verifier owns the closure-heavy verification and replay details. The engine is down to 446 lines, and the branch diff is limited to the Qwen3.6-MoE engine/loop/spec-verify modules.

## Validation
- cargo check -p runner --all-targets --quiet
- cargo test -p runner --bin supersonic --quiet
- git diff --check
- cargo test --workspace --no-fail-fast