### PR TITLE
Add Qwen3 30B A3B HIP INT4 decode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1645,6 +1645,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "qwen3_moe"
+version = "0.1.0"
+dependencies = [
+ "gpu-hal",
+ "kernel-ffi",
+ "memmap2",
+ "model-store",
+ "safetensors",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1853,6 +1867,7 @@ dependencies = [
  "qwen35",
  "qwen35_dflash",
  "qwen36_moe",
+ "qwen3_moe",
  "safetensors",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/phi4",
     "crates/qwen35",
     "crates/qwen35_dflash",
+    "crates/qwen3_moe",
     "crates/qwen36_moe",
     "crates/runtime",
     "crates/runner",

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ to disable network fetches.
   per-feature parity tests.
 - **[DFlash speculative decode](docs/dflash.md)** — Qwen3.5-9B INT4
   speculative decode design and milestones.
+- **[Qwen3-30B-A3B HIP bring-up](docs/qwen3-30b-a3b-hip.md)** —
+  separate Qwen3 MoE scaffolding and INT4 bake contract for HIP.
 - **[SpecPrefill](docs/specprefill.md)** — long-prompt TTFT optimization
   via speculator-driven sparse prefill.
 - **[Certified KV (Llama 3.1)](docs/certified-kv-audit-map.md)** — KV

--- a/crates/core/src/capabilities.rs
+++ b/crates/core/src/capabilities.rs
@@ -35,6 +35,9 @@ pub fn capabilities_for_variant(
     let family = variant.family();
     let serve_status = match family {
         ModelFamily::Qwen35 | ModelFamily::Gemma4 => ServeStatus::Ready,
+        ModelFamily::Qwen3Moe => {
+            ServeStatus::CliOnly("Qwen3 MoE runtime is still wired through the CLI flow")
+        }
         ModelFamily::Qwen36Moe => {
             ServeStatus::CliOnly("Qwen3.6 MoE runtime is still wired through the CLI flow")
         }
@@ -65,6 +68,10 @@ mod tests {
         let cases = [
             (ModelVariant::Qwen3_5_0_8B, ServeStatus::Ready),
             (ModelVariant::Gemma4_E2B, ServeStatus::Ready),
+            (
+                ModelVariant::Qwen3_30B_A3B,
+                ServeStatus::CliOnly("Qwen3 MoE runtime is still wired through the CLI flow"),
+            ),
             (
                 ModelVariant::Qwen3_6_35B_A3B,
                 ServeStatus::CliOnly("Qwen3.6 MoE runtime is still wired through the CLI flow"),

--- a/crates/core/src/registry.rs
+++ b/crates/core/src/registry.rs
@@ -6,6 +6,7 @@ pub use gpu_hal::{AllocStrategy, Backend, BufferPolicy, MemoryArchitecture};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ModelFamily {
+    Qwen3Moe,
     Qwen35,
     Qwen36Moe,
     Gemma4,
@@ -16,6 +17,7 @@ pub enum ModelFamily {
 impl fmt::Display for ModelFamily {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::Qwen3Moe => write!(f, "qwen3-moe"),
             Self::Qwen35 => write!(f, "qwen3.5"),
             Self::Qwen36Moe => write!(f, "qwen3.6-moe"),
             Self::Gemma4 => write!(f, "gemma4"),
@@ -31,6 +33,7 @@ pub enum ModelVariant {
     Qwen3_5_2B,
     Qwen3_5_4B,
     Qwen3_5_9B,
+    Qwen3_30B_A3B,
     Qwen3_6_27B,
     Qwen3_6_35B_A3B,
     Gemma4_E2B,
@@ -46,6 +49,9 @@ impl ModelVariant {
             "qwen3.5-2b" | "qwen35-2b" | "2b" => Some(Self::Qwen3_5_2B),
             "qwen3.5-4b" | "qwen35-4b" | "4b" => Some(Self::Qwen3_5_4B),
             "qwen3.5-9b" | "qwen35-9b" | "9b" => Some(Self::Qwen3_5_9B),
+            "qwen3-30b-a3b" | "qwen3-30b-a3b-int4" | "qwen3moe-30b-a3b" => {
+                Some(Self::Qwen3_30B_A3B)
+            }
             "qwen3.6-27b" | "qwen36-27b" | "qwen3.6-27b-fp8" | "qwen36-27b-fp8" => {
                 Some(Self::Qwen3_6_27B)
             }
@@ -66,6 +72,7 @@ impl ModelVariant {
             Self::Qwen3_5_2B => "Qwen/Qwen3.5-2B",
             Self::Qwen3_5_4B => "Qwen/Qwen3.5-4B",
             Self::Qwen3_5_9B => "Qwen/Qwen3.5-9B",
+            Self::Qwen3_30B_A3B => "Qwen/Qwen3-30B-A3B",
             Self::Qwen3_6_27B => "Qwen/Qwen3.6-27B-FP8",
             Self::Qwen3_6_35B_A3B => "Qwen/Qwen3.6-35B-A3B-FP8",
             Self::Gemma4_E2B => "google/gemma-4-E2B",
@@ -82,6 +89,7 @@ impl ModelVariant {
             | Self::Qwen3_5_4B
             | Self::Qwen3_5_9B
             | Self::Qwen3_6_27B => ModelFamily::Qwen35,
+            Self::Qwen3_30B_A3B => ModelFamily::Qwen3Moe,
             Self::Qwen3_6_35B_A3B => ModelFamily::Qwen36Moe,
             Self::Gemma4_E2B | Self::Gemma4_E4B => ModelFamily::Gemma4,
             Self::Phi4_Mini => ModelFamily::Phi4,
@@ -97,6 +105,7 @@ impl fmt::Display for ModelVariant {
             Self::Qwen3_5_2B => write!(f, "qwen3.5-2b"),
             Self::Qwen3_5_4B => write!(f, "qwen3.5-4b"),
             Self::Qwen3_5_9B => write!(f, "qwen3.5-9b"),
+            Self::Qwen3_30B_A3B => write!(f, "qwen3-30b-a3b"),
             Self::Qwen3_6_27B => write!(f, "qwen3.6-27b"),
             Self::Qwen3_6_35B_A3B => write!(f, "qwen3.6-35b-a3b"),
             Self::Gemma4_E2B => write!(f, "gemma4-e2b"),
@@ -277,7 +286,24 @@ pub struct Qwen36MoeKernelParams {
     pub shared_expert_intermediate_size: u32,
 }
 
+#[derive(Clone, Copy)]
+pub struct Qwen3MoeKernelParams {
+    pub weight_prefix: &'static str,
+    pub kv_chunk_size: usize,
+    pub hidden_size: u32,
+    pub vocab_size: u32,
+    pub num_layers: u32,
+    pub num_attention_heads: u32,
+    pub num_kv_heads: u32,
+    pub head_dim: u32,
+    pub num_experts: u32,
+    pub top_k: u32,
+    pub moe_intermediate_size: u32,
+    pub scratch_floats: usize,
+}
+
 pub enum FamilyParams {
+    Qwen3Moe(Qwen3MoeKernelParams),
     Qwen35(Qwen35KernelParams),
     Qwen36Moe(Qwen36MoeKernelParams),
     Gemma4(Gemma4KernelParams),
@@ -785,6 +811,32 @@ static REGISTRY: &[RegistryEntry] = &[
             kv_chunk_size: 256,
         }),
     },
+    // Qwen3-30B-A3B BF16 checkpoint is ~56.9 GiB, so the gfx1100 v1 lane is
+    // INT4-GPTQ only. The runtime policy rejects BF16 until a large-VRAM
+    // profile and kernel path are added.
+    RegistryEntry {
+        model: ModelVariant::Qwen3_30B_A3B,
+        backend: Backend::Hip,
+        arch: GpuArch::Gfx1100,
+        vram: VramBudget {
+            fixed_bytes: 19 * GIB,
+            overhead_factor: 1.1,
+        },
+        params: FamilyParams::Qwen3Moe(Qwen3MoeKernelParams {
+            weight_prefix: "model",
+            kv_chunk_size: 256,
+            hidden_size: 2048,
+            vocab_size: 151_936,
+            num_layers: 48,
+            num_attention_heads: 32,
+            num_kv_heads: 4,
+            head_dim: 128,
+            num_experts: 128,
+            top_k: 8,
+            moe_intermediate_size: 768,
+            scratch_floats: 16_384,
+        }),
+    },
     // Qwen3.6-35B-A3B INT4 GPTQ on AMD gfx1100. Primary AMD v1 target.
     // BF16 won't fit 24 GiB; this entry assumes the INT4 bake. PR 3
     // wires it for the dry-run path; PR 6 lands the kernel.
@@ -878,6 +930,7 @@ pub fn supported_models_list() -> Vec<&'static str> {
             ModelVariant::Qwen3_5_2B => "qwen3.5-2b",
             ModelVariant::Qwen3_5_4B => "qwen3.5-4b",
             ModelVariant::Qwen3_5_9B => "qwen3.5-9b",
+            ModelVariant::Qwen3_30B_A3B => "qwen3-30b-a3b",
             ModelVariant::Qwen3_6_27B => "qwen3.6-27b",
             ModelVariant::Qwen3_6_35B_A3B => "qwen3.6-35b-a3b",
             ModelVariant::Gemma4_E2B => "gemma4-e2b",
@@ -931,6 +984,7 @@ mod tests {
             ModelVariant::Qwen3_5_2B,
             ModelVariant::Qwen3_5_4B,
             ModelVariant::Qwen3_5_9B,
+            ModelVariant::Qwen3_30B_A3B,
             ModelVariant::Gemma4_E2B,
             ModelVariant::Gemma4_E4B,
             ModelVariant::Phi4_Mini,
@@ -999,6 +1053,37 @@ mod tests {
         assert_eq!(ModelVariant::Qwen3_6_35B_A3B.to_string(), "qwen3.6-35b-a3b");
         assert!(supported_models_list().contains(&"qwen3.6-27b"));
         assert!(supported_models_list().contains(&"qwen3.6-35b-a3b"));
+    }
+
+    #[test]
+    fn qwen3_moe_aliases_and_registry_are_public() {
+        assert_eq!(
+            ModelVariant::from_cli_str("qwen3-30b-a3b-int4"),
+            Some(ModelVariant::Qwen3_30B_A3B)
+        );
+        assert_eq!(ModelVariant::Qwen3_30B_A3B.family(), ModelFamily::Qwen3Moe);
+        assert_eq!(
+            ModelVariant::Qwen3_30B_A3B.hf_model_id(),
+            "Qwen/Qwen3-30B-A3B"
+        );
+        assert!(supported_models_list().contains(&"qwen3-30b-a3b"));
+
+        let entry = lookup(
+            &ModelVariant::Qwen3_30B_A3B,
+            &Backend::Hip,
+            &GpuArch::Gfx1100,
+        )
+        .expect("qwen3-30b-a3b HIP gfx1100 registry entry");
+        match entry.params {
+            FamilyParams::Qwen3Moe(p) => {
+                assert_eq!(p.weight_prefix, "model");
+                assert_eq!(p.num_layers, 48);
+                assert_eq!(p.num_experts, 128);
+                assert_eq!(p.top_k, 8);
+                assert_eq!(p.moe_intermediate_size, 768);
+            }
+            _ => panic!("qwen3-30b-a3b must use Qwen3Moe family params"),
+        }
     }
 
     #[test]

--- a/crates/kernel-ffi/build.rs
+++ b/crates/kernel-ffi/build.rs
@@ -234,6 +234,11 @@ fn compile_hip(kernel_dir: &Path, out_dir: &Path) {
             "qwen36_moe_hip.o",
             "building Qwen3.6-MoE HIP bridge",
         ),
+        (
+            "qwen3_moe_bridge.cpp",
+            "qwen3_moe_hip.o",
+            "building Qwen3-MoE HIP bridge",
+        ),
     ];
     let archs = detect_hip_archs();
     if archs.is_empty() {
@@ -427,6 +432,8 @@ fn main() {
         "qwen36_moe_cuda_prelude.cuh",
         "qwen36_moe_bridge.cpp",
         "qwen36_moe_bridge_cuda.cu",
+        "qwen3_moe.hip",
+        "qwen3_moe_bridge.cpp",
         "qwen36_moe_persistent/helpers.cuh",
         "qwen36_moe_persistent/full_attn_phase.cuh",
         "qwen36_moe_persistent/linear_attn_phase.cuh",

--- a/crates/kernel-ffi/src/lib.rs
+++ b/crates/kernel-ffi/src/lib.rs
@@ -8,6 +8,7 @@ pub mod phi4;
 pub mod prefill_ffi;
 mod qwen35;
 pub mod qwen36_moe;
+pub mod qwen3_moe;
 
 pub use layer_desc::{
     BatchSeqDesc, DecodeLayerDesc, FP8ScaleDesc, INT4ScaleDesc, KVCacheFp8Desc, MAX_BATCH_SIZE,

--- a/crates/kernel-ffi/src/qwen3_moe.rs
+++ b/crates/kernel-ffi/src/qwen3_moe.rs
@@ -1,0 +1,309 @@
+//! FFI bridge for the Qwen3-MoE HIP kernel family.
+//!
+//! This is deliberately separate from `qwen36_moe`: Qwen3-30B-A3B is a
+//! pure-attention MoE model with different geometry and no Qwen3.6 hybrid
+//! linear-attention/shared-expert path.
+
+#![cfg_attr(not(supersonic_backend_hip), allow(unused_variables))]
+
+use std::ffi::{c_int, c_void};
+use std::os::raw::c_uint;
+
+use gpu_hal::{Backend, GpuBuffer, GpuError, ScalarType};
+
+#[repr(C)]
+#[derive(Debug, Clone)]
+pub struct Qwen3MoeDecodeLayerDesc {
+    pub layer_idx: c_int,
+    pub input_norm_w: *const c_void,
+    pub input_norm_eps: f32,
+    pub post_attn_norm_w: *const c_void,
+    pub post_attn_norm_eps: f32,
+
+    pub q_proj_w: *const c_void,
+    pub k_proj_w: *const c_void,
+    pub v_proj_w: *const c_void,
+    pub o_proj_w: *const c_void,
+    pub q_norm_w: *const c_void,
+    pub k_norm_w: *const c_void,
+    pub rope_theta: f32,
+    pub head_dim: c_int,
+    pub num_heads: c_int,
+    pub num_kv_heads: c_int,
+    pub kv_cache_k: *mut c_void,
+    pub kv_cache_v: *mut c_void,
+    pub kv_len: c_int,
+    pub kv_max_t: c_int,
+
+    pub router_w: *const c_void,
+    pub experts_gate_up_w: *const c_void,
+    pub experts_down_w: *const c_void,
+    pub num_experts: c_int,
+    pub top_k: c_int,
+    pub moe_intermediate_size: c_int,
+    pub norm_topk_prob: c_int,
+}
+
+unsafe impl Send for Qwen3MoeDecodeLayerDesc {}
+unsafe impl Sync for Qwen3MoeDecodeLayerDesc {}
+
+impl Default for Qwen3MoeDecodeLayerDesc {
+    fn default() -> Self {
+        unsafe { std::mem::zeroed() }
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Clone)]
+pub struct Qwen3MoeInt4ScaleDesc {
+    pub q_proj_scale: *const c_void,
+    pub q_proj_zero: *const c_void,
+    pub k_proj_scale: *const c_void,
+    pub k_proj_zero: *const c_void,
+    pub v_proj_scale: *const c_void,
+    pub v_proj_zero: *const c_void,
+    pub o_proj_scale: *const c_void,
+    pub o_proj_zero: *const c_void,
+    pub experts_gate_up_scale: *const c_void,
+    pub experts_gate_up_zero: *const c_void,
+    pub experts_down_scale: *const c_void,
+    pub experts_down_zero: *const c_void,
+    pub group_size: c_int,
+}
+
+unsafe impl Send for Qwen3MoeInt4ScaleDesc {}
+unsafe impl Sync for Qwen3MoeInt4ScaleDesc {}
+
+impl Default for Qwen3MoeInt4ScaleDesc {
+    fn default() -> Self {
+        unsafe { std::mem::zeroed() }
+    }
+}
+
+#[cfg(supersonic_backend_hip)]
+extern "C" {
+    pub fn qwen3_moe_hip_stub_launch(
+        dtype: c_int,
+        device_ordinal: usize,
+        num_layers: usize,
+        layers: *const Qwen3MoeDecodeLayerDesc,
+        workspace: *mut f32,
+        counters: *mut c_uint,
+    ) -> c_int;
+
+    pub fn qwen3_moe_hip_decode_layer_launch(
+        dtype: c_int,
+        device_ordinal: usize,
+        layer: *const Qwen3MoeDecodeLayerDesc,
+        int4: *const Qwen3MoeInt4ScaleDesc,
+        hidden: c_int,
+        position: c_int,
+        input_hidden: *const c_void,
+        output_hidden: *mut c_void,
+        workspace: *mut f32,
+    ) -> c_int;
+
+    pub fn qwen3_moe_hip_lm_head_launch(
+        dtype: c_int,
+        device_ordinal: usize,
+        hidden: c_int,
+        vocab: c_int,
+        rms_norm_eps: f32,
+        final_hidden: *const c_void,
+        final_norm_w: *const c_void,
+        lm_head_w: *const c_void,
+        logits: *mut c_void,
+        counter: *mut c_uint,
+    ) -> c_int;
+}
+
+pub fn stub_launch(
+    ordinal: usize,
+    dtype: ScalarType,
+    layer_descs_device: &GpuBuffer,
+    workspace: &mut GpuBuffer,
+    sync_buf: &mut GpuBuffer,
+    num_layers: usize,
+) -> Result<(), GpuError> {
+    if dtype != ScalarType::BF16 {
+        return Err(GpuError::InvalidArg(format!(
+            "qwen3_moe::stub_launch: only BF16 is wired, got {dtype:?}"
+        )));
+    }
+    let backend = layer_descs_device.backend();
+    let status: c_int = match backend {
+        Backend::Hip => {
+            #[cfg(supersonic_backend_hip)]
+            unsafe {
+                qwen3_moe_hip_stub_launch(
+                    dtype.kernel_dtype_code(),
+                    ordinal,
+                    num_layers,
+                    layer_descs_device.as_ptr() as *const Qwen3MoeDecodeLayerDesc,
+                    workspace.as_mut_ptr() as *mut f32,
+                    sync_buf.as_mut_ptr() as *mut c_uint,
+                )
+            }
+            #[cfg(not(supersonic_backend_hip))]
+            {
+                return Err(GpuError::InvalidArg(
+                    "qwen3_moe::stub_launch: HIP backend not compiled".into(),
+                ));
+            }
+        }
+        Backend::Cuda | Backend::Metal => {
+            return Err(GpuError::InvalidArg(
+                "qwen3_moe::stub_launch: Qwen3-MoE is HIP-only".into(),
+            ));
+        }
+    };
+    if status != 0 {
+        return Err(GpuError::backend(
+            backend,
+            format!("qwen3_moe stub launch failed with status {status}"),
+        ));
+    }
+    Ok(())
+}
+
+pub fn decode_layer_launch(
+    ordinal: usize,
+    dtype: ScalarType,
+    layer: &Qwen3MoeDecodeLayerDesc,
+    int4: &Qwen3MoeInt4ScaleDesc,
+    hidden: i32,
+    position: i32,
+    input_hidden: &GpuBuffer,
+    output_hidden: &mut GpuBuffer,
+    workspace: &mut GpuBuffer,
+) -> Result<(), GpuError> {
+    if dtype != ScalarType::BF16 {
+        return Err(GpuError::InvalidArg(format!(
+            "qwen3_moe::decode_layer_launch: only BF16 is wired, got {dtype:?}"
+        )));
+    }
+    let backend = input_hidden.backend();
+    let status: c_int = match backend {
+        Backend::Hip => {
+            #[cfg(supersonic_backend_hip)]
+            unsafe {
+                qwen3_moe_hip_decode_layer_launch(
+                    dtype.kernel_dtype_code(),
+                    ordinal,
+                    layer as *const Qwen3MoeDecodeLayerDesc,
+                    int4 as *const Qwen3MoeInt4ScaleDesc,
+                    hidden,
+                    position,
+                    input_hidden.as_ptr(),
+                    output_hidden.as_mut_ptr(),
+                    workspace.as_mut_ptr() as *mut f32,
+                )
+            }
+            #[cfg(not(supersonic_backend_hip))]
+            {
+                let _ = (
+                    ordinal,
+                    layer,
+                    int4,
+                    hidden,
+                    position,
+                    output_hidden,
+                    workspace,
+                );
+                return Err(GpuError::InvalidArg(
+                    "qwen3_moe::decode_layer_launch: HIP backend not compiled".into(),
+                ));
+            }
+        }
+        Backend::Cuda | Backend::Metal => {
+            return Err(GpuError::InvalidArg(
+                "qwen3_moe::decode_layer_launch: Qwen3-MoE is HIP-only".into(),
+            ));
+        }
+    };
+    if status != 0 {
+        return Err(GpuError::backend(
+            backend,
+            format!("qwen3_moe decode layer launch failed with status {status}"),
+        ));
+    }
+    Ok(())
+}
+
+pub fn lm_head_launch(
+    ordinal: usize,
+    dtype: ScalarType,
+    hidden: i32,
+    vocab: i32,
+    rms_norm_eps: f32,
+    final_hidden: &GpuBuffer,
+    final_norm_w: &GpuBuffer,
+    lm_head_w: &GpuBuffer,
+    logits: &mut GpuBuffer,
+    counter: &mut GpuBuffer,
+) -> Result<(), GpuError> {
+    if dtype != ScalarType::BF16 {
+        return Err(GpuError::InvalidArg(format!(
+            "qwen3_moe::lm_head_launch: only BF16 is wired, got {dtype:?}"
+        )));
+    }
+    let backend = final_hidden.backend();
+    let status: c_int = match backend {
+        Backend::Hip => {
+            #[cfg(supersonic_backend_hip)]
+            unsafe {
+                qwen3_moe_hip_lm_head_launch(
+                    dtype.kernel_dtype_code(),
+                    ordinal,
+                    hidden,
+                    vocab,
+                    rms_norm_eps,
+                    final_hidden.as_ptr(),
+                    final_norm_w.as_ptr(),
+                    lm_head_w.as_ptr(),
+                    logits.as_mut_ptr(),
+                    counter.as_mut_ptr() as *mut c_uint,
+                )
+            }
+            #[cfg(not(supersonic_backend_hip))]
+            {
+                let _ = (
+                    ordinal,
+                    hidden,
+                    vocab,
+                    rms_norm_eps,
+                    final_norm_w,
+                    lm_head_w,
+                    logits,
+                    counter,
+                );
+                return Err(GpuError::InvalidArg(
+                    "qwen3_moe::lm_head_launch: HIP backend not compiled".into(),
+                ));
+            }
+        }
+        Backend::Cuda | Backend::Metal => {
+            return Err(GpuError::InvalidArg(
+                "qwen3_moe::lm_head_launch: Qwen3-MoE is HIP-only".into(),
+            ));
+        }
+    };
+    if status != 0 {
+        return Err(GpuError::backend(
+            backend,
+            format!("qwen3_moe lm_head launch failed with status {status}"),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn descriptor_sizes_match_bridge_static_asserts() {
+        assert_eq!(std::mem::size_of::<Qwen3MoeDecodeLayerDesc>(), 168);
+        assert_eq!(std::mem::size_of::<Qwen3MoeInt4ScaleDesc>(), 104);
+    }
+}

--- a/crates/qwen3_moe/Cargo.toml
+++ b/crates/qwen3_moe/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "qwen3_moe"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+gpu-hal = { path = "../gpu-hal" }
+kernel-ffi = { path = "../kernel-ffi" }
+model-store = { path = "../model-store" }
+memmap2 = "0.9"
+safetensors = "0.5"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "2"

--- a/crates/qwen3_moe/src/baked.rs
+++ b/crates/qwen3_moe/src/baked.rs
@@ -1,0 +1,387 @@
+use std::path::{Path, PathBuf};
+
+use model_store::{
+    manifest::{LayoutTag, TensorMeta},
+    BakedStore,
+};
+use thiserror::Error;
+
+use crate::{
+    config::TextConfig,
+    weights::{baked_tensor_contract, BakedLayout, BakedTensorSpec},
+};
+
+pub const DEFAULT_INT4_GROUP_SIZE: usize = 128;
+
+#[derive(Debug, Error)]
+pub enum BakedIndexError {
+    #[error("Qwen3 INT4 bake does not match runtime contract")]
+    Contract(BakedContractReport),
+    #[error("required baked tensor disappeared after contract validation: {0}")]
+    MissingTensor(String),
+}
+
+#[derive(Debug)]
+pub enum Int4BakeInspection {
+    MissingOrOutdated {
+        bake_dir: PathBuf,
+    },
+    Present {
+        bake_dir: PathBuf,
+        report: BakedContractReport,
+    },
+}
+
+impl Int4BakeInspection {
+    pub fn bake_dir(&self) -> &Path {
+        match self {
+            Self::MissingOrOutdated { bake_dir } | Self::Present { bake_dir, .. } => bake_dir,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct BakedContractReport {
+    pub present: usize,
+    pub missing: usize,
+    pub shape_mismatches: usize,
+    pub dtype_mismatches: usize,
+    pub layout_mismatches: usize,
+    pub int4_layouts: usize,
+    pub raw_layouts: usize,
+    pub other_layouts: usize,
+    pub bytes: u64,
+    pub missing_examples: Vec<String>,
+    pub shape_examples: Vec<String>,
+    pub dtype_examples: Vec<String>,
+    pub layout_examples: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BakedTensorRef {
+    pub name: String,
+    pub dtype: String,
+    pub shape: Vec<usize>,
+    pub byte_len: u64,
+}
+
+impl BakedTensorRef {
+    fn from_meta(meta: &TensorMeta) -> Self {
+        Self {
+            name: meta.name.clone(),
+            dtype: meta.dtype.clone(),
+            shape: meta.shape.clone(),
+            byte_len: meta.byte_len,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Qwen3MoeInt4BakedIndex {
+    pub embed_tokens: BakedTensorRef,
+    pub final_norm: BakedTensorRef,
+    pub lm_head: Option<Qwen3MoeInt4Tensor>,
+    pub layers: Vec<Qwen3MoeInt4LayerIndex>,
+    pub total_bytes: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Qwen3MoeInt4LayerIndex {
+    pub input_norm: BakedTensorRef,
+    pub post_attn_norm: BakedTensorRef,
+    pub q_proj: Qwen3MoeInt4Tensor,
+    pub k_proj: Qwen3MoeInt4Tensor,
+    pub v_proj: Qwen3MoeInt4Tensor,
+    pub o_proj: Qwen3MoeInt4Tensor,
+    pub q_norm: BakedTensorRef,
+    pub k_norm: BakedTensorRef,
+    pub router: BakedTensorRef,
+    pub experts_gate_up: Qwen3MoeInt4Tensor,
+    pub experts_down: Qwen3MoeInt4Tensor,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Qwen3MoeInt4Tensor {
+    pub weight: BakedTensorRef,
+    pub scale: BakedTensorRef,
+    pub zero: BakedTensorRef,
+}
+
+impl BakedContractReport {
+    pub fn is_complete(&self) -> bool {
+        self.missing == 0
+            && self.shape_mismatches == 0
+            && self.dtype_mismatches == 0
+            && self.layout_mismatches == 0
+    }
+}
+
+pub fn int4_contract(config: &TextConfig, prefix: &str) -> Vec<BakedTensorSpec> {
+    baked_tensor_contract(config, prefix, DEFAULT_INT4_GROUP_SIZE)
+}
+
+pub fn inspect_int4_bake(
+    model_dir: &Path,
+    config: &TextConfig,
+    prefix: &str,
+) -> Result<Int4BakeInspection, model_store::Error> {
+    let bake_dir = model_store::bake_dir_for_quant_profile(
+        model_dir,
+        model_store::manifest::QuantProfile::Int4Gptq,
+    );
+    if !model_store::version_ok_for_quant_profile(
+        &bake_dir,
+        model_store::manifest::QuantProfile::Int4Gptq,
+    ) {
+        return Ok(Int4BakeInspection::MissingOrOutdated { bake_dir });
+    }
+
+    let store = BakedStore::open(&bake_dir)?;
+    let report = inspect_int4_store(&store, config, prefix);
+    Ok(Int4BakeInspection::Present { bake_dir, report })
+}
+
+pub fn inspect_int4_store(
+    store: &BakedStore,
+    config: &TextConfig,
+    prefix: &str,
+) -> BakedContractReport {
+    inspect_contract(store, &int4_contract(config, prefix))
+}
+
+pub fn build_int4_baked_index(
+    store: &BakedStore,
+    config: &TextConfig,
+    prefix: &str,
+) -> Result<Qwen3MoeInt4BakedIndex, BakedIndexError> {
+    let report = inspect_int4_store(store, config, prefix);
+    if !report.is_complete() {
+        return Err(BakedIndexError::Contract(report));
+    }
+
+    let embed_tokens = required_ref(store, &format!("{prefix}.embed_tokens.weight"))?;
+    let final_norm = required_ref(store, &format!("{prefix}.norm.weight"))?;
+    let lm_head = if config.tie_word_embeddings {
+        None
+    } else {
+        Some(required_int4_tensor(store, "lm_head.weight")?)
+    };
+
+    let mut layers = Vec::with_capacity(config.num_hidden_layers);
+    for layer in 0..config.num_hidden_layers {
+        let lp = format!("{prefix}.layers.{layer}");
+        let ap = format!("{lp}.self_attn");
+        let mp = format!("{lp}.mlp");
+        layers.push(Qwen3MoeInt4LayerIndex {
+            input_norm: required_ref(store, &format!("{lp}.input_layernorm.weight"))?,
+            post_attn_norm: required_ref(store, &format!("{lp}.post_attention_layernorm.weight"))?,
+            q_proj: required_int4_tensor(store, &format!("{ap}.q_proj.weight"))?,
+            k_proj: required_int4_tensor(store, &format!("{ap}.k_proj.weight"))?,
+            v_proj: required_int4_tensor(store, &format!("{ap}.v_proj.weight"))?,
+            o_proj: required_int4_tensor(store, &format!("{ap}.o_proj.weight"))?,
+            q_norm: required_ref(store, &format!("{ap}.q_norm.weight"))?,
+            k_norm: required_ref(store, &format!("{ap}.k_norm.weight"))?,
+            router: required_ref(store, &format!("{mp}.gate.weight"))?,
+            experts_gate_up: required_int4_tensor(store, &format!("{mp}.experts.gate_up_proj"))?,
+            experts_down: required_int4_tensor(store, &format!("{mp}.experts.down_proj"))?,
+        });
+    }
+
+    let mut total_bytes = embed_tokens.byte_len + final_norm.byte_len;
+    if let Some(lm_head) = &lm_head {
+        total_bytes = total_bytes.saturating_add(lm_head.total_bytes());
+    }
+    for layer in &layers {
+        total_bytes = total_bytes.saturating_add(layer.total_bytes());
+    }
+
+    Ok(Qwen3MoeInt4BakedIndex {
+        embed_tokens,
+        final_norm,
+        lm_head,
+        layers,
+        total_bytes,
+    })
+}
+
+impl Qwen3MoeInt4LayerIndex {
+    pub fn total_bytes(&self) -> u64 {
+        self.input_norm
+            .byte_len
+            .saturating_add(self.post_attn_norm.byte_len)
+            .saturating_add(self.q_proj.total_bytes())
+            .saturating_add(self.k_proj.total_bytes())
+            .saturating_add(self.v_proj.total_bytes())
+            .saturating_add(self.o_proj.total_bytes())
+            .saturating_add(self.q_norm.byte_len)
+            .saturating_add(self.k_norm.byte_len)
+            .saturating_add(self.router.byte_len)
+            .saturating_add(self.experts_gate_up.total_bytes())
+            .saturating_add(self.experts_down.total_bytes())
+    }
+}
+
+impl Qwen3MoeInt4Tensor {
+    pub fn total_bytes(&self) -> u64 {
+        self.weight
+            .byte_len
+            .saturating_add(self.scale.byte_len)
+            .saturating_add(self.zero.byte_len)
+    }
+}
+
+pub fn inspect_contract(store: &BakedStore, specs: &[BakedTensorSpec]) -> BakedContractReport {
+    let mut report = BakedContractReport::default();
+    for spec in specs {
+        let Some(meta) = store.meta(&spec.name) else {
+            report.missing += 1;
+            push_example(&mut report.missing_examples, spec.name.clone());
+            continue;
+        };
+        report.present += 1;
+        report.bytes = report.bytes.saturating_add(meta.byte_len);
+
+        let got_layout = store.layout(&spec.name);
+        match got_layout {
+            Some(LayoutTag::Int4Quantized) => report.int4_layouts += 1,
+            Some(LayoutTag::Raw) => report.raw_layouts += 1,
+            Some(_) => report.other_layouts += 1,
+            None => {}
+        }
+        if !layout_matches(got_layout, spec.layout) {
+            report.layout_mismatches += 1;
+            push_example(
+                &mut report.layout_examples,
+                format!("{} has layout {:?}", spec.name, got_layout),
+            );
+        }
+        if meta.dtype != spec.dtype {
+            report.dtype_mismatches += 1;
+            push_example(
+                &mut report.dtype_examples,
+                format!(
+                    "{} has dtype {}, expected {}",
+                    spec.name, meta.dtype, spec.dtype
+                ),
+            );
+        }
+        if meta.shape != spec.shape {
+            report.shape_mismatches += 1;
+            push_example(
+                &mut report.shape_examples,
+                format!(
+                    "{} has {:?}, expected {:?}",
+                    spec.name, meta.shape, spec.shape
+                ),
+            );
+        }
+    }
+    report
+}
+
+fn required_int4_tensor(
+    store: &BakedStore,
+    name: &str,
+) -> Result<Qwen3MoeInt4Tensor, BakedIndexError> {
+    Ok(Qwen3MoeInt4Tensor {
+        weight: required_ref(store, name)?,
+        scale: required_ref(store, &format!("{name}_int4_scale"))?,
+        zero: required_ref(store, &format!("{name}_int4_zero"))?,
+    })
+}
+
+fn required_ref(store: &BakedStore, name: &str) -> Result<BakedTensorRef, BakedIndexError> {
+    store
+        .meta(name)
+        .map(BakedTensorRef::from_meta)
+        .ok_or_else(|| BakedIndexError::MissingTensor(name.to_string()))
+}
+
+fn layout_matches(got: Option<&LayoutTag>, expected: BakedLayout) -> bool {
+    matches!(
+        (got, expected),
+        (Some(LayoutTag::Raw), BakedLayout::Raw)
+            | (Some(LayoutTag::Int4Quantized), BakedLayout::Int4Quantized)
+    )
+}
+
+fn push_example(examples: &mut Vec<String>, value: String) {
+    if examples.len() < 3 {
+        examples.push(value);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{Activation, TextConfig};
+
+    fn config_30b_a3b() -> TextConfig {
+        TextConfig {
+            vocab_size: 151_936,
+            hidden_size: 2048,
+            num_hidden_layers: 48,
+            num_attention_heads: 32,
+            num_key_value_heads: 4,
+            max_position_embeddings: 40_960,
+            rms_norm_eps: 1e-6,
+            intermediate_size: 6144,
+            num_experts: 128,
+            num_experts_per_tok: 8,
+            moe_intermediate_size: 768,
+            hidden_act: Activation::Silu,
+            tie_word_embeddings: false,
+            eos_token_id: None,
+            bos_token_id: None,
+            head_dim: 128,
+            rope_theta: 1_000_000.0,
+            norm_topk_prob: true,
+            router_aux_loss_coef: 0.001,
+        }
+    }
+
+    #[test]
+    fn int4_contract_uses_qwen3_group_size() {
+        let contract = int4_contract(&config_30b_a3b(), crate::weights::DEFAULT_PREFIX);
+        let q0_scale = contract
+            .iter()
+            .find(|s| s.name == "model.layers.0.self_attn.q_proj.weight_int4_scale")
+            .unwrap();
+        assert_eq!(q0_scale.shape, vec![32, 16]);
+    }
+
+    #[test]
+    fn complete_report_has_no_contract_errors() {
+        let report = BakedContractReport {
+            present: 1,
+            ..BakedContractReport::default()
+        };
+        assert!(report.is_complete());
+
+        let report = BakedContractReport {
+            missing: 1,
+            ..BakedContractReport::default()
+        };
+        assert!(!report.is_complete());
+    }
+
+    #[test]
+    fn qwen3_int4_index_byte_accounting_matches_contract_projection() {
+        let cfg = config_30b_a3b();
+        let contract = int4_contract(&cfg, crate::weights::DEFAULT_PREFIX);
+        let expected_bytes: u64 = contract
+            .iter()
+            .map(|spec| {
+                let dtype_size = match spec.dtype {
+                    "bf16" => 2,
+                    "u8" => 1,
+                    other => panic!("unexpected dtype {other}"),
+                };
+                spec.shape.iter().product::<usize>() as u64 * dtype_size
+            })
+            .sum();
+        let projected = crate::weights::CheckpointAccount::from_config(&cfg)
+            .project_int4_total_bytes(&cfg, DEFAULT_INT4_GROUP_SIZE as u64);
+        assert_eq!(expected_bytes, projected);
+    }
+}

--- a/crates/qwen3_moe/src/config.rs
+++ b/crates/qwen3_moe/src/config.rs
@@ -1,0 +1,180 @@
+use serde::Deserialize;
+
+fn default_head_dim() -> usize {
+    128
+}
+
+fn default_rope_theta() -> f64 {
+    1_000_000.0
+}
+
+fn default_norm_topk_prob() -> bool {
+    true
+}
+
+fn default_router_aux_loss_coef() -> f64 {
+    0.001
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum Activation {
+    #[default]
+    Silu,
+    Gelu,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct TextConfig {
+    pub vocab_size: usize,
+    pub hidden_size: usize,
+    pub num_hidden_layers: usize,
+    pub num_attention_heads: usize,
+    pub num_key_value_heads: usize,
+    pub max_position_embeddings: usize,
+    pub rms_norm_eps: f64,
+    pub intermediate_size: usize,
+    pub num_experts: usize,
+    pub num_experts_per_tok: usize,
+    pub moe_intermediate_size: usize,
+
+    #[serde(default)]
+    pub hidden_act: Activation,
+    #[serde(default)]
+    pub tie_word_embeddings: bool,
+    #[serde(default)]
+    pub eos_token_id: Option<serde_json::Value>,
+    #[serde(default)]
+    pub bos_token_id: Option<serde_json::Value>,
+    #[serde(default = "default_head_dim")]
+    pub head_dim: usize,
+    #[serde(default = "default_rope_theta")]
+    pub rope_theta: f64,
+    #[serde(default = "default_norm_topk_prob")]
+    pub norm_topk_prob: bool,
+    #[serde(default = "default_router_aux_loss_coef")]
+    pub router_aux_loss_coef: f64,
+}
+
+impl TextConfig {
+    pub fn rotary_dim(&self) -> usize {
+        self.head_dim
+    }
+
+    pub fn top_k(&self) -> usize {
+        self.num_experts_per_tok
+    }
+
+    pub fn kv_bytes_per_token(&self, dtype_bytes: usize) -> u64 {
+        let per_layer = 2 * self.num_key_value_heads * self.head_dim * dtype_bytes;
+        (self.num_hidden_layers * per_layer) as u64
+    }
+
+    pub fn eos_token_ids(&self) -> Vec<u32> {
+        extract_token_ids(&self.eos_token_id)
+    }
+
+    pub fn bos_token_ids(&self) -> Vec<u32> {
+        extract_token_ids(&self.bos_token_id)
+    }
+}
+
+fn extract_token_ids(value: &Option<serde_json::Value>) -> Vec<u32> {
+    match value {
+        Some(serde_json::Value::Number(n)) => {
+            n.as_u64().map(|v| vec![v as u32]).unwrap_or_default()
+        }
+        Some(serde_json::Value::Array(arr)) => arr
+            .iter()
+            .filter_map(|v| v.as_u64().map(|n| n as u32))
+            .collect(),
+        _ => vec![],
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct Config {
+    #[serde(flatten)]
+    pub text_config: TextConfig,
+    #[serde(default)]
+    pub architectures: Vec<String>,
+    #[serde(default)]
+    pub model_type: Option<String>,
+}
+
+pub fn load_config(model_dir: &std::path::Path) -> Result<Config, String> {
+    let config_path = model_dir.join("config.json");
+    let text =
+        std::fs::read_to_string(&config_path).map_err(|e| format!("read config.json: {e}"))?;
+    let config: Config =
+        serde_json::from_str(&text).map_err(|e| format!("parse config.json: {e}"))?;
+    validate(&config)?;
+    Ok(config)
+}
+
+fn validate(config: &Config) -> Result<(), String> {
+    let t = &config.text_config;
+    if config.model_type.as_deref() != Some("qwen3_moe") {
+        return Err(format!(
+            "model_type must be qwen3_moe for Qwen3-MoE, got {:?}",
+            config.model_type
+        ));
+    }
+    if !config
+        .architectures
+        .iter()
+        .any(|a| a == "Qwen3MoeForCausalLM")
+    {
+        return Err("architectures must include Qwen3MoeForCausalLM".to_string());
+    }
+    if t.num_hidden_layers == 0 {
+        return Err("num_hidden_layers must be > 0".to_string());
+    }
+    if t.hidden_size == 0 || t.num_attention_heads == 0 {
+        return Err("hidden_size and num_attention_heads must be > 0".to_string());
+    }
+    if t.head_dim == 0 {
+        return Err("head_dim must be > 0".to_string());
+    }
+    if t.num_key_value_heads == 0 || t.num_attention_heads % t.num_key_value_heads != 0 {
+        return Err("num_attention_heads must be divisible by num_key_value_heads".to_string());
+    }
+    if t.num_experts == 0 || t.num_experts_per_tok == 0 {
+        return Err("num_experts and num_experts_per_tok must be > 0".to_string());
+    }
+    if t.num_experts_per_tok > t.num_experts {
+        return Err("num_experts_per_tok must be <= num_experts".to_string());
+    }
+    if t.moe_intermediate_size == 0 {
+        return Err("moe_intermediate_size must be > 0".to_string());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn qwen3_30b_geometry_sanity() {
+        let json = r#"{
+            "architectures": ["Qwen3MoeForCausalLM"],
+            "model_type": "qwen3_moe",
+            "vocab_size": 151936,
+            "hidden_size": 2048,
+            "num_hidden_layers": 48,
+            "num_attention_heads": 32,
+            "num_key_value_heads": 4,
+            "head_dim": 128,
+            "intermediate_size": 6144,
+            "moe_intermediate_size": 768,
+            "num_experts": 128,
+            "num_experts_per_tok": 8,
+            "max_position_embeddings": 40960,
+            "rms_norm_eps": 1e-6
+        }"#;
+        let cfg: Config = serde_json::from_str(json).unwrap();
+        validate(&cfg).unwrap();
+        assert_eq!(cfg.text_config.kv_bytes_per_token(2), 48 * 2 * 4 * 128 * 2);
+    }
+}

--- a/crates/qwen3_moe/src/desc_builder.rs
+++ b/crates/qwen3_moe/src/desc_builder.rs
@@ -1,0 +1,222 @@
+use std::ffi::c_void;
+
+use kernel_ffi::qwen3_moe::{Qwen3MoeDecodeLayerDesc, Qwen3MoeInt4ScaleDesc};
+use thiserror::Error;
+
+use crate::config::TextConfig;
+
+#[derive(Debug, Error)]
+pub enum DescBuildError {
+    #[error("expected {expected} layer pointer records, got {got}")]
+    LayerCount { expected: usize, got: usize },
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Qwen3MoeLayerPtrs {
+    pub input_norm_w: *const c_void,
+    pub post_attn_norm_w: *const c_void,
+    pub q_proj_w: *const c_void,
+    pub k_proj_w: *const c_void,
+    pub v_proj_w: *const c_void,
+    pub o_proj_w: *const c_void,
+    pub q_norm_w: *const c_void,
+    pub k_norm_w: *const c_void,
+    pub kv_cache_k: *mut c_void,
+    pub kv_cache_v: *mut c_void,
+    pub router_w: *const c_void,
+    pub experts_gate_up_w: *const c_void,
+    pub experts_down_w: *const c_void,
+}
+
+impl Default for Qwen3MoeLayerPtrs {
+    fn default() -> Self {
+        Self {
+            input_norm_w: std::ptr::null(),
+            post_attn_norm_w: std::ptr::null(),
+            q_proj_w: std::ptr::null(),
+            k_proj_w: std::ptr::null(),
+            v_proj_w: std::ptr::null(),
+            o_proj_w: std::ptr::null(),
+            q_norm_w: std::ptr::null(),
+            k_norm_w: std::ptr::null(),
+            kv_cache_k: std::ptr::null_mut(),
+            kv_cache_v: std::ptr::null_mut(),
+            router_w: std::ptr::null(),
+            experts_gate_up_w: std::ptr::null(),
+            experts_down_w: std::ptr::null(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Qwen3MoeInt4ScalePtrs {
+    pub q_proj_scale: *const c_void,
+    pub q_proj_zero: *const c_void,
+    pub k_proj_scale: *const c_void,
+    pub k_proj_zero: *const c_void,
+    pub v_proj_scale: *const c_void,
+    pub v_proj_zero: *const c_void,
+    pub o_proj_scale: *const c_void,
+    pub o_proj_zero: *const c_void,
+    pub experts_gate_up_scale: *const c_void,
+    pub experts_gate_up_zero: *const c_void,
+    pub experts_down_scale: *const c_void,
+    pub experts_down_zero: *const c_void,
+}
+
+impl Default for Qwen3MoeInt4ScalePtrs {
+    fn default() -> Self {
+        Self {
+            q_proj_scale: std::ptr::null(),
+            q_proj_zero: std::ptr::null(),
+            k_proj_scale: std::ptr::null(),
+            k_proj_zero: std::ptr::null(),
+            v_proj_scale: std::ptr::null(),
+            v_proj_zero: std::ptr::null(),
+            o_proj_scale: std::ptr::null(),
+            o_proj_zero: std::ptr::null(),
+            experts_gate_up_scale: std::ptr::null(),
+            experts_gate_up_zero: std::ptr::null(),
+            experts_down_scale: std::ptr::null(),
+            experts_down_zero: std::ptr::null(),
+        }
+    }
+}
+
+pub fn build_layer_descs(
+    config: &TextConfig,
+    ptrs: &[Qwen3MoeLayerPtrs],
+    kv_len: usize,
+    kv_max_t: usize,
+) -> Result<Vec<Qwen3MoeDecodeLayerDesc>, DescBuildError> {
+    if ptrs.len() != config.num_hidden_layers {
+        return Err(DescBuildError::LayerCount {
+            expected: config.num_hidden_layers,
+            got: ptrs.len(),
+        });
+    }
+
+    let mut out = Vec::with_capacity(config.num_hidden_layers);
+    for (layer_idx, p) in ptrs.iter().enumerate() {
+        let mut d = Qwen3MoeDecodeLayerDesc::default();
+        d.layer_idx = layer_idx as i32;
+        d.input_norm_w = p.input_norm_w;
+        d.input_norm_eps = config.rms_norm_eps as f32;
+        d.post_attn_norm_w = p.post_attn_norm_w;
+        d.post_attn_norm_eps = config.rms_norm_eps as f32;
+        d.q_proj_w = p.q_proj_w;
+        d.k_proj_w = p.k_proj_w;
+        d.v_proj_w = p.v_proj_w;
+        d.o_proj_w = p.o_proj_w;
+        d.q_norm_w = p.q_norm_w;
+        d.k_norm_w = p.k_norm_w;
+        d.rope_theta = config.rope_theta as f32;
+        d.head_dim = config.head_dim as i32;
+        d.num_heads = config.num_attention_heads as i32;
+        d.num_kv_heads = config.num_key_value_heads as i32;
+        d.kv_cache_k = p.kv_cache_k;
+        d.kv_cache_v = p.kv_cache_v;
+        d.kv_len = kv_len as i32;
+        d.kv_max_t = kv_max_t as i32;
+        d.router_w = p.router_w;
+        d.experts_gate_up_w = p.experts_gate_up_w;
+        d.experts_down_w = p.experts_down_w;
+        d.num_experts = config.num_experts as i32;
+        d.top_k = config.top_k() as i32;
+        d.moe_intermediate_size = config.moe_intermediate_size as i32;
+        d.norm_topk_prob = i32::from(config.norm_topk_prob);
+        out.push(d);
+    }
+    Ok(out)
+}
+
+pub fn build_int4_scale_descs(
+    ptrs: &[Qwen3MoeInt4ScalePtrs],
+    group_size: usize,
+) -> Vec<Qwen3MoeInt4ScaleDesc> {
+    ptrs.iter()
+        .map(|p| {
+            let mut d = Qwen3MoeInt4ScaleDesc::default();
+            d.q_proj_scale = p.q_proj_scale;
+            d.q_proj_zero = p.q_proj_zero;
+            d.k_proj_scale = p.k_proj_scale;
+            d.k_proj_zero = p.k_proj_zero;
+            d.v_proj_scale = p.v_proj_scale;
+            d.v_proj_zero = p.v_proj_zero;
+            d.o_proj_scale = p.o_proj_scale;
+            d.o_proj_zero = p.o_proj_zero;
+            d.experts_gate_up_scale = p.experts_gate_up_scale;
+            d.experts_gate_up_zero = p.experts_gate_up_zero;
+            d.experts_down_scale = p.experts_down_scale;
+            d.experts_down_zero = p.experts_down_zero;
+            d.group_size = group_size as i32;
+            d
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+
+    fn qwen3_30b_text_config() -> TextConfig {
+        let json = r#"{
+            "architectures": ["Qwen3MoeForCausalLM"],
+            "model_type": "qwen3_moe",
+            "vocab_size": 151936,
+            "hidden_size": 2048,
+            "num_hidden_layers": 48,
+            "num_attention_heads": 32,
+            "num_key_value_heads": 4,
+            "head_dim": 128,
+            "intermediate_size": 6144,
+            "moe_intermediate_size": 768,
+            "num_experts": 128,
+            "num_experts_per_tok": 8,
+            "max_position_embeddings": 40960,
+            "rms_norm_eps": 1e-6,
+            "norm_topk_prob": true
+        }"#;
+        serde_json::from_str::<Config>(json).unwrap().text_config
+    }
+
+    #[test]
+    fn qwen3_desc_builder_sets_full_attention_moe_geometry() {
+        let cfg = qwen3_30b_text_config();
+        let ptrs = vec![Qwen3MoeLayerPtrs::default(); cfg.num_hidden_layers];
+        let descs = build_layer_descs(&cfg, &ptrs, 7, 256).unwrap();
+        assert_eq!(descs.len(), 48);
+        assert_eq!(descs[12].layer_idx, 12);
+        assert_eq!(descs[12].head_dim, 128);
+        assert_eq!(descs[12].num_heads, 32);
+        assert_eq!(descs[12].num_kv_heads, 4);
+        assert_eq!(descs[12].kv_len, 7);
+        assert_eq!(descs[12].kv_max_t, 256);
+        assert_eq!(descs[12].num_experts, 128);
+        assert_eq!(descs[12].top_k, 8);
+        assert_eq!(descs[12].moe_intermediate_size, 768);
+        assert_eq!(descs[12].norm_topk_prob, 1);
+    }
+
+    #[test]
+    fn qwen3_desc_builder_rejects_wrong_layer_count() {
+        let cfg = qwen3_30b_text_config();
+        let err = build_layer_descs(&cfg, &[], 0, 0).unwrap_err();
+        assert!(matches!(
+            err,
+            DescBuildError::LayerCount {
+                expected: 48,
+                got: 0
+            }
+        ));
+    }
+
+    #[test]
+    fn qwen3_int4_desc_builder_sets_group_size() {
+        let ptrs = vec![Qwen3MoeInt4ScalePtrs::default(); 48];
+        let descs = build_int4_scale_descs(&ptrs, 128);
+        assert_eq!(descs.len(), 48);
+        assert_eq!(descs[0].group_size, 128);
+    }
+}

--- a/crates/qwen3_moe/src/device_weights.rs
+++ b/crates/qwen3_moe/src/device_weights.rs
@@ -1,0 +1,186 @@
+use gpu_hal::GpuBuffer;
+use model_store::BakedStore;
+use thiserror::Error;
+
+use crate::{
+    baked::{build_int4_baked_index, BakedIndexError, Qwen3MoeInt4BakedIndex},
+    config::TextConfig,
+    desc_builder::{Qwen3MoeInt4ScalePtrs, Qwen3MoeLayerPtrs},
+};
+
+#[derive(Debug, Error)]
+pub enum DeviceWeightsError {
+    #[error("{0}")]
+    BakedIndex(#[from] BakedIndexError),
+    #[error("model-store error: {0}")]
+    Store(#[from] model_store::Error),
+}
+
+pub struct Qwen3MoeInt4DeviceWeights {
+    pub embed_tokens: GpuBuffer,
+    pub final_norm: GpuBuffer,
+    pub lm_head: Option<Qwen3MoeInt4DeviceTensor>,
+    pub layers: Vec<Qwen3MoeInt4DeviceLayer>,
+    pub total_bytes: u64,
+}
+
+pub struct Qwen3MoeInt4DeviceLayer {
+    pub input_norm: GpuBuffer,
+    pub post_attn_norm: GpuBuffer,
+    pub q_proj: Qwen3MoeInt4DeviceTensor,
+    pub k_proj: Qwen3MoeInt4DeviceTensor,
+    pub v_proj: Qwen3MoeInt4DeviceTensor,
+    pub o_proj: Qwen3MoeInt4DeviceTensor,
+    pub q_norm: GpuBuffer,
+    pub k_norm: GpuBuffer,
+    pub router: GpuBuffer,
+    pub experts_gate_up: Qwen3MoeInt4DeviceTensor,
+    pub experts_down: Qwen3MoeInt4DeviceTensor,
+}
+
+pub struct Qwen3MoeInt4DeviceTensor {
+    pub weight: GpuBuffer,
+    pub scale: GpuBuffer,
+    pub zero: GpuBuffer,
+}
+
+impl Qwen3MoeInt4DeviceWeights {
+    pub fn load(
+        store: &BakedStore,
+        ordinal: usize,
+        config: &TextConfig,
+        prefix: &str,
+    ) -> Result<Self, DeviceWeightsError> {
+        let index = build_int4_baked_index(store, config, prefix)?;
+        Self::load_from_index(store, ordinal, index)
+    }
+
+    pub fn layer_ptrs(&self) -> Vec<Qwen3MoeLayerPtrs> {
+        self.layers
+            .iter()
+            .map(|layer| Qwen3MoeLayerPtrs {
+                input_norm_w: layer.input_norm.as_ptr(),
+                post_attn_norm_w: layer.post_attn_norm.as_ptr(),
+                q_proj_w: layer.q_proj.weight.as_ptr(),
+                k_proj_w: layer.k_proj.weight.as_ptr(),
+                v_proj_w: layer.v_proj.weight.as_ptr(),
+                o_proj_w: layer.o_proj.weight.as_ptr(),
+                q_norm_w: layer.q_norm.as_ptr(),
+                k_norm_w: layer.k_norm.as_ptr(),
+                kv_cache_k: std::ptr::null_mut(),
+                kv_cache_v: std::ptr::null_mut(),
+                router_w: layer.router.as_ptr(),
+                experts_gate_up_w: layer.experts_gate_up.weight.as_ptr(),
+                experts_down_w: layer.experts_down.weight.as_ptr(),
+            })
+            .collect()
+    }
+
+    pub fn int4_scale_ptrs(&self) -> Vec<Qwen3MoeInt4ScalePtrs> {
+        self.layers
+            .iter()
+            .map(|layer| Qwen3MoeInt4ScalePtrs {
+                q_proj_scale: layer.q_proj.scale.as_ptr(),
+                q_proj_zero: layer.q_proj.zero.as_ptr(),
+                k_proj_scale: layer.k_proj.scale.as_ptr(),
+                k_proj_zero: layer.k_proj.zero.as_ptr(),
+                v_proj_scale: layer.v_proj.scale.as_ptr(),
+                v_proj_zero: layer.v_proj.zero.as_ptr(),
+                o_proj_scale: layer.o_proj.scale.as_ptr(),
+                o_proj_zero: layer.o_proj.zero.as_ptr(),
+                experts_gate_up_scale: layer.experts_gate_up.scale.as_ptr(),
+                experts_gate_up_zero: layer.experts_gate_up.zero.as_ptr(),
+                experts_down_scale: layer.experts_down.scale.as_ptr(),
+                experts_down_zero: layer.experts_down.zero.as_ptr(),
+            })
+            .collect()
+    }
+
+    fn load_from_index(
+        store: &BakedStore,
+        ordinal: usize,
+        index: Qwen3MoeInt4BakedIndex,
+    ) -> Result<Self, DeviceWeightsError> {
+        let embed_tokens = store.load_to_gpu(&index.embed_tokens.name, ordinal)?;
+        let final_norm = store.load_to_gpu(&index.final_norm.name, ordinal)?;
+        let lm_head = index
+            .lm_head
+            .as_ref()
+            .map(|tensor| load_int4_tensor(store, ordinal, tensor))
+            .transpose()?;
+
+        let mut layers = Vec::with_capacity(index.layers.len());
+        for layer in &index.layers {
+            layers.push(Qwen3MoeInt4DeviceLayer {
+                input_norm: store.load_to_gpu(&layer.input_norm.name, ordinal)?,
+                post_attn_norm: store.load_to_gpu(&layer.post_attn_norm.name, ordinal)?,
+                q_proj: load_int4_tensor(store, ordinal, &layer.q_proj)?,
+                k_proj: load_int4_tensor(store, ordinal, &layer.k_proj)?,
+                v_proj: load_int4_tensor(store, ordinal, &layer.v_proj)?,
+                o_proj: load_int4_tensor(store, ordinal, &layer.o_proj)?,
+                q_norm: store.load_to_gpu(&layer.q_norm.name, ordinal)?,
+                k_norm: store.load_to_gpu(&layer.k_norm.name, ordinal)?,
+                router: store.load_to_gpu(&layer.router.name, ordinal)?,
+                experts_gate_up: load_int4_tensor(store, ordinal, &layer.experts_gate_up)?,
+                experts_down: load_int4_tensor(store, ordinal, &layer.experts_down)?,
+            });
+        }
+
+        Ok(Self {
+            embed_tokens,
+            final_norm,
+            lm_head,
+            layers,
+            total_bytes: index.total_bytes,
+        })
+    }
+}
+
+fn load_int4_tensor(
+    store: &BakedStore,
+    ordinal: usize,
+    tensor: &crate::baked::Qwen3MoeInt4Tensor,
+) -> Result<Qwen3MoeInt4DeviceTensor, model_store::Error> {
+    Ok(Qwen3MoeInt4DeviceTensor {
+        weight: store.load_to_gpu(&tensor.weight.name, ordinal)?,
+        scale: store.load_to_gpu(&tensor.scale.name, ordinal)?,
+        zero: store.load_to_gpu(&tensor.zero.name, ordinal)?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{Activation, TextConfig};
+
+    fn config_30b_a3b() -> TextConfig {
+        TextConfig {
+            vocab_size: 151_936,
+            hidden_size: 2048,
+            num_hidden_layers: 48,
+            num_attention_heads: 32,
+            num_key_value_heads: 4,
+            max_position_embeddings: 40_960,
+            rms_norm_eps: 1e-6,
+            intermediate_size: 6144,
+            num_experts: 128,
+            num_experts_per_tok: 8,
+            moe_intermediate_size: 768,
+            hidden_act: Activation::Silu,
+            tie_word_embeddings: false,
+            eos_token_id: None,
+            bos_token_id: None,
+            head_dim: 128,
+            rope_theta: 1_000_000.0,
+            norm_topk_prob: true,
+            router_aux_loss_coef: 0.001,
+        }
+    }
+
+    #[test]
+    fn device_weight_layer_count_follows_config() {
+        let cfg = config_30b_a3b();
+        let ptrs = vec![Qwen3MoeLayerPtrs::default(); cfg.num_hidden_layers];
+        assert_eq!(ptrs.len(), cfg.num_hidden_layers);
+    }
+}

--- a/crates/qwen3_moe/src/lib.rs
+++ b/crates/qwen3_moe/src/lib.rs
@@ -1,0 +1,8 @@
+pub mod baked;
+pub mod config;
+pub mod desc_builder;
+pub mod device_weights;
+pub mod loader;
+pub mod scratch;
+pub mod state;
+pub mod weights;

--- a/crates/qwen3_moe/src/loader.rs
+++ b/crates/qwen3_moe/src/loader.rs
@@ -1,0 +1,218 @@
+use std::collections::BTreeMap;
+use std::fs::File;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use memmap2::Mmap;
+use safetensors::{Dtype, SafeTensors};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum LoadError {
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("safetensors error: {0}")]
+    Safetensors(#[from] safetensors::SafeTensorError),
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("tensor not found: {0}")]
+    NotFound(String),
+    #[error("unsupported dtype: {0}")]
+    UnsupportedDtype(String),
+    #[error("malformed model dir: {0}")]
+    Malformed(String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScalarKind {
+    Bf16,
+    F16,
+    F32,
+    F64,
+    I64,
+    I32,
+    U8,
+    Bool,
+}
+
+impl ScalarKind {
+    pub fn size_bytes(self) -> usize {
+        match self {
+            Self::Bf16 | Self::F16 => 2,
+            Self::F32 | Self::I32 => 4,
+            Self::F64 | Self::I64 => 8,
+            Self::U8 | Self::Bool => 1,
+        }
+    }
+
+    pub fn from_safetensors(d: Dtype) -> Result<Self, LoadError> {
+        Ok(match d {
+            Dtype::BF16 => Self::Bf16,
+            Dtype::F16 => Self::F16,
+            Dtype::F32 => Self::F32,
+            Dtype::F64 => Self::F64,
+            Dtype::I64 => Self::I64,
+            Dtype::I32 => Self::I32,
+            Dtype::U8 => Self::U8,
+            Dtype::BOOL => Self::Bool,
+            other => return Err(LoadError::UnsupportedDtype(format!("{other:?}"))),
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TensorMeta {
+    pub shape: Vec<usize>,
+    pub dtype: ScalarKind,
+}
+
+impl TensorMeta {
+    pub fn elem_count(&self) -> u64 {
+        self.shape.iter().product::<usize>() as u64
+    }
+
+    pub fn byte_size(&self) -> u64 {
+        self.elem_count() * self.dtype.size_bytes() as u64
+    }
+}
+
+/// Read-only safetensors weight loader. Enumerates the BF16 HF download (or any
+/// safetensors-compatible model dir). Built for the dry-run and shape-validation
+/// path; the GPU-allocating path lands in PR 4 alongside the kernel work.
+pub struct WeightLoader {
+    shards: Vec<Arc<Mmap>>,
+    /// tensor name -> shard index
+    index: BTreeMap<String, usize>,
+}
+
+impl WeightLoader {
+    pub fn from_dir(dir: &Path) -> Result<Self, LoadError> {
+        let index_path = dir.join("model.safetensors.index.json");
+        if index_path.exists() {
+            Self::from_sharded(dir, &index_path)
+        } else {
+            let single = dir.join("model.safetensors");
+            if single.exists() {
+                Self::from_single(&single)
+            } else {
+                Err(LoadError::Malformed(format!(
+                    "no safetensors files found in {}",
+                    dir.display()
+                )))
+            }
+        }
+    }
+
+    fn from_single(path: &Path) -> Result<Self, LoadError> {
+        let file = File::open(path)?;
+        let mmap = Arc::new(unsafe { Mmap::map(&file)? });
+        let tensors = SafeTensors::deserialize(&mmap[..])?;
+        let mut index = BTreeMap::new();
+        for name in tensors.names() {
+            index.insert(name.to_string(), 0);
+        }
+        Ok(Self {
+            shards: vec![mmap],
+            index,
+        })
+    }
+
+    fn from_sharded(dir: &Path, index_path: &Path) -> Result<Self, LoadError> {
+        let raw: serde_json::Value = serde_json::from_str(&std::fs::read_to_string(index_path)?)?;
+        let weight_map = raw["weight_map"].as_object().ok_or_else(|| {
+            LoadError::Malformed("missing weight_map in safetensors index".into())
+        })?;
+        let mut shard_files: Vec<PathBuf> = Vec::new();
+        let mut shard_idx_map: BTreeMap<String, usize> = BTreeMap::new();
+        for filename in weight_map.values() {
+            let filename = filename.as_str().unwrap_or("").to_string();
+            if !shard_idx_map.contains_key(&filename) {
+                shard_idx_map.insert(filename.clone(), shard_files.len());
+                shard_files.push(dir.join(&filename));
+            }
+        }
+        let mut shards = Vec::with_capacity(shard_files.len());
+        for path in &shard_files {
+            let file = File::open(path)?;
+            shards.push(Arc::new(unsafe { Mmap::map(&file)? }));
+        }
+        let mut index = BTreeMap::new();
+        for (tensor_name, filename) in weight_map {
+            let filename = filename.as_str().unwrap_or("");
+            if let Some(&shard_idx) = shard_idx_map.get(filename) {
+                index.insert(tensor_name.clone(), shard_idx);
+            }
+        }
+        Ok(Self { shards, index })
+    }
+
+    pub fn contains(&self, name: &str) -> bool {
+        self.index.contains_key(name)
+    }
+
+    /// Total number of tensors across all shards.
+    pub fn tensor_count(&self) -> usize {
+        self.index.len()
+    }
+
+    /// All tensor names known to this loader, sorted lexicographically.
+    pub fn names(&self) -> impl Iterator<Item = &str> {
+        self.index.keys().map(String::as_str)
+    }
+
+    pub fn meta(&self, name: &str) -> Result<TensorMeta, LoadError> {
+        let &shard_idx = self
+            .index
+            .get(name)
+            .ok_or_else(|| LoadError::NotFound(name.to_string()))?;
+        let tensors = SafeTensors::deserialize(&self.shards[shard_idx][..])?;
+        let view = tensors.tensor(name)?;
+        Ok(TensorMeta {
+            shape: view.shape().to_vec(),
+            dtype: ScalarKind::from_safetensors(view.dtype())?,
+        })
+    }
+
+    /// Sum of byte sizes for the listed tensors. Reports any missing names so the
+    /// caller can flag schema drift before allocating.
+    pub fn accumulate_bytes<I, S>(&self, names: I) -> Result<u64, LoadError>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let mut total: u64 = 0;
+        for name in names {
+            let m = self.meta(name.as_ref())?;
+            total = total.saturating_add(m.byte_size());
+        }
+        Ok(total)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_dir_reports_malformed() {
+        let dir = std::env::temp_dir().join("supersonic-qwen3-moe-no-such-dir");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let err = WeightLoader::from_dir(&dir)
+            .err()
+            .expect("expected error from empty dir");
+        assert!(
+            matches!(err, LoadError::Malformed(_)),
+            "expected Malformed, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn scalar_kind_size_table() {
+        assert_eq!(ScalarKind::Bf16.size_bytes(), 2);
+        assert_eq!(ScalarKind::F16.size_bytes(), 2);
+        assert_eq!(ScalarKind::F32.size_bytes(), 4);
+        assert_eq!(ScalarKind::I64.size_bytes(), 8);
+        assert_eq!(ScalarKind::U8.size_bytes(), 1);
+    }
+}

--- a/crates/qwen3_moe/src/scratch.rs
+++ b/crates/qwen3_moe/src/scratch.rs
@@ -1,0 +1,82 @@
+use std::ffi::c_void;
+use std::mem;
+
+use gpu_hal::{GpuBuffer, GpuError, ScalarType};
+use kernel_ffi::qwen3_moe::{Qwen3MoeDecodeLayerDesc, Qwen3MoeInt4ScaleDesc};
+
+/// Scratch/upload buffers for the Qwen3-MoE persistent decode path.
+///
+/// The current HIP kernel surface is a descriptor-walk stub, but these buffers
+/// are sized for the eventual one-token decode kernel: F32 workspace,
+/// descriptor arrays, INT4 sidecar descriptors, and a small work-stealing sync
+/// region.
+pub struct Qwen3MoeScratch {
+    ordinal: usize,
+    pub workspace: GpuBuffer,
+    pub sync_buf: GpuBuffer,
+    pub desc_device: GpuBuffer,
+    desc_capacity_bytes: usize,
+    pub int4_desc_device: GpuBuffer,
+    int4_desc_capacity_bytes: usize,
+}
+
+impl Qwen3MoeScratch {
+    pub fn new(
+        ordinal: usize,
+        num_layers: usize,
+        workspace_floats: usize,
+    ) -> Result<Self, GpuError> {
+        let workspace = GpuBuffer::zeros(ordinal, ScalarType::F32, &[workspace_floats.max(4)])?;
+        let sync_buf = GpuBuffer::zeros(ordinal, ScalarType::U8, &[96])?;
+        let desc_bytes = num_layers * mem::size_of::<Qwen3MoeDecodeLayerDesc>();
+        let desc_device = GpuBuffer::zeros(ordinal, ScalarType::U8, &[desc_bytes.max(1)])?;
+        let int4_desc_bytes = num_layers * mem::size_of::<Qwen3MoeInt4ScaleDesc>();
+        let int4_desc_device =
+            GpuBuffer::zeros(ordinal, ScalarType::U8, &[int4_desc_bytes.max(1)])?;
+        Ok(Self {
+            ordinal,
+            workspace,
+            sync_buf,
+            desc_device,
+            desc_capacity_bytes: desc_bytes,
+            int4_desc_device,
+            int4_desc_capacity_bytes: int4_desc_bytes,
+        })
+    }
+
+    pub fn upload_descs(&mut self, descs: &[Qwen3MoeDecodeLayerDesc]) -> Result<(), GpuError> {
+        let bytes = descs.len() * mem::size_of::<Qwen3MoeDecodeLayerDesc>();
+        if bytes > self.desc_capacity_bytes {
+            self.desc_device = GpuBuffer::zeros(self.ordinal, ScalarType::U8, &[bytes])?;
+            self.desc_capacity_bytes = bytes;
+        }
+        gpu_hal::copy_h2d(
+            self.ordinal,
+            self.desc_device.as_mut_ptr() as *mut c_void,
+            descs.as_ptr() as *const c_void,
+            bytes,
+        )
+    }
+
+    pub fn upload_int4_descs(&mut self, descs: &[Qwen3MoeInt4ScaleDesc]) -> Result<(), GpuError> {
+        let bytes = descs.len() * mem::size_of::<Qwen3MoeInt4ScaleDesc>();
+        if bytes > self.int4_desc_capacity_bytes {
+            self.int4_desc_device = GpuBuffer::zeros(self.ordinal, ScalarType::U8, &[bytes])?;
+            self.int4_desc_capacity_bytes = bytes;
+        }
+        gpu_hal::copy_h2d(
+            self.ordinal,
+            self.int4_desc_device.as_mut_ptr() as *mut c_void,
+            descs.as_ptr() as *const c_void,
+            bytes,
+        )
+    }
+
+    pub fn reset_sync(&mut self) -> Result<(), GpuError> {
+        gpu_hal::memset_zeros(
+            self.ordinal,
+            self.sync_buf.as_mut_ptr(),
+            self.sync_buf.len_bytes(),
+        )
+    }
+}

--- a/crates/qwen3_moe/src/state.rs
+++ b/crates/qwen3_moe/src/state.rs
@@ -1,0 +1,90 @@
+use crate::config::TextConfig;
+
+pub struct StateAccount {
+    pub kv_bytes: u64,
+    pub moe_scratch_bytes: u64,
+    pub activation_bytes: u64,
+    pub total_bytes: u64,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct StateLayout {
+    pub kv_dtype_bytes: u64,
+    pub context_tokens: u64,
+    pub batch_size: u64,
+}
+
+impl StateLayout {
+    pub fn new(context_tokens: usize, batch_size: usize, kv_fp8: bool) -> Self {
+        Self {
+            kv_dtype_bytes: if kv_fp8 { 1 } else { 2 },
+            context_tokens: context_tokens as u64,
+            batch_size: batch_size as u64,
+        }
+    }
+}
+
+impl StateAccount {
+    pub fn from_config(config: &TextConfig, layout: StateLayout) -> Self {
+        let hidden = config.hidden_size as u64;
+        let head_dim = config.head_dim as u64;
+        let kv_heads = config.num_key_value_heads as u64;
+        let layers = config.num_hidden_layers as u64;
+        let kv_bytes = layers
+            * 2
+            * kv_heads
+            * head_dim
+            * layout.kv_dtype_bytes
+            * layout.context_tokens
+            * layout.batch_size;
+
+        let top_k = config.num_experts_per_tok as u64;
+        let num_experts = config.num_experts as u64;
+        let router_logits = 4 * num_experts * layout.batch_size;
+        let topk_indices = 4 * top_k * layout.batch_size;
+        let topk_weights = 4 * top_k * layout.batch_size;
+        let expert_acc = 2 * hidden * layout.batch_size;
+        let moe_scratch_bytes = router_logits + topk_indices + topk_weights + expert_acc;
+        let activation_bytes = 2 * hidden * layout.batch_size * 8;
+        let total_bytes = kv_bytes + moe_scratch_bytes + activation_bytes;
+        Self {
+            kv_bytes,
+            moe_scratch_bytes,
+            activation_bytes,
+            total_bytes,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Activation;
+
+    #[test]
+    fn qwen3_state_account_counts_all_layers_as_full_attention() {
+        let cfg = TextConfig {
+            vocab_size: 151_936,
+            hidden_size: 2048,
+            num_hidden_layers: 48,
+            num_attention_heads: 32,
+            num_key_value_heads: 4,
+            max_position_embeddings: 40_960,
+            rms_norm_eps: 1e-6,
+            intermediate_size: 6144,
+            num_experts: 128,
+            num_experts_per_tok: 8,
+            moe_intermediate_size: 768,
+            hidden_act: Activation::Silu,
+            tie_word_embeddings: false,
+            eos_token_id: None,
+            bos_token_id: None,
+            head_dim: 128,
+            rope_theta: 1_000_000.0,
+            norm_topk_prob: true,
+            router_aux_loss_coef: 0.001,
+        };
+        let acct = StateAccount::from_config(&cfg, StateLayout::new(1024, 1, false));
+        assert_eq!(acct.kv_bytes, 48 * 2 * 4 * 128 * 2 * 1024);
+    }
+}

--- a/crates/qwen3_moe/src/weights.rs
+++ b/crates/qwen3_moe/src/weights.rs
@@ -1,0 +1,513 @@
+use crate::config::TextConfig;
+
+pub const DEFAULT_PREFIX: &str = "model";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TensorRole {
+    Embed,
+    Norm,
+    LmHead,
+    LayerInputNorm,
+    LayerPostAttnNorm,
+    QProj,
+    KProj,
+    VProj,
+    OProj,
+    QNorm,
+    KNorm,
+    Router,
+    ExpertGateProj,
+    ExpertUpProj,
+    ExpertDownProj,
+    FusedExpertGateUpProj,
+    FusedExpertDownProj,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CheckpointDtype {
+    Bf16,
+    F32,
+}
+
+impl CheckpointDtype {
+    pub const fn size(self) -> u64 {
+        match self {
+            Self::Bf16 => 2,
+            Self::F32 => 4,
+        }
+    }
+}
+
+pub fn checkpoint_dtype_for(_role: TensorRole) -> CheckpointDtype {
+    CheckpointDtype::Bf16
+}
+
+pub fn checkpoint_dtype_acceptable(role: TensorRole, got: CheckpointDtype) -> bool {
+    match role {
+        TensorRole::Norm
+        | TensorRole::LayerInputNorm
+        | TensorRole::LayerPostAttnNorm
+        | TensorRole::QNorm
+        | TensorRole::KNorm => matches!(got, CheckpointDtype::Bf16 | CheckpointDtype::F32),
+        _ => got == CheckpointDtype::Bf16,
+    }
+}
+
+pub fn checkpoint_elems_for(config: &TextConfig, role: TensorRole) -> u64 {
+    let hidden = config.hidden_size as u64;
+    let head_dim = config.head_dim as u64;
+    let q_dim = config.num_attention_heads as u64 * head_dim;
+    let kv_dim = config.num_key_value_heads as u64 * head_dim;
+    let moe = config.moe_intermediate_size as u64;
+
+    match role {
+        TensorRole::Embed | TensorRole::LmHead => hidden * config.vocab_size as u64,
+        TensorRole::Norm | TensorRole::LayerInputNorm | TensorRole::LayerPostAttnNorm => hidden,
+        TensorRole::QProj => q_dim * hidden,
+        TensorRole::KProj | TensorRole::VProj => kv_dim * hidden,
+        TensorRole::OProj => hidden * q_dim,
+        TensorRole::QNorm | TensorRole::KNorm => head_dim,
+        TensorRole::Router => config.num_experts as u64 * hidden,
+        TensorRole::ExpertGateProj | TensorRole::ExpertUpProj => moe * hidden,
+        TensorRole::ExpertDownProj => hidden * moe,
+        TensorRole::FusedExpertGateUpProj => config.num_experts as u64 * 2 * moe * hidden,
+        TensorRole::FusedExpertDownProj => config.num_experts as u64 * hidden * moe,
+    }
+}
+
+pub fn checkpoint_bytes_for(config: &TextConfig, role: TensorRole) -> u64 {
+    checkpoint_elems_for(config, role) * checkpoint_dtype_for(role).size()
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TensorSpec {
+    pub name: String,
+    pub role: TensorRole,
+    pub layer_idx: Option<usize>,
+    pub expert_idx: Option<usize>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum BakedLayout {
+    Raw,
+    Int4Quantized,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct BakedTensorSpec {
+    pub name: String,
+    pub role: TensorRole,
+    pub layer_idx: Option<usize>,
+    pub layout: BakedLayout,
+    pub dtype: &'static str,
+    pub shape: Vec<usize>,
+}
+
+impl TensorSpec {
+    fn new(role: TensorRole, name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            role,
+            layer_idx: None,
+            expert_idx: None,
+        }
+    }
+
+    fn for_layer(role: TensorRole, name: impl Into<String>, layer: usize) -> Self {
+        Self {
+            name: name.into(),
+            role,
+            layer_idx: Some(layer),
+            expert_idx: None,
+        }
+    }
+
+    fn for_expert(role: TensorRole, name: impl Into<String>, layer: usize, expert: usize) -> Self {
+        Self {
+            name: name.into(),
+            role,
+            layer_idx: Some(layer),
+            expert_idx: Some(expert),
+        }
+    }
+}
+
+pub fn expected_tensor_specs(config: &TextConfig, prefix: &str) -> Vec<TensorSpec> {
+    let mut out = Vec::new();
+    out.push(TensorSpec::new(
+        TensorRole::Embed,
+        format!("{prefix}.embed_tokens.weight"),
+    ));
+    out.push(TensorSpec::new(
+        TensorRole::Norm,
+        format!("{prefix}.norm.weight"),
+    ));
+    if !config.tie_word_embeddings {
+        out.push(TensorSpec::new(TensorRole::LmHead, "lm_head.weight"));
+    }
+
+    for layer in 0..config.num_hidden_layers {
+        let lp = format!("{prefix}.layers.{layer}");
+        out.push(TensorSpec::for_layer(
+            TensorRole::LayerInputNorm,
+            format!("{lp}.input_layernorm.weight"),
+            layer,
+        ));
+        out.push(TensorSpec::for_layer(
+            TensorRole::LayerPostAttnNorm,
+            format!("{lp}.post_attention_layernorm.weight"),
+            layer,
+        ));
+
+        let ap = format!("{lp}.self_attn");
+        for (role, suffix) in [
+            (TensorRole::QProj, "q_proj.weight"),
+            (TensorRole::KProj, "k_proj.weight"),
+            (TensorRole::VProj, "v_proj.weight"),
+            (TensorRole::OProj, "o_proj.weight"),
+            (TensorRole::QNorm, "q_norm.weight"),
+            (TensorRole::KNorm, "k_norm.weight"),
+        ] {
+            out.push(TensorSpec::for_layer(role, format!("{ap}.{suffix}"), layer));
+        }
+
+        let mp = format!("{lp}.mlp");
+        out.push(TensorSpec::for_layer(
+            TensorRole::Router,
+            format!("{mp}.gate.weight"),
+            layer,
+        ));
+        for expert in 0..config.num_experts {
+            let ep = format!("{mp}.experts.{expert}");
+            out.push(TensorSpec::for_expert(
+                TensorRole::ExpertGateProj,
+                format!("{ep}.gate_proj.weight"),
+                layer,
+                expert,
+            ));
+            out.push(TensorSpec::for_expert(
+                TensorRole::ExpertUpProj,
+                format!("{ep}.up_proj.weight"),
+                layer,
+                expert,
+            ));
+            out.push(TensorSpec::for_expert(
+                TensorRole::ExpertDownProj,
+                format!("{ep}.down_proj.weight"),
+                layer,
+                expert,
+            ));
+        }
+    }
+    out
+}
+
+pub fn baked_tensor_specs(config: &TextConfig, prefix: &str) -> Vec<TensorSpec> {
+    let mut out = expected_tensor_specs(config, prefix)
+        .into_iter()
+        .filter(|s| {
+            !matches!(
+                s.role,
+                TensorRole::ExpertGateProj | TensorRole::ExpertUpProj | TensorRole::ExpertDownProj
+            )
+        })
+        .collect::<Vec<_>>();
+    for layer in 0..config.num_hidden_layers {
+        let mp = format!("{prefix}.layers.{layer}.mlp.experts");
+        out.push(TensorSpec::for_layer(
+            TensorRole::FusedExpertGateUpProj,
+            format!("{mp}.gate_up_proj"),
+            layer,
+        ));
+        out.push(TensorSpec::for_layer(
+            TensorRole::FusedExpertDownProj,
+            format!("{mp}.down_proj"),
+            layer,
+        ));
+    }
+    out
+}
+
+pub fn baked_tensor_contract(
+    config: &TextConfig,
+    prefix: &str,
+    group_size: usize,
+) -> Vec<BakedTensorSpec> {
+    let mut out = Vec::new();
+    for spec in baked_tensor_specs(config, prefix) {
+        let layout = baked_layout_for(spec.role);
+        let dtype = match layout {
+            BakedLayout::Raw => "bf16",
+            BakedLayout::Int4Quantized => "u8",
+        };
+        let shape = baked_shape_for(config, spec.role, layout, group_size);
+        out.push(BakedTensorSpec {
+            name: spec.name.clone(),
+            role: spec.role,
+            layer_idx: spec.layer_idx,
+            layout,
+            dtype,
+            shape,
+        });
+        if layout == BakedLayout::Int4Quantized {
+            let sidecar_shape = int4_sidecar_shape_for(config, spec.role, group_size);
+            for suffix in ["_int4_scale", "_int4_zero"] {
+                out.push(BakedTensorSpec {
+                    name: format!("{}{}", spec.name, suffix),
+                    role: spec.role,
+                    layer_idx: spec.layer_idx,
+                    layout: BakedLayout::Raw,
+                    dtype: "bf16",
+                    shape: sidecar_shape.clone(),
+                });
+            }
+        }
+    }
+    out
+}
+
+pub fn baked_layout_for(role: TensorRole) -> BakedLayout {
+    match role {
+        TensorRole::LmHead
+        | TensorRole::QProj
+        | TensorRole::KProj
+        | TensorRole::VProj
+        | TensorRole::OProj
+        | TensorRole::FusedExpertGateUpProj
+        | TensorRole::FusedExpertDownProj => BakedLayout::Int4Quantized,
+        _ => BakedLayout::Raw,
+    }
+}
+
+pub fn baked_shape_for(
+    config: &TextConfig,
+    role: TensorRole,
+    layout: BakedLayout,
+    _group_size: usize,
+) -> Vec<usize> {
+    let hidden = config.hidden_size;
+    let q_dim = config.num_attention_heads * config.head_dim;
+    let kv_dim = config.num_key_value_heads * config.head_dim;
+    let moe = config.moe_intermediate_size;
+    let pack_cols = |cols: usize| match layout {
+        BakedLayout::Raw => cols,
+        BakedLayout::Int4Quantized => cols.div_ceil(2),
+    };
+
+    match role {
+        TensorRole::Embed | TensorRole::LmHead => vec![config.vocab_size, pack_cols(hidden)],
+        TensorRole::Norm | TensorRole::LayerInputNorm | TensorRole::LayerPostAttnNorm => {
+            vec![hidden]
+        }
+        TensorRole::QProj => vec![q_dim, pack_cols(hidden)],
+        TensorRole::KProj | TensorRole::VProj => vec![kv_dim, pack_cols(hidden)],
+        TensorRole::OProj => vec![hidden, pack_cols(q_dim)],
+        TensorRole::QNorm | TensorRole::KNorm => vec![config.head_dim],
+        TensorRole::Router => vec![config.num_experts, hidden],
+        TensorRole::ExpertGateProj | TensorRole::ExpertUpProj => vec![moe, hidden],
+        TensorRole::ExpertDownProj => vec![hidden, moe],
+        TensorRole::FusedExpertGateUpProj => {
+            vec![config.num_experts, 2 * moe, pack_cols(hidden)]
+        }
+        TensorRole::FusedExpertDownProj => vec![config.num_experts, hidden, pack_cols(moe)],
+    }
+}
+
+pub fn int4_sidecar_shape_for(
+    config: &TextConfig,
+    role: TensorRole,
+    group_size: usize,
+) -> Vec<usize> {
+    let g = group_size.max(1);
+    let hidden = config.hidden_size;
+    let q_dim = config.num_attention_heads * config.head_dim;
+    let kv_dim = config.num_key_value_heads * config.head_dim;
+    let moe = config.moe_intermediate_size;
+
+    match role {
+        TensorRole::LmHead => vec![config.vocab_size.div_ceil(g), hidden.div_ceil(g)],
+        TensorRole::QProj => vec![q_dim.div_ceil(g), hidden.div_ceil(g)],
+        TensorRole::KProj | TensorRole::VProj => vec![kv_dim.div_ceil(g), hidden.div_ceil(g)],
+        TensorRole::OProj => vec![hidden.div_ceil(g), q_dim.div_ceil(g)],
+        TensorRole::FusedExpertGateUpProj => {
+            vec![
+                config.num_experts,
+                (2 * moe).div_ceil(g),
+                hidden.div_ceil(g),
+            ]
+        }
+        TensorRole::FusedExpertDownProj => {
+            vec![config.num_experts, hidden.div_ceil(g), moe.div_ceil(g)]
+        }
+        _ => Vec::new(),
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct CheckpointAccount {
+    pub embed_bytes: u64,
+    pub final_norm_bytes: u64,
+    pub lm_head_bytes: u64,
+    pub per_layer_norm_bytes: u64,
+    pub attn_bytes_per_layer: u64,
+    pub router_bytes_per_layer: u64,
+    pub experts_bytes_per_layer: u64,
+    pub total_bytes: u64,
+}
+
+impl CheckpointAccount {
+    pub fn from_config(config: &TextConfig) -> Self {
+        let cb = |role| checkpoint_bytes_for(config, role);
+        let embed_bytes = cb(TensorRole::Embed);
+        let final_norm_bytes = cb(TensorRole::Norm);
+        let lm_head_bytes = if config.tie_word_embeddings {
+            0
+        } else {
+            cb(TensorRole::LmHead)
+        };
+        let per_layer_norm_bytes =
+            cb(TensorRole::LayerInputNorm) + cb(TensorRole::LayerPostAttnNorm);
+        let attn_bytes_per_layer = cb(TensorRole::QProj)
+            + cb(TensorRole::KProj)
+            + cb(TensorRole::VProj)
+            + cb(TensorRole::OProj)
+            + cb(TensorRole::QNorm)
+            + cb(TensorRole::KNorm);
+        let router_bytes_per_layer = cb(TensorRole::Router);
+        let experts_bytes_per_layer = config.num_experts as u64
+            * (cb(TensorRole::ExpertGateProj)
+                + cb(TensorRole::ExpertUpProj)
+                + cb(TensorRole::ExpertDownProj));
+        let layers = config.num_hidden_layers as u64;
+        let total_bytes = embed_bytes
+            + final_norm_bytes
+            + lm_head_bytes
+            + layers
+                * (per_layer_norm_bytes
+                    + attn_bytes_per_layer
+                    + router_bytes_per_layer
+                    + experts_bytes_per_layer);
+        Self {
+            embed_bytes,
+            final_norm_bytes,
+            lm_head_bytes,
+            per_layer_norm_bytes,
+            attn_bytes_per_layer,
+            router_bytes_per_layer,
+            experts_bytes_per_layer,
+            total_bytes,
+        }
+    }
+
+    pub fn project_int4_total_bytes(&self, config: &TextConfig, group_size: u64) -> u64 {
+        let hidden = config.hidden_size as u64;
+        let vocab = config.vocab_size as u64;
+        let head_dim = config.head_dim as u64;
+        let q_dim = config.num_attention_heads as u64 * head_dim;
+        let kv_dim = config.num_key_value_heads as u64 * head_dim;
+        let moe = config.moe_intermediate_size as u64;
+
+        let mut total = self.embed_bytes + self.final_norm_bytes;
+        if !config.tie_word_embeddings {
+            total += int4_bytes(vocab * hidden, vocab, hidden, group_size);
+        }
+
+        let per_layer_norms = self.per_layer_norm_bytes;
+        let attn = int4_bytes(q_dim * hidden, q_dim, hidden, group_size)
+            + int4_bytes(kv_dim * hidden, kv_dim, hidden, group_size)
+            + int4_bytes(kv_dim * hidden, kv_dim, hidden, group_size)
+            + int4_bytes(hidden * q_dim, hidden, q_dim, group_size)
+            + 2 * 2 * head_dim;
+        let router = self.router_bytes_per_layer;
+        let per_expert = int4_bytes(moe * hidden, moe, hidden, group_size)
+            + int4_bytes(moe * hidden, moe, hidden, group_size)
+            + int4_bytes(hidden * moe, hidden, moe, group_size);
+        total += config.num_hidden_layers as u64
+            * (per_layer_norms + attn + router + config.num_experts as u64 * per_expert);
+        total
+    }
+}
+
+fn int4_bytes(elems: u64, out_dim: u64, in_dim: u64, group_size: u64) -> u64 {
+    let packed = elems / 2;
+    let tiles = out_dim.div_ceil(group_size).max(1) * in_dim.div_ceil(group_size).max(1);
+    packed + 2 * 2 * tiles
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Activation;
+
+    fn config_30b_a3b() -> TextConfig {
+        TextConfig {
+            vocab_size: 151_936,
+            hidden_size: 2048,
+            num_hidden_layers: 48,
+            num_attention_heads: 32,
+            num_key_value_heads: 4,
+            max_position_embeddings: 40_960,
+            rms_norm_eps: 1e-6,
+            intermediate_size: 6144,
+            num_experts: 128,
+            num_experts_per_tok: 8,
+            moe_intermediate_size: 768,
+            hidden_act: Activation::Silu,
+            tie_word_embeddings: false,
+            eos_token_id: None,
+            bos_token_id: None,
+            head_dim: 128,
+            rope_theta: 1_000_000.0,
+            norm_topk_prob: true,
+            router_aux_loss_coef: 0.001,
+        }
+    }
+
+    #[test]
+    fn enumeration_counts_match_qwen3_30b_a3b() {
+        let cfg = config_30b_a3b();
+        let specs = expected_tensor_specs(&cfg, DEFAULT_PREFIX);
+        assert_eq!(specs.len(), 3 + 48 * 393);
+        assert_eq!(baked_tensor_specs(&cfg, DEFAULT_PREFIX).len(), 3 + 48 * 11);
+    }
+
+    #[test]
+    fn baked_contract_counts_and_shapes_match_qwen3_30b_a3b() {
+        let cfg = config_30b_a3b();
+        let contract = baked_tensor_contract(&cfg, DEFAULT_PREFIX, 128);
+        let quantized = contract
+            .iter()
+            .filter(|s| s.layout == BakedLayout::Int4Quantized)
+            .count();
+        assert_eq!(quantized, 1 + 48 * 6);
+        assert_eq!(contract.len(), (3 + 48 * 11) + 2 * quantized);
+
+        let q0 = contract
+            .iter()
+            .find(|s| s.name == "model.layers.0.self_attn.q_proj.weight")
+            .unwrap();
+        assert_eq!(q0.shape, vec![4096, 1024]);
+        let q0_scale = contract
+            .iter()
+            .find(|s| s.name == "model.layers.0.self_attn.q_proj.weight_int4_scale")
+            .unwrap();
+        assert_eq!(q0_scale.shape, vec![32, 16]);
+        let gate_up = contract
+            .iter()
+            .find(|s| s.name == "model.layers.0.mlp.experts.gate_up_proj")
+            .unwrap();
+        assert_eq!(gate_up.shape, vec![128, 1536, 1024]);
+        let gate_up_scale = contract
+            .iter()
+            .find(|s| s.name == "model.layers.0.mlp.experts.gate_up_proj_int4_scale")
+            .unwrap();
+        assert_eq!(gate_up_scale.shape, vec![128, 12, 16]);
+    }
+
+    #[test]
+    fn account_matches_hf_index_total() {
+        let cfg = config_30b_a3b();
+        let acct = CheckpointAccount::from_config(&cfg);
+        assert_eq!(acct.total_bytes, 61_064_245_248);
+    }
+}

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -84,6 +84,7 @@ kernel-ffi = { path = "../kernel-ffi" }
 model-store = { path = "../model-store" }
 qwen35 = { path = "../qwen35" }
 qwen35_dflash = { path = "../qwen35_dflash" }
+qwen3_moe = { path = "../qwen3_moe" }
 qwen36_moe = { path = "../qwen36_moe" }
 gemma4 = { path = "../gemma4" }
 phi4 = { path = "../phi4" }

--- a/crates/runner/src/gemma4_runtime.rs
+++ b/crates/runner/src/gemma4_runtime.rs
@@ -139,6 +139,7 @@ pub(crate) fn run_gemma4(
     let params = match &entry.params {
         FamilyParams::Gemma4(p) => p,
         FamilyParams::Qwen35(_) => unreachable!("dispatch filtered to Gemma4"),
+        FamilyParams::Qwen3Moe(_) => unreachable!("dispatch filtered to Gemma4"),
         FamilyParams::Qwen36Moe(_) => unreachable!("dispatch filtered to Gemma4"),
         FamilyParams::Phi4(_) => unreachable!("dispatch filtered to Gemma4"),
         FamilyParams::Llama31(_) => unreachable!("dispatch filtered to Gemma4"),

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -62,6 +62,7 @@ mod qwen36_moe_state;
 mod qwen36_moe_telemetry;
 #[path = "qwen36_moe/types.rs"]
 mod qwen36_moe_types;
+mod qwen3_moe;
 mod registry;
 mod specprefill;
 mod specprefill_engine;
@@ -134,7 +135,13 @@ fn main() -> Result<()> {
     // Bail early for unsupported families so the user gets a clear message.
     if cli.teacher_forced {
         match model_variant.family() {
-            ModelFamily::Llama31 | ModelFamily::Qwen35 | ModelFamily::Gemma4 | ModelFamily::Phi4 => {} // supported; handled inside engine
+            ModelFamily::Llama31
+            | ModelFamily::Qwen35
+            | ModelFamily::Gemma4
+            | ModelFamily::Phi4 => {} // supported; handled inside engine
+            ModelFamily::Qwen3Moe => {
+                anyhow::bail!("Qwen3-MoE teacher-forced decode is out of v1 scope")
+            }
             ModelFamily::Qwen36Moe => {
                 anyhow::bail!("Qwen3.6-MoE teacher-forced out of Phase 1 scope")
             }
@@ -149,6 +156,7 @@ fn main() -> Result<()> {
         ModelFamily::Llama31 => {
             llama31_engine::run_llama31(&cli, &model_variant, entry, ordinal, gpu.total_vram)
         }
+        ModelFamily::Qwen3Moe => qwen3_moe::run(&cli, entry, gpu.total_vram),
         ModelFamily::Qwen36Moe => {
             // Route Qwen3.6-MoE through the SpecPrefill orchestrator when the
             // drafter flag is set, so the cross-family R1 path

--- a/crates/runner/src/phi4_engine.rs
+++ b/crates/runner/src/phi4_engine.rs
@@ -67,6 +67,7 @@ pub fn run_phi4(
     let params = match &entry.params {
         FamilyParams::Phi4(p) => p,
         FamilyParams::Qwen35(_)
+        | FamilyParams::Qwen3Moe(_)
         | FamilyParams::Qwen36Moe(_)
         | FamilyParams::Gemma4(_)
         | FamilyParams::Llama31(_) => {

--- a/crates/runner/src/policy.rs
+++ b/crates/runner/src/policy.rs
@@ -28,13 +28,21 @@ pub(crate) fn validate_global_flags(
     if q4km_like
         && !matches!(
             model_variant.family(),
-            ModelFamily::Qwen35 | ModelFamily::Qwen36Moe
+            ModelFamily::Qwen35 | ModelFamily::Qwen3Moe | ModelFamily::Qwen36Moe
         )
     {
         anyhow::bail!("--q4km/--q4km-gptq are currently supported only for Qwen models");
     }
     if q4km_like && backend != Backend::Cuda {
         anyhow::bail!("--q4km/--q4km-gptq are currently supported only on CUDA");
+    }
+    if matches!(model_variant.family(), ModelFamily::Qwen3Moe) {
+        if !cli.int4 || profile != QuantProfile::Int4Gptq {
+            anyhow::bail!("qwen3-30b-a3b v1 requires --int4 / int4-gptq");
+        }
+        if backend != Backend::Hip {
+            anyhow::bail!("qwen3-30b-a3b v1 is supported only on HIP");
+        }
     }
     if cli.gguf_file.is_some() && profile != QuantProfile::Q4Km {
         anyhow::bail!("--gguf-file requires --q4km");
@@ -56,11 +64,11 @@ pub(crate) fn validate_global_flags(
         (profile, model_variant.family()),
         (
             QuantProfile::Int4Awq | QuantProfile::Int4Autoround | QuantProfile::Int4Hqq,
-            ModelFamily::Qwen36Moe
+            ModelFamily::Qwen3Moe | ModelFamily::Qwen36Moe
         )
     ) {
         anyhow::bail!(
-            "--weight-quant {profile} is currently supported only for Qwen3.5; Qwen3.6-MoE bake selection/runtime support is not wired for this profile yet"
+            "--weight-quant {profile} is currently supported only for Qwen3.5; Qwen3/Qwen3.6-MoE bake selection/runtime support is not wired for this profile yet"
         );
     }
     if profile == QuantProfile::Int4Awq && backend == Backend::Cuda {
@@ -73,7 +81,7 @@ pub(crate) fn validate_global_flags(
         QuantProfile::Int4Awq | QuantProfile::Int4Autoround | QuantProfile::Int4Hqq
     ) && !matches!(
         model_variant.family(),
-        ModelFamily::Qwen35 | ModelFamily::Qwen36Moe
+        ModelFamily::Qwen35 | ModelFamily::Qwen3Moe | ModelFamily::Qwen36Moe
     ) {
         anyhow::bail!(
             "--weight-quant {profile} is Qwen-first; Gemma 4 and Phi 4 ports are follow-up work"

--- a/crates/runner/src/qwen35_dflash_engine.rs
+++ b/crates/runner/src/qwen35_dflash_engine.rs
@@ -71,7 +71,8 @@ pub fn run_qwen35_dflash(
 
     let params = match &entry.params {
         FamilyParams::Qwen35(p) => *p,
-        FamilyParams::Qwen36Moe(_)
+        FamilyParams::Qwen3Moe(_)
+        | FamilyParams::Qwen36Moe(_)
         | FamilyParams::Gemma4(_)
         | FamilyParams::Phi4(_)
         | FamilyParams::Llama31(_) => {

--- a/crates/runner/src/qwen35_runtime.rs
+++ b/crates/runner/src/qwen35_runtime.rs
@@ -42,6 +42,7 @@ pub(crate) fn run_qwen35(
 
     let params = match &entry.params {
         FamilyParams::Qwen35(p) => p,
+        FamilyParams::Qwen3Moe(_) => unreachable!("qwen3-moe handled above"),
         FamilyParams::Qwen36Moe(_) => unreachable!("qwen3.6-moe handled above"),
         FamilyParams::Gemma4(_) => unreachable!("gemma4 handled above"),
         FamilyParams::Phi4(_) => unreachable!("phi4 handled above"),

--- a/crates/runner/src/qwen3_moe.rs
+++ b/crates/runner/src/qwen3_moe.rs
@@ -1,0 +1,720 @@
+use std::io::Write as _;
+
+use anyhow::{anyhow, Context, Result};
+use gpu_hal::{Backend, GpuBuffer, ScalarType};
+use kernel_ffi::qwen3_moe as q3ffi;
+use model_store::BakedStore;
+use qwen3_moe::baked::{
+    inspect_int4_bake as inspect_qwen3_int4_bake, int4_contract, Int4BakeInspection,
+    DEFAULT_INT4_GROUP_SIZE,
+};
+use qwen3_moe::desc_builder::{build_int4_scale_descs, build_layer_descs};
+use qwen3_moe::device_weights::Qwen3MoeInt4DeviceWeights;
+use qwen3_moe::loader::{LoadError, ScalarKind, WeightLoader};
+use qwen3_moe::state::{StateAccount, StateLayout};
+use qwen3_moe::weights::{
+    baked_tensor_specs, checkpoint_dtype_acceptable, checkpoint_elems_for, expected_tensor_specs,
+    CheckpointAccount, CheckpointDtype, TensorSpec,
+};
+
+use crate::qwen36_moe_logits::{dequant_int4_to_bf16_bytes, sample_bf16_logits, XorshiftRng};
+use crate::registry::{FamilyParams, RegistryEntry};
+use crate::Cli;
+
+pub(crate) fn run(cli: &Cli, entry: &RegistryEntry, total_vram: u64) -> Result<()> {
+    validate_policy(cli, entry)?;
+
+    let params = match entry.params {
+        FamilyParams::Qwen3Moe(p) => p,
+        _ => return Err(anyhow!("registry entry is not Qwen3Moe family")),
+    };
+
+    let config = qwen3_moe::config::load_config(&cli.model_dir)
+        .map_err(|e| anyhow!("loading Qwen3-MoE config.json: {e}"))?;
+    let text = &config.text_config;
+    validate_config_matches_registry(text, &params)?;
+
+    let checkpoint = CheckpointAccount::from_config(text);
+    let projected_int4 = checkpoint.project_int4_total_bytes(text, 128);
+    let context_tokens = cli.context_size.unwrap_or_else(|| {
+        cli.prompt
+            .chars()
+            .count()
+            .saturating_add(cli.max_new_tokens.max(1))
+    });
+    let state = StateAccount::from_config(text, StateLayout::new(context_tokens.max(1), 1, false));
+
+    if cli.dry_run {
+        println!("Qwen3-MoE dry run: qwen3-30b-a3b");
+        println!("  backend: {:?} {:?}", entry.backend, entry.arch);
+        println!("  layers: {}", text.num_hidden_layers);
+        println!("  hidden: {}", text.hidden_size);
+        println!(
+            "  heads/kv/head_dim: {}/{}/{}",
+            text.num_attention_heads, text.num_key_value_heads, text.head_dim
+        );
+        println!(
+            "  experts/top_k/moe_hidden: {}/{}/{}",
+            text.num_experts,
+            text.top_k(),
+            text.moe_intermediate_size
+        );
+        println!(
+            "  checkpoint tensors: {}",
+            expected_tensor_specs(text, params.weight_prefix).len()
+        );
+        println!(
+            "  baked tensors: {}",
+            baked_tensor_specs(text, params.weight_prefix).len()
+        );
+        println!(
+            "  checkpoint bytes: {:.2} GiB",
+            checkpoint.total_bytes as f64 / 1024.0_f64.powi(3)
+        );
+        println!(
+            "  projected INT4 bytes: {:.2} GiB",
+            projected_int4 as f64 / 1024.0_f64.powi(3)
+        );
+        println!(
+            "  state bytes @ ctx={context_tokens}: {:.2} GiB",
+            state.total_bytes as f64 / 1024.0_f64.powi(3)
+        );
+        println!(
+            "  total VRAM: {:.2} GiB",
+            total_vram as f64 / 1024.0_f64.powi(3)
+        );
+        inspect_checkpoint(cli, text, params.weight_prefix)?;
+        inspect_int4_bake(cli, text, params.weight_prefix)?;
+        return Ok(());
+    }
+
+    decode_text(cli, entry, text, params.weight_prefix)
+}
+
+fn validate_policy(cli: &Cli, entry: &RegistryEntry) -> Result<()> {
+    if entry.backend != Backend::Hip {
+        anyhow::bail!("Qwen3-30B-A3B v1 is HIP-only");
+    }
+    if !cli.int4 {
+        anyhow::bail!("Qwen3-30B-A3B v1 requires --int4; BF16 weights do not fit gfx1100 24 GB");
+    }
+    if cli.fp8_runtime || cli.kv_fp8 || cli.q4km || cli.q4km_gptq {
+        anyhow::bail!(
+            "Qwen3-30B-A3B v1 supports only native --int4; FP8/KV-FP8/q4km are out of scope"
+        );
+    }
+    if cli.batch_size != 1 {
+        anyhow::bail!("Qwen3-30B-A3B v1 supports only --batch-size 1");
+    }
+    Ok(())
+}
+
+fn decode_text(
+    cli: &Cli,
+    entry: &RegistryEntry,
+    text: &qwen3_moe::config::TextConfig,
+    weight_prefix: &str,
+) -> Result<()> {
+    ensure_int4_bake(cli, entry)?;
+    let bake_dir = model_store::bake_dir_int4(&cli.model_dir);
+    let store = BakedStore::open(&bake_dir)
+        .with_context(|| format!("open Qwen3-MoE INT4 bake at {}", bake_dir.display()))?;
+
+    let prompt = prepare_prompt(cli, text)?;
+    println!(
+        "  prompt: {:?} -> {} token{}",
+        cli.prompt,
+        prompt.prompt_ids.len(),
+        if prompt.prompt_ids.len() == 1 {
+            ""
+        } else {
+            "s"
+        }
+    );
+
+    let ordinal = cli.device;
+    let max_new = cli.max_new_tokens.max(1);
+    let context = cli
+        .context_size
+        .unwrap_or(prompt.prompt_ids.len() + max_new)
+        .max(prompt.prompt_ids.len() + max_new)
+        .max(1);
+
+    println!(
+        "  loading Qwen3-30B-A3B INT4 weights from {}",
+        bake_dir.display()
+    );
+    let weights = Qwen3MoeInt4DeviceWeights::load(&store, ordinal, text, weight_prefix)
+        .context("load Qwen3-MoE INT4 weights to GPU")?;
+    println!(
+        "  uploaded Qwen3-MoE weights referenced by manifest ({:.2} GiB)",
+        weights.total_bytes as f64 / 1024.0_f64.powi(3)
+    );
+
+    let mut kv_caches = Vec::with_capacity(text.num_hidden_layers);
+    let kv_dim = text.num_key_value_heads * text.head_dim;
+    for _ in 0..text.num_hidden_layers {
+        let k = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[context, kv_dim])
+            .context("alloc Qwen3 K cache")?;
+        let v = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[context, kv_dim])
+            .context("alloc Qwen3 V cache")?;
+        kv_caches.push((k, v));
+    }
+
+    let mut layer_ptrs = weights.layer_ptrs();
+    for (i, (k, v)) in kv_caches.iter_mut().enumerate() {
+        layer_ptrs[i].kv_cache_k = k.as_mut_ptr();
+        layer_ptrs[i].kv_cache_v = v.as_mut_ptr();
+    }
+    let scale_ptrs = weights.int4_scale_ptrs();
+    let int4_descs = build_int4_scale_descs(&scale_ptrs, DEFAULT_INT4_GROUP_SIZE);
+
+    let mut hidden_a = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[text.hidden_size])
+        .context("alloc Qwen3 hidden_a")?;
+    let mut hidden_b = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[text.hidden_size])
+        .context("alloc Qwen3 hidden_b")?;
+    let workspace_floats = qwen3_workspace_floats(text);
+    let mut workspace = GpuBuffer::zeros(ordinal, ScalarType::F32, &[workspace_floats])
+        .context("alloc Qwen3 layer workspace")?;
+
+    let lm_head_bf16 = load_lm_head_bf16(&store, text, weight_prefix)
+        .context("load/dequant Qwen3 lm_head BF16")?;
+    let lm_head = GpuBuffer::from_host_bytes(
+        ordinal,
+        ScalarType::BF16,
+        &[text.vocab_size, text.hidden_size],
+        &lm_head_bf16,
+    )
+    .context("upload Qwen3 lm_head BF16")?;
+    let mut logits =
+        GpuBuffer::zeros(ordinal, ScalarType::BF16, &[text.vocab_size]).context("alloc logits")?;
+    let mut lm_counter =
+        GpuBuffer::zeros(ordinal, ScalarType::U32, &[1]).context("alloc lm_head counter")?;
+
+    print_prompt_prefix(prompt.tokenizer.as_ref(), &prompt.prompt_ids);
+
+    let mut rng = XorshiftRng::new(cli.sampling_seed);
+    let mut current = prompt.prompt_ids[0];
+    let total_steps = prompt.prompt_ids.len() + max_new - 1;
+    let mut generated = Vec::with_capacity(max_new);
+    let mut last_logits = Vec::new();
+    let start = std::time::Instant::now();
+
+    for step in 0..total_steps {
+        let row = lookup_embed_row(&store, weight_prefix, current as usize, text.hidden_size)
+            .with_context(|| format!("lookup Qwen3 embedding row for token {current}"))?;
+        gpu_hal::copy_h2d(
+            ordinal,
+            hidden_a.as_mut_ptr(),
+            row.as_ptr() as *const _,
+            row.len(),
+        )
+        .context("h2d Qwen3 token embedding")?;
+
+        let descs = build_layer_descs(text, &layer_ptrs, step, context)
+            .context("build Qwen3 layer descriptors")?;
+        let mut front_a = true;
+        for (layer_idx, (desc, int4)) in descs.iter().zip(int4_descs.iter()).enumerate() {
+            let (input, output) = if front_a {
+                (&hidden_a, &mut hidden_b)
+            } else {
+                (&hidden_b, &mut hidden_a)
+            };
+            q3ffi::decode_layer_launch(
+                ordinal,
+                ScalarType::BF16,
+                desc,
+                int4,
+                text.hidden_size as i32,
+                step as i32,
+                input,
+                output,
+                &mut workspace,
+            )
+            .with_context(|| format!("Qwen3 decode layer {layer_idx}"))?;
+            front_a = !front_a;
+        }
+
+        let final_hidden = if front_a { &hidden_a } else { &hidden_b };
+        if step + 1 < prompt.prompt_ids.len() {
+            current = prompt.prompt_ids[step + 1];
+            continue;
+        }
+
+        q3ffi::lm_head_launch(
+            ordinal,
+            ScalarType::BF16,
+            text.hidden_size as i32,
+            text.vocab_size as i32,
+            text.rms_norm_eps as f32,
+            final_hidden,
+            &weights.final_norm,
+            &lm_head,
+            &mut logits,
+            &mut lm_counter,
+        )
+        .context("Qwen3 lm_head")?;
+        last_logits = logits.to_host_bytes().context("d2h Qwen3 logits")?;
+        let next = sample_bf16_logits(
+            &last_logits,
+            cli.temperature,
+            cli.top_k,
+            cli.top_p,
+            &mut rng,
+        );
+        generated.push(next);
+        print_token(prompt.tokenizer.as_ref(), next);
+        std::io::stdout().flush().ok();
+        current = next;
+        if Some(next) == prompt.eos_id || generated.len() >= max_new {
+            break;
+        }
+    }
+
+    if cli.dump_last_logits && !last_logits.is_empty() {
+        let vals = crate::qwen36_moe_logits::bf16_bytes_to_f32(&last_logits);
+        println!(
+            "\nLAST_LOGITS: {}",
+            vals.iter()
+                .map(|v| v.to_string())
+                .collect::<Vec<_>>()
+                .join(",")
+        );
+    } else {
+        println!();
+    }
+    let elapsed = start.elapsed().as_secs_f64();
+    println!(
+        "Generated {} token{} in {:.2}s ({:.2} tok/s).",
+        generated.len(),
+        if generated.len() == 1 { "" } else { "s" },
+        elapsed,
+        generated.len() as f64 / elapsed.max(1e-9)
+    );
+    Ok(())
+}
+
+fn ensure_int4_bake(cli: &Cli, entry: &RegistryEntry) -> Result<()> {
+    let bake_dir = model_store::bake_dir_int4(&cli.model_dir);
+    let _lock = model_store::BakeLock::acquire(&cli.model_dir)
+        .map_err(|e| anyhow!("acquire bake lock: {e}"))?;
+    if !cli.no_download
+        && crate::should_fetch_exact_bake(cli.download_bake, model_store::version_ok(&bake_dir))
+    {
+        let canonical_model = entry.model.to_string();
+        match crate::try_download_bake(
+            cli,
+            model_store::fetch::BakeVariant::Int4Gptq,
+            &canonical_model,
+            &bake_dir,
+        ) {
+            Ok(true) => eprintln!(
+                "[fetch] installed Qwen3-MoE INT4 bake at {}",
+                bake_dir.display()
+            ),
+            Ok(false) => {}
+            Err(e) => eprintln!("[fetch] Qwen3-MoE INT4 bake fetch failed: {e}"),
+        }
+    }
+    if !model_store::version_ok(&bake_dir) {
+        anyhow::bail!(
+            "Qwen3-30B-A3B decode requires an INT4-GPTQ bake at {}",
+            bake_dir.display()
+        );
+    }
+    Ok(())
+}
+
+struct PromptSetup {
+    tokenizer: Option<tokenizers::Tokenizer>,
+    prompt_ids: Vec<u32>,
+    eos_id: Option<u32>,
+}
+
+fn prepare_prompt(cli: &Cli, text: &qwen3_moe::config::TextConfig) -> Result<PromptSetup> {
+    let tokenizer = crate::load_tokenizer(&cli.model_dir.join("tokenizer.json")).ok();
+    let bos_id = text
+        .bos_token_id
+        .as_ref()
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as u32;
+    let eos_id = text
+        .eos_token_id
+        .as_ref()
+        .and_then(|v| v.as_u64())
+        .map(|v| v as u32);
+    let prompt_ids = match (&tokenizer, cli.prompt.is_empty()) {
+        (Some(tok), false) => {
+            let enc = tok
+                .encode(cli.prompt.as_str(), !cli.prompt_no_special_tokens)
+                .map_err(|e| anyhow!("tokenize prompt: {e}"))?;
+            let ids = enc.get_ids().to_vec();
+            if ids.is_empty() {
+                vec![bos_id]
+            } else {
+                ids
+            }
+        }
+        _ => vec![bos_id],
+    };
+    Ok(PromptSetup {
+        tokenizer,
+        prompt_ids,
+        eos_id,
+    })
+}
+
+fn print_prompt_prefix(tokenizer: Option<&tokenizers::Tokenizer>, ids: &[u32]) {
+    if let Some(tok) = tokenizer {
+        if let Ok(text) = tok.decode(ids, false) {
+            print!("{text}");
+            std::io::stdout().flush().ok();
+        }
+    }
+}
+
+fn print_token(tokenizer: Option<&tokenizers::Tokenizer>, id: u32) {
+    if let Some(tok) = tokenizer {
+        if let Ok(text) = tok.decode(&[id], false) {
+            print!("{text}");
+        } else {
+            print!("<{id}>");
+        }
+    } else {
+        print!(" {id}");
+    }
+}
+
+fn lookup_embed_row(
+    store: &BakedStore,
+    weight_prefix: &str,
+    token_id: usize,
+    hidden: usize,
+) -> Result<Vec<u8>> {
+    let name = format!("{weight_prefix}.embed_tokens.weight");
+    let bytes = store
+        .raw_bytes(&name)
+        .ok_or_else(|| anyhow!("missing {name} in bake"))?;
+    let row_bytes = hidden * 2;
+    let start = token_id
+        .checked_mul(row_bytes)
+        .ok_or_else(|| anyhow!("embedding row offset overflow for token {token_id}"))?;
+    let end = start + row_bytes;
+    if end > bytes.len() {
+        anyhow::bail!(
+            "embed_tokens row {token_id} out of bounds (need {end} bytes, have {})",
+            bytes.len()
+        );
+    }
+    Ok(bytes[start..end].to_vec())
+}
+
+fn load_lm_head_bf16(
+    store: &BakedStore,
+    text: &qwen3_moe::config::TextConfig,
+    weight_prefix: &str,
+) -> Result<Vec<u8>> {
+    let (name, packed) = if text.tie_word_embeddings {
+        let name = format!("{weight_prefix}.embed_tokens.weight");
+        let bytes = store
+            .raw_bytes(&name)
+            .ok_or_else(|| anyhow!("missing tied lm_head tensor {name}"))?
+            .to_vec();
+        (name, bytes)
+    } else {
+        let name = "lm_head.weight".to_string();
+        let bytes = store
+            .raw_bytes(&name)
+            .ok_or_else(|| anyhow!("missing lm_head.weight in bake"))?
+            .to_vec();
+        (name, bytes)
+    };
+    let scale_name = format!("{name}_int4_scale");
+    if !store.contains(&scale_name) {
+        return Ok(packed);
+    }
+    let zero_name = format!("{name}_int4_zero");
+    let scale = store
+        .raw_bytes(&scale_name)
+        .ok_or_else(|| anyhow!("missing {scale_name} in bake"))?;
+    let zero = store
+        .raw_bytes(&zero_name)
+        .ok_or_else(|| anyhow!("missing {zero_name} in bake"))?;
+    println!(
+        "  dequantizing Qwen3 lm_head INT4 ({:.1} MiB -> {:.1} MiB BF16)",
+        packed.len() as f64 / (1024.0 * 1024.0),
+        (text.vocab_size * text.hidden_size * 2) as f64 / (1024.0 * 1024.0)
+    );
+    Ok(dequant_int4_to_bf16_bytes(
+        &packed,
+        scale,
+        zero,
+        text.vocab_size,
+        text.hidden_size,
+        DEFAULT_INT4_GROUP_SIZE,
+    ))
+}
+
+fn qwen3_workspace_floats(text: &qwen3_moe::config::TextConfig) -> usize {
+    let hidden = text.hidden_size;
+    let q_dim = text.num_attention_heads * text.head_dim;
+    let kv_dim = text.num_key_value_heads * text.head_dim;
+    let experts = text.num_experts;
+    let top_k = text.top_k();
+    let i = text.moe_intermediate_size;
+    hidden
+        + q_dim
+        + kv_dim
+        + kv_dim
+        + q_dim
+        + hidden
+        + experts
+        + experts
+        + top_k
+        + top_k
+        + 2 * i
+        + i
+        + hidden
+        + hidden
+}
+
+fn inspect_checkpoint(cli: &Cli, text: &qwen3_moe::config::TextConfig, prefix: &str) -> Result<()> {
+    let specs = expected_tensor_specs(text, prefix);
+    match WeightLoader::from_dir(&cli.model_dir) {
+        Ok(loader) => {
+            let report = inspect_loader_specs(&loader, text, &specs)?;
+            println!(
+                "  HF safetensors: present ({} tensors)",
+                loader.tensor_count()
+            );
+            println!(
+                "    expected tensors present: {}/{}",
+                report.present,
+                specs.len()
+            );
+            if report.missing > 0 {
+                println!(
+                    "    missing expected tensors: {}{}",
+                    report.missing,
+                    format_examples(&report.examples)
+                );
+            }
+            if report.shape_mismatches > 0 {
+                println!(
+                    "    shape mismatches: {}{}",
+                    report.shape_mismatches,
+                    format_examples(&report.shape_examples)
+                );
+            }
+            if report.dtype_mismatches > 0 {
+                println!(
+                    "    dtype mismatches: {}{}",
+                    report.dtype_mismatches,
+                    format_examples(&report.dtype_examples)
+                );
+            }
+            if report.missing == 0 && report.shape_mismatches == 0 && report.dtype_mismatches == 0 {
+                println!(
+                    "    expected tensor bytes: {:.2} GiB",
+                    report.bytes as f64 / 1024.0_f64.powi(3)
+                );
+            }
+        }
+        Err(LoadError::Malformed(msg)) => {
+            println!("  HF safetensors: not found ({msg})");
+        }
+        Err(err) => {
+            println!("  HF safetensors: unreadable ({err})");
+        }
+    }
+    Ok(())
+}
+
+fn inspect_int4_bake(cli: &Cli, text: &qwen3_moe::config::TextConfig, prefix: &str) -> Result<()> {
+    let specs = int4_contract(text, prefix);
+    let inspection = inspect_qwen3_int4_bake(&cli.model_dir, text, prefix).map_err(|e| {
+        anyhow!(
+            "opening Qwen3-MoE INT4 bake at {}: {e}",
+            cli.model_dir.display()
+        )
+    })?;
+    let Int4BakeInspection::Present { bake_dir, report } = inspection else {
+        println!(
+            "  INT4 bake: missing or outdated at {}",
+            inspection.bake_dir().display()
+        );
+        return Ok(());
+    };
+
+    println!("  INT4 bake: present at {}", bake_dir.display());
+    println!(
+        "    expected tensors present: {}/{}",
+        report.present,
+        specs.len()
+    );
+    if report.missing > 0 {
+        println!(
+            "    missing expected baked tensors: {}{}",
+            report.missing,
+            format_examples(&report.missing_examples)
+        );
+    }
+    println!(
+        "    layouts over expected tensors: int4={} raw={} other={}",
+        report.int4_layouts, report.raw_layouts, report.other_layouts
+    );
+    if report.shape_mismatches > 0 {
+        println!(
+            "    shape mismatches: {}{}",
+            report.shape_mismatches,
+            format_examples(&report.shape_examples)
+        );
+    }
+    if report.dtype_mismatches > 0 {
+        println!(
+            "    dtype mismatches: {}{}",
+            report.dtype_mismatches,
+            format_examples(&report.dtype_examples)
+        );
+    }
+    if report.layout_mismatches > 0 {
+        println!(
+            "    layout mismatches: {}{}",
+            report.layout_mismatches,
+            format_examples(&report.layout_examples)
+        );
+    }
+    println!(
+        "    expected tensor bytes in bake: {:.2} GiB",
+        report.bytes as f64 / 1024.0_f64.powi(3)
+    );
+    Ok(())
+}
+
+#[derive(Default)]
+struct LoaderReport {
+    present: usize,
+    missing: usize,
+    shape_mismatches: usize,
+    dtype_mismatches: usize,
+    bytes: u64,
+    examples: Vec<String>,
+    shape_examples: Vec<String>,
+    dtype_examples: Vec<String>,
+}
+
+fn inspect_loader_specs(
+    loader: &WeightLoader,
+    text: &qwen3_moe::config::TextConfig,
+    specs: &[TensorSpec],
+) -> Result<LoaderReport> {
+    let mut report = LoaderReport::default();
+    for spec in specs {
+        let Ok(meta) = loader.meta(&spec.name) else {
+            report.missing += 1;
+            push_example(&mut report.examples, spec.name.clone());
+            continue;
+        };
+        report.present += 1;
+        report.bytes = report.bytes.saturating_add(meta.byte_size());
+
+        let expected_elems = checkpoint_elems_for(text, spec.role);
+        if meta.elem_count() != expected_elems {
+            report.shape_mismatches += 1;
+            push_example(
+                &mut report.shape_examples,
+                format!(
+                    "{} has {:?} ({} elems), expected {} elems",
+                    spec.name,
+                    meta.shape,
+                    meta.elem_count(),
+                    expected_elems
+                ),
+            );
+        }
+
+        let Some(dtype) = checkpoint_dtype_from_scalar(meta.dtype) else {
+            report.dtype_mismatches += 1;
+            push_example(
+                &mut report.dtype_examples,
+                format!("{} has unsupported dtype {:?}", spec.name, meta.dtype),
+            );
+            continue;
+        };
+        if !checkpoint_dtype_acceptable(spec.role, dtype) {
+            report.dtype_mismatches += 1;
+            push_example(
+                &mut report.dtype_examples,
+                format!("{} has dtype {:?}", spec.name, meta.dtype),
+            );
+        }
+    }
+    Ok(report)
+}
+
+fn checkpoint_dtype_from_scalar(dtype: ScalarKind) -> Option<CheckpointDtype> {
+    match dtype {
+        ScalarKind::Bf16 => Some(CheckpointDtype::Bf16),
+        ScalarKind::F32 => Some(CheckpointDtype::F32),
+        _ => None,
+    }
+}
+
+fn push_example(examples: &mut Vec<String>, value: String) {
+    if examples.len() < 3 {
+        examples.push(value);
+    }
+}
+
+fn format_examples(examples: &[String]) -> String {
+    if examples.is_empty() {
+        String::new()
+    } else {
+        format!(" (examples: {})", examples.join(", "))
+    }
+}
+
+fn validate_config_matches_registry(
+    text: &qwen3_moe::config::TextConfig,
+    params: &crate::registry::Qwen3MoeKernelParams,
+) -> Result<()> {
+    let checks = [
+        ("hidden_size", text.hidden_size as u32, params.hidden_size),
+        ("vocab_size", text.vocab_size as u32, params.vocab_size),
+        (
+            "num_hidden_layers",
+            text.num_hidden_layers as u32,
+            params.num_layers,
+        ),
+        (
+            "num_attention_heads",
+            text.num_attention_heads as u32,
+            params.num_attention_heads,
+        ),
+        (
+            "num_key_value_heads",
+            text.num_key_value_heads as u32,
+            params.num_kv_heads,
+        ),
+        ("head_dim", text.head_dim as u32, params.head_dim),
+        ("num_experts", text.num_experts as u32, params.num_experts),
+        (
+            "num_experts_per_tok",
+            text.num_experts_per_tok as u32,
+            params.top_k,
+        ),
+        (
+            "moe_intermediate_size",
+            text.moe_intermediate_size as u32,
+            params.moe_intermediate_size,
+        ),
+    ];
+    for (name, got, expected) in checks {
+        if got != expected {
+            anyhow::bail!(
+                "Qwen3-MoE registry/config mismatch for {name}: config has {got}, registry expects {expected}"
+            );
+        }
+    }
+    Ok(())
+}

--- a/crates/runtime/src/builders.rs
+++ b/crates/runtime/src/builders.rs
@@ -19,6 +19,7 @@ pub(crate) fn build_qwen(
 ) -> Result<(InferenceSession, Vec<u32>)> {
     let mut params = match &entry.params {
         FamilyParams::Qwen35(p) => *p,
+        FamilyParams::Qwen3Moe(_) => unreachable!("caller filtered to Qwen3.5"),
         FamilyParams::Qwen36Moe(_) => unreachable!("caller filtered to Qwen3.5"),
         FamilyParams::Gemma4(_) => unreachable!("caller filtered to Qwen"),
         FamilyParams::Phi4(_) => unreachable!("caller filtered to Qwen"),
@@ -96,6 +97,7 @@ pub(crate) fn build_gemma4(
     let params = match &entry.params {
         FamilyParams::Gemma4(p) => p,
         FamilyParams::Qwen35(_) => unreachable!("caller filtered to Gemma 4"),
+        FamilyParams::Qwen3Moe(_) => unreachable!("caller filtered to Gemma 4"),
         FamilyParams::Qwen36Moe(_) => unreachable!("caller filtered to Gemma 4"),
         FamilyParams::Phi4(_) => unreachable!("caller filtered to Gemma 4"),
         FamilyParams::Llama31(_) => unreachable!("caller filtered to Gemma 4"),

--- a/crates/runtime/src/state.rs
+++ b/crates/runtime/src/state.rs
@@ -171,6 +171,7 @@ pub fn build(cfg: LoaderConfig) -> Result<ServerState> {
     let max_context = cfg.max_context.max(8);
     let (session, eos_ids) = match variant.family() {
         ModelFamily::Qwen35 => build_qwen(&cfg, entry, max_context)?,
+        ModelFamily::Qwen3Moe => bail!("qwen3-30b-a3b MoE runtime is not implemented yet"),
         ModelFamily::Qwen36Moe => bail!("qwen3.6-35b-a3b MoE runtime is not implemented yet"),
         ModelFamily::Gemma4 => build_gemma4(&cfg, entry, max_context)?,
         ModelFamily::Phi4 => {
@@ -252,7 +253,7 @@ fn validate_runtime_policy(
     if q4km_like
         && !matches!(
             variant.family(),
-            ModelFamily::Qwen35 | ModelFamily::Qwen36Moe
+            ModelFamily::Qwen35 | ModelFamily::Qwen3Moe | ModelFamily::Qwen36Moe
         )
     {
         bail!("--q4km/--q4km-gptq are currently supported only for Qwen models");
@@ -278,6 +279,9 @@ fn validate_runtime_policy(
 
     match variant.family() {
         ModelFamily::Qwen35 | ModelFamily::Gemma4 => Ok(()),
+        ModelFamily::Qwen3Moe => {
+            bail!("qwen3-30b-a3b MoE runtime is not implemented yet")
+        }
         ModelFamily::Qwen36Moe => {
             bail!("qwen3.6-35b-a3b MoE runtime is not implemented yet")
         }

--- a/docs/bake-distribution.md
+++ b/docs/bake-distribution.md
@@ -32,8 +32,9 @@ One release per `FORMAT_VERSION`; tag `bakes-v{FORMAT_VERSION}` on
 - One `{model}-{variant}-fmt{N}-cvt{M}.tar.zst` (or
   `…tar.zst.partNN` when >1800 MiB) per bake.
 
-Models: `qwen3.5-{0.8b,2b,4b,9b}`, `qwen3.6-27b`,
-`qwen3.6-35b-a3b`, `gemma4-{e2b,e4b}`, `phi4-mini`.
+Models: `qwen3.5-{0.8b,2b,4b,9b}`, `qwen3-30b-a3b`,
+`qwen3.6-27b`, `qwen3.6-35b-a3b`, `gemma4-{e2b,e4b}`,
+`phi4-mini`.
 Variants: `bf16`, `fp8-native`, `int4-gptq`, `q4km`, `q4km-gptq`.
 
 Example: `gemma4-e4b-int4-gptq-fmt1-cvt2.tar.zst`.

--- a/docs/qwen3-30b-a3b-hip.md
+++ b/docs/qwen3-30b-a3b-hip.md
@@ -1,0 +1,153 @@
+# Qwen3-30B-A3B HIP Bring-Up
+
+This document tracks the Qwen3-30B-A3B implementation in SuperSonic. This is
+the HuggingFace `Qwen/Qwen3-30B-A3B` model, not Qwen3.6. It has a separate
+Rust crate, FFI module, and HIP compilation unit so it does not share the
+Qwen3.6-MoE runtime implementation beyond generic infrastructure such as
+`gpu-hal`, `model-store`, and registry plumbing.
+
+## Scope
+
+The first PR wires the model as an explicit HIP-only INT4 bring-up target:
+
+- model registry alias: `qwen3-30b-a3b`
+- HuggingFace id: `Qwen/Qwen3-30B-A3B`
+- model family: `Qwen3Moe`
+- implementation crate: `crates/qwen3_moe`
+- FFI module: `kernel-ffi::qwen3_moe`
+- HIP source: `kernels/qwen3_moe.hip`
+- bridge source: `kernels/qwen3_moe_bridge.cpp`
+
+The current code supports config validation, checkpoint tensor enumeration,
+INT4 baked tensor contract validation, baked manifest indexing, GPU upload of
+the INT4 weights, descriptor pointer construction, scratch allocation, full
+single-token decode math, and lm-head sampling. The HIP kernel is a
+correctness-first layer kernel, not the optimized persistent megakernel that
+the older Qwen3.5/Gemma paths use.
+
+## Model Geometry
+
+Qwen3-30B-A3B uses dense full-attention layers plus MoE feed-forward blocks:
+
+- hidden size: 2048
+- layers: 48
+- query heads: 32
+- KV heads: 4
+- head dim: 128
+- query projection width: 4096
+- experts: 128
+- experts per token: 8
+- MoE intermediate size: 768
+- vocab size: 151936
+
+Unlike Qwen3.5 dense models, `num_attention_heads * head_dim` is larger than
+`hidden_size`. The Qwen3 config parser deliberately validates this model's
+real geometry instead of assuming `q_dim == hidden_size`.
+
+## Runtime Policy
+
+The first bring-up lane is intentionally narrow:
+
+- HIP only
+- `--int4` required
+- `--batch-size 1` only
+- `--fp8-runtime`, `--kv-fp8`, `--q4km`, and `--q4km-gptq` rejected
+- no serve path yet
+- no teacher-forced HF logit validation path yet
+
+The CLI accepts dry-run validation:
+
+```bash
+cargo run --release --bin supersonic -- \
+  --model qwen3-30b-a3b \
+  --model-dir /path/to/Qwen3-30B-A3B \
+  --int4 \
+  --dry-run
+```
+
+Non-dry-run execution is supported for one-token-at-a-time decode. It is slow
+by design in this bring-up branch because each layer launches independently.
+
+## INT4 Bake Contract
+
+The Qwen3 INT4 contract uses group size 128. Quantized tensors are stored as
+packed `u8` weights with BF16 `_int4_scale` and `_int4_zero` sidecars.
+
+Quantized tensors:
+
+- `lm_head.weight`
+- per-layer `self_attn.{q,k,v,o}_proj.weight`
+- per-layer fused `mlp.experts.gate_up_proj`
+- per-layer fused `mlp.experts.down_proj`
+
+Raw BF16 tensors:
+
+- `model.embed_tokens.weight`
+- `model.norm.weight`
+- per-layer input and post-attention norms
+- per-layer `self_attn.{q,k}_norm.weight`
+- per-layer router `mlp.gate.weight`
+
+The split HuggingFace expert tensors are expected in the source checkpoint as
+`experts.N.{gate,up,down}_proj.weight`. The baked contract replaces those with
+the fused expert tensors consumed by the Qwen3 runtime.
+
+### Producer Paths
+
+`oracle/bake_int4.py` has two Qwen3-MoE producer modes:
+
+- default `int4-gptq`: loads the HF model and runs the normal calibration
+  workflow. On the 24 GiB GPU / 64 GiB host test machine this OOMed during the
+  full `128 x 2048` calibration path with CPU/disk offload.
+- `--qwen3-raw-minmax`: Qwen3-only fallback that never instantiates the HF
+  model. It reads safetensors directly, writes the same runtime INT4 layout,
+  fuses per-expert HF tensors into the runtime expert slabs, and uses
+  calibration-free min/max scale search. This is OOM-safe and decode-capable,
+  but should not be represented as Hessian-calibrated GPTQ quality.
+
+Example OOM-safe bake:
+
+```bash
+python oracle/bake_int4.py \
+  --model-dir /mnt/data/models/Qwen3-30B-A3B \
+  --device cuda \
+  --qwen3-raw-minmax
+```
+
+## PR-Ready Verification
+
+The expected local checks for this bring-up are:
+
+```bash
+cargo test -p qwen3_moe
+cargo test -p supersonic-core qwen3
+cargo test -p kernel-ffi qwen3_moe --lib
+cargo check -p runner --bin supersonic
+cargo check -p supersonic-runtime
+python -m py_compile oracle/upload_bake.py
+python -m py_compile oracle/bake_int4.py
+```
+
+These checks validate the model geometry, registry entry, descriptor ABI,
+INT4 bake contract, Qwen3-owned baked index, and the runner/runtime policy
+surface.
+
+Local runtime smoke commands used during bring-up:
+
+```bash
+cargo run --release --bin supersonic -- \
+  --model qwen3-30b-a3b \
+  --model-dir /mnt/data/models/Qwen3-30B-A3B \
+  --prompt "Hello" \
+  --max-new-tokens 1 \
+  --context-size 8 \
+  --int4
+
+cargo run --release --bin supersonic -- \
+  --model qwen3-30b-a3b \
+  --model-dir /mnt/data/models/Qwen3-30B-A3B \
+  --prompt "Hello, can you explain HIP kernels in one sentence?" \
+  --max-new-tokens 8 \
+  --context-size 128 \
+  --int4
+```

--- a/kernels/qwen3_moe.hip
+++ b/kernels/qwen3_moe.hip
@@ -1,0 +1,567 @@
+// Qwen3-MoE HIP decode kernels.
+//
+// This file is intentionally separate from Qwen3.6-MoE. Qwen3-30B-A3B is a
+// pure full-attention MoE model with different tensor geometry and no hybrid
+// linear-attention/shared-expert path. The decode kernel below is the first
+// correctness-oriented HIP path: one cooperative block runs one layer, with
+// INT4 dequant for attention and expert weights and BF16 KV cache.
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_bfloat16.h>
+#include <math.h>
+#include <stdint.h>
+
+namespace qwen3_moe {
+
+struct DecodeLayerDesc {
+    int         layer_idx;
+    const void* input_norm_w;
+    float       input_norm_eps;
+    const void* post_attn_norm_w;
+    float       post_attn_norm_eps;
+
+    const void* q_proj_w;
+    const void* k_proj_w;
+    const void* v_proj_w;
+    const void* o_proj_w;
+    const void* q_norm_w;
+    const void* k_norm_w;
+    float       rope_theta;
+    int         head_dim;
+    int         num_heads;
+    int         num_kv_heads;
+    void*       kv_cache_k;
+    void*       kv_cache_v;
+    int         kv_len;
+    int         kv_max_t;
+
+    const void* router_w;
+    const void* experts_gate_up_w;
+    const void* experts_down_w;
+    int         num_experts;
+    int         top_k;
+    int         moe_intermediate_size;
+    int         norm_topk_prob;
+};
+
+struct Int4ScaleDesc {
+    const void* q_proj_scale;
+    const void* q_proj_zero;
+    const void* k_proj_scale;
+    const void* k_proj_zero;
+    const void* v_proj_scale;
+    const void* v_proj_zero;
+    const void* o_proj_scale;
+    const void* o_proj_zero;
+    const void* experts_gate_up_scale;
+    const void* experts_gate_up_zero;
+    const void* experts_down_scale;
+    const void* experts_down_zero;
+    int         group_size;
+};
+
+__global__ void qwen3_moe_descriptor_walk_stub(
+    int                              num_layers,
+    const DecodeLayerDesc* __restrict__ layers,
+    float* __restrict__              workspace,
+    unsigned int* __restrict__       counters) {
+    if (blockIdx.x == 0 && threadIdx.x == 0) {
+        workspace[0] = 0.0f; // layers seen
+        workspace[1] = 0.0f; // total experts
+        workspace[2] = 0.0f; // total top_k
+        workspace[3] = 1.0f; // descriptor geometry OK
+    }
+    __syncthreads();
+
+    while (true) {
+        const unsigned int idx = atomicAdd(&counters[0], 1u);
+        if (idx >= static_cast<unsigned int>(num_layers)) return;
+
+        const DecodeLayerDesc& d = layers[idx];
+        if (threadIdx.x == 0) {
+            atomicAdd(&workspace[0], 1.0f);
+            atomicAdd(&workspace[1], static_cast<float>(d.num_experts));
+            atomicAdd(&workspace[2], static_cast<float>(d.top_k));
+            if (d.layer_idx != static_cast<int>(idx) ||
+                d.head_dim <= 0 ||
+                d.num_heads <= 0 ||
+                d.num_kv_heads <= 0 ||
+                d.num_experts <= 0 ||
+                d.top_k <= 0 ||
+                d.moe_intermediate_size <= 0) {
+                workspace[3] = 0.0f;
+            }
+        }
+    }
+}
+
+__device__ __forceinline__ float bf16_round_rne_f32(float x) {
+    uint32_t bits;
+    __builtin_memcpy(&bits, &x, 4);
+    uint32_t bias = 0x7FFFu + ((bits >> 16) & 1u);
+    bits += bias;
+    bits &= 0xFFFF0000u;
+    float y;
+    __builtin_memcpy(&y, &bits, 4);
+    return y;
+}
+
+__device__ __forceinline__ float load_bf16(const void* p, int idx) {
+    return static_cast<float>(static_cast<const hip_bfloat16*>(p)[idx]);
+}
+
+__device__ __forceinline__ void store_bf16(void* p, int idx, float v) {
+    static_cast<hip_bfloat16*>(p)[idx] = static_cast<hip_bfloat16>(v);
+}
+
+__device__ float block_sum(float v, float* scratch) {
+    const int tid = threadIdx.x;
+    const int bs = blockDim.x;
+    scratch[tid] = v;
+    __syncthreads();
+    for (int s = bs / 2; s > 0; s >>= 1) {
+        if (tid < s) scratch[tid] += scratch[tid + s];
+        __syncthreads();
+    }
+    return scratch[0];
+}
+
+__device__ float int4_value(
+    const uint8_t* __restrict__ packed,
+    const hip_bfloat16* __restrict__ scale,
+    const hip_bfloat16* __restrict__ zero,
+    int row,
+    int col,
+    int cols,
+    int group_size) {
+    const int byte_cols = (cols + 1) / 2;
+    const uint8_t byte = packed[static_cast<size_t>(row) * byte_cols + col / 2];
+    const int nibble = (col & 1) ? ((byte >> 4) & 0xF) : (byte & 0xF);
+    const int scale_cols = (cols + group_size - 1) / group_size;
+    const int scale_idx = (row / group_size) * scale_cols + (col / group_size);
+    const float s = static_cast<float>(scale[scale_idx]);
+    const float z = static_cast<float>(zero[scale_idx]);
+    return bf16_round_rne_f32(static_cast<float>(nibble) * s - z * s);
+}
+
+__device__ float int4_value_3d(
+    const uint8_t* __restrict__ packed,
+    const hip_bfloat16* __restrict__ scale,
+    const hip_bfloat16* __restrict__ zero,
+    int expert,
+    int row,
+    int col,
+    int rows,
+    int cols,
+    int group_size) {
+    const int byte_cols = (cols + 1) / 2;
+    const size_t packed_base =
+        (static_cast<size_t>(expert) * rows + row) * byte_cols;
+    const uint8_t byte = packed[packed_base + col / 2];
+    const int nibble = (col & 1) ? ((byte >> 4) & 0xF) : (byte & 0xF);
+
+    const int scale_rows = (rows + group_size - 1) / group_size;
+    const int scale_cols = (cols + group_size - 1) / group_size;
+    const size_t scale_idx =
+        (static_cast<size_t>(expert) * scale_rows + row / group_size) *
+            scale_cols +
+        col / group_size;
+    const float s = static_cast<float>(scale[scale_idx]);
+    const float z = static_cast<float>(zero[scale_idx]);
+    return bf16_round_rne_f32(static_cast<float>(nibble) * s - z * s);
+}
+
+__device__ float dense_or_int4_dot(
+    const void* weight,
+    const void* scale,
+    const void* zero,
+    int row,
+    const float* x,
+    int cols,
+    int group_size,
+    float* scratch) {
+    float partial = 0.0f;
+    if (scale != nullptr) {
+        const uint8_t* w = static_cast<const uint8_t*>(weight);
+        const hip_bfloat16* s = static_cast<const hip_bfloat16*>(scale);
+        const hip_bfloat16* z = static_cast<const hip_bfloat16*>(zero);
+        for (int c = threadIdx.x; c < cols; c += blockDim.x) {
+            partial += int4_value(w, s, z, row, c, cols, group_size) * x[c];
+        }
+    } else {
+        const hip_bfloat16* w = static_cast<const hip_bfloat16*>(weight);
+        const size_t base = static_cast<size_t>(row) * cols;
+        for (int c = threadIdx.x; c < cols; c += blockDim.x) {
+            partial += static_cast<float>(w[base + c]) * x[c];
+        }
+    }
+    return block_sum(partial, scratch);
+}
+
+__device__ float expert_int4_dot(
+    const void* weight,
+    const void* scale,
+    const void* zero,
+    int expert,
+    int row,
+    const float* x,
+    int rows,
+    int cols,
+    int group_size,
+    float* scratch) {
+    const uint8_t* w = static_cast<const uint8_t*>(weight);
+    const hip_bfloat16* s = static_cast<const hip_bfloat16*>(scale);
+    const hip_bfloat16* z = static_cast<const hip_bfloat16*>(zero);
+    float partial = 0.0f;
+    for (int c = threadIdx.x; c < cols; c += blockDim.x) {
+        partial += int4_value_3d(w, s, z, expert, row, c, rows, cols, group_size) * x[c];
+    }
+    return block_sum(partial, scratch);
+}
+
+__device__ void rms_norm_vec(
+    const float* in,
+    const void* weight,
+    float eps,
+    float* out,
+    int n,
+    float* scratch) {
+    float partial = 0.0f;
+    for (int i = threadIdx.x; i < n; i += blockDim.x) partial += in[i] * in[i];
+    const float sum = block_sum(partial, scratch);
+    const float inv = rsqrtf(sum / static_cast<float>(n) + eps);
+    for (int i = threadIdx.x; i < n; i += blockDim.x) {
+        const float w = load_bf16(weight, i);
+        out[i] = bf16_round_rne_f32(in[i] * inv * w);
+    }
+    __syncthreads();
+}
+
+__global__ void qwen3_moe_decode_layer_kernel(
+    const DecodeLayerDesc layer,
+    const Int4ScaleDesc int4,
+    int hidden,
+    int position,
+    const hip_bfloat16* __restrict__ input_hidden,
+    hip_bfloat16* __restrict__ output_hidden,
+    float* __restrict__ workspace) {
+    extern __shared__ float lds[];
+    float* scratch = lds;
+
+    const int tid = threadIdx.x;
+    const int hd = layer.head_dim;
+    const int h = layer.num_heads;
+    const int hkv = layer.num_kv_heads;
+    const int q_dim = h * hd;
+    const int kv_dim = hkv * hd;
+    const int group_size = int4.group_size;
+    const int top_k = layer.top_k;
+    const int experts = layer.num_experts;
+    const int moe_i = layer.moe_intermediate_size;
+
+    const int OFF_X = 0;
+    const int OFF_Q = OFF_X + hidden;
+    const int OFF_K = OFF_Q + q_dim;
+    const int OFF_V = OFF_K + kv_dim;
+    const int OFF_ATTN = OFF_V + kv_dim;
+    const int OFF_HN = OFF_ATTN + q_dim;
+    const int OFF_ROUTER = OFF_HN + hidden;
+    const int OFF_PROBS = OFF_ROUTER + experts;
+    const int OFF_TOPK_VAL = OFF_PROBS + experts;
+    const int OFF_TOPK_IDX = OFF_TOPK_VAL + top_k;
+    const int OFF_GU = OFF_TOPK_IDX + top_k;
+    const int OFF_MID = OFF_GU + 2 * moe_i;
+    const int OFF_EXPERT_OUT = OFF_MID + moe_i;
+    const int OFF_MOE_OUT = OFF_EXPERT_OUT + hidden;
+
+    float* x = workspace + OFF_X;
+    float* q = workspace + OFF_Q;
+    float* k = workspace + OFF_K;
+    float* v = workspace + OFF_V;
+    float* attn = workspace + OFF_ATTN;
+    float* hnorm = workspace + OFF_HN;
+    float* router = workspace + OFF_ROUTER;
+    float* probs = workspace + OFF_PROBS;
+    float* topk_val = workspace + OFF_TOPK_VAL;
+    float* topk_idx = workspace + OFF_TOPK_IDX;
+    float* gu = workspace + OFF_GU;
+    float* mid = workspace + OFF_MID;
+    float* expert_out = workspace + OFF_EXPERT_OUT;
+    float* moe_out = workspace + OFF_MOE_OUT;
+
+    for (int i = tid; i < hidden; i += blockDim.x) {
+        x[i] = static_cast<float>(input_hidden[i]);
+    }
+    __syncthreads();
+
+    rms_norm_vec(x, layer.input_norm_w, layer.input_norm_eps, hnorm, hidden, scratch);
+
+    for (int row = 0; row < q_dim; ++row) {
+        const float sum = dense_or_int4_dot(
+            layer.q_proj_w, int4.q_proj_scale, int4.q_proj_zero,
+            row, hnorm, hidden, group_size, scratch);
+        if (tid == 0) q[row] = bf16_round_rne_f32(sum);
+        __syncthreads();
+    }
+    for (int row = 0; row < kv_dim; ++row) {
+        float sum = dense_or_int4_dot(
+            layer.k_proj_w, int4.k_proj_scale, int4.k_proj_zero,
+            row, hnorm, hidden, group_size, scratch);
+        if (tid == 0) k[row] = bf16_round_rne_f32(sum);
+        __syncthreads();
+        sum = dense_or_int4_dot(
+            layer.v_proj_w, int4.v_proj_scale, int4.v_proj_zero,
+            row, hnorm, hidden, group_size, scratch);
+        if (tid == 0) v[row] = bf16_round_rne_f32(sum);
+        __syncthreads();
+    }
+
+    for (int head = 0; head < h; ++head) {
+        float partial = 0.0f;
+        for (int i = tid; i < hd; i += blockDim.x) {
+            const float val = q[head * hd + i];
+            partial += val * val;
+        }
+        const float sum = block_sum(partial, scratch);
+        const float inv = rsqrtf(sum / static_cast<float>(hd) + layer.input_norm_eps);
+        for (int i = tid; i < hd; i += blockDim.x) {
+            const float w = load_bf16(layer.q_norm_w, i);
+            q[head * hd + i] = bf16_round_rne_f32(q[head * hd + i] * inv * w);
+        }
+        __syncthreads();
+    }
+    for (int head = 0; head < hkv; ++head) {
+        float partial = 0.0f;
+        for (int i = tid; i < hd; i += blockDim.x) {
+            const float val = k[head * hd + i];
+            partial += val * val;
+        }
+        const float sum = block_sum(partial, scratch);
+        const float inv = rsqrtf(sum / static_cast<float>(hd) + layer.input_norm_eps);
+        for (int i = tid; i < hd; i += blockDim.x) {
+            const float w = load_bf16(layer.k_norm_w, i);
+            k[head * hd + i] = bf16_round_rne_f32(k[head * hd + i] * inv * w);
+        }
+        __syncthreads();
+    }
+
+    const int half = hd / 2;
+    const float theta_log = logf(layer.rope_theta);
+    for (int head = 0; head < h; ++head) {
+        for (int i = tid; i < half; i += blockDim.x) {
+            const float a = q[head * hd + i];
+            const float b = q[head * hd + half + i];
+            const float freq = static_cast<float>(position) *
+                expf(-(static_cast<float>(i) / static_cast<float>(half)) * theta_log);
+            const float c = bf16_round_rne_f32(cosf(freq));
+            const float s = bf16_round_rne_f32(sinf(freq));
+            q[head * hd + i] = bf16_round_rne_f32(bf16_round_rne_f32(a * c) - bf16_round_rne_f32(b * s));
+            q[head * hd + half + i] = bf16_round_rne_f32(bf16_round_rne_f32(b * c) + bf16_round_rne_f32(a * s));
+        }
+        __syncthreads();
+    }
+    for (int head = 0; head < hkv; ++head) {
+        for (int i = tid; i < half; i += blockDim.x) {
+            const float a = k[head * hd + i];
+            const float b = k[head * hd + half + i];
+            const float freq = static_cast<float>(position) *
+                expf(-(static_cast<float>(i) / static_cast<float>(half)) * theta_log);
+            const float c = bf16_round_rne_f32(cosf(freq));
+            const float s = bf16_round_rne_f32(sinf(freq));
+            k[head * hd + i] = bf16_round_rne_f32(bf16_round_rne_f32(a * c) - bf16_round_rne_f32(b * s));
+            k[head * hd + half + i] = bf16_round_rne_f32(bf16_round_rne_f32(b * c) + bf16_round_rne_f32(a * s));
+        }
+        __syncthreads();
+    }
+
+    hip_bfloat16* cache_k = static_cast<hip_bfloat16*>(layer.kv_cache_k);
+    hip_bfloat16* cache_v = static_cast<hip_bfloat16*>(layer.kv_cache_v);
+    const int kv_slot = layer.kv_len;
+    if (cache_k != nullptr && cache_v != nullptr && kv_slot < layer.kv_max_t) {
+        const int base = kv_slot * kv_dim;
+        for (int i = tid; i < kv_dim; i += blockDim.x) {
+            cache_k[base + i] = static_cast<hip_bfloat16>(k[i]);
+            cache_v[base + i] = static_cast<hip_bfloat16>(v[i]);
+        }
+    }
+    __syncthreads();
+
+    const int kv_len = (cache_k != nullptr && cache_v != nullptr) ? (kv_slot + 1) : 1;
+    const float attn_scale = rsqrtf(static_cast<float>(hd));
+    const int rep = h / hkv;
+    for (int head = 0; head < h; ++head) {
+        const int kv_head = head / rep;
+        float my_acc = 0.0f;
+        float my_max = -INFINITY;
+        float my_sum = 0.0f;
+        const float qv = (tid < hd) ? q[head * hd + tid] : 0.0f;
+        for (int t = 0; t < kv_len; ++t) {
+            float partial = 0.0f;
+            if (tid < hd) {
+                const float kval = (cache_k != nullptr)
+                    ? static_cast<float>(cache_k[t * kv_dim + kv_head * hd + tid])
+                    : k[kv_head * hd + tid];
+                partial = qv * kval;
+            }
+            const float score = block_sum(partial, scratch) * attn_scale;
+            float vv = 0.0f;
+            if (tid < hd) {
+                vv = (cache_v != nullptr)
+                    ? static_cast<float>(cache_v[t * kv_dim + kv_head * hd + tid])
+                    : v[kv_head * hd + tid];
+            }
+            const float new_max = fmaxf(my_max, score);
+            const float old_scale = expf(my_max - new_max);
+            const float new_weight = expf(score - new_max);
+            my_acc = my_acc * old_scale + new_weight * vv;
+            my_sum = my_sum * old_scale + new_weight;
+            my_max = new_max;
+            __syncthreads();
+        }
+        if (tid < hd) {
+            attn[head * hd + tid] = bf16_round_rne_f32(my_sum > 0.0f ? my_acc / my_sum : 0.0f);
+        }
+        __syncthreads();
+    }
+
+    for (int row = 0; row < hidden; ++row) {
+        const float sum = dense_or_int4_dot(
+            layer.o_proj_w, int4.o_proj_scale, int4.o_proj_zero,
+            row, attn, q_dim, group_size, scratch);
+        if (tid == 0) x[row] = bf16_round_rne_f32(x[row] + bf16_round_rne_f32(sum));
+        __syncthreads();
+    }
+
+    rms_norm_vec(x, layer.post_attn_norm_w, layer.post_attn_norm_eps, hnorm, hidden, scratch);
+
+    for (int e = 0; e < experts; ++e) {
+        const float sum = dense_or_int4_dot(
+            layer.router_w, nullptr, nullptr, e, hnorm, hidden, group_size, scratch);
+        if (tid == 0) router[e] = bf16_round_rne_f32(sum);
+        __syncthreads();
+    }
+    if (tid == 0) {
+        float maxv = -INFINITY;
+        for (int e = 0; e < experts; ++e) maxv = fmaxf(maxv, router[e]);
+        float denom = 0.0f;
+        for (int e = 0; e < experts; ++e) {
+            probs[e] = expf(router[e] - maxv);
+            denom += probs[e];
+        }
+        for (int e = 0; e < experts; ++e) probs[e] = bf16_round_rne_f32(probs[e] / denom);
+        for (int kpos = 0; kpos < top_k; ++kpos) {
+            int best_i = 0;
+            float best_v = -INFINITY;
+            for (int e = 0; e < experts; ++e) {
+                if (probs[e] > best_v) {
+                    best_v = probs[e];
+                    best_i = e;
+                }
+            }
+            topk_idx[kpos] = static_cast<float>(best_i);
+            topk_val[kpos] = best_v;
+            probs[best_i] = -INFINITY;
+        }
+        if (layer.norm_topk_prob) {
+            float sum = 0.0f;
+            for (int kpos = 0; kpos < top_k; ++kpos) sum += topk_val[kpos];
+            const float inv = 1.0f / sum;
+            for (int kpos = 0; kpos < top_k; ++kpos) topk_val[kpos] = bf16_round_rne_f32(topk_val[kpos] * inv);
+        }
+    }
+    __syncthreads();
+
+    for (int i = tid; i < hidden; i += blockDim.x) moe_out[i] = 0.0f;
+    __syncthreads();
+
+    for (int kpos = 0; kpos < top_k; ++kpos) {
+        const int expert = static_cast<int>(topk_idx[kpos]);
+        for (int row = 0; row < 2 * moe_i; ++row) {
+            const float sum = expert_int4_dot(
+                layer.experts_gate_up_w,
+                int4.experts_gate_up_scale,
+                int4.experts_gate_up_zero,
+                expert, row, hnorm, 2 * moe_i, hidden, group_size, scratch);
+            if (tid == 0) gu[row] = bf16_round_rne_f32(sum);
+            __syncthreads();
+        }
+        for (int i = tid; i < moe_i; i += blockDim.x) {
+            const float g = gu[i];
+            const float u = gu[moe_i + i];
+            mid[i] = bf16_round_rne_f32((g / (1.0f + expf(-g))) * u);
+        }
+        __syncthreads();
+        for (int row = 0; row < hidden; ++row) {
+            const float sum = expert_int4_dot(
+                layer.experts_down_w,
+                int4.experts_down_scale,
+                int4.experts_down_zero,
+                expert, row, mid, hidden, moe_i, group_size, scratch);
+            if (tid == 0) expert_out[row] = bf16_round_rne_f32(sum);
+            __syncthreads();
+        }
+        for (int i = tid; i < hidden; i += blockDim.x) {
+            moe_out[i] += topk_val[kpos] * expert_out[i];
+        }
+        __syncthreads();
+    }
+
+    for (int i = tid; i < hidden; i += blockDim.x) {
+        output_hidden[i] = static_cast<hip_bfloat16>(bf16_round_rne_f32(x[i] + bf16_round_rne_f32(moe_out[i])));
+    }
+}
+
+__global__ void qwen3_moe_lm_head_kernel(
+    int hidden,
+    int vocab,
+    float rms_norm_eps,
+    const hip_bfloat16* __restrict__ final_hidden,
+    const hip_bfloat16* __restrict__ final_norm_w,
+    const hip_bfloat16* __restrict__ lm_head_w,
+    hip_bfloat16* __restrict__ logits,
+    unsigned int* __restrict__ counter) {
+    extern __shared__ float lds[];
+    const int tid = threadIdx.x;
+    const int bs = blockDim.x;
+
+    float partial_sq = 0.0f;
+    for (int i = tid; i < hidden; i += bs) {
+        const float v = static_cast<float>(final_hidden[i]);
+        partial_sq += v * v;
+    }
+    lds[tid] = partial_sq;
+    __syncthreads();
+    for (int s = bs / 2; s > 0; s >>= 1) {
+        if (tid < s) lds[tid] += lds[tid + s];
+        __syncthreads();
+    }
+    const float inv = rsqrtf(lds[0] / static_cast<float>(hidden) + rms_norm_eps);
+    __syncthreads();
+
+    for (;;) {
+        __shared__ unsigned int row_s;
+        if (tid == 0) row_s = atomicAdd(counter, 1u);
+        __syncthreads();
+        const int row = static_cast<int>(row_s);
+        if (row >= vocab) return;
+
+        float partial = 0.0f;
+        const size_t base = static_cast<size_t>(row) * hidden;
+        for (int i = tid; i < hidden; i += bs) {
+            const float x = bf16_round_rne_f32(
+                static_cast<float>(final_hidden[i]) * inv *
+                static_cast<float>(final_norm_w[i]));
+            partial += static_cast<float>(lm_head_w[base + i]) * x;
+        }
+        lds[tid] = partial;
+        __syncthreads();
+        for (int s = bs / 2; s > 0; s >>= 1) {
+            if (tid < s) lds[tid] += lds[tid + s];
+            __syncthreads();
+        }
+        if (tid == 0) logits[row] = static_cast<hip_bfloat16>(bf16_round_rne_f32(lds[0]));
+        __syncthreads();
+    }
+}
+
+} // namespace qwen3_moe

--- a/kernels/qwen3_moe_bridge.cpp
+++ b/kernels/qwen3_moe_bridge.cpp
@@ -1,0 +1,172 @@
+// Qwen3-MoE HIP launch bridge.
+
+#include "qwen3_moe.hip"
+
+#include <cstdlib>
+#include <hip/hip_runtime.h>
+#include <stdint.h>
+
+namespace {
+
+bool sync_each_kernel_enabled() {
+    const char* env = std::getenv("SUPERSONIC_SYNC_EACH_KERNEL");
+    return env != nullptr && env[0] != '\0' && env[0] != '0';
+}
+
+struct ScopedHipDevice {
+    int  previous = -1;
+    bool changed  = false;
+
+    explicit ScopedHipDevice(int target) {
+        hipGetDevice(&previous);
+        if (previous != target) {
+            hipSetDevice(target);
+            changed = true;
+        }
+    }
+    ~ScopedHipDevice() {
+        if (changed && previous >= 0) hipSetDevice(previous);
+    }
+};
+
+static_assert(sizeof(qwen3_moe::DecodeLayerDesc) == 168,
+              "Qwen3MoeDecodeLayerDesc size drift; update Rust and C++ together");
+static_assert(sizeof(qwen3_moe::Int4ScaleDesc) == 104,
+              "Qwen3MoeInt4ScaleDesc size drift; update Rust and C++ together");
+
+} // namespace
+
+extern "C" int qwen3_moe_hip_stub_launch(
+    int                                dtype,
+    size_t                             device_ordinal,
+    size_t                             num_layers,
+    const qwen3_moe::DecodeLayerDesc*  layers,
+    float*                             workspace,
+    unsigned int*                      counters) {
+    if (dtype != 2) return 110; // BF16 only for the descriptor smoke path.
+    if (num_layers == 0 || num_layers > 1024) return 100;
+    if (layers == nullptr || workspace == nullptr || counters == nullptr) {
+        return 101;
+    }
+
+    ScopedHipDevice scoped(static_cast<int>(device_ordinal));
+
+    hipDeviceProp_t props;
+    if (hipGetDeviceProperties(&props, static_cast<int>(device_ordinal)) !=
+        hipSuccess) {
+        return 250;
+    }
+    const int num_blocks =
+        props.multiProcessorCount > 0 ? props.multiProcessorCount : 16;
+
+    if (hipMemsetAsync(counters, 0, sizeof(unsigned int)) != hipSuccess) {
+        return 200;
+    }
+
+    hipLaunchKernelGGL(qwen3_moe::qwen3_moe_descriptor_walk_stub,
+                       dim3(static_cast<unsigned int>(num_blocks)),
+                       dim3(64),
+                       0, 0,
+                       static_cast<int>(num_layers),
+                       layers,
+                       workspace,
+                       counters);
+    hipError_t launch_err = hipGetLastError();
+    hipError_t sync_err =
+        sync_each_kernel_enabled() ? hipDeviceSynchronize() : hipSuccess;
+    if (launch_err != hipSuccess) return 254;
+    if (sync_err != hipSuccess) return 255;
+    return 0;
+}
+
+extern "C" int qwen3_moe_hip_decode_layer_launch(
+    int                                      dtype,
+    size_t                                   device_ordinal,
+    const qwen3_moe::DecodeLayerDesc*        layer,
+    const qwen3_moe::Int4ScaleDesc*          int4,
+    int                                      hidden,
+    int                                      position,
+    const void*                              input_hidden,
+    void*                                    output_hidden,
+    float*                                   workspace) {
+    if (dtype != 2) return 110; // BF16 activations only.
+    if (layer == nullptr || int4 == nullptr || input_hidden == nullptr ||
+        output_hidden == nullptr || workspace == nullptr) {
+        return 101;
+    }
+    if (hidden <= 0 || position < 0) return 102;
+    if (int4->group_size <= 0) return 103;
+
+    ScopedHipDevice scoped(static_cast<int>(device_ordinal));
+
+    const int block_threads = 256;
+    const size_t shmem = block_threads * sizeof(float);
+    hipLaunchKernelGGL(qwen3_moe::qwen3_moe_decode_layer_kernel,
+                       dim3(1),
+                       dim3(block_threads),
+                       shmem, 0,
+                       *layer,
+                       *int4,
+                       hidden,
+                       position,
+                       static_cast<const hip_bfloat16*>(input_hidden),
+                       static_cast<hip_bfloat16*>(output_hidden),
+                       workspace);
+    hipError_t launch_err = hipGetLastError();
+    hipError_t sync_err =
+        sync_each_kernel_enabled() ? hipDeviceSynchronize() : hipSuccess;
+    if (launch_err != hipSuccess) return 254;
+    if (sync_err != hipSuccess) return 255;
+    return 0;
+}
+
+extern "C" int qwen3_moe_hip_lm_head_launch(
+    int          dtype,
+    size_t       device_ordinal,
+    int          hidden,
+    int          vocab,
+    float        rms_norm_eps,
+    const void*  final_hidden,
+    const void*  final_norm_w,
+    const void*  lm_head_w,
+    void*        logits,
+    unsigned int* counter) {
+    if (dtype != 2) return 110;
+    if (hidden <= 0 || vocab <= 0) return 100;
+    if (final_hidden == nullptr || final_norm_w == nullptr ||
+        lm_head_w == nullptr || logits == nullptr || counter == nullptr) {
+        return 101;
+    }
+
+    ScopedHipDevice scoped(static_cast<int>(device_ordinal));
+    hipDeviceProp_t props;
+    if (hipGetDeviceProperties(&props, static_cast<int>(device_ordinal)) !=
+        hipSuccess) {
+        return 250;
+    }
+    const int num_blocks =
+        props.multiProcessorCount > 0 ? props.multiProcessorCount : 16;
+    const int block_threads = 256;
+    const size_t shmem = block_threads * sizeof(float);
+    if (hipMemsetAsync(counter, 0, sizeof(unsigned int)) != hipSuccess) {
+        return 200;
+    }
+    hipLaunchKernelGGL(qwen3_moe::qwen3_moe_lm_head_kernel,
+                       dim3(static_cast<unsigned int>(num_blocks)),
+                       dim3(block_threads),
+                       shmem, 0,
+                       hidden,
+                       vocab,
+                       rms_norm_eps,
+                       static_cast<const hip_bfloat16*>(final_hidden),
+                       static_cast<const hip_bfloat16*>(final_norm_w),
+                       static_cast<const hip_bfloat16*>(lm_head_w),
+                       static_cast<hip_bfloat16*>(logits),
+                       counter);
+    hipError_t launch_err = hipGetLastError();
+    hipError_t sync_err =
+        sync_each_kernel_enabled() ? hipDeviceSynchronize() : hipSuccess;
+    if (launch_err != hipSuccess) return 254;
+    if (sync_err != hipSuccess) return 255;
+    return 0;
+}

--- a/oracle/bake_int4.py
+++ b/oracle/bake_int4.py
@@ -112,9 +112,17 @@ FUSED_EXPERT_SUFFIXES = (
     ".mlp.experts.down_proj",
 )
 
+UNFUSED_EXPERT_RE = re.compile(
+    r"^(.+\.mlp\.experts)\.(\d+)\.(gate_proj|up_proj|down_proj)\.weight$"
+)
+
 
 def is_fused_expert_target(name: str) -> bool:
     return any(name.endswith(s) for s in FUSED_EXPERT_SUFFIXES)
+
+
+def is_unfused_expert_target(name: str) -> bool:
+    return UNFUSED_EXPERT_RE.match(name) is not None
 
 
 def is_int4_target(name: str) -> bool:
@@ -410,6 +418,45 @@ def pack_nibbles(nibbles: torch.Tensor) -> torch.Tensor:
     leading = nibbles.shape[:-1]
     r = nibbles.reshape(*leading, cols // 2, 2).to(torch.uint8)
     return (r[..., 0] | (r[..., 1] << 4)).contiguous()
+
+
+@torch.no_grad()
+def minmax_int4_2d_packed(
+    W: torch.Tensor,
+    group_size: int,
+    work_device: torch.device | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Calibration-free INT4 group quantization for one 2D matrix.
+
+    This writes the same runtime layout as GPTQ (packed u8 weight plus BF16
+    scale/zero sidecars), but chooses scales from the raw weight ranges. It is
+    used only by the Qwen3 raw-safetensors producer path for hosts that cannot
+    fit the full HF model plus calibration activations.
+    """
+    if W.dim() != 2:
+        raise ValueError(f"dense tensor must be 2D, got shape {tuple(W.shape)}")
+    out_f, in_f = W.shape
+    gs = group_size
+    if in_f % gs != 0 or in_f % 2 != 0:
+        raise ValueError(
+            f"in_features {in_f} must be divisible by group_size={gs} and even"
+        )
+    if out_f % gs != 0:
+        raise ValueError(f"out_features {out_f} must be divisible by group_size={gs}")
+    scale_rows = out_f // gs
+    scale_cols = in_f // gs
+    dev = work_device if work_device is not None else W.device
+    slab = W.to(device=dev, dtype=torch.float32)
+    tiles = slab.reshape(scale_rows, gs, scale_cols, gs)
+    sc, zf = _minmax_int4_search_2d(tiles)
+    sc_full = sc.repeat_interleave(gs, dim=0).repeat_interleave(gs, dim=1)
+    zf_full = zf.repeat_interleave(gs, dim=0).repeat_interleave(gs, dim=1)
+    q = torch.clamp(torch.round(slab / sc_full + zf_full), 0.0, 15.0).to(torch.uint8)
+    packed = (q[:, 0::2] | (q[:, 1::2] << 4)).contiguous().cpu()
+    scale = sc.cpu()
+    zero = zf.cpu()
+    del slab, tiles, sc_full, zf_full, q
+    return packed, scale, zero
 
 
 @torch.no_grad()
@@ -1211,6 +1258,9 @@ def quantize_model(
     writer: "StreamingPackageWriter",
     hf_to_raw: dict[str, str],
     safetensors_loader: Callable[[str], torch.Tensor | None] | None = None,
+    model_dir: Path | None = None,
+    raw_keys: set[str] | None = None,
+    model_family: str = "qwen35",
 ) -> dict[str, Any]:
     """
     Run sequential GPTQ, **streaming** each quantized tensor to `writer` as
@@ -1277,6 +1327,8 @@ def quantize_model(
         for mod in layer.modules():
             if isinstance(mod, nn.Linear):
                 name = module_to_name[id(mod)]
+                if model_family == "qwen3-moe" and is_unfused_expert_target(name):
+                    continue
                 if is_int4_target(name):
                     targets.append((name, mod))
 
@@ -1462,7 +1514,7 @@ def quantize_model(
     # a time on `device`, pack nibbles immediately to halve RAM use vs the
     # unpacked layout, then free the BF16 source. Writing path detects packed
     # 3D shapes via `dim() == 3` (dense GPTQ stays 2D + unpacked).
-    fused_param_names = sorted(
+    fused_param_names = [] if model_family == "qwen3-moe" else sorted(
         n for n, _ in model.named_parameters() if is_fused_expert_target(n)
     )
     if fused_param_names:
@@ -1504,6 +1556,56 @@ def quantize_model(
             # malloc_trim, glibc keeps them in its arena cache and we drift
             # ~10 GiB upward over the 80-tensor pass.
             _release_host_memory()
+
+    # Qwen3-30B-A3B ships the experts as individual HF Linear weights:
+    #   mlp.experts.{E}.gate_proj.weight / up_proj.weight / down_proj.weight
+    # The HIP runtime consumes the same fused slab contract as Qwen3.6-MoE:
+    #   mlp.experts.gate_up_proj [E, 2*moe, hidden]
+    #   mlp.experts.down_proj    [E, hidden, moe]
+    # Synthesize those fused tensors directly from safetensors so the dense
+    # GPTQ loop above does not spend hours calibrating thousands of tiny expert
+    # modules that the runtime will never load by name.
+    if model_family == "qwen3-moe":
+        if model_dir is None or raw_keys is None:
+            raise SystemExit("qwen3-moe bake requires model_dir and raw_keys")
+        raw_bases = sorted({
+            m.group(1)
+            for k in raw_keys
+            if (m := UNFUSED_EXPERT_RE.match(k)) is not None
+        })
+        if raw_bases:
+            log(f"[gptq] Qwen3 unfused MoE experts: fusing+quantizing "
+                f"{len(raw_bases) * 2} runtime tensors (min/max group-quant)")
+            loader = RawTensorLoader(model_dir)
+            for raw_base in raw_bases:
+                for kind in ("gate_up_proj", "down_proj"):
+                    raw_name = f"{raw_base}.{kind}"
+                    if writer.has(raw_name):
+                        continue
+                    t0 = time.perf_counter()
+                    W = load_fused_expert_bf16(
+                        model_dir, raw_keys, raw_base, kind, loader,
+                    )
+                    packed, scale_t, zero_t = fused_expert_minmax_int4_packed(
+                        W, group_size=group_size, work_device=device,
+                    )
+                    elapsed = time.perf_counter() - t0
+                    log(f"[gptq]   {raw_name}: shape={tuple(W.shape)} -> "
+                        f"packed={tuple(packed.shape)} took {elapsed:.1f}s")
+                    _stream_quantized_tensor(writer, raw_name, packed, scale_t, zero_t)
+                    stats["quantized_names"].add(raw_name)
+                    stats["fused_total"] += 1
+                    range_ok, linf = _selfcheck_fused(
+                        packed, scale_t, zero_t, W, group_size,
+                    )
+                    if not range_ok:
+                        stats["nibble_range_ok"] = False
+                    if linf > stats["fused_worst"][1]:
+                        stats["fused_worst"] = (raw_name, linf)
+                    del W, packed, scale_t, zero_t
+                    if device.type == "cuda":
+                        torch.cuda.empty_cache()
+                    _release_host_memory()
 
     return stats
 
@@ -2465,6 +2567,185 @@ def _build_name_map(hf_keys: list[str], raw_keys: set[str]) -> dict[str, str]:
     return out
 
 
+def infer_weight_prefix(raw_keys: set[str]) -> str:
+    for k in raw_keys:
+        if k.endswith(".embed_tokens.weight"):
+            return k[: -len(".embed_tokens.weight")]
+    for k in sorted(raw_keys):
+        if ".layers.0." in k:
+            return k.split(".layers.")[0]
+    raise SystemExit("could not infer weight prefix from safetensors keys")
+
+
+def infer_qwen_model_family(model_dir: Path, raw_keys: set[str]) -> tuple[str, Any]:
+    from transformers import AutoConfig
+
+    config = AutoConfig.from_pretrained(str(model_dir), trust_remote_code=True)
+    text_cfg = getattr(config, "text_config", config)
+    model_type = getattr(text_cfg, "model_type", getattr(config, "model_type", ""))
+    architectures = list(getattr(config, "architectures", None) or [])
+    if model_type == "qwen3_moe" or "Qwen3MoeForCausalLM" in architectures:
+        return "qwen3-moe", text_cfg
+    if any(is_fused_expert_target(k) for k in raw_keys):
+        return "qwen36-moe", text_cfg
+    return "qwen35", text_cfg
+
+
+def qwen3_raw_minmax_bake(
+    *,
+    model_dir: Path,
+    raw_keys: set[str],
+    out_dir: Path,
+    device: torch.device,
+    group_size: int,
+    quant_profile: str,
+) -> None:
+    """Qwen3-MoE OOM-safe producer that never instantiates the HF model.
+
+    Dense projections, lm_head, and synthesized fused experts are quantized
+    with per-tile min/max search directly from safetensors. Non-quantized
+    runtime tensors are streamed raw from safetensors.
+    """
+    model_family, text_cfg = infer_qwen_model_family(model_dir, raw_keys)
+    if model_family != "qwen3-moe":
+        raise SystemExit("--qwen3-raw-minmax is only valid for Qwen3-MoE checkpoints")
+    weight_prefix = infer_weight_prefix(raw_keys)
+    num_layers = int(text_cfg.num_hidden_layers)
+    layer_types = ["full_attention"] * num_layers
+    quant_method: dict[str, Any] = {
+        "profile": quant_profile,
+        "parameters": {
+            "group_size": group_size,
+            "dense_method": "raw_minmax_shrink_grid",
+            "expert_method": "raw_minmax_shrink_grid",
+        },
+        "source_dtype": "bf16/f32",
+        "producer_version": f"oracle/bake_int4.py fmt{FORMAT_VERSION} cvt{CONVERTER_VERSION}",
+        "calibration_corpus": None,
+        "calibration_samples": 0,
+        "calibration_seqlen": 0,
+        "note": "Qwen3 OOM-safe raw-safetensors producer; not Hessian GPTQ.",
+    }
+    log(f"[bake-int4] qwen3 raw-minmax path: prefix={weight_prefix!r} "
+        f"layers={num_layers}")
+    dense_names = sorted(
+        k for k in raw_keys
+        if is_int4_target(k) and not is_unfused_expert_target(k)
+    )
+    fused_bases = sorted({
+        m.group(1)
+        for k in raw_keys
+        if (m := UNFUSED_EXPERT_RE.match(k)) is not None
+    })
+    stats = {
+        "dense_total": 0,
+        "dense_worst": ("", 0.0),
+        "fused_total": 0,
+        "fused_worst": ("", 0.0),
+        "nibble_range_ok": True,
+    }
+    with StreamingPackageWriter(
+        out_dir,
+        model_family=model_family,
+        quant_profile=quant_profile,
+        quant_method=quant_method,
+    ) as writer:
+        log(f"[bake-int4] raw-minmax dense tensors: {len(dense_names)}")
+        for raw_name in dense_names:
+            t0 = time.perf_counter()
+            W = load_raw_tensor(model_dir, raw_name)
+            if W is None:
+                raise RuntimeError(f"missing raw tensor {raw_name}")
+            packed, scale_t, zero_t = minmax_int4_2d_packed(
+                W, group_size=group_size, work_device=device,
+            )
+            elapsed = time.perf_counter() - t0
+            writer.write_tensor(
+                raw_name, packed.numpy().tobytes(),
+                list(packed.shape), "u8", LAYOUT_INT4,
+            )
+            writer.write_tensor(
+                f"{raw_name}_int4_scale", bf16_to_bytes(scale_t),
+                list(scale_t.shape), "bf16", LAYOUT_RAW,
+            )
+            writer.write_tensor(
+                f"{raw_name}_int4_zero", bf16_to_bytes(zero_t),
+                list(zero_t.shape), "bf16", LAYOUT_RAW,
+            )
+            stats["dense_total"] += 1
+            log(f"[bake-int4]   {raw_name}: shape={tuple(W.shape)} "
+                f"-> packed={tuple(packed.shape)} took {elapsed:.1f}s")
+            del W, packed, scale_t, zero_t
+            if device.type == "cuda":
+                torch.cuda.empty_cache()
+            _release_host_memory()
+
+        log(f"[bake-int4] raw-minmax fused Qwen3 experts: {len(fused_bases) * 2}")
+        loader = RawTensorLoader(model_dir)
+        for raw_base in fused_bases:
+            for kind in ("gate_up_proj", "down_proj"):
+                raw_name = f"{raw_base}.{kind}"
+                t0 = time.perf_counter()
+                W = load_fused_expert_bf16(model_dir, raw_keys, raw_base, kind, loader)
+                packed, scale_t, zero_t = fused_expert_minmax_int4_packed(
+                    W, group_size=group_size, work_device=device,
+                )
+                elapsed = time.perf_counter() - t0
+                writer.write_tensor(
+                    raw_name, packed.numpy().tobytes(),
+                    list(packed.shape), "u8", LAYOUT_INT4,
+                )
+                writer.write_tensor(
+                    f"{raw_name}_int4_scale", bf16_to_bytes(scale_t),
+                    list(scale_t.shape), "bf16", LAYOUT_RAW,
+                )
+                writer.write_tensor(
+                    f"{raw_name}_int4_zero", bf16_to_bytes(zero_t),
+                    list(zero_t.shape), "bf16", LAYOUT_RAW,
+                )
+                range_ok, linf = _selfcheck_fused(
+                    packed, scale_t, zero_t, W, group_size,
+                )
+                if not range_ok:
+                    stats["nibble_range_ok"] = False
+                if linf > stats["fused_worst"][1]:
+                    stats["fused_worst"] = (raw_name, linf)
+                stats["fused_total"] += 1
+                log(f"[bake-int4]   {raw_name}: shape={tuple(W.shape)} "
+                    f"-> packed={tuple(packed.shape)} took {elapsed:.1f}s")
+                del W, packed, scale_t, zero_t
+                if device.type == "cuda":
+                    torch.cuda.empty_cache()
+                _release_host_memory()
+
+        log("[bake-int4] streaming raw non-quantized Qwen3 tensors...")
+        eligible = [
+            k for k in raw_keys
+            if not k.endswith("_scale_inv")
+            and not is_unfused_expert_target(k)
+            and (k.startswith(f"{weight_prefix}.") or k == "lm_head.weight")
+        ]
+        for raw_name in sorted(eligible):
+            if writer.has(raw_name):
+                continue
+            t = load_raw_tensor(model_dir, raw_name)
+            if t is None:
+                continue
+            shape = list(t.shape)
+            dtype_str = torch_dtype_to_str(t.dtype)
+            layout = classify_tensor(raw_name, shape, weight_prefix, layer_types)
+            b, final_shape, final_dtype = apply_layout(t, shape, layout, dtype_str)
+            writer.write_tensor(raw_name, b, final_shape, final_dtype, layout)
+            del t, b
+            _release_host_memory()
+        log(f"[self-check] raw-minmax dense INT4: {stats['dense_total']} tensors")
+        log(f"[self-check] raw-minmax fused MoE INT4: {stats['fused_total']} tensors, "
+            f"nibble_range_ok={stats['nibble_range_ok']}, "
+            f"worst-Linf-vs-bf16={stats['fused_worst'][0]} "
+            f"({stats['fused_worst'][1]:.2e})")
+    log(f"[bake-int4] done. Output: {out_dir}")
+
+
 class StreamingPackageWriter:
     """Streaming sink for the bake's `weights.bin` + `manifest.json`.
 
@@ -2644,6 +2925,11 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--offload-folder", default=None, type=Path,
                    help="Disk-offload folder for params that don't fit GPU+CPU "
                         "(needed for ~3 GiB shortfall on 35B-A3B with 24+50 GiB).")
+    p.add_argument("--qwen3-raw-minmax", action="store_true",
+                   help="Qwen3-MoE only: produce the runtime INT4 package directly "
+                        "from safetensors with min/max scale search, without loading "
+                        "the HF model or calibration activations. OOM-safe but not "
+                        "Hessian-calibrated GPTQ quality.")
     return p.parse_args()
 
 
@@ -2686,12 +2972,28 @@ def main() -> None:
         log("[bake-int4] WARNING: running GPTQ on CPU will be very slow for a 4B "
             "model. Use a CUDA/ROCm GPU if available.")
 
+    raw_keys = _load_raw_tensor_names(model_dir)
+    out_dir = args.out_dir or (
+        model_dir / ".supersonic" / f"v{FORMAT_VERSION}-{profile.name}"
+    )
+    if args.qwen3_raw_minmax:
+        if profile.name != "int4-gptq":
+            raise SystemExit("--qwen3-raw-minmax currently writes the int4-gptq runtime package")
+        qwen3_raw_minmax_bake(
+            model_dir=model_dir,
+            raw_keys=raw_keys,
+            out_dir=out_dir,
+            device=device,
+            group_size=args.group_size,
+            quant_profile=profile.name,
+        )
+        return
+
     # --- Load model + tokenizer ---
     from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
     log(f"[bake-int4] loading tokenizer from {model_dir}")
     tokenizer = AutoTokenizer.from_pretrained(str(model_dir), trust_remote_code=True)
     log(f"[bake-int4] loading model (bf16) from {model_dir}")
-    raw_keys = _load_raw_tensor_names(model_dir)
 
     load_kwargs: dict[str, Any] = {
         "torch_dtype": torch.bfloat16,
@@ -2740,25 +3042,10 @@ def main() -> None:
     # Anchor the prefix on ".embed_tokens.weight" — some checkpoints also
     # include an "mtp.layers.*" multi-token-prediction module, so matching
     # on ".layers.0." alone picks the wrong one.
-    weight_prefix = None
-    for k in raw_keys:
-        if k.endswith(".embed_tokens.weight"):
-            weight_prefix = k[: -len(".embed_tokens.weight")]
-            break
-    if weight_prefix is None:
-        # Fallback: first key with ".layers.0." — sorted so it's stable.
-        for k in sorted(raw_keys):
-            if ".layers.0." in k:
-                weight_prefix = k.split(".layers.")[0]
-                break
-    if weight_prefix is None:
-        raise SystemExit("could not infer weight prefix from safetensors keys")
+    weight_prefix = infer_weight_prefix(raw_keys)
     log(f"[bake-int4] canonical weight prefix (from safetensors): {weight_prefix!r}")
-    model_family = (
-        "qwen36-moe"
-        if any(".mlp.experts." in k for k in raw_keys)
-        else "qwen35"
-    )
+    config = model.config
+    model_family, text_cfg = infer_qwen_model_family(model_dir, raw_keys)
     log(f"[bake-int4] model_family={model_family!r}")
 
     # Avoid `model.state_dict()` here — under `device_map="auto"` it gathers
@@ -2778,8 +3065,6 @@ def main() -> None:
         log(f"[bake-int4] {len(missing_in_raw)} state-dict tensors have no "
             f"safetensors counterpart (e.g. tied weights) — skipping them.")
 
-    config = model.config
-    text_cfg = getattr(config, "text_config", config)
     num_layers = int(text_cfg.num_hidden_layers)
     layer_types = list(getattr(text_cfg, "layer_types", None) or [])
     if not layer_types:
@@ -2833,9 +3118,6 @@ def main() -> None:
     # than one (nibbles, scale, zero) triple in RAM at a time; on 35B-A3B
     # that's ~1 GiB peak (largest fused expert slab) instead of the ~17 GiB
     # the in-RAM `tensors_out` list reached before this refactor.
-    out_dir = args.out_dir or (
-        model_dir / ".supersonic" / f"v{FORMAT_VERSION}-{profile.name}"
-    )
     # Context-manager form: on a partial run (exception propagating out),
     # `__exit__` closes the file handle but skips manifest emission so a
     # downstream bake-consumer can't accidentally read a half-written package
@@ -2890,6 +3172,9 @@ def main() -> None:
                 writer=writer,
                 hf_to_raw=hf_to_raw,
                 safetensors_loader=safetensors_loader,
+                model_dir=model_dir,
+                raw_keys=raw_keys,
+                model_family=model_family,
             )
         elif profile.name == "int4-awq":
             assert calib is not None
@@ -2984,6 +3269,10 @@ def main() -> None:
             hf_name for hf_name in sd_keys
             if hf_name in hf_to_raw
             and not hf_to_raw[hf_name].endswith("_scale_inv")
+            and not (
+                model_family == "qwen3-moe"
+                and is_unfused_expert_target(hf_to_raw[hf_name])
+            )
             and (
                 hf_to_raw[hf_name].startswith(f"{weight_prefix}.")
                 or hf_to_raw[hf_name] == "lm_head.weight"

--- a/oracle/upload_bake.py
+++ b/oracle/upload_bake.py
@@ -7,6 +7,7 @@ upserts a single `bakes-index.json` asset, and uploads everything via `gh`.
 
 Typical use on a big-box producer:
     python oracle/upload_bake.py --model qwen3.5-4b --int4 --model-dir /path/to/Qwen3.5-4B
+    python oracle/upload_bake.py --model qwen3-30b-a3b --int4 --model-dir /path/to/Qwen3-30B-A3B
     python oracle/upload_bake.py --model gemma4-e4b --int4 --model-dir /path/to/gemma-4-E4B
 
 Dry-run leaves the tarball in /tmp/ and prints the `gh` commands without
@@ -57,6 +58,7 @@ OPTIONAL_HF_FILES = [
 KNOWN_MODELS = {
     "qwen3.5-0.8b", "qwen3.5-2b", "qwen3.5-4b", "qwen3.5-9b",
     "qwen3.6-27b", "qwen3.6-35b-a3b",
+    "qwen3-30b-a3b",
     "gemma4-e2b", "gemma4-e4b",
     "phi4-mini",
 }
@@ -82,6 +84,7 @@ FAMILY_FOR = {
     "qwen3.5-9b": "qwen35",
     "qwen3.6-27b": "qwen35",
     "qwen3.6-35b-a3b": "qwen36-moe",
+    "qwen3-30b-a3b": "qwen3-moe",
     "gemma4-e2b": "gemma4",
     "gemma4-e4b": "gemma4",
     "phi4-mini": "phi4",


### PR DESCRIPTION
## Summary
- Add a separate Qwen3-MoE model family for Qwen/Qwen3-30B-A3B, distinct from Qwen3.6-MoE.
- Add Qwen3-owned HIP kernel/bridge, FFI descriptors, weight/state loaders, registry aliases, and runner decode path.
- Add INT4 bake support for Qwen3 split HF expert tensors, including an OOM-safe raw-safetensors min/max producer path.

## Validation
- `cargo test -p qwen3_moe`
- `cargo test -p kernel-ffi qwen3_moe --lib`
- `cargo test -p supersonic-core qwen3`
- `cargo check -p runner --bin supersonic`
- `cargo check -p supersonic-runtime`
- `rustfmt --check crates/kernel-ffi/src/qwen3_moe.rs crates/qwen3_moe/src/*.rs crates/runner/src/qwen3_moe.rs`
- `/home/deano/venvs/rocm/bin/python -m py_compile oracle/bake_int4.py oracle/upload_bake.py`
- `git diff --check`
- Local dry-run contract against `/mnt/data/models/Qwen3-30B-A3B`: `1109/1109` expected runtime tensors present.
- HIP smoke decode: prompt `Hello`, `--max-new-tokens 1`, `--context-size 8`, `--int4` generated one token.
- Longer HIP smoke: context 128, 8 generated tokens completed without KV/state failure.

## Notes
- Current HIP decode is correctness-first and slow; it is not yet an optimized persistent megakernel.
- Full default GPTQ calibration OOMed on the 24 GiB GPU / 64 GiB host producer path.
- `oracle/bake_int4.py --qwen3-raw-minmax` produces an OOM-safe runtime-valid artifact directly from safetensors. It writes the same INT4 runtime contract but is calibration-free min/max, not Hessian GPTQ quality.
- GitHub release upload is blocked locally because `gh auth status` reports the stored DeanoC token is invalid, although branch push over SSH works.
