### PR TITLE
Add gfx1100 kernel-lab baseline

### DIFF
--- a/.github/workflows/kernel-lab.yml
+++ b/.github/workflows/kernel-lab.yml
@@ -73,15 +73,15 @@ jobs:
             rocm-smi --showuse --showmemuse --showtemp | tee /tmp/kernel-lab-rocm-smi.txt
             gpu_use="$(
               awk -F': ' '/GPU use \(%\)/ {
-                gsub(/[^0-9.]/, "", $2);
-                print int($2);
+                gsub(/[^0-9.]/, "", $NF);
+                print int($NF);
                 exit;
               }' /tmp/kernel-lab-rocm-smi.txt
             )"
             vram_use="$(
               awk -F': ' '/GPU Memory Allocated \(VRAM%\)/ {
-                gsub(/[^0-9.]/, "", $2);
-                print int($2);
+                gsub(/[^0-9.]/, "", $NF);
+                print int($NF);
                 exit;
               }' /tmp/kernel-lab-rocm-smi.txt
             )"

--- a/crates/kernel-lab/baselines/gfx1100/required.md
+++ b/crates/kernel-lab/baselines/gfx1100/required.md
@@ -1,0 +1,14 @@
+# SuperSonic Kernel Lab
+
+- run: `2026-05-06-e25cd03`
+- git: `e25cd03`
+- backend: `HIP` device `0` arch `gfx1100`
+- required: 5/5
+
+| task | correct | timing | median us |
+| --- | --- | --- | ---: |
+| `qwen35.full_attention_prefill` | yes | `hip_event` | 91.520 |
+| `qwen36.batched_prefill_attn_full` | yes | `hip_event` | 127.001 |
+| `qwen36.router_permute` | yes | `hip_event` | 35.680 |
+| `qwen36.grouped_expert_int4` | yes | `hip_event` | 249.502 |
+| `qwen36.unpermute_combine` | yes | `hip_event` | 36.780 |

--- a/crates/kernel-lab/baselines/gfx1100/required.summary.json
+++ b/crates/kernel-lab/baselines/gfx1100/required.summary.json
@@ -1,0 +1,376 @@
+{
+  "schema_version": 1,
+  "meta": {
+    "schema_version": 1,
+    "run_id": "2026-05-06-e25cd03",
+    "timestamp_utc": "2026-05-06T09:00:26.729653125+00:00",
+    "git_sha": "e25cd03",
+    "git_dirty": false,
+    "backend": "HIP",
+    "device": 0,
+    "arch": "gfx1100",
+    "rocm_smi": "============================ ROCm System Management Interface ============================\n=================================== % time GPU is busy ===================================\nGPU[0]\t\t: GPU use (%): 4\n==========================================================================================\n================================== End of ROCm SMI Log ==================================="
+  },
+  "task_count": 5,
+  "passed_tasks": 5,
+  "required_task_count": 5,
+  "passed_required_tasks": 5,
+  "tasks": [
+    {
+      "schema_version": 1,
+      "task_id": "qwen35.full_attention_prefill",
+      "family": "qwen3.5",
+      "tags": [
+        "qwen35",
+        "attention",
+        "prefill",
+        "required"
+      ],
+      "required": true,
+      "correct": true,
+      "cases": [
+        {
+          "name": "qwen35_attn",
+          "shape": {
+            "head_dim": 256,
+            "kv_heads": 2,
+            "kv_len": 16,
+            "q_heads": 4,
+            "q_len": 16
+          },
+          "correct": true,
+          "max_abs": 5.9604645e-8,
+          "max_rel": 0.003623162,
+          "min_cos": null,
+          "exact": null,
+          "warmup": 5,
+          "iters": 20,
+          "timing_source": "hip_event",
+          "median_us": 89.14100006222725,
+          "mean_us": 89.73930031061172,
+          "min_us": 88.80099654197693,
+          "p95_us": 94.32099759578703
+        },
+        {
+          "name": "qwen35_attn",
+          "shape": {
+            "head_dim": 256,
+            "kv_heads": 2,
+            "kv_len": 17,
+            "q_heads": 4,
+            "q_len": 17
+          },
+          "correct": true,
+          "max_abs": 8.940697e-8,
+          "max_rel": 0.0006012507,
+          "min_cos": null,
+          "exact": null,
+          "warmup": 5,
+          "iters": 20,
+          "timing_source": "hip_event",
+          "median_us": 91.5204994380474,
+          "mean_us": 91.52080044150352,
+          "min_us": 91.16099774837494,
+          "p95_us": 91.88099950551988
+        },
+        {
+          "name": "qwen35_attn",
+          "shape": {
+            "head_dim": 256,
+            "kv_heads": 2,
+            "kv_len": 256,
+            "q_heads": 4,
+            "q_len": 16
+          },
+          "correct": true,
+          "max_abs": 1.937151e-7,
+          "max_rel": 0.00011633209,
+          "min_cos": null,
+          "exact": null,
+          "warmup": 5,
+          "iters": 20,
+          "timing_source": "hip_event",
+          "median_us": 385.3039890527725,
+          "mean_us": 456.4822494983673,
+          "min_us": 348.44300150871277,
+          "p95_us": 674.6860146522522
+        }
+      ],
+      "error": null
+    },
+    {
+      "schema_version": 1,
+      "task_id": "qwen36.batched_prefill_attn_full",
+      "family": "qwen3.6-moe",
+      "tags": [
+        "qwen36",
+        "attention",
+        "prefill",
+        "required"
+      ],
+      "required": true,
+      "correct": true,
+      "cases": [
+        {
+          "name": "qwen36_attn",
+          "shape": {
+            "head_dim": 256,
+            "kv_heads": 2,
+            "kv_len": 16,
+            "q_heads": 16,
+            "q_len": 16
+          },
+          "correct": true,
+          "max_abs": 1.1920929e-7,
+          "max_rel": 0.000037587597,
+          "min_cos": null,
+          "exact": null,
+          "warmup": 5,
+          "iters": 20,
+          "timing_source": "hip_event",
+          "median_us": 52.94100008904934,
+          "mean_us": 53.6785501986742,
+          "min_us": 52.560001611709595,
+          "p95_us": 57.00000002980232
+        },
+        {
+          "name": "qwen36_attn",
+          "shape": {
+            "head_dim": 256,
+            "kv_heads": 2,
+            "kv_len": 64,
+            "q_heads": 16,
+            "q_len": 33
+          },
+          "correct": true,
+          "max_abs": 8.940697e-8,
+          "max_rel": 0.000018975697,
+          "min_cos": null,
+          "exact": null,
+          "warmup": 5,
+          "iters": 20,
+          "timing_source": "hip_event",
+          "median_us": 127.00100243091585,
+          "mean_us": 128.1612016260624,
+          "min_us": 123.28200042247772,
+          "p95_us": 132.04100728034973
+        },
+        {
+          "name": "qwen36_attn",
+          "shape": {
+            "head_dim": 256,
+            "kv_heads": 2,
+            "kv_len": 64,
+            "q_heads": 16,
+            "q_len": 64
+          },
+          "correct": true,
+          "max_abs": 1.1920929e-7,
+          "max_rel": 0.00003061723,
+          "min_cos": null,
+          "exact": null,
+          "warmup": 5,
+          "iters": 20,
+          "timing_source": "hip_event",
+          "median_us": 187.76199966669083,
+          "mean_us": 187.74470016360283,
+          "min_us": 172.4810004234314,
+          "p95_us": 198.48200678825376
+        }
+      ],
+      "error": null
+    },
+    {
+      "schema_version": 1,
+      "task_id": "qwen36.router_permute",
+      "family": "qwen3.6-moe",
+      "tags": [
+        "qwen36",
+        "moe",
+        "router",
+        "required"
+      ],
+      "required": true,
+      "correct": true,
+      "cases": [
+        {
+          "name": "router_permute",
+          "shape": {
+            "n_tokens": 1,
+            "num_experts": 256,
+            "top_k": 8
+          },
+          "correct": true,
+          "max_abs": null,
+          "max_rel": null,
+          "min_cos": null,
+          "exact": true,
+          "warmup": 5,
+          "iters": 20,
+          "timing_source": "hip_event",
+          "median_us": 35.679999738931656,
+          "mean_us": 35.7183501124382,
+          "min_us": 35.19999980926514,
+          "p95_us": 36.40099987387657
+        },
+        {
+          "name": "router_permute",
+          "shape": {
+            "n_tokens": 64,
+            "num_experts": 256,
+            "top_k": 8
+          },
+          "correct": true,
+          "max_abs": null,
+          "max_rel": null,
+          "min_cos": null,
+          "exact": true,
+          "warmup": 5,
+          "iters": 20,
+          "timing_source": "hip_event",
+          "median_us": 35.50049848854542,
+          "mean_us": 35.630349814891815,
+          "min_us": 35.16099974513054,
+          "p95_us": 36.44099831581116
+        },
+        {
+          "name": "router_permute",
+          "shape": {
+            "n_tokens": 128,
+            "num_experts": 256,
+            "top_k": 8
+          },
+          "correct": true,
+          "max_abs": null,
+          "max_rel": null,
+          "min_cos": null,
+          "exact": true,
+          "warmup": 5,
+          "iters": 20,
+          "timing_source": "hip_event",
+          "median_us": 36.3599993288517,
+          "mean_us": 36.52039933949709,
+          "min_us": 35.999998450279236,
+          "p95_us": 37.43999823927879
+        }
+      ],
+      "error": null
+    },
+    {
+      "schema_version": 1,
+      "task_id": "qwen36.grouped_expert_int4",
+      "family": "qwen3.6-moe",
+      "tags": [
+        "qwen36",
+        "moe",
+        "int4",
+        "required"
+      ],
+      "required": true,
+      "correct": true,
+      "cases": [
+        {
+          "name": "grouped_expert_int4",
+          "shape": {
+            "hidden": 128,
+            "moe_intermediate": 128,
+            "n_tokens": 4,
+            "num_experts": 8,
+            "top_k": 2
+          },
+          "correct": true,
+          "max_abs": 0.0,
+          "max_rel": null,
+          "min_cos": 1.0,
+          "exact": null,
+          "warmup": 5,
+          "iters": 20,
+          "timing_source": "hip_event",
+          "median_us": 46.78049869835377,
+          "mean_us": 47.00029976665974,
+          "min_us": 46.19999974966049,
+          "p95_us": 48.28000068664551
+        },
+        {
+          "name": "grouped_expert_int4",
+          "shape": {
+            "hidden": 512,
+            "moe_intermediate": 256,
+            "n_tokens": 16,
+            "num_experts": 64,
+            "top_k": 8
+          },
+          "correct": true,
+          "max_abs": 0.0007022472,
+          "max_rel": null,
+          "min_cos": 0.9999997,
+          "exact": null,
+          "warmup": 5,
+          "iters": 20,
+          "timing_source": "hip_event",
+          "median_us": 452.224001288414,
+          "mean_us": 465.93990325927734,
+          "min_us": 364.6830022335053,
+          "p95_us": 556.5659999847412
+        }
+      ],
+      "error": null
+    },
+    {
+      "schema_version": 1,
+      "task_id": "qwen36.unpermute_combine",
+      "family": "qwen3.6-moe",
+      "tags": [
+        "qwen36",
+        "moe",
+        "combine",
+        "required"
+      ],
+      "required": true,
+      "correct": true,
+      "cases": [
+        {
+          "name": "unpermute_combine",
+          "shape": {
+            "hidden": 128,
+            "n_tokens": 4,
+            "top_k": 2
+          },
+          "correct": true,
+          "max_abs": 0.0,
+          "max_rel": 0.0,
+          "min_cos": null,
+          "exact": null,
+          "warmup": 5,
+          "iters": 20,
+          "timing_source": "hip_event",
+          "median_us": 35.86049936711788,
+          "mean_us": 35.8943996950984,
+          "min_us": 35.39999946951866,
+          "p95_us": 36.24099865555763
+        },
+        {
+          "name": "unpermute_combine",
+          "shape": {
+            "hidden": 512,
+            "n_tokens": 64,
+            "top_k": 8
+          },
+          "correct": true,
+          "max_abs": 0.0,
+          "max_rel": 0.0,
+          "min_cos": null,
+          "exact": null,
+          "warmup": 5,
+          "iters": 20,
+          "timing_source": "hip_event",
+          "median_us": 37.70050033926964,
+          "mean_us": 37.742299772799015,
+          "min_us": 37.00000047683716,
+          "p95_us": 38.28100115060806
+        }
+      ],
+      "error": null
+    }
+  ]
+}

--- a/crates/kernel-lab/src/run.rs
+++ b/crates/kernel-lab/src/run.rs
@@ -154,7 +154,7 @@ pub fn run_tasks(cfg: &KernelLabConfig, tasks: &[TaskDef]) -> Result<(PathBuf, R
     gpu_hal::set_device(cfg.device).context("set GPU device")?;
 
     let git_sha = capture(["rev-parse", "--short", "HEAD"]).unwrap_or_else(|| "unknown".into());
-    let git_dirty = !capture(["status", "--porcelain"])
+    let git_dirty = !capture(["status", "--porcelain", "--untracked-files=no"])
         .unwrap_or_default()
         .is_empty();
     let date = chrono::Utc::now().format("%Y-%m-%d").to_string();


### PR DESCRIPTION
## Summary
- fix ROCm idle-gate parsing to read numeric rocm-smi fields
- ignore untracked scratch files when recording kernel-lab git_dirty provenance
- add reviewed gfx1100 required-suite baseline artifacts

## Baseline
- source run: target/kernel-lab-runs/2026-05-06-e25cd03
- commit measured: e25cd03
- arch: gfx1100
- required tasks: 5/5
- tracked tree dirty flag: false

## Verification
- cargo fmt -p supersonic-kernel-lab --check
- cargo test -p supersonic-kernel-lab --lib
- cargo test -p supersonic-kernel-lab --bin kernel-lab
- cargo build --release -p supersonic-kernel-lab --bin kernel-lab
- python YAML parse for .github/workflows/kernel-lab.yml
- corrected local GPU idle wait: 3 consecutive samples at gpu=0%, vram=5%
- ./target/release/kernel-lab run --tasks all --backend hip --device 0 --warmup 5 --iters 20
- ./target/release/kernel-lab baseline --run target/kernel-lab-runs/2026-05-06-e25cd03 --name required
- ./target/release/kernel-lab diff --baseline crates/kernel-lab/baselines/gfx1100/required.summary.json --candidate target/kernel-lab-runs/2026-05-06-e25cd03 --max-regression 0.10 --min-speedup 0.0 --markdown-out target/kernel-lab-runs/baseline-self-diff.md
