### PR TITLE
kernel-lab: add task metadata and richer reports

### DIFF
--- a/crates/kernel-lab/baselines/README.md
+++ b/crates/kernel-lab/baselines/README.md
@@ -19,6 +19,10 @@ cargo run --release -p supersonic-kernel-lab --bin kernel-lab -- baseline \
 The JSON file is the canonical artifact used by `kernel-lab diff`. The markdown
 sidecar is for review and should be regenerated from the same run.
 
+Run directories also contain `task_manifest.json` and `summary.md`. Those files
+are derived from the Rust task registry and the run summary; they are review
+artifacts, not separate sources of truth for baseline membership.
+
 CI compares pull-request candidates against both the PR base ref and the checked-in
 `gfx1100/required.summary.json` baseline. Manual `kernel-lab` workflow runs expose
 presets:

--- a/crates/kernel-lab/src/bin/kernel_lab.rs
+++ b/crates/kernel-lab/src/bin/kernel_lab.rs
@@ -5,8 +5,11 @@ use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::process::{Command as ProcessCommand, ExitStatus};
 use supersonic_kernel_lab::run::{
-    diff_exit_code, diff_runs, load_summary, render_diff_markdown, render_markdown, resolve_tasks,
-    run_tasks, KernelLabConfig,
+    diff_exit_code, diff_runs_with_min_speedup, load_summary, render_diff_markdown,
+    render_markdown, resolve_tasks, run_tasks, KernelLabConfig,
+};
+use supersonic_kernel_lab::{
+    all_tag_metadata, all_task_metadata, describe_task_selector, TaskMetadata,
 };
 
 #[derive(Parser, Debug)]
@@ -19,7 +22,17 @@ struct Cli {
 
 #[derive(Subcommand, Debug)]
 enum Command {
-    List,
+    List {
+        #[arg(long)]
+        json: bool,
+        #[arg(long)]
+        tags: bool,
+    },
+    Describe {
+        selector: String,
+        #[arg(long)]
+        json: bool,
+    },
     Run {
         #[arg(long, default_value = "all")]
         tasks: String,
@@ -101,15 +114,19 @@ enum Command {
 fn main() -> Result<()> {
     let cli = Cli::parse();
     match cli.command {
-        Command::List => {
-            for task in supersonic_kernel_lab::all_tasks() {
-                println!(
-                    "{}\tfamily={}\trequired={}\ttags={}",
-                    task.id,
-                    task.family,
-                    task.required,
-                    task.tags.join(",")
-                );
+        Command::List { json, tags } => {
+            if tags {
+                print_tags(json)?;
+            } else {
+                print_tasks(json)?;
+            }
+        }
+        Command::Describe { selector, json } => {
+            let tasks = describe_task_selector(&selector)?;
+            if json {
+                println!("{}", serde_json::to_string_pretty(&tasks)?);
+            } else {
+                print_task_descriptions(&tasks);
             }
         }
         Command::Run {
@@ -156,7 +173,8 @@ fn main() -> Result<()> {
         } => {
             let baseline = load_summary(&baseline)?;
             let candidate = load_summary(&candidate)?;
-            let diff = diff_runs(&baseline, &candidate, max_regression);
+            let diff =
+                diff_runs_with_min_speedup(&baseline, &candidate, max_regression, min_speedup);
             println!("{}", serde_json::to_string_pretty(&diff)?);
             write_diff_markdown(&diff, min_speedup, markdown_out, github_summary)?;
             let code = diff_exit_code(&diff, min_speedup);
@@ -215,7 +233,12 @@ fn main() -> Result<()> {
             if let Some(path) = candidate_summary_copy {
                 copy_summary_json(&candidate, &path)?;
             }
-            let diff = diff_runs(&baseline_summary, &candidate_summary, max_regression);
+            let diff = diff_runs_with_min_speedup(
+                &baseline_summary,
+                &candidate_summary,
+                max_regression,
+                min_speedup,
+            );
             println!("{}", serde_json::to_string_pretty(&diff)?);
             write_diff_markdown(&diff, min_speedup, markdown_out, github_summary)?;
             let code = diff_exit_code(&diff, min_speedup);
@@ -232,13 +255,69 @@ fn main() -> Result<()> {
     Ok(())
 }
 
+fn print_tasks(json: bool) -> Result<()> {
+    let tasks = all_task_metadata();
+    if json {
+        println!("{}", serde_json::to_string_pretty(&tasks)?);
+    } else {
+        for task in tasks {
+            println!(
+                "{}\tfamily={}\trequired={}\tbackends={}\ttags={}",
+                task.id,
+                task.family,
+                task.required,
+                task.backend_support.join(","),
+                task.tags.join(",")
+            );
+        }
+    }
+    Ok(())
+}
+
+fn print_tags(json: bool) -> Result<()> {
+    let tags = all_tag_metadata();
+    if json {
+        println!("{}", serde_json::to_string_pretty(&tags)?);
+    } else {
+        for tag in tags {
+            println!(
+                "{}\ttasks={}\trequired={}",
+                tag.tag, tag.task_count, tag.required_task_count
+            );
+        }
+    }
+    Ok(())
+}
+
+fn print_task_descriptions(tasks: &[TaskMetadata]) {
+    for (idx, task) in tasks.iter().enumerate() {
+        if idx > 0 {
+            println!();
+        }
+        println!("{}", format_task_description(task));
+    }
+}
+
+fn format_task_description(task: &TaskMetadata) -> String {
+    format!(
+        "{}\n  family: {}\n  suite: {}\n  backends: {}\n  tags: {}\n  description: {}\n  correctness: {}",
+        task.id,
+        task.family,
+        if task.required { "required" } else { "optional" },
+        task.backend_support.join(","),
+        task.tags.join(","),
+        task.description,
+        task.correctness
+    )
+}
+
 fn copy_summary_json(run_dir: &Path, dst: &Path) -> Result<()> {
     let src = run_dir.join("summary.json");
     if let Some(parent) = dst.parent() {
         std::fs::create_dir_all(parent)?;
     }
     std::fs::copy(&src, dst)?;
-    println!("[kernel-lab] copied candidate summary to {}", dst.display());
+    eprintln!("[kernel-lab] copied candidate summary to {}", dst.display());
     Ok(())
 }
 
@@ -271,7 +350,7 @@ fn write_diff_markdown(
     let markdown = render_diff_markdown(diff, min_speedup);
     if let Some(path) = markdown_out {
         std::fs::write(&path, &markdown)?;
-        println!("[kernel-lab] wrote {}", path.display());
+        eprintln!("[kernel-lab] wrote {}", path.display());
     }
     if github_summary {
         let path = std::env::var_os("GITHUB_STEP_SUMMARY")
@@ -611,6 +690,30 @@ mod tests {
         copy_summary_json(&run_dir, &out).unwrap();
 
         assert_eq!(std::fs::read_to_string(out).unwrap(), "{\"ok\":true}\n");
+    }
+
+    #[test]
+    fn list_json_helpers_expose_task_and_tag_metadata() {
+        let tasks = all_task_metadata();
+        let tasks_json = serde_json::to_string(&tasks).unwrap();
+        assert!(tasks_json.contains("qwen35.full_attention_prefill"));
+        assert!(tasks_json.contains("backend_support"));
+        assert!(tasks_json.contains("correctness"));
+
+        let tags = all_tag_metadata();
+        let tags_json = serde_json::to_string(&tags).unwrap();
+        assert!(tags_json.contains("\"tag\":\"required\""));
+        assert!(tags_json.contains("required_task_count"));
+    }
+
+    #[test]
+    fn describe_helper_formats_task_metadata() {
+        let tasks = describe_task_selector("qwen35.full_attention_prefill").unwrap();
+        let text = format_task_description(&tasks[0]);
+        assert!(text.contains("suite: required"));
+        assert!(text.contains("backends: hip"));
+        assert!(text.contains("description:"));
+        assert!(text.contains("correctness:"));
     }
 
     fn test_summary(

--- a/crates/kernel-lab/src/lib.rs
+++ b/crates/kernel-lab/src/lib.rs
@@ -2,8 +2,11 @@ pub mod registry;
 pub mod run;
 pub mod tasks;
 
-pub use registry::{all_tasks, find_task, TaskDef};
+pub use registry::{
+    all_tag_metadata, all_task_metadata, all_tasks, describe_task_selector, find_task,
+    task_metadata, TagMetadata, TaskDef, TaskMetadata,
+};
 pub use run::{
-    diff_exit_code, diff_runs, render_diff_markdown, render_markdown, run_tasks, CaseResult,
-    DiffReport, KernelLabConfig, RunSummary, TaskResult,
+    diff_exit_code, diff_runs, diff_runs_with_min_speedup, render_diff_markdown, render_markdown,
+    run_tasks, CaseResult, DiffReport, KernelLabConfig, RunSummary, TaskResult,
 };

--- a/crates/kernel-lab/src/registry.rs
+++ b/crates/kernel-lab/src/registry.rs
@@ -1,89 +1,146 @@
 use crate::tasks;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy)]
 pub struct TaskDef {
     pub id: &'static str,
     pub family: &'static str,
+    pub description: &'static str,
     pub tags: &'static [&'static str],
+    pub backend_support: &'static [&'static str],
+    pub correctness: &'static str,
     pub required: bool,
     pub run: fn(&crate::run::KernelLabConfig) -> anyhow::Result<crate::run::TaskResult>,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TaskMetadata {
+    pub id: String,
+    pub family: String,
+    pub description: String,
+    pub tags: Vec<String>,
+    pub backend_support: Vec<String>,
+    pub correctness: String,
+    pub required: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TagMetadata {
+    pub tag: String,
+    pub task_count: usize,
+    pub required_task_count: usize,
+}
+
+const HIP_BACKEND: &[&str] = &["hip"];
 
 const TASKS: &[TaskDef] = &[
     TaskDef {
         id: "qwen35.full_attention_prefill",
         family: "qwen3.5",
+        description: "Qwen3.5 full-attention prefill microbenchmark over short and longer KV contexts.",
         tags: &["qwen35", "attention", "prefill", "required"],
+        backend_support: HIP_BACKEND,
+        correctness: "Compares HIP output against the CPU attention reference with max_abs/max_rel/min_cos tolerances.",
         required: true,
         run: tasks::qwen35_full_attention_prefill,
     },
     TaskDef {
         id: "qwen35.int4_matvec",
         family: "qwen3.5",
+        description: "Qwen3.5 INT4 matvec baseline without AWQ sidecar correction.",
         tags: &["qwen35", "int4", "awq", "quant"],
+        backend_support: HIP_BACKEND,
+        correctness: "Compares HIP BF16 matvec output against the CPU INT4 dequant reference.",
         required: false,
         run: tasks::qwen35_int4_matvec,
     },
     TaskDef {
         id: "qwen35.int4_awq_dense_matvec",
         family: "qwen3.5",
+        description: "Qwen3.5 INT4 matvec with dense AWQ inverse-scale sidecar.",
         tags: &["qwen35", "int4", "awq", "quant"],
+        backend_support: HIP_BACKEND,
+        correctness: "Compares HIP BF16 matvec output against the CPU INT4 plus dense AWQ reference.",
         required: false,
         run: tasks::qwen35_int4_awq_dense_matvec,
     },
     TaskDef {
         id: "qwen35.int4_awq_sparse_outlier_matvec",
         family: "qwen3.5",
+        description: "Qwen3.5 INT4 matvec with sparse outlier sidecar accumulation.",
         tags: &["qwen35", "int4", "awq", "quant"],
+        backend_support: HIP_BACKEND,
+        correctness: "Compares HIP BF16 matvec output against the CPU INT4 plus sparse outlier reference.",
         required: false,
         run: tasks::qwen35_int4_awq_sparse_outlier_matvec,
     },
     TaskDef {
         id: "qwen36.batched_prefill_attn_full",
         family: "qwen3.6-moe",
+        description: "Qwen3.6 MoE batched full-attention prefill over representative decode-prefill shapes.",
         tags: &["qwen36", "attention", "prefill", "required"],
+        backend_support: HIP_BACKEND,
+        correctness: "Compares HIP output against the CPU attention reference with max_abs/max_rel/min_cos tolerances.",
         required: true,
         run: tasks::qwen36_batched_prefill_attn_full,
     },
     TaskDef {
         id: "qwen36.router_permute",
         family: "qwen3.6-moe",
+        description: "Qwen3.6 MoE router top-k permutation and token routing layout benchmark.",
         tags: &["qwen36", "moe", "router", "required"],
+        backend_support: HIP_BACKEND,
+        correctness: "Checks exact router indices, expert counts, token offsets, and routing weights against the CPU reference.",
         required: true,
         run: tasks::qwen36_router_permute,
     },
     TaskDef {
         id: "qwen36.grouped_expert_int4",
         family: "qwen3.6-moe",
+        description: "Qwen3.6 MoE grouped INT4 expert projection benchmark.",
         tags: &["qwen36", "moe", "int4", "required"],
+        backend_support: HIP_BACKEND,
+        correctness: "Compares grouped HIP expert output against the CPU INT4 grouped-expert reference.",
         required: true,
         run: tasks::qwen36_grouped_expert_int4,
     },
     TaskDef {
         id: "qwen36.unpermute_combine",
         family: "qwen3.6-moe",
+        description: "Qwen3.6 MoE unpermute and top-k weighted combine benchmark.",
         tags: &["qwen36", "moe", "combine", "required"],
+        backend_support: HIP_BACKEND,
+        correctness: "Compares combined HIP token output against the CPU unpermute/combine reference.",
         required: true,
         run: tasks::qwen36_unpermute_combine,
     },
     TaskDef {
         id: "qwen36.batched_prefill_attn_full.stress",
         family: "qwen3.6-moe",
+        description: "Qwen3.6 MoE batched full-attention prefill stress cases with larger contexts.",
         tags: &["qwen36", "attention-stress", "stress"],
+        backend_support: HIP_BACKEND,
+        correctness: "Compares HIP output against the CPU attention reference with max_abs/max_rel/min_cos tolerances.",
         required: false,
         run: tasks::qwen36_batched_prefill_attn_full_stress,
     },
     TaskDef {
         id: "qwen36.router_permute.stress",
         family: "qwen3.6-moe",
+        description: "Qwen3.6 MoE router permutation stress cases at larger token counts.",
         tags: &["qwen36", "router-stress", "stress"],
+        backend_support: HIP_BACKEND,
+        correctness: "Checks exact router indices, expert counts, token offsets, and routing weights against the CPU reference.",
         required: false,
         run: tasks::qwen36_router_permute_stress,
     },
     TaskDef {
         id: "qwen36.grouped_expert_int4.stress",
         family: "qwen3.6-moe",
+        description: "Qwen3.6 MoE grouped INT4 expert stress cases at larger token counts.",
         tags: &["qwen36", "int4-stress", "stress"],
+        backend_support: HIP_BACKEND,
+        correctness: "Compares grouped HIP expert output against the CPU INT4 grouped-expert reference.",
         required: false,
         run: tasks::qwen36_grouped_expert_int4_stress,
     },
@@ -95,4 +152,142 @@ pub fn all_tasks() -> &'static [TaskDef] {
 
 pub fn find_task(id: &str) -> Option<&'static TaskDef> {
     TASKS.iter().find(|task| task.id == id)
+}
+
+pub fn task_metadata(task: &TaskDef) -> TaskMetadata {
+    TaskMetadata {
+        id: task.id.to_string(),
+        family: task.family.to_string(),
+        description: task.description.to_string(),
+        tags: task.tags.iter().map(|tag| tag.to_string()).collect(),
+        backend_support: task
+            .backend_support
+            .iter()
+            .map(|backend| backend.to_string())
+            .collect(),
+        correctness: task.correctness.to_string(),
+        required: task.required,
+    }
+}
+
+pub fn all_task_metadata() -> Vec<TaskMetadata> {
+    TASKS.iter().map(task_metadata).collect()
+}
+
+pub fn describe_task_selector(selector: &str) -> anyhow::Result<Vec<TaskMetadata>> {
+    if let Some(tag) = selector.strip_prefix("tag:") {
+        let matches: Vec<_> = TASKS
+            .iter()
+            .filter(|task| task.tags.iter().any(|task_tag| *task_tag == tag))
+            .map(task_metadata)
+            .collect();
+        if matches.is_empty() {
+            anyhow::bail!("unknown task tag: {tag}");
+        }
+        return Ok(matches);
+    }
+
+    let task = find_task(selector).ok_or_else(|| anyhow::anyhow!("unknown task: {selector}"))?;
+    Ok(vec![task_metadata(task)])
+}
+
+pub fn all_tag_metadata() -> Vec<TagMetadata> {
+    let mut counts = std::collections::BTreeMap::<String, (usize, usize)>::new();
+    for task in TASKS {
+        for tag in task.tags {
+            let entry = counts.entry((*tag).to_string()).or_default();
+            entry.0 += 1;
+            if task.required {
+                entry.1 += 1;
+            }
+        }
+    }
+    counts
+        .into_iter()
+        .map(|(tag, (task_count, required_task_count))| TagMetadata {
+            tag,
+            task_count,
+            required_task_count,
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+
+    #[test]
+    fn task_metadata_is_complete_and_well_formed() {
+        let mut ids = BTreeSet::new();
+        for task in all_tasks() {
+            assert!(ids.insert(task.id), "duplicate task id {}", task.id);
+            assert!(
+                !task.family.trim().is_empty(),
+                "empty family for {}",
+                task.id
+            );
+            assert!(
+                !task.description.trim().is_empty(),
+                "empty description for {}",
+                task.id
+            );
+            assert!(
+                !task.correctness.trim().is_empty(),
+                "empty correctness for {}",
+                task.id
+            );
+            assert!(
+                !task.backend_support.is_empty(),
+                "empty backend support for {}",
+                task.id
+            );
+            assert!(!task.tags.is_empty(), "empty tags for {}", task.id);
+            let mut tags = BTreeSet::new();
+            for tag in task.tags {
+                assert!(!tag.trim().is_empty(), "empty tag for {}", task.id);
+                assert!(
+                    tag.chars().all(|ch| ch.is_ascii_lowercase()
+                        || ch.is_ascii_digit()
+                        || ch == '-'
+                        || ch == '_'),
+                    "invalid tag {tag} for {}",
+                    task.id
+                );
+                assert!(tags.insert(*tag), "duplicate tag {tag} for {}", task.id);
+            }
+        }
+    }
+
+    #[test]
+    fn task_metadata_snapshots_are_derived_from_registry() {
+        let meta = all_task_metadata();
+        assert_eq!(meta.len(), all_tasks().len());
+        assert_eq!(meta[0].id, all_tasks()[0].id);
+        assert_eq!(meta[0].description, all_tasks()[0].description);
+        assert_eq!(meta[0].backend_support, vec!["hip"]);
+    }
+
+    #[test]
+    fn tag_metadata_counts_tasks() {
+        let tags = all_tag_metadata();
+        let required = tags.iter().find(|tag| tag.tag == "required").unwrap();
+        assert_eq!(required.task_count, 5);
+        assert_eq!(required.required_task_count, 5);
+
+        let stress = tags.iter().find(|tag| tag.tag == "stress").unwrap();
+        assert_eq!(stress.task_count, 3);
+        assert_eq!(stress.required_task_count, 0);
+    }
+
+    #[test]
+    fn describe_selector_accepts_task_id_and_tag() {
+        let task = describe_task_selector("qwen35.full_attention_prefill").unwrap();
+        assert_eq!(task.len(), 1);
+        assert_eq!(task[0].id, "qwen35.full_attention_prefill");
+
+        let tagged = describe_task_selector("tag:stress").unwrap();
+        assert_eq!(tagged.len(), 3);
+        assert!(tagged.iter().all(|task| !task.required));
+    }
 }

--- a/crates/kernel-lab/src/run.rs
+++ b/crates/kernel-lab/src/run.rs
@@ -1,4 +1,4 @@
-use crate::registry::{all_tasks, TaskDef};
+use crate::registry::{all_tasks, task_metadata, TaskDef, TaskMetadata};
 use anyhow::{anyhow, Context, Result};
 use gpu_hal::Backend;
 use serde::{Deserialize, Serialize};
@@ -52,7 +52,13 @@ pub struct TaskResult {
     pub schema_version: u32,
     pub task_id: String,
     pub family: String,
+    #[serde(default)]
+    pub description: String,
     pub tags: Vec<String>,
+    #[serde(default)]
+    pub backend_support: Vec<String>,
+    #[serde(default)]
+    pub correctness: String,
     pub required: bool,
     pub correct: bool,
     pub cases: Vec<CaseResult>,
@@ -78,6 +84,10 @@ pub struct DiffTask {
     pub candidate_median_us: f64,
     pub speedup: f64,
     pub regression: bool,
+    #[serde(default)]
+    pub status: String,
+    #[serde(default)]
+    pub reason: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -85,6 +95,10 @@ pub struct DiffReport {
     pub correct: bool,
     pub fast_p: f64,
     pub geomean_speedup: f64,
+    #[serde(default)]
+    pub status: String,
+    #[serde(default)]
+    pub reason: String,
     pub worst_regression: Option<DiffTask>,
     pub tasks: Vec<DiffTask>,
 }
@@ -188,6 +202,10 @@ pub fn run_tasks(cfg: &KernelLabConfig, tasks: &[TaskDef]) -> Result<(PathBuf, R
         run_dir.join("meta.json"),
         serde_json::to_string_pretty(&meta)?,
     )?;
+    std::fs::write(
+        run_dir.join("task_manifest.json"),
+        serde_json::to_string_pretty(&task_manifest(tasks))?,
+    )?;
 
     let mut results = Vec::new();
     for task in tasks {
@@ -195,12 +213,20 @@ pub fn run_tasks(cfg: &KernelLabConfig, tasks: &[TaskDef]) -> Result<(PathBuf, R
             schema_version: SCHEMA_VERSION,
             task_id: task.id.to_string(),
             family: task.family.to_string(),
+            description: task.description.to_string(),
             tags: task.tags.iter().map(|s| s.to_string()).collect(),
+            backend_support: task
+                .backend_support
+                .iter()
+                .map(|backend| backend.to_string())
+                .collect(),
+            correctness: task.correctness.to_string(),
             required: task.required,
             correct: false,
             cases: Vec::new(),
             error: Some(err.to_string()),
         });
+        apply_task_metadata(task, &mut result);
         result.correct = result.error.is_none() && result.cases.iter().all(|case| case.correct);
         std::fs::write(
             run_dir
@@ -227,6 +253,7 @@ pub fn run_tasks(cfg: &KernelLabConfig, tasks: &[TaskDef]) -> Result<(PathBuf, R
         run_dir.join("summary.json"),
         serde_json::to_string_pretty(&summary)?,
     )?;
+    std::fs::write(run_dir.join("summary.md"), render_markdown(&summary))?;
     append_history(&cfg.run_root.join("history.jsonl"), &summary)?;
     Ok((run_dir, summary))
 }
@@ -243,6 +270,15 @@ pub fn load_summary(path: &Path) -> Result<RunSummary> {
 }
 
 pub fn diff_runs(baseline: &RunSummary, candidate: &RunSummary, max_regression: f64) -> DiffReport {
+    diff_runs_with_min_speedup(baseline, candidate, max_regression, 1.0)
+}
+
+pub fn diff_runs_with_min_speedup(
+    baseline: &RunSummary,
+    candidate: &RunSummary,
+    max_regression: f64,
+    min_speedup: f64,
+) -> DiffReport {
     let mut candidate_by_id = BTreeMap::new();
     for task in &candidate.tasks {
         candidate_by_id.insert(task.task_id.as_str(), task);
@@ -259,6 +295,8 @@ pub fn diff_runs(baseline: &RunSummary, candidate: &RunSummary, max_regression: 
                 candidate_median_us: 0.0,
                 speedup: 0.0,
                 regression: true,
+                status: "correctness_failure".into(),
+                reason: "candidate task is missing".into(),
             });
             continue;
         };
@@ -270,7 +308,28 @@ pub fn diff_runs(baseline: &RunSummary, candidate: &RunSummary, max_regression: 
             0.0
         };
         let correct = base_task.correct && cand_task.correct;
-        let regression = !correct || cand_med > base_med * (1.0 + max_regression);
+        let latency_regression = cand_med > base_med * (1.0 + max_regression);
+        let regression = !correct || latency_regression;
+        let (status, reason) = if !correct {
+            (
+                "correctness_failure",
+                if !cand_task.correct {
+                    "candidate task is incorrect"
+                } else {
+                    "baseline task is incorrect"
+                },
+            )
+        } else if latency_regression {
+            (
+                "latency_regression",
+                "candidate latency exceeds max_regression",
+            )
+        } else {
+            (
+                "ok",
+                "candidate task is correct and within latency threshold",
+            )
+        };
         tasks.push(DiffTask {
             task_id: base_task.task_id.clone(),
             correct,
@@ -278,6 +337,8 @@ pub fn diff_runs(baseline: &RunSummary, candidate: &RunSummary, max_regression: 
             candidate_median_us: cand_med,
             speedup,
             regression,
+            status: status.into(),
+            reason: reason.into(),
         });
     }
 
@@ -304,10 +365,28 @@ pub fn diff_runs(baseline: &RunSummary, candidate: &RunSummary, max_regression: 
         .min_by(|a, b| a.speedup.total_cmp(&b.speedup))
         .cloned();
 
+    let task_checks_passed = worst_regression.is_none();
+    let correct = task_checks_passed;
+    let (status, reason) = if !task_checks_passed {
+        (
+            "failed",
+            "one or more required tasks failed correctness or latency checks",
+        )
+    } else if geomean_speedup < min_speedup {
+        ("speedup_failure", "geomean speedup is below min_speedup")
+    } else {
+        (
+            "ok",
+            "all required tasks are correct and within latency threshold",
+        )
+    };
+
     DiffReport {
-        correct: worst_regression.is_none(),
+        correct,
         fast_p,
         geomean_speedup,
+        status: status.to_string(),
+        reason: reason.to_string(),
         worst_regression,
         tasks,
     }
@@ -343,20 +422,45 @@ pub fn render_markdown(summary: &RunSummary) -> String {
         summary.passed_required_tasks,
         summary.required_task_count
     ));
-    s.push_str("| task | correct | timing | median us |\n| --- | --- | --- | ---: |\n");
+    s.push_str("| task | case | suite | tags | shape | correctness | max_abs | max_rel | exact | min_cos | median us | min us | p95 us |\n");
+    s.push_str(
+        "| --- | --- | --- | --- | --- | --- | ---: | ---: | --- | ---: | ---: | ---: | ---: |\n",
+    );
     for task in &summary.tasks {
-        let timing_source = task
-            .cases
-            .first()
-            .map(|case| case.timing_source.as_str())
-            .unwrap_or("unknown");
-        s.push_str(&format!(
-            "| `{}` | {} | `{}` | {:.3} |\n",
-            task.task_id,
-            if task.correct { "yes" } else { "no" },
-            timing_source,
-            task_median(task)
-        ));
+        let suite = if task.required {
+            "required"
+        } else {
+            "optional"
+        };
+        let tags = task.tags.join(",");
+        if task.cases.is_empty() {
+            s.push_str(&format!(
+                "| `{}` | error | {} | `{}` |  | {} |  |  |  |  |  |  |  |\n",
+                task.task_id,
+                suite,
+                tags,
+                task.error.as_deref().unwrap_or("no cases")
+            ));
+            continue;
+        }
+        for case in &task.cases {
+            s.push_str(&format!(
+                "| `{}` | `{}` | {} | `{}` | `{}` | {} | {} | {} | {} | {} | {:.3} | {:.3} | {:.3} |\n",
+                task.task_id,
+                case.name,
+                suite,
+                tags,
+                compact_shape(&case.shape),
+                if case.correct { "pass" } else { "fail" },
+                fmt_opt_f32(case.max_abs),
+                fmt_opt_f32(case.max_rel),
+                fmt_opt_bool(case.exact),
+                fmt_opt_f32(case.min_cos),
+                case.median_us,
+                case.min_us,
+                case.p95_us
+            ));
+        }
     }
     s
 }
@@ -364,16 +468,29 @@ pub fn render_markdown(summary: &RunSummary) -> String {
 pub fn render_diff_markdown(diff: &DiffReport, min_speedup: f64) -> String {
     let mut s = String::new();
     s.push_str("# SuperSonic Kernel Lab Diff\n\n");
+    let speedup_status = if diff.geomean_speedup < min_speedup {
+        "failed"
+    } else {
+        "ok"
+    };
     s.push_str(&format!(
-        "- correct: `{}`\n- fast_p: `{:.3}`\n- geomean speedup: `{:.3}`\n- min speedup: `{:.3}`\n\n",
-        diff.correct, diff.fast_p, diff.geomean_speedup, min_speedup
+        "- correct: `{}`\n- status: `{}`\n- reason: {}\n- fast_p: `{:.3}`\n- geomean speedup: `{:.3}` ({})\n- min speedup: `{:.3}`\n\n",
+        diff.correct,
+        diff.status,
+        diff.reason,
+        diff.fast_p,
+        diff.geomean_speedup,
+        speedup_status,
+        min_speedup
     ));
-    s.push_str("| task | correct | baseline us | candidate us | speedup | regression |\n");
-    s.push_str("| --- | --- | ---: | ---: | ---: | --- |\n");
+    s.push_str("| task | status | reason | correct | baseline us | candidate us | speedup | regression |\n");
+    s.push_str("| --- | --- | --- | --- | ---: | ---: | ---: | --- |\n");
     for task in &diff.tasks {
         s.push_str(&format!(
-            "| `{}` | {} | {:.3} | {:.3} | {:.3} | {} |\n",
+            "| `{}` | `{}` | {} | {} | {:.3} | {:.3} | {:.3} | {} |\n",
             task.task_id,
+            task.status,
+            task.reason,
             if task.correct { "yes" } else { "no" },
             task.baseline_median_us,
             task.candidate_median_us,
@@ -382,6 +499,10 @@ pub fn render_diff_markdown(diff: &DiffReport, min_speedup: f64) -> String {
         ));
     }
     s
+}
+
+pub fn task_manifest(tasks: &[TaskDef]) -> Vec<TaskMetadata> {
+    tasks.iter().map(task_metadata).collect()
 }
 
 pub fn task_median(task: &TaskResult) -> f64 {
@@ -440,6 +561,39 @@ fn append_history(path: &Path, summary: &RunSummary) -> Result<()> {
     Ok(())
 }
 
+fn apply_task_metadata(task: &TaskDef, result: &mut TaskResult) {
+    result.family = task.family.to_string();
+    result.description = task.description.to_string();
+    result.tags = task.tags.iter().map(|tag| tag.to_string()).collect();
+    result.backend_support = task
+        .backend_support
+        .iter()
+        .map(|backend| backend.to_string())
+        .collect();
+    result.correctness = task.correctness.to_string();
+    result.required = task.required;
+}
+
+fn compact_shape(shape: &BTreeMap<String, usize>) -> String {
+    shape
+        .iter()
+        .map(|(key, value)| format!("{key}={value}"))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn fmt_opt_f32(value: Option<f32>) -> String {
+    value
+        .map(|value| format!("{value:.6}"))
+        .unwrap_or_else(|| String::from(""))
+}
+
+fn fmt_opt_bool(value: Option<bool>) -> String {
+    value
+        .map(|value| if value { "true" } else { "false" }.to_string())
+        .unwrap_or_else(|| String::from(""))
+}
+
 fn median(samples: &mut [f64]) -> f64 {
     if samples.is_empty() {
         return 0.0;
@@ -485,16 +639,19 @@ mod tests {
             schema_version: SCHEMA_VERSION,
             task_id: id.into(),
             family: "test".into(),
-            tags: Vec::new(),
+            description: "test task".into(),
+            tags: vec!["required".into()],
+            backend_support: vec!["hip".into()],
+            correctness: "test correctness".into(),
             required: true,
             correct,
             cases: vec![CaseResult {
                 name: "case".into(),
-                shape: BTreeMap::new(),
+                shape: BTreeMap::from([("m".into(), 1), ("n".into(), 2)]),
                 correct,
-                max_abs: None,
-                max_rel: None,
-                min_cos: None,
+                max_abs: Some(0.001),
+                max_rel: Some(0.002),
+                min_cos: Some(0.999),
                 exact: Some(correct),
                 warmup: 0,
                 iters: 1,
@@ -569,6 +726,8 @@ mod tests {
         assert_eq!(diff.tasks.len(), 2);
         assert_eq!(diff.tasks[1].task_id, "b");
         assert!(diff.tasks[1].regression);
+        assert_eq!(diff.tasks[1].status, "correctness_failure");
+        assert_eq!(diff.tasks[1].reason, "candidate task is missing");
         assert_eq!(diff.tasks[1].candidate_median_us, 0.0);
     }
 
@@ -586,6 +745,17 @@ mod tests {
 
         let flat = summary(vec![task("a", true, 100.0)]);
         assert_eq!(diff_exit_code(&diff_runs(&base, &flat, 0.03), 1.02), 4);
+    }
+
+    #[test]
+    fn diff_report_classifies_geomean_speedup_failure_with_threshold() {
+        let base = summary(vec![task("a", true, 100.0)]);
+        let flat = summary(vec![task("a", true, 100.0)]);
+        let diff = diff_runs_with_min_speedup(&base, &flat, 0.03, 1.02);
+        assert!(diff.correct);
+        assert_eq!(diff.status, "speedup_failure");
+        assert_eq!(diff.reason, "geomean speedup is below min_speedup");
+        assert_eq!(diff_exit_code(&diff, 1.02), 4);
     }
 
     #[test]
@@ -608,18 +778,57 @@ mod tests {
         assert!(md.contains("# SuperSonic Kernel Lab"));
         assert!(md.contains("arch `gfx1100`"));
         assert!(md.contains("`qwen35.full_attention_prefill`"));
-        assert!(md.contains("`wall_sync`"));
+        assert!(md.contains("required"));
+        assert!(md.contains("`m=1 n=2`"));
+        assert!(md.contains("0.001000"));
         assert!(md.contains("123.457"));
     }
 
     #[test]
-    fn render_diff_markdown_includes_task_rows() {
+    fn render_diff_markdown_includes_task_rows_and_reasons() {
         let base = summary(vec![task("a", true, 100.0)]);
         let cand = summary(vec![task("a", true, 80.0)]);
         let md = render_diff_markdown(&diff_runs(&base, &cand, 0.03), 1.02);
         assert!(md.contains("# SuperSonic Kernel Lab Diff"));
         assert!(md.contains("`a`"));
+        assert!(md.contains("candidate task is correct"));
         assert!(md.contains("1.250"));
+    }
+
+    #[test]
+    fn load_summary_accepts_old_v1_without_added_task_metadata() {
+        let json = r#"{
+          "schema_version": 1,
+          "meta": {
+            "schema_version": 1,
+            "run_id": "old",
+            "timestamp_utc": "2026-05-06T00:00:00Z",
+            "git_sha": "abc123",
+            "git_dirty": false,
+            "backend": "hip",
+            "device": 0,
+            "arch": "gfx1100",
+            "rocm_smi": ""
+          },
+          "task_count": 1,
+          "passed_tasks": 1,
+          "required_task_count": 1,
+          "passed_required_tasks": 1,
+          "tasks": [{
+            "schema_version": 1,
+            "task_id": "old.task",
+            "family": "test",
+            "tags": ["required"],
+            "required": true,
+            "correct": true,
+            "cases": [],
+            "error": null
+          }]
+        }"#;
+        let summary: RunSummary = serde_json::from_str(json).unwrap();
+        assert_eq!(summary.tasks[0].description, "");
+        assert!(summary.tasks[0].backend_support.is_empty());
+        assert_eq!(summary.tasks[0].correctness, "");
     }
 
     #[test]

--- a/crates/kernel-lab/src/tasks.rs
+++ b/crates/kernel-lab/src/tasks.rs
@@ -327,7 +327,14 @@ fn task_result(task: &TaskDef, cases: Result<Vec<CaseResult>>) -> Result<TaskRes
         schema_version: SCHEMA_VERSION,
         task_id: task.id.to_string(),
         family: task.family.to_string(),
+        description: task.description.to_string(),
         tags: task.tags.iter().map(|s| s.to_string()).collect(),
+        backend_support: task
+            .backend_support
+            .iter()
+            .map(|backend| backend.to_string())
+            .collect(),
+        correctness: task.correctness.to_string(),
         required: task.required,
         correct,
         cases,

--- a/docs/kernel-lab.md
+++ b/docs/kernel-lab.md
@@ -10,6 +10,12 @@ on a candidate checkout, then compare the two run directories.
 ```bash
 cargo run --release -p supersonic-kernel-lab --bin kernel-lab -- list
 
+cargo run --release -p supersonic-kernel-lab --bin kernel-lab -- list --json
+
+cargo run --release -p supersonic-kernel-lab --bin kernel-lab -- list --tags
+
+cargo run --release -p supersonic-kernel-lab --bin kernel-lab -- describe tag:prefill
+
 cargo run --release -p supersonic-kernel-lab --bin kernel-lab -- run \
   --tasks all \
   --backend hip \
@@ -39,11 +45,17 @@ cargo run --release -p supersonic-kernel-lab --bin kernel-lab -- baseline \
   --name required
 ```
 
-The harness writes `meta.json`, one `tasks/*.json` file per task, and a
-`summary.json` under `target/kernel-lab-runs/<date>-<git-sha>/`.
+The harness writes `meta.json`, `task_manifest.json`, one `tasks/*.json` file
+per task, `summary.json`, and `summary.md` under
+`target/kernel-lab-runs/<date>-<git-sha>/`.
 Per-case timings use HIP events when available and record
 `timing_source: "hip_event"` in JSON; unsupported timing backends fall back to
 synchronized wall-clock timing.
+
+The Rust task registry is the source of truth for task metadata. `list --json`
+prints serializable task snapshots, `list --tags` summarizes tag membership, and
+`describe <task-id|tag:tag> [--json]` shows the description, backend support,
+tags, required/optional status, and correctness contract.
 
 `--tasks` accepts `all` for the required suite, `everything` for every registry
 entry, comma-separated task ids, or comma-separated `tag:<name>` selectors. Tag
@@ -71,6 +83,10 @@ harness lands on `main`.
 Scoring is conservative: a task is valid only if every correctness case passes.
 `diff` reports per-task speedup, `fast_p`, geometric mean speedup, and fails on
 correctness regressions or median latency regressions above `--max-regression`.
+Diff JSON and markdown include machine-readable status/reason fields for each
+required task, including missing candidate tasks, incorrect candidate tasks, and
+latency regressions. The top-level diff status/reason also classifies geomean
+speedup failures.
 Exit code `2` means correctness failed, `3` means latency regression, and `4`
 means the run was correct but missed `--min-speedup`. `--github-summary`
 appends the markdown diff to `$GITHUB_STEP_SUMMARY` for Actions jobs.


### PR DESCRIPTION
## Summary
- add static task metadata snapshots from the Rust registry
- expose list/describe metadata commands for tasks and tags
- write task_manifest.json and summary.md for runs
- enrich diff JSON/markdown with status and reason fields

## Validation
- cargo fmt -p supersonic-kernel-lab --check
- cargo test -p supersonic-kernel-lab --lib
- cargo test -p supersonic-kernel-lab --bin kernel-lab
- cargo test -p supersonic-kernel-lab
- cargo build -p supersonic-kernel-lab --bin kernel-lab
- cargo build --release -p supersonic-kernel-lab --bin kernel-lab
- git diff --check
- ./target/release/kernel-lab run --tasks all --backend hip --device 0 --warmup 2 --iters 5
