### PR TITLE
Add SuperSonic kernel lab harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2108,6 +2108,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "supersonic-kernel-lab"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "clap",
+ "gpu-hal",
+ "half",
+ "kernel-ffi",
+ "serde",
+ "serde_json",
+ "tempfile",
+]
+
+[[package]]
 name = "supersonic-runtime"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/gemma4",
     "crates/gpu-hal",
     "crates/kernel-ffi",
+    "crates/kernel-lab",
     "crates/model-store",
     "crates/phi4",
     "crates/qwen35",

--- a/crates/kernel-lab/Cargo.toml
+++ b/crates/kernel-lab/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "supersonic-kernel-lab"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "supersonic_kernel_lab"
+path = "src/lib.rs"
+
+[[bin]]
+name = "kernel-lab"
+path = "src/bin/kernel_lab.rs"
+
+[dependencies]
+anyhow = "1"
+chrono = { version = "0.4", features = ["serde"] }
+clap = { version = "4", features = ["derive"] }
+gpu-hal = { path = "../gpu-hal" }
+half = "2"
+kernel-ffi = { path = "../kernel-ffi" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/kernel-lab/src/bin/kernel_lab.rs
+++ b/crates/kernel-lab/src/bin/kernel_lab.rs
@@ -1,8 +1,9 @@
 use anyhow::{anyhow, Result};
 use clap::{Parser, Subcommand};
 use gpu_hal::Backend;
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
-use std::process::Command as ProcessCommand;
+use std::process::{Command as ProcessCommand, ExitStatus};
 use supersonic_kernel_lab::run::{
     diff_exit_code, diff_runs, load_summary, render_diff_markdown, render_markdown, resolve_tasks,
     run_tasks, KernelLabConfig,
@@ -129,7 +130,7 @@ fn main() -> Result<()> {
                     summary.required_task_count
                 );
             }
-            if summary.passed_required_tasks != summary.required_task_count {
+            if run_has_failed_tasks(&summary) {
                 std::process::exit(1);
             }
         }
@@ -240,6 +241,7 @@ fn run_ref(
     worktree_root: &PathBuf,
 ) -> Result<PathBuf> {
     if git_ref == "worktree" {
+        let before = existing_run_dirs(run_root);
         let status = ProcessCommand::new("cargo")
             .args([
                 "run",
@@ -264,10 +266,7 @@ fn run_ref(
                 run_root.to_string_lossy().as_ref(),
             ])
             .status()?;
-        if !status.success() {
-            return Err(anyhow!("candidate worktree run failed"));
-        }
-        return newest_run_dir(run_root);
+        return child_run_dir_after(status, run_root, &before, "candidate worktree");
     }
 
     std::fs::create_dir_all(worktree_root)?;
@@ -296,6 +295,7 @@ fn run_ref(
     )?;
     overlay_harness_crate(&dir)?;
     let absolute_run_root = std::env::current_dir()?.join(run_root);
+    let before = existing_run_dirs(&absolute_run_root);
     let status = ProcessCommand::new("cargo")
         .current_dir(&dir)
         .args([
@@ -321,10 +321,16 @@ fn run_ref(
             absolute_run_root.to_string_lossy().as_ref(),
         ])
         .status()?;
-    if !status.success() {
-        return Err(anyhow!("baseline ref {git_ref} run failed"));
-    }
-    newest_run_dir(&absolute_run_root)
+    child_run_dir_after(
+        status,
+        &absolute_run_root,
+        &before,
+        &format!("ref {git_ref}"),
+    )
+}
+
+fn run_has_failed_tasks(summary: &supersonic_kernel_lab::run::RunSummary) -> bool {
+    summary.passed_tasks != summary.task_count
 }
 
 fn overlay_harness_crate(worktree: &Path) -> Result<()> {
@@ -370,10 +376,37 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
     Ok(())
 }
 
-fn newest_run_dir(run_root: &PathBuf) -> Result<PathBuf> {
+fn child_run_dir_after(
+    status: ExitStatus,
+    run_root: &PathBuf,
+    before: &BTreeSet<PathBuf>,
+    label: &str,
+) -> Result<PathBuf> {
+    match newest_run_dir_excluding(run_root, before) {
+        Ok(path) => Ok(path),
+        Err(err) if status.success() => Err(err),
+        Err(_) => Err(anyhow!("{label} run failed before writing summary.json")),
+    }
+}
+
+fn existing_run_dirs(run_root: &PathBuf) -> BTreeSet<PathBuf> {
+    std::fs::read_dir(run_root)
+        .ok()
+        .into_iter()
+        .flatten()
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| path.join("summary.json").exists())
+        .collect()
+}
+
+fn newest_run_dir_excluding(run_root: &PathBuf, before: &BTreeSet<PathBuf>) -> Result<PathBuf> {
     let mut entries: Vec<_> = std::fs::read_dir(run_root)?
         .filter_map(Result::ok)
-        .filter(|entry| entry.path().join("summary.json").exists())
+        .filter(|entry| {
+            let path = entry.path();
+            path.join("summary.json").exists() && !before.contains(&path)
+        })
         .filter_map(|entry| {
             let modified = entry.metadata().ok()?.modified().ok()?;
             Some((modified, entry.path()))
@@ -383,7 +416,7 @@ fn newest_run_dir(run_root: &PathBuf) -> Result<PathBuf> {
     entries
         .pop()
         .map(|(_, path)| path)
-        .ok_or_else(|| anyhow!("no kernel-lab run found under {}", run_root.display()))
+        .ok_or_else(|| anyhow!("no new kernel-lab run found under {}", run_root.display()))
 }
 
 fn run_checked(cmd: &str, args: &[&str]) -> Result<()> {
@@ -410,6 +443,7 @@ fn sanitize_ref(git_ref: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use supersonic_kernel_lab::run::{MetaJson, RunSummary, SCHEMA_VERSION};
 
     #[test]
     fn sanitize_ref_keeps_path_safe_characters_only() {
@@ -455,5 +489,65 @@ mod tests {
         overlay_harness_crate_from(&source, &worktree).unwrap();
         let cargo_toml = std::fs::read_to_string(worktree.join("Cargo.toml")).unwrap();
         assert_eq!(cargo_toml.matches("\"crates/kernel-lab\"").count(), 1);
+    }
+
+    #[test]
+    fn run_has_failed_tasks_checks_all_selected_tasks() {
+        let mut summary = test_summary(0, 0, 0, 0);
+        assert!(!run_has_failed_tasks(&summary));
+
+        summary = test_summary(1, 0, 0, 0);
+        assert!(run_has_failed_tasks(&summary));
+
+        summary = test_summary(2, 1, 1, 1);
+        assert!(run_has_failed_tasks(&summary));
+
+        summary = test_summary(2, 2, 1, 1);
+        assert!(!run_has_failed_tasks(&summary));
+    }
+
+    #[test]
+    fn newest_run_dir_excluding_returns_only_new_summaries() {
+        let tmp = tempfile::tempdir().unwrap();
+        let run_root = tmp.path().to_path_buf();
+        let old = run_root.join("old");
+        std::fs::create_dir_all(&old).unwrap();
+        std::fs::write(old.join("summary.json"), "{}").unwrap();
+
+        let before = existing_run_dirs(&run_root);
+        assert!(newest_run_dir_excluding(&run_root, &before).is_err());
+
+        let new = run_root.join("new");
+        std::fs::create_dir_all(&new).unwrap();
+        std::fs::write(new.join("summary.json"), "{}").unwrap();
+
+        assert_eq!(newest_run_dir_excluding(&run_root, &before).unwrap(), new);
+    }
+
+    fn test_summary(
+        task_count: usize,
+        passed_tasks: usize,
+        required_task_count: usize,
+        passed_required_tasks: usize,
+    ) -> RunSummary {
+        RunSummary {
+            schema_version: SCHEMA_VERSION,
+            meta: MetaJson {
+                schema_version: SCHEMA_VERSION,
+                run_id: "test".into(),
+                timestamp_utc: "2026-05-06T00:00:00Z".into(),
+                git_sha: "test".into(),
+                git_dirty: false,
+                backend: "hip".into(),
+                device: 0,
+                arch: "gfx1100".into(),
+                rocm_smi: String::new(),
+            },
+            task_count,
+            passed_tasks,
+            required_task_count,
+            passed_required_tasks,
+            tasks: Vec::new(),
+        }
     }
 }

--- a/crates/kernel-lab/src/bin/kernel_lab.rs
+++ b/crates/kernel-lab/src/bin/kernel_lab.rs
@@ -1,0 +1,459 @@
+use anyhow::{anyhow, Result};
+use clap::{Parser, Subcommand};
+use gpu_hal::Backend;
+use std::path::{Path, PathBuf};
+use std::process::Command as ProcessCommand;
+use supersonic_kernel_lab::run::{
+    diff_exit_code, diff_runs, load_summary, render_diff_markdown, render_markdown, resolve_tasks,
+    run_tasks, KernelLabConfig,
+};
+
+#[derive(Parser, Debug)]
+#[command(name = "kernel-lab")]
+#[command(about = "KernelBench-style harness for SuperSonic kernel candidates")]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand, Debug)]
+enum Command {
+    List,
+    Run {
+        #[arg(long, default_value = "all")]
+        tasks: String,
+        #[arg(long, default_value = "hip")]
+        backend: String,
+        #[arg(long, default_value_t = 0)]
+        device: usize,
+        #[arg(long, default_value_t = 5)]
+        warmup: usize,
+        #[arg(long, default_value_t = 20)]
+        iters: usize,
+        #[arg(long, default_value = "target/kernel-lab-runs")]
+        run_root: PathBuf,
+        #[arg(long)]
+        json: bool,
+    },
+    Diff {
+        #[arg(long)]
+        baseline: PathBuf,
+        #[arg(long)]
+        candidate: PathBuf,
+        #[arg(long, default_value_t = 0.03)]
+        max_regression: f64,
+        #[arg(long, default_value_t = 1.02)]
+        min_speedup: f64,
+        #[arg(long)]
+        markdown_out: Option<PathBuf>,
+        #[arg(long)]
+        github_summary: bool,
+    },
+    CompareRef {
+        #[arg(long, default_value = "main")]
+        baseline_ref: String,
+        #[arg(long, default_value = "worktree")]
+        candidate_ref: String,
+        #[arg(long, default_value = "all")]
+        tasks: String,
+        #[arg(long, default_value = "hip")]
+        backend: String,
+        #[arg(long, default_value_t = 0)]
+        device: usize,
+        #[arg(long, default_value_t = 5)]
+        warmup: usize,
+        #[arg(long, default_value_t = 20)]
+        iters: usize,
+        #[arg(long, default_value = "target/kernel-lab-runs")]
+        run_root: PathBuf,
+        #[arg(long, default_value = "target/kernel-lab-worktrees")]
+        worktree_root: PathBuf,
+        #[arg(long, default_value_t = 0.03)]
+        max_regression: f64,
+        #[arg(long, default_value_t = 1.02)]
+        min_speedup: f64,
+        #[arg(long)]
+        markdown_out: Option<PathBuf>,
+        #[arg(long)]
+        github_summary: bool,
+    },
+    Render {
+        #[arg(long)]
+        run: PathBuf,
+        #[arg(long)]
+        out: PathBuf,
+    },
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+    match cli.command {
+        Command::List => {
+            for task in supersonic_kernel_lab::all_tasks() {
+                println!(
+                    "{}\tfamily={}\trequired={}\ttags={}",
+                    task.id,
+                    task.family,
+                    task.required,
+                    task.tags.join(",")
+                );
+            }
+        }
+        Command::Run {
+            tasks,
+            backend,
+            device,
+            warmup,
+            iters,
+            run_root,
+            json,
+        } => {
+            let backend =
+                Backend::parse(&backend).ok_or_else(|| anyhow!("unknown backend: {backend}"))?;
+            let tasks = resolve_tasks(&tasks)?;
+            let cfg = KernelLabConfig {
+                backend,
+                device,
+                warmup,
+                iters,
+                run_root,
+            };
+            let (run_dir, summary) = run_tasks(&cfg, &tasks)?;
+            if json {
+                println!("{}", serde_json::to_string_pretty(&summary)?);
+            } else {
+                println!(
+                    "[kernel-lab] wrote {} (required {}/{})",
+                    run_dir.display(),
+                    summary.passed_required_tasks,
+                    summary.required_task_count
+                );
+            }
+            if summary.passed_required_tasks != summary.required_task_count {
+                std::process::exit(1);
+            }
+        }
+        Command::Diff {
+            baseline,
+            candidate,
+            max_regression,
+            min_speedup,
+            markdown_out,
+            github_summary,
+        } => {
+            let baseline = load_summary(&baseline)?;
+            let candidate = load_summary(&candidate)?;
+            let diff = diff_runs(&baseline, &candidate, max_regression);
+            println!("{}", serde_json::to_string_pretty(&diff)?);
+            write_diff_markdown(&diff, min_speedup, markdown_out, github_summary)?;
+            let code = diff_exit_code(&diff, min_speedup);
+            if code != 0 {
+                std::process::exit(code);
+            }
+        }
+        Command::CompareRef {
+            baseline_ref,
+            candidate_ref,
+            tasks,
+            backend,
+            device,
+            warmup,
+            iters,
+            run_root,
+            worktree_root,
+            max_regression,
+            min_speedup,
+            markdown_out,
+            github_summary,
+        } => {
+            let baseline = run_ref(
+                &baseline_ref,
+                &tasks,
+                &backend,
+                device,
+                warmup,
+                iters,
+                &run_root,
+                &worktree_root,
+            )?;
+            let candidate = run_ref(
+                &candidate_ref,
+                &tasks,
+                &backend,
+                device,
+                warmup,
+                iters,
+                &run_root,
+                &worktree_root,
+            )?;
+            let baseline_summary = load_summary(&baseline)?;
+            let candidate_summary = load_summary(&candidate)?;
+            let diff = diff_runs(&baseline_summary, &candidate_summary, max_regression);
+            println!("{}", serde_json::to_string_pretty(&diff)?);
+            write_diff_markdown(&diff, min_speedup, markdown_out, github_summary)?;
+            let code = diff_exit_code(&diff, min_speedup);
+            if code != 0 {
+                std::process::exit(code);
+            }
+        }
+        Command::Render { run, out } => {
+            let summary = load_summary(&run)?;
+            std::fs::write(&out, render_markdown(&summary))?;
+            println!("[kernel-lab] wrote {}", out.display());
+        }
+    }
+    Ok(())
+}
+
+fn write_diff_markdown(
+    diff: &supersonic_kernel_lab::run::DiffReport,
+    min_speedup: f64,
+    markdown_out: Option<PathBuf>,
+    github_summary: bool,
+) -> Result<()> {
+    let markdown = render_diff_markdown(diff, min_speedup);
+    if let Some(path) = markdown_out {
+        std::fs::write(&path, &markdown)?;
+        println!("[kernel-lab] wrote {}", path.display());
+    }
+    if github_summary {
+        let path = std::env::var_os("GITHUB_STEP_SUMMARY")
+            .ok_or_else(|| anyhow!("GITHUB_STEP_SUMMARY is not set"))?;
+        use std::io::Write;
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(PathBuf::from(path))?;
+        writeln!(file, "{markdown}")?;
+    }
+    Ok(())
+}
+
+fn run_ref(
+    git_ref: &str,
+    tasks: &str,
+    backend: &str,
+    device: usize,
+    warmup: usize,
+    iters: usize,
+    run_root: &PathBuf,
+    worktree_root: &PathBuf,
+) -> Result<PathBuf> {
+    if git_ref == "worktree" {
+        let status = ProcessCommand::new("cargo")
+            .args([
+                "run",
+                "--release",
+                "-p",
+                "supersonic-kernel-lab",
+                "--bin",
+                "kernel-lab",
+                "--",
+                "run",
+                "--tasks",
+                tasks,
+                "--backend",
+                backend,
+                "--device",
+                &device.to_string(),
+                "--warmup",
+                &warmup.to_string(),
+                "--iters",
+                &iters.to_string(),
+                "--run-root",
+                run_root.to_string_lossy().as_ref(),
+            ])
+            .status()?;
+        if !status.success() {
+            return Err(anyhow!("candidate worktree run failed"));
+        }
+        return newest_run_dir(run_root);
+    }
+
+    std::fs::create_dir_all(worktree_root)?;
+    let label = sanitize_ref(git_ref);
+    let dir = worktree_root.join(label);
+    if dir.exists() {
+        run_checked(
+            "git",
+            &[
+                "worktree",
+                "remove",
+                "--force",
+                dir.to_string_lossy().as_ref(),
+            ],
+        )?;
+    }
+    run_checked(
+        "git",
+        &[
+            "worktree",
+            "add",
+            "--detach",
+            dir.to_string_lossy().as_ref(),
+            git_ref,
+        ],
+    )?;
+    overlay_harness_crate(&dir)?;
+    let absolute_run_root = std::env::current_dir()?.join(run_root);
+    let status = ProcessCommand::new("cargo")
+        .current_dir(&dir)
+        .args([
+            "run",
+            "--release",
+            "-p",
+            "supersonic-kernel-lab",
+            "--bin",
+            "kernel-lab",
+            "--",
+            "run",
+            "--tasks",
+            tasks,
+            "--backend",
+            backend,
+            "--device",
+            &device.to_string(),
+            "--warmup",
+            &warmup.to_string(),
+            "--iters",
+            &iters.to_string(),
+            "--run-root",
+            absolute_run_root.to_string_lossy().as_ref(),
+        ])
+        .status()?;
+    if !status.success() {
+        return Err(anyhow!("baseline ref {git_ref} run failed"));
+    }
+    newest_run_dir(&absolute_run_root)
+}
+
+fn overlay_harness_crate(worktree: &Path) -> Result<()> {
+    let source_root = std::env::current_dir()?;
+    overlay_harness_crate_from(&source_root, worktree)
+}
+
+fn overlay_harness_crate_from(source_root: &Path, worktree: &Path) -> Result<()> {
+    let src_crate = source_root.join("crates/kernel-lab");
+    let dst_crate = worktree.join("crates/kernel-lab");
+    if dst_crate.exists() {
+        std::fs::remove_dir_all(&dst_crate)?;
+    }
+    copy_dir_recursive(&src_crate, &dst_crate)?;
+
+    let workspace_toml = worktree.join("Cargo.toml");
+    let mut cargo_toml = std::fs::read_to_string(&workspace_toml)?;
+    if !cargo_toml.contains("\"crates/kernel-lab\"") {
+        let marker = "members = [";
+        let idx = cargo_toml
+            .find(marker)
+            .ok_or_else(|| anyhow!("workspace Cargo.toml has no members array"))?
+            + marker.len();
+        cargo_toml.insert_str(idx, "\n    \"crates/kernel-lab\",");
+        std::fs::write(&workspace_toml, cargo_toml)?;
+    }
+    Ok(())
+}
+
+fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
+    std::fs::create_dir_all(dst)?;
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            copy_dir_recursive(&src_path, &dst_path)?;
+        } else if file_type.is_file() {
+            std::fs::copy(&src_path, &dst_path)?;
+        }
+    }
+    Ok(())
+}
+
+fn newest_run_dir(run_root: &PathBuf) -> Result<PathBuf> {
+    let mut entries: Vec<_> = std::fs::read_dir(run_root)?
+        .filter_map(Result::ok)
+        .filter(|entry| entry.path().join("summary.json").exists())
+        .filter_map(|entry| {
+            let modified = entry.metadata().ok()?.modified().ok()?;
+            Some((modified, entry.path()))
+        })
+        .collect();
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+    entries
+        .pop()
+        .map(|(_, path)| path)
+        .ok_or_else(|| anyhow!("no kernel-lab run found under {}", run_root.display()))
+}
+
+fn run_checked(cmd: &str, args: &[&str]) -> Result<()> {
+    let status = ProcessCommand::new(cmd).args(args).status()?;
+    if !status.success() {
+        return Err(anyhow!("{cmd} failed"));
+    }
+    Ok(())
+}
+
+fn sanitize_ref(git_ref: &str) -> String {
+    git_ref
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+                ch
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_ref_keeps_path_safe_characters_only() {
+        assert_eq!(sanitize_ref("main"), "main");
+        assert_eq!(
+            sanitize_ref("feature/quant+bake@123"),
+            "feature-quant-bake-123"
+        );
+        assert_eq!(sanitize_ref("origin/main~1"), "origin-main-1");
+    }
+
+    #[test]
+    fn overlay_harness_crate_copies_crate_and_injects_workspace_member() {
+        let tmp = tempfile::tempdir().unwrap();
+        let source = tmp.path().join("source");
+        let worktree = tmp.path().join("worktree");
+        std::fs::create_dir_all(source.join("crates/kernel-lab/src")).unwrap();
+        std::fs::create_dir_all(worktree.join("crates")).unwrap();
+
+        std::fs::write(
+            source.join("crates/kernel-lab/Cargo.toml"),
+            "[package]\nname = \"supersonic-kernel-lab\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            source.join("crates/kernel-lab/src/lib.rs"),
+            "pub fn marker() {}\n",
+        )
+        .unwrap();
+        std::fs::write(
+            worktree.join("Cargo.toml"),
+            "[workspace]\nmembers = [\n    \"crates/gpu-hal\",\n]\n",
+        )
+        .unwrap();
+
+        overlay_harness_crate_from(&source, &worktree).unwrap();
+
+        let cargo_toml = std::fs::read_to_string(worktree.join("Cargo.toml")).unwrap();
+        assert!(cargo_toml.contains("\"crates/kernel-lab\""));
+        let lib = std::fs::read_to_string(worktree.join("crates/kernel-lab/src/lib.rs")).unwrap();
+        assert!(lib.contains("marker"));
+
+        overlay_harness_crate_from(&source, &worktree).unwrap();
+        let cargo_toml = std::fs::read_to_string(worktree.join("Cargo.toml")).unwrap();
+        assert_eq!(cargo_toml.matches("\"crates/kernel-lab\"").count(), 1);
+    }
+}

--- a/crates/kernel-lab/src/lib.rs
+++ b/crates/kernel-lab/src/lib.rs
@@ -1,0 +1,9 @@
+pub mod registry;
+pub mod run;
+pub mod tasks;
+
+pub use registry::{all_tasks, find_task, TaskDef};
+pub use run::{
+    diff_exit_code, diff_runs, render_diff_markdown, render_markdown, run_tasks, CaseResult,
+    DiffReport, KernelLabConfig, RunSummary, TaskResult,
+};

--- a/crates/kernel-lab/src/registry.rs
+++ b/crates/kernel-lab/src/registry.rs
@@ -1,0 +1,77 @@
+use crate::tasks;
+
+#[derive(Debug, Clone, Copy)]
+pub struct TaskDef {
+    pub id: &'static str,
+    pub family: &'static str,
+    pub tags: &'static [&'static str],
+    pub required: bool,
+    pub run: fn(&crate::run::KernelLabConfig) -> anyhow::Result<crate::run::TaskResult>,
+}
+
+const TASKS: &[TaskDef] = &[
+    TaskDef {
+        id: "qwen35.full_attention_prefill",
+        family: "qwen3.5",
+        tags: &["qwen35", "attention", "prefill", "required"],
+        required: true,
+        run: tasks::qwen35_full_attention_prefill,
+    },
+    TaskDef {
+        id: "qwen36.batched_prefill_attn_full",
+        family: "qwen3.6-moe",
+        tags: &["qwen36", "attention", "prefill", "required"],
+        required: true,
+        run: tasks::qwen36_batched_prefill_attn_full,
+    },
+    TaskDef {
+        id: "qwen36.router_permute",
+        family: "qwen3.6-moe",
+        tags: &["qwen36", "moe", "router", "required"],
+        required: true,
+        run: tasks::qwen36_router_permute,
+    },
+    TaskDef {
+        id: "qwen36.grouped_expert_int4",
+        family: "qwen3.6-moe",
+        tags: &["qwen36", "moe", "int4", "required"],
+        required: true,
+        run: tasks::qwen36_grouped_expert_int4,
+    },
+    TaskDef {
+        id: "qwen36.unpermute_combine",
+        family: "qwen3.6-moe",
+        tags: &["qwen36", "moe", "combine", "required"],
+        required: true,
+        run: tasks::qwen36_unpermute_combine,
+    },
+    TaskDef {
+        id: "qwen36.batched_prefill_attn_full.stress",
+        family: "qwen3.6-moe",
+        tags: &["qwen36", "attention-stress", "stress"],
+        required: false,
+        run: tasks::qwen36_batched_prefill_attn_full_stress,
+    },
+    TaskDef {
+        id: "qwen36.router_permute.stress",
+        family: "qwen3.6-moe",
+        tags: &["qwen36", "router-stress", "stress"],
+        required: false,
+        run: tasks::qwen36_router_permute_stress,
+    },
+    TaskDef {
+        id: "qwen36.grouped_expert_int4.stress",
+        family: "qwen3.6-moe",
+        tags: &["qwen36", "int4-stress", "stress"],
+        required: false,
+        run: tasks::qwen36_grouped_expert_int4_stress,
+    },
+];
+
+pub fn all_tasks() -> &'static [TaskDef] {
+    TASKS
+}
+
+pub fn find_task(id: &str) -> Option<&'static TaskDef> {
+    TASKS.iter().find(|task| task.id == id)
+}

--- a/crates/kernel-lab/src/run.rs
+++ b/crates/kernel-lab/src/run.rs
@@ -1,0 +1,673 @@
+use crate::registry::{all_tasks, TaskDef};
+use anyhow::{anyhow, Context, Result};
+use gpu_hal::Backend;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+pub const SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone)]
+pub struct KernelLabConfig {
+    pub backend: Backend,
+    pub device: usize,
+    pub warmup: usize,
+    pub iters: usize,
+    pub run_root: PathBuf,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MetaJson {
+    pub schema_version: u32,
+    pub run_id: String,
+    pub timestamp_utc: String,
+    pub git_sha: String,
+    pub git_dirty: bool,
+    pub backend: String,
+    pub device: usize,
+    pub arch: String,
+    pub rocm_smi: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CaseResult {
+    pub name: String,
+    pub shape: BTreeMap<String, usize>,
+    pub correct: bool,
+    pub max_abs: Option<f32>,
+    pub max_rel: Option<f32>,
+    pub min_cos: Option<f32>,
+    pub exact: Option<bool>,
+    pub warmup: usize,
+    pub iters: usize,
+    pub timing_source: String,
+    pub median_us: f64,
+    pub mean_us: f64,
+    pub min_us: f64,
+    pub p95_us: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TaskResult {
+    pub schema_version: u32,
+    pub task_id: String,
+    pub family: String,
+    pub tags: Vec<String>,
+    pub required: bool,
+    pub correct: bool,
+    pub cases: Vec<CaseResult>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunSummary {
+    pub schema_version: u32,
+    pub meta: MetaJson,
+    pub task_count: usize,
+    pub passed_tasks: usize,
+    pub required_task_count: usize,
+    pub passed_required_tasks: usize,
+    pub tasks: Vec<TaskResult>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiffTask {
+    pub task_id: String,
+    pub correct: bool,
+    pub baseline_median_us: f64,
+    pub candidate_median_us: f64,
+    pub speedup: f64,
+    pub regression: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiffReport {
+    pub correct: bool,
+    pub fast_p: f64,
+    pub geomean_speedup: f64,
+    pub worst_regression: Option<DiffTask>,
+    pub tasks: Vec<DiffTask>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HistoryEntry {
+    pub schema_version: u32,
+    pub run_id: String,
+    pub timestamp_utc: String,
+    pub git_sha: String,
+    pub git_dirty: bool,
+    pub backend: String,
+    pub device: usize,
+    pub arch: String,
+    pub required: String,
+    pub tasks: BTreeMap<String, f64>,
+}
+
+pub fn resolve_tasks(spec: &str) -> Result<Vec<TaskDef>> {
+    if spec == "all" {
+        return Ok(all_tasks()
+            .iter()
+            .filter(|task| task.required)
+            .copied()
+            .collect());
+    }
+    if spec == "everything" {
+        return Ok(all_tasks().to_vec());
+    }
+    let mut out = Vec::new();
+    let mut seen = BTreeSet::new();
+    for raw in spec.split(',') {
+        let item = raw.trim();
+        if item.is_empty() {
+            continue;
+        }
+        if let Some(tag) = item.strip_prefix("tag:") {
+            let mut matched = false;
+            for task in all_tasks()
+                .iter()
+                .filter(|task| task.tags.iter().any(|task_tag| *task_tag == tag))
+            {
+                matched = true;
+                if seen.insert(task.id.to_string()) {
+                    out.push(*task);
+                }
+            }
+            if !matched {
+                return Err(anyhow!("unknown task tag: {tag}"));
+            }
+            continue;
+        }
+
+        let task = crate::find_task(item).ok_or_else(|| anyhow!("unknown task: {item}"))?;
+        if seen.insert(task.id.to_string()) {
+            out.push(*task);
+        }
+    }
+    Ok(out)
+}
+
+pub fn run_tasks(cfg: &KernelLabConfig, tasks: &[TaskDef]) -> Result<(PathBuf, RunSummary)> {
+    if !gpu_hal::is_backend_compiled(cfg.backend) {
+        return Err(anyhow!("backend {} is not compiled", cfg.backend));
+    }
+    gpu_hal::set_backend(cfg.backend);
+    gpu_hal::set_device(cfg.device).context("set GPU device")?;
+
+    let git_sha = capture(["rev-parse", "--short", "HEAD"]).unwrap_or_else(|| "unknown".into());
+    let git_dirty = !capture(["status", "--porcelain"])
+        .unwrap_or_default()
+        .is_empty();
+    let date = chrono::Utc::now().format("%Y-%m-%d").to_string();
+    let run_dir = allocate_run_dir(&cfg.run_root, &git_sha, &date);
+    std::fs::create_dir_all(run_dir.join("tasks"))?;
+
+    let meta = MetaJson {
+        schema_version: SCHEMA_VERSION,
+        run_id: run_dir
+            .file_name()
+            .map(|s| s.to_string_lossy().to_string())
+            .unwrap_or_else(|| "kernel-lab-run".into()),
+        timestamp_utc: chrono::Utc::now().to_rfc3339(),
+        git_sha,
+        git_dirty,
+        backend: cfg.backend.to_string(),
+        device: cfg.device,
+        arch: capture_cmd("rocminfo", &[])
+            .and_then(|s| {
+                s.lines()
+                    .filter_map(|line| line.trim().strip_prefix("Name:"))
+                    .map(str::trim)
+                    .find(|name| name.starts_with("gfx") || name.starts_with("sm"))
+                    .map(str::to_string)
+            })
+            .unwrap_or_else(|| "unknown".into()),
+        rocm_smi: capture_cmd("rocm-smi", &["--showuse"]).unwrap_or_else(|| "unavailable".into()),
+    };
+
+    std::fs::write(
+        run_dir.join("meta.json"),
+        serde_json::to_string_pretty(&meta)?,
+    )?;
+
+    let mut results = Vec::new();
+    for task in tasks {
+        let mut result = (task.run)(cfg).unwrap_or_else(|err| TaskResult {
+            schema_version: SCHEMA_VERSION,
+            task_id: task.id.to_string(),
+            family: task.family.to_string(),
+            tags: task.tags.iter().map(|s| s.to_string()).collect(),
+            required: task.required,
+            correct: false,
+            cases: Vec::new(),
+            error: Some(err.to_string()),
+        });
+        result.correct = result.error.is_none() && result.cases.iter().all(|case| case.correct);
+        std::fs::write(
+            run_dir
+                .join("tasks")
+                .join(format!("{}.json", result.task_id.replace('.', "_"))),
+            serde_json::to_string_pretty(&result)?,
+        )?;
+        results.push(result);
+    }
+
+    let summary = RunSummary {
+        schema_version: SCHEMA_VERSION,
+        meta,
+        task_count: results.len(),
+        passed_tasks: results.iter().filter(|task| task.correct).count(),
+        required_task_count: results.iter().filter(|task| task.required).count(),
+        passed_required_tasks: results
+            .iter()
+            .filter(|task| task.required && task.correct)
+            .count(),
+        tasks: results,
+    };
+    std::fs::write(
+        run_dir.join("summary.json"),
+        serde_json::to_string_pretty(&summary)?,
+    )?;
+    append_history(&cfg.run_root.join("history.jsonl"), &summary)?;
+    Ok((run_dir, summary))
+}
+
+pub fn load_summary(path: &Path) -> Result<RunSummary> {
+    let summary_path = if path.is_dir() {
+        path.join("summary.json")
+    } else {
+        path.to_path_buf()
+    };
+    let bytes =
+        std::fs::read(&summary_path).with_context(|| format!("read {}", summary_path.display()))?;
+    Ok(serde_json::from_slice(&bytes)?)
+}
+
+pub fn diff_runs(baseline: &RunSummary, candidate: &RunSummary, max_regression: f64) -> DiffReport {
+    let mut candidate_by_id = BTreeMap::new();
+    for task in &candidate.tasks {
+        candidate_by_id.insert(task.task_id.as_str(), task);
+    }
+
+    let mut tasks = Vec::new();
+    for base_task in baseline.tasks.iter().filter(|task| task.required) {
+        let Some(cand_task) = candidate_by_id.get(base_task.task_id.as_str()) else {
+            let base_med = task_median(base_task);
+            tasks.push(DiffTask {
+                task_id: base_task.task_id.clone(),
+                correct: false,
+                baseline_median_us: base_med,
+                candidate_median_us: 0.0,
+                speedup: 0.0,
+                regression: true,
+            });
+            continue;
+        };
+        let base_med = task_median(base_task);
+        let cand_med = task_median(cand_task);
+        let speedup = if cand_med > 0.0 {
+            base_med / cand_med
+        } else {
+            0.0
+        };
+        let correct = base_task.correct && cand_task.correct;
+        let regression = !correct || cand_med > base_med * (1.0 + max_regression);
+        tasks.push(DiffTask {
+            task_id: base_task.task_id.clone(),
+            correct,
+            baseline_median_us: base_med,
+            candidate_median_us: cand_med,
+            speedup,
+            regression,
+        });
+    }
+
+    let valid: Vec<_> = tasks.iter().filter(|task| task.correct).collect();
+    let fast_count = valid.iter().filter(|task| task.speedup > 1.0).count();
+    let fast_p = if tasks.is_empty() {
+        0.0
+    } else {
+        fast_count as f64 / tasks.len() as f64
+    };
+    let geomean_speedup = if valid.is_empty() {
+        0.0
+    } else {
+        (valid
+            .iter()
+            .map(|task| task.speedup.max(1e-9).ln())
+            .sum::<f64>()
+            / valid.len() as f64)
+            .exp()
+    };
+    let worst_regression = tasks
+        .iter()
+        .filter(|task| task.regression)
+        .min_by(|a, b| a.speedup.total_cmp(&b.speedup))
+        .cloned();
+
+    DiffReport {
+        correct: worst_regression.is_none(),
+        fast_p,
+        geomean_speedup,
+        worst_regression,
+        tasks,
+    }
+}
+
+pub fn diff_exit_code(diff: &DiffReport, min_speedup: f64) -> i32 {
+    if diff.tasks.iter().any(|task| !task.correct) {
+        2
+    } else if diff.tasks.iter().any(|task| task.regression) {
+        3
+    } else if diff.geomean_speedup < min_speedup {
+        4
+    } else {
+        0
+    }
+}
+
+pub fn render_markdown(summary: &RunSummary) -> String {
+    let mut s = String::new();
+    s.push_str("# SuperSonic Kernel Lab\n\n");
+    s.push_str(&format!(
+        "- run: `{}`\n- git: `{}`{}\n- backend: `{}` device `{}` arch `{}`\n- required: {}/{}\n\n",
+        summary.meta.run_id,
+        summary.meta.git_sha,
+        if summary.meta.git_dirty {
+            " (dirty)"
+        } else {
+            ""
+        },
+        summary.meta.backend,
+        summary.meta.device,
+        summary.meta.arch,
+        summary.passed_required_tasks,
+        summary.required_task_count
+    ));
+    s.push_str("| task | correct | timing | median us |\n| --- | --- | --- | ---: |\n");
+    for task in &summary.tasks {
+        let timing_source = task
+            .cases
+            .first()
+            .map(|case| case.timing_source.as_str())
+            .unwrap_or("unknown");
+        s.push_str(&format!(
+            "| `{}` | {} | `{}` | {:.3} |\n",
+            task.task_id,
+            if task.correct { "yes" } else { "no" },
+            timing_source,
+            task_median(task)
+        ));
+    }
+    s
+}
+
+pub fn render_diff_markdown(diff: &DiffReport, min_speedup: f64) -> String {
+    let mut s = String::new();
+    s.push_str("# SuperSonic Kernel Lab Diff\n\n");
+    s.push_str(&format!(
+        "- correct: `{}`\n- fast_p: `{:.3}`\n- geomean speedup: `{:.3}`\n- min speedup: `{:.3}`\n\n",
+        diff.correct, diff.fast_p, diff.geomean_speedup, min_speedup
+    ));
+    s.push_str("| task | correct | baseline us | candidate us | speedup | regression |\n");
+    s.push_str("| --- | --- | ---: | ---: | ---: | --- |\n");
+    for task in &diff.tasks {
+        s.push_str(&format!(
+            "| `{}` | {} | {:.3} | {:.3} | {:.3} | {} |\n",
+            task.task_id,
+            if task.correct { "yes" } else { "no" },
+            task.baseline_median_us,
+            task.candidate_median_us,
+            task.speedup,
+            if task.regression { "yes" } else { "no" }
+        ));
+    }
+    s
+}
+
+pub fn task_median(task: &TaskResult) -> f64 {
+    let mut samples: Vec<f64> = task.cases.iter().map(|case| case.median_us).collect();
+    median(&mut samples)
+}
+
+pub fn summarize_times_us(samples: &[f64]) -> (f64, f64, f64, f64) {
+    let mut sorted = samples.to_vec();
+    sorted.sort_by(|a, b| a.total_cmp(b));
+    let median = median(&mut sorted.clone());
+    let mean = if samples.is_empty() {
+        0.0
+    } else {
+        samples.iter().sum::<f64>() / samples.len() as f64
+    };
+    let min = sorted.first().copied().unwrap_or(0.0);
+    let p95 = if sorted.is_empty() {
+        0.0
+    } else {
+        sorted[((sorted.len() - 1) as f64 * 0.95).round() as usize]
+    };
+    (median, mean, min, p95)
+}
+
+fn append_history(path: &Path, summary: &RunSummary) -> Result<()> {
+    let mut tasks = BTreeMap::new();
+    for task in &summary.tasks {
+        tasks.insert(task.task_id.clone(), task_median(task));
+    }
+    let entry = HistoryEntry {
+        schema_version: SCHEMA_VERSION,
+        run_id: summary.meta.run_id.clone(),
+        timestamp_utc: summary.meta.timestamp_utc.clone(),
+        git_sha: summary.meta.git_sha.clone(),
+        git_dirty: summary.meta.git_dirty,
+        backend: summary.meta.backend.clone(),
+        device: summary.meta.device,
+        arch: summary.meta.arch.clone(),
+        required: format!(
+            "{}/{}",
+            summary.passed_required_tasks, summary.required_task_count
+        ),
+        tasks,
+    };
+    let line = serde_json::to_string(&entry)?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    use std::io::Write;
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)?;
+    writeln!(file, "{line}")?;
+    Ok(())
+}
+
+fn median(samples: &mut [f64]) -> f64 {
+    if samples.is_empty() {
+        return 0.0;
+    }
+    samples.sort_by(|a, b| a.total_cmp(b));
+    let mid = samples.len() / 2;
+    if samples.len() % 2 == 0 {
+        (samples[mid - 1] + samples[mid]) * 0.5
+    } else {
+        samples[mid]
+    }
+}
+
+fn allocate_run_dir(parent: &Path, git_sha: &str, today: &str) -> PathBuf {
+    let base = format!("{today}-{git_sha}");
+    let mut candidate = parent.join(&base);
+    let mut n = 2;
+    while candidate.exists() {
+        candidate = parent.join(format!("{base}-{n}"));
+        n += 1;
+    }
+    candidate
+}
+
+fn capture<const N: usize>(args: [&str; N]) -> Option<String> {
+    capture_cmd("git", &args)
+}
+
+fn capture_cmd(cmd: &str, args: &[&str]) -> Option<String> {
+    let output = std::process::Command::new(cmd).args(args).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn task(id: &str, correct: bool, median: f64) -> TaskResult {
+        TaskResult {
+            schema_version: SCHEMA_VERSION,
+            task_id: id.into(),
+            family: "test".into(),
+            tags: Vec::new(),
+            required: true,
+            correct,
+            cases: vec![CaseResult {
+                name: "case".into(),
+                shape: BTreeMap::new(),
+                correct,
+                max_abs: None,
+                max_rel: None,
+                min_cos: None,
+                exact: Some(correct),
+                warmup: 0,
+                iters: 1,
+                timing_source: "wall_sync".into(),
+                median_us: median,
+                mean_us: median,
+                min_us: median,
+                p95_us: median,
+            }],
+            error: None,
+        }
+    }
+
+    fn summary(tasks: Vec<TaskResult>) -> RunSummary {
+        RunSummary {
+            schema_version: SCHEMA_VERSION,
+            meta: MetaJson {
+                schema_version: SCHEMA_VERSION,
+                run_id: "test".into(),
+                timestamp_utc: "now".into(),
+                git_sha: "sha".into(),
+                git_dirty: false,
+                backend: "HIP".into(),
+                device: 0,
+                arch: "gfx1100".into(),
+                rocm_smi: String::new(),
+            },
+            task_count: tasks.len(),
+            passed_tasks: tasks.iter().filter(|task| task.correct).count(),
+            required_task_count: tasks.len(),
+            passed_required_tasks: tasks.iter().filter(|task| task.correct).count(),
+            tasks,
+        }
+    }
+
+    #[test]
+    fn diff_flags_latency_regression() {
+        let base = summary(vec![task("a", true, 100.0)]);
+        let cand = summary(vec![task("a", true, 110.0)]);
+        let diff = diff_runs(&base, &cand, 0.03);
+        assert!(!diff.correct);
+        assert!(diff.tasks[0].regression);
+    }
+
+    #[test]
+    fn diff_accepts_correct_speedup() {
+        let base = summary(vec![task("a", true, 100.0), task("b", true, 200.0)]);
+        let cand = summary(vec![task("a", true, 80.0), task("b", true, 160.0)]);
+        let diff = diff_runs(&base, &cand, 0.03);
+        assert!(diff.correct);
+        assert_eq!(diff.fast_p, 1.0);
+        assert!(diff.geomean_speedup > 1.24 && diff.geomean_speedup < 1.26);
+        assert!(diff.worst_regression.is_none());
+    }
+
+    #[test]
+    fn diff_flags_correctness_regression() {
+        let base = summary(vec![task("a", true, 100.0)]);
+        let cand = summary(vec![task("a", false, 80.0)]);
+        let diff = diff_runs(&base, &cand, 0.03);
+        assert!(!diff.correct);
+        assert!(diff.tasks[0].regression);
+        assert_eq!(diff.fast_p, 0.0);
+    }
+
+    #[test]
+    fn diff_flags_missing_required_candidate_task() {
+        let base = summary(vec![task("a", true, 100.0), task("b", true, 200.0)]);
+        let cand = summary(vec![task("a", true, 80.0)]);
+        let diff = diff_runs(&base, &cand, 0.03);
+        assert!(!diff.correct);
+        assert_eq!(diff.tasks.len(), 2);
+        assert_eq!(diff.tasks[1].task_id, "b");
+        assert!(diff.tasks[1].regression);
+        assert_eq!(diff.tasks[1].candidate_median_us, 0.0);
+    }
+
+    #[test]
+    fn diff_exit_code_distinguishes_failure_modes() {
+        let base = summary(vec![task("a", true, 100.0)]);
+        let bad_correctness = summary(vec![task("a", false, 80.0)]);
+        assert_eq!(
+            diff_exit_code(&diff_runs(&base, &bad_correctness, 0.03), 1.02),
+            2
+        );
+
+        let slow = summary(vec![task("a", true, 110.0)]);
+        assert_eq!(diff_exit_code(&diff_runs(&base, &slow, 0.03), 1.02), 3);
+
+        let flat = summary(vec![task("a", true, 100.0)]);
+        assert_eq!(diff_exit_code(&diff_runs(&base, &flat, 0.03), 1.02), 4);
+    }
+
+    #[test]
+    fn load_summary_accepts_file_or_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        let summary = summary(vec![task("a", true, 100.0)]);
+        let path = tmp.path().join("summary.json");
+        std::fs::write(&path, serde_json::to_string_pretty(&summary).unwrap()).unwrap();
+
+        let from_file = load_summary(&path).unwrap();
+        let from_dir = load_summary(tmp.path()).unwrap();
+        assert_eq!(from_file.task_count, 1);
+        assert_eq!(from_dir.tasks[0].task_id, "a");
+    }
+
+    #[test]
+    fn render_markdown_includes_run_and_task_rows() {
+        let summary = summary(vec![task("qwen35.full_attention_prefill", true, 123.4567)]);
+        let md = render_markdown(&summary);
+        assert!(md.contains("# SuperSonic Kernel Lab"));
+        assert!(md.contains("arch `gfx1100`"));
+        assert!(md.contains("`qwen35.full_attention_prefill`"));
+        assert!(md.contains("`wall_sync`"));
+        assert!(md.contains("123.457"));
+    }
+
+    #[test]
+    fn render_diff_markdown_includes_task_rows() {
+        let base = summary(vec![task("a", true, 100.0)]);
+        let cand = summary(vec![task("a", true, 80.0)]);
+        let md = render_diff_markdown(&diff_runs(&base, &cand, 0.03), 1.02);
+        assert!(md.contains("# SuperSonic Kernel Lab Diff"));
+        assert!(md.contains("`a`"));
+        assert!(md.contains("1.250"));
+    }
+
+    #[test]
+    fn summarize_times_handles_empty_and_even_samples() {
+        assert_eq!(summarize_times_us(&[]), (0.0, 0.0, 0.0, 0.0));
+        let (median, mean, min, p95) = summarize_times_us(&[4.0, 1.0, 2.0, 3.0]);
+        assert_eq!(median, 2.5);
+        assert_eq!(mean, 2.5);
+        assert_eq!(min, 1.0);
+        assert_eq!(p95, 4.0);
+    }
+
+    #[test]
+    fn resolve_tasks_accepts_csv() {
+        let tasks = resolve_tasks("qwen35.full_attention_prefill,qwen36.router_permute").unwrap();
+        assert_eq!(tasks.len(), 2);
+    }
+
+    #[test]
+    fn resolve_tasks_all_means_required_suite() {
+        let tasks = resolve_tasks("all").unwrap();
+        assert_eq!(tasks.len(), 5);
+        assert!(tasks.iter().all(|task| task.required));
+    }
+
+    #[test]
+    fn resolve_tasks_accepts_tags_and_deduplicates() {
+        let tasks = resolve_tasks("tag:prefill,qwen35.full_attention_prefill").unwrap();
+        let ids: Vec<_> = tasks.iter().map(|task| task.id).collect();
+        assert_eq!(
+            ids,
+            vec![
+                "qwen35.full_attention_prefill",
+                "qwen36.batched_prefill_attn_full"
+            ]
+        );
+    }
+
+    #[test]
+    fn resolve_tasks_rejects_unknown_tag() {
+        let err = resolve_tasks("tag:not-a-real-tag").unwrap_err();
+        assert!(err.to_string().contains("unknown task tag"));
+    }
+
+    #[test]
+    fn resolve_tasks_accepts_stress_tag() {
+        let tasks = resolve_tasks("tag:stress").unwrap();
+        assert_eq!(tasks.len(), 3);
+        assert!(tasks.iter().all(|task| !task.required));
+    }
+}

--- a/crates/kernel-lab/src/tasks.rs
+++ b/crates/kernel-lab/src/tasks.rs
@@ -1,0 +1,1383 @@
+use crate::registry::TaskDef;
+use crate::run::{summarize_times_us, CaseResult, KernelLabConfig, TaskResult, SCHEMA_VERSION};
+use anyhow::{anyhow, Result};
+use gpu_hal::{Backend, GpuBuffer, ScalarType};
+use kernel_ffi::{prefill_ffi, qwen36_moe};
+use std::collections::BTreeMap;
+use std::time::Instant;
+
+const GROUP_SIZE: usize = 128;
+
+#[derive(Clone, Copy)]
+struct AttnShape {
+    q_heads: usize,
+    kv_heads: usize,
+    q_len: usize,
+    kv_len: usize,
+    head_dim: usize,
+    seed: usize,
+}
+
+#[derive(Clone, Copy)]
+struct RouterShape {
+    n_tokens: usize,
+    top_k: usize,
+    num_experts: usize,
+    seed: u64,
+}
+
+#[derive(Clone, Copy)]
+struct ExpertShape {
+    n_tokens: usize,
+    top_k: usize,
+    num_experts: usize,
+    hidden: usize,
+    moe_intermediate: usize,
+    seed: u64,
+}
+
+struct TimedSamples {
+    source: &'static str,
+    us: Vec<f64>,
+}
+
+pub fn qwen35_full_attention_prefill(cfg: &KernelLabConfig) -> Result<TaskResult> {
+    let task = crate::find_task("qwen35.full_attention_prefill").unwrap();
+    let shapes = [
+        AttnShape {
+            q_heads: 4,
+            kv_heads: 2,
+            q_len: 16,
+            kv_len: 16,
+            head_dim: 256,
+            seed: 0xCAFE,
+        },
+        AttnShape {
+            q_heads: 4,
+            kv_heads: 2,
+            q_len: 17,
+            kv_len: 17,
+            head_dim: 256,
+            seed: 0xCAFE,
+        },
+        AttnShape {
+            q_heads: 4,
+            kv_heads: 2,
+            q_len: 16,
+            kv_len: 256,
+            head_dim: 256,
+            seed: 0xCAFE,
+        },
+    ];
+    task_result(
+        task,
+        shapes
+            .iter()
+            .map(|&shape| run_qwen35_attn_case(cfg, shape))
+            .collect(),
+    )
+}
+
+pub fn qwen36_batched_prefill_attn_full(cfg: &KernelLabConfig) -> Result<TaskResult> {
+    let task = crate::find_task("qwen36.batched_prefill_attn_full").unwrap();
+    let shapes = [
+        AttnShape {
+            q_heads: 16,
+            kv_heads: 2,
+            q_len: 16,
+            kv_len: 16,
+            head_dim: 256,
+            seed: 0xC36E,
+        },
+        AttnShape {
+            q_heads: 16,
+            kv_heads: 2,
+            q_len: 33,
+            kv_len: 64,
+            head_dim: 256,
+            seed: 0xC36E,
+        },
+        AttnShape {
+            q_heads: 16,
+            kv_heads: 2,
+            q_len: 64,
+            kv_len: 64,
+            head_dim: 256,
+            seed: 0xC36E,
+        },
+    ];
+    task_result(
+        task,
+        shapes
+            .iter()
+            .map(|&shape| run_qwen36_attn_case(cfg, shape))
+            .collect(),
+    )
+}
+
+pub fn qwen36_batched_prefill_attn_full_stress(cfg: &KernelLabConfig) -> Result<TaskResult> {
+    let task = crate::find_task("qwen36.batched_prefill_attn_full.stress").unwrap();
+    let shapes = [
+        AttnShape {
+            q_heads: 16,
+            kv_heads: 2,
+            q_len: 128,
+            kv_len: 512,
+            head_dim: 256,
+            seed: 0x5A36,
+        },
+        AttnShape {
+            q_heads: 16,
+            kv_heads: 2,
+            q_len: 256,
+            kv_len: 1024,
+            head_dim: 256,
+            seed: 0x5A37,
+        },
+    ];
+    task_result(
+        task,
+        shapes
+            .iter()
+            .map(|&shape| run_qwen36_attn_case(cfg, shape))
+            .collect(),
+    )
+}
+
+pub fn qwen36_router_permute(cfg: &KernelLabConfig) -> Result<TaskResult> {
+    let task = crate::find_task("qwen36.router_permute").unwrap();
+    let shapes = [
+        RouterShape {
+            n_tokens: 1,
+            top_k: 8,
+            num_experts: 256,
+            seed: 0x1,
+        },
+        RouterShape {
+            n_tokens: 64,
+            top_k: 8,
+            num_experts: 256,
+            seed: 0x3,
+        },
+        RouterShape {
+            n_tokens: 128,
+            top_k: 8,
+            num_experts: 256,
+            seed: 0x4,
+        },
+    ];
+    task_result(
+        task,
+        shapes
+            .iter()
+            .map(|&shape| run_router_case(cfg, shape))
+            .collect(),
+    )
+}
+
+pub fn qwen36_router_permute_stress(cfg: &KernelLabConfig) -> Result<TaskResult> {
+    let task = crate::find_task("qwen36.router_permute.stress").unwrap();
+    let shapes = [
+        RouterShape {
+            n_tokens: 512,
+            top_k: 8,
+            num_experts: 256,
+            seed: 0x44,
+        },
+        RouterShape {
+            n_tokens: 1024,
+            top_k: 8,
+            num_experts: 256,
+            seed: 0x45,
+        },
+    ];
+    task_result(
+        task,
+        shapes
+            .iter()
+            .map(|&shape| run_router_case(cfg, shape))
+            .collect(),
+    )
+}
+
+pub fn qwen36_grouped_expert_int4(cfg: &KernelLabConfig) -> Result<TaskResult> {
+    let task = crate::find_task("qwen36.grouped_expert_int4").unwrap();
+    let shapes = [
+        ExpertShape {
+            n_tokens: 4,
+            top_k: 2,
+            num_experts: 8,
+            hidden: 128,
+            moe_intermediate: 128,
+            seed: 0x10,
+        },
+        ExpertShape {
+            n_tokens: 16,
+            top_k: 8,
+            num_experts: 64,
+            hidden: 512,
+            moe_intermediate: 256,
+            seed: 0x20,
+        },
+    ];
+    task_result(
+        task,
+        shapes
+            .iter()
+            .map(|&shape| run_grouped_expert_case(cfg, shape))
+            .collect(),
+    )
+}
+
+pub fn qwen36_grouped_expert_int4_stress(cfg: &KernelLabConfig) -> Result<TaskResult> {
+    let task = crate::find_task("qwen36.grouped_expert_int4.stress").unwrap();
+    let shapes = [ExpertShape {
+        n_tokens: 64,
+        top_k: 8,
+        num_experts: 256,
+        hidden: 1024,
+        moe_intermediate: 256,
+        seed: 0x2036,
+    }];
+    task_result(
+        task,
+        shapes
+            .iter()
+            .map(|&shape| run_grouped_expert_case(cfg, shape))
+            .collect(),
+    )
+}
+
+pub fn qwen36_unpermute_combine(cfg: &KernelLabConfig) -> Result<TaskResult> {
+    let task = crate::find_task("qwen36.unpermute_combine").unwrap();
+    let shapes = [
+        ExpertShape {
+            n_tokens: 4,
+            top_k: 2,
+            num_experts: 8,
+            hidden: 128,
+            moe_intermediate: 128,
+            seed: 0x42,
+        },
+        ExpertShape {
+            n_tokens: 64,
+            top_k: 8,
+            num_experts: 256,
+            hidden: 512,
+            moe_intermediate: 128,
+            seed: 0x43,
+        },
+    ];
+    task_result(
+        task,
+        shapes
+            .iter()
+            .map(|&shape| run_unpermute_case(cfg, shape))
+            .collect(),
+    )
+}
+
+fn task_result(task: &TaskDef, cases: Result<Vec<CaseResult>>) -> Result<TaskResult> {
+    let cases = cases?;
+    let correct = cases.iter().all(|case| case.correct);
+    Ok(TaskResult {
+        schema_version: SCHEMA_VERSION,
+        task_id: task.id.to_string(),
+        family: task.family.to_string(),
+        tags: task.tags.iter().map(|s| s.to_string()).collect(),
+        required: task.required,
+        correct,
+        cases,
+        error: None,
+    })
+}
+
+fn ensure_hip(cfg: &KernelLabConfig) -> Result<()> {
+    if cfg.backend != Backend::Hip {
+        return Err(anyhow!(
+            "kernel-lab v1 task requires HIP backend, got {}",
+            cfg.backend
+        ));
+    }
+    if !gpu_hal::is_backend_compiled(Backend::Hip) {
+        return Err(anyhow!("HIP backend is not compiled"));
+    }
+    Ok(())
+}
+
+fn run_qwen35_attn_case(cfg: &KernelLabConfig, shape: AttnShape) -> Result<CaseResult> {
+    ensure_hip(cfg)?;
+    let batch = 1;
+    let scale = 1.0 / (shape.head_dim as f32).sqrt();
+    let seqlen_offset = shape.kv_len.saturating_sub(shape.q_len);
+    let (q_buf, k_buf, v_buf, q_f32, k_f32, v_f32) = make_attn_buffers(cfg.device, shape, batch)?;
+    let mut out_buf = GpuBuffer::zeros(
+        cfg.device,
+        ScalarType::F32,
+        &[batch, shape.q_heads, shape.q_len, shape.head_dim],
+    )?;
+
+    prefill_ffi::full_attention_prefill(
+        cfg.device,
+        ScalarType::BF16,
+        batch,
+        shape.q_heads,
+        shape.kv_heads,
+        shape.q_len,
+        shape.kv_len,
+        shape.head_dim,
+        scale,
+        seqlen_offset,
+        &q_buf,
+        &k_buf,
+        &v_buf,
+        &mut out_buf,
+    )?;
+    gpu_hal::sync(cfg.device)?;
+    let got = download_f32(&out_buf)?;
+    let want = cpu_attention_fp32(
+        batch,
+        shape.q_heads,
+        shape.kv_heads,
+        shape.q_len,
+        shape.kv_len,
+        shape.head_dim,
+        scale,
+        seqlen_offset,
+        &q_f32,
+        &k_f32,
+        &v_f32,
+    );
+    let (max_abs, max_rel) = max_abs_rel(&got, &want, 1e-6);
+    let samples = measure_us(cfg, || {
+        prefill_ffi::full_attention_prefill(
+            cfg.device,
+            ScalarType::BF16,
+            batch,
+            shape.q_heads,
+            shape.kv_heads,
+            shape.q_len,
+            shape.kv_len,
+            shape.head_dim,
+            scale,
+            seqlen_offset,
+            &q_buf,
+            &k_buf,
+            &v_buf,
+            &mut out_buf,
+        )
+    })?;
+    Ok(case_result(
+        "qwen35_attn",
+        attn_shape_map(shape),
+        max_abs < 2e-2 && max_rel < 1e-2,
+        Some(max_abs),
+        Some(max_rel),
+        None,
+        None,
+        cfg,
+        &samples,
+    ))
+}
+
+fn run_qwen36_attn_case(cfg: &KernelLabConfig, shape: AttnShape) -> Result<CaseResult> {
+    ensure_hip(cfg)?;
+    let batch = 1;
+    let scale = 1.0 / (shape.head_dim as f32).sqrt();
+    let seqlen_offset = shape.kv_len.saturating_sub(shape.q_len);
+    let (q_buf, k_buf, v_buf, q_f32, k_f32, v_f32) = make_attn_buffers(cfg.device, shape, batch)?;
+    let mut out_buf = GpuBuffer::zeros(
+        cfg.device,
+        ScalarType::F32,
+        &[batch, shape.q_heads, shape.q_len, shape.head_dim],
+    )?;
+    qwen36_moe::batched_prefill_attn_full_launch(
+        cfg.device,
+        batch,
+        shape.q_heads,
+        shape.kv_heads,
+        shape.q_len,
+        shape.kv_len,
+        shape.head_dim,
+        scale,
+        seqlen_offset,
+        &q_buf,
+        &k_buf,
+        &v_buf,
+        &mut out_buf,
+    )?;
+    gpu_hal::sync(cfg.device)?;
+    let got = download_f32(&out_buf)?;
+    let want = cpu_attention_fp32(
+        batch,
+        shape.q_heads,
+        shape.kv_heads,
+        shape.q_len,
+        shape.kv_len,
+        shape.head_dim,
+        scale,
+        seqlen_offset,
+        &q_f32,
+        &k_f32,
+        &v_f32,
+    );
+    let (max_abs, max_rel) = max_abs_rel(&got, &want, 1e-3);
+    let samples = measure_us(cfg, || {
+        qwen36_moe::batched_prefill_attn_full_launch(
+            cfg.device,
+            batch,
+            shape.q_heads,
+            shape.kv_heads,
+            shape.q_len,
+            shape.kv_len,
+            shape.head_dim,
+            scale,
+            seqlen_offset,
+            &q_buf,
+            &k_buf,
+            &v_buf,
+            &mut out_buf,
+        )
+    })?;
+    Ok(case_result(
+        "qwen36_attn",
+        attn_shape_map(shape),
+        max_abs < 2e-2 && max_rel < 5e-2,
+        Some(max_abs),
+        Some(max_rel),
+        None,
+        None,
+        cfg,
+        &samples,
+    ))
+}
+
+fn run_router_case(cfg: &KernelLabConfig, shape: RouterShape) -> Result<CaseResult> {
+    ensure_hip(cfg)?;
+    let total = shape.n_tokens * shape.top_k;
+    let topk_idx_host = make_topk_idx(shape.n_tokens, shape.top_k, shape.num_experts, shape.seed);
+    let topk_w_host = make_topk_weight(shape.n_tokens, shape.top_k, shape.seed + 0xA5A5);
+    let topk_idx = upload_i32(cfg.device, &topk_idx_host, &[shape.n_tokens, shape.top_k])?;
+    let topk_weight = upload_bf16(cfg.device, &topk_w_host, &[shape.n_tokens, shape.top_k])?;
+    let mut offsets = GpuBuffer::zeros(cfg.device, ScalarType::U32, &[shape.num_experts + 1])?;
+    let mut p_token = GpuBuffer::zeros(cfg.device, ScalarType::U32, &[total])?;
+    let mut p_kpos = GpuBuffer::zeros(cfg.device, ScalarType::U32, &[total])?;
+    let mut p_weight = GpuBuffer::zeros(cfg.device, ScalarType::BF16, &[total])?;
+
+    qwen36_moe::batched_prefill_router_permute_launch(
+        cfg.device,
+        shape.n_tokens,
+        shape.top_k,
+        shape.num_experts,
+        &topk_idx,
+        &topk_weight,
+        &mut offsets,
+        &mut p_token,
+        &mut p_kpos,
+        &mut p_weight,
+    )?;
+    gpu_hal::sync(cfg.device)?;
+    let got_offsets = download_i32(&offsets)?;
+    let got_token = download_i32(&p_token)?;
+    let got_kpos = download_i32(&p_kpos)?;
+    let got_w = download_bf16(&p_weight)?;
+    let (want_offsets, want_token, want_kpos, want_w) = cpu_router_reference(
+        shape.n_tokens,
+        shape.top_k,
+        shape.num_experts,
+        &topk_idx_host,
+        &topk_w_host,
+    );
+    let exact = router_exact(
+        shape,
+        &got_offsets,
+        &got_token,
+        &got_kpos,
+        &got_w,
+        &want_offsets,
+        &want_token,
+        &want_kpos,
+        &want_w,
+    );
+    let samples = measure_us(cfg, || {
+        qwen36_moe::batched_prefill_router_permute_launch(
+            cfg.device,
+            shape.n_tokens,
+            shape.top_k,
+            shape.num_experts,
+            &topk_idx,
+            &topk_weight,
+            &mut offsets,
+            &mut p_token,
+            &mut p_kpos,
+            &mut p_weight,
+        )
+    })?;
+    Ok(case_result(
+        "router_permute",
+        router_shape_map(shape),
+        exact,
+        None,
+        None,
+        None,
+        Some(exact),
+        cfg,
+        &samples,
+    ))
+}
+
+fn run_grouped_expert_case(cfg: &KernelLabConfig, shape: ExpertShape) -> Result<CaseResult> {
+    ensure_hip(cfg)?;
+    let total_rows = shape.n_tokens * shape.top_k;
+    let x_host = make_x_norm(shape.n_tokens, shape.hidden, shape.seed);
+    let topk_idx = make_topk_idx(
+        shape.n_tokens,
+        shape.top_k,
+        shape.num_experts,
+        shape.seed + 0x101,
+    );
+    let (offsets_host, perm_token_host) =
+        cpu_router_permute_indices(shape.n_tokens, shape.top_k, shape.num_experts, &topk_idx);
+    let (gu_w, gu_s, gu_z, dp_w, dp_s, dp_z) = make_expert_weights(shape);
+
+    let x = upload_bf16(cfg.device, &x_host, &[shape.n_tokens, shape.hidden])?;
+    let offsets = upload_i32(cfg.device, &offsets_host, &[shape.num_experts + 1])?;
+    let perm_token = upload_i32(cfg.device, &perm_token_host, &[total_rows])?;
+    let two_i = 2 * shape.moe_intermediate;
+    let gu_w_buf = upload_u8(
+        cfg.device,
+        &gu_w,
+        &[shape.num_experts, two_i, shape.hidden / 2],
+    )?;
+    let gu_s_buf = upload_bf16(
+        cfg.device,
+        &gu_s,
+        &[
+            shape.num_experts,
+            two_i / GROUP_SIZE,
+            shape.hidden / GROUP_SIZE,
+        ],
+    )?;
+    let gu_z_buf = upload_bf16(
+        cfg.device,
+        &gu_z,
+        &[
+            shape.num_experts,
+            two_i / GROUP_SIZE,
+            shape.hidden / GROUP_SIZE,
+        ],
+    )?;
+    let dp_w_buf = upload_u8(
+        cfg.device,
+        &dp_w,
+        &[shape.num_experts, shape.hidden, shape.moe_intermediate / 2],
+    )?;
+    let dp_s_buf = upload_bf16(
+        cfg.device,
+        &dp_s,
+        &[
+            shape.num_experts,
+            shape.hidden / GROUP_SIZE,
+            shape.moe_intermediate / GROUP_SIZE,
+        ],
+    )?;
+    let dp_z_buf = upload_bf16(
+        cfg.device,
+        &dp_z,
+        &[
+            shape.num_experts,
+            shape.hidden / GROUP_SIZE,
+            shape.moe_intermediate / GROUP_SIZE,
+        ],
+    )?;
+    let mut out = GpuBuffer::zeros(cfg.device, ScalarType::BF16, &[total_rows, shape.hidden])?;
+    let mut counters = GpuBuffer::zeros(cfg.device, ScalarType::U32, &[1])?;
+    qwen36_moe::batched_prefill_grouped_expert_launch(
+        cfg.device,
+        shape.n_tokens,
+        shape.top_k,
+        shape.num_experts,
+        shape.hidden,
+        shape.moe_intermediate,
+        GROUP_SIZE,
+        &x,
+        &offsets,
+        &perm_token,
+        &gu_w_buf,
+        &gu_s_buf,
+        &gu_z_buf,
+        &dp_w_buf,
+        &dp_s_buf,
+        &dp_z_buf,
+        &mut out,
+        &mut counters,
+    )?;
+    gpu_hal::sync(cfg.device)?;
+    let got = download_bf16(&out)?;
+    let want = cpu_grouped_expert(
+        shape,
+        &x_host,
+        &perm_token_host,
+        &offsets_host,
+        &gu_w,
+        &gu_s,
+        &gu_z,
+        &dp_w,
+        &dp_s,
+        &dp_z,
+    );
+    let (max_abs_norm, min_cos) = vector_abs_norm_and_min_cos(&got, &want, shape.hidden);
+    let samples = measure_us(cfg, || {
+        gpu_hal::memset_zeros(
+            cfg.device,
+            counters.as_mut_ptr(),
+            counters.elem_count() * std::mem::size_of::<u32>(),
+        )?;
+        qwen36_moe::batched_prefill_grouped_expert_launch(
+            cfg.device,
+            shape.n_tokens,
+            shape.top_k,
+            shape.num_experts,
+            shape.hidden,
+            shape.moe_intermediate,
+            GROUP_SIZE,
+            &x,
+            &offsets,
+            &perm_token,
+            &gu_w_buf,
+            &gu_s_buf,
+            &gu_z_buf,
+            &dp_w_buf,
+            &dp_s_buf,
+            &dp_z_buf,
+            &mut out,
+            &mut counters,
+        )
+    })?;
+    Ok(case_result(
+        "grouped_expert_int4",
+        expert_shape_map(shape),
+        max_abs_norm < 2e-2 && min_cos >= 0.999,
+        Some(max_abs_norm),
+        None,
+        Some(min_cos),
+        None,
+        cfg,
+        &samples,
+    ))
+}
+
+fn run_unpermute_case(cfg: &KernelLabConfig, shape: ExpertShape) -> Result<CaseResult> {
+    ensure_hip(cfg)?;
+    let total = shape.n_tokens * shape.top_k;
+    let topk_idx = make_topk_idx(shape.n_tokens, shape.top_k, shape.num_experts, shape.seed);
+    let topk_w = make_topk_weight(shape.n_tokens, shape.top_k, shape.seed + 0x55);
+    let (_offsets, perm_token, perm_kpos, perm_weight) = cpu_router_reference(
+        shape.n_tokens,
+        shape.top_k,
+        shape.num_experts,
+        &topk_idx,
+        &topk_w,
+    );
+    let mut inverse = vec![0i32; total];
+    for row in 0..total {
+        inverse[perm_token[row] as usize * shape.top_k + perm_kpos[row] as usize] = row as i32;
+    }
+    let expert_out_host = make_bf16(total * shape.hidden, shape.seed + 0x777).0;
+    let want = cpu_unpermute_combine(
+        shape.n_tokens,
+        shape.top_k,
+        shape.hidden,
+        &inverse,
+        &perm_weight,
+        &expert_out_host,
+    );
+
+    let inverse_buf = upload_i32(cfg.device, &inverse, &[total])?;
+    let weight_buf = upload_bf16(cfg.device, &perm_weight, &[total])?;
+    let expert_buf = upload_bf16(cfg.device, &expert_out_host, &[total, shape.hidden])?;
+    let mut combined = GpuBuffer::zeros(
+        cfg.device,
+        ScalarType::BF16,
+        &[shape.n_tokens, shape.hidden],
+    )?;
+    qwen36_moe::batched_prefill_unpermute_combine_launch(
+        cfg.device,
+        shape.n_tokens,
+        shape.top_k,
+        shape.hidden,
+        &inverse_buf,
+        &weight_buf,
+        &expert_buf,
+        &mut combined,
+    )?;
+    gpu_hal::sync(cfg.device)?;
+    let got = download_bf16(&combined)?;
+    let (max_abs, max_rel) = max_abs_rel_bf16(&got, &want, 1e-3);
+    let samples = measure_us(cfg, || {
+        qwen36_moe::batched_prefill_unpermute_combine_launch(
+            cfg.device,
+            shape.n_tokens,
+            shape.top_k,
+            shape.hidden,
+            &inverse_buf,
+            &weight_buf,
+            &expert_buf,
+            &mut combined,
+        )
+    })?;
+    let mut shape_map = expert_shape_map(shape);
+    shape_map.remove("moe_intermediate");
+    shape_map.remove("num_experts");
+    Ok(case_result(
+        "unpermute_combine",
+        shape_map,
+        max_abs < 2e-2 && max_rel < 5e-2,
+        Some(max_abs),
+        Some(max_rel),
+        None,
+        None,
+        cfg,
+        &samples,
+    ))
+}
+
+fn measure_us<F>(cfg: &KernelLabConfig, mut f: F) -> Result<TimedSamples>
+where
+    F: FnMut() -> Result<(), gpu_hal::GpuError>,
+{
+    for _ in 0..cfg.warmup {
+        f()?;
+        gpu_hal::sync(cfg.device)?;
+    }
+
+    if let Ok(samples) = measure_gpu_event_us(cfg, &mut f) {
+        return Ok(TimedSamples {
+            source: "hip_event",
+            us: samples,
+        });
+    }
+
+    let mut us = Vec::with_capacity(cfg.iters);
+    for _ in 0..cfg.iters {
+        let start = Instant::now();
+        f()?;
+        gpu_hal::sync(cfg.device)?;
+        us.push(start.elapsed().as_secs_f64() * 1_000_000.0);
+    }
+    Ok(TimedSamples {
+        source: "wall_sync",
+        us,
+    })
+}
+
+fn measure_gpu_event_us<F>(cfg: &KernelLabConfig, f: &mut F) -> Result<Vec<f64>>
+where
+    F: FnMut() -> Result<(), gpu_hal::GpuError>,
+{
+    let mut samples = Vec::with_capacity(cfg.iters);
+    for _ in 0..cfg.iters {
+        let start = gpu_hal::GpuEvent::new(cfg.device)?;
+        let end = gpu_hal::GpuEvent::new(cfg.device)?;
+        start.record()?;
+        f()?;
+        end.record()?;
+        end.synchronize()?;
+        samples.push(gpu_hal::GpuEvent::elapsed_ms(&start, &end)? as f64 * 1000.0);
+    }
+    Ok(samples)
+}
+
+fn case_result(
+    name: &str,
+    shape: BTreeMap<String, usize>,
+    correct: bool,
+    max_abs: Option<f32>,
+    max_rel: Option<f32>,
+    min_cos: Option<f32>,
+    exact: Option<bool>,
+    cfg: &KernelLabConfig,
+    samples: &TimedSamples,
+) -> CaseResult {
+    let (median_us, mean_us, min_us, p95_us) = summarize_times_us(&samples.us);
+    CaseResult {
+        name: name.to_string(),
+        shape,
+        correct,
+        max_abs,
+        max_rel,
+        min_cos,
+        exact,
+        warmup: cfg.warmup,
+        iters: cfg.iters,
+        timing_source: samples.source.to_string(),
+        median_us,
+        mean_us,
+        min_us,
+        p95_us,
+    }
+}
+
+fn make_attn_buffers(
+    ordinal: usize,
+    shape: AttnShape,
+    batch: usize,
+) -> Result<(
+    GpuBuffer,
+    GpuBuffer,
+    GpuBuffer,
+    Vec<f32>,
+    Vec<f32>,
+    Vec<f32>,
+)> {
+    let q_elems = batch * shape.q_heads * shape.q_len * shape.head_dim;
+    let k_elems = batch * shape.kv_heads * shape.kv_len * shape.head_dim;
+    let v_elems = batch * shape.kv_heads * shape.kv_len * shape.head_dim;
+    let (q_bf, q_f32) = make_bf16(q_elems, shape.seed as u64);
+    let (k_bf, k_f32) = make_bf16(k_elems, shape.seed as u64 + 1000);
+    let (v_bf, v_f32) = make_bf16(v_elems, shape.seed as u64 + 2000);
+    Ok((
+        upload_bf16(
+            ordinal,
+            &q_bf,
+            &[batch, shape.q_heads, shape.q_len, shape.head_dim],
+        )?,
+        upload_bf16(
+            ordinal,
+            &k_bf,
+            &[batch, shape.kv_heads, shape.kv_len, shape.head_dim],
+        )?,
+        upload_bf16(
+            ordinal,
+            &v_bf,
+            &[batch, shape.kv_heads, shape.kv_len, shape.head_dim],
+        )?,
+        q_f32,
+        k_f32,
+        v_f32,
+    ))
+}
+
+fn upload_bf16(ordinal: usize, host: &[half::bf16], shape: &[usize]) -> Result<GpuBuffer> {
+    assert_eq!(host.len(), shape.iter().product::<usize>());
+    let mut buf = GpuBuffer::zeros(ordinal, ScalarType::BF16, shape)?;
+    let bytes = unsafe { std::slice::from_raw_parts(host.as_ptr() as *const u8, host.len() * 2) };
+    gpu_hal::copy_h2d(
+        ordinal,
+        buf.as_mut_ptr(),
+        bytes.as_ptr() as *const _,
+        bytes.len(),
+    )?;
+    Ok(buf)
+}
+
+fn upload_i32(ordinal: usize, host: &[i32], shape: &[usize]) -> Result<GpuBuffer> {
+    assert_eq!(host.len(), shape.iter().product::<usize>());
+    let mut buf = GpuBuffer::zeros(ordinal, ScalarType::U32, shape)?;
+    let bytes = unsafe { std::slice::from_raw_parts(host.as_ptr() as *const u8, host.len() * 4) };
+    gpu_hal::copy_h2d(
+        ordinal,
+        buf.as_mut_ptr(),
+        bytes.as_ptr() as *const _,
+        bytes.len(),
+    )?;
+    Ok(buf)
+}
+
+fn upload_u8(ordinal: usize, host: &[u8], shape: &[usize]) -> Result<GpuBuffer> {
+    Ok(GpuBuffer::from_host_bytes(
+        ordinal,
+        ScalarType::U8,
+        shape,
+        host,
+    )?)
+}
+
+fn download_f32(buf: &GpuBuffer) -> Result<Vec<f32>> {
+    let mut bytes = vec![0u8; buf.elem_count() * 4];
+    gpu_hal::copy_d2h(
+        buf.device_ordinal(),
+        bytes.as_mut_ptr() as *mut _,
+        buf.as_ptr(),
+        bytes.len(),
+    )?;
+    Ok(bytes
+        .chunks_exact(4)
+        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .collect())
+}
+
+fn download_i32(buf: &GpuBuffer) -> Result<Vec<i32>> {
+    let mut bytes = vec![0u8; buf.elem_count() * 4];
+    gpu_hal::copy_d2h(
+        buf.device_ordinal(),
+        bytes.as_mut_ptr() as *mut _,
+        buf.as_ptr(),
+        bytes.len(),
+    )?;
+    Ok(bytes
+        .chunks_exact(4)
+        .map(|c| i32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .collect())
+}
+
+fn download_bf16(buf: &GpuBuffer) -> Result<Vec<half::bf16>> {
+    let mut bytes = vec![0u8; buf.elem_count() * 2];
+    gpu_hal::copy_d2h(
+        buf.device_ordinal(),
+        bytes.as_mut_ptr() as *mut _,
+        buf.as_ptr(),
+        bytes.len(),
+    )?;
+    Ok(bytes
+        .chunks_exact(2)
+        .map(|c| half::bf16::from_bits(u16::from_le_bytes([c[0], c[1]])))
+        .collect())
+}
+
+fn make_bf16(n: usize, seed: u64) -> (Vec<half::bf16>, Vec<f32>) {
+    let bf: Vec<_> = (0..n)
+        .map(|i| {
+            let v = ((i as u64 + seed) as f32 * 0.0017).sin() * 0.4 + 0.05;
+            half::bf16::from_f32(v)
+        })
+        .collect();
+    let f32_round = bf.iter().map(|x| x.to_f32()).collect();
+    (bf, f32_round)
+}
+
+fn cpu_attention_fp32(
+    batch: usize,
+    q_heads: usize,
+    kv_heads: usize,
+    q_len: usize,
+    kv_len: usize,
+    head_dim: usize,
+    scale: f32,
+    seqlen_offset: usize,
+    q: &[f32],
+    k: &[f32],
+    v: &[f32],
+) -> Vec<f32> {
+    let groups = q_heads / kv_heads;
+    let mut out = vec![0.0f32; batch * q_heads * q_len * head_dim];
+    for b in 0..batch {
+        for hq in 0..q_heads {
+            let hk = hq / groups;
+            for qi in 0..q_len {
+                let limit = (seqlen_offset + qi + 1).min(kv_len);
+                let q_off = ((b * q_heads + hq) * q_len + qi) * head_dim;
+                let k_head = (b * kv_heads + hk) * kv_len * head_dim;
+                let v_head = (b * kv_heads + hk) * kv_len * head_dim;
+                let mut scores = vec![0f32; limit];
+                for kp in 0..limit {
+                    let k_row = k_head + kp * head_dim;
+                    let mut s = 0.0f32;
+                    for d in 0..head_dim {
+                        s += q[q_off + d] * k[k_row + d];
+                    }
+                    scores[kp] = s * scale;
+                }
+                let m = scores.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+                let mut denom = 0.0f32;
+                for s in scores.iter_mut() {
+                    *s = (*s - m).exp();
+                    denom += *s;
+                }
+                let out_off = ((b * q_heads + hq) * q_len + qi) * head_dim;
+                for d in 0..head_dim {
+                    let mut acc = 0.0f32;
+                    for kp in 0..limit {
+                        acc += scores[kp] * v[v_head + kp * head_dim + d];
+                    }
+                    out[out_off + d] = acc / denom.max(1e-12);
+                }
+            }
+        }
+    }
+    out
+}
+
+fn max_abs_rel(got: &[f32], want: &[f32], rel_floor: f32) -> (f32, f32) {
+    let mut max_abs = 0.0f32;
+    let mut max_rel = 0.0f32;
+    for (&g, &w) in got.iter().zip(want) {
+        let abs = (g - w).abs();
+        let rel = abs / w.abs().max(rel_floor);
+        max_abs = max_abs.max(abs);
+        max_rel = max_rel.max(rel);
+    }
+    (max_abs, max_rel)
+}
+
+fn max_abs_rel_bf16(got: &[half::bf16], want: &[half::bf16], rel_floor: f32) -> (f32, f32) {
+    let got_f32: Vec<_> = got.iter().map(|x| x.to_f32()).collect();
+    let want_f32: Vec<_> = want.iter().map(|x| x.to_f32()).collect();
+    max_abs_rel(&got_f32, &want_f32, rel_floor)
+}
+
+fn lcg(state: u64) -> (u64, u64) {
+    let next = state
+        .wrapping_mul(6364136223846793005)
+        .wrapping_add(1442695040888963407);
+    (next, next >> 32)
+}
+
+fn make_topk_idx(n_tokens: usize, top_k: usize, num_experts: usize, seed: u64) -> Vec<i32> {
+    let mut state = seed;
+    let mut out = Vec::with_capacity(n_tokens * top_k);
+    for _ in 0..n_tokens {
+        let mut chosen = Vec::with_capacity(top_k);
+        while chosen.len() < top_k {
+            let (next, raw) = lcg(state);
+            state = next;
+            let cand = (raw as usize % num_experts) as i32;
+            if !chosen.contains(&cand) {
+                chosen.push(cand);
+            }
+        }
+        out.extend_from_slice(&chosen);
+    }
+    out
+}
+
+fn make_topk_weight(n_tokens: usize, top_k: usize, seed: u64) -> Vec<half::bf16> {
+    let mut state = seed;
+    let mut out = Vec::with_capacity(n_tokens * top_k);
+    for _ in 0..n_tokens * top_k {
+        let (next, raw) = lcg(state);
+        state = next;
+        let v = ((raw % 10_000) as f32) / 10_000.0;
+        out.push(half::bf16::from_f32(v * 0.5 + 0.01));
+    }
+    out
+}
+
+fn cpu_router_reference(
+    n_tokens: usize,
+    top_k: usize,
+    num_experts: usize,
+    topk_idx: &[i32],
+    topk_weight: &[half::bf16],
+) -> (Vec<i32>, Vec<i32>, Vec<i32>, Vec<half::bf16>) {
+    let total = n_tokens * top_k;
+    let mut counts = vec![0i32; num_experts];
+    for &e in topk_idx {
+        counts[e as usize] += 1;
+    }
+    let mut offsets = vec![0i32; num_experts + 1];
+    for e in 0..num_experts {
+        offsets[e + 1] = offsets[e] + counts[e];
+    }
+    let mut token = vec![0i32; total];
+    let mut kpos = vec![0i32; total];
+    let mut weight = vec![half::bf16::ZERO; total];
+    let mut cursors = vec![0i32; num_experts];
+    for entry in 0..total {
+        let e = topk_idx[entry] as usize;
+        let dst = (offsets[e] + cursors[e]) as usize;
+        token[dst] = (entry / top_k) as i32;
+        kpos[dst] = (entry % top_k) as i32;
+        weight[dst] = topk_weight[entry];
+        cursors[e] += 1;
+    }
+    (offsets, token, kpos, weight)
+}
+
+fn cpu_router_permute_indices(
+    n_tokens: usize,
+    top_k: usize,
+    num_experts: usize,
+    topk_idx: &[i32],
+) -> (Vec<i32>, Vec<i32>) {
+    let weights = vec![half::bf16::ZERO; n_tokens * top_k];
+    let (offsets, token, _, _) =
+        cpu_router_reference(n_tokens, top_k, num_experts, topk_idx, &weights);
+    (offsets, token)
+}
+
+fn router_exact(
+    shape: RouterShape,
+    got_offsets: &[i32],
+    got_token: &[i32],
+    got_kpos: &[i32],
+    got_w: &[half::bf16],
+    want_offsets: &[i32],
+    want_token: &[i32],
+    want_kpos: &[i32],
+    want_w: &[half::bf16],
+) -> bool {
+    if got_offsets != want_offsets
+        || got_offsets[shape.num_experts] as usize != shape.n_tokens * shape.top_k
+    {
+        return false;
+    }
+    for e in 0..shape.num_experts {
+        let lo = got_offsets[e] as usize;
+        let hi = got_offsets[e + 1] as usize;
+        let mut got: Vec<_> = (lo..hi)
+            .map(|i| (got_token[i], got_kpos[i], got_w[i].to_bits()))
+            .collect();
+        let mut want: Vec<_> = (lo..hi)
+            .map(|i| (want_token[i], want_kpos[i], want_w[i].to_bits()))
+            .collect();
+        got.sort();
+        want.sort();
+        if got != want {
+            return false;
+        }
+    }
+    true
+}
+
+fn make_x_norm(n_tokens: usize, hidden: usize, seed: u64) -> Vec<half::bf16> {
+    let mut state = seed;
+    let mut out = Vec::with_capacity(n_tokens * hidden);
+    for _ in 0..n_tokens * hidden {
+        let (next, raw) = lcg(state);
+        state = next;
+        let v = ((raw % 10_000) as f32) / 10_000.0 - 0.5;
+        out.push(half::bf16::from_f32(v * 0.4));
+    }
+    out
+}
+
+fn bf16_round_rne_f32(x: f32) -> f32 {
+    let bits = x.to_bits();
+    let rounding_bias = 0x7FFF_u32 + ((bits >> 16) & 1);
+    f32::from_bits((bits.wrapping_add(rounding_bias)) & 0xFFFF_0000)
+}
+
+fn int4_dequant_scalar(nibble: u32, scale: half::bf16, zero: half::bf16) -> f32 {
+    bf16_round_rne_f32((nibble as f32) * scale.to_f32() - zero.to_f32() * scale.to_f32())
+}
+
+fn make_int4_slab(
+    out_rows: usize,
+    in_cols: usize,
+    gs: usize,
+    seed: u64,
+) -> (Vec<u8>, Vec<half::bf16>, Vec<half::bf16>) {
+    let scale_rows = out_rows / gs;
+    let scale_cols = in_cols / gs;
+    let mut state = seed;
+    let mut packed = vec![0u8; out_rows * (in_cols / 2)];
+    for byte in packed.iter_mut() {
+        let (next, raw) = lcg(state);
+        state = next;
+        *byte = (raw & 0xFF) as u8;
+    }
+    let mut scales = vec![half::bf16::ZERO; scale_rows * scale_cols];
+    let mut zeros = vec![half::bf16::ZERO; scale_rows * scale_cols];
+    for i in 0..scales.len() {
+        let (next, raw) = lcg(state);
+        state = next;
+        scales[i] = half::bf16::from_f32(0.001 + ((raw % 1000) as f32 / 1000.0) * 0.02);
+        let (next, raw) = lcg(state);
+        state = next;
+        zeros[i] = half::bf16::from_f32((raw % 16) as f32);
+    }
+    (packed, scales, zeros)
+}
+
+type ExpertWeights = (
+    Vec<u8>,
+    Vec<half::bf16>,
+    Vec<half::bf16>,
+    Vec<u8>,
+    Vec<half::bf16>,
+    Vec<half::bf16>,
+);
+
+fn make_expert_weights(shape: ExpertShape) -> ExpertWeights {
+    let two_i = 2 * shape.moe_intermediate;
+    let mut gu_w = Vec::new();
+    let mut gu_s = Vec::new();
+    let mut gu_z = Vec::new();
+    let mut dp_w = Vec::new();
+    let mut dp_s = Vec::new();
+    let mut dp_z = Vec::new();
+    for e in 0..shape.num_experts {
+        let (w, s, z) = make_int4_slab(
+            two_i,
+            shape.hidden,
+            GROUP_SIZE,
+            shape.seed + 0x200 + e as u64,
+        );
+        gu_w.extend(w);
+        gu_s.extend(s);
+        gu_z.extend(z);
+        let (w, s, z) = make_int4_slab(
+            shape.hidden,
+            shape.moe_intermediate,
+            GROUP_SIZE,
+            shape.seed + 0x300 + e as u64,
+        );
+        dp_w.extend(w);
+        dp_s.extend(s);
+        dp_z.extend(z);
+    }
+    (gu_w, gu_s, gu_z, dp_w, dp_s, dp_z)
+}
+
+fn int4_matvec_row(
+    packed: &[u8],
+    scales: &[half::bf16],
+    zeros: &[half::bf16],
+    in_cols: usize,
+    gs: usize,
+    row: usize,
+    x: &[f32],
+) -> f32 {
+    let byte_cols = in_cols / 2;
+    let scale_cols = in_cols / gs;
+    let scale_row = row / gs;
+    let row_byte_off = row * byte_cols;
+    let mut acc = 0.0f32;
+    let mut col = 0usize;
+    while col < in_cols {
+        for i in 0..8 {
+            let c = col + i;
+            let byte = packed[row_byte_off + c / 2];
+            let nibble = if c % 2 == 0 { byte & 0xF } else { byte >> 4 };
+            let g = c / gs;
+            acc += int4_dequant_scalar(
+                nibble as u32,
+                scales[scale_row * scale_cols + g],
+                zeros[scale_row * scale_cols + g],
+            ) * x[c];
+        }
+        col += 8;
+    }
+    acc
+}
+
+#[allow(clippy::too_many_arguments)]
+fn cpu_grouped_expert(
+    shape: ExpertShape,
+    x_norm: &[half::bf16],
+    permuted_token_idx: &[i32],
+    expert_offsets: &[i32],
+    gu_w_all: &[u8],
+    gu_s_all: &[half::bf16],
+    gu_z_all: &[half::bf16],
+    dp_w_all: &[u8],
+    dp_s_all: &[half::bf16],
+    dp_z_all: &[half::bf16],
+) -> Vec<half::bf16> {
+    let total_rows = shape.n_tokens * shape.top_k;
+    let i_dim = shape.moe_intermediate;
+    let two_i = 2 * i_dim;
+    let gu_per_expert_packed = two_i * (shape.hidden / 2);
+    let gu_per_expert_scales = (two_i / GROUP_SIZE) * (shape.hidden / GROUP_SIZE);
+    let dp_per_expert_packed = shape.hidden * (i_dim / 2);
+    let dp_per_expert_scales = (shape.hidden / GROUP_SIZE) * (i_dim / GROUP_SIZE);
+    let mut out = vec![half::bf16::ZERO; total_rows * shape.hidden];
+    for e in 0..shape.num_experts {
+        let lo = expert_offsets[e] as usize;
+        let hi = expert_offsets[e + 1] as usize;
+        let gu_w = &gu_w_all[e * gu_per_expert_packed..(e + 1) * gu_per_expert_packed];
+        let gu_s = &gu_s_all[e * gu_per_expert_scales..(e + 1) * gu_per_expert_scales];
+        let gu_z = &gu_z_all[e * gu_per_expert_scales..(e + 1) * gu_per_expert_scales];
+        let dp_w = &dp_w_all[e * dp_per_expert_packed..(e + 1) * dp_per_expert_packed];
+        let dp_s = &dp_s_all[e * dp_per_expert_scales..(e + 1) * dp_per_expert_scales];
+        let dp_z = &dp_z_all[e * dp_per_expert_scales..(e + 1) * dp_per_expert_scales];
+        for row in lo..hi {
+            let token_idx = permuted_token_idx[row] as usize;
+            let x: Vec<f32> = (0..shape.hidden)
+                .map(|c| bf16_round_rne_f32(x_norm[token_idx * shape.hidden + c].to_f32()))
+                .collect();
+            let mut gu = vec![0.0f32; two_i];
+            for r in 0..two_i {
+                gu[r] = int4_matvec_row(gu_w, gu_s, gu_z, shape.hidden, GROUP_SIZE, r, &x);
+            }
+            let mut mid = vec![0.0f32; i_dim];
+            for k in 0..i_dim {
+                let gp = gu[k];
+                mid[k] = bf16_round_rne_f32((gp / (1.0 + (-gp).exp())) * gu[i_dim + k]);
+            }
+            for r in 0..shape.hidden {
+                let val = int4_matvec_row(dp_w, dp_s, dp_z, i_dim, GROUP_SIZE, r, &mid);
+                out[row * shape.hidden + r] = half::bf16::from_f32(bf16_round_rne_f32(val));
+            }
+        }
+    }
+    out
+}
+
+fn vector_abs_norm_and_min_cos(
+    got: &[half::bf16],
+    want: &[half::bf16],
+    row_width: usize,
+) -> (f32, f32) {
+    let rows = got.len() / row_width;
+    let mut max_abs = 0.0f32;
+    let mut max_mag = 0.0f32;
+    let mut min_cos = 1.0f32;
+    for row in 0..rows {
+        let mut dot = 0.0f64;
+        let mut nrm_g = 0.0f64;
+        let mut nrm_w = 0.0f64;
+        for c in 0..row_width {
+            let g = got[row * row_width + c].to_f32();
+            let w = want[row * row_width + c].to_f32();
+            max_abs = max_abs.max((g - w).abs());
+            max_mag = max_mag.max(g.abs().max(w.abs()));
+            dot += (g as f64) * (w as f64);
+            nrm_g += (g as f64) * (g as f64);
+            nrm_w += (w as f64) * (w as f64);
+        }
+        min_cos = min_cos.min((dot / (nrm_g.sqrt() * nrm_w.sqrt()).max(1e-12)) as f32);
+    }
+    (max_abs / max_mag.max(1e-3), min_cos)
+}
+
+fn cpu_unpermute_combine(
+    n_tokens: usize,
+    top_k: usize,
+    hidden: usize,
+    inverse: &[i32],
+    permuted_weight: &[half::bf16],
+    expert_out: &[half::bf16],
+) -> Vec<half::bf16> {
+    let mut out = vec![half::bf16::ZERO; n_tokens * hidden];
+    for t in 0..n_tokens {
+        for c in 0..hidden {
+            let mut acc = 0.0f32;
+            for k in 0..top_k {
+                let row = inverse[t * top_k + k] as usize;
+                acc += permuted_weight[row].to_f32() * expert_out[row * hidden + c].to_f32();
+            }
+            out[t * hidden + c] = half::bf16::from_f32(bf16_round_rne_f32(acc));
+        }
+    }
+    out
+}
+
+fn attn_shape_map(shape: AttnShape) -> BTreeMap<String, usize> {
+    BTreeMap::from([
+        ("q_heads".into(), shape.q_heads),
+        ("kv_heads".into(), shape.kv_heads),
+        ("q_len".into(), shape.q_len),
+        ("kv_len".into(), shape.kv_len),
+        ("head_dim".into(), shape.head_dim),
+    ])
+}
+
+fn router_shape_map(shape: RouterShape) -> BTreeMap<String, usize> {
+    BTreeMap::from([
+        ("n_tokens".into(), shape.n_tokens),
+        ("top_k".into(), shape.top_k),
+        ("num_experts".into(), shape.num_experts),
+    ])
+}
+
+fn expert_shape_map(shape: ExpertShape) -> BTreeMap<String, usize> {
+    BTreeMap::from([
+        ("n_tokens".into(), shape.n_tokens),
+        ("top_k".into(), shape.top_k),
+        ("num_experts".into(), shape.num_experts),
+        ("hidden".into(), shape.hidden),
+        ("moe_intermediate".into(), shape.moe_intermediate),
+    ])
+}

--- a/docs/kernel-lab.md
+++ b/docs/kernel-lab.md
@@ -1,0 +1,72 @@
+# SuperSonic Kernel Lab
+
+`kernel-lab` is a KernelBench-style harness for isolated SuperSonic kernels.
+It is intentionally in this repository because the tasks call the same
+`gpu-hal` and `kernel-ffi` launch paths as the runtime and parity tests.
+
+V1 evaluates candidate worktrees. Run it once on a baseline checkout and once
+on a candidate checkout, then compare the two run directories.
+
+```bash
+cargo run --release -p supersonic-kernel-lab --bin kernel-lab -- list
+
+cargo run --release -p supersonic-kernel-lab --bin kernel-lab -- run \
+  --tasks all \
+  --backend hip \
+  --device 0 \
+  --warmup 5 \
+  --iters 20
+
+cargo run --release -p supersonic-kernel-lab --bin kernel-lab -- run \
+  --tasks tag:prefill,tag:moe \
+  --backend hip \
+  --device 0
+
+cargo run --release -p supersonic-kernel-lab --bin kernel-lab -- diff \
+  --baseline target/kernel-lab-runs/BASELINE \
+  --candidate target/kernel-lab-runs/CANDIDATE \
+  --markdown-out target/kernel-lab-runs/diff.md
+
+cargo run --release -p supersonic-kernel-lab --bin kernel-lab -- compare-ref \
+  --baseline-ref main \
+  --candidate-ref worktree \
+  --tasks all \
+  --backend hip \
+  --device 0
+```
+
+The harness writes `meta.json`, one `tasks/*.json` file per task, and a
+`summary.json` under `target/kernel-lab-runs/<date>-<git-sha>/`.
+Per-case timings use HIP events when available and record
+`timing_source: "hip_event"` in JSON; unsupported timing backends fall back to
+synchronized wall-clock timing.
+
+`--tasks` accepts `all` for the required suite, `everything` for every registry
+entry, comma-separated task ids, or comma-separated `tag:<name>` selectors. Tag
+expansion is de-duplicated in registry order. The required task set stays fast;
+larger optional shapes are behind `--tasks tag:stress`.
+
+V1 required tasks cover the current high-leverage Qwen kernel surface:
+
+- `qwen35.full_attention_prefill`
+- `qwen36.batched_prefill_attn_full`
+- `qwen36.router_permute`
+- `qwen36.grouped_expert_int4`
+- `qwen36.unpermute_combine`
+
+Every run appends one compact line to `target/kernel-lab-runs/history.jsonl`,
+including metadata and per-task median latency. This gives a local regression
+trail across candidate runs.
+
+`compare-ref` checks out non-`worktree` refs into `target/kernel-lab-worktrees/`
+and overlays only the current `crates/kernel-lab` harness crate into that
+temporary checkout. The kernels and FFI crates are still built from the checked
+out ref, so a baseline run measures baseline kernel code even before this
+harness lands on `main`.
+
+Scoring is conservative: a task is valid only if every correctness case passes.
+`diff` reports per-task speedup, `fast_p`, geometric mean speedup, and fails on
+correctness regressions or median latency regressions above `--max-regression`.
+Exit code `2` means correctness failed, `3` means latency regression, and `4`
+means the run was correct but missed `--min-speedup`. `--github-summary`
+appends the markdown diff to `$GITHUB_STEP_SUMMARY` for Actions jobs.


### PR DESCRIPTION
## Summary
- add `supersonic-kernel-lab`, a KernelBench-style harness for isolated SuperSonic HIP kernel tasks
- cover required Qwen prefill/MoE tasks plus opt-in `tag:stress` cases
- add JSON/markdown run artifacts, history JSONL, diff exit codes, GitHub summary output, and `compare-ref` baseline/candidate workflow with harness overlay

## Verification
- `cargo fmt -p supersonic-kernel-lab --check`
- `cargo test -p supersonic-kernel-lab --lib`
- `cargo test -p supersonic-kernel-lab --bin kernel-lab`
- `cargo build --release -p supersonic-kernel-lab --bin kernel-lab`
- `rocm-smi --showuse --showmemuse --showtemp`
- `./target/release/kernel-lab run --tasks all --backend hip --device 0 --warmup 0 --iters 1`
- `./target/release/kernel-lab compare-ref --baseline-ref HEAD --candidate-ref worktree --tasks qwen36.router_permute --backend hip --device 0 --warmup 0 --iters 1 --max-regression 10.0 --min-speedup 0.0 --markdown-out target/kernel-lab-runs/compare-head-overlay-final.md`

## Notes
- `kernel-ffi` still emits existing warnings unrelated to this crate.
- `compare-ref` overlays only the harness crate into checked-out refs; kernel crates are built from the selected ref.