### PR TITLE
[codex] Wire Qwen3.6 CUDA v1 decode

### DIFF
--- a/crates/core/src/registry.rs
+++ b/crates/core/src/registry.rs
@@ -843,7 +843,7 @@ static REGISTRY: &[RegistryEntry] = &[
         backend: Backend::Cuda,
         arch: GpuArch::Sm86,
         vram: VramBudget {
-            fixed_bytes: 22 * GIB,
+            fixed_bytes: 20 * GIB,
             overhead_factor: 1.1,
         },
         params: FamilyParams::Qwen36Moe(Qwen36MoeKernelParams {

--- a/crates/kernel-ffi/build.rs
+++ b/crates/kernel-ffi/build.rs
@@ -317,6 +317,11 @@ fn compile_cuda(kernel_dir: &Path, out_dir: &Path) {
             "gemma4_cuda.o",
             "building Gemma 4 CUDA bridge",
         ),
+        (
+            "qwen36_moe_bridge_cuda.cu",
+            "qwen36_moe_cuda.o",
+            "building Qwen3.6-MoE CUDA bridge",
+        ),
     ];
     let archs = detect_cuda_archs();
     if verbose_build_warnings() {
@@ -419,7 +424,9 @@ fn main() {
         "dflash_draft.hip",
         "dflash_draft_bridge.cpp",
         "qwen36_moe.hip",
+        "qwen36_moe_cuda_prelude.cuh",
         "qwen36_moe_bridge.cpp",
+        "qwen36_moe_bridge_cuda.cu",
         "qwen36_moe_persistent/helpers.cuh",
         "qwen36_moe_persistent/full_attn_phase.cuh",
         "qwen36_moe_persistent/linear_attn_phase.cuh",

--- a/crates/kernel-ffi/src/qwen36_moe.rs
+++ b/crates/kernel-ffi/src/qwen36_moe.rs
@@ -248,7 +248,7 @@ impl Default for Qwen36MoeBatchSeqDesc {
     }
 }
 
-#[cfg(supersonic_backend_hip)]
+#[cfg(any(supersonic_backend_hip, supersonic_backend_cuda))]
 extern "C" {
     /// Stub launch entry. Walks the descriptor array, validates field
     /// integrity by writing recognizable sentinel values into the workspace
@@ -683,8 +683,8 @@ pub fn stub_launch(
     let barrier_flag = unsafe { (counters as *mut u8).add(68) as *mut c_uint };
 
     let status: c_int = match backend {
-        Backend::Hip => {
-            #[cfg(supersonic_backend_hip)]
+        Backend::Hip | Backend::Cuda => {
+            #[cfg(any(supersonic_backend_hip, supersonic_backend_cuda))]
             unsafe {
                 qwen36_moe_hip_stub_launch(
                     dtype.kernel_dtype_code(),
@@ -697,17 +697,12 @@ pub fn stub_launch(
                     barrier_flag,
                 )
             }
-            #[cfg(not(supersonic_backend_hip))]
+            #[cfg(not(any(supersonic_backend_hip, supersonic_backend_cuda)))]
             {
                 return Err(GpuError::InvalidArg(
-                    "qwen36_moe::stub_launch: HIP backend not compiled".into(),
+                    "qwen36_moe::stub_launch: GPU backend not compiled".into(),
                 ));
             }
-        }
-        Backend::Cuda => {
-            return Err(GpuError::InvalidArg(
-                "qwen36_moe::stub_launch: CUDA backend not yet wired".into(),
-            ));
         }
         Backend::Metal => {
             return Err(GpuError::InvalidArg(
@@ -888,8 +883,8 @@ pub fn persistent_decode_launch_range(
     };
 
     let status: c_int = match backend {
-        Backend::Hip => {
-            #[cfg(supersonic_backend_hip)]
+        Backend::Hip | Backend::Cuda => {
+            #[cfg(any(supersonic_backend_hip, supersonic_backend_cuda))]
             unsafe {
                 qwen36_moe_hip_persistent_decode_launch(
                     dtype.kernel_dtype_code(),
@@ -931,17 +926,12 @@ pub fn persistent_decode_launch_range(
                     barrier_flag,
                 )
             }
-            #[cfg(not(supersonic_backend_hip))]
+            #[cfg(not(any(supersonic_backend_hip, supersonic_backend_cuda)))]
             {
                 return Err(GpuError::InvalidArg(
-                    "qwen36_moe::persistent_decode_launch: HIP backend not compiled".into(),
+                    "qwen36_moe::persistent_decode_launch: GPU backend not compiled".into(),
                 ));
             }
-        }
-        Backend::Cuda => {
-            return Err(GpuError::InvalidArg(
-                "qwen36_moe::persistent_decode_launch: CUDA backend not yet wired".into(),
-            ));
         }
         Backend::Metal => {
             return Err(GpuError::InvalidArg(
@@ -1114,8 +1104,8 @@ pub fn attn_step_launch(
     let barrier_flag = unsafe { (counters as *mut u8).add(68) as *mut c_uint };
 
     let status: c_int = match backend {
-        Backend::Hip => {
-            #[cfg(supersonic_backend_hip)]
+        Backend::Hip | Backend::Cuda => {
+            #[cfg(any(supersonic_backend_hip, supersonic_backend_cuda))]
             unsafe {
                 qwen36_moe_hip_attn_step_launch(
                     dtype.kernel_dtype_code(),
@@ -1157,17 +1147,12 @@ pub fn attn_step_launch(
                     barrier_flag,
                 )
             }
-            #[cfg(not(supersonic_backend_hip))]
+            #[cfg(not(any(supersonic_backend_hip, supersonic_backend_cuda)))]
             {
                 return Err(GpuError::InvalidArg(
-                    "qwen36_moe::attn_step_launch: HIP backend not compiled".into(),
+                    "qwen36_moe::attn_step_launch: GPU backend not compiled".into(),
                 ));
             }
-        }
-        Backend::Cuda => {
-            return Err(GpuError::InvalidArg(
-                "qwen36_moe::attn_step_launch: CUDA backend not yet wired".into(),
-            ));
         }
         Backend::Metal => {
             return Err(GpuError::InvalidArg(
@@ -1294,8 +1279,8 @@ pub fn linear_step_launch(
     let barrier_flag = unsafe { (counters as *mut u8).add(68) as *mut c_uint };
 
     let status: c_int = match backend {
-        Backend::Hip => {
-            #[cfg(supersonic_backend_hip)]
+        Backend::Hip | Backend::Cuda => {
+            #[cfg(any(supersonic_backend_hip, supersonic_backend_cuda))]
             unsafe {
                 qwen36_moe_hip_linear_step_launch(
                     dtype.kernel_dtype_code(),
@@ -1336,17 +1321,12 @@ pub fn linear_step_launch(
                     barrier_flag,
                 )
             }
-            #[cfg(not(supersonic_backend_hip))]
+            #[cfg(not(any(supersonic_backend_hip, supersonic_backend_cuda)))]
             {
                 return Err(GpuError::InvalidArg(
-                    "qwen36_moe::linear_step_launch: HIP backend not compiled".into(),
+                    "qwen36_moe::linear_step_launch: GPU backend not compiled".into(),
                 ));
             }
-        }
-        Backend::Cuda => {
-            return Err(GpuError::InvalidArg(
-                "qwen36_moe::linear_step_launch: CUDA backend not yet wired".into(),
-            ));
         }
         Backend::Metal => {
             return Err(GpuError::InvalidArg(
@@ -1506,8 +1486,8 @@ pub fn ffn_step_launch(
     let barrier_flag = unsafe { (counters as *mut u8).add(68) as *mut c_uint };
 
     let status: c_int = match backend {
-        Backend::Hip => {
-            #[cfg(supersonic_backend_hip)]
+        Backend::Hip | Backend::Cuda => {
+            #[cfg(any(supersonic_backend_hip, supersonic_backend_cuda))]
             unsafe {
                 qwen36_moe_hip_ffn_step_launch(
                     dtype.kernel_dtype_code(),
@@ -1547,17 +1527,12 @@ pub fn ffn_step_launch(
                     barrier_flag,
                 )
             }
-            #[cfg(not(supersonic_backend_hip))]
+            #[cfg(not(any(supersonic_backend_hip, supersonic_backend_cuda)))]
             {
                 return Err(GpuError::InvalidArg(
-                    "qwen36_moe::ffn_step_launch: HIP backend not compiled".into(),
+                    "qwen36_moe::ffn_step_launch: GPU backend not compiled".into(),
                 ));
             }
-        }
-        Backend::Cuda => {
-            return Err(GpuError::InvalidArg(
-                "qwen36_moe::ffn_step_launch: CUDA backend not yet wired".into(),
-            ));
         }
         Backend::Metal => {
             return Err(GpuError::InvalidArg(
@@ -1621,8 +1596,8 @@ pub fn int4_dequant_smoke_launch(
 
     let backend = packed_buf.backend();
     let status: c_int = match backend {
-        Backend::Hip => {
-            #[cfg(supersonic_backend_hip)]
+        Backend::Hip | Backend::Cuda => {
+            #[cfg(any(supersonic_backend_hip, supersonic_backend_cuda))]
             unsafe {
                 qwen36_moe_hip_int4_dequant_smoke_launch(
                     ordinal,
@@ -1636,17 +1611,12 @@ pub fn int4_dequant_smoke_launch(
                     dq_scalar_out.as_mut_ptr() as *mut f32,
                 )
             }
-            #[cfg(not(supersonic_backend_hip))]
+            #[cfg(not(any(supersonic_backend_hip, supersonic_backend_cuda)))]
             {
                 return Err(GpuError::InvalidArg(
-                    "qwen36_moe::int4_dequant_smoke_launch: HIP backend not compiled".into(),
+                    "qwen36_moe::int4_dequant_smoke_launch: GPU backend not compiled".into(),
                 ));
             }
-        }
-        Backend::Cuda => {
-            return Err(GpuError::InvalidArg(
-                "qwen36_moe::int4_dequant_smoke_launch: CUDA backend not yet wired".into(),
-            ));
         }
         Backend::Metal => {
             return Err(GpuError::InvalidArg(
@@ -1711,8 +1681,8 @@ pub fn lm_head_launch(
         .map(|b| b.as_mut_ptr())
         .unwrap_or(std::ptr::null_mut());
     let status: c_int = match backend {
-        Backend::Hip => {
-            #[cfg(supersonic_backend_hip)]
+        Backend::Hip | Backend::Cuda => {
+            #[cfg(any(supersonic_backend_hip, supersonic_backend_cuda))]
             unsafe {
                 qwen36_moe_hip_lm_head_launch(
                     /* dtype = bf16 */ 2,
@@ -1728,17 +1698,12 @@ pub fn lm_head_launch(
                     counter_buf.as_mut_ptr() as *mut c_uint,
                 )
             }
-            #[cfg(not(supersonic_backend_hip))]
+            #[cfg(not(any(supersonic_backend_hip, supersonic_backend_cuda)))]
             {
                 return Err(GpuError::InvalidArg(
-                    "qwen36_moe::lm_head_launch: HIP backend not compiled".into(),
+                    "qwen36_moe::lm_head_launch: GPU backend not compiled".into(),
                 ));
             }
-        }
-        Backend::Cuda => {
-            return Err(GpuError::InvalidArg(
-                "qwen36_moe::lm_head_launch: CUDA backend not yet wired".into(),
-            ));
         }
         Backend::Metal => {
             return Err(GpuError::InvalidArg(
@@ -1832,8 +1797,8 @@ pub fn lm_head_batched_launch(
         .map(|b| b.as_mut_ptr())
         .unwrap_or(std::ptr::null_mut());
     let status: c_int = match backend {
-        Backend::Hip => {
-            #[cfg(supersonic_backend_hip)]
+        Backend::Hip | Backend::Cuda => {
+            #[cfg(any(supersonic_backend_hip, supersonic_backend_cuda))]
             unsafe {
                 qwen36_moe_hip_lm_head_batched_launch(
                     /* dtype = bf16 */ 2,
@@ -1849,17 +1814,12 @@ pub fn lm_head_batched_launch(
                     x_normed_ptr,
                 )
             }
-            #[cfg(not(supersonic_backend_hip))]
+            #[cfg(not(any(supersonic_backend_hip, supersonic_backend_cuda)))]
             {
                 return Err(GpuError::InvalidArg(
-                    "qwen36_moe::lm_head_batched_launch: HIP backend not compiled".into(),
+                    "qwen36_moe::lm_head_batched_launch: GPU backend not compiled".into(),
                 ));
             }
-        }
-        Backend::Cuda => {
-            return Err(GpuError::InvalidArg(
-                "qwen36_moe::lm_head_batched_launch: CUDA backend not yet wired".into(),
-            ));
         }
         Backend::Metal => {
             return Err(GpuError::InvalidArg(
@@ -1939,8 +1899,8 @@ pub fn mtp_pre_fusion_launch(
 
     let backend = fc_w_buf.backend();
     let status: c_int = match backend {
-        Backend::Hip => {
-            #[cfg(supersonic_backend_hip)]
+        Backend::Hip | Backend::Cuda => {
+            #[cfg(any(supersonic_backend_hip, supersonic_backend_cuda))]
             unsafe {
                 qwen36_moe_hip_mtp_pre_fusion_launch(
                     /* dtype = bf16 */ 2,
@@ -1957,17 +1917,12 @@ pub fn mtp_pre_fusion_launch(
                     fused_out_buf.as_mut_ptr(),
                 )
             }
-            #[cfg(not(supersonic_backend_hip))]
+            #[cfg(not(any(supersonic_backend_hip, supersonic_backend_cuda)))]
             {
                 return Err(GpuError::InvalidArg(
-                    "qwen36_moe::mtp_pre_fusion_launch: HIP backend not compiled".into(),
+                    "qwen36_moe::mtp_pre_fusion_launch: GPU backend not compiled".into(),
                 ));
             }
-        }
-        Backend::Cuda => {
-            return Err(GpuError::InvalidArg(
-                "qwen36_moe::mtp_pre_fusion_launch: CUDA backend not yet wired".into(),
-            ));
         }
         Backend::Metal => {
             return Err(GpuError::InvalidArg(
@@ -6395,7 +6350,7 @@ mod tests {
     /// BF16 round-to-nearest-even of an F32 value, returning the 16-bit
     /// big-end-of-F32 representation. Same math as the kernel's
     /// `bf16_round_rne_f32`.
-    #[cfg(supersonic_backend_hip)]
+    #[cfg(any(supersonic_backend_hip, supersonic_backend_cuda))]
     fn bf16_round_bits(x: f32) -> u16 {
         let bits = x.to_bits();
         let rounding_bias = 0x7FFFu32 + ((bits >> 16) & 1);
@@ -6404,7 +6359,7 @@ mod tests {
     }
 
     /// Reverse: F32 from a BF16 bit pattern.
-    #[cfg(supersonic_backend_hip)]
+    #[cfg(any(supersonic_backend_hip, supersonic_backend_cuda))]
     fn f32_from_bf16(b: u16) -> f32 {
         f32::from_bits((b as u32) << 16)
     }
@@ -6413,7 +6368,7 @@ mod tests {
     /// of `minmax_int4_packed_and_recon` in the FFN oracle. Returns
     /// `(packed [out, in/2] u8, scale [out/gs, in/gs] u16-as-BF16,
     /// zero [out/gs, in/gs] u16-as-BF16)`.
-    #[cfg(supersonic_backend_hip)]
+    #[cfg(any(supersonic_backend_hip, supersonic_backend_cuda))]
     fn host_minmax_int4(
         w: &[f32],
         out_rows: usize,
@@ -6473,7 +6428,7 @@ mod tests {
 
     /// Reference reconstruction: `bf16(q*s - z*s)` per element. Returns
     /// F32 values whose lower 16 bits are zero (i.e. exactly BF16-precision).
-    #[cfg(supersonic_backend_hip)]
+    #[cfg(any(supersonic_backend_hip, supersonic_backend_cuda))]
     fn host_dequant_recon(
         packed: &[u8],
         scale: &[u16],
@@ -6503,7 +6458,7 @@ mod tests {
     }
 
     /// Encode a slice of BF16 16-bit values to LE bytes for `from_host_bytes`.
-    #[cfg(supersonic_backend_hip)]
+    #[cfg(any(supersonic_backend_hip, supersonic_backend_cuda))]
     fn bf16_bits_to_bytes(bits: &[u16]) -> Vec<u8> {
         let mut bytes = Vec::with_capacity(bits.len() * 2);
         for b in bits {
@@ -6515,10 +6470,15 @@ mod tests {
     /// Drives one (out_rows, in_cols, gsz) configuration through the smoke
     /// kernel and asserts both helper outputs match the host reference
     /// exactly.
-    #[cfg(supersonic_backend_hip)]
+    #[cfg(any(supersonic_backend_hip, supersonic_backend_cuda))]
     fn run_int4_dequant_smoke(out_rows: usize, in_cols: usize, gsz: usize, label: &str) {
-        use gpu_hal::{set_backend, Backend, GpuBuffer, ScalarType};
-        set_backend(Backend::Hip);
+        use gpu_hal::{is_backend_compiled, set_backend, Backend, GpuBuffer, ScalarType};
+        let backend = if is_backend_compiled(Backend::Cuda) {
+            Backend::Cuda
+        } else {
+            Backend::Hip
+        };
+        set_backend(backend);
         let ordinal = 0usize;
 
         // Deterministic synthetic weights: a 32-bit LCG seeded by config so
@@ -6603,7 +6563,7 @@ mod tests {
         }
     }
 
-    #[cfg(supersonic_backend_hip)]
+    #[cfg(any(supersonic_backend_hip, supersonic_backend_cuda))]
     #[test]
     fn qwen36_moe_int4_dequant_smoke_fast_path() {
         // gsz=8, in_cols=16 → every 8-col span lies in one group, so
@@ -6611,7 +6571,7 @@ mod tests {
         run_int4_dequant_smoke(8, 16, 8, "fast (gsz=8)");
     }
 
-    #[cfg(supersonic_backend_hip)]
+    #[cfg(any(supersonic_backend_hip, supersonic_backend_cuda))]
     #[test]
     fn qwen36_moe_int4_dequant_smoke_slow_path() {
         // gsz=4, in_cols=16 → 8-col spans starting at col=0 cross from
@@ -6632,12 +6592,17 @@ mod tests {
     /// strictly less precise than the host F32-throughout reference. A
     /// high cos_sim catches any systematic kernel bug while tolerating
     /// the inherent BF16 rounding noise.
-    #[cfg(supersonic_backend_hip)]
+    #[cfg(any(supersonic_backend_hip, supersonic_backend_cuda))]
     #[test]
     fn qwen36_moe_lm_head_matches_host_f32_reference() {
-        use gpu_hal::{copy_d2h, set_backend, Backend, GpuBuffer, ScalarType};
+        use gpu_hal::{copy_d2h, is_backend_compiled, set_backend, Backend, GpuBuffer, ScalarType};
 
-        set_backend(Backend::Hip);
+        let backend = if is_backend_compiled(Backend::Cuda) {
+            Backend::Cuda
+        } else {
+            Backend::Hip
+        };
+        set_backend(backend);
         let ordinal = 0usize;
         let hidden: i32 = 256;
         let vocab: i32 = 512;

--- a/crates/runner/src/qwen36_moe/engine.rs
+++ b/crates/runner/src/qwen36_moe/engine.rs
@@ -24,7 +24,8 @@ use crate::qwen36_moe_cli::output::{
     print_sampling_summary,
 };
 use crate::qwen36_moe_cli::policy::{
-    resolve_context_size, validate_decode_backend, validate_persistent_kv_fp8_flags,
+    resolve_context_size, validate_cuda_v1_flags, validate_decode_backend,
+    validate_persistent_kv_fp8_flags,
 };
 use crate::qwen36_moe_cli::prompt::{
     prepare_prompt, print_prompt_summary, validate_speculative_sampling,
@@ -46,6 +47,7 @@ pub fn run(cli: &crate::Cli, entry: &RegistryEntry, total_vram: u64) -> Result<(
 
     let (context_size, context_size_source) = resolve_context_size(cli);
     validate_persistent_kv_fp8_flags(cli)?;
+    validate_cuda_v1_flags(cli, entry)?;
 
     let report = run_qwen36_moe_dry_run(
         &cli.model_dir,
@@ -144,6 +146,13 @@ fn decode_text(
 
     let bake_open_start = std::time::Instant::now();
     let bake = select_decode_bake(model_dir, fp8_runtime)?;
+    if backend == Backend::Cuda && !bake.weight_mode.is_int4() {
+        anyhow::bail!(
+            "Qwen3.6-35B-A3B CUDA v1 requires an INT4/q4km bake; selected {} from {}",
+            bake.weight_mode.display_name(),
+            bake.bake_dir.display(),
+        );
+    }
     println!(
         "  loading from bake: {} ({})",
         bake.bake_dir.display(),

--- a/crates/runner/src/qwen36_moe/policy.rs
+++ b/crates/runner/src/qwen36_moe/policy.rs
@@ -30,13 +30,107 @@ pub fn validate_persistent_kv_fp8_flags(cli: &crate::Cli) -> Result<()> {
 }
 
 pub fn validate_decode_backend(entry: &RegistryEntry) -> Result<()> {
-    if entry.backend != Backend::Hip {
+    if !matches!(entry.backend, Backend::Hip | Backend::Cuda) {
         anyhow::bail!(
-            "qwen3.6-35b-a3b decode kernels are HIP-only at this stage; \
-             registry-selected backend was {:?}. Re-run with --backend hip, \
+            "qwen3.6-35b-a3b decode kernels are wired for HIP and CUDA sm86; \
+             registry-selected backend was {:?}. Re-run with --backend hip/cuda, \
              or use --dry-run for analytic accounting.",
             entry.backend,
         );
     }
     Ok(())
+}
+
+pub fn validate_cuda_v1_flags(cli: &crate::Cli, entry: &RegistryEntry) -> Result<()> {
+    if entry.backend != Backend::Cuda {
+        return Ok(());
+    }
+    if cli.fp8_runtime {
+        anyhow::bail!(
+            "Qwen3.6-35B-A3B CUDA v1 supports INT4/q4km decode only; \
+             --fp8-runtime is still HIP-only."
+        );
+    }
+    if cli.kv_fp8 {
+        anyhow::bail!("Qwen3.6-35B-A3B CUDA v1 keeps BF16 KV cache; --kv-fp8 is still HIP-only.");
+    }
+    if cli.speculative_decode || cli.batched_spec_verify {
+        anyhow::bail!("Qwen3.6-35B-A3B CUDA v1 does not wire the MTP/speculative decode path yet.");
+    }
+    if std::env::var("SUPERSONIC_VMM_KV").ok().as_deref() == Some("1") {
+        anyhow::bail!(
+            "Qwen3.6-35B-A3B CUDA v1 uses dense KV buffers; SUPERSONIC_VMM_KV=1 is not supported."
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use clap::Parser;
+
+    use super::*;
+    use crate::registry::{lookup, GpuArch, ModelVariant};
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn cuda_entry() -> &'static RegistryEntry {
+        lookup(
+            &ModelVariant::Qwen3_6_35B_A3B,
+            &Backend::Cuda,
+            &GpuArch::Sm86,
+        )
+        .expect("qwen3.6-35b-a3b CUDA sm86 registry entry")
+    }
+
+    fn cli(extra: &[&str]) -> crate::Cli {
+        let mut args = vec![
+            "supersonic",
+            "--model",
+            "qwen3.6-35b-a3b",
+            "--model-dir",
+            "/tmp/qwen36",
+            "--dry-run",
+        ];
+        args.extend_from_slice(extra);
+        crate::Cli::parse_from(args)
+    }
+
+    fn cuda_v1_error(extra: &[&str]) -> String {
+        validate_cuda_v1_flags(&cli(extra), cuda_entry())
+            .expect_err("CUDA v1 policy should reject this flag set")
+            .to_string()
+    }
+
+    #[test]
+    fn cuda_v1_accepts_default_int4_path() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        std::env::remove_var("SUPERSONIC_VMM_KV");
+
+        validate_cuda_v1_flags(&cli(&[]), cuda_entry()).expect("default CUDA v1 flags");
+    }
+
+    #[test]
+    fn cuda_v1_rejects_hip_only_weight_and_kv_modes() {
+        assert!(cuda_v1_error(&["--fp8-runtime"]).contains("--fp8-runtime"));
+        assert!(cuda_v1_error(&["--kv-fp8"]).contains("--kv-fp8"));
+    }
+
+    #[test]
+    fn cuda_v1_rejects_speculative_decode_modes() {
+        assert!(cuda_v1_error(&["--speculative-decode"]).contains("speculative"));
+        assert!(cuda_v1_error(&["--batched-spec-verify"]).contains("speculative"));
+    }
+
+    #[test]
+    fn cuda_v1_rejects_forced_kv_vmm() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        std::env::set_var("SUPERSONIC_VMM_KV", "1");
+        let err = cuda_v1_error(&[]);
+        std::env::remove_var("SUPERSONIC_VMM_KV");
+
+        assert!(err.contains("SUPERSONIC_VMM_KV=1"));
+    }
 }

--- a/crates/runner/src/qwen36_moe/vmm_config.rs
+++ b/crates/runner/src/qwen36_moe/vmm_config.rs
@@ -207,7 +207,16 @@ pub(crate) fn prepare_moe_runtime_config(
     backend: Backend,
     top_k: usize,
 ) -> Result<MoeRuntimeConfig> {
-    let vmm_mode = MoeExpertVmmMode::from_env()?;
+    let mut vmm_mode = MoeExpertVmmMode::from_env()?;
+    if backend == Backend::Cuda {
+        if vmm_mode == MoeExpertVmmMode::Force {
+            anyhow::bail!(
+                "SUPERSONIC_VMM_MOE_ISLANDS=1 is not supported for Qwen3.6-MoE CUDA v1; \
+                 unset it or use SUPERSONIC_VMM_MOE_ISLANDS=0"
+            );
+        }
+        vmm_mode = MoeExpertVmmMode::Disabled;
+    }
     let island_cap_experts = moe_island_cap_experts_from_env()?;
     let protected_experts = moe_island_protected_experts_from_env()?;
     if island_cap_experts.is_some() && speculative_decode {

--- a/kernels/qwen36_moe.hip
+++ b/kernels/qwen36_moe.hip
@@ -20,11 +20,7 @@
 // fragile, merging this with full_attention*.hip caused codegen
 // regressions in the past. Keep this file standalone.
 
-#include <hip/hip_bf16.h>
-#include <hip/hip_bfloat16.h>
-#include <hip/hip_runtime.h>
-#include <math.h>
-#include <stdint.h>
+#include "qwen36_moe_cuda_prelude.cuh"
 
 // Phase 3a: shared __device__ primitives (bf16 rounding, INT4 dequant,
 // WMMA tile, grid_barrier, load_as_float). Lives in

--- a/kernels/qwen36_moe_bridge.cpp
+++ b/kernels/qwen36_moe_bridge.cpp
@@ -15,7 +15,10 @@
 #include "qwen36_moe_persistent/persistent_decode.hip"
 
 #include <cstdlib>
+#include <cstdio>
+#ifndef SUPERSONIC_QWEN36_CUDA_BRIDGE
 #include <hip/hip_runtime.h>
+#endif
 #include <mutex>
 #include <stdint.h>
 
@@ -31,6 +34,10 @@ namespace {
 // shared with the qwen35-4b/Gemma 4 prefill paths) so a single env var
 // disables every WMMA route in the runtime; useful for A/B perf work.
 bool device_supports_wmma_bf16(int device_ordinal) {
+#ifdef SUPERSONIC_QWEN36_CUDA_BRIDGE
+    (void)device_ordinal;
+    return false;
+#else
     static std::once_flag env_once;
     static bool env_disabled = false;
     std::call_once(env_once, [] {
@@ -56,6 +63,7 @@ bool device_supports_wmma_bf16(int device_ordinal) {
         cached[device_ordinal] = probe_arch(device_ordinal);
     });
     return cached[device_ordinal];
+#endif
 }
 
 

--- a/kernels/qwen36_moe_bridge_cuda.cu
+++ b/kernels/qwen36_moe_bridge_cuda.cu
@@ -1,0 +1,3 @@
+#define SUPERSONIC_QWEN36_CUDA_BRIDGE 1
+#include "qwen36_moe_cuda_prelude.cuh"
+#include "qwen36_moe_bridge.cpp"

--- a/kernels/qwen36_moe_cuda_prelude.cuh
+++ b/kernels/qwen36_moe_cuda_prelude.cuh
@@ -4,6 +4,7 @@
 #include <cuda_bf16.h>
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
+#include <cuda/atomic>
 #include <math.h>
 #include <stdint.h>
 #include <string.h>
@@ -26,27 +27,38 @@ using hip_bfloat16 = __nv_bfloat16;
 #define hipDeviceSynchronize cudaDeviceSynchronize
 
 __device__ __forceinline__ unsigned int supersonic_cuda_atomic_load_u32(
-    const unsigned int* ptr,
+    unsigned int* ptr,
     int order) {
-    unsigned int value = *(const volatile unsigned int*)ptr;
-    if (order != __ATOMIC_RELAXED) {
-        __threadfence();
+    cuda::atomic_ref<unsigned int, cuda::thread_scope_device> atom(*ptr);
+    switch (order) {
+        case __ATOMIC_ACQUIRE:
+        case __ATOMIC_ACQ_REL:
+        case __ATOMIC_SEQ_CST:
+            return atom.load(cuda::memory_order_acquire);
+        default:
+            return atom.load(cuda::memory_order_relaxed);
     }
-    return value;
 }
 
 __device__ __forceinline__ void supersonic_cuda_atomic_store_u32(
     unsigned int* ptr,
     unsigned int value,
     int order) {
-    if (order != __ATOMIC_RELAXED) {
-        __threadfence();
+    cuda::atomic_ref<unsigned int, cuda::thread_scope_device> atom(*ptr);
+    switch (order) {
+        case __ATOMIC_RELEASE:
+        case __ATOMIC_ACQ_REL:
+        case __ATOMIC_SEQ_CST:
+            atom.store(value, cuda::memory_order_release);
+            break;
+        default:
+            atom.store(value, cuda::memory_order_relaxed);
+            break;
     }
-    *(volatile unsigned int*)ptr = value;
 }
 
 #define __atomic_load_n(ptr, order) \
-    supersonic_cuda_atomic_load_u32((const unsigned int*)(ptr), (order))
+    supersonic_cuda_atomic_load_u32((unsigned int*)(ptr), (order))
 #define __atomic_store_n(ptr, val, order) \
     supersonic_cuda_atomic_store_u32((unsigned int*)(ptr), (unsigned int)(val), (order))
 

--- a/kernels/qwen36_moe_cuda_prelude.cuh
+++ b/kernels/qwen36_moe_cuda_prelude.cuh
@@ -25,8 +25,30 @@ using hip_bfloat16 = __nv_bfloat16;
 #define hipGetLastError cudaGetLastError
 #define hipDeviceSynchronize cudaDeviceSynchronize
 
-#define __atomic_load_n(ptr, order) (*(volatile unsigned int*)(ptr))
-#define __atomic_store_n(ptr, val, order) (*(volatile unsigned int*)(ptr) = (val))
+__device__ __forceinline__ unsigned int supersonic_cuda_atomic_load_u32(
+    const unsigned int* ptr,
+    int order) {
+    unsigned int value = *(const volatile unsigned int*)ptr;
+    if (order != __ATOMIC_RELAXED) {
+        __threadfence();
+    }
+    return value;
+}
+
+__device__ __forceinline__ void supersonic_cuda_atomic_store_u32(
+    unsigned int* ptr,
+    unsigned int value,
+    int order) {
+    if (order != __ATOMIC_RELAXED) {
+        __threadfence();
+    }
+    *(volatile unsigned int*)ptr = value;
+}
+
+#define __atomic_load_n(ptr, order) \
+    supersonic_cuda_atomic_load_u32((const unsigned int*)(ptr), (order))
+#define __atomic_store_n(ptr, val, order) \
+    supersonic_cuda_atomic_store_u32((unsigned int*)(ptr), (unsigned int)(val), (order))
 
 #ifndef __HIP_PLATFORM_AMD__
 #define __shfl(val, lane) __shfl_sync(0xffffffffu, val, lane)

--- a/kernels/qwen36_moe_cuda_prelude.cuh
+++ b/kernels/qwen36_moe_cuda_prelude.cuh
@@ -1,0 +1,42 @@
+#pragma once
+
+#if defined(SUPERSONIC_QWEN36_CUDA_BRIDGE) || defined(__CUDACC__)
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <math.h>
+#include <stdint.h>
+#include <string.h>
+
+using hip_bfloat16 = __nv_bfloat16;
+
+#define HIP_KERNEL_NAME(...) __VA_ARGS__
+#define hipLaunchKernelGGL(kernel, grid, block, shmem, stream, ...) \
+    kernel<<<grid, block, shmem, stream>>>(__VA_ARGS__)
+
+#define hipSuccess cudaSuccess
+#define hipError_t cudaError_t
+#define hipDeviceProp_t cudaDeviceProp
+#define hipGetDevice cudaGetDevice
+#define hipSetDevice cudaSetDevice
+#define hipGetDeviceProperties cudaGetDeviceProperties
+#define hipMemset cudaMemset
+#define hipMemsetAsync cudaMemsetAsync
+#define hipGetLastError cudaGetLastError
+#define hipDeviceSynchronize cudaDeviceSynchronize
+
+#define __atomic_load_n(ptr, order) (*(volatile unsigned int*)(ptr))
+#define __atomic_store_n(ptr, val, order) (*(volatile unsigned int*)(ptr) = (val))
+
+#ifndef __HIP_PLATFORM_AMD__
+#define __shfl(val, lane) __shfl_sync(0xffffffffu, val, lane)
+#define __shfl_down(val, delta) __shfl_down_sync(0xffffffffu, val, delta)
+#define __shfl_xor(val, lane_mask) __shfl_xor_sync(0xffffffffu, val, lane_mask)
+#endif
+#else
+#include <hip/hip_bf16.h>
+#include <hip/hip_bfloat16.h>
+#include <hip/hip_runtime.h>
+#include <math.h>
+#include <stdint.h>
+#endif

--- a/kernels/qwen36_moe_persistent/helpers.cuh
+++ b/kernels/qwen36_moe_persistent/helpers.cuh
@@ -20,11 +20,7 @@
 
 #pragma once
 
-#include <hip/hip_bf16.h>
-#include <hip/hip_bfloat16.h>
-#include <hip/hip_runtime.h>
-#include <math.h>
-#include <stdint.h>
+#include "../qwen36_moe_cuda_prelude.cuh"
 
 namespace qwen36_moe {
 


### PR DESCRIPTION
## Summary
- build a CUDA bridge for the Qwen3.6-MoE HIP compilation unit via a small CUDA prelude
- route the Qwen3.6 FFI launchers through CUDA as well as HIP
- enable the sm86 Qwen3.6-35B-A3B registry path for INT4 decode and reject unsupported CUDA v1 flag combinations
- keep CUDA v1 on dense BF16 KV and dense MoE buffers; FP8 runtime, KV-FP8, VMM KV, and speculative/MTP remain HIP-only

## Validation
- `SUPERSONIC_BACKENDS=cuda CUDA_ARCH=86 cargo check -p runner --bin supersonic`
- `SUPERSONIC_BACKENDS=cuda CUDA_ARCH=86 cargo test -p kernel-ffi qwen36_moe_int4_dequant_smoke -- --nocapture`
- `SUPERSONIC_BACKENDS=cuda CUDA_ARCH=86 cargo test -p kernel-ffi qwen36_moe_lm_head_matches_host_f32_reference -- --nocapture`
- `SUPERSONIC_BACKENDS=cuda CUDA_ARCH=86 cargo test -p runner cuda_v1 -- --nocapture`
- `git diff --check`
- real CUDA sm86 decode on this box using the release Qwen3.6-35B-A3B INT4 bake: `--prompt Hello --max-new-tokens 1 --context-size 64 --no-download` loaded all 40 layers, used persistent decode, and generated 1 token successfully

## Notes
- The full release bake is larger than the container overlay, so the local validation streamed the split tarball into `/dev/shm` and symlinked the model `.supersonic` directory there. This PR does not change the downloader; that should stay separate from the CUDA runtime wiring.
