### PR TITLE
[codex] server prefix cache byte budget

### DIFF
--- a/crates/qwen35/src/state.rs
+++ b/crates/qwen35/src/state.rs
@@ -999,6 +999,40 @@ fn restore_virtual_kv_image_mapped(
 }
 
 impl LayerState {
+    pub fn resident_gpu_bytes(&self) -> usize {
+        let mut total = 0usize;
+        let mut add = |buf: &Option<GpuBuffer>| {
+            if let Some(buf) = buf {
+                total = total.saturating_add(buf.len_bytes());
+            }
+        };
+        add(&self.kv_cache_k);
+        add(&self.kv_cache_v);
+        add(&self.kv_scale_k);
+        add(&self.kv_scale_v);
+        add(&self.kv_shadow_k);
+        add(&self.kv_shadow_v);
+        add(&self.certified_kv_key_i8);
+        add(&self.certified_kv_key_scale);
+        add(&self.certified_kv_key_zero);
+        add(&self.certified_kv_value_i4);
+        add(&self.certified_kv_value_scale);
+        add(&self.certified_kv_value_zero);
+        add(&self.certified_kv_value_error);
+        add(&self.certified_kv_value_norm);
+        add(&self.certified_kv_tail_k);
+        add(&self.certified_kv_tail_v);
+        add(&self.certified_kv_promoted_key_cache);
+        add(&self.certified_kv_promoted_key_cache_tags_gpu);
+        add(&self.certified_kv_promoted_key_cache_lru_gpu);
+        add(&self.certified_kv_promoted_value_cache);
+        add(&self.certified_kv_ranking_prefix_k);
+        add(&self.certified_kv_ranking_prefix_v);
+        add(&self.conv_state);
+        add(&self.recurrent_state);
+        total
+    }
+
     /// Deep-copy all GPU buffers to create an independent clone.
     pub fn clone_gpu(&self) -> Result<Self, GpuError> {
         let clone_opt = |opt: &Option<GpuBuffer>| -> Result<Option<GpuBuffer>, GpuError> {
@@ -1236,6 +1270,13 @@ impl ModelState {
             layers.push(ls.clone_gpu()?);
         }
         Ok(Self { layers })
+    }
+
+    pub fn resident_gpu_bytes(&self) -> usize {
+        self.layers
+            .iter()
+            .map(LayerState::resident_gpu_bytes)
+            .fold(0usize, usize::saturating_add)
     }
 
     /// Capture `(conv_state, recurrent_state)` for every linear-attention

--- a/crates/runner/src/decode_engine.rs
+++ b/crates/runner/src/decode_engine.rs
@@ -869,6 +869,12 @@ pub struct DecodeEngineSnapshot {
 }
 
 impl DecodeEngineSnapshot {
+    pub fn resident_bytes(&self) -> usize {
+        self.state
+            .resident_gpu_bytes()
+            .saturating_add(self.logits.len().saturating_mul(std::mem::size_of::<f32>()))
+    }
+
     pub fn try_clone(&self) -> Result<Self> {
         Ok(Self {
             state: self
@@ -10397,6 +10403,12 @@ impl DecodeEngine {
                 .map_err(|e| anyhow::anyhow!("snapshot Qwen prefix state: {e}"))?,
             logits,
         })
+    }
+
+    pub fn prefix_snapshot_bytes(&self, logits_len: usize) -> usize {
+        self.state
+            .resident_gpu_bytes()
+            .saturating_add(logits_len.saturating_mul(std::mem::size_of::<f32>()))
     }
 
     pub fn restore_prefix(&mut self, snapshot: &DecodeEngineSnapshot) -> Result<Vec<f32>> {

--- a/crates/runner/src/gemma4_engine.rs
+++ b/crates/runner/src/gemma4_engine.rs
@@ -604,6 +604,12 @@ pub struct Gemma4EngineSnapshot {
 }
 
 impl Gemma4EngineSnapshot {
+    pub fn resident_bytes(&self) -> usize {
+        buffers_bytes(&self.k_caches)
+            .saturating_add(buffers_bytes(&self.v_caches))
+            .saturating_add(self.logits.len().saturating_mul(std::mem::size_of::<f32>()))
+    }
+
     pub fn try_clone(&self) -> Result<Self> {
         Ok(Self {
             k_caches: clone_buffers(&self.k_caches, "Gemma 4 K snapshot")?,
@@ -611,6 +617,13 @@ impl Gemma4EngineSnapshot {
             logits: self.logits.clone(),
         })
     }
+}
+
+fn buffers_bytes(buffers: &[GpuBuffer]) -> usize {
+    buffers
+        .iter()
+        .map(GpuBuffer::len_bytes)
+        .fold(0usize, usize::saturating_add)
 }
 
 fn clone_buffers(buffers: &[GpuBuffer], label: &str) -> Result<Vec<GpuBuffer>> {
@@ -1198,6 +1211,12 @@ impl Gemma4Engine {
             v_caches: clone_buffers(&self.v_caches[0], "Gemma 4 V prefix")?,
             logits,
         })
+    }
+
+    pub fn prefix_snapshot_bytes(&self, logits_len: usize) -> usize {
+        buffers_bytes(&self.k_caches[0])
+            .saturating_add(buffers_bytes(&self.v_caches[0]))
+            .saturating_add(logits_len.saturating_mul(std::mem::size_of::<f32>()))
     }
 
     pub fn restore_prefix(&mut self, snapshot: &Gemma4EngineSnapshot) -> Result<Vec<f32>> {

--- a/crates/runner/src/gemma4_int4_engine.rs
+++ b/crates/runner/src/gemma4_int4_engine.rs
@@ -444,6 +444,12 @@ pub struct Gemma4Int4EngineSnapshot {
 }
 
 impl Gemma4Int4EngineSnapshot {
+    pub fn resident_bytes(&self) -> usize {
+        buffers_bytes(&self.k_caches)
+            .saturating_add(buffers_bytes(&self.v_caches))
+            .saturating_add(self.logits.len().saturating_mul(std::mem::size_of::<f32>()))
+    }
+
     pub fn try_clone(&self) -> Result<Self> {
         Ok(Self {
             k_caches: clone_buffers(&self.k_caches, "Gemma 4 INT4 K snapshot")?,
@@ -451,6 +457,13 @@ impl Gemma4Int4EngineSnapshot {
             logits: self.logits.clone(),
         })
     }
+}
+
+fn buffers_bytes(buffers: &[GpuBuffer]) -> usize {
+    buffers
+        .iter()
+        .map(GpuBuffer::len_bytes)
+        .fold(0usize, usize::saturating_add)
 }
 
 fn clone_buffers(buffers: &[GpuBuffer], label: &str) -> Result<Vec<GpuBuffer>> {
@@ -883,6 +896,12 @@ impl Gemma4Int4Engine {
             v_caches: clone_buffers(&self.v_caches, "Gemma 4 INT4 V prefix")?,
             logits,
         })
+    }
+
+    pub fn prefix_snapshot_bytes(&self, logits_len: usize) -> usize {
+        buffers_bytes(&self.k_caches)
+            .saturating_add(buffers_bytes(&self.v_caches))
+            .saturating_add(logits_len.saturating_mul(std::mem::size_of::<f32>()))
     }
 
     pub fn restore_prefix(&mut self, snapshot: &Gemma4Int4EngineSnapshot) -> Result<Vec<f32>> {

--- a/crates/runtime/src/generate.rs
+++ b/crates/runtime/src/generate.rs
@@ -343,14 +343,7 @@ fn run(
     };
 
     if let Some(cache_req) = cache.as_ref() {
-        match guard.snapshot_prefix(prefill_logits.clone()) {
-            Ok(snapshot) => {
-                if let Err(e) = state.prefix_cache.insert(cache_req, &prompt_ids, snapshot) {
-                    tracing::warn!("prefix cache insert failed: {e}");
-                }
-            }
-            Err(e) => tracing::debug!("prefix cache snapshot skipped: {e}"),
-        }
+        snapshot_prefix_if_admitted(&guard, &state, cache_req, &prompt_ids, &prefill_logits);
     }
 
     let mut rng = rng_from_seed(params.seed);
@@ -429,17 +422,13 @@ fn run(
 
     if state_token_ids.len() > prompt_ids.len() {
         if let Some(cache_req) = cache.as_ref() {
-            match guard.snapshot_prefix(current_logits.clone()) {
-                Ok(snapshot) => {
-                    if let Err(e) = state
-                        .prefix_cache
-                        .insert(cache_req, &state_token_ids, snapshot)
-                    {
-                        tracing::warn!("prefix cache generated-prefix insert failed: {e}");
-                    }
-                }
-                Err(e) => tracing::debug!("generated prefix cache snapshot skipped: {e}"),
-            }
+            snapshot_prefix_if_admitted(
+                &guard,
+                &state,
+                cache_req,
+                &state_token_ids,
+                &current_logits,
+            );
         }
     }
 
@@ -467,21 +456,33 @@ fn prefill_with_cache_anchor(
     }
 
     let mut logits = guard.prefill(&prompt_ids[..anchor_len])?;
-    match guard.snapshot_prefix(logits.clone()) {
-        Ok(snapshot) => {
-            if let Err(e) = state
-                .prefix_cache
-                .insert(cache_req, &prompt_ids[..anchor_len], snapshot)
-            {
-                tracing::warn!("prefix cache anchor insert failed: {e}");
-            }
-        }
-        Err(e) => tracing::debug!("prefix cache anchor snapshot skipped: {e}"),
-    }
+    snapshot_prefix_if_admitted(guard, state, cache_req, &prompt_ids[..anchor_len], &logits);
     for (idx, token) in prompt_ids.iter().copied().enumerate().skip(anchor_len) {
         logits = guard.decode_step(token, idx)?;
     }
     Ok(logits)
+}
+
+fn snapshot_prefix_if_admitted(
+    guard: &InferenceSession,
+    state: &ServerState,
+    cache_req: &CacheRequest,
+    token_ids: &[u32],
+    logits: &[f32],
+) {
+    let estimate = guard.prefix_snapshot_bytes(logits.len());
+    if !state.prefix_cache.can_admit(token_ids.len(), estimate) {
+        state.prefix_cache.record_admission_skip();
+        return;
+    }
+    match guard.snapshot_prefix(logits.to_vec()) {
+        Ok(snapshot) => {
+            if let Err(e) = state.prefix_cache.insert(cache_req, token_ids, snapshot) {
+                tracing::warn!("prefix cache insert failed: {e}");
+            }
+        }
+        Err(e) => tracing::debug!("prefix cache snapshot skipped: {e}"),
+    }
 }
 
 fn detokenize(tokenizer: &Tokenizer, ids: &[u32]) -> String {

--- a/crates/runtime/src/prefix_cache.rs
+++ b/crates/runtime/src/prefix_cache.rs
@@ -51,6 +51,7 @@ pub struct PrefixCacheConfig {
     pub dir: PathBuf,
     pub min_tokens: usize,
     pub max_entries: usize,
+    pub max_bytes: usize,
     pub memory_ttl_secs: u64,
     pub disk_ttl_secs: u64,
 }
@@ -64,18 +65,21 @@ pub struct PrefixCache {
     evictions: AtomicU64,
     disk_writes: AtomicU64,
     restore_failures: AtomicU64,
+    admission_skips: AtomicU64,
 }
 
 #[derive(Default)]
 struct PrefixCacheInner {
     entries: HashMap<String, PrefixCacheEntry>,
     lru: VecDeque<String>,
+    resident_bytes: usize,
 }
 
 pub struct PrefixCacheEntry {
     namespace: String,
     token_ids: Vec<u32>,
     snapshot: SessionSnapshot,
+    resident_bytes: usize,
     expires_at_secs: u64,
     last_used_secs: u64,
 }
@@ -91,6 +95,8 @@ pub struct PrefixCacheStats {
     pub dir: String,
     pub min_tokens: usize,
     pub max_entries: usize,
+    pub max_bytes: usize,
+    pub resident_bytes: usize,
     pub entries: usize,
     pub hits: u64,
     pub misses: u64,
@@ -98,6 +104,7 @@ pub struct PrefixCacheStats {
     pub evictions: u64,
     pub disk_writes: u64,
     pub restore_failures: u64,
+    pub admission_skips: u64,
 }
 
 #[derive(Serialize)]
@@ -126,11 +133,22 @@ impl PrefixCache {
             evictions: AtomicU64::new(0),
             disk_writes: AtomicU64::new(0),
             restore_failures: AtomicU64::new(0),
+            admission_skips: AtomicU64::new(0),
         }
     }
 
     pub fn config(&self) -> &PrefixCacheConfig {
         &self.cfg
+    }
+
+    pub fn can_admit(&self, token_count: usize, resident_bytes: usize) -> bool {
+        if !self.cfg.enabled || token_count < self.cfg.min_tokens {
+            return false;
+        }
+        if self.cfg.max_entries == 0 {
+            return false;
+        }
+        self.cfg.max_bytes == 0 || resident_bytes <= self.cfg.max_bytes
     }
 
     pub fn lookup(&self, req: &CacheRequest, prompt_ids: &[u32]) -> Option<PrefixCacheHit> {
@@ -200,10 +218,23 @@ impl PrefixCache {
         let token_hash = token_hash(token_ids);
         let key = format!("{namespace}:{token_hash}");
         let expires_at_secs = now.saturating_add(req.retention.ttl(&self.cfg).as_secs());
+        let resident_bytes = snapshot.resident_bytes();
+        if !self.can_admit(token_ids.len(), resident_bytes) {
+            self.admission_skips.fetch_add(1, Ordering::Relaxed);
+            tracing::debug!(
+                token_count = token_ids.len(),
+                resident_bytes,
+                max_bytes = self.cfg.max_bytes,
+                max_entries = self.cfg.max_entries,
+                "prefix cache snapshot skipped by admission policy"
+            );
+            return Ok(());
+        }
         let entry = PrefixCacheEntry {
             namespace: namespace.clone(),
             token_ids: token_ids.to_vec(),
             snapshot,
+            resident_bytes,
             expires_at_secs,
             last_used_secs: now,
         };
@@ -212,18 +243,13 @@ impl PrefixCache {
             .entries
             .lock()
             .map_err(|_| anyhow::anyhow!("prefix cache lock poisoned"))?;
-        inner.entries.insert(key.clone(), entry);
+        if let Some(old) = inner.entries.insert(key.clone(), entry) {
+            inner.resident_bytes = inner.resident_bytes.saturating_sub(old.resident_bytes);
+        }
+        inner.resident_bytes = inner.resident_bytes.saturating_add(resident_bytes);
         touch_lru(&mut inner.lru, &key);
         self.prune_locked(&mut inner, now);
-        while inner.entries.len() > self.cfg.max_entries {
-            if let Some(old) = inner.lru.pop_front() {
-                if inner.entries.remove(&old).is_some() {
-                    self.evictions.fetch_add(1, Ordering::Relaxed);
-                }
-            } else {
-                break;
-            }
-        }
+        self.enforce_capacity_locked(&mut inner);
         drop(inner);
 
         if req.retention == CacheRetention::TwentyFourHours {
@@ -236,13 +262,23 @@ impl PrefixCache {
         self.restore_failures.fetch_add(1, Ordering::Relaxed);
     }
 
+    pub fn record_admission_skip(&self) {
+        self.admission_skips.fetch_add(1, Ordering::Relaxed);
+    }
+
     pub fn stats(&self) -> PrefixCacheStats {
-        let entries = self.entries.lock().map(|e| e.entries.len()).unwrap_or(0);
+        let (entries, resident_bytes) = self
+            .entries
+            .lock()
+            .map(|e| (e.entries.len(), e.resident_bytes))
+            .unwrap_or((0, 0));
         PrefixCacheStats {
             enabled: self.cfg.enabled,
             dir: self.cfg.dir.display().to_string(),
             min_tokens: self.cfg.min_tokens,
             max_entries: self.cfg.max_entries,
+            max_bytes: self.cfg.max_bytes,
+            resident_bytes,
             entries,
             hits: self.hits.load(Ordering::Relaxed),
             misses: self.misses.load(Ordering::Relaxed),
@@ -250,6 +286,7 @@ impl PrefixCache {
             evictions: self.evictions.load(Ordering::Relaxed),
             disk_writes: self.disk_writes.load(Ordering::Relaxed),
             restore_failures: self.restore_failures.load(Ordering::Relaxed),
+            admission_skips: self.admission_skips.load(Ordering::Relaxed),
         }
     }
 
@@ -261,10 +298,27 @@ impl PrefixCache {
             }
         }
         for key in expired {
-            if inner.entries.remove(&key).is_some() {
-                self.evictions.fetch_add(1, Ordering::Relaxed);
-            }
+            self.remove_locked(inner, &key);
             inner.lru.retain(|k| k != &key);
+        }
+    }
+
+    fn enforce_capacity_locked(&self, inner: &mut PrefixCacheInner) {
+        while inner.entries.len() > self.cfg.max_entries
+            || (self.cfg.max_bytes > 0 && inner.resident_bytes > self.cfg.max_bytes)
+        {
+            if let Some(old) = inner.lru.pop_front() {
+                self.remove_locked(inner, &old);
+            } else {
+                break;
+            }
+        }
+    }
+
+    fn remove_locked(&self, inner: &mut PrefixCacheInner, key: &str) {
+        if let Some(old) = inner.entries.remove(key) {
+            inner.resident_bytes = inner.resident_bytes.saturating_sub(old.resident_bytes);
+            self.evictions.fetch_add(1, Ordering::Relaxed);
         }
     }
 
@@ -387,5 +441,32 @@ mod tests {
         assert_ne!(a, b);
         assert_eq!(a.file_name().unwrap(), "1111222233334444-abcd.json");
         assert_eq!(b.file_name().unwrap(), "9999888877776666-abcd.json");
+    }
+
+    #[test]
+    fn admission_policy_checks_entry_and_byte_budget() {
+        let cache = PrefixCache::new(PrefixCacheConfig {
+            enabled: true,
+            dir: PathBuf::from("/tmp/cache"),
+            min_tokens: 4,
+            max_entries: 1,
+            max_bytes: 1024,
+            memory_ttl_secs: 600,
+            disk_ttl_secs: 86_400,
+        });
+        assert!(!cache.can_admit(3, 512));
+        assert!(cache.can_admit(4, 1024));
+        assert!(!cache.can_admit(4, 1025));
+
+        let disabled = PrefixCache::new(PrefixCacheConfig {
+            enabled: true,
+            dir: PathBuf::from("/tmp/cache"),
+            min_tokens: 1,
+            max_entries: 0,
+            max_bytes: 0,
+            memory_ttl_secs: 600,
+            disk_ttl_secs: 86_400,
+        });
+        assert!(!disabled.can_admit(10, 10));
     }
 }

--- a/crates/runtime/src/session.rs
+++ b/crates/runtime/src/session.rs
@@ -23,6 +23,14 @@ pub enum SessionSnapshot {
 }
 
 impl SessionSnapshot {
+    pub fn resident_bytes(&self) -> usize {
+        match self {
+            Self::Qwen(s) => s.resident_bytes(),
+            Self::Gemma4Bf16(s) => s.resident_bytes(),
+            Self::Gemma4Int4(s) => s.resident_bytes(),
+        }
+    }
+
     pub fn try_clone(&self) -> Result<Self> {
         match self {
             Self::Qwen(s) => Ok(Self::Qwen(s.try_clone()?)),
@@ -90,6 +98,14 @@ impl InferenceSession {
             Self::Qwen(e) => Ok(SessionSnapshot::Qwen(e.snapshot_prefix(logits)?)),
             Self::Gemma4Bf16(e) => Ok(SessionSnapshot::Gemma4Bf16(e.snapshot_prefix(logits)?)),
             Self::Gemma4Int4(e) => Ok(SessionSnapshot::Gemma4Int4(e.snapshot_prefix(logits)?)),
+        }
+    }
+
+    pub fn prefix_snapshot_bytes(&self, logits_len: usize) -> usize {
+        match self {
+            Self::Qwen(e) => e.prefix_snapshot_bytes(logits_len),
+            Self::Gemma4Bf16(e) => e.prefix_snapshot_bytes(logits_len),
+            Self::Gemma4Int4(e) => e.prefix_snapshot_bytes(logits_len),
         }
     }
 

--- a/crates/runtime/src/state.rs
+++ b/crates/runtime/src/state.rs
@@ -87,6 +87,7 @@ pub struct LoaderConfig {
     pub prefix_cache_dir: Option<PathBuf>,
     pub prefix_cache_min_tokens: usize,
     pub prefix_cache_max_entries: usize,
+    pub prefix_cache_max_bytes: Option<usize>,
     pub prefix_cache_memory_ttl_secs: u64,
     pub prefix_cache_disk_ttl_secs: u64,
 }
@@ -215,10 +216,20 @@ pub fn build(cfg: LoaderConfig) -> Result<ServerState> {
             dir: cache_dir,
             min_tokens: cfg.prefix_cache_min_tokens,
             max_entries: cfg.prefix_cache_max_entries,
+            max_bytes: cfg
+                .prefix_cache_max_bytes
+                .unwrap_or_else(|| default_prefix_cache_max_bytes(total_vram)),
             memory_ttl_secs: cfg.prefix_cache_memory_ttl_secs,
             disk_ttl_secs: cfg.prefix_cache_disk_ttl_secs,
         })),
     })
+}
+
+fn default_prefix_cache_max_bytes(total_vram: u64) -> usize {
+    const MIN_BUDGET: u64 = 64 * 1024 * 1024;
+    const MAX_BUDGET: u64 = 2 * 1024 * 1024 * 1024;
+    let budget = (total_vram / 20).clamp(MIN_BUDGET, MAX_BUDGET);
+    budget.min(usize::MAX as u64) as usize
 }
 
 fn validate_flag_exclusions(cfg: &LoaderConfig) -> Result<()> {
@@ -305,6 +316,7 @@ mod tests {
             prefix_cache_dir: None,
             prefix_cache_min_tokens: 128,
             prefix_cache_max_entries: 1,
+            prefix_cache_max_bytes: None,
             prefix_cache_memory_ttl_secs: 600,
             prefix_cache_disk_ttl_secs: 86_400,
         }

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -127,6 +127,11 @@ struct Cli {
     )]
     prefix_cache_max_entries: usize,
 
+    /// Maximum resident prefix snapshot bytes. Defaults to an automatic
+    /// conservative VRAM budget; set to 0 to disable the byte cap.
+    #[arg(long, env = "SUPERSONIC_PREFIX_CACHE_MAX_BYTES")]
+    prefix_cache_max_bytes: Option<usize>,
+
     /// In-memory prefix cache TTL in seconds.
     #[arg(
         long,
@@ -174,6 +179,7 @@ fn main() -> Result<()> {
         prefix_cache_dir: cli.prefix_cache_dir,
         prefix_cache_min_tokens: cli.prefix_cache_min_tokens,
         prefix_cache_max_entries: cli.prefix_cache_max_entries,
+        prefix_cache_max_bytes: cli.prefix_cache_max_bytes,
         prefix_cache_memory_ttl_secs: cli.prefix_cache_memory_ttl_secs,
         prefix_cache_disk_ttl_secs: cli.prefix_cache_disk_ttl_secs,
     };

--- a/crates/server/src/routes/models.rs
+++ b/crates/server/src/routes/models.rs
@@ -157,6 +157,10 @@ pub async fn metrics(State(state): State<Arc<ServerState>>) -> impl IntoResponse
          supersonic_max_context {}\n\
          # TYPE supersonic_prefix_cache_entries gauge\n\
          supersonic_prefix_cache_entries {}\n\
+         # TYPE supersonic_prefix_cache_resident_bytes gauge\n\
+         supersonic_prefix_cache_resident_bytes {}\n\
+         # TYPE supersonic_prefix_cache_max_bytes gauge\n\
+         supersonic_prefix_cache_max_bytes {}\n\
          # TYPE supersonic_prefix_cache_hits counter\n\
          supersonic_prefix_cache_hits {}\n\
          # TYPE supersonic_prefix_cache_misses counter\n\
@@ -168,19 +172,24 @@ pub async fn metrics(State(state): State<Arc<ServerState>>) -> impl IntoResponse
          # TYPE supersonic_prefix_cache_disk_writes counter\n\
          supersonic_prefix_cache_disk_writes {}\n\
          # TYPE supersonic_prefix_cache_restore_failures counter\n\
-         supersonic_prefix_cache_restore_failures {}\n",
+         supersonic_prefix_cache_restore_failures {}\n\
+         # TYPE supersonic_prefix_cache_admission_skips counter\n\
+         supersonic_prefix_cache_admission_skips {}\n",
         queue.active,
         queue.queued,
         queue.max_queue,
         queue.queue_timeout_ms,
         state.max_context,
         cache.entries,
+        cache.resident_bytes,
+        cache.max_bytes,
         cache.hits,
         cache.misses,
         cache.cached_tokens,
         cache.evictions,
         cache.disk_writes,
         cache.restore_failures,
+        cache.admission_skips,
     );
     ([(CONTENT_TYPE, "text/plain; version=0.0.4")], body)
 }

--- a/crates/server/tests/chat_integration.rs
+++ b/crates/server/tests/chat_integration.rs
@@ -72,6 +72,7 @@ fn load_test_config() -> Option<LoaderConfig> {
             .and_then(|s| s.parse().ok())
             .unwrap_or(32),
         prefix_cache_max_entries: 1,
+        prefix_cache_max_bytes: None,
         prefix_cache_memory_ttl_secs: 600,
         prefix_cache_disk_ttl_secs: 86_400,
     })

--- a/crates/server/tests/protocol_mock.rs
+++ b/crates/server/tests/protocol_mock.rs
@@ -64,6 +64,7 @@ fn test_state_with_scheduler(
             dir: std::env::temp_dir().join("supersonic-test-prefix-cache"),
             min_tokens: 1,
             max_entries: 1,
+            max_bytes: 64 * 1024 * 1024,
             memory_ttl_secs: 600,
             disk_ttl_secs: 86_400,
         })),
@@ -441,6 +442,7 @@ async fn mock_auth_cors_and_model_mismatch() {
         .expect("capabilities json");
     assert_eq!(capabilities["prefix_cache"]["enabled"], true);
     assert_eq!(capabilities["prefix_cache"]["min_tokens"], 1);
+    assert_eq!(capabilities["prefix_cache"]["max_bytes"], 64 * 1024 * 1024);
 
     let missing_model = h
         .client
@@ -465,6 +467,8 @@ async fn mock_auth_cors_and_model_mismatch() {
     assert!(metrics.contains("supersonic_queued_requests"));
     assert!(metrics.contains("supersonic_prefix_cache_hits"));
     assert!(metrics.contains("supersonic_prefix_cache_cached_tokens"));
+    assert!(metrics.contains("supersonic_prefix_cache_resident_bytes"));
+    assert!(metrics.contains("supersonic_prefix_cache_admission_skips"));
 
     let cors = h
         .client

--- a/docs/server.md
+++ b/docs/server.md
@@ -42,6 +42,9 @@ Optional deployment flags:
     caching. The default is `128`.
   - `--prefix-cache-max-entries N` caps resident prefix snapshots. Snapshots
     clone model state on GPU; the conservative default is `1`.
+  - `--prefix-cache-max-bytes N` caps resident prefix snapshot bytes. The
+    default is an automatic conservative VRAM budget; set `0` to disable the
+    byte cap.
   - `--prefix-cache-memory-ttl-secs N` controls `in_memory` retention. The
     default is `600`.
   - `--prefix-cache-disk-ttl-secs N` controls `24h` metadata retention. The
@@ -123,6 +126,11 @@ uncached suffix, and reports the reused prompt tokens as
 `usage.prompt_tokens_details.cached_tokens`. The cache is scoped by model, API
 key, user/thread metadata, and `prompt_cache_key` to avoid accidental cross-user
 reuse.
+
+Resident snapshots are admitted only when they fit both the entry-count cap and
+the byte budget. This avoids cloning large model states into cache on GPUs that
+do not have enough spare VRAM. `/v1/capabilities` and `/metrics` expose current
+resident bytes, byte budget, and admission skips.
 
 `prompt_cache_retention` accepts:
 


### PR DESCRIPTION
## Summary

Adds memory-aware admission for server prefix-cache snapshots so the cache is bounded by resident bytes as well as entry count.

## What changed

- Adds byte accounting for Qwen, Gemma 4 BF16, and Gemma 4 INT4 prefix snapshots.
- Checks the byte budget before cloning GPU-backed snapshots, avoiding avoidable VRAM allocation when a snapshot cannot be admitted.
- Enforces the byte budget inside `PrefixCache` with LRU eviction and admission skips.
- Adds `--prefix-cache-max-bytes` / `SUPERSONIC_PREFIX_CACHE_MAX_BYTES`; default is an automatic conservative VRAM budget, and `0` disables the byte cap.
- Exposes `resident_bytes`, `max_bytes`, and `admission_skips` through capabilities and Prometheus metrics.
- Updates docs and tests for byte-budget behavior.

## Validation

- `cargo check -p server --all-targets`
- `cargo test -p supersonic-runtime prefix_cache`
- `cargo test -p server --test protocol_mock`
- `node --check scripts/prefix_cache_smoke.mjs`
- `git diff --check`
- live CUDA completions smoke with normal budget: repeat and extended-prefix cache hits still work
- live CUDA smoke with `--prefix-cache-max-bytes 1`: cache entries remain 0, second request misses, `supersonic_prefix_cache_admission_skips` increments
