### PR TITLE
Add kernel-lab workflow presets and checked baseline diff

### DIFF
--- a/.github/workflows/kernel-lab.yml
+++ b/.github/workflows/kernel-lab.yml
@@ -12,18 +12,28 @@ on:
       - "kernels/**"
   workflow_dispatch:
     inputs:
+      preset:
+        description: "kernel-lab preset"
+        required: true
+        type: choice
+        default: "pr"
+        options:
+          - pr
+          - required
+          - everything
+          - stress
       tasks:
-        description: "kernel-lab task selector"
-        required: true
-        default: "qwen36.router_permute"
+        description: "optional task selector override"
+        required: false
+        default: ""
       warmup:
-        description: "warmup iterations"
-        required: true
-        default: "2"
+        description: "optional warmup iteration override"
+        required: false
+        default: ""
       iters:
-        description: "timed iterations"
-        required: true
-        default: "5"
+        description: "optional timed iteration override"
+        required: false
+        default: ""
       max_regression:
         description: "allowed median latency regression"
         required: true
@@ -32,6 +42,15 @@ on:
         description: "minimum geomean speedup"
         required: true
         default: "0.0"
+      checked_baseline:
+        description: "compare candidate against checked-in gfx1100 baseline"
+        required: true
+        type: choice
+        default: "auto"
+        options:
+          - auto
+          - true
+          - false
 
 concurrency:
   group: kernel-lab-${{ github.workflow }}-${{ github.ref }}
@@ -39,18 +58,22 @@ concurrency:
 
 jobs:
   compare-ref:
-    name: compare-ref (${{ github.event.inputs.tasks || 'qwen36.router_permute' }})
+    name: compare-ref (${{ github.event.inputs.preset || 'pr' }})
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, linux, rocm]
+    runs-on: [self-hosted, linux, rocm, gfx1100]
     timeout-minutes: 45
     env:
-      KERNEL_LAB_TASKS: ${{ github.event.inputs.tasks || 'qwen36.router_permute' }}
-      KERNEL_LAB_WARMUP: ${{ github.event.inputs.warmup || '2' }}
-      KERNEL_LAB_ITERS: ${{ github.event.inputs.iters || '5' }}
+      KERNEL_LAB_PRESET: ${{ github.event.inputs.preset || 'pr' }}
+      KERNEL_LAB_TASKS_INPUT: ${{ github.event.inputs.tasks || '' }}
+      KERNEL_LAB_WARMUP_INPUT: ${{ github.event.inputs.warmup || '' }}
+      KERNEL_LAB_ITERS_INPUT: ${{ github.event.inputs.iters || '' }}
       KERNEL_LAB_MAX_REGRESSION: ${{ github.event.inputs.max_regression || '0.10' }}
       KERNEL_LAB_MIN_SPEEDUP: ${{ github.event.inputs.min_speedup || '0.0' }}
+      KERNEL_LAB_CHECKED_BASELINE_INPUT: ${{ github.event.inputs.checked_baseline || 'auto' }}
       KERNEL_LAB_RUN_ROOT: target/kernel-lab-runs
       KERNEL_LAB_WORKTREE_ROOT: target/kernel-lab-worktrees
+      KERNEL_LAB_CANDIDATE_SUMMARY: target/kernel-lab-runs/candidate.summary.json
+      KERNEL_LAB_CHECKED_BASELINE: crates/kernel-lab/baselines/gfx1100/required.summary.json
     steps:
       - uses: actions/checkout@v4
         with:
@@ -58,6 +81,88 @@ jobs:
 
       - name: Show GPU state
         run: rocm-smi --showuse --showmemuse --showtemp
+
+      - name: Resolve preset
+        run: |
+          case "$KERNEL_LAB_PRESET" in
+            pr)
+              tasks="${KERNEL_LAB_TASKS_INPUT:-all}"
+              warmup="${KERNEL_LAB_WARMUP_INPUT:-2}"
+              iters="${KERNEL_LAB_ITERS_INPUT:-5}"
+              checked_baseline_default=1
+              checked_baseline_blocking_default=0
+              ;;
+            required)
+              tasks="${KERNEL_LAB_TASKS_INPUT:-all}"
+              warmup="${KERNEL_LAB_WARMUP_INPUT:-5}"
+              iters="${KERNEL_LAB_ITERS_INPUT:-20}"
+              checked_baseline_default=1
+              checked_baseline_blocking_default=1
+              ;;
+            everything)
+              tasks="${KERNEL_LAB_TASKS_INPUT:-everything}"
+              warmup="${KERNEL_LAB_WARMUP_INPUT:-5}"
+              iters="${KERNEL_LAB_ITERS_INPUT:-20}"
+              checked_baseline_default=1
+              checked_baseline_blocking_default=1
+              ;;
+            stress)
+              tasks="${KERNEL_LAB_TASKS_INPUT:-tag:stress}"
+              warmup="${KERNEL_LAB_WARMUP_INPUT:-5}"
+              iters="${KERNEL_LAB_ITERS_INPUT:-20}"
+              checked_baseline_default=0
+              checked_baseline_blocking_default=0
+              ;;
+            *)
+              echo "unknown kernel-lab preset: $KERNEL_LAB_PRESET" >&2
+              exit 1
+              ;;
+          esac
+
+          checked_baseline="$checked_baseline_default"
+          checked_baseline_blocking="$checked_baseline_blocking_default"
+          case "$KERNEL_LAB_CHECKED_BASELINE_INPUT" in
+            auto)
+              if [ -n "$KERNEL_LAB_TASKS_INPUT" ]; then
+                checked_baseline=0
+                checked_baseline_blocking=0
+              fi
+              ;;
+            true)
+              checked_baseline=1
+              checked_baseline_blocking=1
+              ;;
+            false)
+              checked_baseline=0
+              checked_baseline_blocking=0
+              ;;
+            *)
+              echo "unknown checked_baseline value: $KERNEL_LAB_CHECKED_BASELINE_INPUT" >&2
+              exit 1
+              ;;
+          esac
+
+          {
+            echo "KERNEL_LAB_TASKS=$tasks"
+            echo "KERNEL_LAB_WARMUP=$warmup"
+            echo "KERNEL_LAB_ITERS=$iters"
+            echo "KERNEL_LAB_COMPARE_CHECKED_BASELINE=$checked_baseline"
+            echo "KERNEL_LAB_CHECKED_BASELINE_BLOCKING=$checked_baseline_blocking"
+          } >> "$GITHUB_ENV"
+
+          {
+            echo "### kernel-lab preset"
+            echo ""
+            echo "- preset: \`$KERNEL_LAB_PRESET\`"
+            echo "- tasks: \`$tasks\`"
+            echo "- warmup: \`$warmup\`"
+            echo "- iters: \`$iters\`"
+            echo "- checked baseline: \`$checked_baseline\`"
+            echo "- checked baseline blocking: \`$checked_baseline_blocking\`"
+            if [ -n "$KERNEL_LAB_TASKS_INPUT" ] && [ "$KERNEL_LAB_CHECKED_BASELINE_INPUT" = "auto" ]; then
+              echo "- checked baseline auto disabled because tasks were overridden"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Wait for GPU idle
         run: |
@@ -136,7 +241,38 @@ jobs:
             --max-regression "$KERNEL_LAB_MAX_REGRESSION" \
             --min-speedup "$KERNEL_LAB_MIN_SPEEDUP" \
             --markdown-out "$KERNEL_LAB_RUN_ROOT/diff.md" \
+            --candidate-summary-copy "$KERNEL_LAB_CANDIDATE_SUMMARY" \
             --github-summary
+
+      - name: Compare candidate against checked-in gfx1100 baseline
+        if: env.KERNEL_LAB_COMPARE_CHECKED_BASELINE == '1'
+        run: |
+          if [ ! -f "$KERNEL_LAB_CHECKED_BASELINE" ]; then
+            echo "missing checked-in baseline: $KERNEL_LAB_CHECKED_BASELINE" >&2
+            exit 1
+          fi
+          set +e
+          ./target/release/kernel-lab diff \
+            --baseline "$KERNEL_LAB_CHECKED_BASELINE" \
+            --candidate "$KERNEL_LAB_CANDIDATE_SUMMARY" \
+            --max-regression "$KERNEL_LAB_MAX_REGRESSION" \
+            --min-speedup "$KERNEL_LAB_MIN_SPEEDUP" \
+            --markdown-out "$KERNEL_LAB_RUN_ROOT/checked-baseline-diff.md" \
+            --github-summary
+          status=$?
+          set -e
+          if [ "$status" -ne 0 ]; then
+            {
+              echo "### checked baseline status"
+              echo ""
+              echo "- result: \`failed\`"
+              echo "- exit code: \`$status\`"
+              echo "- blocking: \`$KERNEL_LAB_CHECKED_BASELINE_BLOCKING\`"
+            } >> "$GITHUB_STEP_SUMMARY"
+            if [ "$KERNEL_LAB_CHECKED_BASELINE_BLOCKING" = "1" ]; then
+              exit "$status"
+            fi
+          fi
 
       - name: Upload kernel-lab artifacts
         if: always()

--- a/crates/kernel-lab/baselines/README.md
+++ b/crates/kernel-lab/baselines/README.md
@@ -18,3 +18,18 @@ cargo run --release -p supersonic-kernel-lab --bin kernel-lab -- baseline \
 
 The JSON file is the canonical artifact used by `kernel-lab diff`. The markdown
 sidecar is for review and should be regenerated from the same run.
+
+CI compares pull-request candidates against both the PR base ref and the checked-in
+`gfx1100/required.summary.json` baseline. Manual `kernel-lab` workflow runs expose
+presets:
+
+- `pr`: required suite with short timing, matching pull-request CI. Checked-baseline
+  comparison is report-only; PR gating comes from the base-ref comparison.
+- `required`: required suite with the default local timing depth.
+- `everything`: all registered tasks, including optional stress tasks.
+- `stress`: only tasks tagged `stress`; checked-baseline comparison is off by default.
+
+When `tasks` is manually overridden, checked-baseline comparison is disabled in
+`auto` mode because subset runs do not contain every task from the required
+baseline. Set `checked_baseline=true` only for overrides that still include the
+required baseline tasks.

--- a/crates/kernel-lab/src/bin/kernel_lab.rs
+++ b/crates/kernel-lab/src/bin/kernel_lab.rs
@@ -87,6 +87,8 @@ enum Command {
         markdown_out: Option<PathBuf>,
         #[arg(long)]
         github_summary: bool,
+        #[arg(long)]
+        candidate_summary_copy: Option<PathBuf>,
     },
     Render {
         #[arg(long)]
@@ -186,6 +188,7 @@ fn main() -> Result<()> {
             min_speedup,
             markdown_out,
             github_summary,
+            candidate_summary_copy,
         } => {
             let baseline = run_ref(
                 &baseline_ref,
@@ -209,6 +212,9 @@ fn main() -> Result<()> {
             )?;
             let baseline_summary = load_summary(&baseline)?;
             let candidate_summary = load_summary(&candidate)?;
+            if let Some(path) = candidate_summary_copy {
+                copy_summary_json(&candidate, &path)?;
+            }
             let diff = diff_runs(&baseline_summary, &candidate_summary, max_regression);
             println!("{}", serde_json::to_string_pretty(&diff)?);
             write_diff_markdown(&diff, min_speedup, markdown_out, github_summary)?;
@@ -223,6 +229,16 @@ fn main() -> Result<()> {
             println!("[kernel-lab] wrote {}", out.display());
         }
     }
+    Ok(())
+}
+
+fn copy_summary_json(run_dir: &Path, dst: &Path) -> Result<()> {
+    let src = run_dir.join("summary.json");
+    if let Some(parent) = dst.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::copy(&src, dst)?;
+    println!("[kernel-lab] copied candidate summary to {}", dst.display());
     Ok(())
 }
 
@@ -582,6 +598,19 @@ mod tests {
         );
         assert!(path.exists());
         assert!(path.with_file_name("required-gfx-smoke.md").exists());
+    }
+
+    #[test]
+    fn copy_summary_json_creates_parent_and_copies_summary() {
+        let tmp = tempfile::tempdir().unwrap();
+        let run_dir = tmp.path().join("run");
+        std::fs::create_dir_all(&run_dir).unwrap();
+        std::fs::write(run_dir.join("summary.json"), "{\"ok\":true}\n").unwrap();
+
+        let out = tmp.path().join("copies/candidate.summary.json");
+        copy_summary_json(&run_dir, &out).unwrap();
+
+        assert_eq!(std::fs::read_to_string(out).unwrap(), "{\"ok\":true}\n");
     }
 
     fn test_summary(


### PR DESCRIPTION
## Summary
- add manual kernel-lab workflow presets for PR, required, everything, and stress sweeps
- compare compatible candidate runs against the checked-in gfx1100 required baseline
- add compare-ref --candidate-summary-copy so workflow steps can consume the exact candidate summary
- document the presets in the baseline README

## Verification
- cargo fmt -p supersonic-kernel-lab --check
- python YAML parse for .github/workflows/kernel-lab.yml
- cargo test -p supersonic-kernel-lab --lib
- cargo test -p supersonic-kernel-lab --bin kernel-lab
- cargo build --release -p supersonic-kernel-lab --bin kernel-lab
- cargo run -p supersonic-kernel-lab --bin kernel-lab -- compare-ref --help | rg -n "candidate-summary-copy|baseline-ref|markdown-out"
- ./target/release/kernel-lab diff --baseline crates/kernel-lab/baselines/gfx1100/required.summary.json --candidate crates/kernel-lab/baselines/gfx1100/required.summary.json --max-regression 0.10 --min-speedup 0.0 --markdown-out target/kernel-lab-runs/checked-baseline-self-diff.md

Leaving this PR open for Codex review bot before merge.
