### PR TITLE
Add Qwen3.6 long-context comparison preset

### DIFF
--- a/docs/research/hip-qwen36-long-context.md
+++ b/docs/research/hip-qwen36-long-context.md
@@ -18,24 +18,40 @@ through the existing `supersonic` CLI and records:
 - dense or sparse VMM residency fields, including total, MoE, and KV bytes
 - JSON plus Markdown summaries under `target/`
 
-Default sweep:
+Preset sweeps:
 
 ```bash
 .venv/bin/python tests/gfx1100/bench_qwen36_longctx.py \
   --binary target/release/supersonic \
   --model-dir /mnt/data/models/Qwen3.6-35B-A3B \
-  --contexts 8192,16384,32768 \
-  --modes int4-vmm,int4-kv-fp8 \
-  --max-new-tokens 16
+  --preset comparison \
+  --out-json target/qwen36_longctx_comparison.json \
+  --out-md target/qwen36_longctx_comparison.md
 ```
+
+`--preset comparison` covers `512,2048,4096,8192` contexts across
+`int4-vmm` and `int4-kv-fp8` with short generation.  It is the first pass to
+run after a merge because it gives a fast answer to "which stage is next?"
+without committing to the 16k/32k profile.  `--preset smoke` is the one-row
+GPU sanity check, `--preset full` keeps the previous 8k/16k/32k sweep, and
+`--preset sparse-comparison` adds sparse MoE cap rows.
 
 Optional sparse-MoE rows can be added with:
 
 ```bash
 .venv/bin/python tests/gfx1100/bench_qwen36_longctx.py \
-  --modes int4-vmm,int4-kv-fp8,sparse,sparse-kv-fp8 \
-  --sparse-caps 320
+  --preset sparse-comparison \
+  --sparse-caps 320 \
+  --out-json target/qwen36_longctx_sparse_comparison.json \
+  --out-md target/qwen36_longctx_sparse_comparison.md
 ```
+
+The Markdown report now starts with a summary table that ranks the best mode
+per context, compares it to the `int4-vmm` baseline, records prefill and
+generation wall timing, and names the likely bottleneck from the chain
+breakdown (`full_attn`, `linear_attn`, `ffn`, or host/output tail fields).
+The JSON report stores the same summary and recommendation alongside raw rows
+so follow-up PRs can quote one artifact instead of manually interpreting logs.
 
 ## VMM Baseline
 

--- a/tests/gfx1100/bench_qwen36_longctx.py
+++ b/tests/gfx1100/bench_qwen36_longctx.py
@@ -25,6 +25,38 @@ MIB = 1024 * 1024
 GIB = 1024 * MIB
 TOKEN_CHARS = 2
 
+PRESETS: dict[str, dict[str, Any]] = {
+    "smoke": {
+        "contexts": "512",
+        "modes": "int4-vmm",
+        "max_new_tokens": 1,
+        "warmup": False,
+        "timeout": 600,
+    },
+    "comparison": {
+        "contexts": "512,2048,4096,8192",
+        "modes": "int4-vmm,int4-kv-fp8",
+        "max_new_tokens": 4,
+        "warmup": True,
+        "timeout": 1800,
+    },
+    "full": {
+        "contexts": "8192,16384,32768",
+        "modes": "int4-vmm,int4-kv-fp8",
+        "max_new_tokens": 16,
+        "warmup": True,
+        "timeout": 1800,
+    },
+    "sparse-comparison": {
+        "contexts": "2048,4096,8192",
+        "modes": "int4-vmm,int4-kv-fp8,sparse,sparse-kv-fp8",
+        "sparse_caps": "320",
+        "max_new_tokens": 4,
+        "warmup": True,
+        "timeout": 1800,
+    },
+}
+
 
 @dataclass(frozen=True)
 class BenchMode:
@@ -126,6 +158,13 @@ def make_niah_prompt(context_tokens: int, seed: int) -> tuple[str, str]:
 
 def parse_stage_timings(output: str) -> dict[str, float]:
     match = re.search(r"\[qwen36-moe stage-timings\]\s+(.+)", output)
+    if not match:
+        return {}
+    return parse_key_value_floats(match.group(1))
+
+
+def parse_chain_breakdown(output: str) -> dict[str, float]:
+    match = re.search(r"\[qwen36-moe chain-breakdown\]\s+(.+)", output)
     if not match:
         return {}
     return parse_key_value_floats(match.group(1))
@@ -248,6 +287,18 @@ def fmt_gib(value: float | int | None) -> str:
     return f"{float(value) / GIB:.2f}"
 
 
+def apply_preset_defaults(args: argparse.Namespace) -> argparse.Namespace:
+    preset = PRESETS.get(args.preset or "full", {})
+    args.contexts = args.contexts or preset.get("contexts") or "8192,16384,32768"
+    args.modes = args.modes or preset.get("modes") or "int4-vmm,int4-kv-fp8"
+    args.sparse_caps = args.sparse_caps or preset.get("sparse_caps") or "320"
+    args.max_new_tokens = args.max_new_tokens or preset.get("max_new_tokens") or 16
+    args.timeout = args.timeout or preset.get("timeout") or 1800
+    if args.warmup is None:
+        args.warmup = bool(preset.get("warmup", True))
+    return args
+
+
 def build_run_env(
     base_env: dict[str, str],
     args: argparse.Namespace,
@@ -344,6 +395,7 @@ def run_one(
             "niah_contains_expected": False,
             "generated_ids": parse_tokens(output),
             "stage": parse_stage_timings(output),
+            "chain_breakdown": parse_chain_breakdown(output),
             "lifecycle": parse_lifecycle_timings(output),
             "result": parse_result(output),
             "vmm_residency": dense_vmm_residency(output),
@@ -370,6 +422,7 @@ def run_one(
         ),
         "generated_ids": parse_tokens(output),
         "stage": parse_stage_timings(output),
+        "chain_breakdown": parse_chain_breakdown(output),
         "lifecycle": parse_lifecycle_timings(output),
         "result": parse_result(output),
         "stdout_tail": proc.stdout[-1600:],
@@ -387,11 +440,136 @@ def run_one(
     return row
 
 
-def markdown(rows: list[dict[str, Any]]) -> str:
+def row_ms_per_tok(row: dict[str, Any]) -> float | None:
+    stage = row.get("stage") or {}
+    result = row.get("result") or {}
+    value = stage.get("total_ms_avg") or result.get("ms_per_tok")
+    return float(value) if value is not None else None
+
+
+def row_prefill_seconds(row: dict[str, Any]) -> float | None:
+    lifecycle = row.get("lifecycle") or {}
+    value = lifecycle.get("prefill_total_ms")
+    return float(value) / 1000.0 if value is not None else None
+
+
+def row_generation_wall_ms(row: dict[str, Any]) -> float | None:
+    lifecycle = row.get("lifecycle") or {}
+    value = lifecycle.get("generation_wall_ms")
+    return float(value) if value is not None else None
+
+
+def likely_bottleneck(row: dict[str, Any]) -> str:
+    chain = row.get("chain_breakdown") or {}
+    stage = row.get("stage") or {}
+    candidates = {
+        "full_attn": chain.get("full_attn_ms_avg"),
+        "linear_attn": chain.get("linear_attn_ms_avg"),
+        "ffn": chain.get("ffn_ms_avg"),
+        "lm_head": stage.get("lm_head_ms_avg"),
+        "sampling": stage.get("sample_ms_avg"),
+        "detok": stage.get("detok_ms_avg"),
+    }
+    candidates = {key: value for key, value in candidates.items() if value is not None}
+    if not candidates:
+        return "-"
+    return max(candidates, key=lambda key: float(candidates[key]))
+
+
+def summarize(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    summaries: list[dict[str, Any]] = []
+    contexts = sorted({row["context_tokens_requested"] for row in rows})
+    for context in contexts:
+        context_rows = [
+            row
+            for row in rows
+            if row["context_tokens_requested"] == context
+            and row.get("returncode") == 0
+            and row_ms_per_tok(row) is not None
+        ]
+        if not context_rows:
+            summaries.append({"context_tokens_requested": context, "status": "no-successful-runs"})
+            continue
+        baseline = next((row for row in context_rows if row["mode"] == "int4-vmm"), None)
+        best = min(context_rows, key=lambda row: row_ms_per_tok(row) or float("inf"))
+        baseline_ms = row_ms_per_tok(baseline) if baseline else None
+        best_ms = row_ms_per_tok(best)
+        delta_pct = (
+            ((best_ms - baseline_ms) / baseline_ms) * 100.0
+            if baseline_ms and best_ms is not None
+            else None
+        )
+        summaries.append(
+            {
+                "context_tokens_requested": context,
+                "status": "ok",
+                "best_mode": best["mode"],
+                "best_ms_per_tok": best_ms,
+                "baseline_ms_per_tok": baseline_ms,
+                "best_vs_baseline_pct": delta_pct,
+                "prefill_seconds": row_prefill_seconds(best),
+                "generation_wall_ms": row_generation_wall_ms(best),
+                "likely_bottleneck": likely_bottleneck(best),
+            }
+        )
+    return summaries
+
+
+def recommendation(summary: list[dict[str, Any]]) -> str:
+    ok = [row for row in summary if row.get("status") == "ok"]
+    if not ok:
+        return "No successful runs; inspect stderr_tail in the JSON report first."
+    bottlenecks: dict[str, int] = {}
+    for row in ok:
+        bottleneck = row.get("likely_bottleneck") or "-"
+        bottlenecks[bottleneck] = bottlenecks.get(bottleneck, 0) + 1
+    top_bottleneck = max(bottlenecks, key=bottlenecks.get)
+    if top_bottleneck == "full_attn":
+        return "Prioritize full-attention/KV bandwidth work for longer contexts."
+    if top_bottleneck == "ffn":
+        return "Prioritize routed expert FFN residency, prefetch, or matvec work."
+    if top_bottleneck in {"lm_head", "sampling", "detok"}:
+        return f"Prioritize host/output tail work; {top_bottleneck} dominates the best rows."
+    return f"Use the detailed rows before kernel work; current top bottleneck is {top_bottleneck}."
+
+
+def markdown(rows: list[dict[str, Any]], summary: list[dict[str, Any]] | None = None) -> str:
+    if summary is None:
+        summary = summarize(rows)
     out = [
+        "## Summary",
+        "",
+        f"Recommendation: {recommendation(summary)}",
+        "",
+        "| Context | best mode | baseline ms/tok | best ms/tok | best vs baseline | prefill s | gen wall ms | likely bottleneck |",
+        "|---:|:---|---:|---:|---:|---:|---:|:---|",
+    ]
+    for item in summary:
+        out.append(
+            "| {context} | {best_mode} | {baseline} | {best} | {delta} | {prefill} | {gen_wall} | {bottleneck} |".format(
+                context=item["context_tokens_requested"],
+                best_mode=item.get("best_mode", "-"),
+                baseline=fmt_num(item.get("baseline_ms_per_tok")),
+                best=fmt_num(item.get("best_ms_per_tok")),
+                delta=(
+                    f"{float(item['best_vs_baseline_pct']):+.1f}%"
+                    if item.get("best_vs_baseline_pct") is not None
+                    else "-"
+                ),
+                prefill=fmt_num(item.get("prefill_seconds")),
+                gen_wall=fmt_num(item.get("generation_wall_ms")),
+                bottleneck=item.get("likely_bottleneck", "-"),
+            )
+        )
+    out.extend(
+        [
+            "",
+            "## Detail",
+            "",
         "| Context | Mode | wall s | prefill s | gen wall s | total ms/tok | tok/s | prompt tokens | total resident GiB | MoE resident GiB | KV resident GiB | generated ids match | NIAH hit |",
         "|---:|:---|---:|---:|---:|---:|---:|---:|---:|---:|---:|:---:|:---:|",
-    ]
+        ]
+    )
     baseline_ids_by_context: dict[int, list[int]] = {}
     for row in rows:
         if row["mode"] == "int4-vmm":
@@ -436,17 +614,27 @@ def markdown(rows: list[dict[str, Any]]) -> str:
 
 def main() -> int:
     parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--preset",
+        choices=sorted(PRESETS),
+        help="named sweep defaults; explicit CLI flags override preset values",
+    )
     parser.add_argument("--binary", type=Path, default=Path("target/release/supersonic"))
     parser.add_argument("--model-dir", type=Path, default=Path("/mnt/data/models/Qwen3.6-35B-A3B"))
     parser.add_argument("--backend", default="hip")
-    parser.add_argument("--contexts", default="8192,16384,32768")
-    parser.add_argument("--modes", default="int4-vmm,int4-kv-fp8")
-    parser.add_argument("--sparse-caps", default="320")
-    parser.add_argument("--max-new-tokens", type=int, default=16)
+    parser.add_argument("--contexts")
+    parser.add_argument("--modes")
+    parser.add_argument("--sparse-caps")
+    parser.add_argument("--max-new-tokens", type=int)
     parser.add_argument("--warmup-new-tokens", type=int, default=2)
     parser.add_argument("--seed", type=int, default=20260504)
-    parser.add_argument("--timeout", type=int, default=1800)
-    parser.add_argument("--no-warmup", action="store_true")
+    parser.add_argument("--timeout", type=int)
+    parser.add_argument(
+        "--warmup",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="run one short warmup before each measured row",
+    )
     parser.add_argument("--no-persistent-decode", action="store_true")
     parser.add_argument(
         "--force-moe-vmm",
@@ -456,7 +644,7 @@ def main() -> int:
     )
     parser.add_argument("--out-json", type=Path, default=Path("target/qwen36_longctx.json"))
     parser.add_argument("--out-md", type=Path, default=Path("target/qwen36_longctx.md"))
-    args = parser.parse_args()
+    args = apply_preset_defaults(parser.parse_args())
 
     try:
         contexts = parse_int_list(args.contexts)
@@ -482,7 +670,7 @@ def main() -> int:
     for context in contexts:
         prompt, expected = prompts[context]
         for mode in modes:
-            if not args.no_warmup:
+            if args.warmup:
                 print(f"[warmup] context={context} mode={mode.label}", flush=True)
                 run_one(args, mode, context, prompt, expected, tmp, warmup=True)
             print(f"[bench] context={context} mode={mode.label}", flush=True)
@@ -502,16 +690,20 @@ def main() -> int:
                 flush=True,
             )
 
-    md = markdown(rows)
+    summary = summarize(rows)
+    md = markdown(rows, summary)
     payload = {
-        "schema": "qwen36-moe-longctx-bench-v2",
+        "schema": "qwen36-moe-longctx-bench-v3",
         "model": "qwen3.6-35b-a3b",
         "model_dir": str(args.model_dir),
         "backend": args.backend,
+        "preset": args.preset,
         "contexts": contexts,
         "modes": [mode.label for mode in modes],
         "max_new_tokens": args.max_new_tokens,
         "seed": args.seed,
+        "summary": summary,
+        "recommendation": recommendation(summary),
         "rows": rows,
     }
     args.out_json.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_qwen36_longctx_bench.py
+++ b/tests/test_qwen36_longctx_bench.py
@@ -43,6 +43,8 @@ class Qwen36LongContextBenchTests(unittest.TestCase):
             "[tokens] [1, 2, 3]\n"
             "[result] prompt_tokens=8190 generated_tokens=3 decode_ms=30 ms_per_tok=10\n"
             "[qwen36-moe stage-timings] gen_steps=3 total_ms_avg=10.5 attn_ms_avg=2 (chain_total_ms=30)\n"
+            "[qwen36-moe chain-breakdown] gen_steps=3 full_attn_ms_avg=7.0 "
+            "linear_attn_ms_avg=1.0 ffn_ms_avg=2.0\n"
             "[qwen36-moe lifecycle-timings] prompt_setup_ms=1.0 bake_open_ms=2.0 "
             "layer_load_ms=3.0 session_ms=4.0 prefill_steps=8190 "
             "prefill_embed_ms=5.0 prefill_chain_ms=6000.0 prefill_total_ms=6005.0 "
@@ -53,10 +55,54 @@ class Qwen36LongContextBenchTests(unittest.TestCase):
         self.assertEqual(bench_qwen36_longctx.parse_result(output)["prompt_tokens"], 8190)
         self.assertEqual(bench_qwen36_longctx.parse_stage_timings(output)["total_ms_avg"], 10.5)
         self.assertEqual(bench_qwen36_longctx.parse_stage_timings(output)["chain_total_ms"], 30)
+        chain = bench_qwen36_longctx.parse_chain_breakdown(output)
+        self.assertEqual(chain["full_attn_ms_avg"], 7.0)
+        self.assertEqual(bench_qwen36_longctx.likely_bottleneck({"chain_breakdown": chain}), "full_attn")
         lifecycle = bench_qwen36_longctx.parse_lifecycle_timings(output)
         self.assertEqual(lifecycle["prefill_steps"], 8190)
         self.assertEqual(lifecycle["prefill_total_ms"], 6005.0)
         self.assertEqual(lifecycle["generation_wall_ms"], 30.0)
+
+    def test_apply_preset_defaults_allows_explicit_overrides(self):
+        args = SimpleNamespace(
+            preset="comparison",
+            contexts=None,
+            modes="int4-vmm",
+            sparse_caps=None,
+            max_new_tokens=None,
+            timeout=None,
+            warmup=None,
+        )
+        applied = bench_qwen36_longctx.apply_preset_defaults(args)
+        self.assertEqual(applied.contexts, "512,2048,4096,8192")
+        self.assertEqual(applied.modes, "int4-vmm")
+        self.assertEqual(applied.max_new_tokens, 4)
+        self.assertTrue(applied.warmup)
+
+    def test_summarize_ranks_best_mode_and_recommendation(self):
+        rows = [
+            {
+                "context_tokens_requested": 512,
+                "mode": "int4-vmm",
+                "returncode": 0,
+                "stage": {"total_ms_avg": 40.0},
+                "chain_breakdown": {"full_attn_ms_avg": 30.0, "ffn_ms_avg": 5.0},
+                "lifecycle": {"prefill_total_ms": 1000.0, "generation_wall_ms": 41.0},
+            },
+            {
+                "context_tokens_requested": 512,
+                "mode": "int4-kv-fp8",
+                "returncode": 0,
+                "stage": {"total_ms_avg": 35.0},
+                "chain_breakdown": {"full_attn_ms_avg": 27.0, "ffn_ms_avg": 4.0},
+                "lifecycle": {"prefill_total_ms": 900.0, "generation_wall_ms": 36.0},
+            },
+        ]
+        summary = bench_qwen36_longctx.summarize(rows)
+        self.assertEqual(summary[0]["best_mode"], "int4-kv-fp8")
+        self.assertEqual(summary[0]["best_vs_baseline_pct"], -12.5)
+        self.assertEqual(summary[0]["likely_bottleneck"], "full_attn")
+        self.assertIn("full-attention", bench_qwen36_longctx.recommendation(summary))
 
     def test_parse_result_accepts_qwen36_generated_summary(self):
         output = "Generated 1 token (418 prompt + 1 new). EOS: no (max_new_tokens hit)."


### PR DESCRIPTION
## Summary
- add named presets for the Qwen3.6 long-context benchmark harness: smoke, comparison, full, sparse-comparison
- parse chain breakdown telemetry and add JSON/Markdown summary recommendations for likely bottlenecks
- document the comparison preset as the next profiling entry point

## Validation
- python3 -m py_compile tests/gfx1100/bench_qwen36_longctx.py
- python3 -m unittest tests/test_qwen36_longctx_bench.py
- python3 tests/gfx1100/bench_qwen36_longctx.py --help

GPU profiling was intentionally deferred because the GPU is currently in use by another workload.