### PR TITLE
Optimize Qwen3-30B-A3B HIP decode

### DIFF
--- a/crates/kernel-ffi/src/qwen3_moe.rs
+++ b/crates/kernel-ffi/src/qwen3_moe.rs
@@ -115,6 +115,36 @@ extern "C" {
         logits: *mut c_void,
         counter: *mut c_uint,
     ) -> c_int;
+
+    pub fn qwen3_moe_hip_persistent_decode_launch(
+        dtype: c_int,
+        device_ordinal: usize,
+        num_layers: c_int,
+        layers: *const Qwen3MoeDecodeLayerDesc,
+        int4_descs: *const Qwen3MoeInt4ScaleDesc,
+        hidden: c_int,
+        position: c_int,
+        input_hidden: *const c_void,
+        hidden_ping: *mut c_void,
+        hidden_pong: *mut c_void,
+        workspace: *mut f32,
+    ) -> c_int;
+
+    pub fn qwen3_moe_hip_lm_head_int4_launch(
+        dtype: c_int,
+        device_ordinal: usize,
+        hidden: c_int,
+        vocab: c_int,
+        rms_norm_eps: f32,
+        final_hidden: *const c_void,
+        final_norm_w: *const c_void,
+        lm_head_w: *const c_void,
+        lm_head_scale: *const c_void,
+        lm_head_zero: *const c_void,
+        group_size: c_int,
+        logits: *mut c_void,
+        counter: *mut c_uint,
+    ) -> c_int;
 }
 
 pub fn stub_launch(
@@ -292,6 +322,152 @@ pub fn lm_head_launch(
         return Err(GpuError::backend(
             backend,
             format!("qwen3_moe lm_head launch failed with status {status}"),
+        ));
+    }
+    Ok(())
+}
+
+pub fn persistent_decode_launch(
+    ordinal: usize,
+    dtype: ScalarType,
+    layer_descs_device: &GpuBuffer,
+    int4_descs_device: &GpuBuffer,
+    num_layers: usize,
+    hidden: i32,
+    position: i32,
+    input_hidden: &GpuBuffer,
+    hidden_ping: &mut GpuBuffer,
+    hidden_pong: &mut GpuBuffer,
+    workspace: &mut GpuBuffer,
+) -> Result<(), GpuError> {
+    if dtype != ScalarType::BF16 {
+        return Err(GpuError::InvalidArg(format!(
+            "qwen3_moe::persistent_decode_launch: only BF16 is wired, got {dtype:?}"
+        )));
+    }
+    let backend = input_hidden.backend();
+    let status: c_int = match backend {
+        Backend::Hip => {
+            #[cfg(supersonic_backend_hip)]
+            unsafe {
+                qwen3_moe_hip_persistent_decode_launch(
+                    dtype.kernel_dtype_code(),
+                    ordinal,
+                    num_layers as c_int,
+                    layer_descs_device.as_ptr() as *const Qwen3MoeDecodeLayerDesc,
+                    int4_descs_device.as_ptr() as *const Qwen3MoeInt4ScaleDesc,
+                    hidden,
+                    position,
+                    input_hidden.as_ptr(),
+                    hidden_ping.as_mut_ptr(),
+                    hidden_pong.as_mut_ptr(),
+                    workspace.as_mut_ptr() as *mut f32,
+                )
+            }
+            #[cfg(not(supersonic_backend_hip))]
+            {
+                let _ = (
+                    ordinal,
+                    layer_descs_device,
+                    int4_descs_device,
+                    num_layers,
+                    hidden,
+                    position,
+                    hidden_ping,
+                    hidden_pong,
+                    workspace,
+                );
+                return Err(GpuError::InvalidArg(
+                    "qwen3_moe::persistent_decode_launch: HIP backend not compiled".into(),
+                ));
+            }
+        }
+        Backend::Cuda | Backend::Metal => {
+            return Err(GpuError::InvalidArg(
+                "qwen3_moe::persistent_decode_launch: Qwen3-MoE is HIP-only".into(),
+            ));
+        }
+    };
+    if status != 0 {
+        return Err(GpuError::backend(
+            backend,
+            format!("qwen3_moe persistent decode launch failed with status {status}"),
+        ));
+    }
+    Ok(())
+}
+
+pub fn lm_head_int4_launch(
+    ordinal: usize,
+    dtype: ScalarType,
+    hidden: i32,
+    vocab: i32,
+    rms_norm_eps: f32,
+    final_hidden: &GpuBuffer,
+    final_norm_w: &GpuBuffer,
+    lm_head_w: &GpuBuffer,
+    lm_head_scale: &GpuBuffer,
+    lm_head_zero: &GpuBuffer,
+    group_size: i32,
+    logits: &mut GpuBuffer,
+    counter: &mut GpuBuffer,
+) -> Result<(), GpuError> {
+    if dtype != ScalarType::BF16 {
+        return Err(GpuError::InvalidArg(format!(
+            "qwen3_moe::lm_head_int4_launch: only BF16 activations are wired, got {dtype:?}"
+        )));
+    }
+    let backend = final_hidden.backend();
+    let status: c_int = match backend {
+        Backend::Hip => {
+            #[cfg(supersonic_backend_hip)]
+            unsafe {
+                qwen3_moe_hip_lm_head_int4_launch(
+                    dtype.kernel_dtype_code(),
+                    ordinal,
+                    hidden,
+                    vocab,
+                    rms_norm_eps,
+                    final_hidden.as_ptr(),
+                    final_norm_w.as_ptr(),
+                    lm_head_w.as_ptr(),
+                    lm_head_scale.as_ptr(),
+                    lm_head_zero.as_ptr(),
+                    group_size,
+                    logits.as_mut_ptr(),
+                    counter.as_mut_ptr() as *mut c_uint,
+                )
+            }
+            #[cfg(not(supersonic_backend_hip))]
+            {
+                let _ = (
+                    ordinal,
+                    hidden,
+                    vocab,
+                    rms_norm_eps,
+                    final_norm_w,
+                    lm_head_w,
+                    lm_head_scale,
+                    lm_head_zero,
+                    group_size,
+                    logits,
+                    counter,
+                );
+                return Err(GpuError::InvalidArg(
+                    "qwen3_moe::lm_head_int4_launch: HIP backend not compiled".into(),
+                ));
+            }
+        }
+        Backend::Cuda | Backend::Metal => {
+            return Err(GpuError::InvalidArg(
+                "qwen3_moe::lm_head_int4_launch: Qwen3-MoE is HIP-only".into(),
+            ));
+        }
+    };
+    if status != 0 {
+        return Err(GpuError::backend(
+            backend,
+            format!("qwen3_moe INT4 lm_head launch failed with status {status}"),
         ));
     }
     Ok(())

--- a/crates/runner/src/qwen3_moe.rs
+++ b/crates/runner/src/qwen3_moe.rs
@@ -17,7 +17,7 @@ use qwen3_moe::weights::{
     CheckpointAccount, CheckpointDtype, TensorSpec,
 };
 
-use crate::qwen36_moe_logits::{dequant_int4_to_bf16_bytes, sample_bf16_logits, XorshiftRng};
+use crate::qwen36_moe_logits::{sample_bf16_logits, XorshiftRng};
 use crate::registry::{FamilyParams, RegistryEntry};
 use crate::Cli;
 
@@ -168,24 +168,30 @@ fn decode_text(
     }
     let scale_ptrs = weights.int4_scale_ptrs();
     let int4_descs = build_int4_scale_descs(&scale_ptrs, DEFAULT_INT4_GROUP_SIZE);
+    let desc_bytes_len =
+        text.num_hidden_layers * std::mem::size_of::<q3ffi::Qwen3MoeDecodeLayerDesc>();
+    let mut persistent_descs_dev = GpuBuffer::zeros(ordinal, ScalarType::U8, &[desc_bytes_len])
+        .context("alloc Qwen3 persistent layer descriptors")?;
+    let persistent_int4_descs_dev = {
+        let int4_bytes = struct_slice_as_bytes(&int4_descs);
+        GpuBuffer::from_host_bytes(ordinal, ScalarType::U8, &[int4_bytes.len()], int4_bytes)
+            .context("upload Qwen3 persistent INT4 descriptors")?
+    };
 
     let mut hidden_a = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[text.hidden_size])
         .context("alloc Qwen3 hidden_a")?;
     let mut hidden_b = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[text.hidden_size])
         .context("alloc Qwen3 hidden_b")?;
+    let mut hidden_c = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[text.hidden_size])
+        .context("alloc Qwen3 hidden_c")?;
     let workspace_floats = qwen3_workspace_floats(text);
     let mut workspace = GpuBuffer::zeros(ordinal, ScalarType::F32, &[workspace_floats])
         .context("alloc Qwen3 layer workspace")?;
 
-    let lm_head_bf16 = load_lm_head_bf16(&store, text, weight_prefix)
-        .context("load/dequant Qwen3 lm_head BF16")?;
-    let lm_head = GpuBuffer::from_host_bytes(
-        ordinal,
-        ScalarType::BF16,
-        &[text.vocab_size, text.hidden_size],
-        &lm_head_bf16,
-    )
-    .context("upload Qwen3 lm_head BF16")?;
+    let lm_head = weights
+        .lm_head
+        .as_ref()
+        .ok_or_else(|| anyhow!("Qwen3-MoE INT4 bake is missing lm_head.weight"))?;
     let mut logits =
         GpuBuffer::zeros(ordinal, ScalarType::BF16, &[text.vocab_size]).context("alloc logits")?;
     let mut lm_counter =
@@ -199,8 +205,20 @@ fn decode_text(
     let mut generated = Vec::with_capacity(max_new);
     let mut last_logits = Vec::new();
     let start = std::time::Instant::now();
+    let mut embed_elapsed = std::time::Duration::ZERO;
+    let mut decode_elapsed = std::time::Duration::ZERO;
+    let mut lm_head_elapsed = std::time::Duration::ZERO;
+    let mut sample_elapsed = std::time::Duration::ZERO;
+    let mut gen_steps = 0usize;
+    let use_persistent = !cli.no_persistent_decode;
+    if use_persistent {
+        eprintln!(
+            "[qwen3-moe] persistent decode enabled; pass --no-persistent-decode for chained A/B"
+        );
+    }
 
     for step in 0..total_steps {
+        let t_embed = std::time::Instant::now();
         let row = lookup_embed_row(&store, weight_prefix, current as usize, text.hidden_size)
             .with_context(|| format!("lookup Qwen3 embedding row for token {current}"))?;
         gpu_hal::copy_h2d(
@@ -210,38 +228,69 @@ fn decode_text(
             row.len(),
         )
         .context("h2d Qwen3 token embedding")?;
+        embed_elapsed += t_embed.elapsed();
 
         let descs = build_layer_descs(text, &layer_ptrs, step, context)
             .context("build Qwen3 layer descriptors")?;
-        let mut front_a = true;
-        for (layer_idx, (desc, int4)) in descs.iter().zip(int4_descs.iter()).enumerate() {
-            let (input, output) = if front_a {
-                (&hidden_a, &mut hidden_b)
-            } else {
-                (&hidden_b, &mut hidden_a)
-            };
-            q3ffi::decode_layer_launch(
+        let t_decode = std::time::Instant::now();
+        let final_in_b = if use_persistent {
+            let desc_bytes = struct_slice_as_bytes(&descs);
+            gpu_hal::copy_h2d(
+                ordinal,
+                persistent_descs_dev.as_mut_ptr(),
+                desc_bytes.as_ptr() as *const _,
+                desc_bytes.len(),
+            )
+            .context("upload Qwen3 persistent layer descriptors")?;
+            q3ffi::persistent_decode_launch(
                 ordinal,
                 ScalarType::BF16,
-                desc,
-                int4,
+                &persistent_descs_dev,
+                &persistent_int4_descs_dev,
+                descs.len(),
                 text.hidden_size as i32,
                 step as i32,
-                input,
-                output,
+                &hidden_a,
+                &mut hidden_b,
+                &mut hidden_c,
                 &mut workspace,
             )
-            .with_context(|| format!("Qwen3 decode layer {layer_idx}"))?;
-            front_a = !front_a;
-        }
+            .context("Qwen3 persistent decode")?;
+            true
+        } else {
+            let mut front_a = true;
+            for (layer_idx, (desc, int4)) in descs.iter().zip(int4_descs.iter()).enumerate() {
+                let (input, output) = if front_a {
+                    (&hidden_a, &mut hidden_b)
+                } else {
+                    (&hidden_b, &mut hidden_a)
+                };
+                q3ffi::decode_layer_launch(
+                    ordinal,
+                    ScalarType::BF16,
+                    desc,
+                    int4,
+                    text.hidden_size as i32,
+                    step as i32,
+                    input,
+                    output,
+                    &mut workspace,
+                )
+                .with_context(|| format!("Qwen3 decode layer {layer_idx}"))?;
+                front_a = !front_a;
+            }
+            !front_a
+        };
+        decode_elapsed += t_decode.elapsed();
 
-        let final_hidden = if front_a { &hidden_a } else { &hidden_b };
+        let final_hidden = if final_in_b { &hidden_b } else { &hidden_a };
         if step + 1 < prompt.prompt_ids.len() {
             current = prompt.prompt_ids[step + 1];
             continue;
         }
 
-        q3ffi::lm_head_launch(
+        let t_lm_head = std::time::Instant::now();
+        q3ffi::lm_head_int4_launch(
             ordinal,
             ScalarType::BF16,
             text.hidden_size as i32,
@@ -249,12 +298,17 @@ fn decode_text(
             text.rms_norm_eps as f32,
             final_hidden,
             &weights.final_norm,
-            &lm_head,
+            &lm_head.weight,
+            &lm_head.scale,
+            &lm_head.zero,
+            DEFAULT_INT4_GROUP_SIZE as i32,
             &mut logits,
             &mut lm_counter,
         )
-        .context("Qwen3 lm_head")?;
+        .context("Qwen3 INT4 lm_head")?;
         last_logits = logits.to_host_bytes().context("d2h Qwen3 logits")?;
+        lm_head_elapsed += t_lm_head.elapsed();
+        let t_sample = std::time::Instant::now();
         let next = sample_bf16_logits(
             &last_logits,
             cli.temperature,
@@ -262,6 +316,8 @@ fn decode_text(
             cli.top_p,
             &mut rng,
         );
+        sample_elapsed += t_sample.elapsed();
+        gen_steps += 1;
         generated.push(next);
         print_token(prompt.tokenizer.as_ref(), next);
         std::io::stdout().flush().ok();
@@ -291,7 +347,23 @@ fn decode_text(
         elapsed,
         generated.len() as f64 / elapsed.max(1e-9)
     );
+    if cli.emit_stage_timings && gen_steps > 0 {
+        let n = gen_steps as f64;
+        eprintln!(
+            "[qwen3-moe stage-timings] gen_steps={} path={} embed_ms_avg={:.3} decode_ms_avg={:.3} lm_head_ms_avg={:.3} sample_ms_avg={:.3}",
+            gen_steps,
+            if use_persistent { "persistent" } else { "chained" },
+            embed_elapsed.as_secs_f64() * 1000.0 / n,
+            decode_elapsed.as_secs_f64() * 1000.0 / n,
+            lm_head_elapsed.as_secs_f64() * 1000.0 / n,
+            sample_elapsed.as_secs_f64() * 1000.0 / n,
+        );
+    }
     Ok(())
+}
+
+fn struct_slice_as_bytes<T>(slice: &[T]) -> &[u8] {
+    unsafe { std::slice::from_raw_parts(slice.as_ptr() as *const u8, std::mem::size_of_val(slice)) }
 }
 
 fn ensure_int4_bake(cli: &Cli, entry: &RegistryEntry) -> Result<()> {
@@ -407,52 +479,6 @@ fn lookup_embed_row(
         );
     }
     Ok(bytes[start..end].to_vec())
-}
-
-fn load_lm_head_bf16(
-    store: &BakedStore,
-    text: &qwen3_moe::config::TextConfig,
-    weight_prefix: &str,
-) -> Result<Vec<u8>> {
-    let (name, packed) = if text.tie_word_embeddings {
-        let name = format!("{weight_prefix}.embed_tokens.weight");
-        let bytes = store
-            .raw_bytes(&name)
-            .ok_or_else(|| anyhow!("missing tied lm_head tensor {name}"))?
-            .to_vec();
-        (name, bytes)
-    } else {
-        let name = "lm_head.weight".to_string();
-        let bytes = store
-            .raw_bytes(&name)
-            .ok_or_else(|| anyhow!("missing lm_head.weight in bake"))?
-            .to_vec();
-        (name, bytes)
-    };
-    let scale_name = format!("{name}_int4_scale");
-    if !store.contains(&scale_name) {
-        return Ok(packed);
-    }
-    let zero_name = format!("{name}_int4_zero");
-    let scale = store
-        .raw_bytes(&scale_name)
-        .ok_or_else(|| anyhow!("missing {scale_name} in bake"))?;
-    let zero = store
-        .raw_bytes(&zero_name)
-        .ok_or_else(|| anyhow!("missing {zero_name} in bake"))?;
-    println!(
-        "  dequantizing Qwen3 lm_head INT4 ({:.1} MiB -> {:.1} MiB BF16)",
-        packed.len() as f64 / (1024.0 * 1024.0),
-        (text.vocab_size * text.hidden_size * 2) as f64 / (1024.0 * 1024.0)
-    );
-    Ok(dequant_int4_to_bf16_bytes(
-        &packed,
-        scale,
-        zero,
-        text.vocab_size,
-        text.hidden_size,
-        DEFAULT_INT4_GROUP_SIZE,
-    ))
 }
 
 fn qwen3_workspace_floats(text: &qwen3_moe::config::TextConfig) -> usize {

--- a/docs/qwen3-30b-a3b-hip.md
+++ b/docs/qwen3-30b-a3b-hip.md
@@ -21,9 +21,10 @@ The first PR wires the model as an explicit HIP-only INT4 bring-up target:
 The current code supports config validation, checkpoint tensor enumeration,
 INT4 baked tensor contract validation, baked manifest indexing, GPU upload of
 the INT4 weights, descriptor pointer construction, scratch allocation, full
-single-token decode math, and lm-head sampling. The HIP kernel is a
-correctness-first layer kernel, not the optimized persistent megakernel that
-the older Qwen3.5/Gemma paths use.
+single-token decode math, direct INT4 lm-head sampling, and a Qwen3-owned
+persistent decode chain. The persistent path is separate from the Qwen3.6-MoE
+runtime and is the default runtime path; pass `--no-persistent-decode` to run
+the chained per-layer A/B path.
 
 ## Model Geometry
 
@@ -65,8 +66,41 @@ cargo run --release --bin supersonic -- \
   --dry-run
 ```
 
-Non-dry-run execution is supported for one-token-at-a-time decode. It is slow
-by design in this bring-up branch because each layer launches independently.
+Non-dry-run execution is supported for one-token-at-a-time decode. Decode runs
+through the Qwen3 persistent chain by default. The chained per-layer path
+remains available for A/B testing:
+
+```bash
+cargo run --release --bin supersonic -- \
+  --model qwen3-30b-a3b \
+  --model-dir /path/to/Qwen3-30B-A3B \
+  --prompt "Hello" \
+  --max-new-tokens 1 \
+  --context-size 8 \
+  --int4 \
+  --no-persistent-decode
+```
+
+Use `--emit-stage-timings` to print per-token averages for embedding upload,
+decode, lm-head, and sampling.
+
+## Decode Optimization Notes
+
+The optimized HIP path in this PR makes three targeted changes:
+
+- the layer decode kernel now uses 1024 threads per cooperative block, which
+  improves the scalar row-dot path substantially on gfx1100-class hardware
+- the default runner path uploads the per-step descriptor table once and runs
+  all 48 layers through `qwen3_moe_persistent_decode_kernel`
+- the lm-head projection reads the INT4 baked `lm_head.weight` directly instead
+  of expanding it to a roughly 593 MiB BF16 GPU buffer at startup
+
+On the local gfx1100 24 GiB smoke setup with `/mnt/data/models/Qwen3-30B-A3B`,
+the synced one-token smoke improved from roughly 5.2 s/token in the initial
+256-thread bring-up path to roughly 2.46 s/token with the 1024-thread decode
+path. Persistent-vs-chained timings are currently very close because the
+single-token work is compute dominated; the persistent path is still useful as
+the Qwen3-owned launch surface for future multi-block/grid-barrier work.
 
 ## INT4 Bake Contract
 
@@ -141,7 +175,8 @@ cargo run --release --bin supersonic -- \
   --prompt "Hello" \
   --max-new-tokens 1 \
   --context-size 8 \
-  --int4
+  --int4 \
+  --emit-stage-timings
 
 cargo run --release --bin supersonic -- \
   --model qwen3-30b-a3b \

--- a/kernels/qwen3_moe.hip
+++ b/kernels/qwen3_moe.hip
@@ -2,9 +2,9 @@
 //
 // This file is intentionally separate from Qwen3.6-MoE. Qwen3-30B-A3B is a
 // pure full-attention MoE model with different tensor geometry and no hybrid
-// linear-attention/shared-expert path. The decode kernel below is the first
-// correctness-oriented HIP path: one cooperative block runs one layer, with
-// INT4 dequant for attention and expert weights and BF16 KV cache.
+// linear-attention/shared-expert path. The decode path uses a Qwen3-owned
+// cooperative block implementation with INT4 dequant for attention/expert
+// weights, BF16 KV cache, and an optional single-launch persistent layer chain.
 
 #include <hip/hip_runtime.h>
 #include <hip/hip_bfloat16.h>
@@ -237,17 +237,15 @@ __device__ void rms_norm_vec(
     __syncthreads();
 }
 
-__global__ void qwen3_moe_decode_layer_kernel(
+__device__ void qwen3_moe_decode_layer_device(
     const DecodeLayerDesc layer,
     const Int4ScaleDesc int4,
     int hidden,
     int position,
     const hip_bfloat16* __restrict__ input_hidden,
     hip_bfloat16* __restrict__ output_hidden,
-    float* __restrict__ workspace) {
-    extern __shared__ float lds[];
-    float* scratch = lds;
-
+    float* __restrict__ workspace,
+    float* __restrict__ scratch) {
     const int tid = threadIdx.x;
     const int hd = layer.head_dim;
     const int h = layer.num_heads;
@@ -511,6 +509,57 @@ __global__ void qwen3_moe_decode_layer_kernel(
     }
 }
 
+__global__ void qwen3_moe_decode_layer_kernel(
+    const DecodeLayerDesc layer,
+    const Int4ScaleDesc int4,
+    int hidden,
+    int position,
+    const hip_bfloat16* __restrict__ input_hidden,
+    hip_bfloat16* __restrict__ output_hidden,
+    float* __restrict__ workspace) {
+    extern __shared__ float lds[];
+    qwen3_moe_decode_layer_device(
+        layer, int4, hidden, position, input_hidden, output_hidden, workspace, lds);
+}
+
+__global__ void qwen3_moe_persistent_decode_kernel(
+    int num_layers,
+    const DecodeLayerDesc* __restrict__ layers,
+    const Int4ScaleDesc* __restrict__ int4_descs,
+    int hidden,
+    int position,
+    const hip_bfloat16* __restrict__ input_hidden,
+    hip_bfloat16* __restrict__ hidden_ping,
+    hip_bfloat16* __restrict__ hidden_pong,
+    float* __restrict__ workspace) {
+    extern __shared__ float lds[];
+    if (blockIdx.x != 0) return;
+    if (num_layers <= 0) return;
+
+    const hip_bfloat16* in = input_hidden;
+    hip_bfloat16* out = hidden_ping;
+    for (int layer_idx = 0; layer_idx < num_layers; ++layer_idx) {
+        qwen3_moe_decode_layer_device(
+            layers[layer_idx],
+            int4_descs[layer_idx],
+            hidden,
+            position,
+            in,
+            out,
+            workspace,
+            lds);
+        __syncthreads();
+        in = out;
+        out = (out == hidden_ping) ? hidden_pong : hidden_ping;
+    }
+
+    if (in != hidden_ping) {
+        for (int i = threadIdx.x; i < hidden; i += blockDim.x) {
+            hidden_ping[i] = in[i];
+        }
+    }
+}
+
 __global__ void qwen3_moe_lm_head_kernel(
     int hidden,
     int vocab,
@@ -552,6 +601,62 @@ __global__ void qwen3_moe_lm_head_kernel(
                 static_cast<float>(final_hidden[i]) * inv *
                 static_cast<float>(final_norm_w[i]));
             partial += static_cast<float>(lm_head_w[base + i]) * x;
+        }
+        lds[tid] = partial;
+        __syncthreads();
+        for (int s = bs / 2; s > 0; s >>= 1) {
+            if (tid < s) lds[tid] += lds[tid + s];
+            __syncthreads();
+        }
+        if (tid == 0) logits[row] = static_cast<hip_bfloat16>(bf16_round_rne_f32(lds[0]));
+        __syncthreads();
+    }
+}
+
+__global__ void qwen3_moe_lm_head_int4_kernel(
+    int hidden,
+    int vocab,
+    float rms_norm_eps,
+    const hip_bfloat16* __restrict__ final_hidden,
+    const hip_bfloat16* __restrict__ final_norm_w,
+    const uint8_t* __restrict__ lm_head_w,
+    const hip_bfloat16* __restrict__ lm_head_scale,
+    const hip_bfloat16* __restrict__ lm_head_zero,
+    int group_size,
+    hip_bfloat16* __restrict__ logits,
+    unsigned int* __restrict__ counter) {
+    extern __shared__ float lds[];
+    const int tid = threadIdx.x;
+    const int bs = blockDim.x;
+
+    float partial_sq = 0.0f;
+    for (int i = tid; i < hidden; i += bs) {
+        const float v = static_cast<float>(final_hidden[i]);
+        partial_sq += v * v;
+    }
+    lds[tid] = partial_sq;
+    __syncthreads();
+    for (int s = bs / 2; s > 0; s >>= 1) {
+        if (tid < s) lds[tid] += lds[tid + s];
+        __syncthreads();
+    }
+    const float inv = rsqrtf(lds[0] / static_cast<float>(hidden) + rms_norm_eps);
+    __syncthreads();
+
+    for (;;) {
+        __shared__ unsigned int row_s;
+        if (tid == 0) row_s = atomicAdd(counter, 1u);
+        __syncthreads();
+        const int row = static_cast<int>(row_s);
+        if (row >= vocab) return;
+
+        float partial = 0.0f;
+        for (int i = tid; i < hidden; i += bs) {
+            const float x = bf16_round_rne_f32(
+                static_cast<float>(final_hidden[i]) * inv *
+                static_cast<float>(final_norm_w[i]));
+            partial += int4_value(lm_head_w, lm_head_scale, lm_head_zero,
+                                  row, i, hidden, group_size) * x;
         }
         lds[tid] = partial;
         __syncthreads();

--- a/kernels/qwen3_moe_bridge.cpp
+++ b/kernels/qwen3_moe_bridge.cpp
@@ -99,7 +99,7 @@ extern "C" int qwen3_moe_hip_decode_layer_launch(
 
     ScopedHipDevice scoped(static_cast<int>(device_ordinal));
 
-    const int block_threads = 256;
+    const int block_threads = 1024;
     const size_t shmem = block_threads * sizeof(float);
     hipLaunchKernelGGL(qwen3_moe::qwen3_moe_decode_layer_kernel,
                        dim3(1),
@@ -111,6 +111,51 @@ extern "C" int qwen3_moe_hip_decode_layer_launch(
                        position,
                        static_cast<const hip_bfloat16*>(input_hidden),
                        static_cast<hip_bfloat16*>(output_hidden),
+                       workspace);
+    hipError_t launch_err = hipGetLastError();
+    hipError_t sync_err =
+        sync_each_kernel_enabled() ? hipDeviceSynchronize() : hipSuccess;
+    if (launch_err != hipSuccess) return 254;
+    if (sync_err != hipSuccess) return 255;
+    return 0;
+}
+
+extern "C" int qwen3_moe_hip_persistent_decode_launch(
+    int                                      dtype,
+    size_t                                   device_ordinal,
+    int                                      num_layers,
+    const qwen3_moe::DecodeLayerDesc*        layers,
+    const qwen3_moe::Int4ScaleDesc*          int4_descs,
+    int                                      hidden,
+    int                                      position,
+    const void*                              input_hidden,
+    void*                                    hidden_ping,
+    void*                                    hidden_pong,
+    float*                                   workspace) {
+    if (dtype != 2) return 110; // BF16 activations only.
+    if (num_layers <= 0 || num_layers > 1024) return 100;
+    if (layers == nullptr || int4_descs == nullptr || input_hidden == nullptr ||
+        hidden_ping == nullptr || hidden_pong == nullptr || workspace == nullptr) {
+        return 101;
+    }
+    if (hidden <= 0 || position < 0) return 102;
+
+    ScopedHipDevice scoped(static_cast<int>(device_ordinal));
+
+    const int block_threads = 1024;
+    const size_t shmem = block_threads * sizeof(float);
+    hipLaunchKernelGGL(qwen3_moe::qwen3_moe_persistent_decode_kernel,
+                       dim3(1),
+                       dim3(block_threads),
+                       shmem, 0,
+                       num_layers,
+                       layers,
+                       int4_descs,
+                       hidden,
+                       position,
+                       static_cast<const hip_bfloat16*>(input_hidden),
+                       static_cast<hip_bfloat16*>(hidden_ping),
+                       static_cast<hip_bfloat16*>(hidden_pong),
                        workspace);
     hipError_t launch_err = hipGetLastError();
     hipError_t sync_err =
@@ -161,6 +206,64 @@ extern "C" int qwen3_moe_hip_lm_head_launch(
                        static_cast<const hip_bfloat16*>(final_hidden),
                        static_cast<const hip_bfloat16*>(final_norm_w),
                        static_cast<const hip_bfloat16*>(lm_head_w),
+                       static_cast<hip_bfloat16*>(logits),
+                       counter);
+    hipError_t launch_err = hipGetLastError();
+    hipError_t sync_err =
+        sync_each_kernel_enabled() ? hipDeviceSynchronize() : hipSuccess;
+    if (launch_err != hipSuccess) return 254;
+    if (sync_err != hipSuccess) return 255;
+    return 0;
+}
+
+extern "C" int qwen3_moe_hip_lm_head_int4_launch(
+    int          dtype,
+    size_t       device_ordinal,
+    int          hidden,
+    int          vocab,
+    float        rms_norm_eps,
+    const void*  final_hidden,
+    const void*  final_norm_w,
+    const void*  lm_head_w,
+    const void*  lm_head_scale,
+    const void*  lm_head_zero,
+    int          group_size,
+    void*        logits,
+    unsigned int* counter) {
+    if (dtype != 2) return 110;
+    if (hidden <= 0 || vocab <= 0 || group_size <= 0) return 100;
+    if (final_hidden == nullptr || final_norm_w == nullptr ||
+        lm_head_w == nullptr || lm_head_scale == nullptr ||
+        lm_head_zero == nullptr || logits == nullptr || counter == nullptr) {
+        return 101;
+    }
+
+    ScopedHipDevice scoped(static_cast<int>(device_ordinal));
+    hipDeviceProp_t props;
+    if (hipGetDeviceProperties(&props, static_cast<int>(device_ordinal)) !=
+        hipSuccess) {
+        return 250;
+    }
+    const int num_blocks =
+        props.multiProcessorCount > 0 ? props.multiProcessorCount : 16;
+    const int block_threads = 256;
+    const size_t shmem = block_threads * sizeof(float);
+    if (hipMemsetAsync(counter, 0, sizeof(unsigned int)) != hipSuccess) {
+        return 200;
+    }
+    hipLaunchKernelGGL(qwen3_moe::qwen3_moe_lm_head_int4_kernel,
+                       dim3(static_cast<unsigned int>(num_blocks)),
+                       dim3(block_threads),
+                       shmem, 0,
+                       hidden,
+                       vocab,
+                       rms_norm_eps,
+                       static_cast<const hip_bfloat16*>(final_hidden),
+                       static_cast<const hip_bfloat16*>(final_norm_w),
+                       static_cast<const uint8_t*>(lm_head_w),
+                       static_cast<const hip_bfloat16*>(lm_head_scale),
+                       static_cast<const hip_bfloat16*>(lm_head_zero),
+                       group_size,
                        static_cast<hip_bfloat16*>(logits),
                        counter);
     hipError_t launch_err = hipGetLastError();


### PR DESCRIPTION
## Summary
- add a Qwen3-owned persistent decode layer chain and make it the default path, with `--no-persistent-decode` kept for A/B testing
- raise the Qwen3 layer decode cooperative block to 1024 threads on HIP
- add a direct INT4 lm_head kernel so runtime no longer expands lm_head to a ~593 MiB BF16 GPU buffer
- document the current optimization state and measured smoke timings

## Verification
- `cargo check -p runner --bin supersonic`
- `cargo test -p qwen3_moe`
- `cargo test -p kernel-ffi qwen3_moe --lib`
- `rustfmt --check crates/kernel-ffi/src/qwen3_moe.rs crates/runner/src/qwen3_moe.rs`
- `git diff --check`
- `SUPERSONIC_SYNC_EACH_KERNEL=1 cargo run --release --bin supersonic -- --model qwen3-30b-a3b --model-dir /mnt/data/models/Qwen3-30B-A3B --prompt "Hello" --max-new-tokens 1 --context-size 8 --int4 --emit-stage-timings`
  - output: `Hello _`
  - timings: `path=persistent embed_ms_avg=0.029 decode_ms_avg=2444.072 lm_head_ms_avg=12.006 sample_ms_avg=0.185`
  - total: `2.46s (0.41 tok/s)`
- `SUPERSONIC_SYNC_EACH_KERNEL=1 cargo run --release --bin supersonic -- --model qwen3-30b-a3b --model-dir /mnt/data/models/Qwen3-30B-A3B --prompt "Hello" --max-new-tokens 1 --context-size 8 --int4 --emit-stage-timings --no-persistent-decode`
  - output: `Hello _`
  - timings: `path=chained embed_ms_avg=0.036 decode_ms_avg=2445.496 lm_head_ms_avg=12.010 sample_ms_avg=0.181`
  - total: `2.46s (0.41 tok/s)`

## Notes
This is intentionally separate from Qwen3.6-MoE. The persistent path here is a single-block layer chain, not the future multi-block/grid-barrier megakernel. The measurable decode speedup in this PR comes primarily from the 1024-thread layer block; persistent vs chained is currently close because this one-token path is compute dominated.

`cargo fmt --check` across the full workspace still reports pre-existing formatting drift in unrelated files, so this PR checks formatting only for the touched Rust files.