### PR TITLE
docs: SpecPrefill prompt-length sweep (2.07× → 3.36× as N grows)

### DIFF
--- a/docs/feature-compatibility.md
+++ b/docs/feature-compatibility.md
@@ -102,16 +102,17 @@ specprefill.md).
 **Performance note:** As of Phase D (2026-05-04), SpecPrefill defaults
 to cosine-similarity scoring (`--specprefill-algorithm cosine`) plus
 drafter early-exit (the drafter stops after the scoring layer instead
-of running its full model), and is **2.07× faster than dense prefill**
-on gfx1100 at the measured prompt length (1353-token prompt,
-Qwen3.5-9B BF16: 2.39s with SpecPrefill vs 4.94s dense,
-`keep_ratio=0.50`). The legacy `lookahead` algorithm remains available
-but is NET SLOWER than dense (7.85s) because its draft decode steps
-route through the component decode path instead of the persistent
-megakernel — kept for parity-test coverage and future research, not
-recommended for production. See
-[specprefill.md § Performance](specprefill.md#performance) for the full
-table.
+of running its full model), and the speedup **compounds with prompt
+length** on gfx1100 (Qwen3.5-9B BF16, `keep_ratio=0.50`):
+**2.07× faster than dense at 1.3k tokens, 2.63× at 4k, 3.36× at 8k**
+(2.39s / 11.16s / 36.94s with SpecPrefill vs 4.94s / 29.37s / 124.22s
+dense — saving ~87 seconds on a single 8k-prompt prefill). The legacy
+`lookahead` algorithm remains available but is slower than dense at
+short prompts and only pulls ahead at ≥4k tokens (still beaten by
+`cosine` at every measured length) — kept for parity-test coverage
+and future research, not recommended for production. See
+[specprefill.md § Performance](specprefill.md#performance) for the
+full prompt-length sweep.
 
 Support:
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -767,22 +767,27 @@ in.
   the FP8 KV cache self-consistent. KV-FP8 on Qwen3.5 is currently a
   memory feature (headroom for longer contexts), not a throughput feature.
 
-² The legacy `--specprefill-algorithm lookahead` path remains slower
-  than dense prefill on gfx1100 because the speculator's lookahead
-  decode steps route through the component decode path (per-head D2D
-  K/V copy fallback added in PR #177) instead of the persistent
-  megakernel. Phase D (2026-05-04) replaced the default scoring
-  algorithm with `cosine` — a hipfire-PFlash-style single-layer
-  cosine-similarity score that does one drafter prefill and a
-  single small HIP kernel launch, dropping the lookahead decode
-  steps entirely. A follow-on change in the same PR series wired in
-  a drafter early-exit (`prefill_kv_through`) so the drafter stops
-  after the chosen scoring layer and skips the rest of its model.
-  The combined default is 2.07× faster than dense at the same
-  workload and also scores marginally higher on correctness (cossim
+² The legacy `--specprefill-algorithm lookahead` path is slower than
+  dense prefill on gfx1100 *at short prompts* because the speculator's
+  lookahead decode steps route through the component decode path
+  (per-head D2D K/V copy fallback added in PR #177) instead of the
+  persistent megakernel. At ≥4k-token prompts the target-prefill
+  savings overtake the speculator overhead and lookahead does pull
+  ahead of dense (1.18× at 4k, 1.55× at 8k) — but it is still beaten
+  by the default `cosine` path at every measured length. Phase D
+  (2026-05-04) replaced the default scoring algorithm with `cosine`
+  — a hipfire-PFlash-style single-layer cosine-similarity score that
+  does one drafter prefill and a single small HIP kernel launch,
+  dropping the lookahead decode steps entirely. A follow-on change
+  wired in a drafter early-exit (`prefill_kv_through`) so the drafter
+  stops after the chosen scoring layer and skips the rest of its
+  model. The combined default is 2.07× faster than dense at 1.3k
+  tokens, **3.36× faster at 8k tokens** (the speedup compounds with
+  prompt length), and scores marginally higher on correctness (cossim
   0.820 vs 0.708 against the dense reference at keep=0.50). See
   [specprefill.md § Algorithm](specprefill.md#algorithm) and
-  [specprefill.md § Performance](specprefill.md#performance).
+  [specprefill.md § Performance](specprefill.md#performance) for the
+  full prompt-length sweep.
 
 ³ SpecPrefill + KV-FP8 is rejected upfront by `validate_specprefill_flags`
   (since 2026-05-04). The underlying issue: the BF16 step-copy fallback

--- a/docs/specprefill.md
+++ b/docs/specprefill.md
@@ -18,10 +18,11 @@ Currently shipping for Qwen3.5-9B target + Qwen3.5-0.8B draft on HIP
   poor at low keep ratios — see Phase A2 measurements.
 - Cross-family draft (e.g. Qwen3.5-0.8B → Qwen3.6-MoE). Deferred —
   see [research/2026-05-03-specprefill-phase-a2-cross-target.md](research/2026-05-03-specprefill-phase-a2-cross-target.md).
-- Very long prompts (>8192 tokens). The look-ahead kernel is bounded
-  by per-block LDS; longer prompts trip a clear FFI error today.
-  (Cosine scoring has no comparable bound, but the rest of the
-  pipeline has not been measured beyond ~1500 tokens yet.)
+- Very long prompts (>8192 tokens). The legacy `lookahead` kernel is
+  bounded by per-block LDS and trips a clear FFI error past that
+  point. The default `cosine` path has no comparable bound and has
+  been measured cleanly at 8k tokens (3.36× faster than dense — see
+  Performance below); beyond 8k is untested.
 - 24 GiB GPU + a model larger than Qwen3.5-9B in BF16. Doesn't fit.
 
 ## Flags
@@ -79,20 +80,37 @@ faster TTFT than dense.
 
 ## Performance
 
-Measured on gfx1100 with Qwen3.5-9B target + Qwen3.5-0.8B draft, a
-1353-token prompt, 4 generated tokens, warmup pass + 3 measurement
-runs (median reported), `--specprefill-keep-ratio 0.50`:
+Measured on gfx1100 with Qwen3.5-9B target + Qwen3.5-0.8B draft,
+warmup pass + 3 measurement runs (median reported),
+`--specprefill-keep-ratio 0.50`. Three prompt lengths: 1.3k tokens
+(the original measurement) plus 4k and 8k (the regimes SpecPrefill is
+actually meant for):
 
-| Mode | TTFT (ms) | vs dense |
-|---|---|---|
-| dense (no SpecPrefill) | 4941 | 1.00× |
-| `--specprefill-algorithm cosine`, `shallowest` (default) | 2385 | **2.07× faster** |
-| `--specprefill-algorithm cosine`, `all_max` | 4144 | 1.19× faster |
-| `--specprefill-algorithm lookahead` | 7846 | 0.63× (slower than dense) |
+| Mode | 1.3k tok | 4k tok | 8k tok |
+|---|---:|---:|---:|
+| dense (no SpecPrefill) | 4941 ms | 29374 ms | 124220 ms |
+| `cosine`, `shallowest` (default) | **2385 ms** | **11157 ms** | **36939 ms** |
+| `cosine`, `all_max` | 4144 ms | 20893 ms | 74948 ms |
+| `lookahead` (legacy) | 7846 ms | 24950 ms | 80363 ms |
 
-Quality at the same `keep_ratio=0.50` (against the dense reference; same
-1353-token prompt; cossim is a regression backstop, argmax-match is
-the primary correctness gate):
+Speedup vs dense:
+
+| Mode | 1.3k | 4k | 8k |
+|---|---:|---:|---:|
+| `cosine`, `shallowest` (default) | **2.07×** | **2.63×** | **3.36×** |
+| `cosine`, `all_max` | 1.19× | 1.41× | 1.66× |
+| `lookahead` (legacy) | 0.63× (slower) | 1.18× | 1.55× |
+
+The default `cosine` + `shallowest` path's speedup *compounds with
+prompt length*: 2.07× at 1.3k → 3.36× at 8k, saving ~87 seconds of
+TTFT on a single 8k prefill. This is the regime SpecPrefill is
+designed for. The legacy `lookahead` path is slower than dense at
+short prompts but pulls ahead of dense at ≥4k tokens; it is still
+beaten by `cosine` at every measured length.
+
+Quality at `keep_ratio=0.50` on the 1353-token prompt (against the
+dense reference; cossim is a regression backstop, argmax-match is the
+primary correctness gate):
 
 | Algorithm | argmax match | cossim |
 |---|---|---|
@@ -100,9 +118,8 @@ the primary correctness gate):
 | `lookahead` | ✓ | 0.708 |
 
 Cosine is the default for new SpecPrefill runs because it is both
-faster *and* more accurate on this configuration. The single-token
-`keep_ratio=0.50` measurement is end-to-end; multi-token keep=1.00 runs
-through cosine produce byte-equal text against dense.
+faster *and* more accurate on this configuration. Multi-token
+`keep=1.00` runs through cosine produce byte-equal text against dense.
 
 ## Quality
 


### PR DESCRIPTION
## Summary

Bench `cosine` vs `dense` vs `lookahead` at 1.3k, 4k, and 8k tokens on gfx1100 (Qwen3.5-9B + 0.8B draft, `keep=0.50`, median of 3 runs). Update `docs/specprefill.md`, `docs/performance.md`, `docs/feature-compatibility.md` to publish the prompt-length sweep.

## Measured

| Mode | 1.3k tok | 4k tok | 8k tok |
|---|---:|---:|---:|
| dense (no SpecPrefill) | 4941 ms | 29374 ms | 124220 ms |
| **cosine, shallowest (default)** | **2385 ms** | **11157 ms** | **36939 ms** |
| cosine, all_max | 4144 ms | 20893 ms | 74948 ms |
| lookahead (legacy) | 7846 ms | 24950 ms | 80363 ms |

Speedup vs dense:

| Mode | 1.3k | 4k | 8k |
|---|---:|---:|---:|
| cosine, shallowest | **2.07×** | **2.63×** | **3.36×** |
| cosine, all_max | 1.19× | 1.41× | 1.66× |
| lookahead | 0.63× (slower) | 1.18× | 1.55× |

## Findings

1. **Cosine shallowest's speedup compounds with prompt length** — 2.07× at 1.3k → 3.36× at 8k. Saves ~87 seconds on a single 8k-prompt prefill. This is the regime SpecPrefill is designed for; PR #199's headline "2.07× faster" understated the value at long prompts.

2. **Lookahead is not "decisively legacy"** — it's slower than dense at 1.3k but pulls ahead at ≥4k tokens (1.18× at 4k, 1.55× at 8k). Cosine still beats it at every measured length, so cosine remains the right default — but the case for *deleting* the lookahead path entirely is weaker than I suggested in chat.

3. **all_max is dominated by shallowest at every length.** No measurement supports `SUPERSONIC_SPECPREFILL_LAYERS=all_max` over the default. Could be retired, but it's a one-line env-var hook so the cost of keeping it is near zero.

## Files

- `docs/specprefill.md` — Performance section now has prompt-length sweep + speedup table; "When NOT to use it" loses the stale "not measured beyond ~1500 tokens" caveat.
- `docs/performance.md` — footnote 2 rewritten: lookahead pulls ahead of dense at ≥4k; cosine 3.36× at 8k.
- `docs/feature-compatibility.md` — Performance note now publishes the 3-point sweep.

## Test plan

- [x] `tests/gfx1100/bench_specprefill_cosine.sh` at `PROMPT_FILE=/tmp/specprefill_3x.txt` (3294 words ≈ 4k tokens)
- [x] `tests/gfx1100/bench_specprefill_cosine.sh` at `PROMPT_FILE=/tmp/specprefill_6x.txt` (6588 words ≈ 8k tokens)
- [x] No code change; existing 9B cosine parity test still pins K-cache correctness at the scoring layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)