### PR TITLE
Optimize Qwen3.6 long-context full attention

### DIFF
--- a/crates/runner/tests/qwen36_moe_longctx_tiled_smoke.rs
+++ b/crates/runner/tests/qwen36_moe_longctx_tiled_smoke.rs
@@ -1,0 +1,154 @@
+//! Long-context tiled full-attention smoke for Qwen3.6-35B-A3B.
+//!
+//! This forces the persistent full-attention path past the 384-token tile
+//! threshold introduced in the long-context perf pass. It is intentionally
+//! model-backed and skips when the local Qwen3.6 directory is unavailable.
+
+use gpu_hal::Backend;
+use std::process::Command;
+
+fn longctx_prompt(context_tokens: usize, seed: usize) -> String {
+    const TOKEN_CHARS: usize = 7;
+    let needle = format!("SSB-NEEDLE-{:05}", seed % 100000);
+    let intro = "You are reading a long diagnostic log. Remember the secret value if one appears. ";
+    let question =
+        "\nQuestion: What is the secret value? Answer with only the secret value.\nAnswer:";
+    let target_chars = std::cmp::max(256, context_tokens * TOKEN_CHARS);
+    let filler_words = [
+        "cache",
+        "route",
+        "kernel",
+        "tensor",
+        "context",
+        "expert",
+        "prefetch",
+        "latency",
+        "resident",
+        "decode",
+        "attention",
+        "wave",
+    ];
+
+    let mut chunks = vec![intro.to_string()];
+    let mut chars = intro.len();
+    let mut i = 0usize;
+    let halfway = target_chars / 2;
+    let mut inserted = false;
+    while chars < target_chars.saturating_sub(question.len()) {
+        let chunk = if !inserted && chars >= halfway {
+            inserted = true;
+            format!(" The secret value is {needle}. ")
+        } else {
+            let word = filler_words[(i + seed) % filler_words.len()];
+            i += 1;
+            format!("{word}-{:03} ", i.saturating_sub(1) % 997)
+        };
+        chars += chunk.len();
+        chunks.push(chunk);
+    }
+    if !inserted {
+        chunks.push(format!(" The secret value is {needle}. "));
+    }
+    chunks.push(question.to_string());
+    chunks.concat()
+}
+
+fn combined_output(output: &std::process::Output) -> String {
+    format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn generated_ids(output: &str) -> Vec<u32> {
+    let line = output
+        .lines()
+        .find(|line| line.trim_start().starts_with("Generated ids: "))
+        .expect("supersonic output should contain generated ids");
+    let (_, ids) = line
+        .split_once(':')
+        .expect("generated ids line should contain ':'");
+    serde_json::from_str(ids.trim()).expect("generated ids should parse as JSON")
+}
+
+fn prefill_steps(output: &str) -> usize {
+    let line = output
+        .lines()
+        .find(|line| line.contains("[qwen36-moe lifecycle-timings]"))
+        .expect("supersonic output should contain qwen36 lifecycle timings");
+    for part in line.split_whitespace() {
+        if let Some(raw) = part.strip_prefix("prefill_steps=") {
+            return raw
+                .parse::<usize>()
+                .expect("prefill_steps should parse as usize");
+        }
+    }
+    panic!("prefill_steps missing from lifecycle line: {line}");
+}
+
+#[test]
+fn qwen36_moe_longctx_tiled_attention_deterministic_ids() {
+    if !gpu_hal::is_backend_compiled(Backend::Hip) {
+        eprintln!("skipped: HIP backend not compiled");
+        return;
+    }
+    if std::env::var("SUPERSONIC_QWEN36_LONGCTX_TILED_SMOKE").as_deref() == Ok("0") {
+        eprintln!("skipped: SUPERSONIC_QWEN36_LONGCTX_TILED_SMOKE=0");
+        return;
+    }
+    let model_dir = match std::env::var("SUPERSONIC_QWEN36_35B_A3B_DIR") {
+        Ok(d) if std::path::Path::new(&d).exists() => d,
+        _ => {
+            eprintln!("skipped: SUPERSONIC_QWEN36_35B_A3B_DIR unset or missing");
+            return;
+        }
+    };
+
+    let prompt = longctx_prompt(512, 20260504);
+    let out = Command::new(env!("CARGO_BIN_EXE_supersonic"))
+        .env("SUPERSONIC_BACKENDS", "hip")
+        .args([
+            "--backend",
+            "hip",
+            "--model",
+            "qwen3.6-35b-a3b",
+            "--model-dir",
+            model_dir.as_str(),
+            "--int4",
+            "--prompt",
+            prompt.as_str(),
+            "--context-size",
+            "512",
+            "--max-new-tokens",
+            "4",
+            "--temperature",
+            "0",
+            "--top-k",
+            "1",
+            "--sampling-seed",
+            "20260504",
+            "--no-download",
+            "--emit-stage-timings",
+        ])
+        .output()
+        .expect("run supersonic qwen36 tiled longctx smoke");
+
+    let combined = combined_output(&out);
+    assert!(
+        out.status.success(),
+        "qwen36 tiled longctx smoke failed with status {:?}:\n{}",
+        out.status.code(),
+        combined
+    );
+    assert!(
+        prefill_steps(&combined) > 384,
+        "prompt should cross the tiled full-attention threshold:\n{}",
+        combined
+    );
+    assert_eq!(
+        generated_ids(&combined),
+        vec![271, 271, 1178, 33],
+        "longctx tiled smoke generated unexpected token IDs"
+    );
+}

--- a/docs/research/2026-05-04-qwen36-longctx-full-attn-pass.md
+++ b/docs/research/2026-05-04-qwen36-longctx-full-attn-pass.md
@@ -1,0 +1,120 @@
+# Qwen3.6 Long-Context Full-Attention Pass - 2026-05-04
+
+This records the first dense full-attention/KV bandwidth pass after
+`docs/research/2026-05-04-qwen36-longctx-comparison-results.md` identified
+`full_attn` as the long-context bottleneck.
+
+## Change
+
+`kernels/qwen36_moe_persistent/full_attn_phase.cuh` Phase G now has two cached
+KV read paths:
+
+1. Short contexts stream KV through an online softmax accumulator for
+   `kv_len > 1`. The old path wrote one score per `(query head, position)` to
+   workspace, then ran a serial softmax pass and a separate V-weighted
+   reduction. The online path keeps the running max, denominator, and per-lane V
+   accumulator in registers and avoids the score workspace write/read.
+2. Long contexts split each query head's KV history into 384-token tiles. Tile
+   workers write `(tile max, tile sum, tile V partial[d])` into the existing
+   per-head `OFF_SCORES` workspace, then a second pass combines those tile
+   partials with max-stable softmax rescaling. This follows the same partial
+   reduction shape used by hipfire-style tiled attention without vendoring
+   hipfire code.
+
+The tiled path is gated on `kv_cache_k != null`, `kv_len > 384`,
+`head_dim <= block_size`, and `tile_count * (head_dim + 2) <= kv_max_t`, so it
+reuses the already allocated `[H * kv_max_t]` score workspace. Cache writes, the
+`kv_len == 1` path, BF16 KV, KV-FP8 scale reads, and the BF16 sidecar window are
+intentionally unchanged.
+
+## Measurements
+
+Baseline is the prior report's `int4-vmm` row from
+`2026-05-04-qwen36-longctx-comparison-results.md`. Candidate rows were run
+without warmup, so these are directional single-process checks rather than a
+full median gate.
+
+| Context | baseline prefill s | candidate prefill s | prefill delta | baseline ms/tok | candidate ms/tok | ms/tok delta |
+|---:|---:|---:|---:|---:|---:|---:|
+| 512 | 13.30 | 13.30 | +0.0% | 34.54 | 33.99 | -1.6% |
+| 8192 | 576.28 | 313.24 | -45.6% | 124.94 | 56.39 | -54.9% |
+
+The final 8192 candidate row:
+
+```text
+prefill_ms=313238.480 total_ms=56.389 tok/s=17.734 generated_ids=[271,248068,271,248069]
+```
+
+The 512 row remains effectively unchanged. Depending on the exact allocated
+`kv_max_t`, it either stays on the online path throughout or only reaches the
+tiled path for the tail end of the 418-token measured prompt.
+
+## Tuning Notes
+
+The initial online-softmax-only pass was useful but stayed near the noise band.
+The tiled path is the first variant that clearly moves the 8192 row.
+
+| Variant | 8192 prefill s | 8192 ms/tok |
+|:---|---:|---:|
+| prior report baseline | 576.28 | 124.94 |
+| online softmax, per-lane exp | 525.52 | 112.95 |
+| tiled partials, 512-token tiles | 321.10 | 54.88 |
+| tiled partials, 384-token tiles | 313.24 | 56.39 |
+
+A follow-up micro-change moved the online-softmax exponentials to lane 0 and
+broadcast the factors through shared memory. It regressed the 8192 row:
+
+| Variant | prefill s | ms/tok |
+|:---|---:|---:|
+| online softmax, per-lane exp | 525.52 | 112.95 |
+| lane-0 exp + shared broadcast | 544.72 | 116.74 |
+
+The extra synchronization cost was worse than the redundant per-lane exponentials
+on this kernel shape, so it was reverted.
+
+The 384-token tiled variant has better 8192 prefill/wall time than 512-token
+tiles, while 512-token tiles have slightly better generated-token latency. This
+branch keeps 384 because the pass is targeted at long-context prefill/full-attn
+wall time; the difference is small enough that a later median gate may choose a
+different tile size.
+
+## Commands
+
+```bash
+SUPERSONIC_BACKENDS=hip cargo build --release --bin supersonic
+
+python3 tests/gfx1100/bench_qwen36_longctx.py \
+  --binary target/release/supersonic \
+  --model-dir /mnt/data/models/Qwen3.6-35B-A3B \
+  --contexts 8192 \
+  --modes int4-vmm \
+  --max-new-tokens 4 \
+  --no-warmup \
+  --timeout 1800 \
+  --out-json target/qwen36_longctx_8192_tiled384_candidate.json \
+  --out-md target/qwen36_longctx_8192_tiled384_candidate.md
+```
+
+## Verification
+
+```bash
+python3 -m unittest tests/test_qwen36_longctx_bench.py
+SUPERSONIC_BACKENDS=hip SUPERSONIC_QWEN36_35B_A3B_DIR=/mnt/data/models/Qwen3.6-35B-A3B \
+  cargo test --release -p runner --test qwen36_moe_bf16_kv_vmm_smoke -- --nocapture
+
+SUPERSONIC_BACKENDS=hip SUPERSONIC_QWEN36_35B_A3B_DIR=/mnt/data/models/Qwen3.6-35B-A3B \
+  cargo test --release -p runner --test qwen36_moe_longctx_tiled_smoke -- --nocapture
+```
+
+Both checks passed after the online-softmax change.
+They also passed after adding the tiled path and after changing the tile length
+from 512 to 384. The long-context tiled smoke forces `prefill_steps > 384` and
+asserts the deterministic generated IDs for that prompt.
+
+## Interpretation
+
+The tiled partial path produces a decisive single-run 8192 improvement relative
+to the prior report and to the online-only candidate. It should still get a clean
+baseline/candidate median gate before being claimed as a final benchmark number,
+but the delta is far beyond the plus/minus 10-15% within-session noise band that
+the prior hipfire comparison warned about.

--- a/docs/research/2026-05-04-qwen36-longctx-full-attn-pass.md
+++ b/docs/research/2026-05-04-qwen36-longctx-full-attn-pass.md
@@ -45,6 +45,33 @@ The final 8192 candidate row:
 prefill_ms=313238.480 total_ms=56.389 tok/s=17.734 generated_ids=[271,248068,271,248069]
 ```
 
+## Median Gate
+
+After committing the code as `cfb1b26`, a clean 3-run 8192 gate compared the
+original base commit `d3a86a1` against candidate commit `cfb1b26`. All runs used
+the same model directory, benchmark harness, `int4-vmm`, `--max-new-tokens 4`,
+`--no-warmup`, and generated IDs `[271,248068,271,248069]`.
+
+| Build | prefill s runs | median prefill s | ms/tok runs | median ms/tok | median wall s |
+|:---|:---|---:|:---|---:|---:|
+| baseline `d3a86a1` | 578.02, 575.57, 575.78 | 575.78 | 126.26, 125.04, 124.99 | 125.04 | 579.16 |
+| candidate `cfb1b26` | 314.00, 313.61, 313.81 | 313.81 | 56.40, 56.50, 56.42 | 56.42 | 316.90 |
+
+Median deltas:
+
+| Metric | Delta |
+|:---|---:|
+| prefill seconds | -45.5% |
+| ms/token | -54.9% |
+| wall seconds | -45.3% |
+
+Artifacts:
+
+```text
+/home/deano/projects/SuperSonicBase-qwen36-longctx-baseline-gate/target/longctx_gate/baseline_8192_run{1,2,3}.json
+/home/deano/projects/SuperSonicBase-qwen36-longctx-perf/target/longctx_gate/candidate_8192_run{1,2,3}.json
+```
+
 The 512 row remains effectively unchanged. Depending on the exact allocated
 `kv_max_t`, it either stays on the online path throughout or only reaches the
 tiled path for the tail end of the 418-token measured prompt.
@@ -113,8 +140,7 @@ asserts the deterministic generated IDs for that prompt.
 
 ## Interpretation
 
-The tiled partial path produces a decisive single-run 8192 improvement relative
-to the prior report and to the online-only candidate. It should still get a clean
-baseline/candidate median gate before being claimed as a final benchmark number,
-but the delta is far beyond the plus/minus 10-15% within-session noise band that
-the prior hipfire comparison warned about.
+The tiled partial path produces a decisive 8192 improvement relative to the
+prior report and to the online-only candidate. The 3-run median gate confirms
+the delta is far beyond the plus/minus 10-15% within-session noise band that the
+prior hipfire comparison warned about.

--- a/kernels/qwen36_moe_persistent/full_attn_phase.cuh
+++ b/kernels/qwen36_moe_persistent/full_attn_phase.cuh
@@ -718,10 +718,9 @@ __device__ inline void qwen36_moe_attn_step_device(
     //
     // 2) KV cache enabled (kv_cache != null): write current (K_rot, V_raw)
     //    at slot `position`, then attend over kv_len = position + 1 past
-    //    tokens with real softmax (max-stabilised, F32 exp). Per-Q-head
-    //    work-stealing; per-head scores live at workspace[OFF_SCORES +
-    //    hq * kv_max_t] so concurrent blocks computing different heads
-    //    don't race. Cap: kv_max_t must accommodate position + 1.
+    //    tokens with real softmax. Short cached reads use online softmax;
+    //    long cached reads reuse the old score workspace for tile partials
+    //    instead of materialising every score.
     {
         const int rep   = H / Hkv;
         const float scale = rsqrtf(static_cast<float>(d));
@@ -833,10 +832,187 @@ __device__ inline void qwen36_moe_attn_step_device(
                                        &counters[0]);
         }
 
-        // Step 2: per-Q-head attention reduction. Each block claims one head
-        // via atomicAdd on counters[0]; the write phase above already reset
-        // it (via grid_barrier_reset_counter when use_kv_cache, or by leaving
-        // it untouched when not).
+        // Step 2: per-Q-head attention reduction. Short contexts use one
+        // block per head. Long cached contexts split KV into tiles so all CUs
+        // can work on one head's history before a second pass combines the
+        // tile-local softmax partials.
+        const int attn_tile_t = 384;
+        const int attn_tile_stride = d + 2;
+        const int attn_tile_count =
+            (kv_len + attn_tile_t - 1) / attn_tile_t;
+        const bool use_tiled_attn =
+            (kv_cache_k != nullptr) && (kv_len > attn_tile_t) &&
+            (d <= block_size) &&
+            (attn_tile_count * attn_tile_stride <= kv_max_t);
+
+        if (use_tiled_attn) {
+            const bool use_fp8_kv = (kv_scale_k != nullptr);
+            const bool sidecar_active =
+                (kv_shadow_k != nullptr && kv_shadow_start >= 0 && kv_shadow_window > 0);
+            const int rolling_shadow_start =
+                sidecar_active
+                    ? ((eff_cache_pos + 1 > kv_shadow_window)
+                        ? (eff_cache_pos + 1 - kv_shadow_window)
+                        : 0)
+                    : 0;
+            const int shadow_start =
+                sidecar_active
+                    ? ((rolling_shadow_start > kv_shadow_start)
+                        ? rolling_shadow_start
+                        : kv_shadow_start)
+                    : 0;
+            const T* shadow_k = sidecar_active ? static_cast<const T*>(kv_shadow_k) : nullptr;
+            const uint8_t* fp8_ck = use_fp8_kv ? reinterpret_cast<const uint8_t*>(kv_cache_k) : nullptr;
+            const float* sk_buf = use_fp8_kv ? kv_scale_k : nullptr;
+            const bool use_fp8_kv_v = (kv_scale_v != nullptr);
+            const bool sidecar_active_v =
+                (kv_shadow_v != nullptr && kv_shadow_start >= 0 && kv_shadow_window > 0);
+            const int rolling_shadow_start_v =
+                sidecar_active_v
+                    ? ((eff_cache_pos + 1 > kv_shadow_window)
+                        ? (eff_cache_pos + 1 - kv_shadow_window)
+                        : 0)
+                    : 0;
+            const int shadow_start_v =
+                sidecar_active_v
+                    ? ((rolling_shadow_start_v > kv_shadow_start)
+                        ? rolling_shadow_start_v
+                        : kv_shadow_start)
+                    : 0;
+            const T* shadow_v = sidecar_active_v ? static_cast<const T*>(kv_shadow_v) : nullptr;
+            const uint8_t* fp8_cv =
+                use_fp8_kv_v ? reinterpret_cast<const uint8_t*>(kv_cache_v) : nullptr;
+            const float* sv_buf = use_fp8_kv_v ? kv_scale_v : nullptr;
+
+            for (;;) {
+                __shared__ unsigned int tile_task_s;
+                if (tid == 0) {
+                    tile_task_s = atomicAdd(&counters[0], 1u);
+                }
+                __syncthreads();
+                const int task = static_cast<int>(tile_task_s);
+                if (task >= H * attn_tile_count) break;
+
+                const int hq = task / attn_tile_count;
+                const int tile = task - hq * attn_tile_count;
+                const int h_kv = hq / rep;
+                const int t0 = tile * attn_tile_t;
+                const int t1 = (t0 + attn_tile_t < kv_len) ? (t0 + attn_tile_t) : kv_len;
+                float* partials =
+                    workspace + OFF_SCORES + hq * kv_max_t + tile * attn_tile_stride;
+
+                float tile_m = -INFINITY;
+                float tile_l = 0.0f;
+                float tile_acc = 0.0f;
+
+                for (int t = t0; t < t1; t++) {
+                    float partial = 0.0f;
+                    const bool use_sidecar_k = sidecar_active && (t >= shadow_start);
+                    const float scale_k_t =
+                        (use_fp8_kv && !use_sidecar_k) ? sk_buf[h_kv * kv_max_t + t] : 0.f;
+                    for (int i = tid; i < d; i += block_size) {
+                        const float q = workspace[OFF_Q_ROT + hq * d + i];
+                        float k;
+                        if (!use_fp8_kv) {
+                            k = static_cast<float>(kv_cache_k[t * Hkv * d + h_kv * d + i]);
+                        } else if (use_sidecar_k) {
+                            const int shadow_slot = t % kv_shadow_window;
+                            k = static_cast<float>(
+                                shadow_k[h_kv * kv_shadow_window * d + shadow_slot * d + i]);
+                        } else {
+                            const uint8_t byte = fp8_ck[t * Hkv * d + h_kv * d + i];
+                            k = fp8_e4m3_to_float(byte) * scale_k_t;
+                        }
+                        partial += q * k;
+                    }
+                    shared_scratch[tid] = partial;
+                    __syncthreads();
+                    for (int s = block_size / 2; s > 0; s >>= 1) {
+                        if (tid < s) shared_scratch[tid] += shared_scratch[tid + s];
+                        __syncthreads();
+                    }
+                    __shared__ float tile_score_s;
+                    if (tid == 0) {
+                        tile_score_s = shared_scratch[0] * scale;
+                    }
+                    __syncthreads();
+
+                    const float new_m = fmaxf(tile_m, tile_score_s);
+                    const float old_scale = expf(tile_m - new_m);
+                    const float new_weight = expf(tile_score_s - new_m);
+                    tile_l = tile_l * old_scale + new_weight;
+
+                    float v = 0.0f;
+                    if (tid < d) {
+                        const bool use_sidecar_v = sidecar_active_v && (t >= shadow_start_v);
+                        if (!use_fp8_kv_v) {
+                            v = static_cast<float>(kv_cache_v[t * Hkv * d + h_kv * d + tid]);
+                        } else if (use_sidecar_v) {
+                            const int shadow_slot = t % kv_shadow_window;
+                            v = static_cast<float>(
+                                shadow_v[h_kv * kv_shadow_window * d + shadow_slot * d + tid]);
+                        } else {
+                            const float scale_v_t = sv_buf[h_kv * kv_max_t + t];
+                            const uint8_t byte = fp8_cv[t * Hkv * d + h_kv * d + tid];
+                            v = fp8_e4m3_to_float(byte) * scale_v_t;
+                        }
+                    }
+                    tile_acc = tile_acc * old_scale + new_weight * v;
+                    tile_m = new_m;
+                    __syncthreads();
+                }
+
+                if (tid == 0) {
+                    partials[0] = tile_m;
+                    partials[1] = tile_l;
+                }
+                if (tid < d) {
+                    partials[2 + tid] = tile_acc;
+                }
+                __syncthreads();
+            }
+
+            grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
+                                       &counters[0]);
+
+            for (;;) {
+                __shared__ unsigned int head_s;
+                if (tid == 0) {
+                    head_s = atomicAdd(&counters[0], 1u);
+                }
+                __syncthreads();
+                const int hq = static_cast<int>(head_s);
+                if (hq >= H) break;
+
+                float global_m = -INFINITY;
+                for (int tile = 0; tile < attn_tile_count; tile++) {
+                    const float* partials =
+                        workspace + OFF_SCORES + hq * kv_max_t + tile * attn_tile_stride;
+                    global_m = fmaxf(global_m, partials[0]);
+                }
+
+                float global_l = 0.0f;
+                float global_acc = 0.0f;
+                for (int tile = 0; tile < attn_tile_count; tile++) {
+                    const float* partials =
+                        workspace + OFF_SCORES + hq * kv_max_t + tile * attn_tile_stride;
+                    const float w = expf(partials[0] - global_m);
+                    global_l += partials[1] * w;
+                    if (tid < d) {
+                        global_acc += partials[2 + tid] * w;
+                    }
+                }
+
+                if (tid < d) {
+                    const float acc = global_l > 0.0f ? (global_acc / global_l) : 0.0f;
+                    workspace[OFF_ATTN + hq * d + tid] = acc;
+                    if (stage == 4) {
+                        output[hq * d + tid] = static_cast<T>(acc);
+                    }
+                }
+                __syncthreads();
+            }
+        } else {
         for (;;) {
             __shared__ unsigned int head_s;
             if (tid == 0) {
@@ -880,10 +1056,10 @@ __device__ inline void qwen36_moe_attn_step_device(
                 continue;
             }
 
-            // KV-cache path. Compute scores[t] = (q · K_cache[t]) * scale
-            // for t in 0..=position. Per-head scores live at
-            // workspace[OFF_SCORES + hq * kv_max_t + t].
-            const int score_base = OFF_SCORES + hq * kv_max_t;
+            // KV-cache path. Stream scores and V through an online softmax:
+            // m' = max(m, score), l' = l*exp(m-m') + exp(score-m'),
+            // acc' = acc*exp(m-m') + V*exp(score-m'). This removes the
+            // previous score write/read and the serial softmax pass.
             const bool use_fp8_kv = (kv_scale_k != nullptr);
             // The bridge guarantees kv_shadow_k/v are paired (or both
             // null), so checking only kv_shadow_k here is sufficient and
@@ -905,63 +1081,6 @@ __device__ inline void qwen36_moe_attn_step_device(
             const T* shadow_k = sidecar_active ? static_cast<const T*>(kv_shadow_k) : nullptr;
             const uint8_t* fp8_ck = use_fp8_kv ? reinterpret_cast<const uint8_t*>(kv_cache_k) : nullptr;
             const float* sk_buf = use_fp8_kv ? kv_scale_k : nullptr;
-
-            for (int t = 0; t < kv_len; t++) {
-                float partial = 0.0f;
-                const bool use_sidecar = sidecar_active && (t >= shadow_start);
-                const float scale_k_t =
-                    (use_fp8_kv && !use_sidecar) ? sk_buf[h_kv * kv_max_t + t] : 0.f;
-                for (int i = tid; i < d; i += block_size) {
-                    const float q = workspace[OFF_Q_ROT + hq * d + i];
-                    float k;
-                    if (!use_fp8_kv) {
-                        k = static_cast<float>(kv_cache_k[t * Hkv * d + h_kv * d + i]);
-                    } else if (use_sidecar) {
-                        const int shadow_slot = t % kv_shadow_window;
-                        k = static_cast<float>(
-                            shadow_k[h_kv * kv_shadow_window * d + shadow_slot * d + i]);
-                    } else {
-                        const uint8_t byte =
-                            fp8_ck[t * Hkv * d + h_kv * d + i];
-                        k = fp8_e4m3_to_float(byte) * scale_k_t;
-                    }
-                    partial += q * k;
-                }
-                shared_scratch[tid] = partial;
-                __syncthreads();
-                for (int s = block_size / 2; s > 0; s >>= 1) {
-                    if (tid < s) shared_scratch[tid] += shared_scratch[tid + s];
-                    __syncthreads();
-                }
-                if (tid == 0) {
-                    workspace[score_base + t] = shared_scratch[0] * scale;
-                }
-                __syncthreads();
-            }
-
-            // Softmax with max-stabilisation. Done by tid==0 to keep the
-            // reduction simple — kv_len is small (≤ context window) and the
-            // remaining work (V-weighted reduction) is the bulk of the cost.
-            __shared__ float max_score;
-            __shared__ float exp_sum;
-            if (tid == 0) {
-                float m = workspace[score_base];
-                for (int t = 1; t < kv_len; t++) {
-                    m = fmaxf(m, workspace[score_base + t]);
-                }
-                max_score = m;
-                float s = 0.0f;
-                for (int t = 0; t < kv_len; t++) {
-                    const float e = expf(workspace[score_base + t] - m);
-                    workspace[score_base + t] = e;
-                    s += e;
-                }
-                exp_sum = s;
-            }
-            __syncthreads();
-
-            // Weighted sum of V over t. Each thread handles a slice of d.
-            const float inv_sum = 1.0f / exp_sum;
             const bool use_fp8_kv_v = (kv_scale_v != nullptr);
             const bool sidecar_active_v =
                 (kv_shadow_v != nullptr && kv_shadow_start >= 0 && kv_shadow_window > 0);
@@ -982,31 +1101,76 @@ __device__ inline void qwen36_moe_attn_step_device(
                 use_fp8_kv_v ? reinterpret_cast<const uint8_t*>(kv_cache_v) : nullptr;
             const float* sv_buf = use_fp8_kv_v ? kv_scale_v : nullptr;
 
-            for (int i = tid; i < d; i += block_size) {
-                float acc = 0.0f;
-                for (int t = 0; t < kv_len; t++) {
-                    const float w = workspace[score_base + t] * inv_sum;
-                    const bool use_sidecar = sidecar_active_v && (t >= shadow_start_v);
-                    float v;
+            float online_m = -INFINITY;
+            float online_l = 0.0f;
+            float online_acc = 0.0f;
+
+            for (int t = 0; t < kv_len; t++) {
+                float partial = 0.0f;
+                const bool use_sidecar_k = sidecar_active && (t >= shadow_start);
+                const float scale_k_t =
+                    (use_fp8_kv && !use_sidecar_k) ? sk_buf[h_kv * kv_max_t + t] : 0.f;
+                for (int i = tid; i < d; i += block_size) {
+                    const float q = workspace[OFF_Q_ROT + hq * d + i];
+                    float k;
+                    if (!use_fp8_kv) {
+                        k = static_cast<float>(kv_cache_k[t * Hkv * d + h_kv * d + i]);
+                    } else if (use_sidecar_k) {
+                        const int shadow_slot = t % kv_shadow_window;
+                        k = static_cast<float>(
+                            shadow_k[h_kv * kv_shadow_window * d + shadow_slot * d + i]);
+                    } else {
+                        const uint8_t byte = fp8_ck[t * Hkv * d + h_kv * d + i];
+                        k = fp8_e4m3_to_float(byte) * scale_k_t;
+                    }
+                    partial += q * k;
+                }
+                shared_scratch[tid] = partial;
+                __syncthreads();
+                for (int s = block_size / 2; s > 0; s >>= 1) {
+                    if (tid < s) shared_scratch[tid] += shared_scratch[tid + s];
+                    __syncthreads();
+                }
+                __shared__ float head_score;
+                if (tid == 0) {
+                    head_score = shared_scratch[0] * scale;
+                }
+                __syncthreads();
+
+                const float new_m = fmaxf(online_m, head_score);
+                const float old_scale = expf(online_m - new_m);
+                const float new_weight = expf(head_score - new_m);
+                online_l = online_l * old_scale + new_weight;
+
+                float v = 0.0f;
+                if (tid < d) {
+                    const bool use_sidecar_v = sidecar_active_v && (t >= shadow_start_v);
                     if (!use_fp8_kv_v) {
-                        v = static_cast<float>(kv_cache_v[t * Hkv * d + h_kv * d + i]);
-                    } else if (use_sidecar) {
+                        v = static_cast<float>(kv_cache_v[t * Hkv * d + h_kv * d + tid]);
+                    } else if (use_sidecar_v) {
                         const int shadow_slot = t % kv_shadow_window;
                         v = static_cast<float>(
-                            shadow_v[h_kv * kv_shadow_window * d + shadow_slot * d + i]);
+                            shadow_v[h_kv * kv_shadow_window * d + shadow_slot * d + tid]);
                     } else {
                         const float scale_v_t = sv_buf[h_kv * kv_max_t + t];
-                        const uint8_t byte = fp8_cv[t * Hkv * d + h_kv * d + i];
+                        const uint8_t byte = fp8_cv[t * Hkv * d + h_kv * d + tid];
                         v = fp8_e4m3_to_float(byte) * scale_v_t;
                     }
-                    acc += w * v;
                 }
-                workspace[OFF_ATTN + hq * d + i] = acc;
+                online_acc = online_acc * old_scale + new_weight * v;
+                online_m = new_m;
+                __syncthreads();
+            }
+
+            if (tid < d) {
+                const float acc = online_l > 0.0f ? (online_acc / online_l) : 0.0f;
+                workspace[OFF_ATTN + hq * d + tid] = acc;
                 if (stage == 4) {
-                    output[hq * d + i] = static_cast<T>(acc);
+                    output[hq * d + tid] = static_cast<T>(acc);
                 }
             }
             __syncthreads();
+        }
         }
     }
 


### PR DESCRIPTION
## Summary
- add tiled long-context cached full-attention reduction for Qwen3.6 full-attn layers
- keep the short-context online softmax path and existing KV write/FP8/sidecar behavior
- add a model-backed tiled-threshold smoke
- document 8192 median gate results

## Results
8192 `int4-vmm`, 3-run median:
- baseline `d3a86a1`: 575.78s prefill, 125.04 ms/tok
- candidate `cfb1b26`: 313.81s prefill, 56.42 ms/tok
- delta: -45.5% prefill, -54.9% ms/tok

Generated IDs matched across all gate runs: `[271, 248068, 271, 248069]`.

## Verification
- `SUPERSONIC_BACKENDS=hip cargo build --release --bin supersonic`
- `python3 -m unittest tests/test_qwen36_longctx_bench.py`
- `SUPERSONIC_BACKENDS=hip SUPERSONIC_QWEN36_35B_A3B_DIR=/mnt/data/models/Qwen3.6-35B-A3B cargo test --release -p runner --test qwen36_moe_longctx_tiled_smoke -- --nocapture`
