### PR TITLE
Wire kernel-lab CI and baselines

### DIFF
--- a/.github/workflows/kernel-lab.yml
+++ b/.github/workflows/kernel-lab.yml
@@ -1,0 +1,96 @@
+name: kernel-lab
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/kernel-lab.yml"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "crates/gpu-hal/**"
+      - "crates/kernel-ffi/**"
+      - "crates/kernel-lab/**"
+      - "kernels/**"
+  workflow_dispatch:
+    inputs:
+      tasks:
+        description: "kernel-lab task selector"
+        required: true
+        default: "qwen36.router_permute"
+      warmup:
+        description: "warmup iterations"
+        required: true
+        default: "2"
+      iters:
+        description: "timed iterations"
+        required: true
+        default: "5"
+      max_regression:
+        description: "allowed median latency regression"
+        required: true
+        default: "0.10"
+      min_speedup:
+        description: "minimum geomean speedup"
+        required: true
+        default: "0.0"
+
+concurrency:
+  group: kernel-lab-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compare-ref:
+    name: compare-ref (${{ github.event.inputs.tasks || 'qwen36.router_permute' }})
+    runs-on: [self-hosted, linux, rocm]
+    timeout-minutes: 45
+    env:
+      KERNEL_LAB_TASKS: ${{ github.event.inputs.tasks || 'qwen36.router_permute' }}
+      KERNEL_LAB_WARMUP: ${{ github.event.inputs.warmup || '2' }}
+      KERNEL_LAB_ITERS: ${{ github.event.inputs.iters || '5' }}
+      KERNEL_LAB_MAX_REGRESSION: ${{ github.event.inputs.max_regression || '0.10' }}
+      KERNEL_LAB_MIN_SPEEDUP: ${{ github.event.inputs.min_speedup || '0.0' }}
+      KERNEL_LAB_RUN_ROOT: target/kernel-lab-runs
+      KERNEL_LAB_WORKTREE_ROOT: target/kernel-lab-worktrees
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Show GPU state
+        run: rocm-smi --showuse --showmemuse --showtemp
+
+      - name: Build kernel-lab
+        run: cargo build --release -p supersonic-kernel-lab --bin kernel-lab
+
+      - name: Unit tests
+        run: |
+          cargo test -p supersonic-kernel-lab --lib
+          cargo test -p supersonic-kernel-lab --bin kernel-lab
+
+      - name: Compare candidate against base ref
+        run: |
+          BASE_REF="${{ github.event.pull_request.base.sha || 'origin/main' }}"
+          ./target/release/kernel-lab compare-ref \
+            --baseline-ref "$BASE_REF" \
+            --candidate-ref worktree \
+            --tasks "$KERNEL_LAB_TASKS" \
+            --backend hip \
+            --device 0 \
+            --warmup "$KERNEL_LAB_WARMUP" \
+            --iters "$KERNEL_LAB_ITERS" \
+            --run-root "$KERNEL_LAB_RUN_ROOT" \
+            --worktree-root "$KERNEL_LAB_WORKTREE_ROOT" \
+            --max-regression "$KERNEL_LAB_MAX_REGRESSION" \
+            --min-speedup "$KERNEL_LAB_MIN_SPEEDUP" \
+            --markdown-out "$KERNEL_LAB_RUN_ROOT/diff.md" \
+            --github-summary
+
+      - name: Upload kernel-lab artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: kernel-lab-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            target/kernel-lab-runs/**/*.json
+            target/kernel-lab-runs/**/*.md
+            target/kernel-lab-runs/history.jsonl
+          if-no-files-found: ignore

--- a/.github/workflows/kernel-lab.yml
+++ b/.github/workflows/kernel-lab.yml
@@ -59,6 +59,59 @@ jobs:
       - name: Show GPU state
         run: rocm-smi --showuse --showmemuse --showtemp
 
+      - name: Wait for GPU idle
+        run: |
+          max_wait_seconds=3600
+          interval_seconds=30
+          required_idle_samples=3
+          max_gpu_use_percent=5
+          max_vram_use_percent=20
+          idle_samples=0
+          elapsed=0
+
+          while true; do
+            rocm-smi --showuse --showmemuse --showtemp | tee /tmp/kernel-lab-rocm-smi.txt
+            gpu_use="$(
+              awk -F': ' '/GPU use \(%\)/ {
+                gsub(/[^0-9.]/, "", $2);
+                print int($2);
+                exit;
+              }' /tmp/kernel-lab-rocm-smi.txt
+            )"
+            vram_use="$(
+              awk -F': ' '/GPU Memory Allocated \(VRAM%\)/ {
+                gsub(/[^0-9.]/, "", $2);
+                print int($2);
+                exit;
+              }' /tmp/kernel-lab-rocm-smi.txt
+            )"
+
+            if [ -z "$gpu_use" ] || [ -z "$vram_use" ]; then
+              echo "failed to parse rocm-smi utilization output" >&2
+              exit 1
+            fi
+
+            if [ "$gpu_use" -le "$max_gpu_use_percent" ] && [ "$vram_use" -le "$max_vram_use_percent" ]; then
+              idle_samples=$((idle_samples + 1))
+              echo "GPU idle sample ${idle_samples}/${required_idle_samples}: gpu=${gpu_use}% vram=${vram_use}%"
+            else
+              idle_samples=0
+              echo "GPU busy: gpu=${gpu_use}% vram=${vram_use}%; waiting ${interval_seconds}s"
+            fi
+
+            if [ "$idle_samples" -ge "$required_idle_samples" ]; then
+              echo "GPU has been idle for ${required_idle_samples} consecutive samples"
+              break
+            fi
+            if [ "$elapsed" -ge "$max_wait_seconds" ]; then
+              echo "timed out waiting for GPU idle after ${max_wait_seconds}s" >&2
+              exit 1
+            fi
+
+            sleep "$interval_seconds"
+            elapsed=$((elapsed + interval_seconds))
+          done
+
       - name: Build kernel-lab
         run: cargo build --release -p supersonic-kernel-lab --bin kernel-lab
 

--- a/.github/workflows/kernel-lab.yml
+++ b/.github/workflows/kernel-lab.yml
@@ -40,6 +40,7 @@ concurrency:
 jobs:
   compare-ref:
     name: compare-ref (${{ github.event.inputs.tasks || 'qwen36.router_permute' }})
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, linux, rocm]
     timeout-minutes: 45
     env:

--- a/crates/kernel-lab/baselines/README.md
+++ b/crates/kernel-lab/baselines/README.md
@@ -1,0 +1,20 @@
+# Kernel Lab Baselines
+
+This directory is the checked-in home for reviewed `kernel-lab` baseline
+summaries. Baselines are grouped by GPU architecture:
+
+```text
+crates/kernel-lab/baselines/<arch>/<name>.summary.json
+crates/kernel-lab/baselines/<arch>/<name>.md
+```
+
+Create or refresh a baseline from a reviewed run with:
+
+```bash
+cargo run --release -p supersonic-kernel-lab --bin kernel-lab -- baseline \
+  --run target/kernel-lab-runs/<run-id> \
+  --name required
+```
+
+The JSON file is the canonical artifact used by `kernel-lab diff`. The markdown
+sidecar is for review and should be regenerated from the same run.

--- a/crates/kernel-lab/src/bin/kernel_lab.rs
+++ b/crates/kernel-lab/src/bin/kernel_lab.rs
@@ -50,6 +50,16 @@ enum Command {
         #[arg(long)]
         github_summary: bool,
     },
+    Baseline {
+        #[arg(long)]
+        run: PathBuf,
+        #[arg(long, default_value = "crates/kernel-lab/baselines")]
+        out_root: PathBuf,
+        #[arg(long)]
+        name: Option<String>,
+        #[arg(long)]
+        no_markdown: bool,
+    },
     CompareRef {
         #[arg(long, default_value = "main")]
         baseline_ref: String,
@@ -152,6 +162,16 @@ fn main() -> Result<()> {
                 std::process::exit(code);
             }
         }
+        Command::Baseline {
+            run,
+            out_root,
+            name,
+            no_markdown,
+        } => {
+            let summary = load_summary(&run)?;
+            let path = write_baseline_artifact(&summary, &out_root, name.as_deref(), !no_markdown)?;
+            println!("[kernel-lab] wrote baseline {}", path.display());
+        }
         Command::CompareRef {
             baseline_ref,
             candidate_ref,
@@ -204,6 +224,26 @@ fn main() -> Result<()> {
         }
     }
     Ok(())
+}
+
+fn write_baseline_artifact(
+    summary: &supersonic_kernel_lab::run::RunSummary,
+    out_root: &Path,
+    name: Option<&str>,
+    write_markdown: bool,
+) -> Result<PathBuf> {
+    let arch = sanitize_label(&summary.meta.arch);
+    let stem = name.map(sanitize_label).unwrap_or_else(|| {
+        sanitize_label(&format!("{}-{}", summary.meta.backend, summary.meta.run_id))
+    });
+    let out_dir = out_root.join(arch);
+    std::fs::create_dir_all(&out_dir)?;
+    let summary_path = out_dir.join(format!("{stem}.summary.json"));
+    std::fs::write(&summary_path, serde_json::to_string_pretty(summary)?)?;
+    if write_markdown {
+        std::fs::write(out_dir.join(format!("{stem}.md")), render_markdown(summary))?;
+    }
+    Ok(summary_path)
 }
 
 fn write_diff_markdown(
@@ -428,7 +468,11 @@ fn run_checked(cmd: &str, args: &[&str]) -> Result<()> {
 }
 
 fn sanitize_ref(git_ref: &str) -> String {
-    git_ref
+    sanitize_label(git_ref)
+}
+
+fn sanitize_label(label: &str) -> String {
+    label
         .chars()
         .map(|ch| {
             if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
@@ -522,6 +566,21 @@ mod tests {
         std::fs::write(new.join("summary.json"), "{}").unwrap();
 
         assert_eq!(newest_run_dir_excluding(&run_root, &before).unwrap(), new);
+    }
+
+    #[test]
+    fn write_baseline_artifact_groups_by_arch_and_sanitizes_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        let summary = test_summary(1, 1, 1, 1);
+        let path = write_baseline_artifact(&summary, tmp.path(), Some("required/gfx+smoke"), true)
+            .unwrap();
+
+        assert_eq!(
+            path.strip_prefix(tmp.path()).unwrap(),
+            Path::new("gfx1100").join("required-gfx-smoke.summary.json")
+        );
+        assert!(path.exists());
+        assert!(path.with_file_name("required-gfx-smoke.md").exists());
     }
 
     fn test_summary(

--- a/crates/kernel-lab/src/bin/kernel_lab.rs
+++ b/crates/kernel-lab/src/bin/kernel_lab.rs
@@ -312,6 +312,7 @@ fn run_ref(
     std::fs::create_dir_all(worktree_root)?;
     let label = sanitize_ref(git_ref);
     let dir = worktree_root.join(label);
+    run_checked("git", &["worktree", "prune"])?;
     if dir.exists() {
         run_checked(
             "git",

--- a/docs/kernel-lab.md
+++ b/docs/kernel-lab.md
@@ -33,6 +33,10 @@ cargo run --release -p supersonic-kernel-lab --bin kernel-lab -- compare-ref \
   --tasks all \
   --backend hip \
   --device 0
+
+cargo run --release -p supersonic-kernel-lab --bin kernel-lab -- baseline \
+  --run target/kernel-lab-runs/CANDIDATE \
+  --name required
 ```
 
 The harness writes `meta.json`, one `tasks/*.json` file per task, and a
@@ -70,3 +74,34 @@ correctness regressions or median latency regressions above `--max-regression`.
 Exit code `2` means correctness failed, `3` means latency regression, and `4`
 means the run was correct but missed `--min-speedup`. `--github-summary`
 appends the markdown diff to `$GITHUB_STEP_SUMMARY` for Actions jobs.
+
+## CI
+
+`.github/workflows/kernel-lab.yml` runs on PRs that touch kernel-lab, kernel FFI,
+GPU HAL, Cargo metadata, or HIP kernel sources. It targets a self-hosted ROCm
+runner labelled `self-hosted`, `linux`, and `rocm`. The default PR suite is the
+cheap `qwen36.router_permute` task with relaxed smoke thresholds; use
+`workflow_dispatch` to run broader selectors such as `all`, `tag:prefill`, or
+`everything` with custom iteration counts.
+
+The workflow compares the checked-out candidate worktree against the PR base
+commit using `compare-ref`, writes markdown to the GitHub step summary, and
+uploads the run JSON/markdown artifacts.
+
+## Baselines
+
+Reviewed baseline summaries live under
+`crates/kernel-lab/baselines/<arch>/<name>.summary.json`. Generate one from a
+run directory with:
+
+```bash
+cargo run --release -p supersonic-kernel-lab --bin kernel-lab -- baseline \
+  --run target/kernel-lab-runs/2026-05-06-abcdef0 \
+  --name required
+```
+
+The command groups artifacts by the run's detected architecture, writes the
+canonical JSON summary, and also writes a markdown sidecar unless
+`--no-markdown` is passed. These checked-in summaries are intended for stable
+release or lab-machine comparisons; PR gating should still prefer `compare-ref`
+when a suitable ROCm runner is available.

--- a/docs/kernel-lab.md
+++ b/docs/kernel-lab.md
@@ -93,6 +93,11 @@ The workflow compares the checked-out candidate worktree against the PR base
 commit using `compare-ref`, writes markdown to the GitHub step summary, and
 uploads the run JSON/markdown artifacts.
 
+Before building, the workflow waits for the ROCm device to report at most 5%
+GPU use and at most 20% VRAM allocation for three consecutive 30-second
+samples. If the device stays busy for one hour, the job fails with a clear
+timeout rather than running a noisy contended benchmark.
+
 ## Baselines
 
 Reviewed baseline summaries live under

--- a/docs/kernel-lab.md
+++ b/docs/kernel-lab.md
@@ -84,6 +84,11 @@ cheap `qwen36.router_permute` task with relaxed smoke thresholds; use
 `workflow_dispatch` to run broader selectors such as `all`, `tag:prefill`, or
 `everything` with custom iteration counts.
 
+Because the job executes candidate code on a persistent self-hosted GPU host,
+the PR trigger is restricted to same-repository branches. Fork PRs must be run
+through a trusted manual `workflow_dispatch` after review, or on disposable
+isolated runners.
+
 The workflow compares the checked-out candidate worktree against the PR base
 commit using `compare-ref`, writes markdown to the GitHub step summary, and
 uploads the run JSON/markdown artifacts.


### PR DESCRIPTION
## Summary
- add a self-hosted ROCm GitHub Actions workflow for `kernel-lab compare-ref` on kernel-related PRs
- add a `kernel-lab baseline` command that exports reviewed run summaries under architecture-grouped baseline paths
- document CI behavior, workflow-dispatch knobs, and the baseline artifact layout

## Verification
- `cargo fmt -p supersonic-kernel-lab --check`
- `cargo test -p supersonic-kernel-lab --bin kernel-lab`
- `cargo test -p supersonic-kernel-lab --lib`
- `cargo build --release -p supersonic-kernel-lab --bin kernel-lab`
- `python - <<PY ... yaml.safe_load(.github/workflows/kernel-lab.yml) ... PY`
- `rocm-smi --showuse --showmemuse --showtemp`
- `./target/release/kernel-lab run --tasks qwen36.router_permute --backend hip --device 0 --warmup 0 --iters 1`
- `./target/release/kernel-lab baseline --run target/kernel-lab-runs/2026-05-06-d191c7e --out-root target/kernel-lab-baselines-smoke --name router-smoke`
- `./target/release/kernel-lab compare-ref --baseline-ref origin/main --candidate-ref worktree --tasks qwen36.router_permute --backend hip --device 0 --warmup 0 --iters 1 --max-regression 10.0 --min-speedup 0.0 --markdown-out target/kernel-lab-runs/ci-smoke-diff.md`

## Notes
- The workflow expects a self-hosted runner with labels `self-hosted`, `linux`, and `rocm`.
- `kernel-ffi` still emits existing warnings unrelated to this change.