### PR TITLE
SpecPrefill: drafter early-exit through scoring layer (2.07× faster)

### DIFF
--- a/crates/runner/src/decode_engine.rs
+++ b/crates/runner/src/decode_engine.rs
@@ -10420,6 +10420,39 @@ impl DecodeEngine {
         Ok(result)
     }
 
+    /// SpecPrefill cosine fast path: prefill the prompt through layer
+    /// `last_layer`, writing KV caches for layers `0..=last_layer`, and
+    /// stop. Skips final norm + lm_head + KV-FP8 conversion. Caller
+    /// reads the K caches directly via `state_mut().layers[i]`.
+    ///
+    /// Used by the speculator when scoring with cosine similarity —
+    /// only the K caches for the chosen scoring layer(s) are needed,
+    /// and running the rest of the model wastes time. For Qwen3.5-0.8B
+    /// + shallowest-layer scoring (default), this prunes ~27 of 28
+    /// drafter layers.
+    pub fn prefill_native_kv_through(
+        &mut self,
+        prompt_ids: &[u32],
+        last_layer: usize,
+    ) -> Result<()> {
+        prefill_engine::prefill_kv_through(
+            &self.weights,
+            &mut self.state,
+            &self.rotary,
+            prompt_ids,
+            self.ordinal,
+            self.kv_chunk_size,
+            self.prefill_chunk_size,
+            self.kv_fp8,
+            self.use_4b_kernel,
+            last_layer,
+        )?;
+        self.scratch
+            .reset_sync()
+            .map_err(|e| anyhow::anyhow!("reset sync after prefill_kv_through: {e}"))?;
+        Ok(())
+    }
+
     /// SpecPrefill (arXiv 2502.02789) target sparse prefill via the engine's
     /// own state/weights/rotary. See `prefill_engine::prefill_kept` for the
     /// `kept_positions` invariants.

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -668,16 +668,17 @@ pub(crate) struct Cli {
     ///
     /// - `cosine` (Phase D, default): per-block cosine(block_mean_K,
     ///   last_K) from one drafter K cache. Fast path — drops the
-    ///   lookahead decode steps entirely. Default scoring layer is the
+    ///   lookahead decode steps entirely AND stops the drafter after
+    ///   the scoring layer (early-exit). Default scoring layer is the
     ///   shallowest full-attention layer; override via env var
     ///   `SUPERSONIC_SPECPREFILL_SCORE_LAYER=N`. Per-layer aggregation
     ///   mode controlled by env var `SUPERSONIC_SPECPREFILL_LAYERS=
-    ///   shallowest|all_max` (default `shallowest`). Measured 4134 ms
-    ///   TTFT on a 1353-token prompt vs 5192 ms dense (1.26× faster)
+    ///   shallowest|all_max` (default `shallowest`). Measured 2385 ms
+    ///   TTFT on a 1353-token prompt vs 4941 ms dense (2.07× faster)
     ///   on gfx1100. See docs/specprefill.md § Algorithm.
     /// - `lookahead` (Phase C, legacy): per-layer softmax(Q·Kᵀ) over
     ///   look-ahead query rows. Correctness-validated but NET SLOWER
-    ///   than dense prefill on gfx1100 (7895 ms in the same
+    ///   than dense prefill on gfx1100 (7846 ms in the same
     ///   measurement) because the lookahead decode steps route through
     ///   the component decode path. Kept available for parity-test
     ///   coverage and future research.

--- a/crates/runner/src/prefill_engine.rs
+++ b/crates/runner/src/prefill_engine.rs
@@ -880,6 +880,7 @@ pub fn prefill(
         None,
         None,
         None,
+        None, // last_layer
     )
 }
 
@@ -916,6 +917,7 @@ pub fn prefill_with_taps(
         Some(tap_layers),
         None,
         None,
+        None, // last_layer
     )
 }
 
@@ -946,6 +948,7 @@ pub fn prefill_with_target_nll(
         None,
         Some((score_hidden_start, score_targets)),
         None,
+        None, // last_layer
     )
 }
 
@@ -988,7 +991,52 @@ pub fn prefill_kept(
         None,                 // tap_layers
         None,                 // target_nll
         Some(kept_positions), // kept_positions
+        None,                 // last_layer
     )
+}
+
+/// SpecPrefill cosine fast path: drafter prefill that only writes K/V
+/// caches for layers `0..=last_layer` and then returns. Skips final
+/// norm + lm_head + target_nll + BF16→FP8 KV conversion. Caller reads
+/// the K cache from `state.layers[i]` for each scored layer `i`.
+///
+/// Required: `last_layer < num_hidden_layers`.
+pub fn prefill_kv_through(
+    weights: &Qwen35Weights,
+    state: &mut ModelState,
+    rotary: &RotaryTables,
+    prompt_ids: &[u32],
+    ordinal: usize,
+    kv_chunk_size: usize,
+    prefill_chunk_size: usize,
+    kv_fp8: bool,
+    use_4b_kernel: bool,
+    last_layer: usize,
+) -> Result<()> {
+    if last_layer >= weights.config.num_hidden_layers {
+        return Err(anyhow::anyhow!(
+            "prefill_kv_through: last_layer {last_layer} out of range (num_hidden_layers={})",
+            weights.config.num_hidden_layers
+        ));
+    }
+    prefill_inner(
+        weights,
+        state,
+        rotary,
+        prompt_ids,
+        ordinal,
+        kv_chunk_size,
+        prefill_chunk_size,
+        kv_fp8,
+        use_4b_kernel,
+        false, // trace_layers
+        None,  // debug_linear_layer
+        None,  // tap_layers
+        None,  // target_nll
+        None,  // kept_positions
+        Some(last_layer),
+    )?;
+    Ok(())
 }
 
 // ---- SpecPrefill Phase C: speculator-side prefill with attention export ----
@@ -1031,7 +1079,17 @@ fn prefill_inner(
     debug_linear_layer: Option<usize>,
     tap_layers: Option<&[usize]>,
     target_nll: Option<(usize, &[u32])>,
-    kept_positions: Option<&[u32]>, // NEW
+    kept_positions: Option<&[u32]>,
+    // SpecPrefill cosine fast path: when Some(N), the per-chunk layer
+    // loop stops after layer N (KV caches for layers 0..=N are written;
+    // layers N+1.. are skipped). Final norm + lm_head + target_nll +
+    // kv_fp8 conversion are all skipped — caller reads the KV caches
+    // directly from `state`. The returned PrefillResult has empty
+    // logits and None traces in this mode. Required: `tap_layers`,
+    // `target_nll`, `debug_linear_layer`, `trace_layers`, and
+    // `kept_positions` must all be unused (None / false) — early-exit
+    // mode is K-only.
+    last_layer: Option<usize>,
 ) -> Result<PrefillResult> {
     let config = &weights.config;
     let seq_len = if let Some(kept) = kept_positions {
@@ -1195,8 +1253,12 @@ fn prefill_inner(
             &mut scratch.hidden,
         )?;
 
-        // Layer loop (all layers for this chunk)
-        for idx in 0..config.num_hidden_layers {
+        // Layer loop (all layers for this chunk, or 0..=last_layer when
+        // the SpecPrefill cosine fast path requests early exit).
+        let last_layer_idx = last_layer
+            .map(|n| n.min(config.num_hidden_layers - 1))
+            .unwrap_or(config.num_hidden_layers - 1);
+        for idx in 0..=last_layer_idx {
             // Input RMSNorm
             rms_norm_rows_model(
                 config,
@@ -1396,6 +1458,25 @@ fn prefill_inner(
         }
 
         chunk_start += chunk_len;
+    }
+
+    // SpecPrefill cosine fast path: caller asked for KV-only prefill
+    // through `last_layer`. Skip final norm + lm_head + target_nll + the
+    // BF16→FP8 KV conversion. Caller reads K caches directly from
+    // `state` for the layers it scored.
+    if last_layer.is_some() {
+        return Ok(PrefillResult {
+            logits: Vec::new(),
+            final_norm_trace: None,
+            layer_attn_trace,
+            layer_post_attn_norm_trace,
+            layer_mlp_swiglu_trace,
+            layer_mlp_out_trace,
+            layer_hidden_trace,
+            tap_hiddens,
+            linear_debug_trace,
+            target_nll: None,
+        });
     }
 
     // Extract logits for the last token of the final chunk. Refactored out

--- a/crates/runner/src/specprefill_engine.rs
+++ b/crates/runner/src/specprefill_engine.rs
@@ -27,10 +27,8 @@ fn score_blocks_cosine(
         anyhow::bail!("score_blocks_cosine: empty prompt");
     }
 
-    // 1. Drafter dense prefill (fast megakernel path; no decode steps).
-    let _base = draft_engine.prefill_native_with_final_norm(prompt_ids)?;
-
-    // 2. Pick scoring layer + mode.
+    // 1. Pick scoring layer(s). Resolve BEFORE prefill so we can stop
+    //    drafter execution after the deepest scoring layer.
     // Clone the config out of the borrow chain so we can re-borrow draft_engine
     // mutably below (state_mut + cosine kernel launch).
     let config = draft_engine.weights().config.clone();
@@ -53,6 +51,17 @@ fn score_blocks_cosine(
         // "shallowest" or any other value: single layer (override or shallowest).
         _ => vec![layer_override.unwrap_or(shallowest)],
     };
+
+    // 2. Drafter prefill, stopping after the deepest scored layer.
+    //    For shallowest mode (default) on Qwen3.5-0.8B this prunes most
+    //    drafter layers — only layers 0..=shallowest execute. For
+    //    all_max mode, runs through the deepest full-attention layer.
+    //    Skips final norm + lm_head + KV-FP8 conversion entirely.
+    let last_layer = *layers_to_score
+        .iter()
+        .max()
+        .expect("layers_to_score non-empty");
+    draft_engine.prefill_native_kv_through(prompt_ids, last_layer)?;
 
     let n_blocks = (prompt_len + block_size - 1) / block_size;
     let last_pos = prompt_len - 1;

--- a/docs/feature-compatibility.md
+++ b/docs/feature-compatibility.md
@@ -100,14 +100,16 @@ Flags: `--specprefill-draft-dir <path>` plus tuning flags (see
 specprefill.md).
 
 **Performance note:** As of Phase D (2026-05-04), SpecPrefill defaults
-to cosine-similarity scoring (`--specprefill-algorithm cosine`) and is
-**1.26× faster than dense prefill** on gfx1100 at the measured prompt
-length (1353-token prompt, Qwen3.5-9B BF16: 4.13s with SpecPrefill vs
-5.19s dense, `keep_ratio=0.50`). The legacy `lookahead` algorithm
-remains available but is NET SLOWER than dense (7.90s) because its
-draft decode steps route through the component decode path instead of
-the persistent megakernel — kept for parity-test coverage and future
-research, not recommended for production. See
+to cosine-similarity scoring (`--specprefill-algorithm cosine`) plus
+drafter early-exit (the drafter stops after the scoring layer instead
+of running its full model), and is **2.07× faster than dense prefill**
+on gfx1100 at the measured prompt length (1353-token prompt,
+Qwen3.5-9B BF16: 2.39s with SpecPrefill vs 4.94s dense,
+`keep_ratio=0.50`). The legacy `lookahead` algorithm remains available
+but is NET SLOWER than dense (7.85s) because its draft decode steps
+route through the component decode path instead of the persistent
+megakernel — kept for parity-test coverage and future research, not
+recommended for production. See
 [specprefill.md § Performance](specprefill.md#performance) for the full
 table.
 
@@ -210,9 +212,10 @@ combo (or one feature implicitly requires the other to be off).
 
 ### ... validate the SpecPrefill correctness chain on Qwen3.5-9B (HIP)
 
-The default `cosine` algorithm runs 1.26× faster than dense prefill on
-gfx1100; the legacy `lookahead` algorithm remains slower than dense
-(see [specprefill.md § Performance](specprefill.md#performance)). For
+The default `cosine` algorithm + drafter early-exit runs 2.07× faster
+than dense prefill on gfx1100; the legacy `lookahead` algorithm remains
+slower than dense (see
+[specprefill.md § Performance](specprefill.md#performance)). For
 production TTFT use the default; pass `--specprefill-algorithm
 lookahead` only if you're actively researching the legacy path.
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -753,9 +753,9 @@ in.
 | KV-FP8 | qwen3.6-35b-a3b INT4 + 6-token prompt + 16 generated tokens, gfx1100 | 28.3 ms/step | 28.5 ms/step | +0.7% (effectively free; the win is VRAM headroom for long contexts) | manual run, 2026-05-03 |
 | KV-FP8 sidecar window | qwen3.6-35b-a3b INT4 + 22-token context (test prompt + 16 gen) | 28.5 ms/step | 28.5 ms/step | identical at this context length (window=256 covers all 22 tokens; the BF16 sidecar is the win at LONG contexts not measured here) | manual run, 2026-05-03 |
 | VMM | qwen3.6-35b-a3b INT4 + 8192-token context, gfx1100 | OOM (24 GiB exceeded) | runs | enables the workload | tests/gfx1100/bench_qwen36_sparse_caps.py |
-| SpecPrefill (cosine, keep=0.50) | qwen3.5-9b BF16 + 1353-token prompt, gfx1100 | 5192 ms TTFT | 4134 ms TTFT (default `--specprefill-algorithm cosine`, shallowest layer) | **1.26× FASTER** | tests/gfx1100/bench_specprefill_cosine.sh, 2026-05-03 |
-| SpecPrefill (cosine all_max, keep=0.50) | qwen3.5-9b BF16 + 1353-token prompt, gfx1100 | 5192 ms TTFT | 4099 ms TTFT (`SUPERSONIC_SPECPREFILL_LAYERS=all_max`) | **1.27× FASTER** | tests/gfx1100/bench_specprefill_cosine.sh, 2026-05-03 |
-| SpecPrefill (lookahead, keep=0.50) | qwen3.5-9b BF16 + 1353-token prompt, gfx1100 | 5192 ms TTFT | 7895 ms TTFT (legacy `--specprefill-algorithm lookahead`) | **1.52× SLOWER**² | tests/gfx1100/bench_specprefill_cosine.sh, 2026-05-03 |
+| SpecPrefill (cosine, keep=0.50) | qwen3.5-9b BF16 + 1353-token prompt, gfx1100 | 4941 ms TTFT | 2385 ms TTFT (default `--specprefill-algorithm cosine`, shallowest layer + drafter early-exit) | **2.07× FASTER** | tests/gfx1100/bench_specprefill_cosine.sh, 2026-05-04 |
+| SpecPrefill (cosine all_max, keep=0.50) | qwen3.5-9b BF16 + 1353-token prompt, gfx1100 | 4941 ms TTFT | 4144 ms TTFT (`SUPERSONIC_SPECPREFILL_LAYERS=all_max`) | **1.19× FASTER** | tests/gfx1100/bench_specprefill_cosine.sh, 2026-05-04 |
+| SpecPrefill (lookahead, keep=0.50) | qwen3.5-9b BF16 + 1353-token prompt, gfx1100 | 4941 ms TTFT | 7846 ms TTFT (legacy `--specprefill-algorithm lookahead`) | **1.59× SLOWER**² | tests/gfx1100/bench_specprefill_cosine.sh, 2026-05-04 |
 | SpecPrefill + KV-FP8 | qwen3.5-9b BF16 + KV-FP8 + 1353-token prompt | — | rejected by validation³ | **REJECTED** | n/a (CLI guard since 2026-05-04) |
 | DFlash (B=3) | qwen3.5-9b INT4 greedy decode, gfx1100 | ~32 ms/step | ~12 ms/step (effective; 2.5-3× speedup) | 2.5-3× FASTER | docs/dflash.md M4.3 numbers |
 | MoE prefetch | qwen3.6-35b-a3b INT4 decode, gfx1100 | included | (default-on) | — | the 28.3 ms/step row above already includes prefetch — the persistent megakernel default path uses it. A/B vs no-prefetch needs `--no-persistent-decode` which falls back to a different decode path entirely. |
@@ -773,9 +773,12 @@ in.
   K/V copy fallback added in PR #177) instead of the persistent
   megakernel. Phase D (2026-05-04) replaced the default scoring
   algorithm with `cosine` — a hipfire-PFlash-style single-layer
-  cosine-similarity score that does one drafter dense prefill and a
-  single small HIP kernel launch, dropping the lookahead decode steps
-  entirely. The new default is 1.26× faster than dense at the same
+  cosine-similarity score that does one drafter prefill and a
+  single small HIP kernel launch, dropping the lookahead decode
+  steps entirely. A follow-on change in the same PR series wired in
+  a drafter early-exit (`prefill_kv_through`) so the drafter stops
+  after the chosen scoring layer and skips the rest of its model.
+  The combined default is 2.07× faster than dense at the same
   workload and also scores marginally higher on correctness (cossim
   0.820 vs 0.708 against the dense reference at keep=0.50). See
   [specprefill.md § Algorithm](specprefill.md#algorithm) and

--- a/docs/specprefill.md
+++ b/docs/specprefill.md
@@ -52,15 +52,19 @@ selection (`keep_ratio` × `chunk_size`) and produce the same kept-token
 schedule downstream:
 
 - `cosine` (default, Phase D): per-block `cosine(block_mean_K, last_K)`
-  computed from one drafter K cache. The drafter does a single dense
-  prefill (megakernel fast path), the orchestrator picks one
-  full-attention layer, and a HIP kernel emits per-block cosine scores
-  in one launch. The default scoring layer is the **shallowest**
-  full-attention layer (env var `SUPERSONIC_SPECPREFILL_SCORE_LAYER=N`
-  overrides). The default aggregation mode is `shallowest`; set
+  computed from one drafter K cache. The drafter prefill stops after
+  the deepest scoring layer (early-exit through `prefill_kv_through`)
+  — for `shallowest` mode on Qwen3.5-0.8B that prunes ~26 of 28 layers.
+  The orchestrator then picks one full-attention layer and a HIP kernel
+  emits per-block cosine scores in one launch. The default scoring
+  layer is the **shallowest** full-attention layer (env var
+  `SUPERSONIC_SPECPREFILL_SCORE_LAYER=N` overrides). The default
+  aggregation mode is `shallowest`; set
   `SUPERSONIC_SPECPREFILL_LAYERS=all_max` to take the per-block max
-  across all full-attention layers (marginal quality bump in our
-  measurements; see Performance below).
+  across all full-attention layers — `all_max` doesn't benefit from
+  early-exit (the deepest full-attention layer is near the end of the
+  drafter), so it ends up at roughly dense-baseline TTFT in our
+  measurements (see Performance below).
 - `lookahead` (legacy, Phase C): per-layer `softmax(Q·Kᵀ)` over
   look-ahead query rows from `--specprefill-lookahead` decode steps on
   the draft. Correctness-validated and structurally faithful to the
@@ -81,10 +85,10 @@ runs (median reported), `--specprefill-keep-ratio 0.50`:
 
 | Mode | TTFT (ms) | vs dense |
 |---|---|---|
-| dense (no SpecPrefill) | 5192 | 1.00× |
-| `--specprefill-algorithm cosine`, `shallowest` (default) | 4134 | **1.26× faster** |
-| `--specprefill-algorithm cosine`, `all_max` | 4099 | 1.27× faster |
-| `--specprefill-algorithm lookahead` | 7895 | 0.66× (slower than dense) |
+| dense (no SpecPrefill) | 4941 | 1.00× |
+| `--specprefill-algorithm cosine`, `shallowest` (default) | 2385 | **2.07× faster** |
+| `--specprefill-algorithm cosine`, `all_max` | 4144 | 1.19× faster |
+| `--specprefill-algorithm lookahead` | 7846 | 0.63× (slower than dense) |
 
 Quality at the same `keep_ratio=0.50` (against the dense reference; same
 1353-token prompt; cossim is a regression backstop, argmax-match is


### PR DESCRIPTION
## Summary

The cosine speculator only needs the K cache from the chosen scoring
layer; running the drafter's remaining layers + final norm + lm_head
is wasted work. Plumb a `last_layer: Option<usize>` parameter through
`prefill_inner` and add `prefill_kv_through` / `prefill_native_kv_through`
entry points that:

- run all chunks through layers `0..=last_layer`
- skip layers `last_layer+1..num_hidden_layers` entirely
- skip final norm + lm_head + target_nll + KV-FP8 conversion

`score_blocks_cosine` resolves the scoring layer(s) before prefill,
then calls `prefill_native_kv_through(prompt_ids, max(layers))`. For
Qwen3.5-0.8B + shallowest mode (default) this prunes ~26 of 28 drafter
layers.

## Measured (gfx1100, Qwen3.5-9B + 0.8B draft, 1353-token prompt, keep=0.50, median of 3)

| Mode | TTFT (ms) | vs dense | vs PR #194 |
|---|---|---|---|
| dense (no SpecPrefill) | 4941 | 1.00× | — |
| **cosine, shallowest (default)** | **2385** | **2.07× faster** | **1.73× faster than PR #194's 4134** |
| cosine, all_max | 4144 | 1.19× faster | ≈ unchanged |
| lookahead (legacy) | 7846 | 0.63× | unchanged |

`all_max` doesn't benefit because the deepest full-attention layer is
near the end of the drafter — early-exit prunes nothing meaningful for
that mode. `shallowest` is now decisively the right default.

## Quality (unchanged)

The 9B cosine parity test (3 subtests) re-passes with identical
numbers: cossim 0.820 at keep=0.50, byte-equal multitoken text at
keep=1.00. K cache state at the scoring layer is independent of
whether layers past it execute; the parity check pins this.

## Scope

Existing callers of `prefill_inner` (`prefill`, `prefill_with_taps`,
`prefill_with_target_nll`, `prefill_kept`) all pass `last_layer=None`
and route through the unchanged code path. No behavior change for
target prefill, DFlash, or any path other than cosine SpecPrefill.

## Files

- `crates/runner/src/prefill_engine.rs` — `last_layer` plumbing +
  `prefill_kv_through` (~70 lines added).
- `crates/runner/src/decode_engine.rs` — `prefill_native_kv_through`
  method (~30 lines).
- `crates/runner/src/specprefill_engine.rs` — resolve scoring layer
  first, call new entry (~10 line refactor).
- `docs/specprefill.md`, `docs/performance.md`,
  `docs/feature-compatibility.md`, `crates/runner/src/main.rs` —
  measured-TTFT updates.

## Test plan

- [x] `cargo build --release --bin supersonic`
- [x] 9B cosine parity (3 subtests: keep=0.50 quality, keep=1.00
  identity, keep=1.00 multitoken byte-equal text) — all PASS with
  identical numbers to PR #194.
- [x] TTFT bench: cosine A 2385 ms < dense 4941 ms (2.07× faster) ✓
- [x] Legacy lookahead path unchanged — `prefill_with_lookahead_attention`
  routes through `prefill_inner` with `last_layer=None`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)