### PR TITLE
[codex] allow ad hoc Qwen3.6 SpecPrefill bench lanes

### DIFF
--- a/crates/bench/src/matrix.rs
+++ b/crates/bench/src/matrix.rs
@@ -278,12 +278,30 @@ pub fn combos_for_arch(arch: BenchArch) -> Vec<&'static ComboDescriptor> {
     SUPPORTED_COMBOS.iter().filter(|c| c.arch == arch).collect()
 }
 
-/// True iff `(model, quant, arch)` appears in `SUPPORTED_COMBOS`. Used by
-/// `run_matrix` to skip unsupported pairs from the user's CLI cross-product.
+/// True iff `(model, quant, arch)` can be run by `bench-perf`. Most entries
+/// must appear in `SUPPORTED_COMBOS`; sm86 Qwen3.6 also accepts ad hoc
+/// `int4-specNNN` lanes so local sweeps can try intermediate keep ratios
+/// without adding every exploratory value to the shipping matrix.
 pub fn is_supported_combo(model: &str, quant: &str, arch: &BenchArch) -> bool {
+    if model == "qwen3.6-35b-a3b"
+        && *arch == BenchArch::Sm86
+        && parse_specprefill_quant(quant).is_some()
+    {
+        return true;
+    }
+
     SUPPORTED_COMBOS
         .iter()
         .any(|c| c.model == model && c.quant == quant && c.arch == *arch)
+}
+
+fn parse_specprefill_quant(quant: &str) -> Option<u32> {
+    let suffix = quant.strip_prefix("int4-spec")?;
+    if suffix.len() != 3 || !suffix.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    let keep_percent = suffix.parse::<u32>().ok()?;
+    (5..=100).contains(&keep_percent).then_some(keep_percent)
 }
 
 pub struct MatrixConfig {

--- a/crates/bench/tests/matrix_writes_run_dir.rs
+++ b/crates/bench/tests/matrix_writes_run_dir.rs
@@ -68,3 +68,38 @@ fn matrix_skips_unsupported_combo_with_skipped_status() {
         "expected reason to mention SUPPORTED_COMBOS, got: {cell_text}"
     );
 }
+
+#[test]
+fn matrix_runs_ad_hoc_sm86_specprefill_lane() {
+    // `int4-spec070` is intentionally not in SUPPORTED_COMBOS because it is an
+    // exploratory keep-ratio lane, but sm86 Qwen3.6 sweeps should still run it
+    // when requested explicitly.
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = MatrixConfig {
+        arch: BenchArch::Sm86,
+        models: vec!["qwen3.6-35b-a3b".into()],
+        quants: vec!["int4-spec070".into()],
+        binary: PathBuf::from("/bin/echo"),
+        model_dir_resolver: Box::new(|_| PathBuf::from("/nonexistent")),
+        specprefill_draft_dir_resolver: Box::new(|_| Some(PathBuf::from("/draft"))),
+        prompt: "x".into(),
+        max_new_tokens: 1,
+        warmup_tokens: 1,
+        measurement_runs: 1,
+        cooldown_seconds: 0,
+        git_sha: "test".into(),
+        runner_version: "test 0.0.0".into(),
+    };
+    let rd = RunDir::new(tmp.path().join("run-ad-hoc-spec"));
+    run_matrix(&cfg, &rd).unwrap();
+    let cell_text =
+        std::fs::read_to_string(rd.perf_path("qwen3.6-35b-a3b", "int4-spec070")).unwrap();
+    assert!(
+        cell_text.contains("\"status\": \"error\""),
+        "expected the binary to be invoked and fail metric extraction, got: {cell_text}"
+    );
+    assert!(
+        !cell_text.contains("\"status\": \"skipped\""),
+        "ad hoc sm86 spec lane should not be filtered out: {cell_text}"
+    );
+}

--- a/crates/bench/tests/registry_filter.rs
+++ b/crates/bench/tests/registry_filter.rs
@@ -1,4 +1,4 @@
-use supersonic_bench::matrix::{combos_for_arch, BenchArch};
+use supersonic_bench::matrix::{combos_for_arch, is_supported_combo, BenchArch};
 
 #[test]
 fn gfx1100_includes_shipping_models() {
@@ -34,4 +34,33 @@ fn sm86_includes_qwen36_specprefill_lanes() {
     assert!(model_quants.contains(&("qwen3.6-35b-a3b", "int4-spec025")));
     assert!(model_quants.contains(&("qwen3.6-35b-a3b", "int4-spec050")));
     assert!(model_quants.contains(&("qwen3.6-35b-a3b", "int4-spec075")));
+}
+
+#[test]
+fn sm86_accepts_ad_hoc_qwen36_specprefill_lanes() {
+    assert!(is_supported_combo(
+        "qwen3.6-35b-a3b",
+        "int4-spec070",
+        &BenchArch::Sm86
+    ));
+    assert!(is_supported_combo(
+        "qwen3.6-35b-a3b",
+        "int4-spec100",
+        &BenchArch::Sm86
+    ));
+    assert!(!is_supported_combo(
+        "qwen3.6-35b-a3b",
+        "int4-spec004",
+        &BenchArch::Sm86
+    ));
+    assert!(!is_supported_combo(
+        "qwen3.6-35b-a3b",
+        "int4-spec070",
+        &BenchArch::Gfx1100
+    ));
+    assert!(!is_supported_combo(
+        "qwen3.5-9b",
+        "int4-spec070",
+        &BenchArch::Sm86
+    ));
 }

--- a/docs/research/2026-05-06-qwen36-specprefill-keep-ratio-sweep.md
+++ b/docs/research/2026-05-06-qwen36-specprefill-keep-ratio-sweep.md
@@ -1,0 +1,63 @@
+# Qwen 3.6 CUDA SpecPrefill Keep-Ratio Sweep
+
+**Date:** 2026-05-06
+**Branch:** `codex/bench-arbitrary-specprefill-lanes`
+**Hardware:** NVIDIA sm86 CUDA target
+**Target:** `qwen3.6-35b-a3b` INT4
+**Draft:** `qwen3.5-0.8b`
+
+## Question
+
+After sparse Qwen3.6 SpecPrefill moved onto the batched prefill path, the
+`int4-spec075` lane became faster than dense instead of slower. We checked
+whether an intermediate keep ratio could preserve the conservative quality
+profile while reclaiming more TTFT than `keep=0.75`.
+
+## Method
+
+Quality used `oracle.bench.specprefill_quality` against the standard prompt
+set, with dense INT4 next-token logits as the reference. Performance used a
+single long synthetic prompt of about 800 target tokens with `max-new-tokens=1`
+so the reported value is effectively target prefill wall time.
+
+The benchmark harness now accepts explicit sm86 Qwen3.6 lanes of the form
+`int4-specNNN` for ad hoc sweeps. The static matrix still lists only the
+regular lanes (`025`, `050`, `075`), but `bench-perf --quants int4-spec070`
+will run instead of being marked skipped.
+
+## Results
+
+Quality sweep:
+
+| lane | keep ratio | argmax match | cosine min | top-5 min | notes |
+|---|---:|---:|---:|---:|---|
+| `int4-spec050` | 0.50 | 0.714 | 0.780312 | 2 | balanced/perf lane; fastest, but not argmax-preserving on the standard set |
+| `int4-spec060` | 0.60 | 0.714 | 0.814386 | 3 | still misses argmax on two cases |
+| `int4-spec065` | 0.65 | 0.857 | 0.829645 | 2 | improves argmax but still misses `json_completion` |
+| `int4-spec070` | 0.70 | 1.000 | 0.881636 | 3 | argmax-preserving, but below the conservative cosine floor on two cases |
+| `int4-spec075` | 0.75 | 1.000 | 0.911746 | 3 | conservative lane; passes current quality gate |
+
+Performance on the about-800-token prompt after the sparse batched-prefill
+optimization:
+
+| lane | target prefill | speedup vs dense |
+|---|---:|---:|
+| dense INT4 | 22981.0 ms | 1.00x |
+| `int4-spec050` | 13290.4 ms | 1.73x |
+| `int4-spec070` | 18652.8 ms | 1.23x |
+| `int4-spec075` | 19368.3 ms | 1.19x |
+
+The direct `int4-spec070` runner measurement reported 579 kept tokens out of
+800 prompt tokens (72.4%). Its target prefill was only about 3.7% faster than
+`int4-spec075`, while weakening the cosine floor enough to fall below the
+current conservative threshold.
+
+## Recommendation
+
+Keep the public CUDA Qwen3.6 cross-family default at `keep_ratio=0.75`. It is
+now faster than dense on short, mid, and long prompts after the batched sparse
+path, and it retains the argmax-preserving quality profile.
+
+Keep `keep_ratio=0.50` as the explicit balanced/perf lane for users who accept
+occasional first-token drift. Do not promote `0.70`: its speed gain over
+`0.75` is too small for the quality regression.

--- a/docs/specprefill.md
+++ b/docs/specprefill.md
@@ -150,11 +150,14 @@ uses dense INT4 next-token logits as reference:
 
 The runtime default for CUDA Qwen3.6 cross-family mode is therefore
 `keep_ratio=0.75`; pass `--specprefill-keep-ratio 0.50` explicitly when
-you want the faster balanced lane.
+you want the faster balanced lane. `bench-perf` also accepts explicit sm86
+Qwen3.6 exploratory lanes such as `int4-spec070`; see the May-06 sweep below
+for why `0.70` was measured but not promoted.
 
 ## Reference docs
 
 - Feasibility memo: [research/2026-05-03-specprefill-feasibility.md](research/2026-05-03-specprefill-feasibility.md).
 - Phase A measurements (4B target): [research/2026-05-03-specprefill-phase-a-results.md](research/2026-05-03-specprefill-phase-a-results.md).
 - Phase A2 measurements (9B target): [research/2026-05-03-specprefill-phase-a2-cross-target.md](research/2026-05-03-specprefill-phase-a2-cross-target.md).
+- CUDA Qwen3.6 keep-ratio sweep: [research/2026-05-06-qwen36-specprefill-keep-ratio-sweep.md](research/2026-05-06-qwen36-specprefill-keep-ratio-sweep.md).
 - Original paper: [papers/SpecPrefill_arXiv_2502.02789.pdf](papers/SpecPrefill_arXiv_2502.02789.pdf).


### PR DESCRIPTION
## Summary

- Allow `bench-perf` to run explicitly requested sm86 Qwen3.6 `int4-specNNN` lanes, such as `int4-spec070`, without adding every exploratory keep ratio to `SUPPORTED_COMBOS`.
- Add focused tests for the support predicate and matrix runner behavior.
- Add a research note for the 2026-05-06 Qwen3.6 CUDA keep-ratio sweep and link it from `docs/specprefill.md`.

## Rationale

The static benchmark matrix should stay limited to known lanes, but local quality/performance sweeps need intermediate keep ratios. This lets those runs execute instead of being written as skipped cells.

The research note records why `keep_ratio=0.75` remains the conservative default: `0.70` preserves argmax on the standard set, but falls below the cosine floor and only improves target prefill by about 3.7% versus `0.75` on the measured long prompt.

## Validation

- `cargo test -p supersonic-bench`
- `python3 -m pytest oracle/bench/tests`
- `rustfmt --check crates/bench/src/matrix.rs crates/bench/tests/registry_filter.rs crates/bench/tests/matrix_writes_run_dir.rs`
- `git diff --check`

Note: full `cargo fmt --check` still reports pre-existing formatting drift in unrelated runner/kernel files that this branch does not touch.