### PR TITLE
[codex] server OpenAI compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1212,6 +1212,7 @@ checksum = "805bfd7352166bae857ee569628b52bcd85a1cecf7810861ebceb1686b72b75d"
 dependencies = [
  "memo-map",
  "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1922,6 +1923,7 @@ dependencies = [
  "serde",
  "serde_json",
  "supersonic-runtime",
+ "tokenizers",
  "tokio",
  "tokio-stream",
  "tower",

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ to disable network fetches.
   (model, arch, quant) and runtime-feature impact.
 - **[Build and run](docs/build-and-run.md)** — per-backend build commands
   and the validated `supersonic` invocation set.
+- **[OpenAI-compatible server](docs/server.md)** — `supersonic-serve`
+  endpoints and harness compatibility notes.
 - **[Producing release bakes](docs/bake-distribution.md)** — how to
   produce, sign, and publish bakes for a new model variant.
 - **[Testing](docs/testing.md)** — E2E test runner, prerequisites, and

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -20,9 +20,9 @@ anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokenizers = "0.22"
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
 tracing = "0.1"
 rand = "0.8"
 rand_chacha = "0.3"
-minijinja = { version = "2", features = ["loop_controls"] }
+minijinja = { version = "2", features = ["json", "loop_controls"] }
 minijinja-contrib = { version = "2", features = ["pycompat"] }

--- a/crates/runtime/src/chat_template.rs
+++ b/crates/runtime/src/chat_template.rs
@@ -17,7 +17,42 @@ use serde_json::Value as JsonValue;
 #[derive(Debug, Clone, Serialize)]
 pub struct ChatMessage {
     pub role: String,
-    pub content: String,
+    pub content: JsonValue,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_calls: Option<JsonValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
+}
+
+impl ChatMessage {
+    pub fn text(role: impl Into<String>, content: impl Into<String>) -> Self {
+        Self {
+            role: role.into(),
+            content: JsonValue::String(content.into()),
+            reasoning_content: None,
+            tool_calls: None,
+            tool_call_id: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RenderOptions {
+    pub add_generation_prompt: bool,
+    pub tools: Option<JsonValue>,
+    pub enable_thinking: bool,
+}
+
+impl Default for RenderOptions {
+    fn default() -> Self {
+        Self {
+            add_generation_prompt: true,
+            tools: None,
+            enable_thinking: false,
+        }
+    }
 }
 
 pub struct ChatTemplate {
@@ -27,6 +62,10 @@ pub struct ChatTemplate {
 }
 
 impl ChatTemplate {
+    pub fn from_template_source(tpl_src: impl Into<String>) -> Result<Arc<Self>> {
+        Self::compile(tpl_src.into(), None, None)
+    }
+
     /// Load `{model_dir}/tokenizer_config.json` and compile its
     /// `chat_template` field. Returns `Ok(None)` if the file or field is
     /// missing — the server can still serve `/v1/completions` in that case.
@@ -55,6 +94,17 @@ impl ChatTemplate {
             _ => return Ok(None),
         };
 
+        let bos_token = extract_token(&cfg, "bos_token");
+        let eos_token = extract_token(&cfg, "eos_token");
+
+        Self::compile(tpl_src, bos_token, eos_token).map(Some)
+    }
+
+    fn compile(
+        tpl_src: String,
+        bos_token: Option<String>,
+        eos_token: Option<String>,
+    ) -> Result<Arc<Self>> {
         let mut env = Environment::new();
         // HF chat templates routinely use Python string methods like
         // `.startswith` / `.endswith` / `.strip` that aren't part of the
@@ -65,32 +115,42 @@ impl ChatTemplate {
         env.add_template_owned("chat", tpl_src)
             .with_context(|| "compile chat_template")?;
 
-        let bos_token = extract_token(&cfg, "bos_token");
-        let eos_token = extract_token(&cfg, "eos_token");
-
-        Ok(Some(Arc::new(Self {
+        Ok(Arc::new(Self {
             env,
             bos_token,
             eos_token,
-        })))
+        }))
     }
 
     /// Render the template against a list of messages. Returns the prompt
     /// text to feed into the tokenizer.
     pub fn render(&self, messages: &[ChatMessage], add_generation_prompt: bool) -> Result<String> {
+        self.render_with_options(
+            messages,
+            RenderOptions {
+                add_generation_prompt,
+                ..RenderOptions::default()
+            },
+        )
+    }
+
+    /// Render the template with optional OpenAI-compatible tool definitions
+    /// and model-family thinking controls.
+    pub fn render_with_options(
+        &self,
+        messages: &[ChatMessage],
+        opts: RenderOptions,
+    ) -> Result<String> {
         let tpl = self.env.get_template("chat")?;
-        let msgs: Vec<Value> = messages
-            .iter()
-            .map(|m| {
-                Value::from_serialize(&serde_json::json!({
-                    "role": m.role,
-                    "content": m.content,
-                }))
-            })
-            .collect();
+        let msgs: Vec<Value> = messages.iter().map(Value::from_serialize).collect();
+        let tools = opts.tools.unwrap_or(JsonValue::Null);
         let ctx = context! {
             messages => msgs,
-            add_generation_prompt => add_generation_prompt,
+            add_generation_prompt => opts.add_generation_prompt,
+            tools => Value::from_serialize(&tools),
+            enable_thinking => opts.enable_thinking,
+            preserve_thinking => opts.enable_thinking,
+            add_vision_id => false,
             bos_token => self.bos_token.clone().unwrap_or_default(),
             eos_token => self.eos_token.clone().unwrap_or_default(),
         };
@@ -115,7 +175,13 @@ fn extract_token(cfg: &JsonValue, key: &str) -> Option<String> {
 pub struct IncomingChatMessage {
     pub role: String,
     #[serde(default)]
-    pub content: String,
+    pub content: JsonValue,
+    #[serde(default)]
+    pub reasoning_content: Option<String>,
+    #[serde(default)]
+    pub tool_calls: Option<JsonValue>,
+    #[serde(default)]
+    pub tool_call_id: Option<String>,
 }
 
 impl From<IncomingChatMessage> for ChatMessage {
@@ -123,6 +189,9 @@ impl From<IncomingChatMessage> for ChatMessage {
         Self {
             role: m.role,
             content: m.content,
+            reasoning_content: m.reasoning_content,
+            tool_calls: m.tool_calls,
+            tool_call_id: m.tool_call_id,
         }
     }
 }

--- a/crates/runtime/src/generate.rs
+++ b/crates/runtime/src/generate.rs
@@ -4,11 +4,14 @@
 //! unbounded channel so the HTTP layer can either collect them into one
 //! response or stream them as SSE.
 
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::{anyhow, Result};
 use tokenizers::Tokenizer;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
+use tokio::sync::{OwnedSemaphorePermit, TryAcquireError};
 
 use crate::sampling::{rng_from_seed, sample};
 use crate::session::InferenceSession;
@@ -51,6 +54,31 @@ pub enum GenEvent {
     Error(String),
 }
 
+#[derive(Debug, Clone)]
+pub struct SchedulerSnapshot {
+    pub active: usize,
+    pub queued: usize,
+    pub max_queue: usize,
+    pub queue_timeout_ms: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct MockGeneration {
+    pub chunks: Vec<String>,
+    pub finish: FinishReason,
+    pub delay_ms: u64,
+}
+
+impl MockGeneration {
+    pub fn text(text: impl Into<String>) -> Self {
+        Self {
+            chunks: vec![text.into()],
+            finish: FinishReason::Stop,
+            delay_ms: 0,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub enum FinishReason {
     Stop,
@@ -81,8 +109,18 @@ pub fn prepare(
         .encode(prompt_text, add_special_tokens)
         .map_err(|e| anyhow!("tokenize: {e}"))?;
     let prompt_ids: Vec<u32> = encoding.get_ids().to_vec();
+    prepare_ids(state, prompt_ids, max_tokens)
+}
+
+/// Bounds-check pre-tokenized prompt IDs. This is used by compatibility
+/// routes that accept OpenAI-style token-array prompts.
+pub fn prepare_ids(
+    state: &ServerState,
+    prompt_ids: Vec<u32>,
+    max_tokens: usize,
+) -> Result<Vec<u32>> {
     if prompt_ids.is_empty() {
-        return Err(anyhow!("empty prompt after tokenization"));
+        return Err(anyhow!("empty prompt"));
     }
     // `saturating_add` so a pathological `max_tokens` near `usize::MAX` is
     // rejected here rather than overflowing and bypassing the bound.
@@ -106,14 +144,136 @@ pub fn spawn(
     state: Arc<ServerState>,
     prompt_ids: Vec<u32>,
     params: GenParams,
-) -> UnboundedReceiver<GenEvent> {
+) -> Result<UnboundedReceiver<GenEvent>> {
     let (tx, rx) = mpsc::unbounded_channel();
-    tokio::task::spawn_blocking(move || {
-        if let Err(e) = run(state, prompt_ids, params, tx.clone()) {
+
+    let scheduler = state.scheduler.clone();
+    match scheduler.permits.clone().try_acquire_owned() {
+        Ok(permit) => {
+            tokio::spawn(run_with_permit(
+                scheduler, state, prompt_ids, params, tx, permit,
+            ));
+            return Ok(rx);
+        }
+        Err(TryAcquireError::Closed) => {
+            return Err(anyhow!("generation scheduler closed"));
+        }
+        Err(TryAcquireError::NoPermits) => {}
+    }
+
+    let queued = scheduler.queued.fetch_add(1, Ordering::SeqCst) + 1;
+    if queued > scheduler.max_queue {
+        scheduler.queued.fetch_sub(1, Ordering::SeqCst);
+        return Err(anyhow!(
+            "generation queue full (queued={}, max_queue={})",
+            queued - 1,
+            scheduler.max_queue
+        ));
+    }
+
+    tokio::spawn(async move {
+        let acquire = scheduler.permits.clone().acquire_owned();
+        let timeout = tokio::time::sleep(Duration::from_millis(scheduler.queue_timeout_ms));
+        tokio::pin!(timeout);
+        let permit = tokio::select! {
+            permit = acquire => match permit {
+                Ok(permit) => permit,
+                Err(_) => {
+                    scheduler.queued.fetch_sub(1, Ordering::SeqCst);
+                    let _ = tx.send(GenEvent::Error("generation scheduler closed".to_string()));
+                    return;
+                }
+            },
+            _ = &mut timeout => {
+                scheduler.queued.fetch_sub(1, Ordering::SeqCst);
+                let _ = tx.send(GenEvent::Error("generation queue timeout".to_string()));
+                return;
+            },
+            _ = tx.closed() => {
+                scheduler.queued.fetch_sub(1, Ordering::SeqCst);
+                return;
+            }
+        };
+        scheduler.queued.fetch_sub(1, Ordering::SeqCst);
+        run_with_permit(scheduler, state, prompt_ids, params, tx, permit).await;
+    });
+    Ok(rx)
+}
+
+async fn run_with_permit(
+    scheduler: Arc<crate::state::GenerationScheduler>,
+    state: Arc<ServerState>,
+    prompt_ids: Vec<u32>,
+    params: GenParams,
+    tx: UnboundedSender<GenEvent>,
+    permit: OwnedSemaphorePermit,
+) {
+    if tx.is_closed() {
+        drop(permit);
+        return;
+    }
+    scheduler.active.fetch_add(1, Ordering::SeqCst);
+
+    if let Some(mock) = state.mock_generation.clone() {
+        run_mock(mock, &prompt_ids, &params, &tx).await;
+        scheduler.active.fetch_sub(1, Ordering::SeqCst);
+        drop(permit);
+        return;
+    }
+
+    let scheduler_done = scheduler.clone();
+    let join = tokio::task::spawn_blocking(move || {
+        let result = run(state, prompt_ids, params, tx.clone());
+        if let Err(e) = result {
             let _ = tx.send(GenEvent::Error(e.to_string()));
         }
+    })
+    .await;
+    if let Err(e) = join {
+        tracing::error!("generation worker join error: {e}");
+    }
+    scheduler_done.active.fetch_sub(1, Ordering::SeqCst);
+    drop(permit);
+}
+
+pub fn scheduler_snapshot(state: &ServerState) -> SchedulerSnapshot {
+    SchedulerSnapshot {
+        active: state.scheduler.active.load(Ordering::SeqCst),
+        queued: state.scheduler.queued.load(Ordering::SeqCst),
+        max_queue: state.scheduler.max_queue,
+        queue_timeout_ms: state.scheduler.queue_timeout_ms,
+    }
+}
+
+async fn run_mock(
+    mock: MockGeneration,
+    prompt_ids: &[u32],
+    params: &GenParams,
+    tx: &UnboundedSender<GenEvent>,
+) {
+    for chunk in &mock.chunks {
+        if tx.is_closed() || tx.send(GenEvent::Token(chunk.clone())).is_err() {
+            return;
+        }
+        if mock.delay_ms > 0 {
+            tokio::time::sleep(Duration::from_millis(mock.delay_ms)).await;
+        }
+        tokio::task::yield_now().await;
+    }
+    let completion_tokens = mock.chunks.iter().filter(|s| !s.is_empty()).count() as u32;
+    let _ = tx.send(GenEvent::Done {
+        reason: if params.max_tokens == 0 {
+            FinishReason::Length
+        } else {
+            mock.finish
+        },
+        prompt_tokens: prompt_ids.len() as u32,
+        completion_tokens: if params.max_tokens == 0 {
+            0
+        } else {
+            completion_tokens
+        },
     });
-    rx
 }
 
 fn run(
@@ -136,7 +296,11 @@ fn run(
         return Ok(());
     }
 
-    let mut guard = state.session.blocking_lock();
+    let session = state
+        .session
+        .as_ref()
+        .ok_or_else(|| anyhow!("no inference session configured"))?;
+    let mut guard = session.blocking_lock();
     guard.reset()?;
     let prefill_logits = guard.prefill(&prompt_ids)?;
 

--- a/crates/runtime/src/state.rs
+++ b/crates/runtime/src/state.rs
@@ -5,9 +5,10 @@
 
 use anyhow::{anyhow, bail, Result};
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 use tokenizers::Tokenizer;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, Semaphore};
 
 use supersonic_core::registry::{self, Backend, GpuArch, ModelFamily, ModelVariant};
 
@@ -15,21 +16,49 @@ use crate::backend_resolver::resolve_backend;
 use crate::bakes::ensure_hf_metadata_present;
 use crate::builders::{build_gemma4, build_qwen};
 use crate::chat_template::ChatTemplate;
+use crate::generate::MockGeneration;
 use crate::session::InferenceSession;
 use supersonic_core::capabilities::{capabilities_for_variant, ModelCapabilities};
+
+static NEXT_SERVER_INSTANCE_ID: AtomicU64 = AtomicU64::new(1);
 
 /// Per-process state shared across every HTTP request. Everything here is
 /// built once at startup.
 pub struct ServerState {
+    pub server_instance_id: u64,
     pub model_id: String,
     pub model_family: ModelFamily,
     pub tokenizer: Arc<Tokenizer>,
     pub chat_template: Option<Arc<ChatTemplate>>,
-    pub session: Arc<Mutex<InferenceSession>>,
+    pub session: Option<Arc<Mutex<InferenceSession>>>,
+    pub mock_generation: Option<MockGeneration>,
     pub eos_ids: Vec<u32>,
     pub max_context: usize,
     pub api_key: Option<String>,
+    pub cors_allow_origin: Option<String>,
+    pub response_store_max_entries: usize,
+    pub scheduler: Arc<GenerationScheduler>,
     pub capabilities: ModelCapabilities,
+}
+
+pub struct GenerationScheduler {
+    pub permits: Arc<Semaphore>,
+    pub active: AtomicUsize,
+    pub queued: AtomicUsize,
+    pub max_queue: usize,
+    pub queue_timeout_ms: u64,
+}
+
+impl GenerationScheduler {
+    pub fn new(max_queue: usize, queue_timeout_ms: u64) -> Self {
+        Self {
+            permits: Arc::new(Semaphore::new(1)),
+            active: AtomicUsize::new(0),
+            queued: AtomicUsize::new(0),
+            max_queue,
+            queue_timeout_ms,
+        }
+    }
 }
 
 /// Arguments captured from the CLI and forwarded into the loader.
@@ -45,6 +74,10 @@ pub struct LoaderConfig {
     pub fp8_runtime: bool,
     pub kv_fp8: bool,
     pub api_key: Option<String>,
+    pub cors_allow_origin: Option<String>,
+    pub response_store_max_entries: usize,
+    pub max_queued_requests: usize,
+    pub queue_timeout_ms: u64,
     /// Disable automatic bake download from the GitHub release. Air-gapped
     /// or reproducibility-focused deploys should set this.
     pub no_download: bool,
@@ -147,14 +180,22 @@ pub fn build(cfg: LoaderConfig) -> Result<ServerState> {
     );
 
     Ok(ServerState {
+        server_instance_id: NEXT_SERVER_INSTANCE_ID.fetch_add(1, Ordering::Relaxed),
         model_id: variant.to_string(),
         model_family: variant.family(),
         tokenizer: Arc::new(tokenizer),
         chat_template,
-        session: Arc::new(Mutex::new(session)),
+        session: Some(Arc::new(Mutex::new(session))),
+        mock_generation: None,
         eos_ids,
         max_context,
         api_key: cfg.api_key,
+        cors_allow_origin: cfg.cors_allow_origin,
+        response_store_max_entries: cfg.response_store_max_entries,
+        scheduler: Arc::new(GenerationScheduler::new(
+            cfg.max_queued_requests,
+            cfg.queue_timeout_ms,
+        )),
         capabilities,
     })
 }
@@ -234,6 +275,10 @@ mod tests {
             fp8_runtime: false,
             kv_fp8: false,
             api_key: None,
+            cors_allow_origin: None,
+            response_store_max_entries: 1024,
+            max_queued_requests: 32,
+            queue_timeout_ms: 30_000,
             no_download: true,
         }
     }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -18,7 +18,7 @@ serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal", "sync"] }
 axum = "0.7"
 tower = "0.5"
-tower-http = { version = "0.5", features = ["trace"] }
+tower-http = { version = "0.5", features = ["cors", "trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 futures = "0.3"
@@ -27,3 +27,4 @@ async-stream = "0.3"
 [dev-dependencies]
 reqwest = { version = "0.12", features = ["json", "stream"] }
 tokio-stream = "0.1"
+tokenizers = "0.22"

--- a/crates/server/src/compat.rs
+++ b/crates/server/src/compat.rs
@@ -1,0 +1,36 @@
+use crate::errors::ApiError;
+
+pub fn validate_model(request_model: Option<&str>, loaded_model: &str) -> Result<(), ApiError> {
+    let Some(model) = request_model else {
+        return Ok(());
+    };
+    let model = model.trim();
+    if model.is_empty()
+        || model == loaded_model
+        || matches!(model, "default" | "local" | "supersonic" | "any")
+    {
+        return Ok(());
+    }
+    Err(ApiError::bad_request(format!(
+        "requested model '{model}' does not match loaded model '{loaded_model}'"
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_loaded_model_and_local_aliases() {
+        validate_model(Some("qwen3.5-0.8b"), "qwen3.5-0.8b").unwrap();
+        validate_model(Some("local"), "qwen3.5-0.8b").unwrap();
+        validate_model(Some("any"), "qwen3.5-0.8b").unwrap();
+        validate_model(None, "qwen3.5-0.8b").unwrap();
+    }
+
+    #[test]
+    fn rejects_unrelated_model() {
+        let err = validate_model(Some("gpt-4.1"), "qwen3.5-0.8b").expect_err("model mismatch");
+        assert!(err.body.message.contains("does not match"));
+    }
+}

--- a/crates/server/src/errors.rs
+++ b/crates/server/src/errors.rs
@@ -52,6 +52,30 @@ impl ApiError {
         }
     }
 
+    pub fn too_many_requests(msg: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::TOO_MANY_REQUESTS,
+            body: ApiErrorBody {
+                message: msg.into(),
+                type_: "rate_limit_error".into(),
+                param: None,
+                code: None,
+            },
+        }
+    }
+
+    pub fn unavailable(msg: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            body: ApiErrorBody {
+                message: msg.into(),
+                type_: "server_error".into(),
+                param: None,
+                code: None,
+            },
+        }
+    }
+
     pub fn internal(msg: impl Into<String>) -> Self {
         Self {
             status: StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -1,7 +1,9 @@
 //! SuperSonic HTTP server — an OpenAI-compatible inference endpoint
 //! wrapping the shared `supersonic-runtime` crate.
 
+pub mod compat;
 pub mod errors;
+pub mod output;
 pub mod routes;
 pub mod schemas;
 

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -71,6 +71,30 @@ struct Cli {
     #[arg(long, env = "SUPERSONIC_API_KEY")]
     api_key: Option<String>,
 
+    /// Optional CORS allow-origin value for browser clients, e.g.
+    /// `http://localhost:3000` or `*`. Also read from
+    /// `SUPERSONIC_CORS_ALLOW_ORIGIN`.
+    #[arg(long, env = "SUPERSONIC_CORS_ALLOW_ORIGIN")]
+    cors_allow_origin: Option<String>,
+
+    /// Maximum number of `/v1/responses` objects retained in memory.
+    #[arg(
+        long,
+        env = "SUPERSONIC_RESPONSE_STORE_MAX_ENTRIES",
+        default_value_t = 1024
+    )]
+    response_store_max_entries: usize,
+
+    /// Maximum number of requests allowed to wait for the single GPU
+    /// generation slot before new requests receive 429.
+    #[arg(long, env = "SUPERSONIC_MAX_QUEUED_REQUESTS", default_value_t = 32)]
+    max_queued_requests: usize,
+
+    /// Maximum time a request may wait in the generation queue before it
+    /// fails. Also read from `SUPERSONIC_QUEUE_TIMEOUT_MS`.
+    #[arg(long, env = "SUPERSONIC_QUEUE_TIMEOUT_MS", default_value_t = 30_000)]
+    queue_timeout_ms: u64,
+
     /// Disable automatic download of pre-baked weights from the GitHub
     /// `bakes-v{FORMAT_VERSION}` release. With this set, a missing INT4 bake
     /// produces a hard error instead of a fetch.
@@ -99,6 +123,10 @@ fn main() -> Result<()> {
         fp8_runtime: cli.fp8_runtime,
         kv_fp8: cli.kv_fp8,
         api_key: cli.api_key,
+        cors_allow_origin: cli.cors_allow_origin,
+        response_store_max_entries: cli.response_store_max_entries,
+        max_queued_requests: cli.max_queued_requests,
+        queue_timeout_ms: cli.queue_timeout_ms,
         no_download: cli.no_download,
     };
 

--- a/crates/server/src/output.rs
+++ b/crates/server/src/output.rs
@@ -1,0 +1,116 @@
+use serde_json::{Map, Value};
+
+use crate::schemas::{OpenAiFunctionCall, OpenAiToolCall};
+
+#[derive(Debug, Clone, Default)]
+pub struct AssistantOutput {
+    pub content: String,
+    pub reasoning_content: Option<String>,
+    pub tool_calls: Option<Vec<OpenAiToolCall>>,
+}
+
+pub fn parse_assistant_output(raw: &str) -> AssistantOutput {
+    let (without_reasoning, reasoning) = strip_think(raw);
+    let (content, tool_calls) = extract_tool_calls(&without_reasoning);
+    AssistantOutput {
+        content: content.trim_start().to_string(),
+        reasoning_content: reasoning.filter(|s| !s.trim().is_empty()),
+        tool_calls: (!tool_calls.is_empty()).then_some(tool_calls),
+    }
+}
+
+pub fn strip_think(raw: &str) -> (String, Option<String>) {
+    let Some(start) = raw.find("<think>") else {
+        return (raw.to_string(), None);
+    };
+    let body_start = start + "<think>".len();
+    let Some(end_rel) = raw[body_start..].find("</think>") else {
+        return (raw.to_string(), None);
+    };
+    let end = body_start + end_rel;
+    let mut visible = String::new();
+    visible.push_str(&raw[..start]);
+    visible.push_str(&raw[end + "</think>".len()..]);
+    (visible, Some(raw[body_start..end].trim().to_string()))
+}
+
+fn extract_tool_calls(raw: &str) -> (String, Vec<OpenAiToolCall>) {
+    let mut rest = raw;
+    let mut visible = String::new();
+    let mut calls = Vec::new();
+    while let Some(start) = rest.find("<tool_call>") {
+        visible.push_str(&rest[..start]);
+        let after_start = &rest[start + "<tool_call>".len()..];
+        let Some(end) = after_start.find("</tool_call>") else {
+            visible.push_str(&rest[start..]);
+            return (visible, calls);
+        };
+        let block = &after_start[..end];
+        if let Some(call) = parse_tool_call_block(block, calls.len()) {
+            calls.push(call);
+        } else {
+            visible.push_str("<tool_call>");
+            visible.push_str(block);
+            visible.push_str("</tool_call>");
+        }
+        rest = &after_start[end + "</tool_call>".len()..];
+    }
+    visible.push_str(rest);
+    (visible, calls)
+}
+
+fn parse_tool_call_block(block: &str, index: usize) -> Option<OpenAiToolCall> {
+    let function_start = block.find("<function=")?;
+    let name_start = function_start + "<function=".len();
+    let name_end = block[name_start..].find('>')? + name_start;
+    let name = block[name_start..name_end].trim().to_string();
+    let close = "</function>";
+    let body_start = name_end + 1;
+    let body_end = block[body_start..].find(close)? + body_start;
+    let body = &block[body_start..body_end];
+
+    let mut args = Map::new();
+    let mut rest = body;
+    while let Some(param_start) = rest.find("<parameter=") {
+        let key_start = param_start + "<parameter=".len();
+        let key_end = rest[key_start..].find('>')? + key_start;
+        let key = rest[key_start..key_end].trim().to_string();
+        let val_start = key_end + 1;
+        let val_end = rest[val_start..].find("</parameter>")? + val_start;
+        let raw_val = rest[val_start..val_end].trim();
+        let value =
+            serde_json::from_str(raw_val).unwrap_or_else(|_| Value::String(raw_val.to_string()));
+        args.insert(key, value);
+        rest = &rest[val_end + "</parameter>".len()..];
+    }
+
+    Some(OpenAiToolCall {
+        id: format!("call_{index:04x}"),
+        type_: "function",
+        function: OpenAiFunctionCall {
+            name,
+            arguments: Value::Object(args).to_string(),
+        },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_reasoning_and_keeps_content() {
+        let out = parse_assistant_output("<think>\nwork\n</think>\n\nanswer");
+        assert_eq!(out.reasoning_content.as_deref(), Some("work"));
+        assert_eq!(out.content.trim(), "answer");
+    }
+
+    #[test]
+    fn parses_qwen_xml_tool_call() {
+        let raw = "<tool_call>\n<function=lookup>\n<parameter=query>\nweather\n</parameter>\n</function>\n</tool_call>";
+        let out = parse_assistant_output(raw);
+        let calls = out.tool_calls.expect("tool calls");
+        assert_eq!(calls[0].function.name, "lookup");
+        assert_eq!(calls[0].function.arguments, "{\"query\":\"weather\"}");
+    }
+}

--- a/crates/server/src/routes/chat.rs
+++ b/crates/server/src/routes/chat.rs
@@ -3,17 +3,20 @@
 use std::sync::Arc;
 
 use axum::extract::State;
-use axum::response::sse::{KeepAlive, Sse};
+use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::response::{IntoResponse, Response};
 use axum::Json;
 use futures::stream::{self, Stream};
 use futures::StreamExt;
+use serde_json::{json, Value};
 
 use super::sse;
-use crate::chat_template::ChatMessage;
+use crate::chat_template::{ChatMessage, IncomingChatMessage, RenderOptions};
+use crate::compat::validate_model;
 use crate::errors::ApiError;
 use crate::generate::{self, GenParams};
 use crate::ids;
+use crate::output::{parse_assistant_output, AssistantOutput};
 use crate::schemas::{
     ChatCompletionChoice, ChatCompletionMessage, ChatCompletionRequest, ChatCompletionResponse,
     ChatStreamChoice, ChatStreamChunk, ChatStreamDelta, Usage,
@@ -32,26 +35,41 @@ pub async fn completions(
     if req.messages.is_empty() {
         return Err(ApiError::bad_request("messages must not be empty"));
     }
+    validate_model(req.model.as_deref(), &state.model_id)?;
+    validate_unsupported(&req)?;
 
-    let messages: Vec<ChatMessage> = req.messages.into_iter().map(Into::into).collect();
+    let include_usage = req
+        .stream_options
+        .as_ref()
+        .map(|o| o.include_usage)
+        .unwrap_or(false);
+    let max_tokens = req.max_tokens.unwrap_or(256);
+    let enable_thinking = reasoning_enabled(req.reasoning_effort.as_deref());
+    let mut messages = normalize_messages(req.messages)?;
+    apply_response_format_hint(
+        &mut messages,
+        response_format_json_object(req.response_format.as_ref())?,
+    );
     let prompt_text = template
-        .render(&messages, true)
+        .render_with_options(
+            &messages,
+            RenderOptions {
+                add_generation_prompt: true,
+                tools: req.tools.clone(),
+                enable_thinking,
+            },
+        )
         .map_err(|e| ApiError::bad_request(format!("chat template render failed: {e}")))?;
 
     let params = GenParams {
         temperature: req.temperature.unwrap_or(1.0),
         top_p: req.top_p.unwrap_or(1.0),
-        max_tokens: req.max_tokens.unwrap_or(256),
+        max_tokens,
         stop: req.stop.map(|s| s.into_vec()).unwrap_or_default(),
         seed: req.seed,
     };
 
-    // Chat templates typically emit their own BOS; avoid doubling it up.
-    let add_special_tokens = false;
-
-    // Tokenize + bounds-check synchronously so setup failures become
-    // structured HTTP errors (400), not in-band SSE error events.
-    let prompt_ids = generate::prepare(&state, &prompt_text, add_special_tokens, params.max_tokens)
+    let prompt_ids = generate::prepare(&state, &prompt_text, false, params.max_tokens)
         .map_err(|e| ApiError::bad_request(e.to_string()))?;
 
     let id = ids::chat_completion_id();
@@ -59,16 +77,15 @@ pub async fn completions(
     let model = state.model_id.clone();
 
     if req.stream {
-        let rx = generate::spawn(state.clone(), prompt_ids, params);
-        let stream = chat_sse_stream(rx, id, created, model);
+        let rx = generate::spawn(state.clone(), prompt_ids, params).map_err(queue_error)?;
+        let stream = chat_sse_stream(rx, id, created, model, include_usage);
         Ok(Sse::new(stream)
             .keep_alive(KeepAlive::default())
             .into_response())
     } else {
-        let rx = generate::spawn(state.clone(), prompt_ids, params);
-        let result = generate::collect(rx)
-            .await
-            .map_err(|e| ApiError::internal(format!("generation failed: {e}")))?;
+        let rx = generate::spawn(state.clone(), prompt_ids, params).map_err(queue_error)?;
+        let result = generate::collect(rx).await.map_err(generation_error)?;
+        let parsed = parse_assistant_output(&result.text);
         let resp = ChatCompletionResponse {
             id,
             object: "chat.completion",
@@ -76,11 +93,13 @@ pub async fn completions(
             model,
             choices: vec![ChatCompletionChoice {
                 index: 0,
+                finish_reason: finish_reason(result.finish.as_str(), &parsed),
                 message: ChatCompletionMessage {
                     role: "assistant",
-                    content: result.text,
+                    content: message_content(&parsed),
+                    reasoning_content: parsed.reasoning_content,
+                    tool_calls: parsed.tool_calls,
                 },
-                finish_reason: result.finish.as_str(),
             }],
             usage: Usage {
                 prompt_tokens: result.prompt_tokens,
@@ -92,11 +111,30 @@ pub async fn completions(
     }
 }
 
+pub(crate) fn queue_error(err: anyhow::Error) -> ApiError {
+    let msg = err.to_string();
+    if msg.contains("generation queue full") {
+        ApiError::too_many_requests(msg)
+    } else {
+        ApiError::internal(msg)
+    }
+}
+
+pub(crate) fn generation_error(err: anyhow::Error) -> ApiError {
+    let msg = err.to_string();
+    if msg.contains("generation queue timeout") || msg.contains("generation scheduler closed") {
+        ApiError::unavailable(format!("generation failed: {msg}"))
+    } else {
+        ApiError::internal(format!("generation failed: {msg}"))
+    }
+}
+
 fn chat_sse_stream(
     rx: tokio::sync::mpsc::UnboundedReceiver<generate::GenEvent>,
     id: String,
     created: u64,
     model: String,
+    include_usage: bool,
 ) -> impl Stream<Item = sse::SseEvent> {
     let role_chunk = ChatStreamChunk {
         id: id.clone(),
@@ -108,45 +146,485 @@ fn chat_sse_stream(
             delta: ChatStreamDelta {
                 role: Some("assistant"),
                 content: None,
+                reasoning_content: None,
+                tool_calls: None,
             },
             finish_reason: None,
         }],
+        usage: None,
     };
     let role_event = sse::json_event(&role_chunk);
-
-    let token_id = id.clone();
-    let token_model = model.clone();
-    let body = sse::generation_events(
-        rx,
-        move |text| ChatStreamChunk {
-            id: token_id.clone(),
-            object: "chat.completion.chunk",
-            created,
-            model: token_model.clone(),
-            choices: vec![ChatStreamChoice {
-                index: 0,
-                delta: ChatStreamDelta {
-                    role: None,
-                    content: Some(text),
-                },
-                finish_reason: None,
-            }],
-        },
-        move |reason| ChatStreamChunk {
-            id: id.clone(),
-            object: "chat.completion.chunk",
-            created,
-            model: model.clone(),
-            choices: vec![ChatStreamChoice {
-                index: 0,
-                delta: ChatStreamDelta {
-                    role: None,
-                    content: None,
-                },
-                finish_reason: Some(reason.as_str()),
-            }],
-        },
-    );
-
+    let body = parsed_chat_events(rx, id.clone(), model.clone(), created, include_usage);
     stream::once(async move { Ok(role_event) }).chain(body)
+}
+
+fn parsed_chat_events(
+    mut rx: tokio::sync::mpsc::UnboundedReceiver<generate::GenEvent>,
+    id: String,
+    model: String,
+    created: u64,
+    include_usage: bool,
+) -> impl Stream<Item = sse::SseEvent> {
+    async_stream::stream! {
+        let mut raw = String::new();
+        let mut emitted_content = String::new();
+        let mut emitted_reasoning = String::new();
+        while let Some(ev) = rx.recv().await {
+            match ev {
+                generate::GenEvent::Token(text) => {
+                    raw.push_str(&text);
+                    if has_incomplete_control_block(&raw) {
+                        continue;
+                    }
+                    let parsed = parse_assistant_output(&raw);
+                    if let Some(reasoning) = parsed.reasoning_content.as_ref() {
+                        if let Some(delta) = reasoning.strip_prefix(&emitted_reasoning) {
+                            if !delta.is_empty() {
+                                emitted_reasoning = reasoning.clone();
+                                yield Ok(sse::json_event(&chat_chunk(
+                                    &id,
+                                    &model,
+                                    created,
+                                    ChatStreamDelta {
+                                        role: None,
+                                        content: None,
+                                        reasoning_content: Some(delta.to_string()),
+                                        tool_calls: None,
+                                    },
+                                    None,
+                                    None,
+                                )));
+                            }
+                        }
+                    }
+                    if let Some(delta) = parsed.content.strip_prefix(&emitted_content) {
+                        if !delta.is_empty() {
+                            emitted_content = parsed.content.clone();
+                            yield Ok(sse::json_event(&chat_chunk(
+                                &id,
+                                &model,
+                                created,
+                                ChatStreamDelta {
+                                    role: None,
+                                    content: Some(delta.to_string()),
+                                    reasoning_content: None,
+                                    tool_calls: None,
+                                },
+                                None,
+                                None,
+                            )));
+                        }
+                    }
+                }
+                generate::GenEvent::Done { reason, prompt_tokens, completion_tokens } => {
+                    let parsed = parse_assistant_output(&raw);
+                    let done_reason = finish_reason(reason.as_str(), &parsed);
+                    yield Ok(sse::json_event(&chat_chunk(
+                        &id,
+                        &model,
+                        created,
+                        ChatStreamDelta {
+                            role: None,
+                            content: None,
+                            reasoning_content: None,
+                            tool_calls: parsed.tool_calls,
+                        },
+                        Some(done_reason),
+                        None,
+                    )));
+                    if include_usage {
+                        yield Ok(sse::json_event(&ChatStreamChunk {
+                            id: id.clone(),
+                            object: "chat.completion.chunk",
+                            created,
+                            model: model.clone(),
+                            choices: Vec::new(),
+                            usage: Some(Usage {
+                                prompt_tokens,
+                                completion_tokens,
+                                total_tokens: prompt_tokens + completion_tokens,
+                            }),
+                        }));
+                    }
+                    yield Ok(Event::default().data("[DONE]"));
+                    return;
+                }
+                generate::GenEvent::Error(msg) => {
+                    let payload = json!({ "error": { "message": msg, "type": "internal_error" } });
+                    yield Ok(Event::default().data(payload.to_string()));
+                    return;
+                }
+            }
+        }
+    }
+}
+
+fn chat_chunk(
+    id: &str,
+    model: &str,
+    created: u64,
+    delta: ChatStreamDelta,
+    finish_reason: Option<&'static str>,
+    usage: Option<Usage>,
+) -> ChatStreamChunk {
+    ChatStreamChunk {
+        id: id.to_string(),
+        object: "chat.completion.chunk",
+        created,
+        model: model.to_string(),
+        choices: vec![ChatStreamChoice {
+            index: 0,
+            delta,
+            finish_reason,
+        }],
+        usage,
+    }
+}
+
+fn finish_reason(default: &'static str, parsed: &AssistantOutput) -> &'static str {
+    if parsed.tool_calls.is_some() {
+        "tool_calls"
+    } else {
+        default
+    }
+}
+
+fn message_content(parsed: &AssistantOutput) -> Option<String> {
+    if parsed.tool_calls.is_some() && parsed.content.trim().is_empty() {
+        None
+    } else {
+        Some(parsed.content.clone())
+    }
+}
+
+fn validate_unsupported(req: &ChatCompletionRequest) -> Result<(), ApiError> {
+    if req.n.unwrap_or(1) != 1 {
+        return Err(ApiError::bad_request("n>1 is not supported"));
+    }
+    if req.logprobs.unwrap_or(false) {
+        return Err(ApiError::bad_request("logprobs=true is not supported"));
+    }
+    if matches!(req.tool_choice.as_ref(), Some(Value::String(s)) if s == "required") {
+        return Err(ApiError::bad_request(
+            "tool_choice=required is not supported",
+        ));
+    }
+    validate_tools(req.tools.as_ref())?;
+    response_format_json_object(req.response_format.as_ref())?;
+    Ok(())
+}
+
+pub(crate) fn validate_tools(tools: Option<&Value>) -> Result<(), ApiError> {
+    let Some(tools) = tools else {
+        return Ok(());
+    };
+    let Value::Array(items) = tools else {
+        return Err(ApiError::bad_request("tools must be an array"));
+    };
+    for item in items {
+        let typ = item.get("type").and_then(Value::as_str).unwrap_or("");
+        if typ != "function" {
+            return Err(ApiError::bad_request(format!(
+                "unsupported tool type: {typ}"
+            )));
+        }
+        if item.get("function").and_then(|f| f.get("name")).is_none() {
+            return Err(ApiError::bad_request("function tool missing function.name"));
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn reasoning_enabled(value: Option<&str>) -> bool {
+    matches!(
+        value.map(|s| s.to_ascii_lowercase()),
+        Some(v) if !matches!(v.as_str(), "none" | "off" | "false" | "disabled")
+    )
+}
+
+pub(crate) fn response_format_json_object(format: Option<&Value>) -> Result<bool, ApiError> {
+    let Some(format) = format else {
+        return Ok(false);
+    };
+    if format.is_null() {
+        return Ok(false);
+    }
+    if let Some(s) = format.as_str() {
+        return match s {
+            "text" => Ok(false),
+            "json_object" => Ok(true),
+            "json_schema" => Err(ApiError::bad_request(
+                "response_format=json_schema is not supported",
+            )),
+            other => Err(ApiError::bad_request(format!(
+                "unsupported response_format: {other}"
+            ))),
+        };
+    }
+    let typ = format
+        .get("type")
+        .or_else(|| format.get("format").and_then(|f| f.get("type")))
+        .and_then(Value::as_str)
+        .unwrap_or("text");
+    match typ {
+        "text" => Ok(false),
+        "json_object" => Ok(true),
+        "json_schema" => Err(ApiError::bad_request(
+            "response_format=json_schema is not supported",
+        )),
+        other => Err(ApiError::bad_request(format!(
+            "unsupported response_format type: {other}"
+        ))),
+    }
+}
+
+pub(crate) fn apply_response_format_hint(messages: &mut Vec<ChatMessage>, json_object: bool) {
+    if !json_object {
+        return;
+    }
+    const HINT: &str = "Return a valid JSON object.";
+    if let Some(first) = messages.first_mut() {
+        if first.role == "system" {
+            let content = content_to_text(&first.content).unwrap_or_default();
+            first.content = Value::String(if content.trim().is_empty() {
+                HINT.to_string()
+            } else {
+                format!("{content}\n\n{HINT}")
+            });
+            return;
+        }
+    }
+    messages.insert(0, ChatMessage::text("system", HINT));
+}
+
+pub(crate) fn has_incomplete_control_block(raw: &str) -> bool {
+    (raw.contains("<think>") && !raw.contains("</think>"))
+        || (raw.contains("<tool_call>") && !raw.contains("</tool_call>"))
+}
+
+pub(crate) fn normalize_messages(
+    messages: Vec<IncomingChatMessage>,
+) -> Result<Vec<ChatMessage>, ApiError> {
+    let mut out = Vec::new();
+    for msg in messages {
+        let mut role = msg.role.to_ascii_lowercase();
+        if role == "developer" {
+            role = "system".to_string();
+        } else if role == "function" {
+            role = "tool".to_string();
+        }
+        let content = content_to_text(&msg.content)?;
+        out.push(ChatMessage {
+            role,
+            content: Value::String(content),
+            reasoning_content: msg.reasoning_content,
+            tool_calls: normalize_tool_calls_for_template(msg.tool_calls),
+            tool_call_id: msg.tool_call_id,
+        });
+    }
+    Ok(out)
+}
+
+pub(crate) fn normalize_tool_calls_for_template(tool_calls: Option<Value>) -> Option<Value> {
+    let mut calls = tool_calls?;
+    let Value::Array(items) = &mut calls else {
+        return Some(calls);
+    };
+    for item in items {
+        let Some(args) = item
+            .get_mut("function")
+            .and_then(|f| f.get_mut("arguments"))
+        else {
+            continue;
+        };
+        if let Some(s) = args.as_str() {
+            if let Ok(parsed) = serde_json::from_str::<Value>(s) {
+                *args = parsed;
+            }
+        }
+    }
+    Some(calls)
+}
+
+pub(crate) fn content_to_text(value: &Value) -> Result<String, ApiError> {
+    match value {
+        Value::Null => Ok(String::new()),
+        Value::String(s) => Ok(s.clone()),
+        Value::Array(items) => {
+            let mut out = String::new();
+            for item in items {
+                let typ = item.get("type").and_then(Value::as_str).unwrap_or("");
+                match typ {
+                    "text" | "input_text" | "output_text" => {
+                        if let Some(text) = item.get("text").and_then(Value::as_str) {
+                            out.push_str(text);
+                        }
+                    }
+                    "image" | "image_url" | "input_image" | "file" | "input_file" => {
+                        return Err(ApiError::bad_request(format!(
+                            "unsupported_content_type: {typ}"
+                        )));
+                    }
+                    _ if item.get("text").is_some() => {
+                        if let Some(text) = item.get("text").and_then(Value::as_str) {
+                            out.push_str(text);
+                        }
+                    }
+                    _ => {
+                        return Err(ApiError::bad_request(format!(
+                            "unsupported_content_type: {typ}"
+                        )));
+                    }
+                }
+            }
+            Ok(out)
+        }
+        _ => Err(ApiError::bad_request(
+            "message content must be a string or text content array",
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn text_content_parts_are_joined() {
+        let text = content_to_text(&json!([
+            {"type": "text", "text": "hello "},
+            {"type": "input_text", "text": "world"}
+        ]))
+        .unwrap();
+        assert_eq!(text, "hello world");
+    }
+
+    #[test]
+    fn image_content_parts_are_rejected() {
+        let err = content_to_text(&json!([
+            {"type": "input_image", "image_url": "data:"}
+        ]))
+        .expect_err("expected unsupported image");
+        assert!(err.body.message.contains("unsupported_content_type"));
+    }
+
+    #[test]
+    fn developer_messages_are_normalized_to_system() {
+        let messages = vec![
+            IncomingChatMessage {
+                role: "developer".to_string(),
+                content: json!("follow policy"),
+                reasoning_content: None,
+                tool_calls: None,
+                tool_call_id: None,
+            },
+            IncomingChatMessage {
+                role: "user".to_string(),
+                content: json!("hi"),
+                reasoning_content: None,
+                tool_calls: None,
+                tool_call_id: None,
+            },
+        ];
+        let out = normalize_messages(messages).unwrap();
+        assert_eq!(out[0].role, "system");
+        assert_eq!(out[1].role, "user");
+    }
+
+    #[test]
+    fn system_messages_preserve_original_order() {
+        let messages = vec![
+            IncomingChatMessage {
+                role: "user".to_string(),
+                content: json!("first"),
+                reasoning_content: None,
+                tool_calls: None,
+                tool_call_id: None,
+            },
+            IncomingChatMessage {
+                role: "developer".to_string(),
+                content: json!("mid instruction"),
+                reasoning_content: None,
+                tool_calls: None,
+                tool_call_id: None,
+            },
+            IncomingChatMessage {
+                role: "assistant".to_string(),
+                content: json!("second"),
+                reasoning_content: None,
+                tool_calls: None,
+                tool_call_id: None,
+            },
+        ];
+        let out = normalize_messages(messages).unwrap();
+        assert_eq!(out[0].role, "user");
+        assert_eq!(out[1].role, "system");
+        assert_eq!(out[2].role, "assistant");
+        assert_eq!(content_to_text(&out[1].content).unwrap(), "mid instruction");
+    }
+
+    #[test]
+    fn reasoning_defaults_off_and_can_be_enabled() {
+        assert!(!reasoning_enabled(None));
+        assert!(!reasoning_enabled(Some("none")));
+        assert!(reasoning_enabled(Some("medium")));
+    }
+
+    #[test]
+    fn response_format_json_object_adds_system_hint() {
+        assert!(!response_format_json_object(Some(&json!({"type": "text"}))).unwrap());
+        assert!(response_format_json_object(Some(&json!({"type": "json_object"}))).unwrap());
+        assert!(response_format_json_object(Some(&json!({"type": "json_schema"}))).is_err());
+
+        let mut messages = vec![ChatMessage::text("user", "hi")];
+        apply_response_format_hint(&mut messages, true);
+        assert_eq!(messages[0].role, "system");
+        assert_eq!(
+            content_to_text(&messages[0].content).unwrap(),
+            "Return a valid JSON object."
+        );
+    }
+
+    #[test]
+    fn incomplete_think_and_tool_blocks_are_buffered() {
+        assert!(has_incomplete_control_block("<think>\npartial"));
+        assert!(has_incomplete_control_block("x <tool_call>\npartial"));
+        assert!(!has_incomplete_control_block("<think>x</think>\ny"));
+        assert!(!has_incomplete_control_block("<tool_call>x</tool_call>"));
+    }
+
+    #[test]
+    fn validates_function_tools_only() {
+        validate_tools(Some(&json!([{
+            "type": "function",
+            "function": {"name": "lookup"}
+        }])))
+        .unwrap();
+        let err = validate_tools(Some(&json!([{"type": "web_search"}])))
+            .expect_err("expected unsupported built-in tool");
+        assert!(err.body.message.contains("unsupported tool type"));
+    }
+
+    #[test]
+    fn assistant_tool_call_arguments_are_template_objects() {
+        let normalized = normalize_tool_calls_for_template(Some(json!([
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {
+                    "name": "lookup",
+                    "arguments": "{\"query\":\"weather\"}"
+                }
+            }
+        ])))
+        .unwrap();
+        assert_eq!(
+            normalized[0]["function"]["arguments"]["query"]
+                .as_str()
+                .unwrap(),
+            "weather"
+        );
+    }
 }

--- a/crates/server/src/routes/completions.rs
+++ b/crates/server/src/routes/completions.rs
@@ -8,13 +8,15 @@ use axum::response::{IntoResponse, Response};
 use axum::Json;
 use futures::stream::Stream;
 
+use super::chat::{generation_error, queue_error};
 use super::sse;
+use crate::compat::validate_model;
 use crate::errors::ApiError;
 use crate::generate::{self, GenParams};
 use crate::ids;
 use crate::schemas::{
     CompletionChoice, CompletionRequest, CompletionResponse, CompletionStreamChoice,
-    CompletionStreamChunk, Usage,
+    CompletionStreamChunk, SinglePrompt, Usage,
 };
 use crate::state::ServerState;
 
@@ -22,10 +24,11 @@ pub async fn completions(
     State(state): State<Arc<ServerState>>,
     Json(req): Json<CompletionRequest>,
 ) -> Result<Response, ApiError> {
-    let prompt =
-        req.prompt.clone().into_single().ok_or_else(|| {
-            ApiError::bad_request("prompt must be a string or single-element array")
-        })?;
+    validate_model(req.model.as_deref(), &state.model_id)?;
+    validate_unsupported(&req)?;
+    let prompt = req.prompt.clone().into_single().ok_or_else(|| {
+        ApiError::bad_request("prompt must be a string, token array, or single-element array")
+    })?;
 
     let params = GenParams {
         temperature: req.temperature.unwrap_or(1.0),
@@ -34,29 +37,37 @@ pub async fn completions(
         stop: req.stop.map(|s| s.into_vec()).unwrap_or_default(),
         seed: req.seed,
     };
-    // Raw-prompt path: let the tokenizer add its own BOS etc.
-    let add_special_tokens = true;
-
     // Tokenize + bounds-check synchronously so setup failures become
     // structured HTTP errors (400), not in-band SSE error events.
-    let prompt_ids = generate::prepare(&state, &prompt, add_special_tokens, params.max_tokens)
-        .map_err(|e| ApiError::bad_request(e.to_string()))?;
+    let prompt_ids = match prompt {
+        SinglePrompt::Text(prompt) => {
+            // Raw-prompt path: let the tokenizer add its own BOS etc.
+            generate::prepare(&state, &prompt, true, params.max_tokens)
+        }
+        SinglePrompt::Tokens(prompt_ids) => {
+            generate::prepare_ids(&state, prompt_ids, params.max_tokens)
+        }
+    }
+    .map_err(|e| ApiError::bad_request(e.to_string()))?;
 
     let id = ids::completion_id();
     let created = ids::epoch_secs();
     let model = state.model_id.clone();
+    let include_usage = req
+        .stream_options
+        .as_ref()
+        .map(|o| o.include_usage)
+        .unwrap_or(false);
 
     if req.stream {
-        let rx = generate::spawn(state.clone(), prompt_ids, params);
-        let stream = completion_sse_stream(rx, id, created, model);
+        let rx = generate::spawn(state.clone(), prompt_ids, params).map_err(queue_error)?;
+        let stream = completion_sse_stream(rx, id, created, model, include_usage);
         Ok(Sse::new(stream)
             .keep_alive(KeepAlive::default())
             .into_response())
     } else {
-        let rx = generate::spawn(state.clone(), prompt_ids, params);
-        let result = generate::collect(rx)
-            .await
-            .map_err(|e| ApiError::internal(format!("generation failed: {e}")))?;
+        let rx = generate::spawn(state.clone(), prompt_ids, params).map_err(queue_error)?;
+        let result = generate::collect(rx).await.map_err(generation_error)?;
         let resp = CompletionResponse {
             id,
             object: "text_completion",
@@ -83,6 +94,7 @@ fn completion_sse_stream(
     id: String,
     created: u64,
     model: String,
+    include_usage: bool,
 ) -> impl Stream<Item = sse::SseEvent> {
     let token_id = id.clone();
     let token_model = model.clone();
@@ -99,8 +111,9 @@ fn completion_sse_stream(
                 logprobs: None,
                 finish_reason: None,
             }],
+            usage: None,
         },
-        move |reason| CompletionStreamChunk {
+        move |reason, usage| CompletionStreamChunk {
             id: id.clone(),
             object: "text_completion",
             created,
@@ -111,6 +124,51 @@ fn completion_sse_stream(
                 logprobs: None,
                 finish_reason: Some(reason.as_str()),
             }],
+            usage: if include_usage { usage } else { None },
         },
     )
+}
+
+fn validate_unsupported(req: &CompletionRequest) -> Result<(), ApiError> {
+    if req.n.unwrap_or(1) != 1 {
+        return Err(ApiError::bad_request("n > 1 is not supported"));
+    }
+    if req.logprobs.is_some() {
+        return Err(ApiError::bad_request("logprobs are not supported"));
+    }
+    if req.echo.unwrap_or(false) {
+        return Err(ApiError::bad_request("echo=true is not supported"));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn rejects_unsupported_completion_options() {
+        let req: CompletionRequest = serde_json::from_value(json!({
+            "prompt": "hi",
+            "n": 2
+        }))
+        .unwrap();
+        assert!(validate_unsupported(&req).is_err());
+
+        let req: CompletionRequest = serde_json::from_value(json!({
+            "prompt": "hi",
+            "logprobs": 1
+        }))
+        .unwrap();
+        assert!(validate_unsupported(&req).is_err());
+
+        let req: CompletionRequest = serde_json::from_value(json!({
+            "prompt": "hi",
+            "echo": true
+        }))
+        .unwrap();
+        assert!(validate_unsupported(&req).is_err());
+    }
 }

--- a/crates/server/src/routes/mod.rs
+++ b/crates/server/src/routes/mod.rs
@@ -3,11 +3,12 @@
 use std::sync::Arc;
 
 use axum::extract::{Request, State};
-use axum::http::{HeaderMap, StatusCode};
+use axum::http::{HeaderMap, HeaderValue, StatusCode};
 use axum::middleware::Next;
 use axum::response::Response;
 use axum::routing::{get, post};
 use axum::Router;
+use tower_http::cors::{Any, CorsLayer};
 
 use crate::errors::{ApiError, ApiErrorBody, ApiErrorEnvelope};
 use crate::state::ServerState;
@@ -15,18 +16,61 @@ use crate::state::ServerState;
 pub mod chat;
 pub mod completions;
 pub mod models;
+pub mod responses;
 mod sse;
+pub mod tokenizer;
 
 pub fn router(state: Arc<ServerState>) -> Router {
-    Router::new()
+    let app = Router::new()
+        .route("/", get(models::health))
+        .route("/v1", get(models::health))
+        .route("/ready", get(models::health))
+        .route("/v1/ready", get(models::health))
         .route("/v1/models", get(models::list))
+        .route("/v1/models/:model", get(models::retrieve))
+        .route("/health", get(models::health))
+        .route("/v1/health", get(models::health))
+        .route("/v1/capabilities", get(models::capabilities))
+        .route("/metrics", get(models::metrics))
         .route("/v1/chat/completions", post(chat::completions))
         .route("/v1/completions", post(completions::completions))
+        .route("/tokenize", post(tokenizer::tokenize))
+        .route("/v1/tokenize", post(tokenizer::tokenize))
+        .route("/detokenize", post(tokenizer::detokenize))
+        .route("/v1/detokenize", post(tokenizer::detokenize))
+        .route("/v1/responses", post(responses::create))
+        .route(
+            "/v1/responses/:response_id",
+            get(responses::get).delete(responses::delete),
+        )
         .layer(axum::middleware::from_fn_with_state(
             state.clone(),
             auth_middleware,
         ))
-        .with_state(state)
+        .with_state(state.clone());
+
+    if let Some(origin) = state.cors_allow_origin.as_deref() {
+        if origin == "*" {
+            app.layer(
+                CorsLayer::new()
+                    .allow_origin(Any)
+                    .allow_methods(Any)
+                    .allow_headers(Any),
+            )
+        } else if let Ok(header) = origin.parse::<HeaderValue>() {
+            app.layer(
+                CorsLayer::new()
+                    .allow_origin(header)
+                    .allow_methods(Any)
+                    .allow_headers(Any),
+            )
+        } else {
+            tracing::warn!(origin, "ignoring invalid CORS allow-origin");
+            app
+        }
+    } else {
+        app
+    }
 }
 
 async fn auth_middleware(

--- a/crates/server/src/routes/models.rs
+++ b/crates/server/src/routes/models.rs
@@ -3,27 +3,151 @@
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use axum::extract::State;
+use axum::extract::{Path, State};
+use axum::http::header::CONTENT_TYPE;
+use axum::response::IntoResponse;
 use axum::Json;
+use serde::Serialize;
 
+use crate::compat::validate_model;
 use crate::errors::ApiError;
+use crate::generate;
 use crate::schemas::{ListModelsResponse, ModelObject};
 use crate::state::ServerState;
 
 pub async fn list(
     State(state): State<Arc<ServerState>>,
 ) -> Result<Json<ListModelsResponse>, ApiError> {
+    Ok(Json(ListModelsResponse {
+        object: "list",
+        data: vec![model_object(&state)],
+    }))
+}
+
+pub async fn retrieve(
+    State(state): State<Arc<ServerState>>,
+    Path(model): Path<String>,
+) -> Result<Json<ModelObject>, ApiError> {
+    validate_model(Some(&model), &state.model_id)?;
+    Ok(Json(model_object(&state)))
+}
+
+fn model_object(state: &ServerState) -> ModelObject {
     let created = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_secs())
         .unwrap_or(0);
-    Ok(Json(ListModelsResponse {
-        object: "list",
-        data: vec![ModelObject {
-            id: state.model_id.clone(),
-            object: "model",
-            created,
-            owned_by: "supersonic",
-        }],
+    ModelObject {
+        id: state.model_id.clone(),
+        object: "model",
+        created,
+        owned_by: "supersonic",
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct HealthResponse {
+    pub status: &'static str,
+    pub model: String,
+    pub max_context: usize,
+    pub active_requests: usize,
+    pub queued_requests: usize,
+    pub max_queued_requests: usize,
+}
+
+pub async fn health(
+    State(state): State<Arc<ServerState>>,
+) -> Result<Json<HealthResponse>, ApiError> {
+    let queue = generate::scheduler_snapshot(&state);
+    Ok(Json(HealthResponse {
+        status: "ok",
+        model: state.model_id.clone(),
+        max_context: state.max_context,
+        active_requests: queue.active,
+        queued_requests: queue.queued,
+        max_queued_requests: queue.max_queue,
     }))
+}
+
+#[derive(Debug, Serialize)]
+pub struct CapabilitiesResponse {
+    pub model: String,
+    pub family: String,
+    pub backend: String,
+    pub max_context: usize,
+    pub endpoints: Vec<&'static str>,
+    pub chat: bool,
+    pub completions: bool,
+    pub responses: bool,
+    pub streaming: bool,
+    pub stream_usage: bool,
+    pub tools: bool,
+    pub reasoning: bool,
+    pub scheduler: SchedulerCapabilities,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SchedulerCapabilities {
+    pub active_requests: usize,
+    pub queued_requests: usize,
+    pub max_queued_requests: usize,
+    pub queue_timeout_ms: u64,
+}
+
+pub async fn capabilities(
+    State(state): State<Arc<ServerState>>,
+) -> Result<Json<CapabilitiesResponse>, ApiError> {
+    let queue = generate::scheduler_snapshot(&state);
+    Ok(Json(CapabilitiesResponse {
+        model: state.model_id.clone(),
+        family: state.model_family.to_string(),
+        backend: state.capabilities.backend.to_string(),
+        max_context: state.max_context,
+        endpoints: vec![
+            "/v1/models",
+            "/v1/models/{model}",
+            "/v1/chat/completions",
+            "/v1/completions",
+            "/v1/tokenize",
+            "/v1/detokenize",
+            "/v1/responses",
+            "/health",
+            "/v1/health",
+            "/ready",
+            "/v1/ready",
+            "/v1/capabilities",
+            "/metrics",
+        ],
+        chat: state.chat_template.is_some(),
+        completions: true,
+        responses: true,
+        streaming: true,
+        stream_usage: true,
+        tools: state.chat_template.is_some(),
+        reasoning: state.chat_template.is_some(),
+        scheduler: SchedulerCapabilities {
+            active_requests: queue.active,
+            queued_requests: queue.queued,
+            max_queued_requests: queue.max_queue,
+            queue_timeout_ms: queue.queue_timeout_ms,
+        },
+    }))
+}
+
+pub async fn metrics(State(state): State<Arc<ServerState>>) -> impl IntoResponse {
+    let queue = generate::scheduler_snapshot(&state);
+    let body = format!(
+        "# TYPE supersonic_active_requests gauge\n\
+         supersonic_active_requests {}\n\
+         # TYPE supersonic_queued_requests gauge\n\
+         supersonic_queued_requests {}\n\
+         # TYPE supersonic_max_queued_requests gauge\n\
+         supersonic_max_queued_requests {}\n\
+         # TYPE supersonic_queue_timeout_ms gauge\n\
+         supersonic_queue_timeout_ms {}\n\
+         # TYPE supersonic_max_context gauge\n\
+         supersonic_max_context {}\n",
+        queue.active, queue.queued, queue.max_queue, queue.queue_timeout_ms, state.max_context
+    );
+    ([(CONTENT_TYPE, "text/plain; version=0.0.4")], body)
 }

--- a/crates/server/src/routes/responses.rs
+++ b/crates/server/src/routes/responses.rs
@@ -1,0 +1,793 @@
+//! Minimal OpenAI Responses API facade over SuperSonic's chat generation.
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::{Arc, Mutex, OnceLock};
+
+use axum::extract::{Path, State};
+use axum::response::sse::{Event, KeepAlive, Sse};
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use futures::Stream;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+use crate::chat_template::{ChatMessage, RenderOptions};
+use crate::compat::validate_model;
+use crate::errors::ApiError;
+use crate::generate::{self, GenParams};
+use crate::output::{parse_assistant_output, AssistantOutput};
+use crate::routes::chat::{
+    apply_response_format_hint, content_to_text, generation_error, has_incomplete_control_block,
+    normalize_tool_calls_for_template, queue_error, reasoning_enabled, response_format_json_object,
+    validate_tools,
+};
+use crate::schemas::{OpenAiToolCall, StopParam, Usage};
+use crate::state::ServerState;
+
+static STORES: OnceLock<Mutex<HashMap<u64, ResponseStore>>> = OnceLock::new();
+
+#[derive(Default)]
+struct ResponseStore {
+    entries: HashMap<String, StoredResponse>,
+    order: VecDeque<String>,
+    next_id: u64,
+}
+
+impl ResponseStore {
+    fn next_response_id(&mut self) -> String {
+        let seq = self.next_id;
+        self.next_id = self.next_id.saturating_add(1);
+        format!("resp-{:x}{seq:04x}", crate::ids::epoch_secs())
+    }
+
+    fn insert(&mut self, id: String, response: StoredResponse, max_entries: usize) {
+        if max_entries == 0 {
+            return;
+        }
+        if !self.entries.contains_key(&id) {
+            self.order.push_back(id.clone());
+        }
+        self.entries.insert(id, response);
+        while self.entries.len() > max_entries {
+            let Some(oldest) = self.order.pop_front() else {
+                break;
+            };
+            self.entries.remove(&oldest);
+        }
+    }
+
+    fn get(&self, id: &str) -> Option<&StoredResponse> {
+        self.entries.get(id)
+    }
+
+    fn remove(&mut self, id: &str) -> bool {
+        let removed = self.entries.remove(id).is_some();
+        if removed {
+            self.order.retain(|k| k != id);
+        }
+        removed
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct StoredResponse {
+    pub id: String,
+    pub object: &'static str,
+    pub created_at: u64,
+    pub model: String,
+    pub status: &'static str,
+    pub output: Vec<ResponseOutputItem>,
+    pub usage: Usage,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type")]
+pub enum ResponseOutputItem {
+    #[serde(rename = "message")]
+    Message {
+        id: String,
+        role: &'static str,
+        content: Vec<ResponseContentPart>,
+    },
+    #[serde(rename = "reasoning")]
+    Reasoning { id: String, summary: Vec<String> },
+    #[serde(rename = "function_call")]
+    FunctionCall {
+        id: String,
+        call_id: String,
+        name: String,
+        arguments: String,
+        status: &'static str,
+    },
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type")]
+pub enum ResponseContentPart {
+    #[serde(rename = "output_text")]
+    OutputText {
+        text: String,
+        annotations: Vec<Value>,
+    },
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ResponseRequest {
+    pub model: Option<String>,
+    pub input: Value,
+    #[serde(default)]
+    pub instructions: Option<String>,
+    #[serde(default)]
+    pub temperature: Option<f32>,
+    #[serde(default)]
+    pub top_p: Option<f32>,
+    #[serde(
+        default,
+        alias = "max_tokens",
+        alias = "max_completion_tokens",
+        alias = "maxOutputTokens",
+        alias = "maxCompletionTokens"
+    )]
+    pub max_output_tokens: Option<usize>,
+    #[serde(default)]
+    pub stream: bool,
+    #[serde(default)]
+    pub stop: Option<StopParam>,
+    #[serde(default)]
+    pub seed: Option<u64>,
+    #[serde(default)]
+    pub tools: Option<Value>,
+    #[serde(default)]
+    pub tool_choice: Option<Value>,
+    #[serde(default)]
+    pub response_format: Option<Value>,
+    #[serde(default)]
+    pub text: Option<Value>,
+    #[serde(default)]
+    pub reasoning: Option<ResponseReasoning>,
+    #[serde(default)]
+    pub previous_response_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ResponseReasoning {
+    #[serde(default)]
+    pub effort: Option<String>,
+}
+
+pub async fn create(
+    State(state): State<Arc<ServerState>>,
+    Json(req): Json<ResponseRequest>,
+) -> Result<Response, ApiError> {
+    validate_model(req.model.as_deref(), &state.model_id)?;
+    if matches!(req.tool_choice.as_ref(), Some(Value::String(s)) if s == "required") {
+        return Err(ApiError::bad_request(
+            "tool_choice=required is not supported",
+        ));
+    }
+    validate_tools(req.tools.as_ref())?;
+    let json_object = response_format_json_object(response_format_value(&req))?;
+
+    let max_tokens = req.max_output_tokens.unwrap_or(256);
+    let mut messages = response_messages(&req, state.server_instance_id)?;
+    apply_response_format_hint(&mut messages, json_object);
+    let prompt_text = if let Some(template) = state.chat_template.clone() {
+        template
+            .render_with_options(
+                &messages,
+                RenderOptions {
+                    add_generation_prompt: true,
+                    tools: req.tools.clone(),
+                    enable_thinking: reasoning_enabled(
+                        req.reasoning.as_ref().and_then(|r| r.effort.as_deref()),
+                    ),
+                },
+            )
+            .map_err(|e| ApiError::bad_request(format!("chat template render failed: {e}")))?
+    } else if req.tools.is_some() {
+        return Err(ApiError::bad_request(
+            "tools require a model chat_template; use a chat-capable model",
+        ));
+    } else {
+        messages
+            .iter()
+            .map(|m| content_to_text(&m.content))
+            .collect::<Result<Vec<_>, _>>()?
+            .join("\n")
+    };
+
+    let params = GenParams {
+        temperature: req.temperature.unwrap_or(1.0),
+        top_p: req.top_p.unwrap_or(1.0),
+        max_tokens,
+        stop: req.stop.map(|s| s.into_vec()).unwrap_or_default(),
+        seed: req.seed,
+    };
+    let prompt_ids = generate::prepare(
+        &state,
+        &prompt_text,
+        state.chat_template.is_none(),
+        params.max_tokens,
+    )
+    .map_err(|e| ApiError::bad_request(e.to_string()))?;
+
+    let id = next_response_id(state.server_instance_id);
+    let created_at = crate::ids::epoch_secs();
+    let model = state.model_id.clone();
+
+    if req.stream {
+        let rx = generate::spawn(state.clone(), prompt_ids, params).map_err(queue_error)?;
+        let stream = response_sse_stream(
+            rx,
+            id,
+            model,
+            created_at,
+            state.server_instance_id,
+            state.response_store_max_entries,
+        );
+        Ok(Sse::new(stream)
+            .keep_alive(KeepAlive::default())
+            .into_response())
+    } else {
+        let rx = generate::spawn(state.clone(), prompt_ids, params).map_err(queue_error)?;
+        let result = generate::collect(rx).await.map_err(generation_error)?;
+        let parsed = parse_assistant_output(&result.text);
+        let stored = build_response(
+            id,
+            model,
+            created_at,
+            parsed,
+            Usage {
+                prompt_tokens: result.prompt_tokens,
+                completion_tokens: result.completion_tokens,
+                total_tokens: result.prompt_tokens + result.completion_tokens,
+            },
+        );
+        insert_response(
+            state.server_instance_id,
+            stored.id.clone(),
+            stored.clone(),
+            state.response_store_max_entries,
+        );
+        Ok(Json(stored).into_response())
+    }
+}
+
+pub async fn get(
+    State(state): State<Arc<ServerState>>,
+    Path(response_id): Path<String>,
+) -> Result<Response, ApiError> {
+    let Some(resp) = get_response(state.server_instance_id, &response_id) else {
+        return Err(ApiError::bad_request("unknown response id"));
+    };
+    Ok(Json(resp).into_response())
+}
+
+pub async fn delete(
+    State(state): State<Arc<ServerState>>,
+    Path(response_id): Path<String>,
+) -> Result<Response, ApiError> {
+    let deleted = delete_response(state.server_instance_id, &response_id);
+    Ok(Json(json!({
+        "id": response_id,
+        "object": "response.deleted",
+        "deleted": deleted,
+    }))
+    .into_response())
+}
+
+fn response_sse_stream(
+    mut rx: tokio::sync::mpsc::UnboundedReceiver<generate::GenEvent>,
+    id: String,
+    model: String,
+    created_at: u64,
+    server_instance_id: u64,
+    response_store_max_entries: usize,
+) -> impl Stream<Item = super::sse::SseEvent> {
+    async_stream::stream! {
+        yield Ok(Event::default()
+            .event("response.created")
+            .data(json!({ "type": "response.created", "response": {
+                "id": id,
+                "object": "response",
+                "created_at": created_at,
+                "model": model,
+                "status": "in_progress",
+            }}).to_string()));
+        let mut raw = String::new();
+        let mut emitted = String::new();
+        while let Some(ev) = rx.recv().await {
+            match ev {
+                generate::GenEvent::Token(text) => {
+                    raw.push_str(&text);
+                    if has_incomplete_control_block(&raw) {
+                        continue;
+                    }
+                    let parsed = parse_assistant_output(&raw);
+                    if let Some(delta) = parsed.content.strip_prefix(&emitted) {
+                        if !delta.is_empty() {
+                            emitted = parsed.content.clone();
+                            yield Ok(Event::default()
+                                .event("response.output_text.delta")
+                                .data(json!({
+                                    "type": "response.output_text.delta",
+                                    "response_id": id,
+                                    "delta": delta,
+                                }).to_string()));
+                        }
+                    }
+                }
+                generate::GenEvent::Done { prompt_tokens, completion_tokens, .. } => {
+                    let parsed = parse_assistant_output(&raw);
+                    let stored = build_response(
+                        id.clone(),
+                        model.clone(),
+                        created_at,
+                        parsed,
+                        Usage {
+                            prompt_tokens,
+                            completion_tokens,
+                            total_tokens: prompt_tokens + completion_tokens,
+                        },
+                    );
+                    insert_response(
+                        server_instance_id,
+                        stored.id.clone(),
+                        stored.clone(),
+                        response_store_max_entries,
+                    );
+                    yield Ok(Event::default()
+                        .event("response.output_text.done")
+                        .data(json!({
+                            "type": "response.output_text.done",
+                            "response_id": id,
+                            "text": emitted,
+                        }).to_string()));
+                    for item in &stored.output {
+                        yield Ok(Event::default()
+                            .event("response.output_item.done")
+                            .data(json!({
+                                "type": "response.output_item.done",
+                                "response_id": id,
+                                "item": item,
+                            }).to_string()));
+                    }
+                    yield Ok(Event::default()
+                        .event("response.completed")
+                        .data(json!({
+                            "type": "response.completed",
+                            "response": stored,
+                        }).to_string()));
+                    yield Ok(Event::default().data("[DONE]"));
+                    return;
+                }
+                generate::GenEvent::Error(msg) => {
+                    yield Ok(Event::default()
+                        .event("response.failed")
+                        .data(json!({ "type": "response.failed", "error": { "message": msg } }).to_string()));
+                    return;
+                }
+            }
+        }
+    }
+}
+
+fn response_messages(
+    req: &ResponseRequest,
+    server_instance_id: u64,
+) -> Result<Vec<ChatMessage>, ApiError> {
+    let mut messages = Vec::new();
+    if let Some(id) = req.previous_response_id.as_ref() {
+        let prev = get_response(server_instance_id, id)
+            .ok_or_else(|| ApiError::bad_request("unknown previous_response_id"))?;
+        append_previous_response_messages(&mut messages, &prev);
+    }
+    if let Some(instructions) = req.instructions.as_ref() {
+        messages.push(ChatMessage::text("system", instructions));
+    }
+    match &req.input {
+        Value::String(s) => messages.push(ChatMessage::text("user", s)),
+        Value::Array(items) => {
+            for item in items {
+                if item.get("type").and_then(Value::as_str) == Some("message") {
+                    let role = normalize_response_role(
+                        item.get("role").and_then(Value::as_str).unwrap_or("user"),
+                    );
+                    let content = item.get("content").unwrap_or(&Value::Null);
+                    messages.push(ChatMessage::text(role, content_to_text(content)?));
+                } else if item.get("type").and_then(Value::as_str) == Some("input_text") {
+                    messages.push(ChatMessage::text(
+                        "user",
+                        item.get("text").and_then(Value::as_str).unwrap_or_default(),
+                    ));
+                } else if item.get("type").and_then(Value::as_str) == Some("function_call_output") {
+                    let output = item
+                        .get("output")
+                        .or_else(|| item.get("content"))
+                        .unwrap_or(&Value::Null);
+                    let output_text = output
+                        .as_str()
+                        .map(ToOwned::to_owned)
+                        .map(Ok)
+                        .unwrap_or_else(|| content_to_text(output))?;
+                    let mut msg = ChatMessage::text("tool", output_text);
+                    msg.tool_call_id = item
+                        .get("call_id")
+                        .and_then(Value::as_str)
+                        .map(ToOwned::to_owned);
+                    messages.push(msg);
+                } else if item.get("type").and_then(Value::as_str) == Some("function_call") {
+                    messages.push(function_call_input_message(item)?);
+                } else if let Some(role) = item.get("role").and_then(Value::as_str) {
+                    let role = normalize_response_role(role);
+                    let content = item.get("content").unwrap_or(&Value::Null);
+                    messages.push(ChatMessage::text(role, content_to_text(content)?));
+                } else {
+                    return Err(ApiError::bad_request("unsupported Responses input item"));
+                }
+            }
+        }
+        _ => {
+            return Err(ApiError::bad_request(
+                "input must be a string or message array",
+            ))
+        }
+    }
+    Ok(messages)
+}
+
+fn append_previous_response_messages(messages: &mut Vec<ChatMessage>, prev: &StoredResponse) {
+    let text = output_text(prev).unwrap_or_default();
+    let tool_calls = response_tool_calls(prev);
+    if !text.is_empty() || tool_calls.as_ref().is_some_and(|v| !v.is_empty()) {
+        let mut msg = ChatMessage::text("assistant", text);
+        if let Some(calls) = tool_calls {
+            msg.tool_calls = normalize_tool_calls_for_template(Some(Value::Array(calls)));
+        }
+        messages.push(msg);
+    }
+}
+
+fn response_tool_calls(resp: &StoredResponse) -> Option<Vec<Value>> {
+    let calls: Vec<Value> = resp
+        .output
+        .iter()
+        .filter_map(|item| {
+            if let ResponseOutputItem::FunctionCall {
+                call_id,
+                name,
+                arguments,
+                ..
+            } = item
+            {
+                Some(json!({
+                    "id": call_id,
+                    "type": "function",
+                    "function": {
+                        "name": name,
+                        "arguments": arguments,
+                    }
+                }))
+            } else {
+                None
+            }
+        })
+        .collect();
+    (!calls.is_empty()).then_some(calls)
+}
+
+fn function_call_input_message(item: &Value) -> Result<ChatMessage, ApiError> {
+    let call_id = item
+        .get("call_id")
+        .or_else(|| item.get("id"))
+        .and_then(Value::as_str)
+        .unwrap_or("call_0");
+    let name = item
+        .get("name")
+        .or_else(|| item.get("function").and_then(|f| f.get("name")))
+        .and_then(Value::as_str)
+        .ok_or_else(|| ApiError::bad_request("function_call input missing name"))?;
+    let arguments = item
+        .get("arguments")
+        .or_else(|| item.get("function").and_then(|f| f.get("arguments")))
+        .cloned()
+        .unwrap_or_else(|| json!("{}"));
+    let arguments = if arguments.is_string() {
+        arguments
+    } else {
+        Value::String(arguments.to_string())
+    };
+    let mut msg = ChatMessage::text("assistant", "");
+    msg.tool_calls = normalize_tool_calls_for_template(Some(json!([{
+        "id": call_id,
+        "type": "function",
+        "function": {
+            "name": name,
+            "arguments": arguments,
+        }
+    }])));
+    Ok(msg)
+}
+
+fn normalize_response_role(role: &str) -> &str {
+    match role {
+        "developer" => "system",
+        "function" => "tool",
+        other => other,
+    }
+}
+
+fn response_format_value(req: &ResponseRequest) -> Option<&Value> {
+    req.response_format
+        .as_ref()
+        .or_else(|| req.text.as_ref().and_then(|text| text.get("format")))
+}
+
+fn build_response(
+    id: String,
+    model: String,
+    created_at: u64,
+    parsed: AssistantOutput,
+    usage: Usage,
+) -> StoredResponse {
+    let mut output = Vec::new();
+    if let Some(reasoning) = parsed.reasoning_content {
+        output.push(ResponseOutputItem::Reasoning {
+            id: format!("{id}-rsn"),
+            summary: vec![reasoning],
+        });
+    }
+    if !parsed.content.trim().is_empty() {
+        output.push(ResponseOutputItem::Message {
+            id: format!("{id}-msg"),
+            role: "assistant",
+            content: vec![ResponseContentPart::OutputText {
+                text: parsed.content,
+                annotations: Vec::new(),
+            }],
+        });
+    }
+    if let Some(calls) = parsed.tool_calls {
+        append_tool_calls(&mut output, calls);
+    }
+    StoredResponse {
+        id,
+        object: "response",
+        created_at,
+        model,
+        status: "completed",
+        output,
+        usage,
+    }
+}
+
+fn append_tool_calls(output: &mut Vec<ResponseOutputItem>, calls: Vec<OpenAiToolCall>) {
+    for call in calls {
+        output.push(ResponseOutputItem::FunctionCall {
+            id: call.id.clone(),
+            call_id: call.id,
+            name: call.function.name,
+            arguments: call.function.arguments,
+            status: "completed",
+        });
+    }
+}
+
+fn output_text(resp: &StoredResponse) -> Option<String> {
+    let mut text = String::new();
+    for item in &resp.output {
+        if let ResponseOutputItem::Message { content, .. } = item {
+            for part in content {
+                let ResponseContentPart::OutputText { text: t, .. } = part;
+                text.push_str(t);
+            }
+        }
+    }
+    (!text.is_empty()).then_some(text)
+}
+
+fn stores() -> &'static Mutex<HashMap<u64, ResponseStore>> {
+    STORES.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn next_response_id(server_instance_id: u64) -> String {
+    let mut stores = stores().lock().unwrap();
+    stores
+        .entry(server_instance_id)
+        .or_default()
+        .next_response_id()
+}
+
+fn insert_response(
+    server_instance_id: u64,
+    id: String,
+    response: StoredResponse,
+    max_entries: usize,
+) {
+    stores()
+        .lock()
+        .unwrap()
+        .entry(server_instance_id)
+        .or_default()
+        .insert(id, response, max_entries);
+}
+
+fn get_response(server_instance_id: u64, id: &str) -> Option<StoredResponse> {
+    stores()
+        .lock()
+        .unwrap()
+        .get(&server_instance_id)
+        .and_then(|store| store.get(id).cloned())
+}
+
+fn delete_response(server_instance_id: u64, id: &str) -> bool {
+    stores()
+        .lock()
+        .unwrap()
+        .get_mut(&server_instance_id)
+        .is_some_and(|store| store.remove(id))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::output::parse_assistant_output;
+
+    #[test]
+    fn response_output_contains_reasoning_text_and_function_call() {
+        let raw = "<think>plan</think>\nanswer\n<tool_call>\n<function=lookup>\n<parameter=q>\n42\n</parameter>\n</function>\n</tool_call>";
+        let resp = build_response(
+            "resp-test".to_string(),
+            "model".to_string(),
+            1,
+            parse_assistant_output(raw),
+            Usage {
+                prompt_tokens: 1,
+                completion_tokens: 2,
+                total_tokens: 3,
+            },
+        );
+        assert!(matches!(
+            resp.output[0],
+            ResponseOutputItem::Reasoning { .. }
+        ));
+        assert!(matches!(resp.output[1], ResponseOutputItem::Message { .. }));
+        assert!(matches!(
+            resp.output[2],
+            ResponseOutputItem::FunctionCall { .. }
+        ));
+    }
+
+    #[test]
+    fn response_store_evicts_oldest_entry() {
+        let mut store = ResponseStore::default();
+        store.insert("first".to_string(), empty_response("first"), 1);
+        store.insert("second".to_string(), empty_response("second"), 1);
+
+        assert!(store.get("first").is_none());
+        assert!(store.get("second").is_some());
+    }
+
+    #[test]
+    fn response_messages_accept_developer_and_text_parts() {
+        let req = ResponseRequest {
+            model: None,
+            input: json!([
+                {
+                    "role": "developer",
+                    "content": [{"type": "input_text", "text": "be concise"}]
+                },
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "hi"}]
+                }
+            ]),
+            instructions: None,
+            temperature: None,
+            top_p: None,
+            max_output_tokens: None,
+            stream: false,
+            stop: None,
+            seed: None,
+            tools: None,
+            tool_choice: None,
+            response_format: None,
+            text: None,
+            reasoning: None,
+            previous_response_id: None,
+        };
+        let messages = response_messages(&req, 0).unwrap();
+        assert_eq!(messages[0].role, "system");
+        assert_eq!(messages[1].role, "user");
+    }
+
+    #[test]
+    fn response_messages_accept_direct_text_and_function_outputs() {
+        let req = ResponseRequest {
+            model: None,
+            input: json!([
+                {"type": "input_text", "text": "hi"},
+                {"type": "function_call_output", "call_id": "call_1", "output": "rainy"}
+            ]),
+            instructions: None,
+            temperature: None,
+            top_p: None,
+            max_output_tokens: None,
+            stream: false,
+            stop: None,
+            seed: None,
+            tools: None,
+            tool_choice: None,
+            response_format: None,
+            text: None,
+            reasoning: None,
+            previous_response_id: None,
+        };
+        let messages = response_messages(&req, 0).unwrap();
+        assert_eq!(messages[0].role, "user");
+        assert_eq!(messages[1].role, "tool");
+        assert_eq!(messages[1].tool_call_id.as_deref(), Some("call_1"));
+    }
+
+    #[test]
+    fn previous_response_function_calls_become_assistant_tool_calls() {
+        let mut prev = empty_response("resp-prev");
+        prev.output.push(ResponseOutputItem::FunctionCall {
+            id: "call_1".to_string(),
+            call_id: "call_1".to_string(),
+            name: "lookup".to_string(),
+            arguments: "{\"query\":\"weather\"}".to_string(),
+            status: "completed",
+        });
+        let mut messages = Vec::new();
+        append_previous_response_messages(&mut messages, &prev);
+        assert_eq!(messages[0].role, "assistant");
+        assert_eq!(
+            messages[0].tool_calls.as_ref().unwrap()[0]["function"]["arguments"]["query"],
+            "weather"
+        );
+    }
+
+    #[test]
+    fn response_function_call_input_becomes_assistant_tool_call() {
+        let msg = function_call_input_message(&json!({
+            "type": "function_call",
+            "call_id": "call_1",
+            "name": "lookup",
+            "arguments": {"query": "weather"}
+        }))
+        .unwrap();
+        assert_eq!(msg.role, "assistant");
+        assert_eq!(
+            msg.tool_calls.as_ref().unwrap()[0]["function"]["arguments"]["query"],
+            "weather"
+        );
+    }
+
+    #[test]
+    fn response_max_completion_tokens_alias_deserializes() {
+        let req: ResponseRequest = serde_json::from_value(json!({
+            "input": "hi",
+            "max_completion_tokens": 9
+        }))
+        .unwrap();
+        assert_eq!(req.max_output_tokens, Some(9));
+    }
+
+    fn empty_response(id: &str) -> StoredResponse {
+        StoredResponse {
+            id: id.to_string(),
+            object: "response",
+            created_at: 1,
+            model: "model".to_string(),
+            status: "completed",
+            output: Vec::new(),
+            usage: Usage {
+                prompt_tokens: 0,
+                completion_tokens: 0,
+                total_tokens: 0,
+            },
+        }
+    }
+}

--- a/crates/server/src/routes/sse.rs
+++ b/crates/server/src/routes/sse.rs
@@ -6,6 +6,7 @@ use serde::Serialize;
 use tokio::sync::mpsc::UnboundedReceiver;
 
 use crate::generate::{FinishReason, GenEvent};
+use crate::schemas::Usage;
 
 pub type SseEvent = Result<Event, Infallible>;
 
@@ -22,7 +23,7 @@ where
     T: Serialize + 'static,
     D: Serialize + 'static,
     FT: FnMut(String) -> T + 'static,
-    FD: FnMut(FinishReason) -> D + 'static,
+    FD: FnMut(FinishReason, Option<Usage>) -> D + 'static,
 {
     async_stream::stream! {
         while let Some(ev) = rx.recv().await {
@@ -30,8 +31,12 @@ where
                 GenEvent::Token(text) => {
                     yield Ok::<_, Infallible>(json_event(&token_chunk(text)));
                 }
-                GenEvent::Done { reason, .. } => {
-                    yield Ok(json_event(&done_chunk(reason)));
+                GenEvent::Done { reason, prompt_tokens, completion_tokens } => {
+                    yield Ok(json_event(&done_chunk(reason, Some(Usage {
+                        prompt_tokens,
+                        completion_tokens,
+                        total_tokens: prompt_tokens + completion_tokens,
+                    }))));
                     yield Ok(Event::default().data("[DONE]"));
                     return;
                 }

--- a/crates/server/src/routes/tokenizer.rs
+++ b/crates/server/src/routes/tokenizer.rs
@@ -1,0 +1,47 @@
+//! Local tokenizer utility endpoints. These are not OpenAI core endpoints,
+//! but local harnesses commonly use them for prompt budgeting and debugging.
+
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::Json;
+
+use crate::compat::validate_model;
+use crate::errors::ApiError;
+use crate::schemas::{DetokenizeRequest, DetokenizeResponse, TokenizeRequest, TokenizeResponse};
+use crate::state::ServerState;
+
+pub async fn tokenize(
+    State(state): State<Arc<ServerState>>,
+    Json(req): Json<TokenizeRequest>,
+) -> Result<Json<TokenizeResponse>, ApiError> {
+    validate_model(req.model.as_deref(), &state.model_id)?;
+    let add_special_tokens = req.add_special_tokens.unwrap_or(true);
+    let encoding = state
+        .tokenizer
+        .encode(req.input.as_str(), add_special_tokens)
+        .map_err(|e| ApiError::bad_request(format!("tokenize failed: {e}")))?;
+    let tokens = encoding.get_ids().to_vec();
+    Ok(Json(TokenizeResponse {
+        object: "tokenization",
+        model: state.model_id.clone(),
+        tokens,
+    }))
+}
+
+pub async fn detokenize(
+    State(state): State<Arc<ServerState>>,
+    Json(req): Json<DetokenizeRequest>,
+) -> Result<Json<DetokenizeResponse>, ApiError> {
+    validate_model(req.model.as_deref(), &state.model_id)?;
+    let skip_special_tokens = req.skip_special_tokens.unwrap_or(true);
+    let text = state
+        .tokenizer
+        .decode(&req.tokens, skip_special_tokens)
+        .map_err(|e| ApiError::bad_request(format!("detokenize failed: {e}")))?;
+    Ok(Json(DetokenizeResponse {
+        object: "detokenization",
+        model: state.model_id.clone(),
+        text,
+    }))
+}

--- a/crates/server/src/schemas.rs
+++ b/crates/server/src/schemas.rs
@@ -5,6 +5,7 @@
 //! on incoming requests are ignored (serde default).
 
 use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
 
 use crate::chat_template::IncomingChatMessage;
 
@@ -53,7 +54,12 @@ pub struct ChatCompletionRequest {
     pub temperature: Option<f32>,
     #[serde(default)]
     pub top_p: Option<f32>,
-    #[serde(default)]
+    #[serde(
+        default,
+        alias = "max_completion_tokens",
+        alias = "maxCompletionTokens",
+        alias = "maxTokens"
+    )]
     pub max_tokens: Option<usize>,
     #[serde(default)]
     pub stream: bool,
@@ -61,12 +67,30 @@ pub struct ChatCompletionRequest {
     pub stop: Option<StopParam>,
     #[serde(default)]
     pub seed: Option<u64>,
+    #[serde(default)]
+    pub tools: Option<JsonValue>,
+    #[serde(default)]
+    pub tool_choice: Option<JsonValue>,
+    #[serde(default)]
+    pub response_format: Option<JsonValue>,
+    #[serde(default, alias = "reasoningEffort")]
+    pub reasoning_effort: Option<String>,
+    #[serde(default)]
+    pub stream_options: Option<StreamOptions>,
+    #[serde(default)]
+    pub n: Option<u32>,
+    #[serde(default)]
+    pub logprobs: Option<bool>,
 }
 
 #[derive(Debug, Serialize)]
 pub struct ChatCompletionMessage {
     pub role: &'static str,
-    pub content: String,
+    pub content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_calls: Option<Vec<OpenAiToolCall>>,
 }
 
 #[derive(Debug, Serialize)]
@@ -76,11 +100,31 @@ pub struct ChatCompletionChoice {
     pub finish_reason: &'static str,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub struct Usage {
     pub prompt_tokens: u32,
     pub completion_tokens: u32,
     pub total_tokens: u32,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct StreamOptions {
+    #[serde(default)]
+    pub include_usage: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct OpenAiFunctionCall {
+    pub name: String,
+    pub arguments: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct OpenAiToolCall {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub type_: &'static str,
+    pub function: OpenAiFunctionCall,
 }
 
 #[derive(Debug, Serialize)]
@@ -101,6 +145,10 @@ pub struct ChatStreamDelta {
     pub role: Option<&'static str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_calls: Option<Vec<OpenAiToolCall>>,
 }
 
 #[derive(Debug, Serialize)]
@@ -118,6 +166,8 @@ pub struct ChatStreamChunk {
     pub created: u64,
     pub model: String,
     pub choices: Vec<ChatStreamChoice>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub usage: Option<Usage>,
 }
 
 /* ---------- /v1/completions ---------- */
@@ -127,16 +177,29 @@ pub struct ChatStreamChunk {
 pub enum PromptParam {
     One(String),
     Many(Vec<String>),
+    Tokens(Vec<u32>),
+    TokenBatches(Vec<Vec<u32>>),
 }
 
 impl PromptParam {
-    pub fn into_single(self) -> Option<String> {
+    pub fn into_single(self) -> Option<SinglePrompt> {
         match self {
-            Self::One(s) => Some(s),
-            Self::Many(mut v) if v.len() == 1 => v.pop(),
+            Self::One(s) => Some(SinglePrompt::Text(s)),
+            Self::Many(mut v) if v.len() == 1 => v.pop().map(SinglePrompt::Text),
             Self::Many(_) => None,
+            Self::Tokens(ids) => Some(SinglePrompt::Tokens(ids)),
+            Self::TokenBatches(mut batches) if batches.len() == 1 => {
+                batches.pop().map(SinglePrompt::Tokens)
+            }
+            Self::TokenBatches(_) => None,
         }
     }
+}
+
+#[derive(Debug, Clone)]
+pub enum SinglePrompt {
+    Text(String),
+    Tokens(Vec<u32>),
 }
 
 #[derive(Debug, Deserialize)]
@@ -148,7 +211,12 @@ pub struct CompletionRequest {
     pub temperature: Option<f32>,
     #[serde(default)]
     pub top_p: Option<f32>,
-    #[serde(default)]
+    #[serde(
+        default,
+        alias = "max_completion_tokens",
+        alias = "maxCompletionTokens",
+        alias = "maxTokens"
+    )]
     pub max_tokens: Option<usize>,
     #[serde(default)]
     pub stream: bool,
@@ -156,6 +224,14 @@ pub struct CompletionRequest {
     pub stop: Option<StopParam>,
     #[serde(default)]
     pub seed: Option<u64>,
+    #[serde(default)]
+    pub stream_options: Option<StreamOptions>,
+    #[serde(default)]
+    pub n: Option<u32>,
+    #[serde(default)]
+    pub logprobs: Option<JsonValue>,
+    #[serde(default)]
+    pub echo: Option<bool>,
 }
 
 #[derive(Debug, Serialize)]
@@ -192,4 +268,96 @@ pub struct CompletionStreamChunk {
     pub created: u64,
     pub model: String,
     pub choices: Vec<CompletionStreamChoice>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub usage: Option<Usage>,
+}
+
+/* ---------- /v1/tokenize + /v1/detokenize ---------- */
+
+#[derive(Debug, Deserialize)]
+pub struct TokenizeRequest {
+    #[serde(default)]
+    pub model: Option<String>,
+    pub input: String,
+    #[serde(default)]
+    pub add_special_tokens: Option<bool>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TokenizeResponse {
+    pub object: &'static str,
+    pub model: String,
+    pub tokens: Vec<u32>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct DetokenizeRequest {
+    #[serde(default)]
+    pub model: Option<String>,
+    pub tokens: Vec<u32>,
+    #[serde(default)]
+    pub skip_special_tokens: Option<bool>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DetokenizeResponse {
+    pub object: &'static str,
+    pub model: String,
+    pub text: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn chat_max_token_aliases_deserialize() {
+        for key in [
+            "max_tokens",
+            "max_completion_tokens",
+            "maxCompletionTokens",
+            "maxTokens",
+        ] {
+            let value = json!({
+                "messages": [{"role": "user", "content": "hi"}],
+                key: 7
+            });
+            let req: ChatCompletionRequest = serde_json::from_value(value).unwrap();
+            assert_eq!(req.max_tokens, Some(7));
+        }
+    }
+
+    #[test]
+    fn completion_stream_usage_deserializes() {
+        let req: CompletionRequest = serde_json::from_value(json!({
+            "prompt": "hi",
+            "stream": true,
+            "stream_options": {"include_usage": true}
+        }))
+        .unwrap();
+        assert!(req.stream_options.unwrap().include_usage);
+    }
+
+    #[test]
+    fn completion_prompt_accepts_token_arrays() {
+        let req: CompletionRequest = serde_json::from_value(json!({
+            "prompt": [1, 2, 3]
+        }))
+        .unwrap();
+        assert!(matches!(
+            req.prompt.into_single(),
+            Some(SinglePrompt::Tokens(ids)) if ids == vec![1, 2, 3]
+        ));
+
+        let req: CompletionRequest = serde_json::from_value(json!({
+            "prompt": [[1, 2, 3]]
+        }))
+        .unwrap();
+        assert!(matches!(
+            req.prompt.into_single(),
+            Some(SinglePrompt::Tokens(ids)) if ids == vec![1, 2, 3]
+        ));
+    }
 }

--- a/crates/server/tests/chat_integration.rs
+++ b/crates/server/tests/chat_integration.rs
@@ -60,6 +60,10 @@ fn load_test_config() -> Option<LoaderConfig> {
         fp8_runtime: fp8,
         kv_fp8,
         api_key: None,
+        cors_allow_origin: None,
+        response_store_max_entries: 1024,
+        max_queued_requests: 32,
+        queue_timeout_ms: 30_000,
         no_download: std::env::var("SUPERSONIC_TEST_NO_DOWNLOAD").is_ok(),
     })
 }

--- a/crates/server/tests/protocol_mock.rs
+++ b/crates/server/tests/protocol_mock.rs
@@ -1,0 +1,738 @@
+use std::sync::Arc;
+
+use futures::StreamExt;
+use reqwest::Client;
+use serde_json::{json, Value};
+use server::generate::MockGeneration;
+use server::state::{GenerationScheduler, ServerState};
+use server::{capabilities, chat_template, registry};
+
+fn test_tokenizer() -> tokenizers::Tokenizer {
+    tokenizers::Tokenizer::from_bytes(
+        r#"{"version":"1.0","model":{"type":"WordLevel","vocab":{"[UNK]":0,"hello":1,"world":2},"unk_token":"[UNK]"}}"#,
+    )
+    .expect("test tokenizer")
+}
+
+fn test_template() -> Arc<chat_template::ChatTemplate> {
+    chat_template::ChatTemplate::from_template_source(
+        r#"{%- for message in messages -%}
+<|im_start|>{{ message.role }}
+{{ message.content }}<|im_end|>
+{%- endfor -%}
+{%- if tools -%}<tools>{{ tools | tojson }}</tools>{%- endif -%}
+{%- if add_generation_prompt -%}<|im_start|>assistant
+{%- if enable_thinking -%}<think>
+{%- endif -%}
+{%- endif -%}"#,
+    )
+    .expect("test chat template")
+}
+
+fn test_state_with_mock(mock_generation: MockGeneration) -> Arc<ServerState> {
+    test_state_with_scheduler(mock_generation, GenerationScheduler::new(32, 30_000))
+}
+
+fn test_state_with_scheduler(
+    mock_generation: MockGeneration,
+    scheduler: GenerationScheduler,
+) -> Arc<ServerState> {
+    Arc::new(ServerState {
+        server_instance_id: next_test_server_instance_id(),
+        model_id: "qwen3.5-0.8b".to_string(),
+        model_family: registry::ModelFamily::Qwen35,
+        tokenizer: Arc::new(test_tokenizer()),
+        chat_template: Some(test_template()),
+        session: None,
+        mock_generation: Some(mock_generation),
+        eos_ids: Vec::new(),
+        max_context: 256,
+        api_key: Some("secret".to_string()),
+        cors_allow_origin: Some("*".to_string()),
+        response_store_max_entries: 1024,
+        scheduler: Arc::new(scheduler),
+        capabilities: capabilities::capabilities_for_variant(
+            &registry::ModelVariant::Qwen3_5_0_8B,
+            registry::Backend::Cuda,
+            false,
+            false,
+            false,
+        ),
+    })
+}
+
+fn next_test_server_instance_id() -> u64 {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static NEXT_ID: AtomicU64 = AtomicU64::new(10_000);
+    NEXT_ID.fetch_add(1, Ordering::Relaxed)
+}
+
+struct Harness {
+    base: String,
+    client: Client,
+    _task: tokio::task::JoinHandle<()>,
+}
+
+async fn spawn(mock_text: &str) -> Harness {
+    spawn_with_mock(MockGeneration::text(mock_text)).await
+}
+
+async fn spawn_chunks(chunks: &[&str]) -> Harness {
+    spawn_with_mock(MockGeneration {
+        chunks: chunks.iter().map(|s| (*s).to_string()).collect(),
+        finish: server::generate::FinishReason::Stop,
+        delay_ms: 0,
+    })
+    .await
+}
+
+async fn spawn_with_mock(mock_generation: MockGeneration) -> Harness {
+    let state = test_state_with_mock(mock_generation);
+    spawn_with_state(state).await
+}
+
+async fn spawn_with_state(state: Arc<ServerState>) -> Harness {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind");
+    let addr = listener.local_addr().unwrap();
+    let task = tokio::spawn(async move {
+        let _ = server::serve(state, listener).await;
+    });
+    Harness {
+        base: format!("http://{addr}"),
+        client: Client::new(),
+        _task: task,
+    }
+}
+
+async fn collect_sse(resp: reqwest::Response) -> Vec<Value> {
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let mut stream = resp.bytes_stream();
+    let mut buf = String::new();
+    let mut events = Vec::new();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.expect("sse chunk");
+        buf.push_str(std::str::from_utf8(&chunk).expect("sse utf8"));
+        while let Some(idx) = buf.find("\n\n") {
+            let raw = buf[..idx].to_string();
+            buf = buf[idx + 2..].to_string();
+            for line in raw.lines() {
+                let Some(data) = line.strip_prefix("data:") else {
+                    continue;
+                };
+                let data = data.trim_start();
+                if data == "[DONE]" {
+                    events.push(json!({"__done": true}));
+                } else {
+                    events.push(serde_json::from_str(data).expect("sse json"));
+                }
+            }
+        }
+    }
+    events
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mock_chat_non_stream_parses_reasoning_and_tools() {
+    let h = spawn(
+        "<think>plan</think>\n<tool_call>\n<function=lookup>\n<parameter=query>\nweather\n</parameter>\n</function>\n</tool_call>",
+    )
+    .await;
+    let http = h
+        .client
+        .post(format!("{}/v1/chat/completions", h.base))
+        .bearer_auth("secret")
+        .json(&json!({
+            "model": "local",
+            "messages": [{"role": "developer", "content": "be brief"}, {"role": "user", "content": "hi"}],
+            "reasoning_effort": "medium",
+            "response_format": {"type": "json_object"},
+            "tools": [{"type": "function", "function": {"name": "lookup"}}],
+            "max_completion_tokens": 8
+        }))
+        .send()
+        .await
+        .expect("send");
+    let status = http.status();
+    let resp: Value = http.json().await.expect("json");
+    assert_eq!(status, reqwest::StatusCode::OK, "body={resp}");
+
+    let choice = &resp["choices"][0];
+    assert_eq!(choice["finish_reason"], "tool_calls");
+    assert_eq!(choice["message"]["content"], Value::Null);
+    assert_eq!(choice["message"]["reasoning_content"], "plan");
+    assert_eq!(
+        choice["message"]["tool_calls"][0]["function"]["name"],
+        "lookup"
+    );
+
+    let unsupported = h
+        .client
+        .post(format!("{}/v1/chat/completions", h.base))
+        .bearer_auth("secret")
+        .json(&json!({
+            "messages": [{"role": "user", "content": "hi"}],
+            "response_format": {"type": "json_schema", "json_schema": {"name": "x"}},
+            "max_completion_tokens": 1
+        }))
+        .send()
+        .await
+        .expect("send unsupported");
+    assert_eq!(unsupported.status(), reqwest::StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mock_responses_get_delete_roundtrip() {
+    let h = spawn("hello world").await;
+    let created: Value = h
+        .client
+        .post(format!("{}/v1/responses", h.base))
+        .bearer_auth("secret")
+        .json(&json!({
+            "model": "qwen3.5-0.8b",
+            "instructions": "brief",
+            "input": [{"type": "input_text", "text": "hi"}],
+            "text": {"format": {"type": "json_object"}},
+            "maxOutputTokens": 4
+        }))
+        .send()
+        .await
+        .expect("send")
+        .json()
+        .await
+        .expect("json");
+    let id = created["id"].as_str().unwrap();
+    assert_eq!(created["output"][0]["type"], "message");
+
+    let fetched: Value = h
+        .client
+        .get(format!("{}/v1/responses/{id}", h.base))
+        .bearer_auth("secret")
+        .send()
+        .await
+        .expect("get")
+        .json()
+        .await
+        .expect("json");
+    assert_eq!(fetched["id"], id);
+
+    let deleted: Value = h
+        .client
+        .delete(format!("{}/v1/responses/{id}", h.base))
+        .bearer_auth("secret")
+        .send()
+        .await
+        .expect("delete")
+        .json()
+        .await
+        .expect("json");
+    assert_eq!(deleted["deleted"], true);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mock_responses_store_is_scoped_per_server_instance() {
+    let first = spawn("hello from first").await;
+    let second = spawn("hello from second").await;
+    let created: Value = first
+        .client
+        .post(format!("{}/v1/responses", first.base))
+        .bearer_auth("secret")
+        .json(&json!({
+            "input": "hi",
+            "max_output_tokens": 4
+        }))
+        .send()
+        .await
+        .expect("create")
+        .json()
+        .await
+        .expect("json");
+    let id = created["id"].as_str().unwrap();
+
+    let cross_fetch = second
+        .client
+        .get(format!("{}/v1/responses/{id}", second.base))
+        .bearer_auth("secret")
+        .send()
+        .await
+        .expect("cross fetch");
+    assert_eq!(cross_fetch.status(), reqwest::StatusCode::BAD_REQUEST);
+
+    let cross_delete = second
+        .client
+        .delete(format!("{}/v1/responses/{id}", second.base))
+        .bearer_auth("secret")
+        .send()
+        .await
+        .expect("cross delete")
+        .json::<Value>()
+        .await
+        .expect("delete json");
+    assert_eq!(cross_delete["deleted"], false);
+
+    let same_fetch = first
+        .client
+        .get(format!("{}/v1/responses/{id}", first.base))
+        .bearer_auth("secret")
+        .send()
+        .await
+        .expect("same fetch");
+    assert_eq!(same_fetch.status(), reqwest::StatusCode::OK);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mock_chat_stream_buffers_reasoning_and_includes_usage() {
+    let h = spawn_chunks(&["<think>plan", "</think>\nhello", " world"]).await;
+    let resp = h
+        .client
+        .post(format!("{}/v1/chat/completions", h.base))
+        .bearer_auth("secret")
+        .json(&json!({
+            "messages": [{"role": "user", "content": "hi"}],
+            "reasoning_effort": "medium",
+            "stream": true,
+            "stream_options": {"include_usage": true},
+            "max_tokens": 8
+        }))
+        .send()
+        .await
+        .expect("send");
+    let events = collect_sse(resp).await;
+
+    assert_eq!(events[0]["choices"][0]["delta"]["role"], "assistant");
+    let mut content = String::new();
+    let mut reasoning = String::new();
+    let mut saw_usage = false;
+    let mut saw_done = false;
+    for event in &events {
+        if event.get("__done").is_some() {
+            saw_done = true;
+            continue;
+        }
+        if let Some(s) = event["choices"][0]["delta"]["content"].as_str() {
+            content.push_str(s);
+        }
+        if let Some(s) = event["choices"][0]["delta"]["reasoning_content"].as_str() {
+            reasoning.push_str(s);
+        }
+        if event.get("usage").is_some_and(|u| !u.is_null()) {
+            saw_usage = true;
+        }
+        let serialized = event.to_string();
+        assert!(
+            !serialized.contains("<think>") && !serialized.contains("</think>"),
+            "stream leaked think tags: {serialized}"
+        );
+    }
+    assert_eq!(reasoning, "plan");
+    assert_eq!(content, "hello world");
+    assert!(saw_usage);
+    assert!(saw_done);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mock_responses_stream_emits_expected_events() {
+    let h = spawn_chunks(&["hello", " world"]).await;
+    let resp = h
+        .client
+        .post(format!("{}/v1/responses", h.base))
+        .bearer_auth("secret")
+        .json(&json!({
+            "input": "hi",
+            "stream": true,
+            "max_output_tokens": 8
+        }))
+        .send()
+        .await
+        .expect("send");
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    let body = resp.text().await.expect("sse text");
+    assert!(body.contains("event: response.created"));
+    assert!(body.contains("event: response.output_text.delta"));
+    assert!(body.contains("event: response.output_text.done"));
+    assert!(body.contains("event: response.output_item.done"));
+    assert!(body.contains("event: response.completed"));
+    assert!(body.contains("data: [DONE]"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mock_auth_cors_and_model_mismatch() {
+    let h = spawn("hello").await;
+    let unauth = h
+        .client
+        .get(format!("{}/health", h.base))
+        .send()
+        .await
+        .expect("unauth");
+    assert_eq!(unauth.status(), reqwest::StatusCode::UNAUTHORIZED);
+
+    let root = h
+        .client
+        .get(format!("{}/", h.base))
+        .bearer_auth("secret")
+        .send()
+        .await
+        .expect("root");
+    assert_eq!(root.status(), reqwest::StatusCode::OK);
+
+    let v1 = h
+        .client
+        .get(format!("{}/v1", h.base))
+        .bearer_auth("secret")
+        .send()
+        .await
+        .expect("v1");
+    assert_eq!(v1.status(), reqwest::StatusCode::OK);
+
+    let ready = h
+        .client
+        .get(format!("{}/ready", h.base))
+        .bearer_auth("secret")
+        .send()
+        .await
+        .expect("ready");
+    assert_eq!(ready.status(), reqwest::StatusCode::OK);
+
+    let v1_ready = h
+        .client
+        .get(format!("{}/v1/ready", h.base))
+        .bearer_auth("secret")
+        .send()
+        .await
+        .expect("v1 ready");
+    assert_eq!(v1_ready.status(), reqwest::StatusCode::OK);
+
+    let model: Value = h
+        .client
+        .get(format!("{}/v1/models/local", h.base))
+        .bearer_auth("secret")
+        .send()
+        .await
+        .expect("model")
+        .json()
+        .await
+        .expect("model json");
+    assert_eq!(model["id"], "qwen3.5-0.8b");
+
+    let missing_model = h
+        .client
+        .get(format!("{}/v1/models/gpt-4.1", h.base))
+        .bearer_auth("secret")
+        .send()
+        .await
+        .expect("missing model");
+    assert_eq!(missing_model.status(), reqwest::StatusCode::BAD_REQUEST);
+
+    let metrics = h
+        .client
+        .get(format!("{}/metrics", h.base))
+        .bearer_auth("secret")
+        .send()
+        .await
+        .expect("metrics")
+        .text()
+        .await
+        .expect("metrics text");
+    assert!(metrics.contains("supersonic_active_requests"));
+    assert!(metrics.contains("supersonic_queued_requests"));
+
+    let cors = h
+        .client
+        .request(
+            reqwest::Method::OPTIONS,
+            format!("{}/v1/chat/completions", h.base),
+        )
+        .header("origin", "http://localhost:3000")
+        .header("access-control-request-method", "POST")
+        .send()
+        .await
+        .expect("cors");
+    assert!(cors.status().is_success());
+
+    let mismatch = h
+        .client
+        .post(format!("{}/v1/completions", h.base))
+        .bearer_auth("secret")
+        .json(&json!({"model": "gpt-4.1", "prompt": "hello", "max_tokens": 1}))
+        .send()
+        .await
+        .expect("mismatch");
+    assert_eq!(mismatch.status(), reqwest::StatusCode::BAD_REQUEST);
+
+    let unsupported = h
+        .client
+        .post(format!("{}/v1/completions", h.base))
+        .bearer_auth("secret")
+        .json(&json!({"prompt": "hello", "n": 2, "max_tokens": 1}))
+        .send()
+        .await
+        .expect("unsupported");
+    assert_eq!(unsupported.status(), reqwest::StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mock_generation_queue_full_returns_429() {
+    let state = test_state_with_scheduler(
+        MockGeneration {
+            chunks: vec!["hello".to_string(), " world".to_string()],
+            finish: server::generate::FinishReason::Stop,
+            delay_ms: 100,
+        },
+        GenerationScheduler::new(0, 30_000),
+    );
+    let h = spawn_with_state(state).await;
+    let first_client = h.client.clone();
+    let first_url = format!("{}/v1/chat/completions", h.base);
+    let first = tokio::spawn(async move {
+        first_client
+            .post(first_url)
+            .bearer_auth("secret")
+            .json(&json!({
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 8
+            }))
+            .send()
+            .await
+            .expect("first")
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+
+    let second = h
+        .client
+        .post(format!("{}/v1/chat/completions", h.base))
+        .bearer_auth("secret")
+        .json(&json!({
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 1
+        }))
+        .send()
+        .await
+        .expect("second");
+    assert_eq!(second.status(), reqwest::StatusCode::TOO_MANY_REQUESTS);
+
+    let health: Value = h
+        .client
+        .get(format!("{}/health", h.base))
+        .bearer_auth("secret")
+        .send()
+        .await
+        .expect("health")
+        .json()
+        .await
+        .expect("health json");
+    assert_eq!(health["max_queued_requests"], 0);
+    assert_eq!(health["queued_requests"], 0);
+
+    let first = first.await.expect("first join");
+    assert_eq!(first.status(), reqwest::StatusCode::OK);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mock_generation_queue_timeout_returns_503() {
+    let state = test_state_with_scheduler(
+        MockGeneration {
+            chunks: vec!["hello".to_string(), " world".to_string()],
+            finish: server::generate::FinishReason::Stop,
+            delay_ms: 100,
+        },
+        GenerationScheduler::new(1, 20),
+    );
+    let h = spawn_with_state(state).await;
+    let first_client = h.client.clone();
+    let first_url = format!("{}/v1/completions", h.base);
+    let first = tokio::spawn(async move {
+        first_client
+            .post(first_url)
+            .bearer_auth("secret")
+            .json(&json!({"prompt": "hello", "max_tokens": 8}))
+            .send()
+            .await
+            .expect("first")
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+
+    let timed_out = h
+        .client
+        .post(format!("{}/v1/completions", h.base))
+        .bearer_auth("secret")
+        .json(&json!({"prompt": "hello", "max_tokens": 8}))
+        .send()
+        .await
+        .expect("timed out");
+    assert_eq!(timed_out.status(), reqwest::StatusCode::SERVICE_UNAVAILABLE);
+
+    let first = first.await.expect("first join");
+    assert_eq!(first.status(), reqwest::StatusCode::OK);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mock_queued_stream_disconnect_releases_queue_slot() {
+    let state = test_state_with_scheduler(
+        MockGeneration {
+            chunks: vec!["hello".to_string(), " world".to_string()],
+            finish: server::generate::FinishReason::Stop,
+            delay_ms: 100,
+        },
+        GenerationScheduler::new(1, 30_000),
+    );
+    let h = spawn_with_state(state).await;
+    let first_client = h.client.clone();
+    let first_url = format!("{}/v1/chat/completions", h.base);
+    let first = tokio::spawn(async move {
+        first_client
+            .post(first_url)
+            .bearer_auth("secret")
+            .json(&json!({
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 8
+            }))
+            .send()
+            .await
+            .expect("first")
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+
+    let queued = h
+        .client
+        .post(format!("{}/v1/chat/completions", h.base))
+        .bearer_auth("secret")
+        .json(&json!({
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": true,
+            "max_tokens": 8
+        }))
+        .send()
+        .await
+        .expect("queued stream");
+    assert_eq!(queued.status(), reqwest::StatusCode::OK);
+
+    let health: Value = h
+        .client
+        .get(format!("{}/health", h.base))
+        .bearer_auth("secret")
+        .send()
+        .await
+        .expect("health before drop")
+        .json()
+        .await
+        .expect("health json");
+    assert_eq!(health["queued_requests"], 1);
+
+    drop(queued);
+    tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    let health: Value = h
+        .client
+        .get(format!("{}/health", h.base))
+        .bearer_auth("secret")
+        .send()
+        .await
+        .expect("health after drop")
+        .json()
+        .await
+        .expect("health json");
+    assert_eq!(health["queued_requests"], 0);
+
+    let first = first.await.expect("first join");
+    assert_eq!(first.status(), reqwest::StatusCode::OK);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mock_tokenize_detokenize_roundtrip() {
+    let h = spawn("hello").await;
+    let tok: Value = h
+        .client
+        .post(format!("{}/v1/tokenize", h.base))
+        .bearer_auth("secret")
+        .json(&json!({
+            "model": "local",
+            "input": "hello world",
+            "add_special_tokens": false
+        }))
+        .send()
+        .await
+        .expect("tokenize")
+        .json()
+        .await
+        .expect("json");
+    assert_eq!(tok["object"], "tokenization");
+    let tokens = tok["tokens"].as_array().expect("tokens");
+    assert!(!tokens.is_empty());
+
+    let detok: Value = h
+        .client
+        .post(format!("{}/v1/detokenize", h.base))
+        .bearer_auth("secret")
+        .json(&json!({
+            "model": "qwen3.5-0.8b",
+            "tokens": [1, 2],
+            "skip_special_tokens": true
+        }))
+        .send()
+        .await
+        .expect("detokenize")
+        .json()
+        .await
+        .expect("json");
+    assert_eq!(detok["object"], "detokenization");
+    assert!(detok["text"].as_str().unwrap_or("").contains("hello"));
+
+    let root_tok = h
+        .client
+        .post(format!("{}/tokenize", h.base))
+        .bearer_auth("secret")
+        .json(&json!({
+            "input": "hello",
+            "add_special_tokens": false
+        }))
+        .send()
+        .await
+        .expect("root tokenize");
+    assert_eq!(root_tok.status(), reqwest::StatusCode::OK);
+
+    let root_detok = h
+        .client
+        .post(format!("{}/detokenize", h.base))
+        .bearer_auth("secret")
+        .json(&json!({"tokens": [1]}))
+        .send()
+        .await
+        .expect("root detokenize");
+    assert_eq!(root_detok.status(), reqwest::StatusCode::OK);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mock_completions_accept_token_prompt() {
+    let h = spawn("hello").await;
+    let resp: Value = h
+        .client
+        .post(format!("{}/v1/completions", h.base))
+        .bearer_auth("secret")
+        .json(&json!({
+            "model": "local",
+            "prompt": [1, 2],
+            "max_tokens": 4
+        }))
+        .send()
+        .await
+        .expect("send")
+        .json()
+        .await
+        .expect("json");
+    assert_eq!(resp["choices"][0]["text"], "hello");
+    assert_eq!(resp["usage"]["prompt_tokens"], 2);
+
+    let batched = h
+        .client
+        .post(format!("{}/v1/completions", h.base))
+        .bearer_auth("secret")
+        .json(&json!({
+            "prompt": [[1], [2]],
+            "max_tokens": 4
+        }))
+        .send()
+        .await
+        .expect("batched");
+    assert_eq!(batched.status(), reqwest::StatusCode::BAD_REQUEST);
+}

--- a/docs/server.md
+++ b/docs/server.md
@@ -1,0 +1,145 @@
+# OpenAI-Compatible Server
+
+`supersonic-serve` exposes a local OpenAI-compatible HTTP surface for common
+OSS clients and harnesses such as Pi, OpenCode, and Hermes.
+
+## Start
+
+```bash
+SUPERSONIC_BACKENDS=cuda cargo build --release -p server
+
+target/release/supersonic-serve \
+  --backend cuda \
+  --model qwen3.5-0.8b \
+  --model-dir /path/to/Qwen3.5-0.8B \
+  --max-context 4096 \
+  --host 127.0.0.1 \
+  --port 8080
+```
+
+Optional deployment flags:
+
+- `--api-key KEY` or `SUPERSONIC_API_KEY=KEY` requires
+  `Authorization: Bearer KEY`.
+- `--cors-allow-origin ORIGIN` or `SUPERSONIC_CORS_ALLOW_ORIGIN=ORIGIN`
+  enables CORS for browser clients. Use a concrete origin when possible;
+  `*` is accepted for local development.
+- `--response-store-max-entries N` or
+  `SUPERSONIC_RESPONSE_STORE_MAX_ENTRIES=N` caps the in-memory
+  `/v1/responses` store. The default is `1024`; oldest entries are evicted.
+- `--max-queued-requests N` or `SUPERSONIC_MAX_QUEUED_REQUESTS=N` caps the
+  number of requests waiting for the single GPU generation slot. The default
+  is `32`; excess requests fail with HTTP 429.
+- `--queue-timeout-ms N` or `SUPERSONIC_QUEUE_TIMEOUT_MS=N` caps how long a
+  queued request may wait before failing. The default is `30000`.
+- `--no-download` disables release-bake downloads.
+
+## Endpoints
+
+- `GET /`, `GET /v1`, `GET /health`, `GET /v1/health`, `GET /ready`,
+  and `GET /v1/ready`
+- `GET /v1/capabilities`
+- `GET /v1/models`
+- `GET /v1/models/{model}`
+- `GET /metrics`
+- `POST /v1/completions`
+- `POST /v1/chat/completions`
+- `POST /v1/responses`
+- `GET /v1/responses/{id}`
+- `DELETE /v1/responses/{id}`
+- `POST /v1/tokenize` and `POST /tokenize`
+- `POST /v1/detokenize` and `POST /detokenize`
+
+## Compatibility Notes
+
+Chat Completions accepts modern client fields including `developer` messages,
+text content-part arrays, `max_completion_tokens`, `stream_options.include_usage`,
+`tools`, `tool_choice`, `response_format`, and `reasoning_effort`.
+
+Responses accepts string input or message-array input, plus `instructions`,
+`max_output_tokens`, `tools`, `tool_choice`, `reasoning.effort`, `stream`, and
+`previous_response_id`. Response objects are kept in process memory only and
+are bounded by `--response-store-max-entries`.
+
+`response_format: {"type":"json_object"}` and Responses
+`text: {"format":{"type":"json_object"}}` add a JSON-object system hint.
+Strict `json_schema` constrained decoding is not implemented and returns a
+clear 400 error.
+
+Tool calls are model-generated and are not executed by SuperSonic. For Qwen
+templates, generated XML `<tool_call>` blocks are parsed into OpenAI-shaped
+`tool_calls` or Responses `function_call` output items. The client remains
+responsible for running tools and sending tool results back.
+
+For Responses tool loops, `previous_response_id` restores prior assistant
+`function_call` items as assistant tool calls before new
+`function_call_output` items are rendered. This lets clients send the tool
+result with the previous response id instead of rebuilding the assistant
+tool-call message themselves.
+
+Reasoning is off by default. Set `reasoning_effort` on Chat Completions or
+`reasoning.effort` on Responses to a non-off value to enable model thinking.
+When present, `<think>...</think>` is stripped from visible assistant text and
+returned separately as `reasoning_content` or a Responses `reasoning` item.
+
+Unsupported features fail explicitly: `n > 1`, `logprobs`, `echo=true`,
+image/file content parts, and `tool_choice="required"`.
+
+`/v1/completions` accepts either a raw string prompt or a single token-id
+array prompt. Batched prompts are rejected because SuperSonic currently serves
+one generation per request.
+
+Generation is scheduled through a bounded one-at-a-time GPU queue. Queue state
+is exposed on `/health` and `/v1/capabilities`; disconnecting streaming
+clients releases queued work before it enters the GPU slot, and in-flight
+generation stops at the next token boundary once the response stream is gone.
+
+`/v1/tokenize` and `/v1/detokenize` are SuperSonic-local helpers for token
+budgeting. They require the same auth as generation endpoints and accept the
+same loaded-model id or local aliases.
+
+## Smoke Tests
+
+```bash
+curl -fsS http://127.0.0.1:8080/v1/capabilities | jq .
+
+curl -fsS http://127.0.0.1:8080/v1/chat/completions \
+  -H 'content-type: application/json' \
+  -d '{
+    "messages": [
+      {"role": "developer", "content": "Answer briefly."},
+      {"role": "user", "content": "Say hi"}
+    ],
+    "max_completion_tokens": 8,
+    "temperature": 0
+  }' | jq .
+
+curl -fsS http://127.0.0.1:8080/v1/responses \
+  -H 'content-type: application/json' \
+  -d '{
+    "instructions": "Answer briefly.",
+    "input": "Say hi",
+    "max_output_tokens": 8,
+    "temperature": 0
+  }' | jq .
+```
+
+## OpenAI SDK Harness Smoke
+
+For a real OpenAI-compatible client smoke, install the Node OpenAI SDK in a
+temporary directory and point it at `supersonic-serve`:
+
+```bash
+tmpdir=$(mktemp -d /tmp/supersonic-openai-smoke.XXXXXX)
+cd "$tmpdir"
+npm init -y >/dev/null
+npm install openai@6 >/dev/null
+
+SUPERSONIC_BASE_URL=http://127.0.0.1:8080 \
+SUPERSONIC_API_KEY=secret \
+node /path/to/SuperSonic/scripts/openai_compat_smoke.mjs
+```
+
+The smoke covers model list/retrieve, Chat Completions, streaming Chat
+Completions with usage, legacy Completions, Responses create/get/delete,
+tokenization, and metrics.

--- a/scripts/openai_compat_smoke.mjs
+++ b/scripts/openai_compat_smoke.mjs
@@ -1,0 +1,116 @@
+import { createRequire } from "node:module";
+
+const requireFromCwd = createRequire(`${process.cwd()}/`);
+const { default: OpenAI } = await import(requireFromCwd.resolve("openai"));
+
+const rootURL = process.env.SUPERSONIC_BASE_URL ?? "http://127.0.0.1:8080";
+const baseURL = rootURL.endsWith("/v1") ? rootURL : `${rootURL}/v1`;
+const apiKey = process.env.SUPERSONIC_API_KEY ?? "secret";
+const model = process.env.SUPERSONIC_SMOKE_MODEL ?? "local";
+
+const client = new OpenAI({ baseURL, apiKey });
+
+const compact = (value) => JSON.stringify(value);
+
+async function main() {
+  const models = await client.models.list();
+  console.log("models", models.data.map((m) => m.id).join(","));
+
+  const retrieved = await client.models.retrieve(model);
+  console.log("model", retrieved.id);
+
+  const chat = await client.chat.completions.create({
+    model,
+    messages: [
+      { role: "developer", content: "Answer briefly." },
+      { role: "user", content: "Say hi" },
+    ],
+    max_completion_tokens: 4,
+    temperature: 0,
+  });
+  console.log(
+    "chat",
+    compact({
+      finish: chat.choices[0].finish_reason,
+      content: chat.choices[0].message.content,
+      usage: chat.usage,
+    }),
+  );
+
+  const stream = await client.chat.completions.create({
+    model,
+    messages: [{ role: "user", content: "Say hi" }],
+    max_tokens: 4,
+    temperature: 0,
+    stream: true,
+    stream_options: { include_usage: true },
+  });
+  let streamed = "";
+  let sawUsage = false;
+  for await (const chunk of stream) {
+    const delta = chunk.choices?.[0]?.delta?.content;
+    if (delta) streamed += delta;
+    if (chunk.usage) sawUsage = true;
+  }
+  console.log("chat_stream", compact({ streamed, sawUsage }));
+
+  const completion = await client.completions.create({
+    model,
+    prompt: "Say hi",
+    max_tokens: 3,
+    temperature: 0,
+  });
+  console.log(
+    "completion",
+    compact({
+      finish: completion.choices[0].finish_reason,
+      text: completion.choices[0].text,
+      usage: completion.usage,
+    }),
+  );
+
+  const response = await client.responses.create({
+    model,
+    input: "Say hi",
+    max_output_tokens: 3,
+    temperature: 0,
+  });
+  console.log(
+    "response",
+    compact({
+      id: response.id,
+      status: response.status,
+      output: response.output?.map((item) => item.type),
+    }),
+  );
+
+  const fetched = await client.responses.retrieve(response.id);
+  console.log("response_get", fetched.id);
+
+  const deleted = await client.responses.delete(response.id);
+  console.log("response_delete", compact(deleted));
+
+  const tokenize = await fetch(baseURL.replace(/\/v1$/, "") + "/tokenize", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${apiKey}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      model,
+      input: "hello world",
+      add_special_tokens: false,
+    }),
+  }).then((r) => r.json());
+  console.log("tokenize", compact({ count: tokenize.tokens.length }));
+
+  const metrics = await fetch(baseURL.replace(/\/v1$/, "") + "/metrics", {
+    headers: { authorization: `Bearer ${apiKey}` },
+  }).then((r) => r.text());
+  console.log("metrics", metrics.includes("supersonic_active_requests"));
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Builds out `supersonic-serve` into a practical OpenAI-compatible local server surface for common OSS harnesses and OpenAI SDK clients.

## What changed

- Expands Chat Completions compatibility: developer messages, content parts, token aliases, stream usage, tool definitions, `response_format`, reasoning extraction, Qwen XML tool-call parsing, and explicit unsupported-option errors.
- Adds Responses API support: create/get/delete, streaming events, `previous_response_id`, function-call output loops, bounded in-memory response storage, and JSON-object response hints.
- Adds tokenizer helpers and aliases: `/v1/tokenize`, `/v1/detokenize`, `/tokenize`, `/detokenize`.
- Adds model/health/ops endpoints: `/v1/models/{model}`, `/`, `/v1`, `/ready`, `/v1/ready`, `/v1/capabilities`, and `/metrics`.
- Adds auth/CORS configuration and explicit model-alias validation.
- Adds a bounded single-GPU generation scheduler with queue depth, queue timeout, disconnect handling, HTTP 429/503 behavior, and queue metrics.
- Adds a mock HTTP protocol harness for server compatibility tests without requiring a model/GPU.
- Adds `docs/server.md` and `scripts/openai_compat_smoke.mjs` for repeatable OpenAI SDK smoke testing.

## Validation

- `cargo fmt -p server -p supersonic-runtime -- --check`
- `cargo test -p server`
- `cargo test -p supersonic-runtime`
- `cargo check --workspace --all-targets`
- Live CUDA smoke on RTX 3090 with `/workspace/models/Qwen3.5-0.8B`
- Official Node `openai` SDK smoke using `scripts/openai_compat_smoke.mjs`, covering:
  - model list/retrieve
  - Chat Completions
  - streaming Chat Completions with usage
  - legacy Completions
  - Responses create/get/delete
  - tokenization
  - metrics

## Notes

A workspace-wide `cargo fmt --check` currently reports formatting diffs in existing `crates/runner` files outside this PR's scope. I kept this PR scoped to server/runtime/docs and validated formatting for the touched crates instead.

Unsupported features still fail explicitly rather than silently degrading: multi-choice `n > 1`, logprobs, images/files, `tool_choice=required`, and strict `json_schema` constrained decoding.
