### PR TITLE
Add CUDA sm90 H100 support

### DIFF
--- a/crates/core/src/registry.rs
+++ b/crates/core/src/registry.rs
@@ -113,6 +113,7 @@ pub enum GpuArch {
     Gfx1150,
     Gfx942,
     Sm86,
+    Sm90,
     AppleM4,
     Unknown(String),
 }
@@ -128,6 +129,7 @@ impl GpuArch {
             },
             Backend::Cuda => match name.trim() {
                 "sm86" => Self::Sm86,
+                "sm90" => Self::Sm90,
                 other => Self::Unknown(other.to_owned()),
             },
             Backend::Metal => match name.trim() {
@@ -145,6 +147,7 @@ impl fmt::Display for GpuArch {
             Self::Gfx1150 => write!(f, "gfx1150"),
             Self::Gfx942 => write!(f, "gfx942"),
             Self::Sm86 => write!(f, "sm86"),
+            Self::Sm90 => write!(f, "sm90"),
             Self::AppleM4 => write!(f, "apple-m4"),
             Self::Unknown(s) => write!(f, "{s}"),
         }
@@ -169,7 +172,9 @@ pub struct ArchProfile {
 impl ArchProfile {
     pub fn for_arch(arch: &GpuArch) -> Self {
         let memory = match arch {
-            GpuArch::Gfx1100 | GpuArch::Gfx942 | GpuArch::Sm86 => MemoryArchitecture::Discrete,
+            GpuArch::Gfx1100 | GpuArch::Gfx942 | GpuArch::Sm86 | GpuArch::Sm90 => {
+                MemoryArchitecture::Discrete
+            }
             GpuArch::Gfx1150 | GpuArch::AppleM4 => MemoryArchitecture::Unified,
             GpuArch::Unknown(_) => MemoryArchitecture::Discrete,
         };
@@ -865,9 +870,24 @@ pub fn lookup(
     backend: &Backend,
     arch: &GpuArch,
 ) -> Option<&'static RegistryEntry> {
-    REGISTRY
+    let direct = REGISTRY
         .iter()
-        .find(|e| e.model == *model && e.backend == *backend && e.arch == *arch)
+        .find(|e| e.model == *model && e.backend == *backend && e.arch == *arch);
+    if direct.is_some() {
+        return direct;
+    }
+
+    // H100-class CUDA devices report `sm90`. The current CUDA kernels are
+    // architecture-neutral enough to reuse the validated CUDA registry
+    // geometry. Builds on an H100 emit native SM90 cubins; builds on older
+    // CUDA hosts embed PTX alongside their native cubins for forward JIT.
+    if *backend == Backend::Cuda && *arch == GpuArch::Sm90 {
+        return REGISTRY
+            .iter()
+            .find(|e| e.model == *model && e.backend == *backend && e.arch == GpuArch::Sm86);
+    }
+
+    None
 }
 
 pub fn supported_models_list() -> Vec<&'static str> {
@@ -892,11 +912,17 @@ pub fn supported_models_list() -> Vec<&'static str> {
 }
 
 pub fn supported_archs_for(model: &ModelVariant, backend: &Backend) -> Vec<String> {
-    REGISTRY
+    let mut archs: Vec<String> = REGISTRY
         .iter()
         .filter(|e| e.model == *model && e.backend == *backend)
         .map(|e| e.arch.to_string())
-        .collect()
+        .collect();
+    if *backend == Backend::Cuda && archs.iter().any(|arch| arch == "sm86") {
+        archs.push("sm90".to_string());
+    }
+    archs.sort();
+    archs.dedup();
+    archs
 }
 
 #[cfg(test)]
@@ -907,6 +933,33 @@ mod tests {
     fn cuda_sm86_qwen_registry_includes_2b_and_9b() {
         assert!(lookup(&ModelVariant::Qwen3_5_2B, &Backend::Cuda, &GpuArch::Sm86,).is_some());
         assert!(lookup(&ModelVariant::Qwen3_5_9B, &Backend::Cuda, &GpuArch::Sm86,).is_some());
+    }
+
+    #[test]
+    fn cuda_sm90_reuses_cuda_registry_entries() {
+        assert_eq!(
+            GpuArch::from_backend_name(&Backend::Cuda, "sm90"),
+            GpuArch::Sm90
+        );
+        let profile = ArchProfile::for_arch(&GpuArch::Sm90);
+        assert_eq!(profile.memory, MemoryArchitecture::Discrete);
+        assert_eq!(profile.buffer_policy, BufferPolicy::all_default());
+        for model in [
+            ModelVariant::Qwen3_5_0_8B,
+            ModelVariant::Qwen3_5_2B,
+            ModelVariant::Qwen3_5_4B,
+            ModelVariant::Qwen3_5_9B,
+            ModelVariant::Qwen3_6_27B,
+            ModelVariant::Qwen3_6_35B_A3B,
+            ModelVariant::Gemma4_E2B,
+            ModelVariant::Phi4_Mini,
+            ModelVariant::Llama3_1_8B,
+        ] {
+            assert!(lookup(&model, &Backend::Cuda, &GpuArch::Sm90).is_some());
+            assert!(supported_archs_for(&model, &Backend::Cuda)
+                .iter()
+                .any(|arch| arch == "sm90"));
+        }
     }
 
     #[test]

--- a/crates/kernel-ffi/build.rs
+++ b/crates/kernel-ffi/build.rs
@@ -347,7 +347,9 @@ fn compile_cuda(kernel_dir: &Path, out_dir: &Path) {
             .arg("-o")
             .arg(&obj_path);
         for arch in &archs {
-            cmd.arg(format!("-gencode=arch=compute_{arch},code=sm_{arch}"));
+            cmd.arg(format!(
+                "-gencode=arch=compute_{arch},code=[sm_{arch},compute_{arch}]"
+            ));
         }
         run(&mut cmd, context);
         objects.push(obj_path);

--- a/docs/feature-compatibility.md
+++ b/docs/feature-compatibility.md
@@ -9,6 +9,12 @@ This doc tracks **correctness**. For measured speedups see
 For the model × quant × arch baseline see
 [supported-matrix.md](supported-matrix.md).
 
+CUDA `sm90` currently follows the `sm86` CUDA feature surface: H100-class
+devices compile native SM90 CUDA kernels but reuse the validated `sm86`
+registry geometry and feature gates. Dedicated H100 validation is tracked in
+[supported-matrix.md § CUDA on sm90](supported-matrix.md#cuda-on-sm90) and
+[performance.md § CUDA — sm90](performance.md#cuda--sm90-nvidia-h100-80gb-hbm3).
+
 ## How to read
 
 - **✅** = validated end-to-end (parity test or oracle agreement).
@@ -48,6 +54,9 @@ stable CLI surface).
 
 Support:
 
+The `sm86` CUDA column also applies to `sm90` unless a per-arch note says
+otherwise; the current H100 path is an inherited CUDA compatibility lane.
+
 | Model            | gfx1100 | gfx1150 | gfx942 | sm86  | apple-m4 |
 |------------------|:-------:|:-------:|:------:|:-----:|:--------:|
 | qwen3.5-0.8b     |    ✅   |   ✅    |  ✅¹  |  ✅   |    —     |
@@ -81,6 +90,9 @@ Flags: `--virtual-kv` (default ON for Qwen3.6-MoE on HIP per
 [lowlevel-memory.md](lowlevel-memory.md)).
 
 Support:
+
+The CUDA `sm86` column also applies to `sm90` for VMM: no VMM surface is
+registered for CUDA dense/Qwen3.6-MoE today.
 
 | Model            | gfx1100 | gfx1150 | gfx942 | sm86  |
 |------------------|:-------:|:-------:|:------:|:-----:|
@@ -116,6 +128,8 @@ full prompt-length sweep.
 
 Support:
 
+The CUDA `sm86` rejection also applies to `sm90`.
+
 | Target × Draft                 | gfx1100 | gfx1150 | gfx942 | sm86 |
 |--------------------------------|:-------:|:-------:|:------:|:----:|
 | qwen3.5-9b BF16 + qwen3.5-0.8b |    ✅   |   TBM   |  TBM   |  ❌¹ |
@@ -136,6 +150,8 @@ See [dflash.md](dflash.md) for the design and the M3/M4 milestones.
 
 Support:
 
+The CUDA `sm86` rejection also applies to `sm90`.
+
 | Target          | gfx1100 | gfx1150 | gfx942 | sm86 |
 |-----------------|:-------:|:-------:|:------:|:----:|
 | qwen3.5-9b INT4 |    ✅   |   ✅    |  TBM   |  ❌  |
@@ -155,6 +171,9 @@ Flags: governed by `--qwen36-moe-prefetch-policy <name>` and a few
 
 Support:
 
+The CUDA `sm86` column also applies to `sm90`: no CUDA MoE prefetch lane is
+registered today.
+
 | Model            | gfx1100 | gfx1150 | gfx942 | sm86 |
 |------------------|:-------:|:-------:|:------:|:----:|
 | qwen3.6-35b-a3b  |    ✅   |    —    |   —    |   —  |
@@ -170,6 +189,9 @@ Flags: `--certified-kv`, `--certified-kv-shadow-validate`. Requires
 [certified-kv-audit-map.md](certified-kv-audit-map.md).
 
 Support:
+
+The CUDA `sm86` column also applies to `sm90`; H100 inherits the same
+certified-KV feature gates pending dedicated quality/performance runs.
 
 | Model        | gfx1100 | gfx1150 | gfx942 | sm86 |
 |--------------|:-------:|:-------:|:------:|:----:|

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -700,6 +700,74 @@ CUDA `sm86` tracks detailed kernel-level optimization history for both the
 `0.8B` and `4B` hero lanes in
 [qwen35-sm86-optimization.md](qwen35-sm86-optimization.md).
 
+## CUDA — `sm90` (NVIDIA H100 80GB HBM3)
+
+Measurements recorded 2026-05-07 on an NVIDIA H100 80GB HBM3, driver
+580.126.09, CUDA toolkit 13.0 (`nvcc` 13.0.88). The H100 path compiles native
+SM90 CUDA objects but currently reuses the CUDA `sm86` registry geometry and
+kernel families. Treat these as a compatibility baseline, not a
+Hopper-optimized result.
+
+Before measuring, a resident vLLM `Qwen/Qwen3-Coder-30B-A3B-Instruct-FP8`
+server using ~74 GiB of VRAM was stopped. The benchmark model directories were
+empty before the run; SuperSonic downloaded the `bakes-v2` BF16 release
+artifacts and bundled HF metadata on first use:
+
+- `/home/deano/models/Qwen3.5-0.8B-sm90`
+- `/home/deano/models/Qwen3.5-4B-sm90`
+
+Smoke checks:
+
+| Model         | Prompt tokens | Generated | Prefill | Decode | Result |
+|---------------|--------------:|----------:|--------:|-------:|--------|
+| qwen3.5-0.8b  |             6 |         4 |   39 ms |  64 ms | pass |
+| qwen3.5-4b    |             6 |         4 |  103 ms | 127 ms | pass |
+
+Warmed benchmark settings:
+
+```bash
+PATH=/home/deano/.cargo/bin:$PATH \
+SUPERSONIC_BACKENDS=cuda TARGET_PROMPT_TOKENS=224 MAX_NEW_TOKENS=32 \
+WARMUP_RUNS=3 TIMED_RUNS=5 COMPARE_LEGACY=0 \
+  ./tests/sm86/bench_qwen08.sh /home/deano/models/Qwen3.5-0.8B-sm90
+
+PATH=/home/deano/.cargo/bin:$PATH \
+SUPERSONIC_BACKENDS=cuda TARGET_PROMPT_TOKENS=224 MAX_NEW_TOKENS=32 \
+WARMUP_RUNS=3 TIMED_RUNS=5 \
+  ./tests/sm86/bench_qwen4b_single.sh /home/deano/models/Qwen3.5-4B-sm90
+
+PATH=/home/deano/.cargo/bin:$PATH \
+SUPERSONIC_BACKENDS=cuda TARGET_PROMPT_TOKENS=224 MAX_NEW_TOKENS=32 \
+WARMUP_RUNS=3 TIMED_RUNS=5 BATCH_SIZE=2 \
+  ./tests/sm86/bench_qwen4b_batch.sh /home/deano/models/Qwen3.5-4B-sm90
+```
+
+The prompt calibrator selected `prompt_repeat=32`, producing 416 prompt
+tokens. The table reports the mean over 5 timed runs after 3 warmup runs.
+
+| Model                       | Path                    | Prefill     | Decode      | Decode mean |
+|-----------------------------|-------------------------|------------:|------------:|------------:|
+| qwen3.5-0.8b                | fast-greedy BF16        | 1362.1 tok/s | 32.2 tok/s  | 994.8 ms / 32 tok |
+| qwen3.5-4b `--batch-size 1` | `--force-kernel-decode` | 784.9 tok/s  | 26.4 tok/s  | 1210.2 ms / 32 tok |
+| qwen3.5-4b `--batch-size 2` | batched BF16            | 785.8 tok/s  | 11.3 tok/s¹ | 5675.2 ms / 64 aggregate tok |
+
+¹ Aggregate tokens/second across `--batch-size 2`.
+
+The quick combined harness also passed:
+
+```bash
+PATH=/home/deano/.cargo/bin:$PATH \
+SUPERSONIC_BACKENDS=cuda RUNS=3 MAX_NEW_TOKENS=16 PROMPT_REPEAT=16 \
+BATCH_SIZE_4B=2 \
+  ./tests/sm86/bench.sh \
+  /home/deano/models/Qwen3.5-0.8B-sm90 \
+  /home/deano/models/Qwen3.5-4B-sm90
+```
+
+That quick pass produced 224 prompt tokens and 16 generated tokens. The first
+0.8B prefill included a cold-start outlier (`4551 ms`, then `189/186 ms`), so
+the warmed table above is the preferred H100 baseline.
+
 ## Metal — `apple-m4` (Apple M4)
 
 The current Metal numbers are still prototype-grade and are scoped narrowly to

--- a/docs/supported-matrix.md
+++ b/docs/supported-matrix.md
@@ -6,12 +6,13 @@ which GPU architecture. The cells below track *correctness* — see
 and [docs/feature-compatibility.md](feature-compatibility.md) for the
 runtime-feature compatibility grid.
 
-Five backend surfaces are validated or in bring-up today:
+Six backend surfaces are validated or in bring-up today:
 
 - **HIP / `gfx1100`** — AMD Radeon RX 7900 XTX (RDNA 3, 24 GiB)
 - **HIP / `gfx1150`** — AMD Radeon 890M iGPU (RDNA 3.5)
 - **HIP / `gfx942`** — AMD Instinct MI300X-class (CDNA 3, wave64 bring-up)
 - **CUDA / `sm86`** — NVIDIA RTX 3090-class (Ampere)
+- **CUDA / `sm90`** — NVIDIA H100 80GB HBM3 (Hopper)
 - **Metal / `apple-m4`** — Apple M4, BF16 Qwen3.5 0.8B (CLI + `supersonic-serve`)
 
 ### HIP on `gfx1100`
@@ -171,6 +172,31 @@ kernel path by default; replayed-prefill decode is legacy debugging behavior
 behind `--force-replay-decode`. CUDA `--kv-fp8` single-sequence decode still
 uses replayed GPU prefill for correctness.
 
+### CUDA on `sm90`
+
+`sm90` currently reuses the CUDA `sm86` registry geometry and kernel families,
+while `kernel-ffi/build.rs` compiles the CUDA sources as native SM90 cubins
+from the detected H100 compute capability. This is a compatibility bring-up
+lane, not a Hopper-specific retune.
+
+| Model            | BF16 | INT4 | FP8 runtime | FP8 KV |
+|------------------|:----:|:----:|:-----------:|:------:|
+| qwen3.5-0.8b     |  ✅¹ |  ✅² |      ✅²    |   ✅²  |
+| qwen3.5-2b       |  ✅² |  ✅² |      ✅²    |   ✅²  |
+| qwen3.5-4b       |  ✅¹ |  ✅² |      ✅²    |   ✅²  |
+| qwen3.5-9b       |  ✅² |  ✅² |      ✅²    |   ✅²  |
+| gemma4-e2b       |  ✅² |  —   |      —      |    —   |
+| phi4-mini        |  ✅² |  ✅² |      ✅²    |   ⏳²  |
+| llama3.1-8b      |  ✅² |  —   |      —      |   ✅²  |
+
+¹ Smoke-tested and benchmarked on an NVIDIA H100 80GB HBM3 on 2026-05-07 with
+  CUDA 13.0 / driver 580.126.09, using the `bakes-v2` BF16 release artifacts.
+  See [docs/performance.md](performance.md#cuda--sm90-nvidia-h100-80gb-hbm3).
+² Registered on `sm90` by reusing the validated CUDA `sm86` entry for this
+  model/lane. Dedicated H100 parity coverage is pending; if you need strict
+  certification for one of these inherited lanes, run the matching `tests/sm86`
+  validation script on the H100 and record the result here.
+
 ### Metal on `apple-m4`
 
 | Model            | BF16 | INT4 | FP8 runtime | FP8 KV |
@@ -190,4 +216,3 @@ Metal v2 is a single supported surface:
   validation against a baked INT4 model is pending hardware time
 - `--fp8-runtime`, `--kv-fp8`, `--batch-size > 1`, `--force-kernel-decode`,
   and `--force-component-decode` are all rejected at startup
-


### PR DESCRIPTION
## Summary

- add CUDA `sm90` / H100 recognition in the core registry
- let `sm90` reuse the existing CUDA `sm86` registry geometry while `kernel-ffi` emits native SM90 CUDA objects
- document H100 compatibility in the supported matrix and feature compatibility docs
- add measured H100 smoke and benchmark results to performance docs

## H100 Results

Hardware: NVIDIA H100 80GB HBM3, driver 580.126.09, CUDA toolkit 13.0 (`nvcc` 13.0.88).

Smoke checks using downloaded `bakes-v2` BF16 artifacts:

| Model | Prompt tokens | Generated | Prefill | Decode | Result |
| --- | ---: | ---: | ---: | ---: | --- |
| qwen3.5-0.8b | 6 | 4 | 39 ms | 64 ms | pass |
| qwen3.5-4b | 6 | 4 | 103 ms | 127 ms | pass |

Warmed benchmark means over 5 timed runs after 3 warmups, 416 prompt tokens, 32 generated tokens:

| Model | Path | Prefill | Decode |
| --- | --- | ---: | ---: |
| qwen3.5-0.8b | fast-greedy BF16 | 1362.1 tok/s | 32.2 tok/s |
| qwen3.5-4b batch 1 | `--force-kernel-decode` | 784.9 tok/s | 26.4 tok/s |
| qwen3.5-4b batch 2 | batched BF16 | 785.8 tok/s | 11.3 tok/s aggregate |

Note: this is a compatibility baseline, not a Hopper-specific retune.

## Validation

- `cargo fmt -p supersonic-core --check`
- `cargo test -p supersonic-core`
- `SUPERSONIC_BACKENDS=cuda cargo build --release --bin supersonic`
- H100 smoke runs for `qwen3.5-0.8b` and `qwen3.5-4b`
- H100 warmed benchmark harnesses for `qwen3.5-0.8b`, `qwen3.5-4b` batch 1, and `qwen3.5-4b` batch 2