### PR TITLE
Add Qwen3.6 long-context VMM FP8 profiles

### DIFF
--- a/docs/research/2026-05-04-qwen36-longctx-vmm-fp8-profile-plan.md
+++ b/docs/research/2026-05-04-qwen36-longctx-vmm-fp8-profile-plan.md
@@ -22,7 +22,9 @@ profile row unless `rocm-smi --showuse --showmemuse --showpidgpus` shows:
 - no listed GPU PIDs
 
 The wrapper `tests/gfx1100/profile_qwen36_longctx_vmm_fp8.py` enforces this
-before each benchmark row.
+before each benchmark row, using the maximum parsed GPU and VRAM use across all
+reported GPU rows and ignoring `showpidgpus` PID rows that report zero attached
+DRM devices.
 
 ## Primary Profile
 

--- a/docs/research/2026-05-04-qwen36-longctx-vmm-fp8-profile-plan.md
+++ b/docs/research/2026-05-04-qwen36-longctx-vmm-fp8-profile-plan.md
@@ -1,0 +1,94 @@
+# Qwen3.6 Long-Context VMM/KV-FP8 Profile Plan - 2026-05-04
+
+This branch profiles the merged long-context full-attention tiled path at larger
+contexts, with emphasis on dense VMM BF16 KV, KV-FP8, sparse MoE VMM, and
+sparse+KV-FP8.
+
+## Worktree
+
+```text
+/home/deano/projects/SuperSonicBase-qwen36-longctx-vmm-fp8-profiles
+branch: research/qwen36-longctx-vmm-fp8-profiles
+base: 3cd856d Merge pull request #205 from DeanoC/perf/qwen36-longctx-full-attn
+```
+
+## GPU Coordination
+
+Another local agent is using the same GPU intermittently. Do not launch a
+profile row unless `rocm-smi --showuse --showmemuse --showpidgpus` shows:
+
+- GPU use at or below 5%
+- VRAM use at or below 5%
+- no listed GPU PIDs
+
+The wrapper `tests/gfx1100/profile_qwen36_longctx_vmm_fp8.py` enforces this
+before each benchmark row.
+
+## Primary Profile
+
+Start with the large VMM/KV-FP8 profile:
+
+```bash
+SUPERSONIC_BACKENDS=hip cargo build --release --bin supersonic
+
+python3 tests/gfx1100/profile_qwen36_longctx_vmm_fp8.py \
+  --profile vmm-fp8-large \
+  --binary target/release/supersonic \
+  --model-dir /mnt/data/models/Qwen3.6-35B-A3B \
+  --max-new-tokens 4 \
+  --timeout 2400 \
+  --out-dir target/qwen36_longctx_profiles/vmm-fp8-large
+```
+
+This runs one row at a time:
+
+| Context | Modes |
+|---:|:---|
+| 8192 | `int4-vmm`, `int4-kv-fp8` |
+| 16384 | `int4-vmm`, `int4-kv-fp8` |
+
+If the 16384 rows are stable and memory headroom is acceptable, extend to:
+
+```bash
+python3 tests/gfx1100/profile_qwen36_longctx_vmm_fp8.py \
+  --profile vmm-fp8-xl \
+  --binary target/release/supersonic \
+  --model-dir /mnt/data/models/Qwen3.6-35B-A3B \
+  --max-new-tokens 4 \
+  --timeout 3600 \
+  --out-dir target/qwen36_longctx_profiles/vmm-fp8-xl
+```
+
+## Sparse Follow-Up
+
+After dense VMM/KV-FP8 rows, run sparse MoE VMM rows:
+
+```bash
+python3 tests/gfx1100/profile_qwen36_longctx_vmm_fp8.py \
+  --profile sparse-vmm-fp8 \
+  --binary target/release/supersonic \
+  --model-dir /mnt/data/models/Qwen3.6-35B-A3B \
+  --sparse-caps 320 \
+  --max-new-tokens 4 \
+  --timeout 3000 \
+  --out-dir target/qwen36_longctx_profiles/sparse-vmm-fp8
+```
+
+This adds `cap320` and `cap320-kv-fp8` rows at 8192 and 16384.
+
+## Readout
+
+For each context, compare:
+
+- prefill seconds
+- generation wall ms
+- total ms/token
+- `full_attn_ms_avg`, `linear_attn_ms_avg`, `ffn_ms_avg`
+- total VMM resident GiB
+- MoE VMM resident GiB
+- KV VMM resident GiB
+- generated ID agreement against `int4-vmm`
+
+The main question is whether KV-FP8 reduces resident memory enough at 16k/32k to
+offset any decode slowdown, and whether sparse MoE VMM changes the bottleneck
+from full-attention back to FFN/residency.

--- a/docs/research/2026-05-04-qwen36-longctx-vmm-fp8-profile-plan.md
+++ b/docs/research/2026-05-04-qwen36-longctx-vmm-fp8-profile-plan.md
@@ -17,7 +17,7 @@ base: 3cd856d Merge pull request #205 from DeanoC/perf/qwen36-longctx-full-attn
 Another local agent is using the same GPU intermittently. Do not launch a
 profile row unless `rocm-smi --showuse --showmemuse --showpidgpus` shows:
 
-- GPU use at or below 5%
+- GPU use at or below 10%
 - VRAM use at or below 5%
 - no listed GPU PIDs
 

--- a/docs/research/2026-05-04-qwen36-longctx-vmm-fp8-profile-results.md
+++ b/docs/research/2026-05-04-qwen36-longctx-vmm-fp8-profile-results.md
@@ -1,0 +1,65 @@
+# Qwen3.6 Long-Context VMM/KV-FP8 Profile Results - 2026-05-04
+
+Branch: `research/qwen36-longctx-vmm-fp8-profiles`  
+Worktree: `/home/deano/projects/SuperSonicBase-qwen36-longctx-vmm-fp8-profiles`  
+Base: `3cd856d` (`Merge pull request #205 from DeanoC/perf/qwen36-longctx-full-attn`)
+
+## Run
+
+The primary profile was run after checking the GPU was idle with
+`rocm-smi --showuse --showmemuse --showpidgpus`. The wrapper also checked for
+idle GPU state before each row.
+
+```bash
+SUPERSONIC_BACKENDS=hip cargo build --release --bin supersonic
+
+python3 tests/gfx1100/profile_qwen36_longctx_vmm_fp8.py \
+  --profile vmm-fp8-large \
+  --binary target/release/supersonic \
+  --model-dir /mnt/data/models/Qwen3.6-35B-A3B \
+  --max-new-tokens 4 \
+  --timeout 2400 \
+  --out-dir target/qwen36_longctx_profiles/vmm-fp8-large
+```
+
+Raw outputs:
+
+- `target/qwen36_longctx_profiles/vmm-fp8-large/vmm-fp8-large_combined.json`
+- `target/qwen36_longctx_profiles/vmm-fp8-large/vmm-fp8-large_*.json`
+- `target/qwen36_longctx_profiles/vmm-fp8-large/vmm-fp8-large_*.md`
+
+## Results
+
+| Context | Mode | Prefill s | Decode ms/tok | Full-attn ms/tok | Tok/s | Total resident GiB | KV resident GiB | IDs match baseline | NIAH hit |
+|---:|:---|---:|---:|---:|---:|---:|---:|:---:|:---:|
+| 8192 | `int4-vmm` | 313.01 | 56.27 | 55.82 | 17.77 | 15.16 | 0.16 | yes | NO |
+| 8192 | `int4-kv-fp8` | 313.67 | 56.35 | 55.86 | 17.75 | 15.08 | 0.08 | - | NO |
+| 16384 | `int4-vmm` | 808.80 | 79.41 | 78.97 | 12.59 | 15.27 | 0.27 | yes | NO |
+| 16384 | `int4-kv-fp8` | 814.04 | 80.69 | 80.25 | 12.39 | 15.16 | 0.16 | - | NO |
+
+## Readout
+
+KV-FP8 reduced resident KV memory as expected:
+
+- 8k: 0.16 GiB to 0.08 GiB, saving 0.08 GiB.
+- 16k: 0.27 GiB to 0.16 GiB, saving 0.12 GiB.
+
+The decode tradeoff was small but not favorable in this run:
+
+- 8k: KV-FP8 was +0.14% slower by decode ms/token.
+- 16k: KV-FP8 was +1.62% slower by decode ms/token.
+
+Full attention remains the measured decode bottleneck. `full_attn_ms_avg`
+accounts for almost all `total_ms_avg` in every row, and FFN timing is not
+visible in the per-token chain breakdown for these measured decode steps.
+
+The NIAH hit was false for all rows despite identical generated IDs across the
+dense and KV-FP8 rows at each context. These runs used only 4 generated tokens,
+so they are useful for performance and ID agreement, not for validating long
+answer recovery.
+
+## Next
+
+Run `sparse-vmm-fp8` before attempting 32k. The dense 16k prefill already took
+about 13.5 minutes per row, and 32k should only be attempted after confirming
+the sparse path does not introduce a residency or prefill regression.

--- a/docs/research/2026-05-04-qwen36-longctx-vmm-fp8-profile-results.md
+++ b/docs/research/2026-05-04-qwen36-longctx-vmm-fp8-profile-results.md
@@ -27,6 +27,8 @@ Raw outputs:
 - `target/qwen36_longctx_profiles/vmm-fp8-large/vmm-fp8-large_combined.json`
 - `target/qwen36_longctx_profiles/vmm-fp8-large/vmm-fp8-large_*.json`
 - `target/qwen36_longctx_profiles/vmm-fp8-large/vmm-fp8-large_*.md`
+- `target/qwen36_longctx_profiles/sparse-vmm-fp8/sparse-vmm-fp8_8192_sparse.json`
+- `target/qwen36_longctx_profiles/sparse-vmm-fp8/sparse-vmm-fp8_8192_sparse.md`
 
 ## Results
 
@@ -36,6 +38,12 @@ Raw outputs:
 | 8192 | `int4-kv-fp8` | 313.67 | 56.35 | 55.86 | 17.75 | 15.08 | 0.08 | - | NO |
 | 16384 | `int4-vmm` | 808.80 | 79.41 | 78.97 | 12.59 | 15.27 | 0.27 | yes | NO |
 | 16384 | `int4-kv-fp8` | 814.04 | 80.69 | 80.25 | 12.39 | 15.16 | 0.16 | - | NO |
+
+Partial sparse follow-up:
+
+| Context | Mode | Prefill s | Decode ms/tok | Full-attn ms/tok | Tok/s | Total resident GiB | MoE resident GiB | KV resident GiB | NIAH hit |
+|---:|:---|---:|---:|---:|---:|---:|---:|---:|:---:|
+| 8192 | `cap320` | 1135.73 | 179.79 | 164.66 | 5.56 | 1.41 | 1.25 | 0.16 | NO |
 
 ## Readout
 
@@ -53,6 +61,12 @@ Full attention remains the measured decode bottleneck. `full_attn_ms_avg`
 accounts for almost all `total_ms_avg` in every row, and FFN timing is not
 visible in the per-token chain breakdown for these measured decode steps.
 
+The sparse `cap320` row cut total residency from 15.16 GiB to 1.41 GiB at 8k,
+but it was much slower: prefill was 3.63x dense and decode ms/token was 3.19x
+dense. The sparse sweep was stopped after this row while the wrapper was
+idle-waiting, because the 16k sparse rows would be expensive and the first row
+already showed the sparse path is not currently performance-competitive.
+
 The NIAH hit was false for all rows despite identical generated IDs across the
 dense and KV-FP8 rows at each context. These runs used only 4 generated tokens,
 so they are useful for performance and ID agreement, not for validating long
@@ -60,6 +74,7 @@ answer recovery.
 
 ## Next
 
-Run `sparse-vmm-fp8` before attempting 32k. The dense 16k prefill already took
-about 13.5 minutes per row, and 32k should only be attempted after confirming
-the sparse path does not introduce a residency or prefill regression.
+Do not spend the next pass on 16k sparse timings until the sparse prefill and
+full-attention decode regressions are understood. The higher-value next step is
+to inspect why `cap320` makes full-attention decode 3x slower despite the much
+smaller MoE residency, then rerun only the 8k sparse and sparse+KV-FP8 rows.

--- a/tests/gfx1100/profile_qwen36_longctx_vmm_fp8.py
+++ b/tests/gfx1100/profile_qwen36_longctx_vmm_fp8.py
@@ -134,7 +134,7 @@ def main() -> int:
     parser.add_argument("--timeout", type=int, default=2400)
     parser.add_argument("--seed", type=int, default=20260504)
     parser.add_argument("--out-dir", type=Path, default=Path("target/qwen36_longctx_profiles"))
-    parser.add_argument("--max-gpu-use", type=int, default=5)
+    parser.add_argument("--max-gpu-use", type=int, default=10)
     parser.add_argument("--max-mem-use", type=int, default=5)
     parser.add_argument("--gpu-idle-timeout", type=int, default=7200)
     parser.add_argument("--gpu-poll-seconds", type=float, default=30.0)

--- a/tests/gfx1100/profile_qwen36_longctx_vmm_fp8.py
+++ b/tests/gfx1100/profile_qwen36_longctx_vmm_fp8.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Run Qwen3.6 long-context VMM/KV-FP8 profile rows with GPU-idle gating.
+
+This wraps bench_qwen36_longctx.py but starts one row at a time. Before each
+row it polls rocm-smi and waits until the GPU is idle, which is useful when
+another local agent may occasionally be using the same device.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+PROFILES: dict[str, dict[str, str]] = {
+    "vmm-fp8-large": {
+        "contexts": "8192,16384",
+        "modes": "int4-vmm,int4-kv-fp8",
+        "sparse_caps": "320",
+    },
+    "vmm-fp8-xl": {
+        "contexts": "8192,16384,32768",
+        "modes": "int4-vmm,int4-kv-fp8",
+        "sparse_caps": "320",
+    },
+    "sparse-vmm-fp8": {
+        "contexts": "8192,16384",
+        "modes": "int4-vmm,int4-kv-fp8,sparse,sparse-kv-fp8",
+        "sparse_caps": "320",
+    },
+}
+
+
+def parse_csv_ints(raw: str) -> list[int]:
+    values = [int(part.strip()) for part in raw.split(",") if part.strip()]
+    if not values:
+        raise ValueError("expected at least one integer")
+    return values
+
+
+def parse_csv(raw: str) -> list[str]:
+    values = [part.strip() for part in raw.split(",") if part.strip()]
+    if not values:
+        raise ValueError("expected at least one value")
+    return values
+
+
+def rocm_smi_snapshot() -> tuple[int | None, int | None, list[int], str]:
+    proc = subprocess.run(
+        ["rocm-smi", "--showuse", "--showmemuse", "--showpidgpus"],
+        text=True,
+        capture_output=True,
+    )
+    output = proc.stdout + proc.stderr
+    if proc.returncode != 0:
+        return None, None, [], output
+
+    gpu_use = None
+    mem_use = None
+    pids: list[int] = []
+    for line in output.splitlines():
+        gpu_match = re.search(r"GPU use \(%\):\s*([0-9]+)", line)
+        if gpu_match:
+            gpu_use = int(gpu_match.group(1))
+        mem_match = re.search(r"VRAM%\):\s*([0-9]+)", line)
+        if mem_match:
+            mem_use = int(mem_match.group(1))
+        pid_match = re.search(r"PID\s+([0-9]+)\s+is using", line)
+        if pid_match:
+            pids.append(int(pid_match.group(1)))
+    return gpu_use, mem_use, pids, output
+
+
+def wait_for_gpu_idle(
+    max_gpu_use: int,
+    max_mem_use: int,
+    poll_seconds: float,
+    timeout_seconds: int,
+) -> None:
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        gpu_use, mem_use, pids, raw = rocm_smi_snapshot()
+        if gpu_use is None or mem_use is None:
+            raise RuntimeError(f"could not read rocm-smi output:\n{raw}")
+        if gpu_use <= max_gpu_use and mem_use <= max_mem_use and not pids:
+            print(
+                f"[gpu-idle] gpu_use={gpu_use}% mem_use={mem_use}% pids=[]",
+                flush=True,
+            )
+            return
+        if time.monotonic() >= deadline:
+            raise TimeoutError(
+                "GPU did not become idle before timeout: "
+                f"gpu_use={gpu_use}% mem_use={mem_use}% pids={pids}"
+            )
+        print(
+            f"[gpu-busy] gpu_use={gpu_use}% mem_use={mem_use}% pids={pids}; "
+            f"sleeping {poll_seconds:.0f}s",
+            flush=True,
+        )
+        time.sleep(poll_seconds)
+
+
+def load_rows(path: Path) -> list[dict[str, Any]]:
+    with path.open() as f:
+        payload = json.load(f)
+    return list(payload.get("rows") or [])
+
+
+def write_combined_report(out_json: Path, rows: list[dict[str, Any]]) -> None:
+    payload = {
+        "schema": "qwen36-moe-longctx-vmm-fp8-profile-v1",
+        "rows": rows,
+    }
+    out_json.parent.mkdir(parents=True, exist_ok=True)
+    out_json.write_text(json.dumps(payload, indent=2))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--profile", choices=sorted(PROFILES), default="vmm-fp8-large")
+    parser.add_argument("--binary", type=Path, default=Path("target/release/supersonic"))
+    parser.add_argument("--model-dir", type=Path, default=Path("/mnt/data/models/Qwen3.6-35B-A3B"))
+    parser.add_argument("--contexts")
+    parser.add_argument("--modes")
+    parser.add_argument("--sparse-caps")
+    parser.add_argument("--max-new-tokens", type=int, default=4)
+    parser.add_argument("--timeout", type=int, default=2400)
+    parser.add_argument("--seed", type=int, default=20260504)
+    parser.add_argument("--out-dir", type=Path, default=Path("target/qwen36_longctx_profiles"))
+    parser.add_argument("--max-gpu-use", type=int, default=5)
+    parser.add_argument("--max-mem-use", type=int, default=5)
+    parser.add_argument("--gpu-idle-timeout", type=int, default=7200)
+    parser.add_argument("--gpu-poll-seconds", type=float, default=30.0)
+    parser.add_argument("--no-wait-gpu-idle", action="store_true")
+    args = parser.parse_args()
+
+    defaults = PROFILES[args.profile]
+    contexts = parse_csv_ints(args.contexts or defaults["contexts"])
+    modes = parse_csv(args.modes or defaults["modes"])
+    sparse_caps = args.sparse_caps or defaults["sparse_caps"]
+
+    rows: list[dict[str, Any]] = []
+    for context in contexts:
+        for mode in modes:
+            if not args.no_wait_gpu_idle:
+                wait_for_gpu_idle(
+                    args.max_gpu_use,
+                    args.max_mem_use,
+                    args.gpu_poll_seconds,
+                    args.gpu_idle_timeout,
+                )
+            label = f"{args.profile}_{context}_{mode}"
+            out_json = args.out_dir / f"{label}.json"
+            out_md = args.out_dir / f"{label}.md"
+            cmd = [
+                sys.executable,
+                "tests/gfx1100/bench_qwen36_longctx.py",
+                "--binary",
+                str(args.binary),
+                "--model-dir",
+                str(args.model_dir),
+                "--contexts",
+                str(context),
+                "--modes",
+                mode,
+                "--sparse-caps",
+                sparse_caps,
+                "--max-new-tokens",
+                str(args.max_new_tokens),
+                "--no-warmup",
+                "--timeout",
+                str(args.timeout),
+                "--seed",
+                str(args.seed),
+                "--out-json",
+                str(out_json),
+                "--out-md",
+                str(out_md),
+            ]
+            print(f"[profile-row] context={context} mode={mode}", flush=True)
+            proc = subprocess.run(cmd)
+            if proc.returncode != 0:
+                return proc.returncode
+            rows.extend(load_rows(out_json))
+
+    write_combined_report(args.out_dir / f"{args.profile}_combined.json", rows)
+    print(f"[wrote] {args.out_dir / f'{args.profile}_combined.json'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/gfx1100/profile_qwen36_longctx_vmm_fp8.py
+++ b/tests/gfx1100/profile_qwen36_longctx_vmm_fp8.py
@@ -61,19 +61,21 @@ def rocm_smi_snapshot() -> tuple[int | None, int | None, list[int], str]:
     if proc.returncode != 0:
         return None, None, [], output
 
-    gpu_use = None
-    mem_use = None
+    gpu_uses: list[int] = []
+    mem_uses: list[int] = []
     pids: list[int] = []
     for line in output.splitlines():
         gpu_match = re.search(r"GPU use \(%\):\s*([0-9]+)", line)
         if gpu_match:
-            gpu_use = int(gpu_match.group(1))
+            gpu_uses.append(int(gpu_match.group(1)))
         mem_match = re.search(r"VRAM%\):\s*([0-9]+)", line)
         if mem_match:
-            mem_use = int(mem_match.group(1))
-        pid_match = re.search(r"PID\s+([0-9]+)\s+is using", line)
-        if pid_match:
+            mem_uses.append(int(mem_match.group(1)))
+        pid_match = re.search(r"PID\s+([0-9]+)\s+is using\s+([0-9]+)\s+DRM", line)
+        if pid_match and int(pid_match.group(2)) > 0:
             pids.append(int(pid_match.group(1)))
+    gpu_use = max(gpu_uses) if gpu_uses else None
+    mem_use = max(mem_uses) if mem_uses else None
     return gpu_use, mem_use, pids, output
 
 


### PR DESCRIPTION
## Summary

Adds a Qwen3.6 long-context profiling wrapper for VMM/KV-FP8 paths and records the first dense plus sparse profile results.

## What changed

- Added `tests/gfx1100/profile_qwen36_longctx_vmm_fp8.py` to run `bench_qwen36_longctx.py` one row at a time.
- Added GPU-idle gating before every row via `rocm-smi --showuse --showmemuse --showpidgpus`.
- Added a profile plan for dense VMM/KV-FP8, 32k follow-up, and sparse follow-up.
- Added research results for dense 8k/16k and one sparse 8k `cap320` row.

## Results

Dense VMM/KV-FP8:

| Context | Mode | Prefill s | Decode ms/tok | Total resident GiB | KV resident GiB |
|---:|:---|---:|---:|---:|---:|
| 8192 | `int4-vmm` | 313.01 | 56.27 | 15.16 | 0.16 |
| 8192 | `int4-kv-fp8` | 313.67 | 56.35 | 15.08 | 0.08 |
| 16384 | `int4-vmm` | 808.80 | 79.41 | 15.27 | 0.27 |
| 16384 | `int4-kv-fp8` | 814.04 | 80.69 | 15.16 | 0.16 |

Sparse signal:

| Context | Mode | Prefill s | Decode ms/tok | Total resident GiB | MoE resident GiB |
|---:|:---|---:|---:|---:|---:|
| 8192 | `cap320` | 1135.73 | 179.79 | 1.41 | 1.25 |

## Readout

- KV-FP8 reduces KV residency, but did not improve decode in this run.
- Full attention remains the decode bottleneck in dense rows.
- Sparse VMM cuts residency dramatically, but currently regresses prefill and decode heavily at 8k, so the sparse sweep was stopped before 16k.

## Validation

- `python3 -m py_compile tests/gfx1100/profile_qwen36_longctx_vmm_fp8.py`
- `SUPERSONIC_BACKENDS=hip cargo build --release --bin supersonic`
- Ran `vmm-fp8-large` profile under GPU-idle gating.
- Ran one `sparse-vmm-fp8` 8k `cap320` row under GPU-idle gating.
