### PR TITLE
kernel-lab: add latency floor for CI timing

### DIFF
--- a/.github/workflows/kernel-lab.yml
+++ b/.github/workflows/kernel-lab.yml
@@ -42,6 +42,10 @@ on:
         description: "minimum geomean speedup"
         required: true
         default: "0.0"
+      latency_floor_us:
+        description: "ignore latency regressions for tasks below this baseline median"
+        required: false
+        default: ""
       checked_baseline:
         description: "compare candidate against checked-in gfx1100 baseline"
         required: true
@@ -69,6 +73,7 @@ jobs:
       KERNEL_LAB_ITERS_INPUT: ${{ github.event.inputs.iters || '' }}
       KERNEL_LAB_MAX_REGRESSION: ${{ github.event.inputs.max_regression || '0.10' }}
       KERNEL_LAB_MIN_SPEEDUP: ${{ github.event.inputs.min_speedup || '0.0' }}
+      KERNEL_LAB_LATENCY_FLOOR_US_INPUT: ${{ github.event.inputs.latency_floor_us || '' }}
       KERNEL_LAB_CHECKED_BASELINE_INPUT: ${{ github.event.inputs.checked_baseline || 'auto' }}
       KERNEL_LAB_RUN_ROOT: target/kernel-lab-runs
       KERNEL_LAB_WORKTREE_ROOT: target/kernel-lab-worktrees
@@ -89,6 +94,7 @@ jobs:
               tasks="${KERNEL_LAB_TASKS_INPUT:-all}"
               warmup="${KERNEL_LAB_WARMUP_INPUT:-2}"
               iters="${KERNEL_LAB_ITERS_INPUT:-5}"
+              latency_floor_us="${KERNEL_LAB_LATENCY_FLOOR_US_INPUT:-75}"
               checked_baseline_default=1
               checked_baseline_blocking_default=0
               ;;
@@ -96,6 +102,7 @@ jobs:
               tasks="${KERNEL_LAB_TASKS_INPUT:-all}"
               warmup="${KERNEL_LAB_WARMUP_INPUT:-5}"
               iters="${KERNEL_LAB_ITERS_INPUT:-20}"
+              latency_floor_us="${KERNEL_LAB_LATENCY_FLOOR_US_INPUT:-0}"
               checked_baseline_default=1
               checked_baseline_blocking_default=1
               ;;
@@ -103,6 +110,7 @@ jobs:
               tasks="${KERNEL_LAB_TASKS_INPUT:-everything}"
               warmup="${KERNEL_LAB_WARMUP_INPUT:-5}"
               iters="${KERNEL_LAB_ITERS_INPUT:-20}"
+              latency_floor_us="${KERNEL_LAB_LATENCY_FLOOR_US_INPUT:-0}"
               checked_baseline_default=1
               checked_baseline_blocking_default=1
               ;;
@@ -110,6 +118,7 @@ jobs:
               tasks="${KERNEL_LAB_TASKS_INPUT:-tag:stress}"
               warmup="${KERNEL_LAB_WARMUP_INPUT:-5}"
               iters="${KERNEL_LAB_ITERS_INPUT:-20}"
+              latency_floor_us="${KERNEL_LAB_LATENCY_FLOOR_US_INPUT:-0}"
               checked_baseline_default=0
               checked_baseline_blocking_default=0
               ;;
@@ -146,6 +155,7 @@ jobs:
             echo "KERNEL_LAB_TASKS=$tasks"
             echo "KERNEL_LAB_WARMUP=$warmup"
             echo "KERNEL_LAB_ITERS=$iters"
+            echo "KERNEL_LAB_LATENCY_FLOOR_US=$latency_floor_us"
             echo "KERNEL_LAB_COMPARE_CHECKED_BASELINE=$checked_baseline"
             echo "KERNEL_LAB_CHECKED_BASELINE_BLOCKING=$checked_baseline_blocking"
           } >> "$GITHUB_ENV"
@@ -157,6 +167,7 @@ jobs:
             echo "- tasks: \`$tasks\`"
             echo "- warmup: \`$warmup\`"
             echo "- iters: \`$iters\`"
+            echo "- latency floor: \`${latency_floor_us}us\`"
             echo "- checked baseline: \`$checked_baseline\`"
             echo "- checked baseline blocking: \`$checked_baseline_blocking\`"
             if [ -n "$KERNEL_LAB_TASKS_INPUT" ] && [ "$KERNEL_LAB_CHECKED_BASELINE_INPUT" = "auto" ]; then
@@ -240,6 +251,7 @@ jobs:
             --worktree-root "$KERNEL_LAB_WORKTREE_ROOT" \
             --max-regression "$KERNEL_LAB_MAX_REGRESSION" \
             --min-speedup "$KERNEL_LAB_MIN_SPEEDUP" \
+            --latency-floor-us "$KERNEL_LAB_LATENCY_FLOOR_US" \
             --markdown-out "$KERNEL_LAB_RUN_ROOT/diff.md" \
             --candidate-summary-copy "$KERNEL_LAB_CANDIDATE_SUMMARY" \
             --github-summary
@@ -257,6 +269,7 @@ jobs:
             --candidate "$KERNEL_LAB_CANDIDATE_SUMMARY" \
             --max-regression "$KERNEL_LAB_MAX_REGRESSION" \
             --min-speedup "$KERNEL_LAB_MIN_SPEEDUP" \
+            --latency-floor-us "$KERNEL_LAB_LATENCY_FLOOR_US" \
             --markdown-out "$KERNEL_LAB_RUN_ROOT/checked-baseline-diff.md" \
             --github-summary
           status=$?

--- a/crates/kernel-lab/src/bin/kernel_lab.rs
+++ b/crates/kernel-lab/src/bin/kernel_lab.rs
@@ -5,8 +5,8 @@ use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::process::{Command as ProcessCommand, ExitStatus};
 use supersonic_kernel_lab::run::{
-    diff_exit_code, diff_runs_with_min_speedup, load_summary, render_diff_markdown,
-    render_markdown, resolve_tasks, run_tasks, KernelLabConfig,
+    diff_exit_code, diff_runs_with_policy, load_summary, render_diff_markdown, render_markdown,
+    resolve_tasks, run_tasks, KernelLabConfig,
 };
 use supersonic_kernel_lab::{
     all_tag_metadata, all_task_metadata, describe_task_selector, TaskMetadata,
@@ -58,6 +58,8 @@ enum Command {
         max_regression: f64,
         #[arg(long, default_value_t = 1.02)]
         min_speedup: f64,
+        #[arg(long, default_value_t = 0.0)]
+        latency_floor_us: f64,
         #[arg(long)]
         markdown_out: Option<PathBuf>,
         #[arg(long)]
@@ -96,6 +98,8 @@ enum Command {
         max_regression: f64,
         #[arg(long, default_value_t = 1.02)]
         min_speedup: f64,
+        #[arg(long, default_value_t = 0.0)]
+        latency_floor_us: f64,
         #[arg(long)]
         markdown_out: Option<PathBuf>,
         #[arg(long)]
@@ -168,13 +172,19 @@ fn main() -> Result<()> {
             candidate,
             max_regression,
             min_speedup,
+            latency_floor_us,
             markdown_out,
             github_summary,
         } => {
             let baseline = load_summary(&baseline)?;
             let candidate = load_summary(&candidate)?;
-            let diff =
-                diff_runs_with_min_speedup(&baseline, &candidate, max_regression, min_speedup);
+            let diff = diff_runs_with_policy(
+                &baseline,
+                &candidate,
+                max_regression,
+                min_speedup,
+                latency_floor_us,
+            );
             println!("{}", serde_json::to_string_pretty(&diff)?);
             write_diff_markdown(&diff, min_speedup, markdown_out, github_summary)?;
             let code = diff_exit_code(&diff, min_speedup);
@@ -204,6 +214,7 @@ fn main() -> Result<()> {
             worktree_root,
             max_regression,
             min_speedup,
+            latency_floor_us,
             markdown_out,
             github_summary,
             candidate_summary_copy,
@@ -233,11 +244,12 @@ fn main() -> Result<()> {
             if let Some(path) = candidate_summary_copy {
                 copy_summary_json(&candidate, &path)?;
             }
-            let diff = diff_runs_with_min_speedup(
+            let diff = diff_runs_with_policy(
                 &baseline_summary,
                 &candidate_summary,
                 max_regression,
                 min_speedup,
+                latency_floor_us,
             );
             println!("{}", serde_json::to_string_pretty(&diff)?);
             write_diff_markdown(&diff, min_speedup, markdown_out, github_summary)?;

--- a/crates/kernel-lab/src/lib.rs
+++ b/crates/kernel-lab/src/lib.rs
@@ -7,6 +7,7 @@ pub use registry::{
     task_metadata, TagMetadata, TaskDef, TaskMetadata,
 };
 pub use run::{
-    diff_exit_code, diff_runs, diff_runs_with_min_speedup, render_diff_markdown, render_markdown,
-    run_tasks, CaseResult, DiffReport, KernelLabConfig, RunSummary, TaskResult,
+    diff_exit_code, diff_runs, diff_runs_with_min_speedup, diff_runs_with_policy,
+    render_diff_markdown, render_markdown, run_tasks, CaseResult, DiffReport, KernelLabConfig,
+    RunSummary, TaskResult,
 };

--- a/crates/kernel-lab/src/run.rs
+++ b/crates/kernel-lab/src/run.rs
@@ -100,6 +100,8 @@ pub struct DiffReport {
     pub fast_p: f64,
     pub geomean_speedup: f64,
     #[serde(default)]
+    pub speedup_task_count: usize,
+    #[serde(default)]
     pub status: String,
     #[serde(default)]
     pub reason: String,
@@ -367,21 +369,27 @@ pub fn diff_runs_with_policy(
         });
     }
 
-    let valid: Vec<_> = tasks.iter().filter(|task| task.correct).collect();
-    let fast_count = valid.iter().filter(|task| task.speedup > 1.0).count();
+    let speedup_gated: Vec<_> = tasks
+        .iter()
+        .filter(|task| task.correct && task.status != "latency_floor")
+        .collect();
+    let fast_count = speedup_gated
+        .iter()
+        .filter(|task| task.speedup > 1.0)
+        .count();
     let fast_p = if tasks.is_empty() {
         0.0
     } else {
         fast_count as f64 / tasks.len() as f64
     };
-    let geomean_speedup = if valid.is_empty() {
-        0.0
+    let geomean_speedup = if speedup_gated.is_empty() {
+        1.0
     } else {
-        (valid
+        (speedup_gated
             .iter()
             .map(|task| task.speedup.max(1e-9).ln())
             .sum::<f64>()
-            / valid.len() as f64)
+            / speedup_gated.len() as f64)
             .exp()
     };
     let worst_regression = tasks
@@ -397,7 +405,7 @@ pub fn diff_runs_with_policy(
             "failed",
             "one or more required tasks failed correctness or latency checks",
         )
-    } else if geomean_speedup < min_speedup {
+    } else if !speedup_gated.is_empty() && geomean_speedup < min_speedup {
         ("speedup_failure", "geomean speedup is below min_speedup")
     } else {
         (
@@ -410,6 +418,7 @@ pub fn diff_runs_with_policy(
         correct,
         fast_p,
         geomean_speedup,
+        speedup_task_count: speedup_gated.len(),
         status: status.to_string(),
         reason: reason.to_string(),
         worst_regression,
@@ -422,7 +431,7 @@ pub fn diff_exit_code(diff: &DiffReport, min_speedup: f64) -> i32 {
         2
     } else if diff.tasks.iter().any(|task| task.regression) {
         3
-    } else if diff.geomean_speedup < min_speedup {
+    } else if diff.speedup_task_count > 0 && diff.geomean_speedup < min_speedup {
         4
     } else {
         0
@@ -493,19 +502,20 @@ pub fn render_markdown(summary: &RunSummary) -> String {
 pub fn render_diff_markdown(diff: &DiffReport, min_speedup: f64) -> String {
     let mut s = String::new();
     s.push_str("# SuperSonic Kernel Lab Diff\n\n");
-    let speedup_status = if diff.geomean_speedup < min_speedup {
+    let speedup_status = if diff.speedup_task_count > 0 && diff.geomean_speedup < min_speedup {
         "failed"
     } else {
         "ok"
     };
     s.push_str(&format!(
-        "- correct: `{}`\n- status: `{}`\n- reason: {}\n- fast_p: `{:.3}`\n- geomean speedup: `{:.3}` ({})\n- min speedup: `{:.3}`\n\n",
+        "- correct: `{}`\n- status: `{}`\n- reason: {}\n- fast_p: `{:.3}`\n- geomean speedup: `{:.3}` ({})\n- speedup-gated tasks: `{}`\n- min speedup: `{:.3}`\n\n",
         diff.correct,
         diff.status,
         diff.reason,
         diff.fast_p,
         diff.geomean_speedup,
         speedup_status,
+        diff.speedup_task_count,
         min_speedup
     ));
     s.push_str("| task | status | reason | correct | baseline us | candidate us | speedup | regression |\n");
@@ -727,13 +737,16 @@ mod tests {
     fn diff_latency_floor_ignores_tiny_task_timing_noise() {
         let base = summary(vec![task("a", true, 37.0)]);
         let cand = summary(vec![task("a", true, 43.0)]);
-        let diff = diff_runs_with_policy(&base, &cand, 0.10, 0.0, 75.0);
+        let diff = diff_runs_with_policy(&base, &cand, 0.10, 1.02, 75.0);
         assert!(diff.correct);
         assert!(!diff.tasks[0].regression);
         assert!(!diff.tasks[0].latency_gate_active);
         assert_eq!(diff.tasks[0].latency_floor_us, 75.0);
         assert_eq!(diff.tasks[0].status, "latency_floor");
-        assert_eq!(diff_exit_code(&diff, 0.0), 0);
+        assert_eq!(diff.geomean_speedup, 1.0);
+        assert_eq!(diff.speedup_task_count, 0);
+        assert_eq!(diff.status, "ok");
+        assert_eq!(diff_exit_code(&diff, 1.02), 0);
     }
 
     #[test]
@@ -754,6 +767,7 @@ mod tests {
         let diff = diff_runs(&base, &cand, 0.03);
         assert!(diff.correct);
         assert_eq!(diff.fast_p, 1.0);
+        assert_eq!(diff.speedup_task_count, 2);
         assert!(diff.geomean_speedup > 1.24 && diff.geomean_speedup < 1.26);
         assert!(diff.worst_regression.is_none());
     }
@@ -804,6 +818,7 @@ mod tests {
         let flat = summary(vec![task("a", true, 100.0)]);
         let diff = diff_runs_with_min_speedup(&base, &flat, 0.03, 1.02);
         assert!(diff.correct);
+        assert_eq!(diff.speedup_task_count, 1);
         assert_eq!(diff.status, "speedup_failure");
         assert_eq!(diff.reason, "geomean speedup is below min_speedup");
         assert_eq!(diff_exit_code(&diff, 1.02), 4);

--- a/crates/kernel-lab/src/run.rs
+++ b/crates/kernel-lab/src/run.rs
@@ -85,6 +85,10 @@ pub struct DiffTask {
     pub speedup: f64,
     pub regression: bool,
     #[serde(default)]
+    pub latency_floor_us: f64,
+    #[serde(default)]
+    pub latency_gate_active: bool,
+    #[serde(default)]
     pub status: String,
     #[serde(default)]
     pub reason: String,
@@ -279,6 +283,16 @@ pub fn diff_runs_with_min_speedup(
     max_regression: f64,
     min_speedup: f64,
 ) -> DiffReport {
+    diff_runs_with_policy(baseline, candidate, max_regression, min_speedup, 0.0)
+}
+
+pub fn diff_runs_with_policy(
+    baseline: &RunSummary,
+    candidate: &RunSummary,
+    max_regression: f64,
+    min_speedup: f64,
+    latency_floor_us: f64,
+) -> DiffReport {
     let mut candidate_by_id = BTreeMap::new();
     for task in &candidate.tasks {
         candidate_by_id.insert(task.task_id.as_str(), task);
@@ -295,6 +309,8 @@ pub fn diff_runs_with_min_speedup(
                 candidate_median_us: 0.0,
                 speedup: 0.0,
                 regression: true,
+                latency_floor_us,
+                latency_gate_active: true,
                 status: "correctness_failure".into(),
                 reason: "candidate task is missing".into(),
             });
@@ -308,7 +324,9 @@ pub fn diff_runs_with_min_speedup(
             0.0
         };
         let correct = base_task.correct && cand_task.correct;
-        let latency_regression = cand_med > base_med * (1.0 + max_regression);
+        let raw_latency_regression = cand_med > base_med * (1.0 + max_regression);
+        let latency_gate_active = base_med >= latency_floor_us;
+        let latency_regression = raw_latency_regression && latency_gate_active;
         let regression = !correct || latency_regression;
         let (status, reason) = if !correct {
             (
@@ -324,6 +342,11 @@ pub fn diff_runs_with_min_speedup(
                 "latency_regression",
                 "candidate latency exceeds max_regression",
             )
+        } else if raw_latency_regression {
+            (
+                "latency_floor",
+                "candidate latency exceeds max_regression but baseline latency is below latency_floor_us",
+            )
         } else {
             (
                 "ok",
@@ -337,6 +360,8 @@ pub fn diff_runs_with_min_speedup(
             candidate_median_us: cand_med,
             speedup,
             regression,
+            latency_floor_us,
+            latency_gate_active,
             status: status.into(),
             reason: reason.into(),
         });
@@ -694,6 +719,32 @@ mod tests {
         let diff = diff_runs(&base, &cand, 0.03);
         assert!(!diff.correct);
         assert!(diff.tasks[0].regression);
+        assert!(diff.tasks[0].latency_gate_active);
+        assert_eq!(diff.tasks[0].status, "latency_regression");
+    }
+
+    #[test]
+    fn diff_latency_floor_ignores_tiny_task_timing_noise() {
+        let base = summary(vec![task("a", true, 37.0)]);
+        let cand = summary(vec![task("a", true, 43.0)]);
+        let diff = diff_runs_with_policy(&base, &cand, 0.10, 0.0, 75.0);
+        assert!(diff.correct);
+        assert!(!diff.tasks[0].regression);
+        assert!(!diff.tasks[0].latency_gate_active);
+        assert_eq!(diff.tasks[0].latency_floor_us, 75.0);
+        assert_eq!(diff.tasks[0].status, "latency_floor");
+        assert_eq!(diff_exit_code(&diff, 0.0), 0);
+    }
+
+    #[test]
+    fn diff_latency_floor_still_gates_larger_tasks() {
+        let base = summary(vec![task("a", true, 100.0)]);
+        let cand = summary(vec![task("a", true, 112.0)]);
+        let diff = diff_runs_with_policy(&base, &cand, 0.10, 0.0, 75.0);
+        assert!(!diff.correct);
+        assert!(diff.tasks[0].regression);
+        assert!(diff.tasks[0].latency_gate_active);
+        assert_eq!(diff.tasks[0].status, "latency_regression");
     }
 
     #[test]

--- a/docs/kernel-lab.md
+++ b/docs/kernel-lab.md
@@ -94,6 +94,9 @@ harness lands on `main`.
 Scoring is conservative: a task is valid only if every correctness case passes.
 `diff` reports per-task speedup, `fast_p`, geometric mean speedup, and fails on
 correctness regressions or median latency regressions above `--max-regression`.
+`--latency-floor-us` can make latency regressions non-blocking for very small
+tasks whose baseline median is below the floor; correctness failures still fail
+regardless of latency.
 Diff JSON and markdown include machine-readable status/reason fields for each
 required task, including missing candidate tasks, incorrect candidate tasks, and
 latency regressions. The top-level diff status/reason also classifies geomean
@@ -106,10 +109,10 @@ appends the markdown diff to `$GITHUB_STEP_SUMMARY` for Actions jobs.
 
 `.github/workflows/kernel-lab.yml` runs on PRs that touch kernel-lab, kernel FFI,
 GPU HAL, Cargo metadata, or HIP kernel sources. It targets a self-hosted ROCm
-runner labelled `self-hosted`, `linux`, and `rocm`. The default PR suite is the
-cheap `qwen36.router_permute` task with relaxed smoke thresholds; use
-`workflow_dispatch` to run broader selectors such as `all`, `tag:prefill`, or
-`everything` with custom iteration counts.
+runner labelled `self-hosted`, `linux`, and `rocm`. The default PR suite is
+`all` with short warmup/iteration counts; use `workflow_dispatch` to run broader
+selectors such as `everything`, `tag:functional`, or `tag:stress` with custom
+iteration counts.
 
 Because the job executes candidate code on a persistent self-hosted GPU host,
 the PR trigger is restricted to same-repository branches. Fork PRs must be run
@@ -120,9 +123,11 @@ The workflow compares the checked-out candidate worktree against the PR base
 commit using `compare-ref`, writes markdown to the GitHub step summary, and
 uploads the run JSON/markdown artifacts.
 
-Before building, the workflow waits for the ROCm device to report at most 5%
+Before building, the workflow waits for the ROCm device to report at most 10%
 GPU use and at most 20% VRAM allocation for three consecutive 30-second
 samples. If the device stays busy for one hour, the job fails with a clear
+error. The default PR preset also uses a `75us` latency floor so tiny required
+tasks remain correctness-gated without failing on incidental GPU timing noise.
 timeout rather than running a noisy contended benchmark.
 
 ## Baselines


### PR DESCRIPTION
## Summary
- add `--latency-floor-us` to `diff` and `compare-ref`
- keep correctness failures strict while ignoring latency regressions for tasks below the floor
- expose latency-floor fields in diff JSON for machine-readable reporting
- set the PR workflow default latency floor to 75us, while required/everything/stress remain strict by default
- update docs for the 10% GPU idle gate and PR timing policy

## Validation
- cargo fmt -p supersonic-kernel-lab --check
- cargo test -p supersonic-kernel-lab --lib
- cargo test -p supersonic-kernel-lab --bin kernel-lab
- cargo test -p supersonic-kernel-lab
- cargo build --release -p supersonic-kernel-lab --bin kernel-lab
- git diff --check
- ./target/release/kernel-lab diff --baseline crates/kernel-lab/baselines/gfx1100/required.summary.json --candidate crates/kernel-lab/baselines/gfx1100/required.summary.json --max-regression 0.10 --min-speedup 0.0 --latency-floor-us 75
