### PR TITLE
perf: K-tiled FlashAttention-style prefill attention for Qwen 3.5 (~10x at 16K)

### DIFF
--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -72,6 +72,10 @@ required-features = ["bughunt"]
 name = "llama31_certified_kv_microbench"
 path = "src/bin/llama31_certified_kv_microbench.rs"
 
+[[bin]]
+name = "bench_prefill_attn"
+path = "src/bin/bench_prefill_attn.rs"
+
 [dependencies]
 supersonic-core = { path = "../core" }
 gpu-hal = { path = "../gpu-hal" }

--- a/crates/runner/src/bin/bench_prefill_attn.rs
+++ b/crates/runner/src/bin/bench_prefill_attn.rs
@@ -62,11 +62,21 @@ fn main() {
     let ordinal = 0usize;
     println!("ordinal: {ordinal}");
 
-    // (q_heads, kv_heads, head_dim) configs:
-    //   - (16, 8, 64)    — qwen3.5-0.8b
-    //   - (16, 8, 128)   — qwen3.5-4b
-    //   - (32, 8, 128)   — qwen3.5-9b
-    let configs = [(16usize, 8usize, 64usize), (16, 8, 128), (32, 8, 128)];
+    // (q_heads, kv_heads, head_dim) configs reflect the real shipping configs.
+    // All flagship models (Qwen 3.5 *, Qwen 3.6 35B-A3B, Gemma 4 sliding) use
+    // head_dim=256 — that's the row that matters for production. The hd=64/128
+    // rows are kept synthetic so future small-head-dim models (e.g. Phi-4-mini)
+    // are covered without a third bench edit.
+    //   - (8,  2, 256)   — qwen3.5-0.8b / 2b
+    //   - (16, 4, 256)   — qwen3.5-4b / 9b   and qwen3.6-35b-a3b
+    //   - (16, 8,  64)   — synthetic (small head_dim regime)
+    //   - (16, 8, 128)   — synthetic (medium head_dim regime)
+    let configs = [
+        (8usize, 2usize, 256usize),
+        (16, 4, 256),
+        (16, 8, 64),
+        (16, 8, 128),
+    ];
 
     for (q_heads, kv_heads, head_dim) in configs {
         println!("\n=== q_heads={q_heads} kv_heads={kv_heads} head_dim={head_dim} ===");

--- a/crates/runner/src/bin/bench_prefill_attn.rs
+++ b/crates/runner/src/bin/bench_prefill_attn.rs
@@ -1,0 +1,82 @@
+//! Micro-benchmark for `prefill_ffi::full_attention_prefill`.
+//!
+//! Times the prefill attention kernel in isolation across a sweep of
+//! (q_len, kv_len, head_dim) shapes, printing ms/call. Used as the perf
+//! gate for Stage 2 (online softmax) and Stage 3 (K-tiled) rewrites.
+//!
+//! Run: `cargo run --release --bin bench_prefill_attn`
+
+use gpu_hal::{Backend, GpuBuffer, ScalarType};
+use kernel_ffi::prefill_ffi;
+use std::time::Instant;
+
+fn upload_zeros_bf16(ordinal: usize, shape: &[usize]) -> GpuBuffer {
+    // Zeros are fine for timing — kernel work is shape-driven, not data-driven.
+    GpuBuffer::zeros(ordinal, ScalarType::BF16, shape).expect("alloc bf16")
+}
+
+fn bench_shape(
+    ordinal: usize,
+    q_heads: usize,
+    kv_heads: usize,
+    head_dim: usize,
+    q_len: usize,
+    kv_len: usize,
+    iters: usize,
+) -> f64 {
+    let batch = 1;
+    let scale = 1.0 / (head_dim as f32).sqrt();
+
+    let q_buf = upload_zeros_bf16(ordinal, &[batch, q_heads, q_len, head_dim]);
+    let k_buf = upload_zeros_bf16(ordinal, &[batch, kv_heads, kv_len, head_dim]);
+    let v_buf = upload_zeros_bf16(ordinal, &[batch, kv_heads, kv_len, head_dim]);
+    let mut out_buf = GpuBuffer::zeros(
+        ordinal, ScalarType::F32, &[batch, q_heads, q_len, head_dim],
+    ).expect("alloc out");
+
+    let seqlen_offset = if kv_len > q_len { kv_len - q_len } else { 0 };
+
+    let mut call = || {
+        prefill_ffi::full_attention_prefill(
+            ordinal, ScalarType::BF16,
+            batch, q_heads, kv_heads, q_len, kv_len, head_dim,
+            scale, seqlen_offset, &q_buf, &k_buf, &v_buf, &mut out_buf,
+        ).expect("ffi");
+    };
+
+    for _ in 0..3 { call(); }
+    gpu_hal::sync(ordinal).expect("sync");
+
+    let t0 = Instant::now();
+    for _ in 0..iters { call(); }
+    gpu_hal::sync(ordinal).expect("sync");
+    let dt = t0.elapsed().as_secs_f64();
+    dt * 1000.0 / iters as f64
+}
+
+fn main() {
+    if !gpu_hal::is_backend_compiled(Backend::Hip) {
+        eprintln!("HIP backend not compiled");
+        return;
+    }
+    let ordinal = 0usize;
+    println!("ordinal: {ordinal}");
+
+    // (q_heads, kv_heads, head_dim) configs:
+    //   - (16, 8, 64)    — qwen3.5-0.8b
+    //   - (16, 8, 128)   — qwen3.5-4b
+    //   - (32, 8, 128)   — qwen3.5-9b
+    let configs = [(16usize, 8usize, 64usize), (16, 8, 128), (32, 8, 128)];
+
+    for (q_heads, kv_heads, head_dim) in configs {
+        println!("\n=== q_heads={q_heads} kv_heads={kv_heads} head_dim={head_dim} ===");
+        println!("{:>8} {:>8} {:>10}  {:>10}", "q_len", "kv_len", "ms/call", "tok/s");
+        for &n in &[256usize, 1024, 4096, 16384] {
+            // Bulk prefill: q_len == kv_len mimics the first chunk of a long prompt.
+            let iters = if n >= 4096 { 5 } else { 20 };
+            let ms = bench_shape(ordinal, q_heads, kv_heads, head_dim, n, n, iters);
+            let tok_per_s = (n as f64 / ms) * 1000.0;
+            println!("{:>8} {:>8} {:>10.3}  {:>10.1}", n, n, ms, tok_per_s);
+        }
+    }
+}

--- a/crates/runner/tests/full_attention_prefill_legacy_parity.rs
+++ b/crates/runner/tests/full_attention_prefill_legacy_parity.rs
@@ -1,17 +1,18 @@
-//! Kernel-direct parity test for `full_attention_prefill`.
+//! Parity sweep for the legacy single-warp online-softmax prefill attention
+//! kernel — the one that ran before the K-tiled kernel was promoted to
+//! default. Forces `SUPERSONIC_PREFILL_ATTN_TILED=0` at the top of the test
+//! so the dispatcher routes to the legacy path.
 //!
-//! Compares the HIP/CUDA prefill attention kernel against a CPU fp32
-//! reference across a sweep of (q_len, kv_len, head_dim) shapes
-//! representative of Qwen 3.5 prefill. Used as the regression gate for
-//! the Stage 2 (online softmax) and Stage 3 (K-tiled) rewrites.
+//! Lives in its own test file (and therefore its own cargo-test binary)
+//! because the C++ dispatcher caches the env value in a function-scope
+//! `static const bool` on first call. Running default-vs-legacy parity in
+//! the same process would race on which value got cached first.
 //!
-//! Skipped silently when HIP backend isn't compiled (matches the pattern
-//! in specprefill_lookahead_attention_parity.rs etc.).
+//! Skipped silently when HIP backend isn't compiled.
 
 use gpu_hal::{Backend, GpuBuffer, ScalarType};
 use kernel_ffi::prefill_ffi;
 
-/// Upload a typed BF16 host vector into a fresh GpuBuffer of the given shape.
 fn upload_bf16(ordinal: usize, host: &[half::bf16], shape: &[usize]) -> GpuBuffer {
     assert_eq!(host.len(), shape.iter().product::<usize>());
     let mut buf = GpuBuffer::zeros(ordinal, ScalarType::BF16, shape).expect("alloc bf16");
@@ -21,7 +22,6 @@ fn upload_bf16(ordinal: usize, host: &[half::bf16], shape: &[usize]) -> GpuBuffe
     buf
 }
 
-/// Download an F32 GpuBuffer to host.
 fn download_f32(buf: &GpuBuffer) -> Vec<f32> {
     let n = buf.elem_count();
     let mut bytes = vec![0u8; n * 4];
@@ -39,8 +39,6 @@ fn download_f32(buf: &GpuBuffer) -> Vec<f32> {
     out
 }
 
-/// Deterministic bf16-round-tripped reference data so CPU and GPU see the
-/// exact same input bit pattern.
 fn make_host_bf16(n: usize, seed: usize) -> (Vec<half::bf16>, Vec<f32>) {
     let bf: Vec<half::bf16> = (0..n)
         .map(|i| {
@@ -156,35 +154,37 @@ fn run_one_shape(
 }
 
 #[test]
-fn full_attention_prefill_parity_sweep() {
+fn full_attention_prefill_legacy_parity_sweep() {
     if !gpu_hal::is_backend_compiled(Backend::Hip) {
         eprintln!("skipped: HIP backend not compiled");
         return;
     }
-    let ordinal = 0usize;
-    // head_dim=256 is the production case (every shipping Qwen 3.5/3.6 model
-    // and Gemma 4 sliding layer). hd=64/128 are kept so the small/medium
-    // head-dim regime stays covered for future models like Phi-4-mini.
+    // Force the dispatcher to take the legacy single-warp online-softmax
+    // path by setting the env var BEFORE the first FFI call. The C++
+    // dispatcher caches this on first call via a function-scope static.
     //
-    // q_len values 15, 17, 33 are deliberately not multiples of BM=4 — they
-    // exercise the tail block where some warps in a block have qr >= q_len
-    // (active=false) and must still participate in cooperative loads +
-    // __syncthreads() while skipping output. Without these, the inactive-warp
-    // code path of the K-tiled kernel goes uncovered.
+    // SAFETY: this test binary is single-threaded with respect to
+    // setting/reading SUPERSONIC_PREFILL_ATTN_TILED. We set it once, before
+    // any FFI call could read it.
+    unsafe { std::env::set_var("SUPERSONIC_PREFILL_ATTN_TILED", "0"); }
+
+    let ordinal = 0usize;
+    // Same sweep as the default-path test (full_attention_prefill_parity.rs);
+    // any divergence between the two means the kernels disagree.
     for (q_len, kv_len, head_dim) in [
         (16usize, 16usize, 64usize),
         (16, 16, 128),
         (16, 16, 256),
-        (15, 15, 256),    // tail: q_len % BM (=4) == 3
-        (17, 17, 256),    // tail: q_len % BM == 1
-        (33, 64, 256),    // tail with kv_len > q_len
+        (15, 15, 256),
+        (17, 17, 256),
+        (33, 64, 256),
         (64, 64, 256),
         (256, 256, 64),
         (256, 256, 256),
         (1024, 1024, 128),
         (1024, 1024, 256),
-        (16, 256, 64),   // q_len < kv_len with seqlen_offset
-        (16, 256, 256),  // same, hd=256
+        (16, 256, 64),
+        (16, 256, 256),
     ] {
         let seqlen_offset = if kv_len > q_len { kv_len - q_len } else { 0 };
         run_one_shape(ordinal, q_len, kv_len, head_dim, seqlen_offset, 0xCAFE);

--- a/crates/runner/tests/full_attention_prefill_parity.rs
+++ b/crates/runner/tests/full_attention_prefill_parity.rs
@@ -1,0 +1,178 @@
+//! Kernel-direct parity test for `full_attention_prefill`.
+//!
+//! Compares the HIP/CUDA prefill attention kernel against a CPU fp32
+//! reference across a sweep of (q_len, kv_len, head_dim) shapes
+//! representative of Qwen 3.5 prefill. Used as the regression gate for
+//! the Stage 2 (online softmax) and Stage 3 (K-tiled) rewrites.
+//!
+//! Skipped silently when HIP backend isn't compiled (matches the pattern
+//! in specprefill_lookahead_attention_parity.rs etc.).
+
+use gpu_hal::{Backend, GpuBuffer, ScalarType};
+use kernel_ffi::prefill_ffi;
+
+/// Upload a typed BF16 host vector into a fresh GpuBuffer of the given shape.
+fn upload_bf16(ordinal: usize, host: &[half::bf16], shape: &[usize]) -> GpuBuffer {
+    assert_eq!(host.len(), shape.iter().product::<usize>());
+    let mut buf = GpuBuffer::zeros(ordinal, ScalarType::BF16, shape).expect("alloc bf16");
+    let bytes = unsafe { std::slice::from_raw_parts(host.as_ptr() as *const u8, host.len() * 2) };
+    gpu_hal::copy_h2d(ordinal, buf.as_mut_ptr(), bytes.as_ptr() as *const _, bytes.len())
+        .expect("h2d bf16");
+    buf
+}
+
+/// Download an F32 GpuBuffer to host.
+fn download_f32(buf: &GpuBuffer) -> Vec<f32> {
+    let n = buf.elem_count();
+    let mut bytes = vec![0u8; n * 4];
+    gpu_hal::copy_d2h(
+        buf.device_ordinal(),
+        bytes.as_mut_ptr() as *mut _,
+        buf.as_ptr(),
+        bytes.len(),
+    )
+    .expect("d2h f32");
+    let mut out = vec![0.0f32; n];
+    for (i, chunk) in bytes.chunks_exact(4).enumerate() {
+        out[i] = f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+    }
+    out
+}
+
+/// Deterministic bf16-round-tripped reference data so CPU and GPU see the
+/// exact same input bit pattern.
+fn make_host_bf16(n: usize, seed: usize) -> (Vec<half::bf16>, Vec<f32>) {
+    let bf: Vec<half::bf16> = (0..n)
+        .map(|i| {
+            let v = ((i + seed) as f32 * 0.0017).sin() * 0.4 + 0.05;
+            half::bf16::from_f32(v)
+        })
+        .collect();
+    let f32_round = bf.iter().map(|x| x.to_f32()).collect();
+    (bf, f32_round)
+}
+
+fn cpu_attention_fp32(
+    batch: usize,
+    q_heads: usize,
+    kv_heads: usize,
+    q_len: usize,
+    kv_len: usize,
+    head_dim: usize,
+    scale: f32,
+    seqlen_offset: usize,
+    q: &[f32], k: &[f32], v: &[f32],
+) -> Vec<f32> {
+    let groups = q_heads / kv_heads;
+    let mut out = vec![0.0f32; batch * q_heads * q_len * head_dim];
+    for b in 0..batch {
+        for hq in 0..q_heads {
+            let hk = hq / groups;
+            for qi in 0..q_len {
+                let limit = (seqlen_offset + qi + 1).min(kv_len);
+                let q_off = ((b * q_heads + hq) * q_len + qi) * head_dim;
+                let k_head = (b * kv_heads + hk) * kv_len * head_dim;
+                let v_head = (b * kv_heads + hk) * kv_len * head_dim;
+                let mut scores = vec![0f32; limit];
+                for kp in 0..limit {
+                    let k_row = k_head + kp * head_dim;
+                    let mut s = 0.0f32;
+                    for d in 0..head_dim { s += q[q_off + d] * k[k_row + d]; }
+                    scores[kp] = s * scale;
+                }
+                let mut m = f32::NEG_INFINITY;
+                for &s in &scores { if s > m { m = s; } }
+                let mut denom = 0.0f32;
+                for s in scores.iter_mut() { *s = (*s - m).exp(); denom += *s; }
+                let inv = if denom > 0.0 { 1.0 / denom } else { 0.0 };
+                let out_off = ((b * q_heads + hq) * q_len + qi) * head_dim;
+                for d in 0..head_dim {
+                    let mut acc = 0.0f32;
+                    for kp in 0..limit {
+                        let v_row = v_head + kp * head_dim;
+                        acc += scores[kp] * v[v_row + d];
+                    }
+                    out[out_off + d] = acc * inv;
+                }
+            }
+        }
+    }
+    out
+}
+
+fn run_one_shape(
+    ordinal: usize,
+    q_len: usize,
+    kv_len: usize,
+    head_dim: usize,
+    seqlen_offset: usize,
+    seed: usize,
+) {
+    let batch = 1;
+    let q_heads = 4;
+    let kv_heads = 2;
+    let scale = 1.0 / (head_dim as f32).sqrt();
+
+    let q_elems = batch * q_heads * q_len * head_dim;
+    let k_elems = batch * kv_heads * kv_len * head_dim;
+    let v_elems = batch * kv_heads * kv_len * head_dim;
+
+    let (q_bf, q_f32) = make_host_bf16(q_elems, seed);
+    let (k_bf, k_f32) = make_host_bf16(k_elems, seed + 1000);
+    let (v_bf, v_f32) = make_host_bf16(v_elems, seed + 2000);
+
+    let q_buf = upload_bf16(ordinal, &q_bf, &[batch, q_heads, q_len, head_dim]);
+    let k_buf = upload_bf16(ordinal, &k_bf, &[batch, kv_heads, kv_len, head_dim]);
+    let v_buf = upload_bf16(ordinal, &v_bf, &[batch, kv_heads, kv_len, head_dim]);
+    let mut out_buf = GpuBuffer::zeros(
+        ordinal, ScalarType::F32, &[batch, q_heads, q_len, head_dim],
+    ).expect("alloc out");
+
+    prefill_ffi::full_attention_prefill(
+        ordinal, ScalarType::BF16,
+        batch, q_heads, kv_heads, q_len, kv_len, head_dim,
+        scale, seqlen_offset, &q_buf, &k_buf, &v_buf, &mut out_buf,
+    ).expect("ffi");
+    gpu_hal::sync(ordinal).expect("sync");
+
+    let got = download_f32(&out_buf);
+    let want = cpu_attention_fp32(
+        batch, q_heads, kv_heads, q_len, kv_len, head_dim,
+        scale, seqlen_offset, &q_f32, &k_f32, &v_f32,
+    );
+
+    let mut max_abs = 0.0f32;
+    let mut max_rel = 0.0f32;
+    for i in 0..got.len() {
+        let a = (got[i] - want[i]).abs();
+        let r = a / want[i].abs().max(1e-6);
+        if a > max_abs { max_abs = a; }
+        if r > max_rel { max_rel = r; }
+    }
+    assert!(
+        max_abs < 2e-2 && max_rel < 1e-2,
+        "shape q_len={q_len} kv_len={kv_len} hd={head_dim}: max_abs={max_abs}, max_rel={max_rel}",
+    );
+}
+
+#[test]
+fn full_attention_prefill_parity_sweep() {
+    if !gpu_hal::is_backend_compiled(Backend::Hip) {
+        eprintln!("skipped: HIP backend not compiled");
+        return;
+    }
+    let ordinal = 0usize;
+    // head_dim=64 covers Qwen 0.8B/2B; head_dim=128 covers 4B/9B.
+    for (q_len, kv_len, head_dim) in [
+        (16usize, 16usize, 64usize),
+        (16, 16, 128),
+        (64, 64, 64),
+        (256, 256, 64),
+        (1024, 1024, 64),
+        (1024, 1024, 128),
+        (16, 256, 64),  // q_len < kv_len with seqlen_offset
+    ] {
+        let seqlen_offset = if kv_len > q_len { kv_len - q_len } else { 0 };
+        run_one_shape(ordinal, q_len, kv_len, head_dim, seqlen_offset, 0xCAFE);
+    }
+}

--- a/crates/runner/tests/full_attention_prefill_parity.rs
+++ b/crates/runner/tests/full_attention_prefill_parity.rs
@@ -162,15 +162,20 @@ fn full_attention_prefill_parity_sweep() {
         return;
     }
     let ordinal = 0usize;
-    // head_dim=64 covers Qwen 0.8B/2B; head_dim=128 covers 4B/9B.
+    // head_dim=256 is the production case (every shipping Qwen 3.5/3.6 model
+    // and Gemma 4 sliding layer). hd=64/128 are kept so the small/medium
+    // head-dim regime stays covered for future models like Phi-4-mini.
     for (q_len, kv_len, head_dim) in [
         (16usize, 16usize, 64usize),
         (16, 16, 128),
-        (64, 64, 64),
+        (16, 16, 256),
+        (64, 64, 256),
         (256, 256, 64),
-        (1024, 1024, 64),
+        (256, 256, 256),
         (1024, 1024, 128),
-        (16, 256, 64),  // q_len < kv_len with seqlen_offset
+        (1024, 1024, 256),
+        (16, 256, 64),   // q_len < kv_len with seqlen_offset
+        (16, 256, 256),  // same, hd=256
     ] {
         let seqlen_offset = if kv_len > q_len { kv_len - q_len } else { 0 };
         run_one_shape(ordinal, q_len, kv_len, head_dim, seqlen_offset, 0xCAFE);

--- a/kernels/full_attention.hip
+++ b/kernels/full_attention.hip
@@ -471,7 +471,10 @@ __global__ void supersonic_qwen35_full_attention_prefill_tiled_kernel(
                 for (int d = lane; d < head_dim; d += warpSize) {
                     partial += supersonic_qwen35_to_float(q_row[d]) * supersonic_qwen35_to_float(k_row[d]);
                 }
-                float score = supersonic_qwen35_wave_sum(partial) * scale;
+                // wave_sum is a __shfl_down butterfly that leaves the sum
+                // only in lane 0; broadcast it so every lane sees the same
+                // score (each lane runs its own per-output-dim recurrence).
+                float score = __shfl(supersonic_qwen35_wave_sum(partial), 0) * scale;
 
                 const float m_old = m_i;
                 const float m_new = score > m_old ? score : m_old;

--- a/kernels/full_attention.hip
+++ b/kernels/full_attention.hip
@@ -293,34 +293,25 @@ __global__ void supersonic_qwen35_full_attention_prefill_kernel(
             local_dims[local_count++] = d;
         }
 
+        // Online single-pass softmax (FlashAttention recurrence).
+        //
+        //   m_i = running max of scores
+        //   l_i = running denom (sum of exp(score - m_i))
+        //   acc = running output accumulator (in registers, per lane)
+        //
+        // On each new k_pos we form score = Q · K[k_pos] * scale, take
+        // m_new = max(m_i, score), rescale (acc, l_i) by alpha = exp(m_i - m_new),
+        // add the new contribution exp(score - m_new) * V[k_pos], and update m_i.
+        // Final out = acc / l_i.
+
         __shared__ float shared_max;
-        __shared__ float shared_denom;
+        __shared__ float shared_alpha;
         __shared__ float shared_weight;
+        __shared__ float shared_denom;
         __shared__ float shared_inv_denom;
 
         if (lane == 0) {
             shared_max = -INFINITY;
-        }
-        __syncthreads();
-
-        for (int k_pos = 0; k_pos < causal_limit; ++k_pos) {
-            const T* k_row = k_head_ptr + k_pos * head_dim;
-
-            float partial = 0.0f;
-            for (int d = lane; d < head_dim; d += warpSize) {
-                partial += supersonic_qwen35_to_float(q_row[d]) * supersonic_qwen35_to_float(k_row[d]);
-            }
-            float score = supersonic_qwen35_wave_sum(partial) * scale;
-
-            if (lane == 0) {
-                if (score > shared_max) {
-                    shared_max = score;
-                }
-            }
-            __syncthreads();
-        }
-
-        if (lane == 0) {
             shared_denom = 0.0f;
         }
         __syncthreads();
@@ -336,13 +327,23 @@ __global__ void supersonic_qwen35_full_attention_prefill_kernel(
             float score = supersonic_qwen35_wave_sum(partial) * scale;
 
             if (lane == 0) {
-                shared_weight = expf(score - shared_max);
-                shared_denom += shared_weight;
+                float m_old = shared_max;
+                float m_new = score > m_old ? score : m_old;
+                // alpha == 0 on the very first iteration (m_old = -inf): we
+                // explicitly zero the accumulators rather than evaluating
+                // expf(-inf - finite) which can produce NaN on some HW.
+                float alpha = (m_old == -INFINITY) ? 0.0f : expf(m_old - m_new);
+                shared_alpha = alpha;
+                shared_weight = expf(score - m_new);
+                shared_denom = shared_denom * alpha + shared_weight;
+                shared_max = m_new;
             }
             __syncthreads();
 
+            const float alpha = shared_alpha;
+            const float weight = shared_weight;
             for (int i = 0; i < local_count; ++i) {
-                local_acc[i] += shared_weight * supersonic_qwen35_to_float(v_row[local_dims[i]]);
+                local_acc[i] = local_acc[i] * alpha + weight * supersonic_qwen35_to_float(v_row[local_dims[i]]);
             }
             __syncthreads();
         }
@@ -351,8 +352,9 @@ __global__ void supersonic_qwen35_full_attention_prefill_kernel(
             shared_inv_denom = shared_denom > 0.0f ? 1.0f / shared_denom : 0.0f;
         }
         __syncthreads();
+        const float inv_denom = shared_inv_denom;
         for (int i = 0; i < local_count; ++i) {
-            out_row[local_dims[i]] = local_acc[i] * shared_inv_denom;
+            out_row[local_dims[i]] = local_acc[i] * inv_denom;
         }
         __syncthreads();
     }

--- a/kernels/full_attention.hip
+++ b/kernels/full_attention.hip
@@ -360,6 +360,142 @@ __global__ void supersonic_qwen35_full_attention_prefill_kernel(
     }
 }
 
+// Stage 3: K-tiled FlashAttention-style prefill attention.
+//
+// Grid:  (ceil(q_len / BM), q_heads, batch)
+// Block: (warpSize, BM)   — BM warps × warpSize lanes
+//
+// Each warp owns one query row qr = block_qr_base + warp_y and walks the
+// K dimension in tiles of BK rows. K and V tiles are loaded into LDS
+// once per tile and shared across all BM warps in the block, dropping
+// global K/V bandwidth by ~BM× vs the single-warp kernel.
+//
+// Per-warp register state:
+//   m_i           (float, running max of softmax scores)
+//   l_i           (float, running denom)
+//   acc[ACC_MAX]  (float per lane, output-side accumulators; up to ACC_MAX
+//                  elements per lane covering ceil(head_dim / warpSize) dims)
+template <typename T, int BM, int BK>
+__global__ void supersonic_qwen35_full_attention_prefill_tiled_kernel(
+    int batch_size,
+    int q_heads,
+    int kv_heads,
+    int q_len,
+    int kv_len,
+    int head_dim,
+    int num_kv_groups,
+    float scale,
+    int seqlen_offset,
+    const T* query,
+    const T* key,
+    const T* value,
+    float* out
+) {
+    constexpr int ACC_MAX = 8;   // head_dim <= 8 * warpSize asserted in launcher
+
+    const int qr_base = blockIdx.x * BM;
+    const int qh      = blockIdx.y;
+    const int batch   = blockIdx.z;
+    const int kv_h    = qh / num_kv_groups;
+    const int warp_y  = threadIdx.y;        // 0..BM-1
+    const int lane    = threadIdx.x;        // 0..warpSize-1
+    const int qr      = qr_base + warp_y;
+    if (lane >= warpSize) return;
+    if (batch >= batch_size || qh >= q_heads) return;
+
+    extern __shared__ unsigned char smem_raw[];
+    T* k_tile = reinterpret_cast<T*>(smem_raw);
+    T* v_tile = k_tile + BK * head_dim;
+
+    const bool active = (qr < q_len);
+    const int causal_limit = active ? min(kv_len, seqlen_offset + qr + 1) : 0;
+
+    const T* q_row = active ? (query + (((batch * q_heads + qh) * q_len + qr) * head_dim)) : nullptr;
+    const T* k_head_ptr = key   + ((batch * kv_heads + kv_h) * kv_len * head_dim);
+    const T* v_head_ptr = value + ((batch * kv_heads + kv_h) * kv_len * head_dim);
+    float*   out_row = active ? (out + (((batch * q_heads + qh) * q_len + qr) * head_dim)) : nullptr;
+
+    // Per-lane output accumulators (in registers). Each lane owns the dims
+    // d = lane, lane + warpSize, lane + 2*warpSize, ... (up to ACC_MAX of them).
+    float acc[ACC_MAX];
+    int   acc_dim[ACC_MAX];
+    int   acc_count = 0;
+    #pragma unroll
+    for (int i = 0; i < ACC_MAX; ++i) acc[i] = 0.0f;
+    for (int d = lane; d < head_dim && acc_count < ACC_MAX; d += warpSize) {
+        acc_dim[acc_count++] = d;
+    }
+
+    float m_i = -INFINITY;
+    float l_i = 0.0f;
+
+    // Iterate K tiles. Even inactive warps must participate in cooperative
+    // loads and __syncthreads() — they just won't write output.
+    const int causal_for_block = active ? causal_limit : 0;
+    // For the cooperative load we need an upper bound on K positions any
+    // warp in this block will need. Different warps can have different
+    // causal_limit values (qr varies). Use the maximum across the block.
+    __shared__ int block_max_kpos;
+    if (threadIdx.x == 0 && threadIdx.y == 0) block_max_kpos = 0;
+    __syncthreads();
+    if (lane == 0) atomicMax(&block_max_kpos, causal_for_block);
+    __syncthreads();
+    const int outer_limit = block_max_kpos;
+
+    for (int tile_base = 0; tile_base < outer_limit; tile_base += BK) {
+        const int tile_len = min(BK, outer_limit - tile_base);
+
+        // Cooperative load: BM warps × warpSize lanes pull tile_len * head_dim
+        // T values into LDS. Stride by total threads = BM * warpSize.
+        const int load_total = tile_len * head_dim;
+        const int total_threads = BM * warpSize;
+        const int linear_tid = warp_y * warpSize + lane;
+        for (int i = linear_tid; i < load_total; i += total_threads) {
+            const int row = i / head_dim;
+            const int col = i - row * head_dim;
+            const int gk_pos = tile_base + row;
+            const size_t off = (size_t)gk_pos * head_dim + (size_t)col;
+            k_tile[i] = k_head_ptr[off];
+            v_tile[i] = v_head_ptr[off];
+        }
+        __syncthreads();
+
+        // Walk this tile, applying the online softmax recurrence per query row.
+        if (active) {
+            const int j_max = min(tile_len, causal_limit - tile_base);
+            for (int j = 0; j < j_max; ++j) {
+                const T* k_row = k_tile + j * head_dim;
+                const T* v_row = v_tile + j * head_dim;
+
+                float partial = 0.0f;
+                for (int d = lane; d < head_dim; d += warpSize) {
+                    partial += supersonic_qwen35_to_float(q_row[d]) * supersonic_qwen35_to_float(k_row[d]);
+                }
+                float score = supersonic_qwen35_wave_sum(partial) * scale;
+
+                const float m_old = m_i;
+                const float m_new = score > m_old ? score : m_old;
+                const float alpha = (m_old == -INFINITY) ? 0.0f : expf(m_old - m_new);
+                const float weight = expf(score - m_new);
+                l_i = l_i * alpha + weight;
+                m_i = m_new;
+
+                for (int i = 0; i < acc_count; ++i) {
+                    acc[i] = acc[i] * alpha + weight * supersonic_qwen35_to_float(v_row[acc_dim[i]]);
+                }
+            }
+        }
+        __syncthreads();   // before next tile reuses k_tile/v_tile
+    }
+
+    if (active) {
+        const float inv = (l_i > 0.0f) ? (1.0f / l_i) : 0.0f;
+        for (int i = 0; i < acc_count; ++i) {
+            out_row[acc_dim[i]] = acc[i] * inv;
+        }
+    }
+}
+
 template <typename T>
 __global__ void supersonic_qwen35_linear_prefill_conv_pack_kernel(
     int batch_size,

--- a/kernels/full_attention_bridge.cpp
+++ b/kernels/full_attention_bridge.cpp
@@ -176,6 +176,16 @@ int full_attention_prefill_tiled_device(
 
     ScopedHipDevice scoped(device_ordinal);
 
+    // The kernel hardcodes block.x = 32 and the per-lane acc_dim/load
+    // strides assume warpSize == 32. On wave64 (CDNA gfx9xx) the kernel
+    // would launch with only 32 of 64 lanes per warp doing useful work and
+    // the strided loops would skip half of head_dim. Refuse the launch so
+    // the dispatcher falls through to the legacy single-warp kernel, which
+    // does adapt to props.warpSize.
+    hipDeviceProp_t props;
+    if (hipGetDeviceProperties(&props, device_ordinal) != hipSuccess) return 136;
+    if (props.warpSize != 32) return 137;
+
     if (head_dim <= 64) {
         return launch_tiled<T, BM, 128>(batch_size, q_heads, kv_heads,
             q_len, kv_len, head_dim, num_kv_groups, scale, seqlen_offset,

--- a/kernels/full_attention_bridge.cpp
+++ b/kernels/full_attention_bridge.cpp
@@ -120,6 +120,39 @@ int full_attention_prefill_device(
     return 0;
 }
 
+// Dispatch the K-tiled kernel with the right BK template instantiation for
+// the given head_dim. BK is picked to keep LDS (= 2 * BK * head_dim * sizeof(T))
+// under the 48 KiB safety cap on RDNA3:
+//   head_dim <=  64 → BK=128 (32 KiB at BF16, max amortization)
+//   head_dim <= 128 → BK=64  (32 KiB at BF16)
+//   head_dim <= 256 → BK=32  (32 KiB at BF16; this is the Qwen 3.5 / 3.6 / Gemma 4 case)
+// head_dim > 256 unsupported (ACC_MAX=8 × warpSize=32 cap).
+template <typename T, int BM, int BK>
+static int launch_tiled(
+    int batch_size, int q_heads, int kv_heads,
+    int q_len, int kv_len, int head_dim, int num_kv_groups,
+    float scale, int seqlen_offset,
+    const void* query, const void* key, const void* value, void* out
+) {
+    const int grid_x = (q_len + BM - 1) / BM;
+    dim3 grid(grid_x, q_heads, batch_size);
+    dim3 block(32, BM, 1);
+    const size_t lds_bytes = (size_t)2 * BK * head_dim * sizeof(T);
+    if (lds_bytes > 48 * 1024) return 133;
+    hipLaunchKernelGGL(
+        HIP_KERNEL_NAME(supersonic_qwen35_full_attention_prefill_tiled_kernel<T, BM, BK>),
+        grid, block, lds_bytes, 0,
+        batch_size, q_heads, kv_heads, q_len, kv_len, head_dim,
+        num_kv_groups, scale, seqlen_offset,
+        static_cast<const T*>(query),
+        static_cast<const T*>(key),
+        static_cast<const T*>(value),
+        static_cast<float*>(out));
+    if (hipGetLastError() != hipSuccess) return 134;
+    if (hipDeviceSynchronize() != hipSuccess) return 135;
+    return 0;
+}
+
 template <typename T>
 int full_attention_prefill_tiled_device(
     int device_ordinal,
@@ -138,31 +171,24 @@ int full_attention_prefill_tiled_device(
     void* out
 ) {
     constexpr int BM = 4;
-    constexpr int BK = 64;
     if (head_dim > 8 * 32) return 132;       // ACC_MAX=8 × warpSize=32 cap
     if (q_len <= 0) return 0;
 
     ScopedHipDevice scoped(device_ordinal);
 
-    const int grid_x = (q_len + BM - 1) / BM;
-    dim3 grid(grid_x, q_heads, batch_size);
-    dim3 block(32, BM, 1);   // warpSize × BM warps
-    const size_t lds_bytes = (size_t)2 * BK * head_dim * sizeof(T);
-    if (lds_bytes > 48 * 1024) return 133;   // safety cap
-
-    hipLaunchKernelGGL(
-        HIP_KERNEL_NAME(supersonic_qwen35_full_attention_prefill_tiled_kernel<T, BM, BK>),
-        grid, block, lds_bytes, 0,
-        batch_size, q_heads, kv_heads, q_len, kv_len, head_dim,
-        num_kv_groups, scale, seqlen_offset,
-        static_cast<const T*>(query),
-        static_cast<const T*>(key),
-        static_cast<const T*>(value),
-        static_cast<float*>(out));
-
-    if (hipGetLastError() != hipSuccess) return 134;
-    if (hipDeviceSynchronize() != hipSuccess) return 135;
-    return 0;
+    if (head_dim <= 64) {
+        return launch_tiled<T, BM, 128>(batch_size, q_heads, kv_heads,
+            q_len, kv_len, head_dim, num_kv_groups, scale, seqlen_offset,
+            query, key, value, out);
+    } else if (head_dim <= 128) {
+        return launch_tiled<T, BM, 64>(batch_size, q_heads, kv_heads,
+            q_len, kv_len, head_dim, num_kv_groups, scale, seqlen_offset,
+            query, key, value, out);
+    } else {
+        return launch_tiled<T, BM, 32>(batch_size, q_heads, kv_heads,
+            q_len, kv_len, head_dim, num_kv_groups, scale, seqlen_offset,
+            query, key, value, out);
+    }
 }
 
 template <typename T>
@@ -1946,12 +1972,15 @@ extern "C" int supersonic_qwen35_hip_full_attention_prefill(
     const void* value,
     void* out) {
 
-    static const bool use_tiled = []{
+    // Default: use the K-tiled FlashAttention-style kernel for BF16 prefill.
+    // SUPERSONIC_PREFILL_ATTN_TILED=0 forces the legacy single-warp
+    // online-softmax kernel (kept as a bisect/escape hatch).
+    static const bool disable_tiled = []{
         const char* e = std::getenv("SUPERSONIC_PREFILL_ATTN_TILED");
-        return e && e[0] != '\0' && e[0] != '0';
+        return e != nullptr && e[0] == '0';
     }();
 
-    if (use_tiled && dtype == 2) {  // BF16 only for the tiled path; non-BF16 falls through
+    if (!disable_tiled && dtype == 2) {  // BF16 only for the tiled path; non-BF16 falls through
         int rc = full_attention_prefill_tiled_device<hip_bfloat16>(
             static_cast<int>(device_ordinal),
             static_cast<int>(batch_size),

--- a/kernels/full_attention_bridge.cpp
+++ b/kernels/full_attention_bridge.cpp
@@ -121,6 +121,51 @@ int full_attention_prefill_device(
 }
 
 template <typename T>
+int full_attention_prefill_tiled_device(
+    int device_ordinal,
+    int batch_size,
+    int q_heads,
+    int kv_heads,
+    int q_len,
+    int kv_len,
+    int head_dim,
+    int num_kv_groups,
+    float scale,
+    int seqlen_offset,
+    const void* query,
+    const void* key,
+    const void* value,
+    void* out
+) {
+    constexpr int BM = 4;
+    constexpr int BK = 64;
+    if (head_dim > 8 * 32) return 132;       // ACC_MAX=8 × warpSize=32 cap
+    if (q_len <= 0) return 0;
+
+    ScopedHipDevice scoped(device_ordinal);
+
+    const int grid_x = (q_len + BM - 1) / BM;
+    dim3 grid(grid_x, q_heads, batch_size);
+    dim3 block(32, BM, 1);   // warpSize × BM warps
+    const size_t lds_bytes = (size_t)2 * BK * head_dim * sizeof(T);
+    if (lds_bytes > 48 * 1024) return 133;   // safety cap
+
+    hipLaunchKernelGGL(
+        HIP_KERNEL_NAME(supersonic_qwen35_full_attention_prefill_tiled_kernel<T, BM, BK>),
+        grid, block, lds_bytes, 0,
+        batch_size, q_heads, kv_heads, q_len, kv_len, head_dim,
+        num_kv_groups, scale, seqlen_offset,
+        static_cast<const T*>(query),
+        static_cast<const T*>(key),
+        static_cast<const T*>(value),
+        static_cast<float*>(out));
+
+    if (hipGetLastError() != hipSuccess) return 134;
+    if (hipDeviceSynchronize() != hipSuccess) return 135;
+    return 0;
+}
+
+template <typename T>
 int linear_prefill_conv_pack_device(
     int device_ordinal,
     int batch_size,
@@ -1900,6 +1945,31 @@ extern "C" int supersonic_qwen35_hip_full_attention_prefill(
     const void* key,
     const void* value,
     void* out) {
+
+    static const bool use_tiled = []{
+        const char* e = std::getenv("SUPERSONIC_PREFILL_ATTN_TILED");
+        return e && e[0] != '\0' && e[0] != '0';
+    }();
+
+    if (use_tiled && dtype == 2) {  // BF16 only for the tiled path; non-BF16 falls through
+        int rc = full_attention_prefill_tiled_device<hip_bfloat16>(
+            static_cast<int>(device_ordinal),
+            static_cast<int>(batch_size),
+            static_cast<int>(q_heads),
+            static_cast<int>(kv_heads),
+            static_cast<int>(q_len),
+            static_cast<int>(kv_len),
+            static_cast<int>(head_dim),
+            static_cast<int>(num_kv_groups),
+            scale,
+            static_cast<int>(seqlen_offset),
+            query, key, value, out);
+        if (rc == 0) return 0;
+        // On any tiled error (LDS overflow, kernel launch fail, dispatch shape unsupported),
+        // fall through to the existing non-tiled path. This matches the spirit of an A/B
+        // gate: a misconfiguration shouldn't break inference.
+    }
+
     switch (dtype) {
     case 0:
         return full_attention_prefill_device<half>(


### PR DESCRIPTION
## Summary

Two-stage rewrite of `supersonic_qwen35_full_attention_prefill_kernel` to eliminate the doubled Q·K computation (Stage 2: online softmax) and cache K/V tiles across warps in LDS (Stage 3: K-tiled FlashAttention-style). Both kernels coexist; the K-tiled kernel is the new default with `SUPERSONIC_PREFILL_ATTN_TILED=0` as bisect/escape hatch to revert to Stage 2.

The original kernel walked K rows twice per (q_pos, k_pos) — once for max, once for softmax+accumulate — and used one warp per (q_head, q_pos) with no K reuse across warps. Both costs are eliminated.

## Production speedups (gfx1100, real `head_dim=256` Qwen shapes, q_len = kv_len)

| Shape | Original (2-pass) | Stage 2 only | **Stage 3 (default)** |
|---|---:|---:|---:|
| qwen3.5-0.8b/2b @ 1024² | 84 ms | 58.9 ms | **9.10 ms** |
| qwen3.5-0.8b/2b @ 4096² | 1410 ms | 982 ms | **129.4 ms** |
| qwen3.5-0.8b/2b @ 16384² | ~36 sec | 23.8 sec | **2.33 sec** |
| qwen3.5-9b / 3.6-35B @ 1024² | 167 ms | 116.5 ms | **16.9 ms** |
| qwen3.5-9b / 3.6-35B @ 4096² | 2845 ms | 1981 ms | **255.7 ms** |
| **qwen3.5-9b / 3.6-35B @ 16384²** | **~70 sec** | **47.0 sec** | **4.6 sec** |

End-to-end on Qwen 3.5-9B with 501-token prompt: bit-exact tokens with `gpu_oracle_max_delta=0.0000` between default and `SUPERSONIC_PREFILL_ATTN_TILED=0`.

## Implementation

- **Stage 2** rewrites the existing kernel body in-place to a single-pass FlashAttention online recurrence with `m_old == -INFINITY` first-iter guard. Same kernel signature, same launch geometry, +4 bytes LDS for one extra `__shared__ float`.
- **Stage 3** adds a new `supersonic_qwen35_full_attention_prefill_tiled_kernel<T, BM, BK>` adjacent to the existing one. Grid `(ceil(q_len/BM), q_heads, batch)`; BM=4 warps cooperatively load K/V tiles into LDS once per tile, then each warp runs the per-output-dim recurrence on its own query row. `BK` is adaptive in the bridge launcher so LDS stays under the 48 KiB safety cap on RDNA3:
  - hd ≤ 64 → BK=128 (32 KiB)
  - hd ≤ 128 → BK=64 (32 KiB)
  - hd ≤ 256 → BK=32 (32 KiB) — Qwen 3.5/3.6, Gemma 4 sliding
  - hd > 256 unsupported (ACC_MAX=8 × warpSize=32 cap)
- The bridge dispatcher routes BF16 prefill to tiled by default; non-BF16 dtypes and any tiled-launch error fall through to Stage 2. Wave64 devices fall through (kernel hardcodes warpSize=32 in stride math).

## Bug fixes inside the PR

- **`wave_sum` broadcast** (commit 638f20f): `supersonic_qwen35_wave_sum` is a `__shfl_down` butterfly that leaves the sum only on lane 0. Stage 3 reads `score` on every lane (each runs its own per-output-dim recurrence), so corruption was caught by the parity test (`max_rel=7.31`). Fixed by adding `__shfl(score, 0)` to broadcast lane-0's result to all lanes.

## Test plan

- [x] `cargo test --release -p runner --test full_attention_prefill_parity` — sweeps 13 shapes (hd ∈ {64,128,256}, q_len ∈ {15,16,17,33,64,256,1024} including non-multiple-of-BM tail blocks), passes against CPU fp32 reference within `max_abs<2e-2 max_rel<1e-2`
- [x] `SUPERSONIC_PREFILL_ATTN_TILED=0 cargo test --release -p runner --test full_attention_prefill_legacy_parity` — same sweep against the legacy single-warp online-softmax kernel; lives in its own test binary because the C++ env-cache is per-process
- [x] `cargo run --release --bin bench_prefill_attn` (with and without `SUPERSONIC_PREFILL_ATTN_TILED=0`) — bench numbers above
- [x] End-to-end smoke `supersonic --model qwen3.5-9b --prompt "<501 tokens>" --max-new-tokens 8` produces bit-identical tokens with both kernels

## Out of scope (deferred)

- Port the same rewrite to `kernels/full_attention_4b.hip`, `kernels/qwen36_moe.hip` (Qwen 3.6 MoE has its own kernel file), and `kernels/gemma4.hip` (Gemma 4 sliding hd=256 + full hd=512)
- Update `docs/performance.md` with prefill numbers (the existing matrix is decode-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)