### PR TITLE
Optimize Qwen3 persistent decode hot paths

### DIFF
--- a/kernels/qwen3_moe.hip
+++ b/kernels/qwen3_moe.hip
@@ -62,6 +62,7 @@ struct Int4ScaleDesc {
 
 constexpr int Q3_MAX_GRID_BLOCKS = 128;
 constexpr int Q3_PROFILE_PHASES = 20;
+constexpr int Q3_ATTN_SCORE_GROUP_T = 128;
 
 enum Q3ProfilePhase {
     Q3_PROF_INPUT_LOAD = 0,
@@ -157,6 +158,17 @@ __device__ __forceinline__ float q3_wave_sum(float v) {
         v += __shfl_down(v, offset);
     }
     return v;
+}
+
+__device__ float q3_group128_sum(float v, float* scratch, int group, int lane) {
+    const int base = group * Q3_ATTN_SCORE_GROUP_T;
+    scratch[base + lane] = v;
+    __syncthreads();
+    for (int s = Q3_ATTN_SCORE_GROUP_T / 2; s > 0; s >>= 1) {
+        if (lane < s) scratch[base + lane] += scratch[base + lane + s];
+        __syncthreads();
+    }
+    return scratch[base];
 }
 
 __device__ float int4_value(
@@ -1119,25 +1131,56 @@ __global__ void qwen3_moe_persistent_decode_kernel(
         const int rep = h / hkv;
         q3_grid_barrier_reset_counter(
             barrier_counter, barrier_flag, nb, work_counter);
-        while (true) {
-            __shared__ unsigned int item_s;
-            if (tid == 0) item_s = atomicAdd(work_counter, 1u);
-            __syncthreads();
-            const int item = static_cast<int>(item_s);
-            if (item >= h * kv_len) break;
-            const int t = item % kv_len;
-            const int head = item / kv_len;
-            const int kv_head = head / rep;
-            float partial = 0.0f;
-            for (int d = tid; d < hd; d += bs) {
-                const float kval = (cache_k != nullptr)
-                    ? static_cast<float>(cache_k[t * kv_dim + kv_head * hd + d])
-                    : k[kv_head * hd + d];
-                partial += q[head * hd + d] * kval;
+        if (hd <= Q3_ATTN_SCORE_GROUP_T && bs >= Q3_ATTN_SCORE_GROUP_T * 2) {
+            const int score_groups = bs / Q3_ATTN_SCORE_GROUP_T;
+            const int group = tid / Q3_ATTN_SCORE_GROUP_T;
+            const int lane = tid - group * Q3_ATTN_SCORE_GROUP_T;
+            while (true) {
+                __shared__ unsigned int base_s;
+                if (tid == 0) {
+                    base_s = atomicAdd(work_counter, static_cast<unsigned int>(score_groups));
+                }
+                __syncthreads();
+                if (static_cast<int>(base_s) >= h * kv_len) break;
+                const int item = static_cast<int>(base_s) + group;
+                const bool active = item < h * kv_len;
+                const int t = active ? (item % kv_len) : 0;
+                const int head = active ? (item / kv_len) : 0;
+                const int kv_head = head / rep;
+                float partial = 0.0f;
+                if (active) {
+                    for (int d = lane; d < hd; d += Q3_ATTN_SCORE_GROUP_T) {
+                        const float kval = (cache_k != nullptr)
+                            ? static_cast<float>(cache_k[t * kv_dim + kv_head * hd + d])
+                            : k[kv_head * hd + d];
+                        partial += q[head * hd + d] * kval;
+                    }
+                }
+                const float score = q3_group128_sum(partial, lds, group, lane) * attn_scale;
+                if (active && lane == 0) scores[head * layer.kv_max_t + t] = score;
+                __syncthreads();
             }
-            const float score = block_sum(partial, lds) * attn_scale;
-            if (tid == 0) scores[head * layer.kv_max_t + t] = score;
-            __syncthreads();
+        } else {
+            while (true) {
+                __shared__ unsigned int item_s;
+                if (tid == 0) item_s = atomicAdd(work_counter, 1u);
+                __syncthreads();
+                const int item = static_cast<int>(item_s);
+                if (item >= h * kv_len) break;
+                const int t = item % kv_len;
+                const int head = item / kv_len;
+                const int kv_head = head / rep;
+                float partial = 0.0f;
+                for (int d = tid; d < hd; d += bs) {
+                    const float kval = (cache_k != nullptr)
+                        ? static_cast<float>(cache_k[t * kv_dim + kv_head * hd + d])
+                        : k[kv_head * hd + d];
+                    partial += q[head * hd + d] * kval;
+                }
+                const float score = block_sum(partial, lds) * attn_scale;
+                if (tid == 0) scores[head * layer.kv_max_t + t] = score;
+                __syncthreads();
+            }
         }
         q3_grid_barrier(barrier_counter, barrier_flag, nb);
         q3_profile_next(profile, layer_idx, Q3_PROF_ATTN_SCORES, &phase_start);

--- a/kernels/qwen3_moe.hip
+++ b/kernels/qwen3_moe.hip
@@ -62,7 +62,7 @@ struct Int4ScaleDesc {
 
 constexpr int Q3_MAX_GRID_BLOCKS = 128;
 constexpr int Q3_PROFILE_PHASES = 20;
-constexpr int Q3_ATTN_SCORE_GROUP_T = 128;
+constexpr int Q3_ATTN_SCORE_GROUP_T = 64;
 
 enum Q3ProfilePhase {
     Q3_PROF_INPUT_LOAD = 0,
@@ -160,8 +160,23 @@ __device__ __forceinline__ float q3_wave_sum(float v) {
     return v;
 }
 
-__device__ float q3_group128_sum(float v, float* scratch, int group, int lane) {
+__device__ float q3_attn_score_group_sum(float v, float* scratch, int group, int lane) {
     const int base = group * Q3_ATTN_SCORE_GROUP_T;
+    if (Q3_ATTN_SCORE_GROUP_T == 64 && warpSize == 32) {
+        scratch[base + lane] = v;
+        __syncthreads();
+        float paired = 0.0f;
+        if (lane < 32) {
+            paired = scratch[base + lane] + scratch[base + lane + 32];
+            for (int offset = 16; offset > 0; offset >>= 1) {
+                paired += __shfl_down(paired, offset);
+            }
+            if (lane == 0) scratch[base] = paired;
+        }
+        __syncthreads();
+        return scratch[base];
+    }
+
     scratch[base + lane] = v;
     __syncthreads();
     for (int s = Q3_ATTN_SCORE_GROUP_T / 2; s > 0; s >>= 1) {
@@ -187,6 +202,88 @@ __device__ float int4_value(
     const float s = static_cast<float>(scale[scale_idx]);
     const float z = static_cast<float>(zero[scale_idx]);
     return bf16_round_rne_f32(static_cast<float>(nibble) * s - z * s);
+}
+
+__device__ void q3_router_topk_select_block(
+    const float* router,
+    float* probs,
+    float* topk_val,
+    float* topk_idx,
+    int experts,
+    int top_k,
+    int norm_topk_prob) {
+    const int tid = threadIdx.x;
+    const int bs = blockDim.x;
+
+    if (norm_topk_prob) {
+        if (tid == 0) {
+            for (int e = 0; e < experts; ++e) probs[e] = router[e];
+            for (int kpos = 0; kpos < top_k; ++kpos) {
+                int best_i = 0;
+                float best_v = -INFINITY;
+                for (int e = 0; e < experts; ++e) {
+                    if (probs[e] > best_v) {
+                        best_v = probs[e];
+                        best_i = e;
+                    }
+                }
+                topk_idx[kpos] = static_cast<float>(best_i);
+                topk_val[kpos] = best_v;
+                probs[best_i] = -INFINITY;
+            }
+        }
+        __syncthreads();
+
+        const float maxv = topk_val[0];
+        for (int e = tid; e < experts; e += bs) {
+            probs[e] = expf(router[e] - maxv);
+        }
+        __syncthreads();
+
+        if (tid == 0) {
+            float denom = 0.0f;
+            for (int e = 0; e < experts; ++e) denom += probs[e];
+            for (int kpos = 0; kpos < top_k; ++kpos) {
+                const int expert = static_cast<int>(topk_idx[kpos]);
+                topk_val[kpos] = bf16_round_rne_f32(probs[expert] / denom);
+            }
+            float sum = 0.0f;
+            for (int kpos = 0; kpos < top_k; ++kpos) sum += topk_val[kpos];
+            const float inv = 1.0f / sum;
+            for (int kpos = 0; kpos < top_k; ++kpos) {
+                topk_val[kpos] = bf16_round_rne_f32(topk_val[kpos] * inv);
+            }
+        }
+        __syncthreads();
+        return;
+    }
+
+    if (tid == 0) {
+        float maxv = -INFINITY;
+        for (int e = 0; e < experts; ++e) maxv = fmaxf(maxv, router[e]);
+        float denom = 0.0f;
+        for (int e = 0; e < experts; ++e) {
+            probs[e] = expf(router[e] - maxv);
+            denom += probs[e];
+        }
+        for (int e = 0; e < experts; ++e) {
+            probs[e] = bf16_round_rne_f32(probs[e] / denom);
+        }
+        for (int kpos = 0; kpos < top_k; ++kpos) {
+            int best_i = 0;
+            float best_v = -INFINITY;
+            for (int e = 0; e < experts; ++e) {
+                if (probs[e] > best_v) {
+                    best_v = probs[e];
+                    best_i = e;
+                }
+            }
+            topk_idx[kpos] = static_cast<float>(best_i);
+            topk_val[kpos] = best_v;
+            probs[best_i] = -INFINITY;
+        }
+    }
+    __syncthreads();
 }
 
 __device__ float int4_value_3d(
@@ -536,35 +633,9 @@ __device__ void qwen3_moe_decode_layer_device(
         if (tid == 0) router[e] = bf16_round_rne_f32(sum);
         __syncthreads();
     }
-    if (tid == 0) {
-        float maxv = -INFINITY;
-        for (int e = 0; e < experts; ++e) maxv = fmaxf(maxv, router[e]);
-        float denom = 0.0f;
-        for (int e = 0; e < experts; ++e) {
-            probs[e] = expf(router[e] - maxv);
-            denom += probs[e];
-        }
-        for (int e = 0; e < experts; ++e) probs[e] = bf16_round_rne_f32(probs[e] / denom);
-        for (int kpos = 0; kpos < top_k; ++kpos) {
-            int best_i = 0;
-            float best_v = -INFINITY;
-            for (int e = 0; e < experts; ++e) {
-                if (probs[e] > best_v) {
-                    best_v = probs[e];
-                    best_i = e;
-                }
-            }
-            topk_idx[kpos] = static_cast<float>(best_i);
-            topk_val[kpos] = best_v;
-            probs[best_i] = -INFINITY;
-        }
-        if (layer.norm_topk_prob) {
-            float sum = 0.0f;
-            for (int kpos = 0; kpos < top_k; ++kpos) sum += topk_val[kpos];
-            const float inv = 1.0f / sum;
-            for (int kpos = 0; kpos < top_k; ++kpos) topk_val[kpos] = bf16_round_rne_f32(topk_val[kpos] * inv);
-        }
-    }
+    q3_router_topk_select_block(
+        router, probs, topk_val, topk_idx, experts, top_k,
+        layer.norm_topk_prob);
     __syncthreads();
 
     for (int i = tid; i < hidden; i += blockDim.x) moe_out[i] = 0.0f;
@@ -941,6 +1012,111 @@ __device__ void q3_dense_wave_rows(
     }
 }
 
+__device__ void q3_dense_pair_wave_rows(
+    const void* weight,
+    const void* scale,
+    const void* zero,
+    const float* x,
+    float* out,
+    int rows,
+    int cols,
+    int group_size,
+    unsigned int* work_counter,
+    bool round_output) {
+    const int lane = threadIdx.x % warpSize;
+    const int wave = threadIdx.x / warpSize;
+    const int waves_per_block = blockDim.x / warpSize;
+    const int row_pairs = (rows + 1) / 2;
+    const uint8_t* w = static_cast<const uint8_t*>(weight);
+    const hip_bfloat16* s = static_cast<const hip_bfloat16*>(scale);
+    const hip_bfloat16* z = static_cast<const hip_bfloat16*>(zero);
+    const int byte_cols = (cols + 1) / 2;
+    const int scale_cols = (cols + group_size - 1) / group_size;
+
+    while (true) {
+        __shared__ unsigned int base_s;
+        if (threadIdx.x == 0) {
+            base_s = atomicAdd(work_counter, static_cast<unsigned int>(waves_per_block));
+        }
+        __syncthreads();
+        if (static_cast<int>(base_s) >= row_pairs) return;
+
+        const int item = static_cast<int>(base_s) + wave;
+        if (item < row_pairs) {
+            const int row0 = item * 2;
+            const int row1 = row0 + 1;
+            const bool has_row1 = row1 < rows;
+            float partial0 = 0.0f;
+            float partial1 = 0.0f;
+
+            if (scale != nullptr) {
+                const size_t packed_base0 = static_cast<size_t>(row0) * byte_cols;
+                const size_t packed_base1 = static_cast<size_t>(row1) * byte_cols;
+                const int scale_base0 = (row0 / group_size) * scale_cols;
+                const int scale_base1 = (row1 / group_size) * scale_cols;
+
+                int c = lane * 8;
+                for (; c + 7 < cols; c += warpSize * 8) {
+                    uint32_t packed0;
+                    uint32_t packed1 = 0;
+                    __builtin_memcpy(&packed0, w + packed_base0 + c / 2, sizeof(packed0));
+                    if (has_row1) {
+                        __builtin_memcpy(&packed1, w + packed_base1 + c / 2, sizeof(packed1));
+                    }
+                    float vals0[8];
+                    float vals1[8];
+                    int4_dequant_8(packed0, s, z, scale_base0 + c / group_size, vals0);
+                    if (has_row1) {
+                        int4_dequant_8(packed1, s, z, scale_base1 + c / group_size, vals1);
+                    }
+                    const float x0 = x[c + 0];
+                    const float x1 = x[c + 1];
+                    const float x2 = x[c + 2];
+                    const float x3 = x[c + 3];
+                    const float x4 = x[c + 4];
+                    const float x5 = x[c + 5];
+                    const float x6 = x[c + 6];
+                    const float x7 = x[c + 7];
+                    partial0 += vals0[0] * x0 + vals0[1] * x1 +
+                                vals0[2] * x2 + vals0[3] * x3 +
+                                vals0[4] * x4 + vals0[5] * x5 +
+                                vals0[6] * x6 + vals0[7] * x7;
+                    if (has_row1) {
+                        partial1 += vals1[0] * x0 + vals1[1] * x1 +
+                                    vals1[2] * x2 + vals1[3] * x3 +
+                                    vals1[4] * x4 + vals1[5] * x5 +
+                                    vals1[6] * x6 + vals1[7] * x7;
+                    }
+                }
+                for (; c < cols; ++c) {
+                    const float xv = x[c];
+                    partial0 += int4_value(w, s, z, row0, c, cols, group_size) * xv;
+                    if (has_row1) {
+                        partial1 += int4_value(w, s, z, row1, c, cols, group_size) * xv;
+                    }
+                }
+            } else {
+                const hip_bfloat16* wf = static_cast<const hip_bfloat16*>(weight);
+                const size_t base0 = static_cast<size_t>(row0) * cols;
+                const size_t base1 = static_cast<size_t>(row1) * cols;
+                for (int c = lane; c < cols; c += warpSize) {
+                    const float xv = x[c];
+                    partial0 += static_cast<float>(wf[base0 + c]) * xv;
+                    if (has_row1) partial1 += static_cast<float>(wf[base1 + c]) * xv;
+                }
+            }
+
+            const float sum0 = q3_wave_sum(partial0);
+            const float sum1 = q3_wave_sum(partial1);
+            if (lane == 0) {
+                out[row0] = round_output ? bf16_round_rne_f32(sum0) : sum0;
+                if (has_row1) out[row1] = round_output ? bf16_round_rne_f32(sum1) : sum1;
+            }
+        }
+        __syncthreads();
+    }
+}
+
 __device__ void q3_expert_batch_wave_rows(
     const void* weight,
     const void* scale,
@@ -1003,6 +1179,271 @@ __device__ void q3_expert_batch_wave_rows(
             }
             const float sum = q3_wave_sum(partial);
             if (lane == 0) out[kpos * rows + row] = bf16_round_rne_f32(sum);
+        }
+        __syncthreads();
+    }
+}
+
+__device__ void q3_expert_gate_up_pair_wave_rows(
+    const void* weight,
+    const void* scale,
+    const void* zero,
+    const float* topk_idx,
+    int top_k,
+    const float* x,
+    float* out,
+    int moe_i,
+    int cols,
+    int group_size,
+    unsigned int* work_counter) {
+    const int lane = threadIdx.x % warpSize;
+    const int wave = threadIdx.x / warpSize;
+    const int waves_per_block = blockDim.x / warpSize;
+    const int total = top_k * moe_i;
+    const int rows = 2 * moe_i;
+    const uint8_t* w = static_cast<const uint8_t*>(weight);
+    const hip_bfloat16* s = static_cast<const hip_bfloat16*>(scale);
+    const hip_bfloat16* z = static_cast<const hip_bfloat16*>(zero);
+    const int byte_cols = (cols + 1) / 2;
+    const int scale_rows = (rows + group_size - 1) / group_size;
+    const int scale_cols = (cols + group_size - 1) / group_size;
+
+    while (true) {
+        __shared__ unsigned int base_s;
+        if (threadIdx.x == 0) {
+            base_s = atomicAdd(work_counter, static_cast<unsigned int>(waves_per_block));
+        }
+        __syncthreads();
+        if (static_cast<int>(base_s) >= total) return;
+
+        const int item = static_cast<int>(base_s) + wave;
+        if (item < total) {
+            const int kpos = item / moe_i;
+            const int row = item - kpos * moe_i;
+            const int expert = static_cast<int>(topk_idx[kpos]);
+            const int gate_row = row;
+            const int up_row = moe_i + row;
+            const size_t expert_base = static_cast<size_t>(expert) * rows;
+            const size_t gate_packed_base = (expert_base + gate_row) * byte_cols;
+            const size_t up_packed_base = (expert_base + up_row) * byte_cols;
+            const int gate_scale_base =
+                (expert * scale_rows + gate_row / group_size) * scale_cols;
+            const int up_scale_base =
+                (expert * scale_rows + up_row / group_size) * scale_cols;
+
+            float gate_partial = 0.0f;
+            float up_partial = 0.0f;
+            if (cols == 2048 && group_size == 128) {
+                for (int c = lane * 8; c < 2048; c += warpSize * 8) {
+                    uint32_t gate_packed;
+                    uint32_t up_packed;
+                    __builtin_memcpy(
+                        &gate_packed, w + gate_packed_base + c / 2, sizeof(gate_packed));
+                    __builtin_memcpy(
+                        &up_packed, w + up_packed_base + c / 2, sizeof(up_packed));
+                    float gate_vals[8];
+                    float up_vals[8];
+                    const int scale_off = c >> 7;
+                    int4_dequant_8(gate_packed, s, z, gate_scale_base + scale_off, gate_vals);
+                    int4_dequant_8(up_packed, s, z, up_scale_base + scale_off, up_vals);
+                    const float x0 = x[c + 0];
+                    const float x1 = x[c + 1];
+                    const float x2 = x[c + 2];
+                    const float x3 = x[c + 3];
+                    const float x4 = x[c + 4];
+                    const float x5 = x[c + 5];
+                    const float x6 = x[c + 6];
+                    const float x7 = x[c + 7];
+                    gate_partial += gate_vals[0] * x0 + gate_vals[1] * x1 +
+                                    gate_vals[2] * x2 + gate_vals[3] * x3 +
+                                    gate_vals[4] * x4 + gate_vals[5] * x5 +
+                                    gate_vals[6] * x6 + gate_vals[7] * x7;
+                    up_partial += up_vals[0] * x0 + up_vals[1] * x1 +
+                                  up_vals[2] * x2 + up_vals[3] * x3 +
+                                  up_vals[4] * x4 + up_vals[5] * x5 +
+                                  up_vals[6] * x6 + up_vals[7] * x7;
+                }
+            } else {
+                int c = lane * 8;
+                for (; c + 7 < cols; c += warpSize * 8) {
+                    uint32_t gate_packed;
+                    uint32_t up_packed;
+                    __builtin_memcpy(
+                        &gate_packed, w + gate_packed_base + c / 2, sizeof(gate_packed));
+                    __builtin_memcpy(
+                        &up_packed, w + up_packed_base + c / 2, sizeof(up_packed));
+                    float gate_vals[8];
+                    float up_vals[8];
+                    int4_dequant_8(
+                        gate_packed, s, z, gate_scale_base + c / group_size, gate_vals);
+                    int4_dequant_8(
+                        up_packed, s, z, up_scale_base + c / group_size, up_vals);
+                    const float x0 = x[c + 0];
+                    const float x1 = x[c + 1];
+                    const float x2 = x[c + 2];
+                    const float x3 = x[c + 3];
+                    const float x4 = x[c + 4];
+                    const float x5 = x[c + 5];
+                    const float x6 = x[c + 6];
+                    const float x7 = x[c + 7];
+                    gate_partial += gate_vals[0] * x0 + gate_vals[1] * x1 +
+                                    gate_vals[2] * x2 + gate_vals[3] * x3 +
+                                    gate_vals[4] * x4 + gate_vals[5] * x5 +
+                                    gate_vals[6] * x6 + gate_vals[7] * x7;
+                    up_partial += up_vals[0] * x0 + up_vals[1] * x1 +
+                                  up_vals[2] * x2 + up_vals[3] * x3 +
+                                  up_vals[4] * x4 + up_vals[5] * x5 +
+                                  up_vals[6] * x6 + up_vals[7] * x7;
+                }
+                for (; c < cols; ++c) {
+                    const float xv = x[c];
+                    gate_partial +=
+                        int4_value_3d(w, s, z, expert, gate_row, c, rows, cols, group_size) * xv;
+                    up_partial +=
+                        int4_value_3d(w, s, z, expert, up_row, c, rows, cols, group_size) * xv;
+                }
+            }
+            const float gate_sum = q3_wave_sum(gate_partial);
+            const float up_sum = q3_wave_sum(up_partial);
+            if (lane == 0) {
+                float* out_k = out + kpos * rows;
+                out_k[gate_row] = bf16_round_rne_f32(gate_sum);
+                out_k[up_row] = bf16_round_rne_f32(up_sum);
+            }
+        }
+        __syncthreads();
+    }
+}
+
+__device__ void q3_expert_down_pair_wave_rows(
+    const void* weight,
+    const void* scale,
+    const void* zero,
+    const float* topk_idx,
+    int top_k,
+    const float* x,
+    float* out,
+    int rows,
+    int cols,
+    int group_size,
+    unsigned int* work_counter) {
+    const int lane = threadIdx.x % warpSize;
+    const int wave = threadIdx.x / warpSize;
+    const int waves_per_block = blockDim.x / warpSize;
+    const int row_pairs = (rows + 1) / 2;
+    const int total = top_k * row_pairs;
+    const uint8_t* w = static_cast<const uint8_t*>(weight);
+    const hip_bfloat16* s = static_cast<const hip_bfloat16*>(scale);
+    const hip_bfloat16* z = static_cast<const hip_bfloat16*>(zero);
+    const int byte_cols = (cols + 1) / 2;
+    const int scale_rows = (rows + group_size - 1) / group_size;
+    const int scale_cols = (cols + group_size - 1) / group_size;
+
+    while (true) {
+        __shared__ unsigned int base_s;
+        if (threadIdx.x == 0) {
+            base_s = atomicAdd(work_counter, static_cast<unsigned int>(waves_per_block));
+        }
+        __syncthreads();
+        if (static_cast<int>(base_s) >= total) return;
+
+        const int item = static_cast<int>(base_s) + wave;
+        if (item < total) {
+            const int kpos = item / row_pairs;
+            const int row0 = (item - kpos * row_pairs) * 2;
+            const int row1 = row0 + 1;
+            const bool has_row1 = row1 < rows;
+            const int expert = static_cast<int>(topk_idx[kpos]);
+            const float* x_row = x + kpos * cols;
+            const size_t expert_base = static_cast<size_t>(expert) * rows;
+            const size_t packed_base0 = (expert_base + row0) * byte_cols;
+            const size_t packed_base1 = (expert_base + row1) * byte_cols;
+            const int scale_base0 =
+                (expert * scale_rows + row0 / group_size) * scale_cols;
+            const int scale_base1 =
+                (expert * scale_rows + row1 / group_size) * scale_cols;
+
+            float partial0 = 0.0f;
+            float partial1 = 0.0f;
+            if (rows == 2048 && cols == 768 && group_size == 128) {
+                for (int c = lane * 8; c < 768; c += warpSize * 8) {
+                    uint32_t packed0;
+                    uint32_t packed1;
+                    __builtin_memcpy(&packed0, w + packed_base0 + c / 2, sizeof(packed0));
+                    __builtin_memcpy(&packed1, w + packed_base1 + c / 2, sizeof(packed1));
+                    float vals0[8];
+                    float vals1[8];
+                    const int scale_off = c >> 7;
+                    int4_dequant_8(packed0, s, z, scale_base0 + scale_off, vals0);
+                    int4_dequant_8(packed1, s, z, scale_base1 + scale_off, vals1);
+                    const float x0 = x_row[c + 0];
+                    const float x1 = x_row[c + 1];
+                    const float x2 = x_row[c + 2];
+                    const float x3 = x_row[c + 3];
+                    const float x4 = x_row[c + 4];
+                    const float x5 = x_row[c + 5];
+                    const float x6 = x_row[c + 6];
+                    const float x7 = x_row[c + 7];
+                    partial0 += vals0[0] * x0 + vals0[1] * x1 +
+                                vals0[2] * x2 + vals0[3] * x3 +
+                                vals0[4] * x4 + vals0[5] * x5 +
+                                vals0[6] * x6 + vals0[7] * x7;
+                    partial1 += vals1[0] * x0 + vals1[1] * x1 +
+                                vals1[2] * x2 + vals1[3] * x3 +
+                                vals1[4] * x4 + vals1[5] * x5 +
+                                vals1[6] * x6 + vals1[7] * x7;
+                }
+            } else {
+                int c = lane * 8;
+                for (; c + 7 < cols; c += warpSize * 8) {
+                    uint32_t packed0;
+                    uint32_t packed1 = 0;
+                    __builtin_memcpy(&packed0, w + packed_base0 + c / 2, sizeof(packed0));
+                    if (has_row1) {
+                        __builtin_memcpy(&packed1, w + packed_base1 + c / 2, sizeof(packed1));
+                    }
+                    float vals0[8];
+                    float vals1[8];
+                    int4_dequant_8(packed0, s, z, scale_base0 + c / group_size, vals0);
+                    if (has_row1) {
+                        int4_dequant_8(packed1, s, z, scale_base1 + c / group_size, vals1);
+                    }
+                    const float x0 = x_row[c + 0];
+                    const float x1 = x_row[c + 1];
+                    const float x2 = x_row[c + 2];
+                    const float x3 = x_row[c + 3];
+                    const float x4 = x_row[c + 4];
+                    const float x5 = x_row[c + 5];
+                    const float x6 = x_row[c + 6];
+                    const float x7 = x_row[c + 7];
+                    partial0 += vals0[0] * x0 + vals0[1] * x1 +
+                                vals0[2] * x2 + vals0[3] * x3 +
+                                vals0[4] * x4 + vals0[5] * x5 +
+                                vals0[6] * x6 + vals0[7] * x7;
+                    if (has_row1) {
+                        partial1 += vals1[0] * x0 + vals1[1] * x1 +
+                                    vals1[2] * x2 + vals1[3] * x3 +
+                                    vals1[4] * x4 + vals1[5] * x5 +
+                                    vals1[6] * x6 + vals1[7] * x7;
+                    }
+                }
+                for (; c < cols; ++c) {
+                    const float xv = x_row[c];
+                    partial0 +=
+                        int4_value_3d(w, s, z, expert, row0, c, rows, cols, group_size) * xv;
+                    if (has_row1) {
+                        partial1 +=
+                            int4_value_3d(w, s, z, expert, row1, c, rows, cols, group_size) * xv;
+                    }
+                }
+            }
+            const float sum0 = q3_wave_sum(partial0);
+            const float sum1 = q3_wave_sum(partial1);
+            if (lane == 0) {
+                float* out_k = out + kpos * rows;
+                out_k[row0] = bf16_round_rne_f32(sum0);
+                if (has_row1) out_k[row1] = bf16_round_rne_f32(sum1);
+            }
         }
         __syncthreads();
     }
@@ -1099,7 +1540,19 @@ __global__ void qwen3_moe_persistent_decode_kernel(
             barrier_counter, barrier_flag, nb, work_counter);
         q3_profile_next(profile, layer_idx, Q3_PROF_INPUT_NORM, &phase_start);
 
-        q3_qkv_wave_rows(layer, int4, hnorm, q, k, v, hidden, q_dim, kv_dim, work_counter);
+        q3_dense_pair_wave_rows(
+            layer.q_proj_w, int4.q_proj_scale, int4.q_proj_zero,
+            hnorm, q, q_dim, hidden, group_size, work_counter, true);
+        q3_grid_barrier_reset_counter(
+            barrier_counter, barrier_flag, nb, work_counter);
+        q3_dense_pair_wave_rows(
+            layer.k_proj_w, int4.k_proj_scale, int4.k_proj_zero,
+            hnorm, k, kv_dim, hidden, group_size, work_counter, true);
+        q3_grid_barrier_reset_counter(
+            barrier_counter, barrier_flag, nb, work_counter);
+        q3_dense_pair_wave_rows(
+            layer.v_proj_w, int4.v_proj_scale, int4.v_proj_zero,
+            hnorm, v, kv_dim, hidden, group_size, work_counter, true);
         q3_grid_barrier(barrier_counter, barrier_flag, nb);
         q3_profile_next(profile, layer_idx, Q3_PROF_QKV, &phase_start);
 
@@ -1131,7 +1584,7 @@ __global__ void qwen3_moe_persistent_decode_kernel(
         const int rep = h / hkv;
         q3_grid_barrier_reset_counter(
             barrier_counter, barrier_flag, nb, work_counter);
-        if (hd <= Q3_ATTN_SCORE_GROUP_T && bs >= Q3_ATTN_SCORE_GROUP_T * 2) {
+        if (hd <= Q3_ATTN_SCORE_GROUP_T * 2 && bs >= Q3_ATTN_SCORE_GROUP_T * 2) {
             const int score_groups = bs / Q3_ATTN_SCORE_GROUP_T;
             const int group = tid / Q3_ATTN_SCORE_GROUP_T;
             const int lane = tid - group * Q3_ATTN_SCORE_GROUP_T;
@@ -1149,14 +1602,20 @@ __global__ void qwen3_moe_persistent_decode_kernel(
                 const int kv_head = head / rep;
                 float partial = 0.0f;
                 if (active) {
-                    for (int d = lane; d < hd; d += Q3_ATTN_SCORE_GROUP_T) {
-                        const float kval = (cache_k != nullptr)
-                            ? static_cast<float>(cache_k[t * kv_dim + kv_head * hd + d])
-                            : k[kv_head * hd + d];
-                        partial += q[head * hd + d] * kval;
+                    const int k_head_base = kv_head * hd;
+                    if (cache_k != nullptr) {
+                        const hip_bfloat16* k_row = cache_k + t * kv_dim + k_head_base;
+                        for (int d = lane; d < hd; d += Q3_ATTN_SCORE_GROUP_T) {
+                            partial += q[head * hd + d] * static_cast<float>(k_row[d]);
+                        }
+                    } else {
+                        const float* k_row = k + k_head_base;
+                        for (int d = lane; d < hd; d += Q3_ATTN_SCORE_GROUP_T) {
+                            partial += q[head * hd + d] * k_row[d];
+                        }
                     }
                 }
-                const float score = q3_group128_sum(partial, lds, group, lane) * attn_scale;
+                const float score = q3_attn_score_group_sum(partial, lds, group, lane) * attn_scale;
                 if (active && lane == 0) scores[head * layer.kv_max_t + t] = score;
                 __syncthreads();
             }
@@ -1217,11 +1676,24 @@ __global__ void qwen3_moe_persistent_decode_kernel(
             const int kv_head = head / rep;
             const float* row = scores + head * layer.kv_max_t;
             float acc = 0.0f;
-            for (int t = 0; t < kv_len; ++t) {
-                const float vv = (cache_v != nullptr)
-                    ? static_cast<float>(cache_v[t * kv_dim + kv_head * hd + d])
-                    : v[kv_head * hd + d];
-                acc += row[t] * vv;
+            const int v_head_offset = kv_head * hd + d;
+            if (cache_v != nullptr) {
+                const hip_bfloat16* v_col = cache_v + v_head_offset;
+                int t = 0;
+                for (; t + 3 < kv_len; t += 4) {
+                    acc += row[t] * static_cast<float>(v_col[0]);
+                    acc += row[t + 1] * static_cast<float>(v_col[kv_dim]);
+                    acc += row[t + 2] * static_cast<float>(v_col[kv_dim * 2]);
+                    acc += row[t + 3] * static_cast<float>(v_col[kv_dim * 3]);
+                    v_col += kv_dim * 4;
+                }
+                for (; t < kv_len; ++t) {
+                    acc += row[t] * static_cast<float>(*v_col);
+                    v_col += kv_dim;
+                }
+            } else {
+                const float vv = v[v_head_offset];
+                for (int t = 0; t < kv_len; ++t) acc += row[t] * vv;
             }
             attn[item] = bf16_round_rne_f32(acc);
         }
@@ -1230,7 +1702,7 @@ __global__ void qwen3_moe_persistent_decode_kernel(
 
         q3_grid_barrier_reset_counter(
             barrier_counter, barrier_flag, nb, work_counter);
-        q3_dense_wave_rows(
+        q3_dense_pair_wave_rows(
             layer.o_proj_w, int4.o_proj_scale, int4.o_proj_zero,
             attn, hnorm, hidden, q_dim, group_size, work_counter, true);
         q3_grid_barrier(barrier_counter, barrier_flag, nb);
@@ -1256,39 +1728,9 @@ __global__ void qwen3_moe_persistent_decode_kernel(
         q3_profile_next(profile, layer_idx, Q3_PROF_ROUTER, &phase_start);
 
         if (blockIdx.x == 0) {
-            if (tid == 0) {
-                float maxv = -INFINITY;
-                for (int e = 0; e < experts; ++e) maxv = fmaxf(maxv, router[e]);
-                float denom = 0.0f;
-                for (int e = 0; e < experts; ++e) {
-                    probs[e] = expf(router[e] - maxv);
-                    denom += probs[e];
-                }
-                for (int e = 0; e < experts; ++e) {
-                    probs[e] = bf16_round_rne_f32(probs[e] / denom);
-                }
-                for (int kpos = 0; kpos < top_k; ++kpos) {
-                    int best_i = 0;
-                    float best_v = -INFINITY;
-                    for (int e = 0; e < experts; ++e) {
-                        if (probs[e] > best_v) {
-                            best_v = probs[e];
-                            best_i = e;
-                        }
-                    }
-                    topk_idx[kpos] = static_cast<float>(best_i);
-                    topk_val[kpos] = best_v;
-                    probs[best_i] = -INFINITY;
-                }
-                if (layer.norm_topk_prob) {
-                    float sum = 0.0f;
-                    for (int kpos = 0; kpos < top_k; ++kpos) sum += topk_val[kpos];
-                    const float inv = 1.0f / sum;
-                    for (int kpos = 0; kpos < top_k; ++kpos) {
-                        topk_val[kpos] = bf16_round_rne_f32(topk_val[kpos] * inv);
-                    }
-                }
-            }
+            q3_router_topk_select_block(
+                router, probs, topk_val, topk_idx, experts, top_k,
+                layer.norm_topk_prob);
         }
         q3_grid_barrier(barrier_counter, barrier_flag, nb);
         q3_profile_next(profile, layer_idx, Q3_PROF_TOPK, &phase_start);
@@ -1299,11 +1741,11 @@ __global__ void qwen3_moe_persistent_decode_kernel(
 
         q3_grid_barrier_reset_counter(
             barrier_counter, barrier_flag, nb, work_counter);
-        q3_expert_batch_wave_rows(
+        q3_expert_gate_up_pair_wave_rows(
             layer.experts_gate_up_w,
             int4.experts_gate_up_scale,
             int4.experts_gate_up_zero,
-            topk_idx, top_k, hnorm, false, gu, 2 * moe_i, hidden,
+            topk_idx, top_k, hnorm, gu, moe_i, hidden,
             group_size, work_counter);
         q3_grid_barrier(barrier_counter, barrier_flag, nb);
         q3_profile_next(profile, layer_idx, Q3_PROF_EXPERT_GATE_UP, &phase_start);
@@ -1321,11 +1763,11 @@ __global__ void qwen3_moe_persistent_decode_kernel(
 
         q3_grid_barrier_reset_counter(
             barrier_counter, barrier_flag, nb, work_counter);
-        q3_expert_batch_wave_rows(
+        q3_expert_down_pair_wave_rows(
             layer.experts_down_w,
             int4.experts_down_scale,
             int4.experts_down_zero,
-            topk_idx, top_k, mid, true, expert_out, hidden, moe_i,
+            topk_idx, top_k, mid, expert_out, hidden, moe_i,
             group_size, work_counter);
         q3_grid_barrier(barrier_counter, barrier_flag, nb);
         q3_profile_next(profile, layer_idx, Q3_PROF_EXPERT_DOWN, &phase_start);

--- a/tests/gfx1100/qwen3_logit_regression.py
+++ b/tests/gfx1100/qwen3_logit_regression.py
@@ -1,0 +1,471 @@
+#!/usr/bin/env python3
+"""Compare Qwen3-30B-A3B one-token logits across SuperSonic binaries.
+
+This is a small regression harness for persistent-attention experiments. It
+runs deterministic one-token decodes, compares candidate persistent logits to
+a reference binary, and optionally records the reference persistent-vs-chained
+drift that already exists at HEAD.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import re
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_MODEL_DIR = Path(
+    os.environ.get("SUPERSONIC_QWEN3_30B_A3B_DIR", "/mnt/data/models/Qwen3-30B-A3B")
+)
+DEFAULT_REFERENCE_BIN = Path("target/qwen3_reference/supersonic")
+DEFAULT_CANDIDATE_BIN = Path("target/release/supersonic")
+DEFAULT_OUT_JSON = Path("target/qwen3_logit_regression/report.json")
+LONG_PROMPT_UNIT = (
+    "Attention kernels dominate decode as context grows and this profiling prompt "
+    "is repeated for Qwen3 persistent attention measurements."
+)
+
+
+@dataclass(frozen=True)
+class Case:
+    name: str
+    prompt: str
+    context_size: int
+
+
+def parse_int_list(raw: str) -> list[int]:
+    values = [int(part.strip()) for part in raw.split(",") if part.strip()]
+    if not values:
+        raise ValueError("list must contain at least one integer")
+    if any(value <= 0 for value in values):
+        raise ValueError("values must be positive integers")
+    seen: set[int] = set()
+    deduped: list[int] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        deduped.append(value)
+    return deduped
+
+
+def available_cases() -> dict[int, Case]:
+    return {
+        8: Case("ctx8", "Hello world", 8),
+        64: Case(
+            "ctx64",
+            (
+                "Qwen3 drift check prompt with enough words to exercise several "
+                "attention cache positions while staying inside a sixty four token "
+                "context window for deterministic one token comparison across "
+                "persistent and chained decode paths."
+            ),
+            64,
+        ),
+        210: Case("ctx210", " ".join([LONG_PROMPT_UNIT] * 10), 256),
+        504: Case("ctx504", " ".join([LONG_PROMPT_UNIT] * 24), 640),
+    }
+
+
+def select_cases(contexts: list[int]) -> list[Case]:
+    cases = available_cases()
+    missing = [ctx for ctx in contexts if ctx not in cases]
+    if missing:
+        valid = ", ".join(str(ctx) for ctx in sorted(cases))
+        raise ValueError(f"unsupported context labels {missing}; valid labels: {valid}")
+    return [cases[ctx] for ctx in contexts]
+
+
+def parse_key_value_floats(raw: str) -> dict[str, float]:
+    values: dict[str, float] = {}
+    for part in raw.split():
+        if "=" not in part:
+            continue
+        key, value = part.strip("()").split("=", 1)
+        try:
+            values[key] = float(value)
+        except ValueError:
+            pass
+    return values
+
+
+def parse_stage_timings(output: str) -> dict[str, float | str]:
+    match = re.search(r"\[qwen3-moe stage-timings\]\s+(.+)", output)
+    if not match:
+        return {}
+    raw = match.group(1)
+    timings: dict[str, float | str] = {}
+    for part in raw.split():
+        if "=" not in part:
+            continue
+        key, value = part.strip("()").split("=", 1)
+        try:
+            timings[key] = float(value)
+        except ValueError:
+            timings[key] = value
+    return timings
+
+
+def parse_prompt_tokens(output: str) -> int | None:
+    match = re.search(r"prompt:\s+.*?\s+->\s+([0-9]+)\s+tokens?", output)
+    return int(match.group(1)) if match else None
+
+
+def parse_generated_count(output: str) -> int | None:
+    match = re.search(r"Generated\s+([0-9]+)\s+tokens?", output)
+    return int(match.group(1)) if match else None
+
+
+def parse_last_logits(output: str) -> list[float]:
+    match = re.search(r"^LAST_LOGITS:\s*(.+)$", output, flags=re.MULTILINE)
+    if not match:
+        raise ValueError("LAST_LOGITS line not found")
+    raw = match.group(1).strip()
+    if not raw:
+        raise ValueError("LAST_LOGITS line is empty")
+    return [float(part) for part in raw.split(",")]
+
+
+def top_k_indices(values: list[float], k: int) -> list[int]:
+    return sorted(range(len(values)), key=lambda idx: values[idx], reverse=True)[:k]
+
+
+def logit_hash(values: list[float]) -> str:
+    h = hashlib.sha256()
+    for value in values:
+        h.update(f"{value:.9g},".encode("ascii"))
+    return h.hexdigest()
+
+
+def compare_logits(reference: list[float], candidate: list[float], top_k: int = 10) -> dict[str, Any]:
+    if len(reference) != len(candidate):
+        raise ValueError(f"logit length mismatch: {len(reference)} vs {len(candidate)}")
+    if not reference:
+        raise ValueError("logits are empty")
+
+    dot = 0.0
+    ref_norm = 0.0
+    cand_norm = 0.0
+    max_abs = 0.0
+    for ref, cand in zip(reference, candidate):
+        dot += ref * cand
+        ref_norm += ref * ref
+        cand_norm += cand * cand
+        max_abs = max(max_abs, abs(ref - cand))
+
+    ref_top = top_k_indices(reference, top_k)
+    cand_top = top_k_indices(candidate, top_k)
+    ref_set = set(ref_top)
+    cand_set = set(cand_top)
+    ref_argmax = ref_top[0]
+    cand_argmax = cand_top[0]
+    denom = math.sqrt(ref_norm) * math.sqrt(cand_norm)
+    cosine = dot / denom if denom else 0.0
+
+    return {
+        "length": len(reference),
+        "reference_argmax": ref_argmax,
+        "candidate_argmax": cand_argmax,
+        "argmax_match": ref_argmax == cand_argmax,
+        "top10_overlap": len(ref_set & cand_set),
+        "top10_reference": ref_top,
+        "top10_candidate": cand_top,
+        "cosine": cosine,
+        "max_abs": max_abs,
+        "reference_hash": logit_hash(reference),
+        "candidate_hash": logit_hash(candidate),
+    }
+
+
+def comparison_passes(
+    metrics: dict[str, Any],
+    *,
+    require_argmax: bool,
+    top10_overlap_floor: int,
+    cosine_floor: float,
+    max_abs_ceil: float,
+) -> bool:
+    return (
+        (not require_argmax or bool(metrics["argmax_match"]))
+        and int(metrics["top10_overlap"]) >= top10_overlap_floor
+        and float(metrics["cosine"]) >= cosine_floor
+        and float(metrics["max_abs"]) <= max_abs_ceil
+    )
+
+
+def run_one(
+    binary: Path,
+    model_dir: Path,
+    case: Case,
+    *,
+    backend: str,
+    persistent: bool,
+    timeout: int,
+    seed: int,
+) -> dict[str, Any]:
+    cmd = [
+        str(binary),
+        "--backend",
+        backend,
+        "--model",
+        "qwen3-30b-a3b",
+        "--model-dir",
+        str(model_dir),
+        "--prompt",
+        case.prompt,
+        "--max-new-tokens",
+        "1",
+        "--context-size",
+        str(case.context_size),
+        "--int4",
+        "--no-download",
+        "--temperature",
+        "0",
+        "--top-k",
+        "1",
+        "--sampling-seed",
+        str(seed),
+        "--dump-last-logits",
+        "--emit-stage-timings",
+    ]
+    if not persistent:
+        cmd.append("--no-persistent-decode")
+
+    start = time.monotonic()
+    try:
+        proc = subprocess.run(cmd, text=True, capture_output=True, timeout=timeout)
+    except subprocess.TimeoutExpired as exc:
+        elapsed = time.monotonic() - start
+        stdout = exc.stdout.decode(errors="replace") if isinstance(exc.stdout, bytes) else (exc.stdout or "")
+        stderr = exc.stderr.decode(errors="replace") if isinstance(exc.stderr, bytes) else (exc.stderr or "")
+        return {
+            "binary": str(binary),
+            "path": "persistent" if persistent else "chained",
+            "returncode": -1,
+            "wall_seconds": elapsed,
+            "timeout_seconds": timeout,
+            "command": cmd,
+            "stdout_tail": stdout[-2000:],
+            "stderr_tail": stderr[-4000:],
+            "error": f"timed out after {timeout} seconds",
+        }
+
+    elapsed = time.monotonic() - start
+    output = proc.stdout + proc.stderr
+    row: dict[str, Any] = {
+        "binary": str(binary),
+        "path": "persistent" if persistent else "chained",
+        "returncode": proc.returncode,
+        "wall_seconds": elapsed,
+        "command": cmd,
+        "prompt_tokens": parse_prompt_tokens(output),
+        "generated_tokens": parse_generated_count(output),
+        "stage": parse_stage_timings(output),
+        "stdout_tail": proc.stdout[-2000:],
+        "stderr_tail": proc.stderr[-4000:],
+    }
+    if proc.returncode != 0:
+        row["error"] = output[-6000:]
+        return row
+    try:
+        logits = parse_last_logits(output)
+    except ValueError as exc:
+        row["returncode"] = -2
+        row["error"] = str(exc)
+        return row
+    row["logits"] = logits
+    row["logits_len"] = len(logits)
+    row["logits_hash"] = logit_hash(logits)
+    row["argmax"] = top_k_indices(logits, 1)[0]
+    row["top10"] = top_k_indices(logits, 10)
+    return row
+
+
+def summarize_run(row: dict[str, Any]) -> dict[str, Any]:
+    return {
+        key: value
+        for key, value in row.items()
+        if key not in {"logits", "command", "stdout_tail", "stderr_tail"}
+    }
+
+
+def build_report(args: argparse.Namespace) -> tuple[dict[str, Any], list[str]]:
+    cases = select_cases(parse_int_list(args.contexts))
+    chained_labels = set(parse_int_list(args.chained_baseline_contexts)) if args.chained_baseline_contexts else set()
+    report_cases: list[dict[str, Any]] = []
+    failures: list[str] = []
+
+    for case in cases:
+        print(f"[qwen3-logit] {case.name}: reference persistent", flush=True)
+        reference = run_one(
+            args.reference_bin,
+            args.model_dir,
+            case,
+            backend=args.backend,
+            persistent=True,
+            timeout=args.timeout,
+            seed=args.seed,
+        )
+        print(f"[qwen3-logit] {case.name}: candidate persistent", flush=True)
+        candidate = run_one(
+            args.candidate_bin,
+            args.model_dir,
+            case,
+            backend=args.backend,
+            persistent=True,
+            timeout=args.timeout,
+            seed=args.seed,
+        )
+
+        case_row: dict[str, Any] = {
+            "name": case.name,
+            "context_size": case.context_size,
+            "prompt_chars": len(case.prompt),
+            "reference": summarize_run(reference),
+            "candidate": summarize_run(candidate),
+        }
+
+        if reference.get("returncode") != 0:
+            failures.append(f"{case.name}: reference failed with {reference.get('returncode')}")
+        if candidate.get("returncode") != 0:
+            failures.append(f"{case.name}: candidate failed with {candidate.get('returncode')}")
+        if reference.get("returncode") == 0 and candidate.get("returncode") == 0:
+            metrics = compare_logits(reference["logits"], candidate["logits"])
+            passed = comparison_passes(
+                metrics,
+                require_argmax=not args.allow_argmax_mismatch,
+                top10_overlap_floor=args.top10_overlap_floor,
+                cosine_floor=args.cosine_floor,
+                max_abs_ceil=args.max_abs_ceil,
+            )
+            metrics["passed"] = passed
+            case_row["candidate_vs_reference"] = metrics
+            if not passed:
+                failures.append(
+                    f"{case.name}: argmax_match={metrics['argmax_match']} "
+                    f"top10={metrics['top10_overlap']}/10 cosine={metrics['cosine']:.8f} "
+                    f"max_abs={metrics['max_abs']:.6f}"
+                )
+
+        label = int(case.name.removeprefix("ctx"))
+        if label in chained_labels:
+            print(f"[qwen3-logit] {case.name}: reference chained baseline", flush=True)
+            chained = run_one(
+                args.reference_bin,
+                args.model_dir,
+                case,
+                backend=args.backend,
+                persistent=False,
+                timeout=args.timeout,
+                seed=args.seed,
+            )
+            case_row["reference_chained"] = summarize_run(chained)
+            if chained.get("returncode") == 0 and reference.get("returncode") == 0:
+                case_row["reference_persistent_vs_chained"] = compare_logits(
+                    chained["logits"], reference["logits"]
+                )
+            elif chained.get("returncode") != 0:
+                failures.append(f"{case.name}: reference chained failed with {chained.get('returncode')}")
+
+        report_cases.append(case_row)
+
+    report = {
+        "schema": "qwen3-30b-a3b-logit-regression-v1",
+        "model": "qwen3-30b-a3b",
+        "model_dir": str(args.model_dir),
+        "reference_bin": str(args.reference_bin),
+        "candidate_bin": str(args.candidate_bin),
+        "thresholds": {
+            "require_argmax": not args.allow_argmax_mismatch,
+            "top10_overlap_floor": args.top10_overlap_floor,
+            "cosine_floor": args.cosine_floor,
+            "max_abs_ceil": args.max_abs_ceil,
+        },
+        "cases": report_cases,
+        "failures": failures,
+    }
+    return report, failures
+
+
+def print_summary(report: dict[str, Any]) -> None:
+    for case in report["cases"]:
+        metrics = case.get("candidate_vs_reference")
+        if not metrics:
+            print(f"{case['name']}: no comparison")
+            continue
+        ref_stage = case.get("reference", {}).get("stage", {})
+        cand_stage = case.get("candidate", {}).get("stage", {})
+        ref_ms = ref_stage.get("decode_ms_avg")
+        cand_ms = cand_stage.get("decode_ms_avg")
+        print(
+            f"{case['name']}: pass={metrics['passed']} "
+            f"argmax={metrics['candidate_argmax']}/{metrics['reference_argmax']} "
+            f"top10={metrics['top10_overlap']}/10 "
+            f"cos={metrics['cosine']:.8f} max_abs={metrics['max_abs']:.6f} "
+            f"decode_ms candidate/reference={cand_ms}/{ref_ms}"
+        )
+        baseline = case.get("reference_persistent_vs_chained")
+        if baseline:
+            print(
+                f"{case['name']} chained-baseline: "
+                f"argmax={baseline['candidate_argmax']}/{baseline['reference_argmax']} "
+                f"top10={baseline['top10_overlap']}/10 "
+                f"cos={baseline['cosine']:.8f} max_abs={baseline['max_abs']:.6f}"
+            )
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--reference-bin", type=Path, default=DEFAULT_REFERENCE_BIN)
+    parser.add_argument("--candidate-bin", type=Path, default=DEFAULT_CANDIDATE_BIN)
+    parser.add_argument("--model-dir", type=Path, default=DEFAULT_MODEL_DIR)
+    parser.add_argument("--backend", default="hip")
+    parser.add_argument("--contexts", default="8,64,210,504")
+    parser.add_argument(
+        "--chained-baseline-contexts",
+        default="8,64",
+        help="context labels for recording reference persistent-vs-chained drift; empty disables",
+    )
+    parser.add_argument("--out-json", type=Path, default=DEFAULT_OUT_JSON)
+    parser.add_argument("--timeout", type=int, default=900)
+    parser.add_argument("--seed", type=int, default=1234)
+    parser.add_argument("--cosine-floor", type=float, default=0.99997)
+    parser.add_argument("--max-abs-ceil", type=float, default=0.25)
+    parser.add_argument("--top10-overlap-floor", type=int, default=10)
+    parser.add_argument("--allow-argmax-mismatch", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    if not args.reference_bin.exists():
+        raise SystemExit(f"reference binary not found: {args.reference_bin}")
+    if not args.candidate_bin.exists():
+        raise SystemExit(f"candidate binary not found: {args.candidate_bin}")
+    if not args.model_dir.exists():
+        raise SystemExit(f"model dir not found: {args.model_dir}")
+
+    report, failures = build_report(args)
+    args.out_json.parent.mkdir(parents=True, exist_ok=True)
+    args.out_json.write_text(json.dumps(report, indent=2) + "\n")
+    print_summary(report)
+    print(f"wrote {args.out_json}")
+    if failures:
+        print("failures:")
+        for failure in failures:
+            print(f"  - {failure}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_qwen3_logit_regression.py
+++ b/tests/test_qwen3_logit_regression.py
@@ -1,0 +1,88 @@
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).parent / "gfx1100" / "qwen3_logit_regression.py"
+SPEC = importlib.util.spec_from_file_location("qwen3_logit_regression", SCRIPT)
+qwen3_logit_regression = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+sys.modules[SPEC.name] = qwen3_logit_regression
+SPEC.loader.exec_module(qwen3_logit_regression)
+
+
+class Qwen3LogitRegressionTests(unittest.TestCase):
+    def test_parse_int_list_dedupes_and_rejects_invalid_values(self):
+        parse = qwen3_logit_regression.parse_int_list
+        self.assertEqual(parse("8,64,8"), [8, 64])
+        with self.assertRaises(ValueError):
+            parse("")
+        with self.assertRaises(ValueError):
+            parse("0")
+
+    def test_select_cases_rejects_unknown_context_label(self):
+        cases = qwen3_logit_regression.select_cases([8, 210])
+        self.assertEqual([case.name for case in cases], ["ctx8", "ctx210"])
+        self.assertEqual(cases[0].context_size, 8)
+        self.assertEqual(cases[1].context_size, 256)
+        with self.assertRaises(ValueError):
+            qwen3_logit_regression.select_cases([9])
+
+    def test_output_parsers_extract_qwen3_fields(self):
+        output = (
+            '  prompt: "Hello world" -> 2 tokens\n'
+            " text\n"
+            "LAST_LOGITS: 1.0,2.5,-3\n"
+            "Generated 1 token in 0.50s (2.00 tok/s).\n"
+            "[qwen3-moe stage-timings] gen_steps=1 path=persistent "
+            "embed_ms_avg=0.010 decode_ms_avg=0.765 lm_head_ms_avg=1.250 sample_ms_avg=0.020\n"
+        )
+        self.assertEqual(qwen3_logit_regression.parse_prompt_tokens(output), 2)
+        self.assertEqual(qwen3_logit_regression.parse_generated_count(output), 1)
+        self.assertEqual(qwen3_logit_regression.parse_last_logits(output), [1.0, 2.5, -3.0])
+        stage = qwen3_logit_regression.parse_stage_timings(output)
+        self.assertEqual(stage["path"], "persistent")
+        self.assertEqual(stage["decode_ms_avg"], 0.765)
+
+    def test_compare_logits_reports_top10_argmax_cosine_and_max_abs(self):
+        reference = [0.0, 4.0, 1.0, -1.0]
+        candidate = [0.0, 3.5, 1.5, -1.0]
+        metrics = qwen3_logit_regression.compare_logits(reference, candidate, top_k=3)
+        self.assertTrue(metrics["argmax_match"])
+        self.assertEqual(metrics["reference_argmax"], 1)
+        self.assertEqual(metrics["candidate_argmax"], 1)
+        self.assertEqual(metrics["top10_overlap"], 3)
+        self.assertAlmostEqual(metrics["max_abs"], 0.5)
+        self.assertGreater(metrics["cosine"], 0.98)
+
+    def test_comparison_passes_uses_all_thresholds(self):
+        metrics = {
+            "argmax_match": True,
+            "top10_overlap": 10,
+            "cosine": 0.99999,
+            "max_abs": 0.1,
+        }
+        self.assertTrue(
+            qwen3_logit_regression.comparison_passes(
+                metrics,
+                require_argmax=True,
+                top10_overlap_floor=10,
+                cosine_floor=0.99997,
+                max_abs_ceil=0.25,
+            )
+        )
+        metrics["max_abs"] = 0.5
+        self.assertFalse(
+            qwen3_logit_regression.comparison_passes(
+                metrics,
+                require_argmax=True,
+                top10_overlap_floor=10,
+                cosine_floor=0.99997,
+                max_abs_ceil=0.25,
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a Qwen3-30B-A3B logit regression harness for persistent decode experiments
- improve persistent attention score scheduling with 64-thread score groups and an exact wave-assisted reducer
- optimize attention value aggregation by hoisting the KV-cache branch and unrolling the serial accumulation without changing reduction order
- pair dense/expert row work and add Qwen3 geometry-specialized expert gate/up and down hot paths

## Correctness
- strict logit regression passes at ctx8, ctx64, ctx210, and ctx504
- candidate persistent logits match reference persistent exactly: same argmax, 10/10 top-10 overlap, cosine 1.0, max_abs 0.0
- existing persistent-vs-chained drift remains visible in the harness and is not introduced by this PR

## Profiling
Phase-profile one-token decode on gfx1100, `/mnt/data/models/Qwen3-30B-A3B`, INT4 bake:

| prompt | before retained changes | after | notes |
| --- | ---: | ---: | --- |
| ctx210 | 28.659 ms | 23.406 ms | final profile `target/qwen3_profile_ctx210_final_attention_expert_specialized.log` |
| ctx504 | 46.670 ms | 35.429 ms | final profile `target/qwen3_profile_ctx504_final_attention_expert_specialized.log` |

Key ctx504 phase movement:
- `attn_values`: 823k -> 196k cycles
- `attn_scores`: 731k -> 315k cycles
- `expert_gate_up`: ~429k -> ~360k cycles
- `expert_down`: ~233k -> ~213k cycles

## Validation
- `HIP_ARCH=gfx1100 cargo build --release --bin supersonic`
- `cargo test -p qwen3_moe`
- `cargo test -p kernel-ffi qwen3_moe --lib`
- `cargo check -p runner --bin supersonic`
- `cargo test -p supersonic-core qwen3`
- `python -m unittest tests/test_qwen3_logit_regression.py`
- `tests/gfx1100/qwen3_logit_regression.py --contexts 8,64,210,504 --out-json target/qwen3_logit_regression/final_attention_expert_specialized_strict.json`
- `git diff --check`