### PR TITLE
[codex] server prefix cache reuse

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2050,6 +2050,7 @@ dependencies = [
  "runner",
  "serde",
  "serde_json",
+ "sha2",
  "supersonic-core",
  "tokenizers",
  "tokio",

--- a/crates/runner/src/decode_engine.rs
+++ b/crates/runner/src/decode_engine.rs
@@ -863,6 +863,23 @@ pub struct DecodeEngine {
     metal_v2_scratch: Option<prefill_engine::MetalV2DecodeScratch>,
 }
 
+pub struct DecodeEngineSnapshot {
+    state: ModelState,
+    pub logits: Vec<f32>,
+}
+
+impl DecodeEngineSnapshot {
+    pub fn try_clone(&self) -> Result<Self> {
+        Ok(Self {
+            state: self
+                .state
+                .clone_gpu()
+                .map_err(|e| anyhow::anyhow!("clone Qwen prefix snapshot: {e}"))?,
+            logits: self.logits.clone(),
+        })
+    }
+}
+
 /// Per-call workspace for `DecodeEngine::verify_block_fused_decode`.
 ///
 /// The fused verify path needs a B-sized workspace (F32 projection +
@@ -10370,6 +10387,35 @@ impl DecodeEngine {
             .reset_sync()
             .map_err(|e| anyhow::anyhow!("reset sync: {e}"))?;
         Ok(())
+    }
+
+    pub fn snapshot_prefix(&self, logits: Vec<f32>) -> Result<DecodeEngineSnapshot> {
+        Ok(DecodeEngineSnapshot {
+            state: self
+                .state
+                .clone_gpu()
+                .map_err(|e| anyhow::anyhow!("snapshot Qwen prefix state: {e}"))?,
+            logits,
+        })
+    }
+
+    pub fn restore_prefix(&mut self, snapshot: &DecodeEngineSnapshot) -> Result<Vec<f32>> {
+        self.state = snapshot
+            .state
+            .clone_gpu()
+            .map_err(|e| anyhow::anyhow!("restore Qwen prefix state: {e}"))?;
+        self.scratch
+            .reset_sync()
+            .map_err(|e| anyhow::anyhow!("reset sync after prefix restore: {e}"))?;
+        Ok(snapshot.logits.clone())
+    }
+
+    pub fn restore_prefix_owned(&mut self, snapshot: DecodeEngineSnapshot) -> Result<Vec<f32>> {
+        self.state = snapshot.state;
+        self.scratch
+            .reset_sync()
+            .map_err(|e| anyhow::anyhow!("reset sync after prefix restore: {e}"))?;
+        Ok(snapshot.logits)
     }
 
     /// Run native GPU prefill on the prompt, returning logits for the last token.

--- a/crates/runner/src/gemma4_engine.rs
+++ b/crates/runner/src/gemma4_engine.rs
@@ -597,6 +597,33 @@ pub struct Gemma4Engine {
     fp8_scale_descs_gpu: Option<GpuBuffer>,
 }
 
+pub struct Gemma4EngineSnapshot {
+    k_caches: Vec<GpuBuffer>,
+    v_caches: Vec<GpuBuffer>,
+    pub logits: Vec<f32>,
+}
+
+impl Gemma4EngineSnapshot {
+    pub fn try_clone(&self) -> Result<Self> {
+        Ok(Self {
+            k_caches: clone_buffers(&self.k_caches, "Gemma 4 K snapshot")?,
+            v_caches: clone_buffers(&self.v_caches, "Gemma 4 V snapshot")?,
+            logits: self.logits.clone(),
+        })
+    }
+}
+
+fn clone_buffers(buffers: &[GpuBuffer], label: &str) -> Result<Vec<GpuBuffer>> {
+    buffers
+        .iter()
+        .enumerate()
+        .map(|(i, b)| {
+            b.clone_device()
+                .map_err(|e| anyhow!("{label} layer {i}: {e}"))
+        })
+        .collect()
+}
+
 impl Gemma4Engine {
     /// Load all weights for a Gemma 4 dense variant and initialize GPU state
     /// for a single decoding sequence (`batch_size = 1`). Convenience wrapper
@@ -1163,6 +1190,39 @@ impl Gemma4Engine {
     /// Number of parallel sequences this engine was sized for.
     pub fn batch_size(&self) -> usize {
         self.batch_size
+    }
+
+    pub fn snapshot_prefix(&self, logits: Vec<f32>) -> Result<Gemma4EngineSnapshot> {
+        Ok(Gemma4EngineSnapshot {
+            k_caches: clone_buffers(&self.k_caches[0], "Gemma 4 K prefix")?,
+            v_caches: clone_buffers(&self.v_caches[0], "Gemma 4 V prefix")?,
+            logits,
+        })
+    }
+
+    pub fn restore_prefix(&mut self, snapshot: &Gemma4EngineSnapshot) -> Result<Vec<f32>> {
+        if snapshot.k_caches.len() != self.k_caches[0].len()
+            || snapshot.v_caches.len() != self.v_caches[0].len()
+        {
+            bail!("Gemma 4 prefix snapshot layer count mismatch");
+        }
+        for (i, src) in snapshot.k_caches.iter().enumerate() {
+            let dst = &mut self.k_caches[0][i];
+            if dst.len_bytes() != src.len_bytes() {
+                bail!("Gemma 4 K prefix snapshot size mismatch at layer {i}");
+            }
+            gpu_hal::copy_d2d(self.device, dst.as_mut_ptr(), src.as_ptr(), src.len_bytes())
+                .map_err(|e| anyhow!("restore Gemma 4 K prefix layer {i}: {e}"))?;
+        }
+        for (i, src) in snapshot.v_caches.iter().enumerate() {
+            let dst = &mut self.v_caches[0][i];
+            if dst.len_bytes() != src.len_bytes() {
+                bail!("Gemma 4 V prefix snapshot size mismatch at layer {i}");
+            }
+            gpu_hal::copy_d2d(self.device, dst.as_mut_ptr(), src.as_ptr(), src.len_bytes())
+                .map_err(|e| anyhow!("restore Gemma 4 V prefix layer {i}: {e}"))?;
+        }
+        Ok(snapshot.logits.clone())
     }
 
     pub fn text_config(&self) -> &TextConfig {

--- a/crates/runner/src/gemma4_int4_engine.rs
+++ b/crates/runner/src/gemma4_int4_engine.rs
@@ -437,6 +437,33 @@ pub struct Gemma4Int4Engine {
     int4_scales_gpu: GpuBuffer,
 }
 
+pub struct Gemma4Int4EngineSnapshot {
+    k_caches: Vec<GpuBuffer>,
+    v_caches: Vec<GpuBuffer>,
+    pub logits: Vec<f32>,
+}
+
+impl Gemma4Int4EngineSnapshot {
+    pub fn try_clone(&self) -> Result<Self> {
+        Ok(Self {
+            k_caches: clone_buffers(&self.k_caches, "Gemma 4 INT4 K snapshot")?,
+            v_caches: clone_buffers(&self.v_caches, "Gemma 4 INT4 V snapshot")?,
+            logits: self.logits.clone(),
+        })
+    }
+}
+
+fn clone_buffers(buffers: &[GpuBuffer], label: &str) -> Result<Vec<GpuBuffer>> {
+    buffers
+        .iter()
+        .enumerate()
+        .map(|(i, b)| {
+            b.clone_device()
+                .map_err(|e| anyhow!("{label} layer {i}: {e}"))
+        })
+        .collect()
+}
+
 impl Gemma4Int4Engine {
     /// Convenience wrapper for single-sequence loads (preserves original
     /// signature). Delegates to [`Self::load_with_batch`] with `batch_size=1`.
@@ -848,6 +875,39 @@ impl Gemma4Int4Engine {
 
     pub fn batch_size(&self) -> usize {
         self.batch_size
+    }
+
+    pub fn snapshot_prefix(&self, logits: Vec<f32>) -> Result<Gemma4Int4EngineSnapshot> {
+        Ok(Gemma4Int4EngineSnapshot {
+            k_caches: clone_buffers(&self.k_caches, "Gemma 4 INT4 K prefix")?,
+            v_caches: clone_buffers(&self.v_caches, "Gemma 4 INT4 V prefix")?,
+            logits,
+        })
+    }
+
+    pub fn restore_prefix(&mut self, snapshot: &Gemma4Int4EngineSnapshot) -> Result<Vec<f32>> {
+        if snapshot.k_caches.len() != self.k_caches.len()
+            || snapshot.v_caches.len() != self.v_caches.len()
+        {
+            bail!("Gemma 4 INT4 prefix snapshot layer count mismatch");
+        }
+        for (i, src) in snapshot.k_caches.iter().enumerate() {
+            let dst = &mut self.k_caches[i];
+            if dst.len_bytes() != src.len_bytes() {
+                bail!("Gemma 4 INT4 K prefix snapshot size mismatch at layer {i}");
+            }
+            gpu_hal::copy_d2d(self.device, dst.as_mut_ptr(), src.as_ptr(), src.len_bytes())
+                .map_err(|e| anyhow!("restore Gemma 4 INT4 K prefix layer {i}: {e}"))?;
+        }
+        for (i, src) in snapshot.v_caches.iter().enumerate() {
+            let dst = &mut self.v_caches[i];
+            if dst.len_bytes() != src.len_bytes() {
+                bail!("Gemma 4 INT4 V prefix snapshot size mismatch at layer {i}");
+            }
+            gpu_hal::copy_d2d(self.device, dst.as_mut_ptr(), src.as_ptr(), src.len_bytes())
+                .map_err(|e| anyhow!("restore Gemma 4 INT4 V prefix layer {i}: {e}"))?;
+        }
+        Ok(snapshot.logits.clone())
     }
 
     /// D2D-copy sequence 0's K/V cache contents into every other sequence's

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -19,6 +19,7 @@ gemma4 = { path = "../gemma4" }
 anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+sha2 = "0.10"
 tokenizers = "0.22"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
 tracing = "0.1"

--- a/crates/runtime/src/generate.rs
+++ b/crates/runtime/src/generate.rs
@@ -13,9 +13,12 @@ use tokenizers::Tokenizer;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tokio::sync::{OwnedSemaphorePermit, TryAcquireError};
 
+use crate::prefix_cache::CacheRequest;
 use crate::sampling::{rng_from_seed, sample};
 use crate::session::InferenceSession;
 use crate::state::ServerState;
+
+const CACHE_ANCHOR_SUFFIX_TOKENS: usize = 16;
 
 /// What a caller can tune per request. Missing fields fall back to
 /// permissive defaults so clients that only supply `messages` still work.
@@ -49,6 +52,7 @@ pub enum GenEvent {
         reason: FinishReason,
         prompt_tokens: u32,
         completion_tokens: u32,
+        cached_prompt_tokens: u32,
     },
     /// Terminal error event: generation failed; no more events will arrive.
     Error(String),
@@ -144,6 +148,7 @@ pub fn spawn(
     state: Arc<ServerState>,
     prompt_ids: Vec<u32>,
     params: GenParams,
+    cache: Option<CacheRequest>,
 ) -> Result<UnboundedReceiver<GenEvent>> {
     let (tx, rx) = mpsc::unbounded_channel();
 
@@ -151,7 +156,7 @@ pub fn spawn(
     match scheduler.permits.clone().try_acquire_owned() {
         Ok(permit) => {
             tokio::spawn(run_with_permit(
-                scheduler, state, prompt_ids, params, tx, permit,
+                scheduler, state, prompt_ids, params, cache, tx, permit,
             ));
             return Ok(rx);
         }
@@ -195,7 +200,7 @@ pub fn spawn(
             }
         };
         scheduler.queued.fetch_sub(1, Ordering::SeqCst);
-        run_with_permit(scheduler, state, prompt_ids, params, tx, permit).await;
+        run_with_permit(scheduler, state, prompt_ids, params, cache, tx, permit).await;
     });
     Ok(rx)
 }
@@ -205,6 +210,7 @@ async fn run_with_permit(
     state: Arc<ServerState>,
     prompt_ids: Vec<u32>,
     params: GenParams,
+    cache: Option<CacheRequest>,
     tx: UnboundedSender<GenEvent>,
     permit: OwnedSemaphorePermit,
 ) {
@@ -223,7 +229,7 @@ async fn run_with_permit(
 
     let scheduler_done = scheduler.clone();
     let join = tokio::task::spawn_blocking(move || {
-        let result = run(state, prompt_ids, params, tx.clone());
+        let result = run(state, prompt_ids, params, cache, tx.clone());
         if let Err(e) = result {
             let _ = tx.send(GenEvent::Error(e.to_string()));
         }
@@ -273,6 +279,7 @@ async fn run_mock(
         } else {
             completion_tokens
         },
+        cached_prompt_tokens: 0,
     });
 }
 
@@ -280,10 +287,12 @@ fn run(
     state: Arc<ServerState>,
     prompt_ids: Vec<u32>,
     params: GenParams,
+    cache: Option<CacheRequest>,
     tx: UnboundedSender<GenEvent>,
 ) -> Result<()> {
     let tokenizer = state.tokenizer.clone();
     let prompt_tokens = prompt_ids.len() as u32;
+    let mut cached_prompt_tokens = 0u32;
 
     // Zero-token request: return an empty completion without touching the
     // engine. OpenAI semantics: `max_tokens=0` means no completion tokens.
@@ -292,6 +301,7 @@ fn run(
             reason: FinishReason::Length,
             prompt_tokens,
             completion_tokens: 0,
+            cached_prompt_tokens: 0,
         });
         return Ok(());
     }
@@ -301,16 +311,64 @@ fn run(
         .as_ref()
         .ok_or_else(|| anyhow!("no inference session configured"))?;
     let mut guard = session.blocking_lock();
-    guard.reset()?;
-    let prefill_logits = guard.prefill(&prompt_ids)?;
+    let prefill_logits = if let Some(cache_req) = cache.as_ref() {
+        if let Some(hit) = state.prefix_cache.lookup(cache_req, &prompt_ids) {
+            match guard.restore_prefix(hit.snapshot) {
+                Ok(mut logits) => {
+                    cached_prompt_tokens = hit.cached_tokens as u32;
+                    for (idx, token) in prompt_ids
+                        .iter()
+                        .copied()
+                        .enumerate()
+                        .skip(hit.cached_tokens)
+                    {
+                        logits = guard.decode_step(token, idx)?;
+                    }
+                    logits
+                }
+                Err(e) => {
+                    tracing::warn!("prefix cache restore failed: {e}");
+                    state.prefix_cache.record_restore_failure();
+                    guard.reset()?;
+                    guard.prefill(&prompt_ids)?
+                }
+            }
+        } else {
+            guard.reset()?;
+            prefill_with_cache_anchor(&mut guard, &state, cache_req, &prompt_ids)?
+        }
+    } else {
+        guard.reset()?;
+        guard.prefill(&prompt_ids)?
+    };
+
+    if let Some(cache_req) = cache.as_ref() {
+        match guard.snapshot_prefix(prefill_logits.clone()) {
+            Ok(snapshot) => {
+                if let Err(e) = state.prefix_cache.insert(cache_req, &prompt_ids, snapshot) {
+                    tracing::warn!("prefix cache insert failed: {e}");
+                }
+            }
+            Err(e) => tracing::debug!("prefix cache snapshot skipped: {e}"),
+        }
+    }
 
     let mut rng = rng_from_seed(params.seed);
 
-    // Sample the first new token from prefill's final logits.
-    let mut logits = prefill_logits;
-    let mut next_token = sample(&mut logits, params.temperature, params.top_p, &mut rng);
+    // Sample the first new token from prefill's final logits. Keep an
+    // unmodified logits row for prefix-cache snapshots; `sample` mutates
+    // its input for non-greedy settings.
+    let mut current_logits = prefill_logits;
+    let mut sample_logits = current_logits.clone();
+    let mut next_token = sample(
+        &mut sample_logits,
+        params.temperature,
+        params.top_p,
+        &mut rng,
+    );
 
     let mut emitted_ids: Vec<u32> = Vec::with_capacity(params.max_tokens);
+    let mut state_token_ids = prompt_ids.clone();
     let mut prev_decoded = String::new();
     let mut completion_tokens: u32 = 0;
 
@@ -357,16 +415,73 @@ fn run(
         }
 
         let pos = prompt_ids.len() + emitted_ids.len() - 1;
-        let mut next_logits = guard.decode_step(next_token, pos)?;
-        next_token = sample(&mut next_logits, params.temperature, params.top_p, &mut rng);
+        let raw_next_logits = guard.decode_step(next_token, pos)?;
+        state_token_ids.push(next_token);
+        current_logits = raw_next_logits;
+        let mut sample_logits = current_logits.clone();
+        next_token = sample(
+            &mut sample_logits,
+            params.temperature,
+            params.top_p,
+            &mut rng,
+        );
     };
+
+    if state_token_ids.len() > prompt_ids.len() {
+        if let Some(cache_req) = cache.as_ref() {
+            match guard.snapshot_prefix(current_logits.clone()) {
+                Ok(snapshot) => {
+                    if let Err(e) = state
+                        .prefix_cache
+                        .insert(cache_req, &state_token_ids, snapshot)
+                    {
+                        tracing::warn!("prefix cache generated-prefix insert failed: {e}");
+                    }
+                }
+                Err(e) => tracing::debug!("generated prefix cache snapshot skipped: {e}"),
+            }
+        }
+    }
 
     let _ = tx.send(GenEvent::Done {
         reason: finish,
         prompt_tokens,
         completion_tokens,
+        cached_prompt_tokens,
     });
     Ok(())
+}
+
+fn prefill_with_cache_anchor(
+    guard: &mut InferenceSession,
+    state: &ServerState,
+    cache_req: &CacheRequest,
+    prompt_ids: &[u32],
+) -> Result<Vec<f32>> {
+    let min_tokens = state.prefix_cache.config().min_tokens;
+    let Some(anchor_len) = prompt_ids.len().checked_sub(CACHE_ANCHOR_SUFFIX_TOKENS) else {
+        return guard.prefill(prompt_ids);
+    };
+    if anchor_len < min_tokens || anchor_len == 0 {
+        return guard.prefill(prompt_ids);
+    }
+
+    let mut logits = guard.prefill(&prompt_ids[..anchor_len])?;
+    match guard.snapshot_prefix(logits.clone()) {
+        Ok(snapshot) => {
+            if let Err(e) = state
+                .prefix_cache
+                .insert(cache_req, &prompt_ids[..anchor_len], snapshot)
+            {
+                tracing::warn!("prefix cache anchor insert failed: {e}");
+            }
+        }
+        Err(e) => tracing::debug!("prefix cache anchor snapshot skipped: {e}"),
+    }
+    for (idx, token) in prompt_ids.iter().copied().enumerate().skip(anchor_len) {
+        logits = guard.decode_step(token, idx)?;
+    }
+    Ok(logits)
 }
 
 fn detokenize(tokenizer: &Tokenizer, ids: &[u32]) -> String {
@@ -422,6 +537,7 @@ pub async fn collect(mut rx: UnboundedReceiver<GenEvent>) -> Result<CollectedRes
     let mut finish: Option<FinishReason> = None;
     let mut prompt_tokens = 0;
     let mut completion_tokens = 0;
+    let mut cached_prompt_tokens = 0;
     while let Some(ev) = rx.recv().await {
         match ev {
             GenEvent::Token(s) => text.push_str(&s),
@@ -429,10 +545,12 @@ pub async fn collect(mut rx: UnboundedReceiver<GenEvent>) -> Result<CollectedRes
                 reason,
                 prompt_tokens: p,
                 completion_tokens: c,
+                cached_prompt_tokens: cached,
             } => {
                 finish = Some(reason);
                 prompt_tokens = p;
                 completion_tokens = c;
+                cached_prompt_tokens = cached;
                 break;
             }
             GenEvent::Error(msg) => return Err(anyhow!(msg)),
@@ -446,6 +564,7 @@ pub async fn collect(mut rx: UnboundedReceiver<GenEvent>) -> Result<CollectedRes
         finish,
         prompt_tokens,
         completion_tokens,
+        cached_prompt_tokens,
     })
 }
 
@@ -454,6 +573,7 @@ pub struct CollectedResult {
     pub finish: FinishReason,
     pub prompt_tokens: u32,
     pub completion_tokens: u32,
+    pub cached_prompt_tokens: u32,
 }
 
 /// Re-export kept so downstream route modules can name the session type.

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -11,6 +11,7 @@ pub(crate) mod builders;
 pub mod chat_template;
 pub mod generate;
 pub mod ids;
+pub mod prefix_cache;
 pub mod sampling;
 pub mod session;
 pub mod state;

--- a/crates/runtime/src/prefix_cache.rs
+++ b/crates/runtime/src/prefix_cache.rs
@@ -1,0 +1,391 @@
+use std::collections::{HashMap, VecDeque};
+use std::fs;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+use crate::session::SessionSnapshot;
+
+const FORMAT_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CacheRetention {
+    None,
+    InMemory,
+    TwentyFourHours,
+}
+
+impl CacheRetention {
+    pub fn from_openai(value: Option<&str>) -> Self {
+        match value.unwrap_or("in_memory").to_ascii_lowercase().as_str() {
+            "none" | "no-cache" | "disabled" | "off" => Self::None,
+            "24h" | "24_h" | "disk" => Self::TwentyFourHours,
+            _ => Self::InMemory,
+        }
+    }
+
+    pub fn ttl(self, cfg: &PrefixCacheConfig) -> Duration {
+        match self {
+            Self::None => Duration::ZERO,
+            Self::InMemory => Duration::from_secs(cfg.memory_ttl_secs),
+            Self::TwentyFourHours => Duration::from_secs(cfg.disk_ttl_secs),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CacheRequest {
+    pub key: Option<String>,
+    pub retention: CacheRetention,
+    pub scope: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct PrefixCacheConfig {
+    pub enabled: bool,
+    pub dir: PathBuf,
+    pub min_tokens: usize,
+    pub max_entries: usize,
+    pub memory_ttl_secs: u64,
+    pub disk_ttl_secs: u64,
+}
+
+pub struct PrefixCache {
+    cfg: PrefixCacheConfig,
+    entries: Mutex<PrefixCacheInner>,
+    hits: AtomicU64,
+    misses: AtomicU64,
+    cached_tokens: AtomicU64,
+    evictions: AtomicU64,
+    disk_writes: AtomicU64,
+    restore_failures: AtomicU64,
+}
+
+#[derive(Default)]
+struct PrefixCacheInner {
+    entries: HashMap<String, PrefixCacheEntry>,
+    lru: VecDeque<String>,
+}
+
+pub struct PrefixCacheEntry {
+    namespace: String,
+    token_ids: Vec<u32>,
+    snapshot: SessionSnapshot,
+    expires_at_secs: u64,
+    last_used_secs: u64,
+}
+
+pub struct PrefixCacheHit {
+    pub cached_tokens: usize,
+    pub snapshot: SessionSnapshot,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PrefixCacheStats {
+    pub enabled: bool,
+    pub dir: String,
+    pub min_tokens: usize,
+    pub max_entries: usize,
+    pub entries: usize,
+    pub hits: u64,
+    pub misses: u64,
+    pub cached_tokens: u64,
+    pub evictions: u64,
+    pub disk_writes: u64,
+    pub restore_failures: u64,
+}
+
+#[derive(Serialize)]
+struct DiskEntry<'a> {
+    format_version: u32,
+    namespace_hash: &'a str,
+    token_hash: &'a str,
+    token_count: usize,
+    expires_at_secs: u64,
+    retention: &'static str,
+}
+
+impl PrefixCache {
+    pub fn new(cfg: PrefixCacheConfig) -> Self {
+        if cfg.enabled && !cfg.dir.as_os_str().is_empty() {
+            if let Err(e) = fs::create_dir_all(&cfg.dir) {
+                tracing::warn!(dir = %cfg.dir.display(), "prefix cache dir create failed: {e}");
+            }
+        }
+        Self {
+            cfg,
+            entries: Mutex::new(PrefixCacheInner::default()),
+            hits: AtomicU64::new(0),
+            misses: AtomicU64::new(0),
+            cached_tokens: AtomicU64::new(0),
+            evictions: AtomicU64::new(0),
+            disk_writes: AtomicU64::new(0),
+            restore_failures: AtomicU64::new(0),
+        }
+    }
+
+    pub fn config(&self) -> &PrefixCacheConfig {
+        &self.cfg
+    }
+
+    pub fn lookup(&self, req: &CacheRequest, prompt_ids: &[u32]) -> Option<PrefixCacheHit> {
+        if !self.cfg.enabled || req.retention == CacheRetention::None {
+            return None;
+        }
+        let now = epoch_secs();
+        let namespace = namespace(req);
+        let mut inner = self.entries.lock().ok()?;
+        self.prune_locked(&mut inner, now);
+
+        let mut best_key: Option<String> = None;
+        let mut best_len = 0usize;
+        for (key, entry) in &inner.entries {
+            if entry.namespace != namespace || entry.expires_at_secs <= now {
+                continue;
+            }
+            let len = entry.token_ids.len();
+            if len > best_len && len <= prompt_ids.len() && prompt_ids.starts_with(&entry.token_ids)
+            {
+                best_key = Some(key.clone());
+                best_len = len;
+            }
+        }
+
+        let Some(key) = best_key else {
+            self.misses.fetch_add(1, Ordering::Relaxed);
+            return None;
+        };
+        let Some(entry) = inner.entries.get_mut(&key) else {
+            self.misses.fetch_add(1, Ordering::Relaxed);
+            return None;
+        };
+        entry.last_used_secs = now;
+        let snapshot = match entry.snapshot.try_clone() {
+            Ok(snapshot) => snapshot,
+            Err(e) => {
+                tracing::warn!("prefix cache snapshot clone failed: {e}");
+                self.restore_failures.fetch_add(1, Ordering::Relaxed);
+                return None;
+            }
+        };
+        touch_lru(&mut inner.lru, &key);
+        self.hits.fetch_add(1, Ordering::Relaxed);
+        self.cached_tokens
+            .fetch_add(best_len as u64, Ordering::Relaxed);
+        Some(PrefixCacheHit {
+            cached_tokens: best_len,
+            snapshot,
+        })
+    }
+
+    pub fn insert(
+        &self,
+        req: &CacheRequest,
+        token_ids: &[u32],
+        snapshot: SessionSnapshot,
+    ) -> Result<()> {
+        if !self.cfg.enabled
+            || req.retention == CacheRetention::None
+            || token_ids.len() < self.cfg.min_tokens
+        {
+            return Ok(());
+        }
+        let now = epoch_secs();
+        let namespace = namespace(req);
+        let token_hash = token_hash(token_ids);
+        let key = format!("{namespace}:{token_hash}");
+        let expires_at_secs = now.saturating_add(req.retention.ttl(&self.cfg).as_secs());
+        let entry = PrefixCacheEntry {
+            namespace: namespace.clone(),
+            token_ids: token_ids.to_vec(),
+            snapshot,
+            expires_at_secs,
+            last_used_secs: now,
+        };
+
+        let mut inner = self
+            .entries
+            .lock()
+            .map_err(|_| anyhow::anyhow!("prefix cache lock poisoned"))?;
+        inner.entries.insert(key.clone(), entry);
+        touch_lru(&mut inner.lru, &key);
+        self.prune_locked(&mut inner, now);
+        while inner.entries.len() > self.cfg.max_entries {
+            if let Some(old) = inner.lru.pop_front() {
+                if inner.entries.remove(&old).is_some() {
+                    self.evictions.fetch_add(1, Ordering::Relaxed);
+                }
+            } else {
+                break;
+            }
+        }
+        drop(inner);
+
+        if req.retention == CacheRetention::TwentyFourHours {
+            self.write_disk_metadata(&namespace, &token_hash, token_ids.len(), expires_at_secs)?;
+        }
+        Ok(())
+    }
+
+    pub fn record_restore_failure(&self) {
+        self.restore_failures.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn stats(&self) -> PrefixCacheStats {
+        let entries = self.entries.lock().map(|e| e.entries.len()).unwrap_or(0);
+        PrefixCacheStats {
+            enabled: self.cfg.enabled,
+            dir: self.cfg.dir.display().to_string(),
+            min_tokens: self.cfg.min_tokens,
+            max_entries: self.cfg.max_entries,
+            entries,
+            hits: self.hits.load(Ordering::Relaxed),
+            misses: self.misses.load(Ordering::Relaxed),
+            cached_tokens: self.cached_tokens.load(Ordering::Relaxed),
+            evictions: self.evictions.load(Ordering::Relaxed),
+            disk_writes: self.disk_writes.load(Ordering::Relaxed),
+            restore_failures: self.restore_failures.load(Ordering::Relaxed),
+        }
+    }
+
+    fn prune_locked(&self, inner: &mut PrefixCacheInner, now: u64) {
+        let mut expired = Vec::new();
+        for (key, entry) in &inner.entries {
+            if entry.expires_at_secs <= now {
+                expired.push(key.clone());
+            }
+        }
+        for key in expired {
+            if inner.entries.remove(&key).is_some() {
+                self.evictions.fetch_add(1, Ordering::Relaxed);
+            }
+            inner.lru.retain(|k| k != &key);
+        }
+    }
+
+    fn write_disk_metadata(
+        &self,
+        namespace: &str,
+        token_hash: &str,
+        token_count: usize,
+        expires_at_secs: u64,
+    ) -> Result<()> {
+        fs::create_dir_all(&self.cfg.dir)
+            .with_context(|| format!("create prefix cache dir {}", self.cfg.dir.display()))?;
+        let path = disk_metadata_path(&self.cfg.dir, namespace, token_hash);
+        let entry = DiskEntry {
+            format_version: FORMAT_VERSION,
+            namespace_hash: namespace,
+            token_hash,
+            token_count,
+            expires_at_secs,
+            retention: "24h",
+        };
+        let bytes = serde_json::to_vec_pretty(&entry)?;
+        fs::write(&path, bytes).with_context(|| format!("write {}", path.display()))?;
+        self.disk_writes.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+}
+
+fn namespace(req: &CacheRequest) -> String {
+    let mut h = Sha256::new();
+    h.update(req.scope.as_bytes());
+    h.update([0]);
+    if let Some(key) = req.key.as_ref() {
+        h.update(key.as_bytes());
+    }
+    format!("{:x}", h.finalize())
+}
+
+fn token_hash(token_ids: &[u32]) -> String {
+    let mut h = Sha256::new();
+    for id in token_ids {
+        h.update(id.to_le_bytes());
+    }
+    format!("{:x}", h.finalize())
+}
+
+fn disk_metadata_path(dir: &std::path::Path, namespace: &str, token_hash: &str) -> PathBuf {
+    let short_namespace = namespace.get(..16).unwrap_or(namespace);
+    dir.join(format!("{short_namespace}-{token_hash}.json"))
+}
+
+fn touch_lru(lru: &mut VecDeque<String>, key: &str) {
+    lru.retain(|k| k != key);
+    lru.push_back(key.to_string());
+}
+
+fn epoch_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+pub fn scope_from_parts(model_id: &str, api_key: Option<&str>, user: Option<&str>) -> String {
+    let mut h = Sha256::new();
+    h.update(model_id.as_bytes());
+    h.update([0]);
+    if let Some(api_key) = api_key {
+        h.update(api_key.as_bytes());
+    }
+    h.update([0]);
+    if let Some(user) = user {
+        h.update(user.as_bytes());
+    }
+    format!("{:x}", h.finalize())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retention_parser_accepts_openai_shapes() {
+        assert_eq!(CacheRetention::from_openai(None), CacheRetention::InMemory);
+        assert_eq!(
+            CacheRetention::from_openai(Some("in_memory")),
+            CacheRetention::InMemory
+        );
+        assert_eq!(
+            CacheRetention::from_openai(Some("24h")),
+            CacheRetention::TwentyFourHours
+        );
+        assert_eq!(CacheRetention::from_openai(Some("disk")), CacheRetention::TwentyFourHours);
+        assert_eq!(CacheRetention::from_openai(Some("none")), CacheRetention::None);
+        assert_eq!(CacheRetention::from_openai(Some("off")), CacheRetention::None);
+    }
+
+    #[test]
+    fn scope_hash_includes_model_key_and_user() {
+        let base = scope_from_parts("model-a", Some("key-a"), Some("user-a"));
+        assert_eq!(base, scope_from_parts("model-a", Some("key-a"), Some("user-a")));
+        assert_ne!(base, scope_from_parts("model-b", Some("key-a"), Some("user-a")));
+        assert_ne!(base, scope_from_parts("model-a", Some("key-b"), Some("user-a")));
+        assert_ne!(base, scope_from_parts("model-a", Some("key-a"), Some("user-b")));
+    }
+
+    #[test]
+    fn token_hash_is_exact_order_sensitive() {
+        assert_eq!(token_hash(&[1, 2, 3]), token_hash(&[1, 2, 3]));
+        assert_ne!(token_hash(&[1, 2, 3]), token_hash(&[1, 3, 2]));
+        assert_ne!(token_hash(&[1, 2, 3]), token_hash(&[1, 2, 3, 4]));
+    }
+
+    #[test]
+    fn disk_metadata_path_is_namespace_qualified() {
+        let dir = PathBuf::from("/tmp/cache");
+        let token = "abcd";
+        let a = disk_metadata_path(&dir, "11112222333344445555", token);
+        let b = disk_metadata_path(&dir, "99998888777766665555", token);
+        assert_ne!(a, b);
+        assert_eq!(a.file_name().unwrap(), "1111222233334444-abcd.json");
+        assert_eq!(b.file_name().unwrap(), "9999888877776666-abcd.json");
+    }
+}

--- a/crates/runtime/src/session.rs
+++ b/crates/runtime/src/session.rs
@@ -16,6 +16,30 @@ pub enum InferenceSession {
     Gemma4Int4(Gemma4Int4Engine),
 }
 
+pub enum SessionSnapshot {
+    Qwen(runner::decode_engine::DecodeEngineSnapshot),
+    Gemma4Bf16(runner::gemma4_engine::Gemma4EngineSnapshot),
+    Gemma4Int4(runner::gemma4_int4_engine::Gemma4Int4EngineSnapshot),
+}
+
+impl SessionSnapshot {
+    pub fn try_clone(&self) -> Result<Self> {
+        match self {
+            Self::Qwen(s) => Ok(Self::Qwen(s.try_clone()?)),
+            Self::Gemma4Bf16(s) => Ok(Self::Gemma4Bf16(s.try_clone()?)),
+            Self::Gemma4Int4(s) => Ok(Self::Gemma4Int4(s.try_clone()?)),
+        }
+    }
+
+    pub fn logits(&self) -> &[f32] {
+        match self {
+            Self::Qwen(s) => &s.logits,
+            Self::Gemma4Bf16(s) => &s.logits,
+            Self::Gemma4Int4(s) => &s.logits,
+        }
+    }
+}
+
 impl InferenceSession {
     /// Reset per-prompt state (KV caches, conv/recurrent). Weights and
     /// scratch allocations stay resident.
@@ -57,6 +81,25 @@ impl InferenceSession {
             Self::Qwen(e) => e.decode_step_replay(token_history),
             Self::Gemma4Bf16(_) | Self::Gemma4Int4(_) => Err(anyhow!(
                 "replay-prefill decode is only implemented for the Qwen3.5 engine"
+            )),
+        }
+    }
+
+    pub fn snapshot_prefix(&self, logits: Vec<f32>) -> Result<SessionSnapshot> {
+        match self {
+            Self::Qwen(e) => Ok(SessionSnapshot::Qwen(e.snapshot_prefix(logits)?)),
+            Self::Gemma4Bf16(e) => Ok(SessionSnapshot::Gemma4Bf16(e.snapshot_prefix(logits)?)),
+            Self::Gemma4Int4(e) => Ok(SessionSnapshot::Gemma4Int4(e.snapshot_prefix(logits)?)),
+        }
+    }
+
+    pub fn restore_prefix(&mut self, snapshot: SessionSnapshot) -> Result<Vec<f32>> {
+        match (self, snapshot) {
+            (Self::Qwen(e), SessionSnapshot::Qwen(s)) => e.restore_prefix_owned(s),
+            (Self::Gemma4Bf16(e), SessionSnapshot::Gemma4Bf16(s)) => e.restore_prefix(&s),
+            (Self::Gemma4Int4(e), SessionSnapshot::Gemma4Int4(s)) => e.restore_prefix(&s),
+            _ => Err(anyhow!(
+                "prefix cache snapshot does not match loaded model family"
             )),
         }
     }

--- a/crates/runtime/src/state.rs
+++ b/crates/runtime/src/state.rs
@@ -17,6 +17,7 @@ use crate::bakes::ensure_hf_metadata_present;
 use crate::builders::{build_gemma4, build_qwen};
 use crate::chat_template::ChatTemplate;
 use crate::generate::MockGeneration;
+use crate::prefix_cache::{PrefixCache, PrefixCacheConfig};
 use crate::session::InferenceSession;
 use supersonic_core::capabilities::{capabilities_for_variant, ModelCapabilities};
 
@@ -39,6 +40,7 @@ pub struct ServerState {
     pub response_store_max_entries: usize,
     pub scheduler: Arc<GenerationScheduler>,
     pub capabilities: ModelCapabilities,
+    pub prefix_cache: Arc<PrefixCache>,
 }
 
 pub struct GenerationScheduler {
@@ -81,6 +83,12 @@ pub struct LoaderConfig {
     /// Disable automatic bake download from the GitHub release. Air-gapped
     /// or reproducibility-focused deploys should set this.
     pub no_download: bool,
+    pub prefix_cache_enabled: bool,
+    pub prefix_cache_dir: Option<PathBuf>,
+    pub prefix_cache_min_tokens: usize,
+    pub prefix_cache_max_entries: usize,
+    pub prefix_cache_memory_ttl_secs: u64,
+    pub prefix_cache_disk_ttl_secs: u64,
 }
 
 /// Preferred runtime-facing name for loader configuration. `LoaderConfig`
@@ -179,6 +187,11 @@ pub fn build(cfg: LoaderConfig) -> Result<ServerState> {
         "server state ready"
     );
 
+    let cache_dir = cfg
+        .prefix_cache_dir
+        .clone()
+        .unwrap_or_else(|| cfg.model_dir.join(".supersonic/serve-cache/v1"));
+
     Ok(ServerState {
         server_instance_id: NEXT_SERVER_INSTANCE_ID.fetch_add(1, Ordering::Relaxed),
         model_id: variant.to_string(),
@@ -197,6 +210,14 @@ pub fn build(cfg: LoaderConfig) -> Result<ServerState> {
             cfg.queue_timeout_ms,
         )),
         capabilities,
+        prefix_cache: Arc::new(PrefixCache::new(PrefixCacheConfig {
+            enabled: cfg.prefix_cache_enabled,
+            dir: cache_dir,
+            min_tokens: cfg.prefix_cache_min_tokens,
+            max_entries: cfg.prefix_cache_max_entries,
+            memory_ttl_secs: cfg.prefix_cache_memory_ttl_secs,
+            disk_ttl_secs: cfg.prefix_cache_disk_ttl_secs,
+        })),
     })
 }
 
@@ -280,6 +301,12 @@ mod tests {
             max_queued_requests: 32,
             queue_timeout_ms: 30_000,
             no_download: true,
+            prefix_cache_enabled: true,
+            prefix_cache_dir: None,
+            prefix_cache_min_tokens: 128,
+            prefix_cache_max_entries: 1,
+            prefix_cache_memory_ttl_secs: 600,
+            prefix_cache_disk_ttl_secs: 86_400,
         }
     }
 

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -8,7 +8,8 @@ pub mod routes;
 pub mod schemas;
 
 pub use supersonic_runtime::{
-    backend, capabilities, chat_template, generate, ids, registry, sampling, session, state,
+    backend, capabilities, chat_template, generate, ids, prefix_cache, registry, sampling, session,
+    state,
 };
 
 use std::sync::Arc;

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -100,6 +100,48 @@ struct Cli {
     /// produces a hard error instead of a fetch.
     #[arg(long)]
     no_download: bool,
+
+    /// Disable exact-prefix cache reuse for chat/agent loops.
+    #[arg(long, env = "SUPERSONIC_PREFIX_CACHE_DISABLE")]
+    prefix_cache_disable: bool,
+
+    /// Prefix cache directory. Defaults to
+    /// `{model-dir}/.supersonic/serve-cache/v1`.
+    #[arg(long, env = "SUPERSONIC_PREFIX_CACHE_DIR")]
+    prefix_cache_dir: Option<PathBuf>,
+
+    /// Minimum prompt prefix length eligible for caching.
+    #[arg(
+        long,
+        env = "SUPERSONIC_PREFIX_CACHE_MIN_TOKENS",
+        default_value_t = 128
+    )]
+    prefix_cache_min_tokens: usize,
+
+    /// Maximum number of resident prefix snapshots. Snapshots clone model
+    /// state on GPU, so the default is intentionally conservative.
+    #[arg(
+        long,
+        env = "SUPERSONIC_PREFIX_CACHE_MAX_ENTRIES",
+        default_value_t = 1
+    )]
+    prefix_cache_max_entries: usize,
+
+    /// In-memory prefix cache TTL in seconds.
+    #[arg(
+        long,
+        env = "SUPERSONIC_PREFIX_CACHE_MEMORY_TTL_SECS",
+        default_value_t = 600
+    )]
+    prefix_cache_memory_ttl_secs: u64,
+
+    /// Disk-retained prefix cache metadata TTL in seconds.
+    #[arg(
+        long,
+        env = "SUPERSONIC_PREFIX_CACHE_DISK_TTL_SECS",
+        default_value_t = 86_400
+    )]
+    prefix_cache_disk_ttl_secs: u64,
 }
 
 fn main() -> Result<()> {
@@ -128,6 +170,12 @@ fn main() -> Result<()> {
         max_queued_requests: cli.max_queued_requests,
         queue_timeout_ms: cli.queue_timeout_ms,
         no_download: cli.no_download,
+        prefix_cache_enabled: !cli.prefix_cache_disable,
+        prefix_cache_dir: cli.prefix_cache_dir,
+        prefix_cache_min_tokens: cli.prefix_cache_min_tokens,
+        prefix_cache_max_entries: cli.prefix_cache_max_entries,
+        prefix_cache_memory_ttl_secs: cli.prefix_cache_memory_ttl_secs,
+        prefix_cache_disk_ttl_secs: cli.prefix_cache_disk_ttl_secs,
     };
 
     let st = state::build(loader).context("build server state")?;

--- a/crates/server/src/routes/chat.rs
+++ b/crates/server/src/routes/chat.rs
@@ -17,9 +17,10 @@ use crate::errors::ApiError;
 use crate::generate::{self, GenParams};
 use crate::ids;
 use crate::output::{parse_assistant_output, AssistantOutput};
+use crate::prefix_cache::{self, CacheRequest, CacheRetention};
 use crate::schemas::{
     ChatCompletionChoice, ChatCompletionMessage, ChatCompletionRequest, ChatCompletionResponse,
-    ChatStreamChoice, ChatStreamChunk, ChatStreamDelta, Usage,
+    ChatStreamChoice, ChatStreamChunk, ChatStreamDelta, PromptTokensDetails, Usage,
 };
 use crate::state::ServerState;
 
@@ -77,13 +78,27 @@ pub async fn completions(
     let model = state.model_id.clone();
 
     if req.stream {
-        let rx = generate::spawn(state.clone(), prompt_ids, params).map_err(queue_error)?;
+        let cache = cache_request(
+            &state,
+            req.user.as_deref(),
+            req.metadata.as_ref(),
+            req.prompt_cache_key.as_deref(),
+            req.prompt_cache_retention.as_deref(),
+        );
+        let rx = generate::spawn(state.clone(), prompt_ids, params, cache).map_err(queue_error)?;
         let stream = chat_sse_stream(rx, id, created, model, include_usage);
         Ok(Sse::new(stream)
             .keep_alive(KeepAlive::default())
             .into_response())
     } else {
-        let rx = generate::spawn(state.clone(), prompt_ids, params).map_err(queue_error)?;
+        let cache = cache_request(
+            &state,
+            req.user.as_deref(),
+            req.metadata.as_ref(),
+            req.prompt_cache_key.as_deref(),
+            req.prompt_cache_retention.as_deref(),
+        );
+        let rx = generate::spawn(state.clone(), prompt_ids, params, cache).map_err(queue_error)?;
         let result = generate::collect(rx).await.map_err(generation_error)?;
         let parsed = parse_assistant_output(&result.text);
         let resp = ChatCompletionResponse {
@@ -105,10 +120,60 @@ pub async fn completions(
                 prompt_tokens: result.prompt_tokens,
                 completion_tokens: result.completion_tokens,
                 total_tokens: result.prompt_tokens + result.completion_tokens,
+                prompt_tokens_details: Some(PromptTokensDetails {
+                    cached_tokens: result.cached_prompt_tokens,
+                }),
             },
         };
         Ok(Json(resp).into_response())
     }
+}
+
+pub(crate) fn usage(
+    prompt_tokens: u32,
+    completion_tokens: u32,
+    cached_prompt_tokens: u32,
+) -> Usage {
+    Usage {
+        prompt_tokens,
+        completion_tokens,
+        total_tokens: prompt_tokens + completion_tokens,
+        prompt_tokens_details: Some(PromptTokensDetails {
+            cached_tokens: cached_prompt_tokens,
+        }),
+    }
+}
+
+pub(crate) fn cache_request(
+    state: &ServerState,
+    user: Option<&str>,
+    metadata: Option<&Value>,
+    prompt_cache_key: Option<&str>,
+    retention: Option<&str>,
+) -> Option<CacheRequest> {
+    let retention = CacheRetention::from_openai(retention);
+    if retention == CacheRetention::None || !state.prefix_cache.config().enabled {
+        return None;
+    }
+    let thread = metadata
+        .and_then(|m| {
+            m.get("thread_id")
+                .or_else(|| m.get("conversation_id"))
+                .or_else(|| m.get("session_id"))
+        })
+        .and_then(Value::as_str);
+    let scoped_user = user.or(thread);
+    Some(CacheRequest {
+        key: prompt_cache_key
+            .map(ToOwned::to_owned)
+            .or_else(|| thread.map(ToOwned::to_owned)),
+        retention,
+        scope: prefix_cache::scope_from_parts(
+            &state.model_id,
+            state.api_key.as_deref(),
+            scoped_user,
+        ),
+    })
 }
 
 pub(crate) fn queue_error(err: anyhow::Error) -> ApiError {
@@ -216,7 +281,12 @@ fn parsed_chat_events(
                         }
                     }
                 }
-                generate::GenEvent::Done { reason, prompt_tokens, completion_tokens } => {
+                generate::GenEvent::Done {
+                    reason,
+                    prompt_tokens,
+                    completion_tokens,
+                    cached_prompt_tokens,
+                } => {
                     let parsed = parse_assistant_output(&raw);
                     let done_reason = finish_reason(reason.as_str(), &parsed);
                     yield Ok(sse::json_event(&chat_chunk(
@@ -239,11 +309,11 @@ fn parsed_chat_events(
                             created,
                             model: model.clone(),
                             choices: Vec::new(),
-                            usage: Some(Usage {
+                            usage: Some(usage(
                                 prompt_tokens,
                                 completion_tokens,
-                                total_tokens: prompt_tokens + completion_tokens,
-                            }),
+                                cached_prompt_tokens,
+                            )),
                         }));
                     }
                     yield Ok(Event::default().data("[DONE]"));

--- a/crates/server/src/routes/completions.rs
+++ b/crates/server/src/routes/completions.rs
@@ -8,7 +8,7 @@ use axum::response::{IntoResponse, Response};
 use axum::Json;
 use futures::stream::Stream;
 
-use super::chat::{generation_error, queue_error};
+use super::chat::{cache_request, generation_error, queue_error, usage};
 use super::sse;
 use crate::compat::validate_model;
 use crate::errors::ApiError;
@@ -16,7 +16,7 @@ use crate::generate::{self, GenParams};
 use crate::ids;
 use crate::schemas::{
     CompletionChoice, CompletionRequest, CompletionResponse, CompletionStreamChoice,
-    CompletionStreamChunk, SinglePrompt, Usage,
+    CompletionStreamChunk, SinglePrompt,
 };
 use crate::state::ServerState;
 
@@ -60,13 +60,27 @@ pub async fn completions(
         .unwrap_or(false);
 
     if req.stream {
-        let rx = generate::spawn(state.clone(), prompt_ids, params).map_err(queue_error)?;
+        let cache = cache_request(
+            &state,
+            req.user.as_deref(),
+            req.metadata.as_ref(),
+            req.prompt_cache_key.as_deref(),
+            req.prompt_cache_retention.as_deref(),
+        );
+        let rx = generate::spawn(state.clone(), prompt_ids, params, cache).map_err(queue_error)?;
         let stream = completion_sse_stream(rx, id, created, model, include_usage);
         Ok(Sse::new(stream)
             .keep_alive(KeepAlive::default())
             .into_response())
     } else {
-        let rx = generate::spawn(state.clone(), prompt_ids, params).map_err(queue_error)?;
+        let cache = cache_request(
+            &state,
+            req.user.as_deref(),
+            req.metadata.as_ref(),
+            req.prompt_cache_key.as_deref(),
+            req.prompt_cache_retention.as_deref(),
+        );
+        let rx = generate::spawn(state.clone(), prompt_ids, params, cache).map_err(queue_error)?;
         let result = generate::collect(rx).await.map_err(generation_error)?;
         let resp = CompletionResponse {
             id,
@@ -79,11 +93,11 @@ pub async fn completions(
                 logprobs: None,
                 finish_reason: result.finish.as_str(),
             }],
-            usage: Usage {
-                prompt_tokens: result.prompt_tokens,
-                completion_tokens: result.completion_tokens,
-                total_tokens: result.prompt_tokens + result.completion_tokens,
-            },
+            usage: usage(
+                result.prompt_tokens,
+                result.completion_tokens,
+                result.cached_prompt_tokens,
+            ),
         };
         Ok(Json(resp).into_response())
     }

--- a/crates/server/src/routes/models.rs
+++ b/crates/server/src/routes/models.rs
@@ -12,6 +12,7 @@ use serde::Serialize;
 use crate::compat::validate_model;
 use crate::errors::ApiError;
 use crate::generate;
+use crate::prefix_cache::PrefixCacheStats;
 use crate::schemas::{ListModelsResponse, ModelObject};
 use crate::state::ServerState;
 
@@ -53,12 +54,14 @@ pub struct HealthResponse {
     pub active_requests: usize,
     pub queued_requests: usize,
     pub max_queued_requests: usize,
+    pub prefix_cache_entries: usize,
 }
 
 pub async fn health(
     State(state): State<Arc<ServerState>>,
 ) -> Result<Json<HealthResponse>, ApiError> {
     let queue = generate::scheduler_snapshot(&state);
+    let cache = state.prefix_cache.stats();
     Ok(Json(HealthResponse {
         status: "ok",
         model: state.model_id.clone(),
@@ -66,6 +69,7 @@ pub async fn health(
         active_requests: queue.active,
         queued_requests: queue.queued,
         max_queued_requests: queue.max_queue,
+        prefix_cache_entries: cache.entries,
     }))
 }
 
@@ -84,6 +88,7 @@ pub struct CapabilitiesResponse {
     pub tools: bool,
     pub reasoning: bool,
     pub scheduler: SchedulerCapabilities,
+    pub prefix_cache: PrefixCacheStats,
 }
 
 #[derive(Debug, Serialize)]
@@ -98,6 +103,7 @@ pub async fn capabilities(
     State(state): State<Arc<ServerState>>,
 ) -> Result<Json<CapabilitiesResponse>, ApiError> {
     let queue = generate::scheduler_snapshot(&state);
+    let cache = state.prefix_cache.stats();
     Ok(Json(CapabilitiesResponse {
         model: state.model_id.clone(),
         family: state.model_family.to_string(),
@@ -131,11 +137,13 @@ pub async fn capabilities(
             max_queued_requests: queue.max_queue,
             queue_timeout_ms: queue.queue_timeout_ms,
         },
+        prefix_cache: cache,
     }))
 }
 
 pub async fn metrics(State(state): State<Arc<ServerState>>) -> impl IntoResponse {
     let queue = generate::scheduler_snapshot(&state);
+    let cache = state.prefix_cache.stats();
     let body = format!(
         "# TYPE supersonic_active_requests gauge\n\
          supersonic_active_requests {}\n\
@@ -146,8 +154,33 @@ pub async fn metrics(State(state): State<Arc<ServerState>>) -> impl IntoResponse
          # TYPE supersonic_queue_timeout_ms gauge\n\
          supersonic_queue_timeout_ms {}\n\
          # TYPE supersonic_max_context gauge\n\
-         supersonic_max_context {}\n",
-        queue.active, queue.queued, queue.max_queue, queue.queue_timeout_ms, state.max_context
+         supersonic_max_context {}\n\
+         # TYPE supersonic_prefix_cache_entries gauge\n\
+         supersonic_prefix_cache_entries {}\n\
+         # TYPE supersonic_prefix_cache_hits counter\n\
+         supersonic_prefix_cache_hits {}\n\
+         # TYPE supersonic_prefix_cache_misses counter\n\
+         supersonic_prefix_cache_misses {}\n\
+         # TYPE supersonic_prefix_cache_cached_tokens counter\n\
+         supersonic_prefix_cache_cached_tokens {}\n\
+         # TYPE supersonic_prefix_cache_evictions counter\n\
+         supersonic_prefix_cache_evictions {}\n\
+         # TYPE supersonic_prefix_cache_disk_writes counter\n\
+         supersonic_prefix_cache_disk_writes {}\n\
+         # TYPE supersonic_prefix_cache_restore_failures counter\n\
+         supersonic_prefix_cache_restore_failures {}\n",
+        queue.active,
+        queue.queued,
+        queue.max_queue,
+        queue.queue_timeout_ms,
+        state.max_context,
+        cache.entries,
+        cache.hits,
+        cache.misses,
+        cache.cached_tokens,
+        cache.evictions,
+        cache.disk_writes,
+        cache.restore_failures,
     );
     ([(CONTENT_TYPE, "text/plain; version=0.0.4")], body)
 }

--- a/crates/server/src/routes/responses.rs
+++ b/crates/server/src/routes/responses.rs
@@ -17,9 +17,9 @@ use crate::errors::ApiError;
 use crate::generate::{self, GenParams};
 use crate::output::{parse_assistant_output, AssistantOutput};
 use crate::routes::chat::{
-    apply_response_format_hint, content_to_text, generation_error, has_incomplete_control_block,
-    normalize_tool_calls_for_template, queue_error, reasoning_enabled, response_format_json_object,
-    validate_tools,
+    apply_response_format_hint, cache_request, content_to_text, generation_error,
+    has_incomplete_control_block, normalize_tool_calls_for_template, queue_error,
+    reasoning_enabled, response_format_json_object, usage, validate_tools,
 };
 use crate::schemas::{OpenAiToolCall, StopParam, Usage};
 use crate::state::ServerState;
@@ -78,6 +78,8 @@ pub struct StoredResponse {
     pub status: &'static str,
     pub output: Vec<ResponseOutputItem>,
     pub usage: Usage,
+    #[serde(skip_serializing)]
+    pub cache_key: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -147,6 +149,14 @@ pub struct ResponseRequest {
     pub reasoning: Option<ResponseReasoning>,
     #[serde(default)]
     pub previous_response_id: Option<String>,
+    #[serde(default)]
+    pub user: Option<String>,
+    #[serde(default)]
+    pub metadata: Option<Value>,
+    #[serde(default)]
+    pub prompt_cache_key: Option<String>,
+    #[serde(default)]
+    pub prompt_cache_retention: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -196,6 +206,11 @@ pub async fn create(
             .join("\n")
     };
 
+    let id = next_response_id(state.server_instance_id);
+    let created_at = crate::ids::epoch_secs();
+    let model = state.model_id.clone();
+    let response_cache_key = response_cache_key(&req, state.server_instance_id, &id);
+
     let params = GenParams {
         temperature: req.temperature.unwrap_or(1.0),
         top_p: req.top_p.unwrap_or(1.0),
@@ -211,12 +226,15 @@ pub async fn create(
     )
     .map_err(|e| ApiError::bad_request(e.to_string()))?;
 
-    let id = next_response_id(state.server_instance_id);
-    let created_at = crate::ids::epoch_secs();
-    let model = state.model_id.clone();
-
     if req.stream {
-        let rx = generate::spawn(state.clone(), prompt_ids, params).map_err(queue_error)?;
+        let cache = cache_request(
+            &state,
+            req.user.as_deref(),
+            req.metadata.as_ref(),
+            response_cache_key.as_deref(),
+            req.prompt_cache_retention.as_deref(),
+        );
+        let rx = generate::spawn(state.clone(), prompt_ids, params, cache).map_err(queue_error)?;
         let stream = response_sse_stream(
             rx,
             id,
@@ -224,12 +242,20 @@ pub async fn create(
             created_at,
             state.server_instance_id,
             state.response_store_max_entries,
+            response_cache_key,
         );
         Ok(Sse::new(stream)
             .keep_alive(KeepAlive::default())
             .into_response())
     } else {
-        let rx = generate::spawn(state.clone(), prompt_ids, params).map_err(queue_error)?;
+        let cache = cache_request(
+            &state,
+            req.user.as_deref(),
+            req.metadata.as_ref(),
+            response_cache_key.as_deref(),
+            req.prompt_cache_retention.as_deref(),
+        );
+        let rx = generate::spawn(state.clone(), prompt_ids, params, cache).map_err(queue_error)?;
         let result = generate::collect(rx).await.map_err(generation_error)?;
         let parsed = parse_assistant_output(&result.text);
         let stored = build_response(
@@ -237,11 +263,12 @@ pub async fn create(
             model,
             created_at,
             parsed,
-            Usage {
-                prompt_tokens: result.prompt_tokens,
-                completion_tokens: result.completion_tokens,
-                total_tokens: result.prompt_tokens + result.completion_tokens,
-            },
+            usage(
+                result.prompt_tokens,
+                result.completion_tokens,
+                result.cached_prompt_tokens,
+            ),
+            response_cache_key,
         );
         insert_response(
             state.server_instance_id,
@@ -283,6 +310,7 @@ fn response_sse_stream(
     created_at: u64,
     server_instance_id: u64,
     response_store_max_entries: usize,
+    cache_key: Option<String>,
 ) -> impl Stream<Item = super::sse::SseEvent> {
     async_stream::stream! {
         yield Ok(Event::default()
@@ -317,18 +345,15 @@ fn response_sse_stream(
                         }
                     }
                 }
-                generate::GenEvent::Done { prompt_tokens, completion_tokens, .. } => {
+                generate::GenEvent::Done { prompt_tokens, completion_tokens, cached_prompt_tokens, .. } => {
                     let parsed = parse_assistant_output(&raw);
                     let stored = build_response(
                         id.clone(),
                         model.clone(),
                         created_at,
                         parsed,
-                        Usage {
-                            prompt_tokens,
-                            completion_tokens,
-                            total_tokens: prompt_tokens + completion_tokens,
-                        },
+                        usage(prompt_tokens, completion_tokens, cached_prompt_tokens),
+                        cache_key.clone(),
                     );
                     insert_response(
                         server_instance_id,
@@ -523,12 +548,29 @@ fn response_format_value(req: &ResponseRequest) -> Option<&Value> {
         .or_else(|| req.text.as_ref().and_then(|text| text.get("format")))
 }
 
+fn response_cache_key(
+    req: &ResponseRequest,
+    server_instance_id: u64,
+    current_response_id: &str,
+) -> Option<String> {
+    if let Some(key) = req.prompt_cache_key.as_ref() {
+        return Some(key.clone());
+    }
+    if let Some(previous_response_id) = req.previous_response_id.as_ref() {
+        return get_response(server_instance_id, previous_response_id)
+            .and_then(|prev| prev.cache_key)
+            .or_else(|| Some(previous_response_id.clone()));
+    }
+    Some(current_response_id.to_string())
+}
+
 fn build_response(
     id: String,
     model: String,
     created_at: u64,
     parsed: AssistantOutput,
     usage: Usage,
+    cache_key: Option<String>,
 ) -> StoredResponse {
     let mut output = Vec::new();
     if let Some(reasoning) = parsed.reasoning_content {
@@ -558,6 +600,7 @@ fn build_response(
         status: "completed",
         output,
         usage,
+        cache_key,
     }
 }
 
@@ -645,7 +688,9 @@ mod tests {
                 prompt_tokens: 1,
                 completion_tokens: 2,
                 total_tokens: 3,
+                prompt_tokens_details: None,
             },
+            Some("thread-cache".to_string()),
         );
         assert!(matches!(
             resp.output[0],
@@ -666,6 +711,74 @@ mod tests {
 
         assert!(store.get("first").is_none());
         assert!(store.get("second").is_some());
+    }
+
+    #[test]
+    fn response_cache_key_inherits_previous_chain_key() {
+        let server_instance_id = 900_001;
+        let first_id = "resp-first".to_string();
+        insert_response(
+            server_instance_id,
+            first_id.clone(),
+            empty_response_with_cache_key(&first_id, Some("resp-first")),
+            8,
+        );
+        let req = ResponseRequest {
+            model: None,
+            input: json!("next"),
+            instructions: None,
+            temperature: None,
+            top_p: None,
+            max_output_tokens: None,
+            stream: false,
+            stop: None,
+            seed: None,
+            tools: None,
+            tool_choice: None,
+            response_format: None,
+            text: None,
+            reasoning: None,
+            previous_response_id: Some(first_id),
+            user: None,
+            metadata: None,
+            prompt_cache_key: None,
+            prompt_cache_retention: None,
+        };
+
+        assert_eq!(
+            response_cache_key(&req, server_instance_id, "resp-second").as_deref(),
+            Some("resp-first")
+        );
+    }
+
+    #[test]
+    fn response_cache_key_prefers_explicit_request_key() {
+        let req = ResponseRequest {
+            model: None,
+            input: json!("next"),
+            instructions: None,
+            temperature: None,
+            top_p: None,
+            max_output_tokens: None,
+            stream: false,
+            stop: None,
+            seed: None,
+            tools: None,
+            tool_choice: None,
+            response_format: None,
+            text: None,
+            reasoning: None,
+            previous_response_id: Some("resp-prev".to_string()),
+            user: None,
+            metadata: None,
+            prompt_cache_key: Some("stable-thread".to_string()),
+            prompt_cache_retention: None,
+        };
+
+        assert_eq!(
+            response_cache_key(&req, 0, "resp-current").as_deref(),
+            Some("stable-thread")
+        );
     }
 
     #[test]
@@ -696,6 +809,10 @@ mod tests {
             text: None,
             reasoning: None,
             previous_response_id: None,
+            user: None,
+            metadata: None,
+            prompt_cache_key: None,
+            prompt_cache_retention: None,
         };
         let messages = response_messages(&req, 0).unwrap();
         assert_eq!(messages[0].role, "system");
@@ -723,6 +840,10 @@ mod tests {
             text: None,
             reasoning: None,
             previous_response_id: None,
+            user: None,
+            metadata: None,
+            prompt_cache_key: None,
+            prompt_cache_retention: None,
         };
         let messages = response_messages(&req, 0).unwrap();
         assert_eq!(messages[0].role, "user");
@@ -776,6 +897,10 @@ mod tests {
     }
 
     fn empty_response(id: &str) -> StoredResponse {
+        empty_response_with_cache_key(id, None)
+    }
+
+    fn empty_response_with_cache_key(id: &str, cache_key: Option<&str>) -> StoredResponse {
         StoredResponse {
             id: id.to_string(),
             object: "response",
@@ -787,7 +912,9 @@ mod tests {
                 prompt_tokens: 0,
                 completion_tokens: 0,
                 total_tokens: 0,
+                prompt_tokens_details: None,
             },
+            cache_key: cache_key.map(ToOwned::to_owned),
         }
     }
 }

--- a/crates/server/src/routes/sse.rs
+++ b/crates/server/src/routes/sse.rs
@@ -31,11 +31,19 @@ where
                 GenEvent::Token(text) => {
                     yield Ok::<_, Infallible>(json_event(&token_chunk(text)));
                 }
-                GenEvent::Done { reason, prompt_tokens, completion_tokens } => {
+                GenEvent::Done {
+                    reason,
+                    prompt_tokens,
+                    completion_tokens,
+                    cached_prompt_tokens,
+                } => {
                     yield Ok(json_event(&done_chunk(reason, Some(Usage {
                         prompt_tokens,
                         completion_tokens,
                         total_tokens: prompt_tokens + completion_tokens,
+                        prompt_tokens_details: Some(crate::schemas::PromptTokensDetails {
+                            cached_tokens: cached_prompt_tokens,
+                        }),
                     }))));
                     yield Ok(Event::default().data("[DONE]"));
                     return;

--- a/crates/server/src/schemas.rs
+++ b/crates/server/src/schemas.rs
@@ -81,6 +81,14 @@ pub struct ChatCompletionRequest {
     pub n: Option<u32>,
     #[serde(default)]
     pub logprobs: Option<bool>,
+    #[serde(default)]
+    pub user: Option<String>,
+    #[serde(default)]
+    pub metadata: Option<JsonValue>,
+    #[serde(default)]
+    pub prompt_cache_key: Option<String>,
+    #[serde(default)]
+    pub prompt_cache_retention: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -105,6 +113,13 @@ pub struct Usage {
     pub prompt_tokens: u32,
     pub completion_tokens: u32,
     pub total_tokens: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_tokens_details: Option<PromptTokensDetails>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PromptTokensDetails {
+    pub cached_tokens: u32,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -232,6 +247,14 @@ pub struct CompletionRequest {
     pub logprobs: Option<JsonValue>,
     #[serde(default)]
     pub echo: Option<bool>,
+    #[serde(default)]
+    pub user: Option<String>,
+    #[serde(default)]
+    pub metadata: Option<JsonValue>,
+    #[serde(default)]
+    pub prompt_cache_key: Option<String>,
+    #[serde(default)]
+    pub prompt_cache_retention: Option<String>,
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/server/tests/chat_integration.rs
+++ b/crates/server/tests/chat_integration.rs
@@ -65,6 +65,15 @@ fn load_test_config() -> Option<LoaderConfig> {
         max_queued_requests: 32,
         queue_timeout_ms: 30_000,
         no_download: std::env::var("SUPERSONIC_TEST_NO_DOWNLOAD").is_ok(),
+        prefix_cache_enabled: true,
+        prefix_cache_dir: None,
+        prefix_cache_min_tokens: std::env::var("SUPERSONIC_TEST_PREFIX_CACHE_MIN_TOKENS")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(32),
+        prefix_cache_max_entries: 1,
+        prefix_cache_memory_ttl_secs: 600,
+        prefix_cache_disk_ttl_secs: 86_400,
     })
 }
 
@@ -405,6 +414,55 @@ async fn test_seed_determinism(h: &Harness) {
     eprintln!("[scenario] seed determinism → OK ({:?})", ta);
 }
 
+async fn test_prefix_cache_reuse(h: &Harness) {
+    let prompt = "Please answer briefly. ".repeat(80);
+    let body = json!({
+        "prompt": prompt,
+        "max_tokens": 1,
+        "temperature": 0,
+        "prompt_cache_key": "integration-prefix-cache",
+        "prompt_cache_retention": "in_memory",
+        "user": "integration-test"
+    });
+    let first: Value = h
+        .client
+        .post(format!("{}/v1/completions", h.base))
+        .json(&body)
+        .send()
+        .await
+        .expect("prefix cache first")
+        .json()
+        .await
+        .expect("first json");
+    let second: Value = h
+        .client
+        .post(format!("{}/v1/completions", h.base))
+        .json(&body)
+        .send()
+        .await
+        .expect("prefix cache second")
+        .json()
+        .await
+        .expect("second json");
+
+    let first_cached = first["usage"]["prompt_tokens_details"]["cached_tokens"]
+        .as_u64()
+        .expect("first cached_tokens");
+    let second_cached = second["usage"]["prompt_tokens_details"]["cached_tokens"]
+        .as_u64()
+        .expect("second cached_tokens");
+    assert_eq!(first_cached, 0, "first request should miss prefix cache");
+    assert!(
+        second_cached > 0,
+        "second request should hit prefix cache: {second}"
+    );
+    assert_eq!(
+        first["choices"][0]["text"], second["choices"][0]["text"],
+        "cached and uncached deterministic outputs should match"
+    );
+    eprintln!("[scenario] prefix cache reuse → OK ({second_cached} cached tokens)");
+}
+
 async fn test_multi_turn(h: &Harness) {
     // Conversation with explicit assistant history — exercises the chat
     // template's handling of assistant turns.
@@ -640,6 +698,7 @@ async fn comprehensive_chat_suite() {
     test_completions_non_stream(&h).await;
     test_completions_stream(&h).await;
     test_seed_determinism(&h).await;
+    test_prefix_cache_reuse(&h).await;
     test_stop_sequence(&h).await;
     test_concurrent_requests(&h).await;
     test_max_tokens_zero(&h).await;

--- a/crates/server/tests/protocol_mock.rs
+++ b/crates/server/tests/protocol_mock.rs
@@ -4,6 +4,7 @@ use futures::StreamExt;
 use reqwest::Client;
 use serde_json::{json, Value};
 use server::generate::MockGeneration;
+use server::prefix_cache::{PrefixCache, PrefixCacheConfig};
 use server::state::{GenerationScheduler, ServerState};
 use server::{capabilities, chat_template, registry};
 
@@ -58,6 +59,14 @@ fn test_state_with_scheduler(
             false,
             false,
         ),
+        prefix_cache: Arc::new(PrefixCache::new(PrefixCacheConfig {
+            enabled: true,
+            dir: std::env::temp_dir().join("supersonic-test-prefix-cache"),
+            min_tokens: 1,
+            max_entries: 1,
+            memory_ttl_secs: 600,
+            disk_ttl_secs: 86_400,
+        })),
     })
 }
 
@@ -294,6 +303,9 @@ async fn mock_chat_stream_buffers_reasoning_and_includes_usage() {
             "reasoning_effort": "medium",
             "stream": true,
             "stream_options": {"include_usage": true},
+            "prompt_cache_key": "protocol-mock",
+            "prompt_cache_retention": "in_memory",
+            "metadata": {"thread_id": "thread-a"},
             "max_tokens": 8
         }))
         .send()
@@ -319,6 +331,7 @@ async fn mock_chat_stream_buffers_reasoning_and_includes_usage() {
         }
         if event.get("usage").is_some_and(|u| !u.is_null()) {
             saw_usage = true;
+            assert_eq!(event["usage"]["prompt_tokens_details"]["cached_tokens"], 0);
         }
         let serialized = event.to_string();
         assert!(
@@ -416,6 +429,19 @@ async fn mock_auth_cors_and_model_mismatch() {
         .expect("model json");
     assert_eq!(model["id"], "qwen3.5-0.8b");
 
+    let capabilities: Value = h
+        .client
+        .get(format!("{}/v1/capabilities", h.base))
+        .bearer_auth("secret")
+        .send()
+        .await
+        .expect("capabilities")
+        .json()
+        .await
+        .expect("capabilities json");
+    assert_eq!(capabilities["prefix_cache"]["enabled"], true);
+    assert_eq!(capabilities["prefix_cache"]["min_tokens"], 1);
+
     let missing_model = h
         .client
         .get(format!("{}/v1/models/gpt-4.1", h.base))
@@ -437,6 +463,8 @@ async fn mock_auth_cors_and_model_mismatch() {
         .expect("metrics text");
     assert!(metrics.contains("supersonic_active_requests"));
     assert!(metrics.contains("supersonic_queued_requests"));
+    assert!(metrics.contains("supersonic_prefix_cache_hits"));
+    assert!(metrics.contains("supersonic_prefix_cache_cached_tokens"));
 
     let cors = h
         .client
@@ -722,6 +750,7 @@ async fn mock_completions_accept_token_prompt() {
         .expect("json");
     assert_eq!(resp["choices"][0]["text"], "hello");
     assert_eq!(resp["usage"]["prompt_tokens"], 2);
+    assert_eq!(resp["usage"]["prompt_tokens_details"]["cached_tokens"], 0);
 
     let batched = h
         .client

--- a/docs/server.md
+++ b/docs/server.md
@@ -33,6 +33,19 @@ Optional deployment flags:
 - `--queue-timeout-ms N` or `SUPERSONIC_QUEUE_TIMEOUT_MS=N` caps how long a
   queued request may wait before failing. The default is `30000`.
 - `--no-download` disables release-bake downloads.
+- Exact-prefix caching is enabled by default for repeated chat/agent turns.
+  Useful knobs:
+  - `--prefix-cache-disable` disables cache lookup and capture.
+  - `--prefix-cache-dir DIR` sets the cache metadata directory; the default is
+    `{model_dir}/.supersonic/serve-cache/v1/`.
+  - `--prefix-cache-min-tokens N` sets the minimum prompt prefix eligible for
+    caching. The default is `128`.
+  - `--prefix-cache-max-entries N` caps resident prefix snapshots. Snapshots
+    clone model state on GPU; the conservative default is `1`.
+  - `--prefix-cache-memory-ttl-secs N` controls `in_memory` retention. The
+    default is `600`.
+  - `--prefix-cache-disk-ttl-secs N` controls `24h` metadata retention. The
+    default is `86400`.
 
 ## Endpoints
 
@@ -55,6 +68,10 @@ Optional deployment flags:
 Chat Completions accepts modern client fields including `developer` messages,
 text content-part arrays, `max_completion_tokens`, `stream_options.include_usage`,
 `tools`, `tool_choice`, `response_format`, and `reasoning_effort`.
+It also accepts OpenAI-style cache controls: `prompt_cache_key`,
+`prompt_cache_retention`, `user`, and `metadata`. `metadata.thread_id`,
+`metadata.conversation_id`, or `metadata.session_id` scopes repeated thread
+turns when no explicit `prompt_cache_key` is provided.
 
 Responses accepts string input or message-array input, plus `instructions`,
 `max_output_tokens`, `tools`, `tool_choice`, `reasoning.effort`, `stream`, and
@@ -97,6 +114,25 @@ generation stops at the next token boundary once the response stream is gone.
 `/v1/tokenize` and `/v1/detokenize` are SuperSonic-local helpers for token
 budgeting. They require the same auth as generation endpoints and accept the
 same loaded-model id or local aliases.
+
+## Prefix Cache
+
+SuperSonic performs exact token-prefix reuse. On a cache hit, the server
+restores the cached model state for the longest matching prefix, runs only the
+uncached suffix, and reports the reused prompt tokens as
+`usage.prompt_tokens_details.cached_tokens`. The cache is scoped by model, API
+key, user/thread metadata, and `prompt_cache_key` to avoid accidental cross-user
+reuse.
+
+`prompt_cache_retention` accepts:
+
+- `in_memory` (default): resident snapshot with a short idle TTL.
+- `24h`: resident snapshot plus disk metadata under the prefix-cache directory.
+- `none`: bypass cache lookup and capture for the request.
+
+The disk files intentionally avoid prompt text and message JSON. They contain
+only hashes, counts, retention, and expiry metadata; resident model-state
+snapshots are what provide the live speedup.
 
 ## Smoke Tests
 
@@ -143,3 +179,25 @@ node /path/to/SuperSonic/scripts/openai_compat_smoke.mjs
 The smoke covers model list/retrieve, Chat Completions, streaming Chat
 Completions with usage, legacy Completions, Responses create/get/delete,
 tokenization, and metrics.
+
+## Prefix Cache Smoke
+
+With a server already running, verify exact-prefix reuse and metrics:
+
+```bash
+SUPERSONIC_BASE_URL=http://127.0.0.1:8080 \
+SUPERSONIC_API_KEY=secret \
+node /path/to/SuperSonic/scripts/prefix_cache_smoke.mjs
+```
+
+The smoke uses `/v1/chat/completions` when `/v1/capabilities` reports chat
+support, otherwise it falls back to `/v1/completions`. Set
+`SUPERSONIC_PREFIX_CACHE_MODE=completions` or `chat` to force one endpoint.
+Set `SUPERSONIC_PROMPT_CACHE_RETENTION=24h` to exercise disk metadata writes.
+It checks both an exact repeat and an extended same-prefix request, matching
+the common agent pattern where later turns replay prior transcript text and
+append new user/tool content.
+
+For short local prompts, start the server with `--prefix-cache-min-tokens 1`
+or set `SUPERSONIC_PREFIX_CACHE_MIN_TOKENS=1`; production defaults avoid
+caching tiny prompts.

--- a/scripts/prefix_cache_smoke.mjs
+++ b/scripts/prefix_cache_smoke.mjs
@@ -1,0 +1,163 @@
+const rootURL = process.env.SUPERSONIC_BASE_URL ?? "http://127.0.0.1:8080";
+const baseURL = rootURL.endsWith("/v1") ? rootURL : `${rootURL}/v1`;
+const apiKey = process.env.SUPERSONIC_API_KEY;
+const model = process.env.SUPERSONIC_SMOKE_MODEL ?? "local";
+const prompt =
+  process.env.SUPERSONIC_PREFIX_CACHE_PROMPT ??
+  "Please answer briefly. ".repeat(80);
+const mode = process.env.SUPERSONIC_PREFIX_CACHE_MODE ?? "auto";
+const retention = process.env.SUPERSONIC_PROMPT_CACHE_RETENTION ?? "in_memory";
+
+const headers = { "content-type": "application/json" };
+if (apiKey) headers.authorization = `Bearer ${apiKey}`;
+
+async function postJSON(path, body) {
+  const resp = await fetch(`${baseURL}${path}`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+  const text = await resp.text();
+  let data;
+  try {
+    data = JSON.parse(text);
+  } catch {
+    data = text;
+  }
+  if (!resp.ok) {
+    throw new Error(`${path} failed with ${resp.status}: ${text}`);
+  }
+  return data;
+}
+
+async function getText(path) {
+  const resp = await fetch(`${rootURL.replace(/\/v1$/, "")}${path}`, {
+    headers: apiKey ? { authorization: `Bearer ${apiKey}` } : undefined,
+  });
+  const text = await resp.text();
+  if (!resp.ok) {
+    throw new Error(`${path} failed with ${resp.status}: ${text}`);
+  }
+  return text;
+}
+
+async function getJSON(path) {
+  const text = await getText(path);
+  return JSON.parse(text);
+}
+
+function cachedTokens(resp) {
+  return resp?.usage?.prompt_tokens_details?.cached_tokens ?? 0;
+}
+
+function outputText(resp) {
+  if (resp.choices?.[0]?.text !== undefined) {
+    return resp.choices[0].text;
+  }
+  return resp.choices?.[0]?.message?.content ?? "";
+}
+
+function promptTokens(resp) {
+  return resp?.usage?.prompt_tokens ?? 0;
+}
+
+async function selectEndpoint() {
+  if (mode === "completions" || mode === "chat") {
+    return mode;
+  }
+  const capabilities = await getJSON("/v1/capabilities");
+  return capabilities.chat ? "chat" : "completions";
+}
+
+async function main() {
+  const endpoint = await selectEndpoint();
+  const cacheFields = {
+    prompt_cache_key: "supersonic-prefix-cache-smoke",
+    prompt_cache_retention: retention,
+    user: "supersonic-smoke",
+  };
+  const body =
+    endpoint === "chat"
+      ? {
+          model,
+          messages: [{ role: "user", content: prompt }],
+          max_tokens: 1,
+          temperature: 0,
+          ...cacheFields,
+        }
+      : {
+          model,
+          prompt,
+          max_tokens: 1,
+          temperature: 0,
+          ...cacheFields,
+        };
+  const path = endpoint === "chat" ? "/chat/completions" : "/completions";
+
+  const first = await postJSON(path, body);
+  const second = await postJSON(path, body);
+  const firstCached = cachedTokens(first);
+  const secondCached = cachedTokens(second);
+
+  if (firstCached !== 0) {
+    throw new Error(`expected first request to miss cache, got ${firstCached}`);
+  }
+  if (secondCached <= 0) {
+    throw new Error(`expected second request to hit cache, got ${secondCached}`);
+  }
+  if (outputText(first) !== outputText(second)) {
+    throw new Error(
+      `deterministic outputs differ: ${JSON.stringify(first)} vs ${JSON.stringify(second)}`,
+    );
+  }
+
+  const extendedBody =
+    endpoint === "chat"
+      ? {
+          ...body,
+          messages: [
+            { role: "user", content: prompt },
+            { role: "assistant", content: outputText(first) || "ok" },
+            { role: "user", content: "Continue." },
+          ],
+        }
+      : {
+          ...body,
+          prompt: `${prompt} Continue.`,
+        };
+  const extended = await postJSON(path, extendedBody);
+  const extendedCached = cachedTokens(extended);
+  const extendedPromptTokens = promptTokens(extended);
+  if (extendedCached <= 0) {
+    throw new Error(`expected extended request to hit prefix cache, got ${extendedCached}`);
+  }
+  if (extendedCached >= extendedPromptTokens) {
+    throw new Error(
+      `expected extended request to be a partial-prefix hit, got cached=${extendedCached} prompt=${extendedPromptTokens}`,
+    );
+  }
+
+  const metrics = await getText("/metrics");
+  const hasHitMetric = /supersonic_prefix_cache_hits\s+[1-9]/.test(metrics);
+  if (!hasHitMetric) {
+    throw new Error("metrics did not report a prefix-cache hit");
+  }
+
+  console.log(
+    "prefix_cache_smoke",
+    JSON.stringify({
+      first_cached_tokens: firstCached,
+      second_cached_tokens: secondCached,
+      extended_cached_tokens: extendedCached,
+      extended_prompt_tokens: extendedPromptTokens,
+      endpoint,
+      retention,
+      text: outputText(second),
+    }),
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds server-side exact token-prefix reuse for common chat and agent loops. Requests can opt into scoped cache reuse through OpenAI-shaped fields such as `prompt_cache_key`, `prompt_cache_retention`, `user`, and thread metadata.

## What changed

- Added a runtime prefix cache with scoped SHA-256 namespaces, TTL/LRU resident snapshots, and `in_memory`, `24h`, and `none` retention handling.
- Added session snapshot/restore support for Qwen, Gemma 4 BF16, and Gemma 4 INT4 decode engines.
- Wired cache lookup/capture through Chat Completions, Completions, and Responses.
- Reports reused tokens via `usage.prompt_tokens_details.cached_tokens` for streaming and non-streaming responses.
- Exposes prefix-cache stats through `/v1/capabilities`, `/health`, and `/metrics`.
- Adds docs plus `scripts/prefix_cache_smoke.mjs` for live harness smoke testing.

## Notes

`24h` retention currently persists prompt-free disk metadata and keeps the reusable model-state snapshot resident while the server is running. The disk files intentionally contain only hashes, counts, retention, and expiry metadata; restart-surviving KV snapshot persistence is a separate follow-up.

## Validation

- `cargo check -p server --all-targets`
- `cargo test -p supersonic-runtime prefix_cache`
- `cargo test -p server --test protocol_mock`
- `SUPERSONIC_TEST_BACKEND=cuda SUPERSONIC_TEST_MODEL=qwen3.5-0.8b SUPERSONIC_TEST_MODEL_DIR=/workspace/models/Qwen3.5-0.8B SUPERSONIC_TEST_MAX_CONTEXT=512 SUPERSONIC_TEST_PREFIX_CACHE_MIN_TOKENS=1 cargo test -p server --test chat_integration comprehensive_chat_suite -- --nocapture`
- live CUDA `scripts/prefix_cache_smoke.mjs` in chat mode with `24h` retention
- live CUDA `scripts/prefix_cache_smoke.mjs` in completions mode with `24h` retention
- `node --check scripts/prefix_cache_smoke.mjs`
- `git diff --check`
