### PR TITLE
[codex] server Qwen prefix disk cache

### DIFF
--- a/crates/qwen35/src/state.rs
+++ b/crates/qwen35/src/state.rs
@@ -3,6 +3,7 @@ use std::ffi::c_void;
 use gpu_hal::{
     copy_h2d, sync, GpuBuffer, GpuError, HostBuffer, ScalarType, VirtualBacking, VirtualBuffer,
 };
+use serde::{Deserialize, Serialize};
 
 use crate::config::TextConfig;
 use crate::weights::LayerKind;
@@ -112,6 +113,33 @@ struct VirtualKvLogicalBackup {
 struct VirtualKvFullBackup {
     k: Vec<u8>,
     v: Option<Vec<u8>>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct ModelStateDiskSnapshot {
+    pub layers: Vec<LayerStateDiskSnapshot>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct LayerStateDiskSnapshot {
+    kind: String,
+    kv_cache_k: Option<BufferDiskSnapshot>,
+    kv_cache_v: Option<BufferDiskSnapshot>,
+    kv_filled: usize,
+    kv_scale_k: Option<BufferDiskSnapshot>,
+    kv_scale_v: Option<BufferDiskSnapshot>,
+    kv_shadow_k: Option<BufferDiskSnapshot>,
+    kv_shadow_v: Option<BufferDiskSnapshot>,
+    kv_shadow_start: usize,
+    conv_state: Option<BufferDiskSnapshot>,
+    recurrent_state: Option<BufferDiskSnapshot>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct BufferDiskSnapshot {
+    dtype: String,
+    shape: Vec<usize>,
+    bytes: Vec<u8>,
 }
 
 impl LayerState {
@@ -999,6 +1027,80 @@ fn restore_virtual_kv_image_mapped(
 }
 
 impl LayerState {
+    pub fn to_disk_snapshot(&self) -> Result<LayerStateDiskSnapshot, GpuError> {
+        if self.has_virtual_kv_cache()
+            || self.certified_kv_host_k.is_some()
+            || self.certified_kv_host_v.is_some()
+            || self.certified_kv_key_i8.is_some()
+            || self.certified_kv_key_scale.is_some()
+            || self.certified_kv_key_zero.is_some()
+            || self.certified_kv_value_i4.is_some()
+            || self.certified_kv_value_scale.is_some()
+            || self.certified_kv_value_zero.is_some()
+            || self.certified_kv_value_error.is_some()
+            || self.certified_kv_value_norm.is_some()
+            || self.certified_kv_tail_k.is_some()
+            || self.certified_kv_tail_v.is_some()
+            || self.certified_kv_promoted_key_cache.is_some()
+            || self.certified_kv_promoted_key_cache_tags_gpu.is_some()
+            || self.certified_kv_promoted_key_cache_lru_gpu.is_some()
+            || self.certified_kv_promoted_value_cache.is_some()
+            || self.certified_kv_ranking_prefix_k.is_some()
+            || self.certified_kv_ranking_prefix_v.is_some()
+        {
+            return Err(GpuError::Unsupported(
+                "Qwen disk prefix snapshots only support standard KV/linear state".into(),
+            ));
+        }
+        Ok(LayerStateDiskSnapshot {
+            kind: match self.kind {
+                LayerKind::Linear => "linear".to_string(),
+                LayerKind::Full => "full".to_string(),
+            },
+            kv_cache_k: buffer_to_disk(&self.kv_cache_k)?,
+            kv_cache_v: buffer_to_disk(&self.kv_cache_v)?,
+            kv_filled: self.kv_filled,
+            kv_scale_k: buffer_to_disk(&self.kv_scale_k)?,
+            kv_scale_v: buffer_to_disk(&self.kv_scale_v)?,
+            kv_shadow_k: buffer_to_disk(&self.kv_shadow_k)?,
+            kv_shadow_v: buffer_to_disk(&self.kv_shadow_v)?,
+            kv_shadow_start: self.kv_shadow_start,
+            conv_state: buffer_to_disk(&self.conv_state)?,
+            recurrent_state: buffer_to_disk(&self.recurrent_state)?,
+        })
+    }
+
+    fn from_disk_snapshot(
+        snapshot: LayerStateDiskSnapshot,
+        config: &TextConfig,
+        ordinal: usize,
+    ) -> Result<Self, GpuError> {
+        let expected_kind = match snapshot.kind.as_str() {
+            "linear" => LayerKind::Linear,
+            "full" => LayerKind::Full,
+            other => {
+                return Err(GpuError::InvalidArg(format!(
+                    "unknown Qwen disk layer kind {other}"
+                )))
+            }
+        };
+        let mut layer = match expected_kind {
+            LayerKind::Linear => Self::new_linear(ordinal, config)?,
+            LayerKind::Full => Self::new_full(ordinal),
+        };
+        layer.kv_cache_k = buffer_from_disk(snapshot.kv_cache_k, ordinal)?;
+        layer.kv_cache_v = buffer_from_disk(snapshot.kv_cache_v, ordinal)?;
+        layer.kv_filled = snapshot.kv_filled;
+        layer.kv_scale_k = buffer_from_disk(snapshot.kv_scale_k, ordinal)?;
+        layer.kv_scale_v = buffer_from_disk(snapshot.kv_scale_v, ordinal)?;
+        layer.kv_shadow_k = buffer_from_disk(snapshot.kv_shadow_k, ordinal)?;
+        layer.kv_shadow_v = buffer_from_disk(snapshot.kv_shadow_v, ordinal)?;
+        layer.kv_shadow_start = snapshot.kv_shadow_start;
+        layer.conv_state = buffer_from_disk(snapshot.conv_state, ordinal)?;
+        layer.recurrent_state = buffer_from_disk(snapshot.recurrent_state, ordinal)?;
+        Ok(layer)
+    }
+
     pub fn resident_gpu_bytes(&self) -> usize {
         let mut total = 0usize;
         let mut add = |buf: &Option<GpuBuffer>| {
@@ -1131,6 +1233,47 @@ impl LayerState {
             conv_state: clone_opt(&self.conv_state)?,
             recurrent_state: clone_opt(&self.recurrent_state)?,
         })
+    }
+}
+
+fn buffer_to_disk(buf: &Option<GpuBuffer>) -> Result<Option<BufferDiskSnapshot>, GpuError> {
+    let Some(buf) = buf else {
+        return Ok(None);
+    };
+    Ok(Some(BufferDiskSnapshot {
+        dtype: dtype_name(buf.dtype()).to_string(),
+        shape: buf.shape().to_vec(),
+        bytes: buf.to_host_bytes()?,
+    }))
+}
+
+fn buffer_from_disk(
+    snapshot: Option<BufferDiskSnapshot>,
+    ordinal: usize,
+) -> Result<Option<GpuBuffer>, GpuError> {
+    let Some(snapshot) = snapshot else {
+        return Ok(None);
+    };
+    let dtype = ScalarType::from_name(&snapshot.dtype).ok_or_else(|| {
+        GpuError::InvalidArg(format!("unknown Qwen disk buffer dtype {}", snapshot.dtype))
+    })?;
+    Ok(Some(GpuBuffer::from_host_bytes(
+        ordinal,
+        dtype,
+        &snapshot.shape,
+        &snapshot.bytes,
+    )?))
+}
+
+fn dtype_name(dtype: ScalarType) -> &'static str {
+    match dtype {
+        ScalarType::F16 => "f16",
+        ScalarType::BF16 => "bf16",
+        ScalarType::F32 => "f32",
+        ScalarType::U8 => "u8",
+        ScalarType::U32 => "u32",
+        ScalarType::I64 => "i64",
+        ScalarType::F8E4M3 => "f8_e4m3",
     }
 }
 
@@ -1277,6 +1420,50 @@ impl ModelState {
             .iter()
             .map(LayerState::resident_gpu_bytes)
             .fold(0usize, usize::saturating_add)
+    }
+
+    pub fn to_disk_snapshot(&self) -> Result<ModelStateDiskSnapshot, GpuError> {
+        Ok(ModelStateDiskSnapshot {
+            layers: self
+                .layers
+                .iter()
+                .map(LayerState::to_disk_snapshot)
+                .collect::<Result<Vec<_>, _>>()?,
+        })
+    }
+
+    pub fn from_disk_snapshot(
+        snapshot: ModelStateDiskSnapshot,
+        config: &TextConfig,
+        ordinal: usize,
+    ) -> Result<Self, GpuError> {
+        if snapshot.layers.len() != config.num_hidden_layers {
+            return Err(GpuError::InvalidArg(format!(
+                "Qwen disk snapshot layer count {} != config {}",
+                snapshot.layers.len(),
+                config.num_hidden_layers
+            )));
+        }
+        let mut layers = Vec::with_capacity(snapshot.layers.len());
+        for (idx, layer_snapshot) in snapshot.layers.into_iter().enumerate() {
+            let expected = if config.is_full_attention(idx) {
+                "full"
+            } else {
+                "linear"
+            };
+            if layer_snapshot.kind != expected {
+                return Err(GpuError::InvalidArg(format!(
+                    "Qwen disk snapshot layer {idx} kind {} != expected {expected}",
+                    layer_snapshot.kind
+                )));
+            }
+            layers.push(LayerState::from_disk_snapshot(
+                layer_snapshot,
+                config,
+                ordinal,
+            )?);
+        }
+        Ok(Self { layers })
     }
 
     /// Capture `(conv_state, recurrent_state)` for every linear-attention

--- a/crates/runner/src/decode_engine.rs
+++ b/crates/runner/src/decode_engine.rs
@@ -18,8 +18,12 @@ use qwen35::rotary::RotaryTables;
 use qwen35::scratch::{
     PersistentDecodeScratch, PERSISTENT_4B_TIMING_SLOTS_PER_LAYER, PERSISTENT_SYNC_COUNTER_BYTES,
 };
-use qwen35::state::{kv_fp8_bf16_sidecar_enabled, kv_fp8_bf16_sidecar_window_tokens, ModelState};
+use qwen35::state::{
+    kv_fp8_bf16_sidecar_enabled, kv_fp8_bf16_sidecar_window_tokens, ModelState,
+    ModelStateDiskSnapshot,
+};
 use qwen35::weights::{LayerKind, Qwen35Weights};
+use serde::{Deserialize, Serialize};
 
 use crate::oracle::OracleOutput;
 use crate::prefill_engine;
@@ -868,6 +872,12 @@ pub struct DecodeEngineSnapshot {
     pub logits: Vec<f32>,
 }
 
+#[derive(Serialize, Deserialize)]
+struct DecodeEngineDiskSnapshot {
+    state: ModelStateDiskSnapshot,
+    logits: Vec<f32>,
+}
+
 impl DecodeEngineSnapshot {
     pub fn resident_bytes(&self) -> usize {
         self.state
@@ -883,6 +893,17 @@ impl DecodeEngineSnapshot {
                 .map_err(|e| anyhow::anyhow!("clone Qwen prefix snapshot: {e}"))?,
             logits: self.logits.clone(),
         })
+    }
+
+    pub fn to_disk_bytes(&self) -> Result<Vec<u8>> {
+        let disk = DecodeEngineDiskSnapshot {
+            state: self
+                .state
+                .to_disk_snapshot()
+                .map_err(|e| anyhow::anyhow!("snapshot Qwen state to disk: {e}"))?,
+            logits: self.logits.clone(),
+        };
+        serde_json::to_vec(&disk).map_err(Into::into)
     }
 }
 
@@ -10428,6 +10449,15 @@ impl DecodeEngine {
             .reset_sync()
             .map_err(|e| anyhow::anyhow!("reset sync after prefix restore: {e}"))?;
         Ok(snapshot.logits)
+    }
+
+    pub fn load_prefix_snapshot_bytes(&self, bytes: &[u8]) -> Result<DecodeEngineSnapshot> {
+        let disk: DecodeEngineDiskSnapshot = serde_json::from_slice(bytes)?;
+        Ok(DecodeEngineSnapshot {
+            state: ModelState::from_disk_snapshot(disk.state, &self.weights.config, self.ordinal)
+                .map_err(|e| anyhow::anyhow!("load Qwen prefix snapshot from disk: {e}"))?,
+            logits: disk.logits,
+        })
     }
 
     /// Run native GPU prefill on the prompt, returning logits for the last token.

--- a/crates/runtime/src/generate.rs
+++ b/crates/runtime/src/generate.rs
@@ -333,6 +333,35 @@ fn run(
                     guard.prefill(&prompt_ids)?
                 }
             }
+        } else if let Some(hit) = state.prefix_cache.lookup_disk_bytes(cache_req, &prompt_ids) {
+            match guard.load_disk_prefix(&hit.bytes) {
+                Ok(snapshot) => match guard.restore_prefix(snapshot) {
+                    Ok(mut logits) => {
+                        cached_prompt_tokens = hit.cached_tokens as u32;
+                        for (idx, token) in prompt_ids
+                            .iter()
+                            .copied()
+                            .enumerate()
+                            .skip(hit.cached_tokens)
+                        {
+                            logits = guard.decode_step(token, idx)?;
+                        }
+                        logits
+                    }
+                    Err(e) => {
+                        tracing::warn!("prefix cache disk restore failed: {e}");
+                        state.prefix_cache.record_restore_failure();
+                        guard.reset()?;
+                        prefill_with_cache_anchor(&mut guard, &state, cache_req, &prompt_ids)?
+                    }
+                },
+                Err(e) => {
+                    tracing::warn!("prefix cache disk load failed: {e}");
+                    state.prefix_cache.record_restore_failure();
+                    guard.reset()?;
+                    prefill_with_cache_anchor(&mut guard, &state, cache_req, &prompt_ids)?
+                }
+            }
         } else {
             guard.reset()?;
             prefill_with_cache_anchor(&mut guard, &state, cache_req, &prompt_ids)?

--- a/crates/runtime/src/prefix_cache.rs
+++ b/crates/runtime/src/prefix_cache.rs
@@ -6,7 +6,7 @@ use std::sync::Mutex;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::session::SessionSnapshot;
@@ -64,6 +64,7 @@ pub struct PrefixCache {
     cached_tokens: AtomicU64,
     evictions: AtomicU64,
     disk_writes: AtomicU64,
+    disk_reads: AtomicU64,
     restore_failures: AtomicU64,
     admission_skips: AtomicU64,
 }
@@ -103,18 +104,20 @@ pub struct PrefixCacheStats {
     pub cached_tokens: u64,
     pub evictions: u64,
     pub disk_writes: u64,
+    pub disk_reads: u64,
     pub restore_failures: u64,
     pub admission_skips: u64,
 }
 
-#[derive(Serialize)]
-struct DiskEntry<'a> {
+#[derive(Serialize, Deserialize)]
+struct DiskEntry {
     format_version: u32,
-    namespace_hash: &'a str,
-    token_hash: &'a str,
+    namespace_hash: String,
+    token_hash: String,
     token_count: usize,
     expires_at_secs: u64,
-    retention: &'static str,
+    retention: String,
+    snapshot_file: Option<String>,
 }
 
 impl PrefixCache {
@@ -132,6 +135,7 @@ impl PrefixCache {
             cached_tokens: AtomicU64::new(0),
             evictions: AtomicU64::new(0),
             disk_writes: AtomicU64::new(0),
+            disk_reads: AtomicU64::new(0),
             restore_failures: AtomicU64::new(0),
             admission_skips: AtomicU64::new(0),
         }
@@ -230,6 +234,17 @@ impl PrefixCache {
             );
             return Ok(());
         }
+        let disk_bytes = if req.retention == CacheRetention::TwentyFourHours {
+            match snapshot.to_disk_bytes() {
+                Ok(bytes) => Some(bytes),
+                Err(e) => {
+                    tracing::debug!("prefix cache disk snapshot skipped: {e}");
+                    None
+                }
+            }
+        } else {
+            None
+        };
         let entry = PrefixCacheEntry {
             namespace: namespace.clone(),
             token_ids: token_ids.to_vec(),
@@ -253,9 +268,90 @@ impl PrefixCache {
         drop(inner);
 
         if req.retention == CacheRetention::TwentyFourHours {
-            self.write_disk_metadata(&namespace, &token_hash, token_ids.len(), expires_at_secs)?;
+            self.write_disk_entry(
+                &namespace,
+                &token_hash,
+                token_ids.len(),
+                expires_at_secs,
+                disk_bytes.as_deref(),
+            )?;
         }
         Ok(())
+    }
+
+    pub fn lookup_disk_bytes(
+        &self,
+        req: &CacheRequest,
+        prompt_ids: &[u32],
+    ) -> Option<PrefixCacheDiskHit> {
+        if !self.cfg.enabled
+            || req.retention != CacheRetention::TwentyFourHours
+            || self.cfg.dir.as_os_str().is_empty()
+        {
+            return None;
+        }
+        let namespace = namespace(req);
+        let now = epoch_secs();
+        let mut best: Option<DiskEntry> = None;
+        let entries = fs::read_dir(&self.cfg.dir).ok()?;
+        for dirent in entries.flatten() {
+            let path = dirent.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                continue;
+            }
+            let name = path.file_name().and_then(|n| n.to_str()).unwrap_or_default();
+            let short_namespace = namespace.get(..16).unwrap_or(&namespace);
+            if !name.starts_with(short_namespace) {
+                continue;
+            }
+            let Some(entry): Option<DiskEntry> = fs::read(&path)
+                .ok()
+                .and_then(|bytes| serde_json::from_slice(&bytes).ok())
+            else {
+                continue;
+            };
+            if entry.expires_at_secs <= now {
+                remove_disk_entry(&path, &entry);
+                continue;
+            }
+            if entry.format_version != FORMAT_VERSION
+                || entry.namespace_hash != namespace
+                || entry.token_count > prompt_ids.len()
+                || entry.snapshot_file.is_none()
+            {
+                continue;
+            }
+            let prefix_hash = token_hash(&prompt_ids[..entry.token_count]);
+            if prefix_hash != entry.token_hash {
+                continue;
+            }
+            if best
+                .as_ref()
+                .is_none_or(|current| entry.token_count > current.token_count)
+            {
+                best = Some(entry);
+            }
+        }
+        let entry = best?;
+        let snapshot_file = entry.snapshot_file.as_ref()?;
+        let snapshot_path = self.cfg.dir.join(snapshot_file);
+        let disk_len = fs::metadata(&snapshot_path)
+            .ok()
+            .and_then(|m| usize::try_from(m.len()).ok())
+            .unwrap_or(0);
+        if !self.can_admit(entry.token_count, disk_len) {
+            self.admission_skips.fetch_add(1, Ordering::Relaxed);
+            return None;
+        }
+        let bytes = fs::read(snapshot_path).ok()?;
+        self.disk_reads.fetch_add(1, Ordering::Relaxed);
+        self.hits.fetch_add(1, Ordering::Relaxed);
+        self.cached_tokens
+            .fetch_add(entry.token_count as u64, Ordering::Relaxed);
+        Some(PrefixCacheDiskHit {
+            cached_tokens: entry.token_count,
+            bytes,
+        })
     }
 
     pub fn record_restore_failure(&self) {
@@ -285,6 +381,7 @@ impl PrefixCache {
             cached_tokens: self.cached_tokens.load(Ordering::Relaxed),
             evictions: self.evictions.load(Ordering::Relaxed),
             disk_writes: self.disk_writes.load(Ordering::Relaxed),
+            disk_reads: self.disk_reads.load(Ordering::Relaxed),
             restore_failures: self.restore_failures.load(Ordering::Relaxed),
             admission_skips: self.admission_skips.load(Ordering::Relaxed),
         }
@@ -322,29 +419,47 @@ impl PrefixCache {
         }
     }
 
-    fn write_disk_metadata(
+    fn write_disk_entry(
         &self,
         namespace: &str,
         token_hash: &str,
         token_count: usize,
         expires_at_secs: u64,
+        snapshot_bytes: Option<&[u8]>,
     ) -> Result<()> {
         fs::create_dir_all(&self.cfg.dir)
             .with_context(|| format!("create prefix cache dir {}", self.cfg.dir.display()))?;
         let path = disk_metadata_path(&self.cfg.dir, namespace, token_hash);
+        let snapshot_file = if let Some(bytes) = snapshot_bytes {
+            let snapshot_path = disk_snapshot_path(&self.cfg.dir, namespace, token_hash);
+            fs::write(&snapshot_path, bytes)
+                .with_context(|| format!("write {}", snapshot_path.display()))?;
+            snapshot_path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .map(ToOwned::to_owned)
+        } else {
+            None
+        };
         let entry = DiskEntry {
             format_version: FORMAT_VERSION,
-            namespace_hash: namespace,
-            token_hash,
+            namespace_hash: namespace.to_string(),
+            token_hash: token_hash.to_string(),
             token_count,
             expires_at_secs,
-            retention: "24h",
+            retention: "24h".to_string(),
+            snapshot_file,
         };
         let bytes = serde_json::to_vec_pretty(&entry)?;
         fs::write(&path, bytes).with_context(|| format!("write {}", path.display()))?;
         self.disk_writes.fetch_add(1, Ordering::Relaxed);
         Ok(())
     }
+}
+
+pub struct PrefixCacheDiskHit {
+    pub cached_tokens: usize,
+    pub bytes: Vec<u8>,
 }
 
 fn namespace(req: &CacheRequest) -> String {
@@ -368,6 +483,27 @@ fn token_hash(token_ids: &[u32]) -> String {
 fn disk_metadata_path(dir: &std::path::Path, namespace: &str, token_hash: &str) -> PathBuf {
     let short_namespace = namespace.get(..16).unwrap_or(namespace);
     dir.join(format!("{short_namespace}-{token_hash}.json"))
+}
+
+fn disk_snapshot_path(dir: &std::path::Path, namespace: &str, token_hash: &str) -> PathBuf {
+    let short_namespace = namespace.get(..16).unwrap_or(namespace);
+    dir.join(format!("{short_namespace}-{token_hash}.qwen-prefix"))
+}
+
+fn remove_disk_entry(metadata_path: &std::path::Path, entry: &DiskEntry) {
+    if let Some(snapshot_file) = entry.snapshot_file.as_ref() {
+        let snapshot_path = metadata_path.with_file_name(snapshot_file);
+        if let Err(e) = fs::remove_file(&snapshot_path) {
+            if e.kind() != std::io::ErrorKind::NotFound {
+                tracing::debug!(path = %snapshot_path.display(), "remove expired prefix snapshot failed: {e}");
+            }
+        }
+    }
+    if let Err(e) = fs::remove_file(metadata_path) {
+        if e.kind() != std::io::ErrorKind::NotFound {
+            tracing::debug!(path = %metadata_path.display(), "remove expired prefix metadata failed: {e}");
+        }
+    }
 }
 
 fn touch_lru(lru: &mut VecDeque<String>, key: &str) {
@@ -468,5 +604,34 @@ mod tests {
             disk_ttl_secs: 86_400,
         });
         assert!(!disabled.can_admit(10, 10));
+    }
+
+    #[test]
+    fn remove_disk_entry_unlinks_metadata_and_snapshot() {
+        let dir = std::env::temp_dir().join(format!(
+            "supersonic-prefix-cache-test-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        let metadata = dir.join("entry.json");
+        let snapshot = dir.join("entry.qwen-prefix");
+        fs::write(&metadata, b"{}").unwrap();
+        fs::write(&snapshot, b"snapshot").unwrap();
+        let entry = DiskEntry {
+            format_version: FORMAT_VERSION,
+            namespace_hash: "namespace".to_string(),
+            token_hash: "token".to_string(),
+            token_count: 1,
+            expires_at_secs: 0,
+            retention: "24h".to_string(),
+            snapshot_file: Some("entry.qwen-prefix".to_string()),
+        };
+
+        remove_disk_entry(&metadata, &entry);
+
+        assert!(!metadata.exists());
+        assert!(!snapshot.exists());
+        let _ = fs::remove_dir_all(&dir);
     }
 }

--- a/crates/runtime/src/session.rs
+++ b/crates/runtime/src/session.rs
@@ -23,6 +23,15 @@ pub enum SessionSnapshot {
 }
 
 impl SessionSnapshot {
+    pub fn to_disk_bytes(&self) -> Result<Vec<u8>> {
+        match self {
+            Self::Qwen(s) => s.to_disk_bytes(),
+            Self::Gemma4Bf16(_) | Self::Gemma4Int4(_) => Err(anyhow!(
+                "disk prefix snapshots are currently implemented for Qwen only"
+            )),
+        }
+    }
+
     pub fn resident_bytes(&self) -> usize {
         match self {
             Self::Qwen(s) => s.resident_bytes(),
@@ -116,6 +125,15 @@ impl InferenceSession {
             (Self::Gemma4Int4(e), SessionSnapshot::Gemma4Int4(s)) => e.restore_prefix(&s),
             _ => Err(anyhow!(
                 "prefix cache snapshot does not match loaded model family"
+            )),
+        }
+    }
+
+    pub fn load_disk_prefix(&self, bytes: &[u8]) -> Result<SessionSnapshot> {
+        match self {
+            Self::Qwen(e) => Ok(SessionSnapshot::Qwen(e.load_prefix_snapshot_bytes(bytes)?)),
+            Self::Gemma4Bf16(_) | Self::Gemma4Int4(_) => Err(anyhow!(
+                "disk prefix snapshots are currently implemented for Qwen only"
             )),
         }
     }

--- a/crates/server/src/routes/models.rs
+++ b/crates/server/src/routes/models.rs
@@ -171,6 +171,8 @@ pub async fn metrics(State(state): State<Arc<ServerState>>) -> impl IntoResponse
          supersonic_prefix_cache_evictions {}\n\
          # TYPE supersonic_prefix_cache_disk_writes counter\n\
          supersonic_prefix_cache_disk_writes {}\n\
+         # TYPE supersonic_prefix_cache_disk_reads counter\n\
+         supersonic_prefix_cache_disk_reads {}\n\
          # TYPE supersonic_prefix_cache_restore_failures counter\n\
          supersonic_prefix_cache_restore_failures {}\n\
          # TYPE supersonic_prefix_cache_admission_skips counter\n\
@@ -188,6 +190,7 @@ pub async fn metrics(State(state): State<Arc<ServerState>>) -> impl IntoResponse
         cache.cached_tokens,
         cache.evictions,
         cache.disk_writes,
+        cache.disk_reads,
         cache.restore_failures,
         cache.admission_skips,
     );

--- a/docs/server.md
+++ b/docs/server.md
@@ -135,12 +135,13 @@ resident bytes, byte budget, and admission skips.
 `prompt_cache_retention` accepts:
 
 - `in_memory` (default): resident snapshot with a short idle TTL.
-- `24h`: resident snapshot plus disk metadata under the prefix-cache directory.
+- `24h`: resident snapshot plus prompt-free disk metadata. Qwen snapshots are
+  also persisted and can be lazily restored after a server restart.
 - `none`: bypass cache lookup and capture for the request.
 
 The disk files intentionally avoid prompt text and message JSON. They contain
-only hashes, counts, retention, and expiry metadata; resident model-state
-snapshots are what provide the live speedup.
+hashes, counts, retention, expiry metadata, logits, and model-state tensor
+bytes keyed by token hashes. Gemma disk snapshots are not persisted yet.
 
 ## Smoke Tests
 
@@ -205,6 +206,17 @@ Set `SUPERSONIC_PROMPT_CACHE_RETENTION=24h` to exercise disk metadata writes.
 It checks both an exact repeat and an extended same-prefix request, matching
 the common agent pattern where later turns replay prior transcript text and
 append new user/tool content.
+
+To verify Qwen disk restore, run the smoke once with `24h`, restart the server
+with the same `--prefix-cache-dir`, then run:
+
+```bash
+SUPERSONIC_BASE_URL=http://127.0.0.1:8080 \
+SUPERSONIC_API_KEY=secret \
+SUPERSONIC_PROMPT_CACHE_RETENTION=24h \
+SUPERSONIC_PREFIX_CACHE_SMOKE_PHASE=restart-probe \
+node /path/to/SuperSonic/scripts/prefix_cache_smoke.mjs
+```
 
 For short local prompts, start the server with `--prefix-cache-min-tokens 1`
 or set `SUPERSONIC_PREFIX_CACHE_MIN_TOKENS=1`; production defaults avoid

--- a/scripts/prefix_cache_smoke.mjs
+++ b/scripts/prefix_cache_smoke.mjs
@@ -7,6 +7,7 @@ const prompt =
   "Please answer briefly. ".repeat(80);
 const mode = process.env.SUPERSONIC_PREFIX_CACHE_MODE ?? "auto";
 const retention = process.env.SUPERSONIC_PROMPT_CACHE_RETENTION ?? "in_memory";
+const phase = process.env.SUPERSONIC_PREFIX_CACHE_SMOKE_PHASE ?? "full";
 
 const headers = { "content-type": "application/json" };
 if (apiKey) headers.authorization = `Bearer ${apiKey}`;
@@ -61,6 +62,11 @@ function promptTokens(resp) {
   return resp?.usage?.prompt_tokens ?? 0;
 }
 
+function metricValue(metrics, name) {
+  const match = metrics.match(new RegExp(`^${name}\\s+(\\d+)`, "m"));
+  return match ? Number(match[1]) : 0;
+}
+
 async function selectEndpoint() {
   if (mode === "completions" || mode === "chat") {
     return mode;
@@ -93,6 +99,31 @@ async function main() {
           ...cacheFields,
         };
   const path = endpoint === "chat" ? "/chat/completions" : "/completions";
+
+  if (phase === "restart-probe") {
+    const resp = await postJSON(path, body);
+    const cached = cachedTokens(resp);
+    if (cached <= 0) {
+      throw new Error(`expected restart probe to hit disk prefix cache, got ${cached}`);
+    }
+    const metrics = await getText("/metrics");
+    const diskReads = metricValue(metrics, "supersonic_prefix_cache_disk_reads");
+    if (diskReads <= 0) {
+      throw new Error("restart probe did not report a disk prefix-cache read");
+    }
+    console.log(
+      "prefix_cache_smoke",
+      JSON.stringify({
+        phase,
+        cached_tokens: cached,
+        disk_reads: diskReads,
+        endpoint,
+        retention,
+        text: outputText(resp),
+      }),
+    );
+    return;
+  }
 
   const first = await postJSON(path, body);
   const second = await postJSON(path, body);


### PR DESCRIPTION
## Summary

Adds restart-surviving disk restore for Qwen prefix-cache snapshots when requests use `prompt_cache_retention: "24h"`.

## What changed

- Adds Qwen model-state host snapshot export/import for standard KV and linear-attention state.
- Wraps Qwen prefix snapshots with logits and serializes them beside existing prompt-free disk metadata.
- On memory miss, `24h` cache lookup now scans metadata by namespace and token-prefix hash, lazily loads the best Qwen snapshot blob, restores it, and decodes only the uncached suffix.
- Disk restores respect the existing byte-budget admission policy before loading snapshot bytes.
- Disk reads now count as prefix-cache hits and increment cached-token metrics.
- Adds `SUPERSONIC_PREFIX_CACHE_SMOKE_PHASE=restart-probe` to `scripts/prefix_cache_smoke.mjs` for restart smoke validation.
- Updates server docs for Qwen disk restore behavior and the restart-probe harness.

## Notes

This intentionally starts with Qwen snapshots only. Gemma `24h` requests still write prompt-free metadata but do not persist a reloadable model-state snapshot yet.

Disk files do not include prompt text, message JSON, or cache keys. They contain hash-addressed metadata plus Qwen tensor/logit bytes needed to restore model state.

## Validation

- `cargo check -p server --all-targets`
- `cargo test -p supersonic-runtime prefix_cache`
- `cargo test -p server --test protocol_mock`
- `node --check scripts/prefix_cache_smoke.mjs`
- `git diff --check`
- live CUDA manual restart smoke: first request writes Qwen `.qwen-prefix`; after restart, second request returns cached prompt tokens and `supersonic_prefix_cache_disk_reads 1`
- live CUDA script restart smoke: `SUPERSONIC_PREFIX_CACHE_SMOKE_PHASE=restart-probe` returns `cached_tokens=321`, `disk_reads=1`
- `rg` over the cache dir did not find the literal prompt text or cache key
