### PR TITLE
SpecPrefill + KV-FP8: lift gate for cosine via replay-prefill decode

### DIFF
--- a/crates/runner/src/policy.rs
+++ b/crates/runner/src/policy.rs
@@ -122,14 +122,15 @@ pub(crate) fn validate_specprefill_flags(
                 );
             }
         }
-        if cli.kv_fp8 {
+        if cli.kv_fp8 && cli.specprefill_algorithm == "lookahead" {
             anyhow::bail!(
-                "--specprefill-draft-dir cannot be combined with --kv-fp8 today: the \
+                "--specprefill-algorithm lookahead cannot be combined with --kv-fp8: the \
                  BF16 step-copy fallback used by the speculator's lookahead decode \
                  (`kernel_ffi::certified_kv::copy_step_bf16`, added in PR #177) requires \
                  BF16 destination buffers, but --kv-fp8 makes the K/V cache U8. The combo \
-                 trips a runtime error several seconds into decode. Tracked as a Phase D \
-                 follow-up: extend the per-head D2D fallback to BF16→FP8 quantise on the fly."
+                 trips a runtime error several seconds into decode. Use \
+                 `--specprefill-algorithm cosine` (the default) to combine SpecPrefill \
+                 with --kv-fp8 — the cosine path doesn't run drafter decode."
             );
         }
         if let Some(keep) = cli.specprefill_keep_ratio {

--- a/crates/runner/src/specprefill_engine.rs
+++ b/crates/runner/src/specprefill_engine.rs
@@ -419,18 +419,33 @@ pub fn run_specprefill(
         std::io::stdout().flush().ok();
     }
 
-    // ---- Decode loop. KV slot and RoPE position are decoupled:
-    //      - kv_slot = kept_count + step  (next available slot in the sparse KV cache)
-    //      - rope_pos = prompt_len + step  (actual sequence position for RoPE rotation)
-    //      This fixes attention math after sparse target prefill: the KV cache only
-    //      has kept_count rows, so each new token must write to slot kept_count+step,
-    //      but must use its true sequence position for RoPE. ----
+    // ---- Decode loop. Two paths:
+    //
+    // (1) Default (BF16 KV cache): incremental decode via
+    //     `decode_step_with_rope_pos`. KV slot and RoPE position are
+    //     decoupled:
+    //       - kv_slot = kept_count + step  (next available slot in the sparse cache)
+    //       - rope_pos = prompt_len + step  (actual sequence position for RoPE)
+    //     The KV cache only has kept_count rows after sparse prefill, so each new
+    //     token writes to slot kept_count+step with its true RoPE rotation.
+    //
+    // (2) `--kv-fp8`: replay-prefill per step. Component decode (the path
+    //     `decode_step_with_rope_pos` takes for use_4b_kernel models) writes
+    //     K/V via `copy_step_bf16` and reads via the BF16 attention kernel
+    //     `full_attention_decode_flat`; neither has an FP8 path. Plain
+    //     `--kv-fp8` already replays prefill per decode step (see main.rs's
+    //     `replay_kv_fp8_enabled`); we mirror that here. The first prefill
+    //     keeps SpecPrefill's TTFT win (sparse `prefill_kept`); each decode
+    //     step then runs a dense replay-prefill on the full unsparsified
+    //     history. Decode tokens-per-second is bounded by replay-prefill
+    //     cost, same as plain `--kv-fp8` decode on Qwen3.5-9B. ----
     let kept_count = kept_positions.len();
     let prompt_len = prompt_ids.len();
     let mut next_id = DecodeEngine::greedy_sample(&prefill_result.logits);
     let mut generated: Vec<u32> = Vec::new();
     let mut step: usize = 0;
     let eos_ids = target_text_config.eos_token_ids();
+    let kv_fp8_replay = cli.kv_fp8;
     while generated.len() < cli.max_new_tokens {
         if eos_ids.contains(&next_id) {
             generated.push(next_id);
@@ -440,9 +455,16 @@ pub fn run_specprefill(
         if generated.len() >= cli.max_new_tokens {
             break;
         }
-        let kv_slot = kept_count + step;
-        let rope_pos = prompt_len + step;
-        let logits = target_engine.decode_step_with_rope_pos(next_id, kv_slot, rope_pos)?;
+        let logits = if kv_fp8_replay {
+            let mut token_ids: Vec<u32> = Vec::with_capacity(prompt_len + generated.len());
+            token_ids.extend_from_slice(&prompt_ids);
+            token_ids.extend_from_slice(&generated);
+            target_engine.rebuild_prefill_state(&token_ids, false)?
+        } else {
+            let kv_slot = kept_count + step;
+            let rope_pos = prompt_len + step;
+            target_engine.decode_step_with_rope_pos(next_id, kv_slot, rope_pos)?
+        };
         next_id = DecodeEngine::greedy_sample(&logits);
         step += 1;
     }

--- a/crates/runner/tests/specprefill_qwen35_9b_cosine_kvfp8_parity.rs
+++ b/crates/runner/tests/specprefill_qwen35_9b_cosine_kvfp8_parity.rs
@@ -1,0 +1,244 @@
+//! End-to-end parity for cosine SpecPrefill + `--kv-fp8` on Qwen3.5-9B.
+//!
+//! The combo was rejected upfront by `validate_specprefill_flags`
+//! before this PR — the gate's stated rationale was the BF16 step-copy
+//! fallback in the SpecPrefill *lookahead* decode (PR #177), which
+//! never runs for the cosine algorithm. After lifting the gate for
+//! cosine only, this test pins:
+//!
+//! - keep=0.50: cossim ≥ 0.65 vs dense `--kv-fp8` reference, argmax
+//!   match, top-5 overlap ≥ 4. Same bars as the non-FP8 cosine parity.
+//! - keep=1.00 logit identity: cossim ≥ 0.999, argmax match, top-5
+//!   overlap = 5.
+//! - keep=1.00 multitoken byte-equal text vs dense `--kv-fp8`.
+//!
+//! The reference is `dense + --kv-fp8` (NOT plain dense BF16) — both
+//! sides quantize their KV cache to FP8, so we measure the SpecPrefill
+//! sparse-vs-dense *delta* under FP8, isolating the SpecPrefill effect
+//! from the FP8 quantization effect.
+//!
+//! Skipped silently when:
+//!  - HIP backend not compiled.
+//!  - SUPERSONIC_QWEN35_9B_DIR or SUPERSONIC_QWEN35_0_8B_DIR unset/missing.
+//!  - SUPERSONIC_SPECPREFILL_PARITY=0.
+
+use gpu_hal::Backend;
+use std::collections::HashSet;
+use std::process::Command;
+
+fn run_supersonic_capture_logits(args: &[&str]) -> anyhow::Result<Vec<f32>> {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_supersonic"));
+    cmd.args(args);
+    cmd.arg("--dump-last-logits");
+    let out = cmd.output()?;
+    if !out.status.success() {
+        anyhow::bail!(
+            "supersonic exited {}: stderr=\n{}",
+            out.status,
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    let stdout = String::from_utf8(out.stdout)?;
+    let line = stdout
+        .lines()
+        .find(|l| l.starts_with("LAST_LOGITS:"))
+        .ok_or_else(|| anyhow::anyhow!("LAST_LOGITS line not found in stdout"))?;
+    let csv = &line["LAST_LOGITS:".len()..];
+    csv.trim()
+        .split(',')
+        .map(|s| s.trim().parse::<f32>().map_err(Into::into))
+        .collect()
+}
+
+fn run_supersonic_capture_logits_and_text(
+    args: &[&str],
+) -> anyhow::Result<(Vec<f32>, String)> {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_supersonic"));
+    cmd.args(args);
+    cmd.arg("--dump-last-logits");
+    let out = cmd.output()?;
+    if !out.status.success() {
+        anyhow::bail!(
+            "supersonic exited {}: stderr=\n{}",
+            out.status,
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    let stdout = String::from_utf8(out.stdout)?;
+    let mut lines = stdout.lines();
+    let mut logits: Option<Vec<f32>> = None;
+    let mut text: String = String::new();
+    while let Some(line) = lines.next() {
+        if let Some(csv) = line.strip_prefix("LAST_LOGITS:") {
+            logits = Some(
+                csv.trim()
+                    .split(',')
+                    .map(|s| s.trim().parse::<f32>())
+                    .collect::<Result<Vec<_>, _>>()?,
+            );
+            for next in lines.by_ref() {
+                let trimmed = next.trim();
+                if trimmed.is_empty() {
+                    continue;
+                }
+                if trimmed.starts_with('[') {
+                    continue;
+                }
+                text = next.to_string();
+                break;
+            }
+            break;
+        }
+    }
+    let logits = logits.ok_or_else(|| anyhow::anyhow!("LAST_LOGITS line not found"))?;
+    if text.is_empty() {
+        anyhow::bail!("generated text not found in stdout");
+    }
+    Ok((logits, text))
+}
+
+fn cossim(a: &[f32], b: &[f32]) -> f64 {
+    let dot: f64 = a.iter().zip(b).map(|(x, y)| f64::from(*x) * f64::from(*y)).sum();
+    let na: f64 = a.iter().map(|x| f64::from(*x).powi(2)).sum::<f64>().sqrt();
+    let nb: f64 = b.iter().map(|x| f64::from(*x).powi(2)).sum::<f64>().sqrt();
+    if na == 0.0 || nb == 0.0 { 0.0 } else { dot / (na * nb) }
+}
+
+fn argmax(v: &[f32]) -> usize {
+    v.iter()
+        .enumerate()
+        .fold((0usize, f32::NEG_INFINITY), |a, (i, &x)| if x > a.1 { (i, x) } else { a })
+        .0
+}
+
+fn top5(v: &[f32]) -> HashSet<usize> {
+    let mut idx: Vec<(usize, f32)> = v.iter().copied().enumerate().collect();
+    idx.sort_unstable_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    idx.into_iter().take(5).map(|p| p.0).collect()
+}
+
+fn check_specprefill_env() -> Option<(String, String)> {
+    if !gpu_hal::is_backend_compiled(Backend::Hip) {
+        eprintln!("skipped: HIP backend not compiled");
+        return None;
+    }
+    if std::env::var("SUPERSONIC_SPECPREFILL_PARITY").as_deref() == Ok("0") {
+        eprintln!("skipped: SUPERSONIC_SPECPREFILL_PARITY=0");
+        return None;
+    }
+    let target = match std::env::var("SUPERSONIC_QWEN35_9B_DIR") {
+        Ok(d) if std::path::Path::new(&d).exists() => d,
+        _ => {
+            eprintln!("skipped: SUPERSONIC_QWEN35_9B_DIR unset/missing");
+            return None;
+        }
+    };
+    let draft = match std::env::var("SUPERSONIC_QWEN35_0_8B_DIR") {
+        Ok(d) if std::path::Path::new(&d).exists() => d,
+        _ => {
+            eprintln!("skipped: SUPERSONIC_QWEN35_0_8B_DIR unset/missing");
+            return None;
+        }
+    };
+    Some((target, draft))
+}
+
+const PROMPT: &str = "The transformer architecture has revolutionized natural language processing through its self-attention mechanism, allowing models to weigh the importance of different parts of the input sequence dynamically. Unlike recurrent networks, transformers can process all tokens in parallel during training, making them highly efficient on modern accelerator hardware. The attention computation involves three projections — query, key, and value — followed by a softmax-normalized dot product that produces a weighted combination of value vectors. Multi-head attention extends this by performing several attention operations in parallel across different learned subspaces, then concatenating and projecting the results. Feed-forward networks between attention layers introduce non-linearity. Residual connections and layer normalization stabilize gradients during training. The overall result is";
+
+fn run_parity_check(
+    target: &str,
+    draft: &str,
+    keep_ratio: &str,
+    expected_label: &str,
+    cossim_floor: f64,
+) {
+    let common: Vec<&str> = vec![
+        "--backend", "hip",
+        "--model", "qwen3.5-9b",
+        "--model-dir", target,
+        "--prompt", PROMPT,
+        "--max-new-tokens", "1",
+        "--kv-fp8",
+    ];
+    let dense_logits = run_supersonic_capture_logits(&common).expect("dense kv-fp8");
+    let mut sparse_args = common.clone();
+    sparse_args.extend_from_slice(&[
+        "--specprefill-draft-dir", draft,
+        "--specprefill-algorithm", "cosine",
+        "--specprefill-unload-draft",
+        "--specprefill-keep-ratio", keep_ratio,
+    ]);
+    let sparse_logits =
+        run_supersonic_capture_logits(&sparse_args).expect("sparse cosine + kv-fp8");
+    assert_eq!(
+        dense_logits.len(),
+        sparse_logits.len(),
+        "[{expected_label}] logits length mismatch"
+    );
+    let dense_argmax = argmax(&dense_logits);
+    let sparse_argmax = argmax(&sparse_logits);
+    let cs = cossim(&dense_logits, &sparse_logits);
+    let dense_top5 = top5(&dense_logits);
+    let sparse_top5 = top5(&sparse_logits);
+    let overlap = dense_top5.intersection(&sparse_top5).count();
+    eprintln!(
+        "[cosine kv-fp8 parity {expected_label}] cossim={:.6} dense_argmax={} sparse_argmax={} top5_overlap={}/5",
+        cs, dense_argmax, sparse_argmax, overlap
+    );
+    assert_eq!(dense_argmax, sparse_argmax, "[{expected_label}] argmax mismatch");
+    assert!(cs >= cossim_floor, "[{expected_label}] cossim {cs} < {cossim_floor}");
+    assert!(overlap >= 4, "[{expected_label}] top-5 overlap {overlap} < 4");
+}
+
+#[test]
+fn cosine_kvfp8_qwen35_9b_keep_050_parity() {
+    let (target, draft) = match check_specprefill_env() {
+        Some(t) => t,
+        None => return,
+    };
+    run_parity_check(&target, &draft, "0.50", "cosine kv-fp8 keep=0.50", 0.65);
+}
+
+#[test]
+fn cosine_kvfp8_qwen35_9b_keep_100_identity() {
+    let (target, draft) = match check_specprefill_env() {
+        Some(t) => t,
+        None => return,
+    };
+    run_parity_check(&target, &draft, "1.00", "cosine kv-fp8 keep=1.00 identity", 0.999);
+}
+
+#[test]
+fn cosine_kvfp8_qwen35_9b_keep_100_multitoken_identity() {
+    let (target, draft) = match check_specprefill_env() {
+        Some(t) => t,
+        None => return,
+    };
+    let common: Vec<&str> = vec![
+        "--backend", "hip",
+        "--model", "qwen3.5-9b",
+        "--model-dir", &target,
+        "--prompt", PROMPT,
+        "--max-new-tokens", "8",
+        "--kv-fp8",
+    ];
+    let (_, dense_text) = run_supersonic_capture_logits_and_text(&common).expect("dense kv-fp8");
+    let mut sparse_args = common.clone();
+    sparse_args.extend_from_slice(&[
+        "--specprefill-draft-dir", &draft,
+        "--specprefill-algorithm", "cosine",
+        "--specprefill-unload-draft",
+        "--specprefill-keep-ratio", "1.00",
+    ]);
+    let (_, sparse_text) =
+        run_supersonic_capture_logits_and_text(&sparse_args).expect("sparse cosine + kv-fp8");
+    eprintln!("[cosine kv-fp8 multitoken-identity] dense:  {:?}", dense_text);
+    eprintln!("[cosine kv-fp8 multitoken-identity] sparse: {:?}", sparse_text);
+    assert_eq!(
+        dense_text.trim(),
+        sparse_text.trim(),
+        "[cosine kv-fp8 multitoken-identity] dense and sparse generations differ on \
+         max_new_tokens=8 with keep_ratio=1.00 (cosine + --kv-fp8 + kept=[0..T] should be \
+         bit-identical to dense + --kv-fp8)"
+    );
+}

--- a/docs/feature-compatibility.md
+++ b/docs/feature-compatibility.md
@@ -187,9 +187,9 @@ combo (or one feature implicitly requires the other to be off).
 |                  | Quant | KV-FP8 | VMM | SpecPrefill | DFlash | MoE prefetch | Certified KV |
 |------------------|:-----:|:------:|:---:|:-----------:|:------:|:------------:|:------------:|
 | **Quant**        |   —   |   ✅¹  | ✅  |     ✅      |   ✅   |     ✅       |     ✅²      |
-| **KV-FP8**       |  ✅¹  |   —    | ✅³ |     ❌⁵     |   ❌   |     ✅       |     ✅       |
+| **KV-FP8**       |  ✅¹  |   —    | ✅³ |     ✅⁵     |   ❌   |     ✅       |     ✅       |
 | **VMM**          |  ✅   |   ✅³  |  —  |     —⁴      |   —⁴   |     ✅       |     —⁴       |
-| **SpecPrefill**  |  ✅   |   ❌⁵  | —⁴  |      —      |   ❌   |     —⁴       |     —⁴       |
+| **SpecPrefill**  |  ✅   |   ✅⁵  | —⁴  |      —      |   ❌   |     —⁴       |     —⁴       |
 | **DFlash**       |  ✅   |   ❌   | —⁴  |     ❌      |   —    |     —⁴       |     —⁴       |
 | **MoE prefetch** |  ✅   |   ✅   | ✅  |     —⁴      |   —⁴   |      —       |     —⁴       |
 | **Certified KV** |  ✅²  |   ✅   | —⁴  |     —⁴      |   —⁴   |     —⁴       |      —       |
@@ -201,13 +201,16 @@ combo (or one feature implicitly requires the other to be off).
 ⁴ Dash means "no validated combo exists today" — the underlying
   features apply to disjoint model families (e.g. SpecPrefill is
   Qwen3.5-9B; MoE prefetch is Qwen3.6-MoE).
-⁵ SpecPrefill + KV-FP8 is rejected upfront by `validate_specprefill_flags`
-  (since 2026-05-04). The underlying issue: the BF16 step-copy fallback
-  added in PR #177 to unblock SpecPrefill on HIP requires BF16 dst
-  buffers, but `--kv-fp8` makes them U8 (FP8). Lifting the gate is a
-  Phase D follow-up — the per-head D2D fallback in
-  `kernel_ffi::certified_kv::copy_step_bf16` (non-CUDA branch) needs
-  a BF16→FP8 quantise-on-the-fly path.
+⁵ SpecPrefill + KV-FP8 is supported on the default `cosine` algorithm
+  (since 2026-05-04). The first prefill stays sparse via `prefill_kept`
+  so the SpecPrefill TTFT win is preserved; each decode step then runs
+  a dense replay-prefill (`rebuild_prefill_state`) on the full
+  unsparsified history — the same fallback plain `--kv-fp8` already
+  uses on Qwen3.5-9B because component decode lacks an FP8 attention
+  path. Per-token decode is bounded by replay-prefill cost. The
+  legacy `--specprefill-algorithm lookahead` + `--kv-fp8` combo is
+  still rejected upfront because the speculator's drafter decode
+  has no replay-prefill workaround.
 
 ## Picker recipes — "I want to ..."
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -756,7 +756,8 @@ in.
 | SpecPrefill (cosine, keep=0.50) | qwen3.5-9b BF16 + 1353-token prompt, gfx1100 | 4941 ms TTFT | 2385 ms TTFT (default `--specprefill-algorithm cosine`, shallowest layer + drafter early-exit) | **2.07× FASTER** | tests/gfx1100/bench_specprefill_cosine.sh, 2026-05-04 |
 | SpecPrefill (cosine all_max, keep=0.50) | qwen3.5-9b BF16 + 1353-token prompt, gfx1100 | 4941 ms TTFT | 4144 ms TTFT (`SUPERSONIC_SPECPREFILL_LAYERS=all_max`) | **1.19× FASTER** | tests/gfx1100/bench_specprefill_cosine.sh, 2026-05-04 |
 | SpecPrefill (lookahead, keep=0.50) | qwen3.5-9b BF16 + 1353-token prompt, gfx1100 | 4941 ms TTFT | 7846 ms TTFT (legacy `--specprefill-algorithm lookahead`) | **1.59× SLOWER**² | tests/gfx1100/bench_specprefill_cosine.sh, 2026-05-04 |
-| SpecPrefill + KV-FP8 | qwen3.5-9b BF16 + KV-FP8 + 1353-token prompt | — | rejected by validation³ | **REJECTED** | n/a (CLI guard since 2026-05-04) |
+| SpecPrefill + KV-FP8 (cosine) | qwen3.5-9b BF16 + KV-FP8 + 1353-token prompt | dense + KV-FP8 (replay-prefill decode) | sparse target prefill (TTFT win preserved) + replay-prefill decode³ | TTFT win same as cosine without KV-FP8; decode bounded by KV-FP8 replay cost | crates/runner/tests/specprefill_qwen35_9b_cosine_kvfp8_parity.rs, 2026-05-04 |
+| SpecPrefill + KV-FP8 (lookahead) | qwen3.5-9b BF16 + KV-FP8 + 1353-token prompt | — | rejected by validation⁴ | **REJECTED** | n/a (CLI guard, lookahead-only since 2026-05-04) |
 | DFlash (B=3) | qwen3.5-9b INT4 greedy decode, gfx1100 | ~32 ms/step | ~12 ms/step (effective; 2.5-3× speedup) | 2.5-3× FASTER | docs/dflash.md M4.3 numbers |
 | MoE prefetch | qwen3.6-35b-a3b INT4 decode, gfx1100 | included | (default-on) | — | the 28.3 ms/step row above already includes prefetch — the persistent megakernel default path uses it. A/B vs no-prefetch needs `--no-persistent-decode` which falls back to a different decode path entirely. |
 | Certified KV (shadow-validate) | llama3.1-8b INT8 + 1024-token prompt, sm86 | TBM ms/step | TBM ms/step | TBM | (script TBM, sm86-only — not measurable on a HIP-only dev box) |
@@ -789,12 +790,24 @@ in.
   [specprefill.md § Performance](specprefill.md#performance) for the
   full prompt-length sweep.
 
-³ SpecPrefill + KV-FP8 is rejected upfront by `validate_specprefill_flags`
-  (since 2026-05-04). The underlying issue: the BF16 step-copy fallback
-  added in PR #177 assumes BF16 destination buffers; `--kv-fp8` makes the
-  K/V cache U8 (FP8). Lifting the gate is a Phase D follow-up — the
-  per-head D2D fallback in `kernel_ffi::certified_kv::copy_step_bf16`
-  (non-CUDA branch) needs a BF16→FP8 quantise-on-the-fly path.
+³ For the cosine path, SpecPrefill + KV-FP8 reuses the same
+  replay-prefill decode strategy plain `--kv-fp8` already uses on
+  Qwen3.5-9B (`replay_kv_fp8_enabled` in main.rs). The first prefill
+  is sparse via `prefill_kept` (TTFT win preserved); each subsequent
+  decode step rebuilds the KV cache from the full unsparsified history
+  via `rebuild_prefill_state`. Per-token decode cost matches plain
+  KV-FP8 decode — bounded by replay-prefill, same as footnote ¹.
+
+⁴ The lookahead path's SpecPrefill + KV-FP8 combo remains rejected
+  upfront by `validate_specprefill_flags`. The underlying issue: the
+  speculator's lookahead decode runs through the component decode path
+  with `copy_step_bf16` (BF16-only) as its K/V step write, and the
+  drafter has no replay-prefill workaround (it doesn't rebuild a
+  scratch state per step like the target does). Lifting it would need
+  a BF16→FP8 quantise-on-the-fly K/V step write plus an FP8 attention
+  read in component decode — a much bigger kernel job. Since the
+  cosine path is the default and works with KV-FP8, the lookahead
+  combo is documented-unsupported, not an active follow-up.
 
 The DFlash numbers are pulled from [dflash.md](dflash.md)'s M4.3
 single-pass fused-verify section. The KV-FP8 number is the gfx1100


### PR DESCRIPTION
## Summary

The combo `--specprefill-draft-dir + --kv-fp8` was rejected upfront in `validate_specprefill_flags`. The gate's stated rationale was the BF16 step-copy fallback in the speculator's lookahead decode (PR #177), which never runs for the cosine algorithm. The actual underlying issue was deeper: Qwen3.5-9B on gfx1100 uses `use_4b_kernel=true`, so the SpecPrefill decode loop calls `decode_step_with_rope_pos` (component decode), and component decode's K/V step-write (`copy_step_bf16`) requires BF16 destinations while its attention kernel (`full_attention_decode_flat`) reads BF16 K/V — neither has an FP8 path.

Plain `--kv-fp8` on Qwen3.5-9B already routes around this by replaying prefill from scratch each decode step (`replay_kv_fp8_enabled` in main.rs). This PR mirrors that here: when `--kv-fp8` is set, the SpecPrefill decode loop calls `target_engine.rebuild_prefill_state(prompt_ids + generated, false)` per step instead of incremental decode. The first prefill keeps the SpecPrefill TTFT win (sparse `prefill_kept`); each decode step then runs a dense replay-prefill on the full unsparsified history. Per-token decode is bounded by replay-prefill cost, same as plain `--kv-fp8` decode on Qwen3.5-9B.

The lookahead path's gate stays — its drafter decode also hits the BF16 step-write issue and there's no replay-prefill workaround on the drafter side.

## Files

- `crates/runner/src/policy.rs` — gate now only fires for `--specprefill-algorithm lookahead` + `--kv-fp8`.
- `crates/runner/src/specprefill_engine.rs` — decode loop branches on `cli.kv_fp8`: incremental `decode_step_with_rope_pos` for the BF16 path, `rebuild_prefill_state` for the FP8 path.
- `crates/runner/tests/specprefill_qwen35_9b_cosine_kvfp8_parity.rs` — new 3-subtest parity (keep=0.50 quality, keep=1.00 logit identity, keep=1.00 multitoken byte-equal text), all reference is `dense + --kv-fp8` (so we measure the SpecPrefill delta under FP8, isolating from the FP8 quantization effect).
- `docs/performance.md`, `docs/feature-compatibility.md` — table flips KV-FP8 × SpecPrefill from ❌ to ✅ with the cosine/lookahead split called out in footnotes.

## Test plan

- [x] `cargo build --release --bin supersonic`
- [x] 9B cosine + kv-fp8 parity (3 subtests):
  - keep=0.50: cossim 0.820, argmax match, top-5 ≥ 4 — same numbers as non-FP8 cosine
  - keep=1.00 logit identity: cossim 1.000
  - keep=1.00 multitoken: byte-equal text against `dense + --kv-fp8`
- [x] 9B non-FP8 cosine parity (3 subtests) — regression-clean.
- [x] Smoke: `--kv-fp8 --specprefill-draft-dir … --specprefill-keep-ratio 1.00` produces coherent output (was previously `Error: certified KV BF16 step copy expects BF16 buffers, got src BF16/BF16 dst U8/U8`).

## Performance characterization

This is a **functional unblock**, not a performance win. The per-token decode cost matches plain `--kv-fp8` decode on Qwen3.5-9B (bounded by replay-prefill, see `docs/performance.md` footnote ¹). The TTFT win from `prefill_kept` is preserved on the first prefill but not on subsequent decode steps. Net win for workloads where TTFT and KV-FP8's memory headroom (long context) matter, and decode tokens-per-second is secondary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)