### PR TITLE
[codex] add apple m5 max metal paths

### DIFF
--- a/crates/core/src/registry.rs
+++ b/crates/core/src/registry.rs
@@ -124,6 +124,7 @@ pub enum GpuArch {
     Sm86,
     Sm90,
     AppleM4,
+    AppleM5Max,
     Unknown(String),
 }
 
@@ -143,6 +144,7 @@ impl GpuArch {
             },
             Backend::Metal => match name.trim() {
                 "apple-m4" => Self::AppleM4,
+                "apple-m5-max" => Self::AppleM5Max,
                 other => Self::Unknown(other.to_owned()),
             },
         }
@@ -158,6 +160,7 @@ impl fmt::Display for GpuArch {
             Self::Sm86 => write!(f, "sm86"),
             Self::Sm90 => write!(f, "sm90"),
             Self::AppleM4 => write!(f, "apple-m4"),
+            Self::AppleM5Max => write!(f, "apple-m5-max"),
             Self::Unknown(s) => write!(f, "{s}"),
         }
     }
@@ -184,7 +187,9 @@ impl ArchProfile {
             GpuArch::Gfx1100 | GpuArch::Gfx942 | GpuArch::Sm86 | GpuArch::Sm90 => {
                 MemoryArchitecture::Discrete
             }
-            GpuArch::Gfx1150 | GpuArch::AppleM4 => MemoryArchitecture::Unified,
+            GpuArch::Gfx1150 | GpuArch::AppleM4 | GpuArch::AppleM5Max => {
+                MemoryArchitecture::Unified
+            }
             GpuArch::Unknown(_) => MemoryArchitecture::Discrete,
         };
         // Per-arch (BufferKind → AllocStrategy) table. `Persistent` always
@@ -607,6 +612,70 @@ static REGISTRY: &[RegistryEntry] = &[
         }),
     },
     RegistryEntry {
+        model: ModelVariant::Qwen3_5_0_8B,
+        backend: Backend::Metal,
+        arch: GpuArch::AppleM5Max,
+        vram: VramBudget {
+            fixed_bytes: 4 * GIB,
+            overhead_factor: 1.1,
+        },
+        params: FamilyParams::Qwen35(Qwen35KernelParams {
+            proj_buf_floats: 8224,
+            attn_scratch_floats: 16384,
+            weight_prefix: "model.language_model",
+            kv_chunk_size: 256,
+            use_4b_kernel: false,
+        }),
+    },
+    RegistryEntry {
+        model: ModelVariant::Qwen3_5_2B,
+        backend: Backend::Metal,
+        arch: GpuArch::AppleM5Max,
+        vram: VramBudget {
+            fixed_bytes: 5 * GIB,
+            overhead_factor: 1.1,
+        },
+        params: FamilyParams::Qwen35(Qwen35KernelParams {
+            proj_buf_floats: 8224,
+            attn_scratch_floats: 16384,
+            weight_prefix: "model.language_model",
+            kv_chunk_size: 256,
+            use_4b_kernel: false,
+        }),
+    },
+    RegistryEntry {
+        model: ModelVariant::Qwen3_5_4B,
+        backend: Backend::Metal,
+        arch: GpuArch::AppleM5Max,
+        vram: VramBudget {
+            fixed_bytes: 10 * GIB,
+            overhead_factor: 1.1,
+        },
+        params: FamilyParams::Qwen35(Qwen35KernelParams {
+            proj_buf_floats: 12352,
+            attn_scratch_floats: 16384,
+            weight_prefix: "model.language_model",
+            kv_chunk_size: 256,
+            use_4b_kernel: false,
+        }),
+    },
+    RegistryEntry {
+        model: ModelVariant::Qwen3_5_9B,
+        backend: Backend::Metal,
+        arch: GpuArch::AppleM5Max,
+        vram: VramBudget {
+            fixed_bytes: 18 * GIB,
+            overhead_factor: 1.1,
+        },
+        params: FamilyParams::Qwen35(Qwen35KernelParams {
+            proj_buf_floats: 12352,
+            attn_scratch_floats: 16384,
+            weight_prefix: "model.language_model",
+            kv_chunk_size: 256,
+            use_4b_kernel: false,
+        }),
+    },
+    RegistryEntry {
         model: ModelVariant::Qwen3_5_4B,
         backend: Backend::Cuda,
         arch: GpuArch::Sm86,
@@ -748,6 +817,32 @@ static REGISTRY: &[RegistryEntry] = &[
             kv_chunk_size: 256,
         }),
     },
+    RegistryEntry {
+        model: ModelVariant::Gemma4_E2B,
+        backend: Backend::Metal,
+        arch: GpuArch::AppleM5Max,
+        vram: VramBudget {
+            fixed_bytes: 11 * GIB,
+            overhead_factor: 1.1,
+        },
+        params: FamilyParams::Gemma4(Gemma4KernelParams {
+            weight_prefix: "model.language_model",
+            kv_chunk_size: 256,
+        }),
+    },
+    RegistryEntry {
+        model: ModelVariant::Gemma4_E4B,
+        backend: Backend::Metal,
+        arch: GpuArch::AppleM5Max,
+        vram: VramBudget {
+            fixed_bytes: 10 * GIB,
+            overhead_factor: 1.1,
+        },
+        params: FamilyParams::Gemma4(Gemma4KernelParams {
+            weight_prefix: "model.language_model",
+            kv_chunk_size: 256,
+        }),
+    },
     // Phi-4-mini: 3.8B dense, full-attention all 32 layers, LongRoPE.
     // BF16 weights ≈ 7.6 GiB; KV cache at 4K ctx ≈ 520 MiB (32 layers × 2 × 8 kv_heads × 128 head_dim × 2 B).
     // Fits gfx1150 with headroom. Weight prefix is bare `model` (Phi stores tensors as `model.*`).
@@ -804,6 +899,19 @@ static REGISTRY: &[RegistryEntry] = &[
         }),
     },
     RegistryEntry {
+        model: ModelVariant::Phi4_Mini,
+        backend: Backend::Metal,
+        arch: GpuArch::AppleM5Max,
+        vram: VramBudget {
+            fixed_bytes: 8 * GIB,
+            overhead_factor: 1.1,
+        },
+        params: FamilyParams::Phi4(Phi4KernelParams {
+            weight_prefix: "model",
+            kv_chunk_size: 256,
+        }),
+    },
+    RegistryEntry {
         model: ModelVariant::Llama3_1_8B,
         backend: Backend::Cuda,
         arch: GpuArch::Sm86,
@@ -842,6 +950,29 @@ static REGISTRY: &[RegistryEntry] = &[
             scratch_floats: 16_384,
         }),
     },
+    RegistryEntry {
+        model: ModelVariant::Qwen3_30B_A3B,
+        backend: Backend::Metal,
+        arch: GpuArch::AppleM5Max,
+        vram: VramBudget {
+            fixed_bytes: 19 * GIB,
+            overhead_factor: 1.1,
+        },
+        params: FamilyParams::Qwen3Moe(Qwen3MoeKernelParams {
+            weight_prefix: "model",
+            kv_chunk_size: 256,
+            hidden_size: 2048,
+            vocab_size: 151_936,
+            num_layers: 48,
+            num_attention_heads: 32,
+            num_kv_heads: 4,
+            head_dim: 128,
+            num_experts: 128,
+            top_k: 8,
+            moe_intermediate_size: 768,
+            scratch_floats: 16_384,
+        }),
+    },
     // Qwen3.6-35B-A3B INT4 GPTQ on AMD gfx1100. Primary AMD v1 target.
     // BF16 won't fit 24 GiB; this entry assumes the INT4 bake. PR 3
     // wires it for the dry-run path; PR 6 lands the kernel.
@@ -851,6 +982,26 @@ static REGISTRY: &[RegistryEntry] = &[
         arch: GpuArch::Gfx1100,
         vram: VramBudget {
             fixed_bytes: 19 * GIB,
+            overhead_factor: 1.1,
+        },
+        params: FamilyParams::Qwen36Moe(Qwen36MoeKernelParams {
+            weight_prefix: "model.language_model",
+            kv_chunk_size: 256,
+            proj_buf_floats: 16_480,
+            attn_scratch_floats: 24_576,
+            moe_scratch_floats: 4_096,
+            num_experts: 256,
+            top_k: 8,
+            moe_intermediate_size: 512,
+            shared_expert_intermediate_size: 512,
+        }),
+    },
+    RegistryEntry {
+        model: ModelVariant::Qwen3_6_35B_A3B,
+        backend: Backend::Metal,
+        arch: GpuArch::AppleM5Max,
+        vram: VramBudget {
+            fixed_bytes: 20 * GIB,
             overhead_factor: 1.1,
         },
         params: FamilyParams::Qwen36Moe(Qwen36MoeKernelParams {
@@ -1145,6 +1296,7 @@ mod tests {
             (Backend::Hip, GpuArch::Gfx1100),
             (Backend::Hip, GpuArch::Gfx942),
             (Backend::Cuda, GpuArch::Sm86),
+            (Backend::Metal, GpuArch::AppleM5Max),
         ] {
             let entry = lookup(&ModelVariant::Qwen3_6_35B_A3B, &backend, &arch)
                 .unwrap_or_else(|| panic!("qwen3.6-35b-a3b {backend} {arch} entry"));
@@ -1170,7 +1322,14 @@ mod tests {
     }
 
     #[test]
-    fn metal_apple_m4_registry_includes_08b_and_2b() {
+    fn metal_apple_silicon_registry_includes_supported_qwen35_models() {
+        assert_eq!(
+            GpuArch::from_backend_name(&Backend::Metal, "apple-m5-max"),
+            GpuArch::AppleM5Max
+        );
+        let profile = ArchProfile::for_arch(&GpuArch::AppleM5Max);
+        assert_eq!(profile.memory, MemoryArchitecture::Unified);
+        assert_eq!(profile.buffer_policy, BufferPolicy::all_default());
         let e08b = lookup(
             &ModelVariant::Qwen3_5_0_8B,
             &Backend::Metal,
@@ -1183,6 +1342,79 @@ mod tests {
         );
         assert!(e08b.is_some());
         assert!(e2b.is_some());
+        let phi4_m5 = lookup(
+            &ModelVariant::Phi4_Mini,
+            &Backend::Metal,
+            &GpuArch::AppleM5Max,
+        );
+        let gemma_e2b_m5 = lookup(
+            &ModelVariant::Gemma4_E2B,
+            &Backend::Metal,
+            &GpuArch::AppleM5Max,
+        );
+        let gemma_e4b_m5 = lookup(
+            &ModelVariant::Gemma4_E4B,
+            &Backend::Metal,
+            &GpuArch::AppleM5Max,
+        );
+        let e08b_m5 = lookup(
+            &ModelVariant::Qwen3_5_0_8B,
+            &Backend::Metal,
+            &GpuArch::AppleM5Max,
+        );
+        let e2b_m5 = lookup(
+            &ModelVariant::Qwen3_5_2B,
+            &Backend::Metal,
+            &GpuArch::AppleM5Max,
+        );
+        let e4b_m5 = lookup(
+            &ModelVariant::Qwen3_5_4B,
+            &Backend::Metal,
+            &GpuArch::AppleM5Max,
+        );
+        let e9b_m5 = lookup(
+            &ModelVariant::Qwen3_5_9B,
+            &Backend::Metal,
+            &GpuArch::AppleM5Max,
+        );
+        let qwen3_moe_m5 = lookup(
+            &ModelVariant::Qwen3_30B_A3B,
+            &Backend::Metal,
+            &GpuArch::AppleM5Max,
+        );
+        assert!(e08b_m5.is_some());
+        assert!(e2b_m5.is_some());
+        assert!(e4b_m5.is_some());
+        assert!(e9b_m5.is_some());
+        assert!(qwen3_moe_m5.is_some());
+        assert!(phi4_m5.is_some());
+        assert!(gemma_e2b_m5.is_some());
+        assert!(gemma_e4b_m5.is_some());
+        assert!(
+            supported_archs_for(&ModelVariant::Qwen3_5_0_8B, &Backend::Metal)
+                .iter()
+                .any(|arch| arch == "apple-m5-max")
+        );
+        assert!(
+            supported_archs_for(&ModelVariant::Phi4_Mini, &Backend::Metal)
+                .iter()
+                .any(|arch| arch == "apple-m5-max")
+        );
+        assert!(
+            supported_archs_for(&ModelVariant::Gemma4_E2B, &Backend::Metal)
+                .iter()
+                .any(|arch| arch == "apple-m5-max")
+        );
+        assert!(
+            supported_archs_for(&ModelVariant::Qwen3_5_4B, &Backend::Metal)
+                .iter()
+                .any(|arch| arch == "apple-m5-max")
+        );
+        assert!(
+            supported_archs_for(&ModelVariant::Qwen3_30B_A3B, &Backend::Metal)
+                .iter()
+                .any(|arch| arch == "apple-m5-max")
+        );
         let p08b = match &e08b.unwrap().params {
             FamilyParams::Qwen35(p) => p,
             _ => panic!("wrong family"),
@@ -1191,7 +1423,22 @@ mod tests {
             FamilyParams::Qwen35(p) => p,
             _ => panic!("wrong family"),
         };
+        let p08b_m5 = match &e08b_m5.unwrap().params {
+            FamilyParams::Qwen35(p) => p,
+            _ => panic!("wrong family"),
+        };
+        let p4b_m5 = match &e4b_m5.unwrap().params {
+            FamilyParams::Qwen35(p) => p,
+            _ => panic!("wrong family"),
+        };
+        let p9b_m5 = match &e9b_m5.unwrap().params {
+            FamilyParams::Qwen35(p) => p,
+            _ => panic!("wrong family"),
+        };
         assert!(!p08b.use_4b_kernel);
         assert!(!p2b.use_4b_kernel);
+        assert!(!p08b_m5.use_4b_kernel);
+        assert!(!p4b_m5.use_4b_kernel);
+        assert!(!p9b_m5.use_4b_kernel);
     }
 }

--- a/crates/kernel-ffi/src/gemma4.rs
+++ b/crates/kernel-ffi/src/gemma4.rs
@@ -11,6 +11,71 @@
 use std::ffi::{c_int, c_uint, c_void};
 
 use gpu_hal::{Backend, GpuBuffer, GpuError, ScalarType};
+use half::bf16;
+
+fn gemma4_metal_error(msg: impl Into<String>) -> GpuError {
+    GpuError::backend(Backend::Metal, msg.into())
+}
+
+fn gelu_pytorch_tanh(x: f32) -> f32 {
+    let inner = (2.0f32 / std::f32::consts::PI).sqrt() * (x + 0.044_715 * x * x * x);
+    0.5 * x * (1.0 + inner.tanh())
+}
+
+fn gelu_tanh_gate_mul_metal_host(
+    ordinal: usize,
+    dtype: ScalarType,
+    output: &mut GpuBuffer,
+    gate: &GpuBuffer,
+    up: &GpuBuffer,
+    n: usize,
+) -> Result<(), GpuError> {
+    let gate_bytes = gate.to_host_bytes()?;
+    let up_bytes = up.to_host_bytes()?;
+    let out_bytes = match dtype {
+        ScalarType::BF16 => {
+            let mut out = Vec::with_capacity(n * 2);
+            for (g, u) in gate_bytes
+                .chunks_exact(2)
+                .zip(up_bytes.chunks_exact(2))
+                .take(n)
+            {
+                let g = bf16::from_bits(u16::from_le_bytes([g[0], g[1]])).to_f32();
+                let u = bf16::from_bits(u16::from_le_bytes([u[0], u[1]])).to_f32();
+                out.extend_from_slice(
+                    &bf16::from_f32(gelu_pytorch_tanh(g) * u)
+                        .to_bits()
+                        .to_le_bytes(),
+                );
+            }
+            out
+        }
+        ScalarType::F32 => {
+            let mut out = Vec::with_capacity(n * 4);
+            for (g, u) in gate_bytes
+                .chunks_exact(4)
+                .zip(up_bytes.chunks_exact(4))
+                .take(n)
+            {
+                let g = f32::from_le_bytes([g[0], g[1], g[2], g[3]]);
+                let u = f32::from_le_bytes([u[0], u[1], u[2], u[3]]);
+                out.extend_from_slice(&(gelu_pytorch_tanh(g) * u).to_le_bytes());
+            }
+            out
+        }
+        other => {
+            return Err(GpuError::InvalidArg(format!(
+                "gemma4 GELU-tanh Metal fallback does not support dtype {other:?}"
+            )));
+        }
+    };
+    gpu_hal::copy_h2d(
+        ordinal,
+        output.as_mut_ptr(),
+        out_bytes.as_ptr() as *const c_void,
+        out_bytes.len(),
+    )
+}
 
 #[cfg(any(supersonic_backend_hip, supersonic_backend_cuda))]
 unsafe extern "C" {
@@ -693,6 +758,16 @@ pub fn rms_norm(
     eps: f32,
     n_cols: usize,
 ) -> Result<(), GpuError> {
+    if output.backend() == Backend::Metal {
+        return match weight {
+            Some(weight) => crate::prefill_ffi::rms_norm_rows_plain(
+                ordinal, dtype, 1, n_cols, eps, input, weight, output,
+            ),
+            None => Err(gemma4_metal_error(
+                "gemma4 rms_norm Metal fallback requires a weight buffer",
+            )),
+        };
+    }
     let weight_ptr = weight.map(|b| b.as_ptr()).unwrap_or(std::ptr::null());
     let status = unsafe {
         supersonic_gemma4_hip_rms_norm(
@@ -733,6 +808,9 @@ pub fn rms_norm_per_row(
     num_rows: usize,
     n_cols: usize,
 ) -> Result<(), GpuError> {
+    if output.backend() == Backend::Metal {
+        return rms_norm_rows(ordinal, dtype, output, input, weight, eps, num_rows, n_cols);
+    }
     let weight_ptr = weight.map(|b| b.as_ptr()).unwrap_or(std::ptr::null());
     let row_bytes = n_cols * dtype.size_in_bytes();
     let in_base = input.as_ptr() as *const u8;
@@ -775,6 +853,12 @@ pub fn matvec(
     out_dim: usize,
     counter_buf: &mut GpuBuffer,
 ) -> Result<(), GpuError> {
+    if output.backend() == Backend::Metal {
+        let _ = counter_buf;
+        return crate::prefill_ffi::matmul_rhs_transposed(
+            ordinal, dtype, 1, 1, out_dim, in_dim, input, weight, output,
+        );
+    }
     let status = unsafe {
         supersonic_gemma4_hip_matvec(
             dtype.kernel_dtype_code(),
@@ -814,6 +898,18 @@ pub fn matvec_int4(
     group_size: usize,
     counter_buf: &mut GpuBuffer,
 ) -> Result<(), GpuError> {
+    if output.backend() == Backend::Metal {
+        let _ = counter_buf;
+        if dtype != ScalarType::BF16 {
+            return Err(gemma4_metal_error(format!(
+                "gemma4 matvec_int4 Metal fallback supports BF16 only, got {dtype:?}"
+            )));
+        }
+        return crate::prefill_ffi::matmul_rhs_transposed_int4(
+            ordinal, 1, 1, out_dim, in_dim, input, w_packed, w_scale, w_zero, None, group_size, 4,
+            output,
+        );
+    }
     let status = unsafe {
         supersonic_gemma4_hip_matvec_int4(
             dtype.kernel_dtype_code(),
@@ -854,6 +950,18 @@ pub fn matvec_batched_int4(
     group_size: usize,
     counter_buf: &mut GpuBuffer,
 ) -> Result<(), GpuError> {
+    if output.backend() == Backend::Metal {
+        let _ = counter_buf;
+        if dtype != ScalarType::BF16 {
+            return Err(gemma4_metal_error(format!(
+                "gemma4 matvec_batched_int4 Metal fallback supports BF16 only, got {dtype:?}"
+            )));
+        }
+        return crate::prefill_ffi::matmul_rhs_transposed_int4(
+            ordinal, 1, seq_len, out_dim, in_dim, input, w_packed, w_scale, w_zero, None,
+            group_size, 4, output,
+        );
+    }
     let status = unsafe {
         supersonic_gemma4_hip_matvec_batched_int4(
             dtype.kernel_dtype_code(),
@@ -889,6 +997,9 @@ pub fn gelu_tanh_gate_mul(
     up: &GpuBuffer,
     n: usize,
 ) -> Result<(), GpuError> {
+    if output.backend() == Backend::Metal {
+        return gelu_tanh_gate_mul_metal_host(ordinal, dtype, output, gate, up, n);
+    }
     let status = unsafe {
         supersonic_gemma4_hip_gelu_tanh_gate_mul(
             dtype.kernel_dtype_code(),
@@ -923,6 +1034,11 @@ pub fn rope_decode(
     rotary_dim: usize,
     position: usize,
 ) -> Result<(), GpuError> {
+    if x.backend() == Backend::Metal {
+        return crate::prefill_ffi::apply_rope_prefill(
+            ordinal, dtype, 1, num_heads, head_dim, rotary_dim, cos_table, sin_table, position, x,
+        );
+    }
     let status = unsafe {
         supersonic_gemma4_hip_rope_decode(
             dtype.kernel_dtype_code(),
@@ -972,6 +1088,35 @@ pub fn swa_attn_decode(
     sliding_window: i32,
     scale: f32,
 ) -> Result<(), GpuError> {
+    if out.backend() == Backend::Metal {
+        if sliding_window > 0 && kv_len > sliding_window as usize {
+            return Err(gemma4_metal_error(format!(
+                "gemma4 Metal decode attention needs a sliding-window cache slice for kv_len={kv_len}, window={sliding_window}"
+            )));
+        }
+        let _ = scores_scratch;
+        return crate::prefill_ffi::metal_full_attention_decode_bf16_f32(
+            num_q_heads,
+            num_kv_heads,
+            kv_len,
+            max_t,
+            head_dim,
+            scale,
+            q,
+            k_cache,
+            v_cache,
+            out,
+        )
+        .and_then(|_| {
+            if out.dtype() == ScalarType::F32 {
+                Ok(())
+            } else {
+                Err(gemma4_metal_error(
+                    "gemma4 Metal decode attention fallback currently writes F32 output",
+                ))
+            }
+        });
+    }
     let status = unsafe {
         supersonic_gemma4_hip_swa_attn_decode(
             dtype.kernel_dtype_code(),
@@ -1015,6 +1160,27 @@ pub fn kv_append(
     pos: usize,
     max_t: usize,
 ) -> Result<(), GpuError> {
+    if k_cache.backend() == Backend::Metal {
+        let elem_bytes = dtype.size_in_bytes();
+        let row_bytes = head_dim * elem_bytes;
+        for h in 0..num_kv_heads {
+            let src_off = h * row_bytes;
+            let dst_off = ((h * max_t + pos) * head_dim) * elem_bytes;
+            gpu_hal::copy_d2d(
+                ordinal,
+                k_cache.offset_ptr(dst_off) as *mut c_void,
+                k_in.offset_ptr(src_off),
+                row_bytes,
+            )?;
+            gpu_hal::copy_d2d(
+                ordinal,
+                v_cache.offset_ptr(dst_off) as *mut c_void,
+                v_in.offset_ptr(src_off),
+                row_bytes,
+            )?;
+        }
+        return Ok(());
+    }
     let status = unsafe {
         supersonic_gemma4_hip_kv_append(
             dtype.kernel_dtype_code(),
@@ -1061,6 +1227,24 @@ pub fn rms_norm_rows(
     n_rows: usize,
     n_cols: usize,
 ) -> Result<(), GpuError> {
+    if output.backend() == Backend::Metal {
+        return match weight {
+            Some(weight) => crate::prefill_ffi::rms_norm_rows_plain(
+                ordinal, dtype, n_rows, n_cols, eps, input, weight, output,
+            ),
+            None => {
+                let ones = vec![bf16::from_f32(1.0).to_bits().to_le_bytes(); n_cols]
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<_>>();
+                let weight =
+                    GpuBuffer::from_host_bytes(ordinal, ScalarType::BF16, &[n_cols], &ones)?;
+                crate::prefill_ffi::rms_norm_rows_plain(
+                    ordinal, dtype, n_rows, n_cols, eps, input, &weight, output,
+                )
+            }
+        };
+    }
     let weight_ptr = weight.map(|b| b.as_ptr()).unwrap_or(std::ptr::null());
     let status = unsafe {
         supersonic_gemma4_hip_rms_norm_rows(
@@ -1096,6 +1280,12 @@ pub fn matvec_batched(
     out_dim: usize,
     counter_buf: &mut GpuBuffer,
 ) -> Result<(), GpuError> {
+    if output.backend() == Backend::Metal {
+        let _ = counter_buf;
+        return crate::prefill_ffi::matmul_rhs_transposed(
+            ordinal, dtype, 1, seq_len, out_dim, in_dim, input, weight, output,
+        );
+    }
     let status = unsafe {
         supersonic_gemma4_hip_matvec_batched(
             dtype.kernel_dtype_code(),
@@ -1134,6 +1324,12 @@ pub fn rope_prefill(
     rotary_dim: usize,
     pos_base: usize,
 ) -> Result<(), GpuError> {
+    if x.backend() == Backend::Metal {
+        return crate::prefill_ffi::apply_rope_prefill(
+            ordinal, dtype, seq_len, num_heads, head_dim, rotary_dim, cos_table, sin_table,
+            pos_base, x,
+        );
+    }
     let status = unsafe {
         supersonic_gemma4_hip_rope_prefill(
             dtype.kernel_dtype_code(),
@@ -1173,6 +1369,29 @@ pub fn kv_append_prefill(
     pos_base: usize,
     max_t: usize,
 ) -> Result<(), GpuError> {
+    if k_cache.backend() == Backend::Metal {
+        let elem_bytes = dtype.size_in_bytes();
+        let row_bytes = head_dim * elem_bytes;
+        for t in 0..seq_len {
+            for h in 0..num_kv_heads {
+                let src_off = ((t * num_kv_heads + h) * head_dim) * elem_bytes;
+                let dst_off = ((h * max_t + pos_base + t) * head_dim) * elem_bytes;
+                gpu_hal::copy_d2d(
+                    ordinal,
+                    k_cache.offset_ptr(dst_off) as *mut c_void,
+                    k_in.offset_ptr(src_off),
+                    row_bytes,
+                )?;
+                gpu_hal::copy_d2d(
+                    ordinal,
+                    v_cache.offset_ptr(dst_off) as *mut c_void,
+                    v_in.offset_ptr(src_off),
+                    row_bytes,
+                )?;
+            }
+        }
+        return Ok(());
+    }
     let status = unsafe {
         supersonic_gemma4_hip_kv_append_prefill(
             dtype.kernel_dtype_code(),
@@ -1222,6 +1441,40 @@ pub fn attn_prefill(
     sliding_window: i32,
     scale: f32,
 ) -> Result<(), GpuError> {
+    if out.backend() == Backend::Metal {
+        let _ = scores_scratch;
+        let kv_len = pos_base + seq_len;
+        if sliding_window > 0 && kv_len > sliding_window as usize {
+            return Err(gemma4_metal_error(format!(
+                "gemma4 Metal prefill attention needs a sliding-window cache slice for kv_len={kv_len}, window={sliding_window}"
+            )));
+        }
+        let mut out_f32 = GpuBuffer::zeros(ordinal, ScalarType::F32, out.shape()).map_err(|e| {
+            gemma4_metal_error(format!("gemma4 Metal attention fallback alloc: {e}"))
+        })?;
+        crate::prefill_ffi::metal_full_attention_prefill_strided_bf16_f32(
+            num_q_heads,
+            num_kv_heads,
+            seq_len,
+            kv_len,
+            max_t,
+            head_dim,
+            scale,
+            pos_base,
+            q,
+            k_cache,
+            v_cache,
+            &mut out_f32,
+        )?;
+        return crate::prefill_ffi::cast(
+            ordinal,
+            ScalarType::F32,
+            dtype,
+            out.elem_count(),
+            &out_f32,
+            out,
+        );
+    }
     let status = unsafe {
         supersonic_gemma4_hip_attn_prefill(
             dtype.kernel_dtype_code(),
@@ -1259,6 +1512,9 @@ pub fn add_residual(
     b: &GpuBuffer,
     n: usize,
 ) -> Result<(), GpuError> {
+    if output.backend() == Backend::Metal {
+        return crate::prefill_ffi::element_add(ordinal, dtype, n, a, b, output);
+    }
     let status = unsafe {
         supersonic_gemma4_hip_add_residual(
             dtype.kernel_dtype_code(),
@@ -1289,6 +1545,13 @@ pub fn add_scaled_residual(
     scalar: f32,
     n: usize,
 ) -> Result<(), GpuError> {
+    if output.backend() == Backend::Metal {
+        let mut tmp = GpuBuffer::zeros(ordinal, dtype, output.shape()).map_err(|e| {
+            gemma4_metal_error(format!("gemma4 Metal add_scaled_residual alloc: {e}"))
+        })?;
+        crate::prefill_ffi::element_add(ordinal, dtype, n, a, b, &mut tmp)?;
+        return crate::prefill_ffi::mul_scalar(ordinal, dtype, n, scalar, &tmp, output);
+    }
     let status = unsafe {
         supersonic_gemma4_hip_add_scaled_residual(
             dtype.kernel_dtype_code(),
@@ -1320,6 +1583,14 @@ pub fn scalar_mul_inplace(
     scalar: f32,
     n: usize,
 ) -> Result<(), GpuError> {
+    if x.backend() == Backend::Metal {
+        let mut tmp = GpuBuffer::zeros(ordinal, dtype, x.shape()).map_err(|e| {
+            gemma4_metal_error(format!("gemma4 Metal scalar_mul_inplace alloc: {e}"))
+        })?;
+        crate::prefill_ffi::mul_scalar(ordinal, dtype, n, scalar, x, &mut tmp)?;
+        gpu_hal::copy_d2d(ordinal, x.as_mut_ptr(), tmp.as_ptr(), x.len_bytes())?;
+        return Ok(());
+    }
     let status = unsafe {
         supersonic_gemma4_hip_scalar_mul_inplace(
             dtype.kernel_dtype_code(),
@@ -1750,6 +2021,21 @@ pub fn gather_layer_slice(
     ple_hidden: usize,
     layer_idx: usize,
 ) -> Result<(), GpuError> {
+    if output.backend() == Backend::Metal {
+        let elem_bytes = dtype.size_in_bytes();
+        let row_bytes = ple_hidden * elem_bytes;
+        for s in 0..seq_len {
+            let src_off = ((s * num_layers + layer_idx) * ple_hidden) * elem_bytes;
+            let dst_off = s * row_bytes;
+            gpu_hal::copy_d2d(
+                ordinal,
+                output.offset_ptr(dst_off) as *mut c_void,
+                src.offset_ptr(src_off),
+                row_bytes,
+            )?;
+        }
+        return Ok(());
+    }
     let status = unsafe {
         supersonic_gemma4_hip_gather_layer_slice(
             dtype.kernel_dtype_code(),
@@ -1787,6 +2073,19 @@ pub fn embed_gather_scaled(
     vocab_size: usize,
     scale: f32,
 ) -> Result<(), GpuError> {
+    if output.backend() == Backend::Metal {
+        crate::prefill_ffi::embedding_lookup(
+            ordinal,
+            dtype,
+            seq_len,
+            vocab_size,
+            hidden_size,
+            table,
+            token_ids,
+            output,
+        )?;
+        return scalar_mul_inplace(ordinal, dtype, output, scale, seq_len * hidden_size);
+    }
     let status = unsafe {
         supersonic_gemma4_hip_embed_gather_scaled(
             dtype.kernel_dtype_code(),
@@ -2675,4 +2974,154 @@ pub fn persistent_decode_batch_int4(
         ));
     }
     Ok(())
+}
+
+#[cfg(all(test, target_os = "macos", supersonic_backend_metal))]
+mod metal_tests {
+    use super::*;
+    use gpu_hal::{set_backend, Backend};
+
+    fn bf16_bytes(values: &[f32]) -> Vec<u8> {
+        values
+            .iter()
+            .flat_map(|v| bf16::from_f32(*v).to_bits().to_le_bytes())
+            .collect()
+    }
+
+    fn read_bf16(buffer: &GpuBuffer) -> Vec<f32> {
+        let bytes = buffer.to_host_bytes().expect("download BF16 test buffer");
+        bytes
+            .chunks_exact(2)
+            .map(|chunk| bf16::from_bits(u16::from_le_bytes([chunk[0], chunk[1]])).to_f32())
+            .collect()
+    }
+
+    fn upload(shape: &[usize], values: &[f32]) -> GpuBuffer {
+        GpuBuffer::from_host_bytes(0, ScalarType::BF16, shape, &bf16_bytes(values))
+            .expect("upload BF16 test tensor")
+    }
+
+    #[test]
+    fn metal_gemma4_component_wrappers_run() {
+        set_backend(Backend::Metal);
+        let mut out = GpuBuffer::zeros(0, ScalarType::BF16, &[2]).expect("alloc out");
+        let input = upload(&[2], &[3.0, 4.0]);
+        let weight = upload(&[2], &[0.5, -0.5]);
+        rms_norm(0, ScalarType::BF16, &mut out, &input, Some(&weight), 0.0, 2)
+            .expect("gemma4 rms_norm Metal fallback");
+        let norm = read_bf16(&out);
+        let inv_rms = 1.0f32 / ((25.0f32 / 2.0).sqrt());
+        assert!((norm[0] - 3.0 * inv_rms * 0.5).abs() <= 0.02);
+        assert!((norm[1] - 4.0 * inv_rms * -0.5).abs() <= 0.02);
+
+        let lhs = upload(&[1, 3], &[1.0, 2.0, 3.0]);
+        let rhs = upload(&[2, 3], &[1.0, 0.0, -1.0, 0.5, 0.5, 0.5]);
+        let mut mat = GpuBuffer::zeros(0, ScalarType::BF16, &[1, 2]).expect("alloc mat");
+        let mut counter = GpuBuffer::zeros(0, ScalarType::U32, &[1]).expect("alloc counter");
+        matvec_batched(
+            0,
+            ScalarType::BF16,
+            &mut mat,
+            &lhs,
+            &rhs,
+            1,
+            3,
+            2,
+            &mut counter,
+        )
+        .expect("gemma4 matvec_batched Metal fallback");
+        let mat = read_bf16(&mat);
+        assert!((mat[0] - -2.0).abs() <= 0.02);
+        assert!((mat[1] - 3.0).abs() <= 0.02);
+
+        let nibbles: [[u8; 4]; 4] = [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 0]];
+        let mut rhs_bytes = Vec::with_capacity(8);
+        for row in &nibbles {
+            rhs_bytes.push(row[0] | (row[1] << 4));
+            rhs_bytes.push(row[2] | (row[3] << 4));
+        }
+        let rhs_int4 = GpuBuffer::from_host_bytes(0, ScalarType::U8, &[1, 4, 2], &rhs_bytes)
+            .expect("upload INT4 rhs");
+        let scale_vals = [0.5, 0.25, 0.125, 1.0];
+        let zero_vals = [2.0, 1.0, 4.0, 0.5];
+        let scale = upload(&[2, 2], &scale_vals);
+        let zero = upload(&[2, 2], &zero_vals);
+        let int4_lhs = upload(&[4], &[1.0, 0.5, -1.0, 2.0]);
+        let mut int4_out =
+            GpuBuffer::zeros(0, ScalarType::BF16, &[4]).expect("alloc INT4 matvec out");
+        matvec_int4(
+            0,
+            ScalarType::BF16,
+            &mut int4_out,
+            &int4_lhs,
+            &rhs_int4,
+            &scale,
+            &zero,
+            4,
+            4,
+            2,
+            &mut counter,
+        )
+        .expect("gemma4 matvec_int4 Metal fallback");
+        let int4_actual = read_bf16(&int4_out);
+        let bf16_round = |x: f32| -> f32 { bf16::from_f32(x).to_f32() };
+        let int4_lhs_vals = [1.0, 0.5, -1.0, 2.0];
+        for col in 0..4usize {
+            let scale_row = col / 2;
+            let mut expected = 0.0f32;
+            for kk in 0..4usize {
+                let si = scale_row * 2 + (kk / 2);
+                let w = bf16_round(
+                    nibbles[col][kk] as f32 * scale_vals[si] - zero_vals[si] * scale_vals[si],
+                );
+                expected += int4_lhs_vals[kk] * w;
+            }
+            assert!(
+                (int4_actual[col] - expected).abs() <= 0.05,
+                "INT4 matvec fallback col {col}: got {}, want {expected}",
+                int4_actual[col]
+            );
+        }
+
+        let gate = upload(&[3], &[-1.0, 0.0, 1.0]);
+        let up = upload(&[3], &[2.0, 2.0, 2.0]);
+        let mut gelu = GpuBuffer::zeros(0, ScalarType::BF16, &[3]).expect("alloc gelu");
+        gelu_tanh_gate_mul(0, ScalarType::BF16, &mut gelu, &gate, &up, 3)
+            .expect("gemma4 gelu_tanh_gate_mul Metal fallback");
+        let gelu = read_bf16(&gelu);
+        for (got, (g, u)) in gelu.iter().zip([(-1.0, 2.0), (0.0, 2.0), (1.0, 2.0)]) {
+            let want = gelu_pytorch_tanh(g) * u;
+            assert!(
+                (got - want).abs() <= 0.02,
+                "gelu fallback mismatch: got {got}, want {want}"
+            );
+        }
+
+        let tokens = GpuBuffer::from_host_bytes(
+            0,
+            ScalarType::U32,
+            &[2],
+            &[1u32.to_le_bytes(), 0u32.to_le_bytes()].concat(),
+        )
+        .expect("upload token ids");
+        let table = upload(&[2, 2], &[1.0, 2.0, 3.0, 4.0]);
+        let mut embed = GpuBuffer::zeros(0, ScalarType::BF16, &[2, 2]).expect("alloc embed");
+        embed_gather_scaled(
+            0,
+            ScalarType::BF16,
+            &mut embed,
+            &tokens,
+            &table,
+            2,
+            2,
+            2,
+            0.5,
+        )
+        .expect("gemma4 embed_gather_scaled Metal fallback");
+        let embed = read_bf16(&embed);
+        let expected = [1.5, 2.0, 0.5, 1.0];
+        for (got, want) in embed.iter().zip(expected) {
+            assert!((got - want).abs() <= 0.02);
+        }
+    }
 }

--- a/crates/kernel-ffi/src/metal_host.rs
+++ b/crates/kernel-ffi/src/metal_host.rs
@@ -48,6 +48,22 @@ fn f32_to_bf16_bits(value: f32) -> u16 {
 }
 
 #[inline(always)]
+fn fp8_e4m3_to_f32(byte: u8) -> f32 {
+    let sign = if byte & 0x80 != 0 { -1.0 } else { 1.0 };
+    let exp = (byte >> 3) & 0x0f;
+    let mant = byte & 0x07;
+    if exp == 0 {
+        if mant == 0 {
+            sign * 0.0
+        } else {
+            sign * (mant as f32 / 8.0) * 2.0f32.powi(1 - 7)
+        }
+    } else {
+        sign * (1.0 + mant as f32 / 8.0) * 2.0f32.powi(exp as i32 - 7)
+    }
+}
+
+#[inline(always)]
 fn sigmoid(x: f32) -> f32 {
     1.0 / (1.0 + (-x).exp())
 }
@@ -269,6 +285,78 @@ pub(crate) fn matmul_rhs_transposed(
                 "matmul_rhs_transposed",
                 format!("unsupported dtype {other:?}"),
             ))
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn matmul_rhs_transposed_fp8(
+    batch_elems: usize,
+    m: usize,
+    n: usize,
+    k: usize,
+    lhs: &GpuBuffer,
+    rhs_fp8: &GpuBuffer,
+    scale: &GpuBuffer,
+    block_size: usize,
+    out: &mut GpuBuffer,
+) -> Result<(), GpuError> {
+    if lhs.dtype() != ScalarType::BF16 || out.dtype() != ScalarType::BF16 {
+        return Err(unsupported(
+            "matmul_rhs_transposed_fp8",
+            format!(
+                "expected BF16 lhs/out buffers, got {:?}/{:?}",
+                lhs.dtype(),
+                out.dtype()
+            ),
+        ));
+    }
+    if rhs_fp8.dtype() != ScalarType::F8E4M3 && rhs_fp8.dtype() != ScalarType::U8 {
+        return Err(unsupported(
+            "matmul_rhs_transposed_fp8",
+            format!("expected F8E4M3/U8 rhs, got {:?}", rhs_fp8.dtype()),
+        ));
+    }
+    if scale.dtype() != ScalarType::BF16 {
+        return Err(unsupported(
+            "matmul_rhs_transposed_fp8",
+            format!("expected BF16 scale, got {:?}", scale.dtype()),
+        ));
+    }
+    if block_size == 0 {
+        return Err(unsupported(
+            "matmul_rhs_transposed_fp8",
+            "block_size must be non-zero",
+        ));
+    }
+
+    let lhs = unsafe { bf16_slice(lhs.as_ptr(), batch_elems * m * k) };
+    let rhs = unsafe { std::slice::from_raw_parts(rhs_fp8.as_ptr() as *const u8, n * k) };
+    let row_blocks = n.div_ceil(block_size);
+    let col_blocks = k.div_ceil(block_size);
+    let scale = unsafe { bf16_slice(scale.as_ptr(), row_blocks * col_blocks) };
+    let out = unsafe { bf16_slice_mut(out.as_mut_ptr(), batch_elems * m * n) };
+
+    for batch in 0..batch_elems {
+        let lhs_batch_base = batch * m * k;
+        let out_batch_base = batch * m * n;
+        for row in 0..m {
+            let lhs_row_base = lhs_batch_base + row * k;
+            let out_row_base = out_batch_base + row * n;
+            for out_col in 0..n {
+                let rhs_row_base = out_col * k;
+                let scale_row = out_col / block_size;
+                let mut acc = 0.0f32;
+                for kk in 0..k {
+                    let scale_col = kk / block_size;
+                    let scale_idx = scale_row * col_blocks + scale_col;
+                    let weight_f32 =
+                        fp8_e4m3_to_f32(rhs[rhs_row_base + kk]) * bf16_to_f32(scale[scale_idx]);
+                    let weight = bf16_to_f32(f32_to_bf16_bits(weight_f32));
+                    acc += bf16_to_f32(lhs[lhs_row_base + kk]) * weight;
+                }
+                out[out_row_base + out_col] = f32_to_bf16_bits(acc);
+            }
         }
     }
     Ok(())

--- a/crates/kernel-ffi/src/phi4.rs
+++ b/crates/kernel-ffi/src/phi4.rs
@@ -320,9 +320,9 @@ pub fn rms_norm(
             }
         }
         Backend::Metal => {
-            return Err(GpuError::InvalidArg(
-                "phi4::rms_norm: Metal backend not yet wired".into(),
-            ));
+            return crate::prefill_ffi::rms_norm_rows_plain(
+                ordinal, dtype, 1, hidden_dim, eps, input, weight, output,
+            );
         }
     };
     if status != 0 {
@@ -488,4 +488,61 @@ pub fn persistent_decode(
         ));
     }
     Ok(())
+}
+
+#[cfg(all(test, target_os = "macos", supersonic_backend_metal))]
+mod tests {
+    use super::*;
+    use gpu_hal::{set_backend, Backend};
+    use half::bf16;
+
+    fn bf16_bytes(values: &[f32]) -> Vec<u8> {
+        values
+            .iter()
+            .flat_map(|value| bf16::from_f32(*value).to_bits().to_le_bytes())
+            .collect()
+    }
+
+    fn read_bf16(buffer: &GpuBuffer) -> Vec<f32> {
+        let bytes = buffer.to_host_bytes().expect("download bf16 buffer");
+        bytes
+            .chunks_exact(2)
+            .map(|chunk| bf16::from_bits(u16::from_le_bytes([chunk[0], chunk[1]])).to_f32())
+            .collect()
+    }
+
+    #[test]
+    fn metal_phi4_rms_norm_uses_plain_weight() {
+        set_backend(Backend::Metal);
+        let ordinal = 0usize;
+        let input =
+            GpuBuffer::from_host_bytes(ordinal, ScalarType::BF16, &[2], &bf16_bytes(&[3.0, 4.0]))
+                .expect("upload input");
+        let weight =
+            GpuBuffer::from_host_bytes(ordinal, ScalarType::BF16, &[2], &bf16_bytes(&[0.5, -0.5]))
+                .expect("upload weight");
+        let mut output = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[2]).expect("alloc output");
+
+        rms_norm(
+            ordinal,
+            ScalarType::BF16,
+            &mut output,
+            &input,
+            &weight,
+            0.0,
+            2,
+        )
+        .expect("run phi4 rms_norm");
+
+        let actual = read_bf16(&output);
+        let inv_rms = 1.0f32 / ((25.0f32 / 2.0).sqrt());
+        let expected = vec![3.0 * inv_rms * 0.5, 4.0 * inv_rms * -0.5];
+        for (idx, (got, want)) in actual.iter().zip(expected.iter()).enumerate() {
+            let delta = (got - want).abs();
+            assert!(
+                delta <= 0.02,
+                "idx {idx}: expected {want}, got {got}, delta {delta}"
+            );
+        }
+    }
 }

--- a/crates/kernel-ffi/src/prefill_ffi.rs
+++ b/crates/kernel-ffi/src/prefill_ffi.rs
@@ -2422,6 +2422,22 @@ pub fn matmul_rhs_transposed_fp8(
     block_size: usize,
     out: &mut GpuBuffer,
 ) -> Result<(), GpuError> {
+    if out.backend() == Backend::Metal {
+        let _ = ordinal;
+        return metal_profile_host_time("matmul_rhs_transposed_fp8", || {
+            metal_host::matmul_rhs_transposed_fp8(
+                batch_elems,
+                m,
+                n,
+                k,
+                lhs,
+                rhs_fp8,
+                scale,
+                block_size,
+                out,
+            )
+        });
+    }
     ffi_profile_time_result("qwen.matmul_rhs_transposed_fp8", ordinal, || {
         let status = unsafe {
             supersonic_qwen35_4b_hip_matmul_fp8_dequant(

--- a/crates/kernel-ffi/src/qwen35.rs
+++ b/crates/kernel-ffi/src/qwen35.rs
@@ -1039,11 +1039,7 @@ pub fn metal_lm_head_argmax_bf16_into(
     {
         crate::prefill_ffi::metal_profile_time("lm_head_argmax", "native", || {
             crate::metal_native::lm_head_argmax_bf16(
-                hidden,
-                weight,
-                &mut out_index,
-                hidden_dim,
-                vocab_size,
+                hidden, weight, out_index, hidden_dim, vocab_size,
             )
         })
     }
@@ -1107,9 +1103,9 @@ pub fn metal_lm_head_argmax_bf16_with_partials_into(
             crate::metal_native::lm_head_argmax_bf16_with_partials(
                 hidden,
                 weight,
-                &mut out_index,
-                Some(&mut partial_values),
-                Some(&mut partial_indices),
+                out_index,
+                Some(partial_values),
+                Some(partial_indices),
                 hidden_dim,
                 vocab_size,
             )
@@ -1154,7 +1150,7 @@ pub fn metal_argmax_bf16_into(
     #[cfg(all(target_os = "macos", supersonic_backend_metal))]
     {
         crate::prefill_ffi::metal_profile_time("argmax_bf16", "native", || {
-            crate::metal_native::argmax_bf16(logits, &mut out_index, n)
+            crate::metal_native::argmax_bf16(logits, out_index, n)
         })
     }
     #[cfg(not(all(target_os = "macos", supersonic_backend_metal)))]
@@ -1255,6 +1251,12 @@ pub fn standalone_matvec_4b(
         )));
     }
     let backend = output.backend();
+    if backend == Backend::Metal {
+        let _ = counter_buf;
+        return crate::prefill_ffi::matmul_rhs_transposed(
+            ordinal, dtype, 1, 1, out_dim, in_dim, input, weight, output,
+        );
+    }
     gpu_hal::memset_zeros(ordinal, counter_buf.as_mut_ptr(), 4)?;
     let status = match backend {
         Backend::Hip => {
@@ -1295,11 +1297,7 @@ pub fn standalone_matvec_4b(
                 return Err(GpuError::InvalidArg("CUDA backend not compiled".into()));
             }
         }
-        Backend::Metal => {
-            return Err(GpuError::InvalidArg(
-                "standalone_matvec_4b is not supported on Metal v1".into(),
-            ))
-        }
+        Backend::Metal => unreachable!("handled above"),
     };
     if status != 0 {
         return Err(backend_error(
@@ -1389,6 +1387,11 @@ pub fn rms_norm_4b_multirow(
     out: &mut GpuBuffer,
 ) -> Result<(), GpuError> {
     let backend = out.backend();
+    if backend == Backend::Metal {
+        return crate::prefill_ffi::rms_norm_rows(
+            ordinal, dtype, n_rows, hidden_dim, eps, input, weight, out,
+        );
+    }
     let status = match backend {
         Backend::Hip => {
             #[cfg(supersonic_backend_hip)]
@@ -1459,6 +1462,19 @@ pub fn matmul_rhs_transposed_4b(
     out: &mut GpuBuffer,
 ) -> Result<(), GpuError> {
     let backend = out.backend();
+    if backend == Backend::Metal {
+        return crate::prefill_ffi::matmul_rhs_transposed(
+            ordinal,
+            dtype,
+            batch_elems,
+            m,
+            n,
+            k,
+            lhs,
+            rhs,
+            out,
+        );
+    }
     let status = match backend {
         Backend::Hip => {
             #[cfg(supersonic_backend_hip)]
@@ -1500,11 +1516,7 @@ pub fn matmul_rhs_transposed_4b(
                 return Err(GpuError::InvalidArg("CUDA backend not compiled".into()));
             }
         }
-        Backend::Metal => {
-            return Err(GpuError::InvalidArg(
-                "matmul_rhs_transposed_4b is not supported on Metal v1".into(),
-            ))
-        }
+        Backend::Metal => unreachable!("handled above"),
     };
     if status != 0 {
         return Err(backend_error(
@@ -1634,6 +1646,50 @@ mod tests {
         let actual = read_bf16(&output);
         let inv_rms = 1.0f32 / ((25.0f32 / 2.0).sqrt());
         let expected = vec![3.0 * inv_rms * 1.5, 4.0 * inv_rms * 0.5];
+        for (idx, (got, want)) in actual.iter().zip(expected.iter()).enumerate() {
+            let delta = (got - want).abs();
+            assert!(
+                delta <= 0.02,
+                "idx {idx}: expected {want}, got {got}, delta {delta}"
+            );
+        }
+    }
+
+    #[test]
+    fn metal_standalone_matvec_4b_uses_generic_matmul_path() {
+        set_backend(Backend::Metal);
+        let ordinal = 0usize;
+        let input = GpuBuffer::from_host_bytes(
+            ordinal,
+            ScalarType::BF16,
+            &[3],
+            &bf16_bytes(&[1.0, 2.0, 3.0]),
+        )
+        .expect("upload input");
+        let weight = GpuBuffer::from_host_bytes(
+            ordinal,
+            ScalarType::BF16,
+            &[2, 3],
+            &bf16_bytes(&[1.0, 0.0, -1.0, 0.5, 0.5, 0.5]),
+        )
+        .expect("upload weight");
+        let mut output = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[2]).expect("alloc output");
+        let mut counter = GpuBuffer::zeros(ordinal, ScalarType::U32, &[1]).expect("alloc counter");
+
+        standalone_matvec_4b(
+            ordinal,
+            ScalarType::BF16,
+            &mut output,
+            &input,
+            &weight,
+            3,
+            2,
+            &mut counter,
+        )
+        .expect("run standalone_matvec_4b");
+
+        let actual = read_bf16(&output);
+        let expected = [-2.0, 3.0];
         for (idx, (got, want)) in actual.iter().zip(expected.iter()).enumerate() {
             let delta = (got - want).abs();
             assert!(

--- a/crates/kernel-ffi/src/qwen36_moe.rs
+++ b/crates/kernel-ffi/src/qwen36_moe.rs
@@ -1290,9 +1290,11 @@ pub fn attn_step_launch(
             params.stage
         )));
     }
-    // All five stages are wired through PR 4b2 step 5.
-
     let backend = output.backend();
+    if backend == Backend::Metal {
+        return attn_step_stage1_5_metal_host(params, weights, int4, output, workspace);
+    }
+
     let counters = sync_buf.as_mut_ptr() as *mut c_uint;
     // Layout: 16 u32 work-stealing counter slots at +0..+63 (the FFN
     // concurrent-experts dispatch uses 2*K_top of these; attn/linear/stub
@@ -1353,9 +1355,7 @@ pub fn attn_step_launch(
             }
         }
         Backend::Metal => {
-            return Err(GpuError::InvalidArg(
-                "qwen36_moe::attn_step_launch: Metal backend not yet wired".into(),
-            ));
+            unreachable!("Metal attn_step handled above");
         }
     };
     if status != 0 {
@@ -1364,6 +1364,389 @@ pub fn attn_step_launch(
             format!("qwen36_moe attn_step launch failed with status {status}"),
         ));
     }
+    Ok(())
+}
+
+fn attn_step_stage1_5_metal_host(
+    params: Qwen36MoeAttnStepParams,
+    weights: &Qwen36MoeAttnStepWeights,
+    int4: &Qwen36MoeAttnStepInt4,
+    output: &mut GpuBuffer,
+    workspace: &mut GpuBuffer,
+) -> Result<(), GpuError> {
+    if output.dtype() != ScalarType::BF16 || workspace.dtype() != ScalarType::F32 {
+        return Err(GpuError::InvalidArg(format!(
+            "qwen36_moe::attn_step_launch: Metal stage1-5 expects BF16/F32 \
+             output buffers, got {:?}/{:?}",
+            output.dtype(),
+            workspace.dtype(),
+        )));
+    }
+    if int4.group_size < 0 {
+        return Err(GpuError::InvalidArg(
+            "qwen36_moe::attn_step_launch: Metal stage1-5 does not yet support FP8 sidecars".into(),
+        ));
+    }
+    if weights.input_hidden.is_null()
+        || weights.input_norm_w.is_null()
+        || weights.q_proj_w.is_null()
+        || weights.q_norm_w.is_null()
+    {
+        return Err(GpuError::InvalidArg(
+            "qwen36_moe::attn_step_launch: Metal stage1 requires input_hidden, \
+             input_norm_w, q_proj_w, and q_norm_w"
+                .into(),
+        ));
+    }
+    if params.stage >= 2
+        && (weights.k_proj_w.is_null() || weights.v_proj_w.is_null() || weights.k_norm_w.is_null())
+    {
+        return Err(GpuError::InvalidArg(
+            "qwen36_moe::attn_step_launch: Metal stage2 requires k_proj_w, \
+             v_proj_w, and k_norm_w"
+                .into(),
+        ));
+    }
+    if params.stage >= 3 && (params.rotary_dim < 0 || params.rotary_dim > params.head_dim) {
+        return Err(GpuError::InvalidArg(format!(
+            "qwen36_moe::attn_step_launch: Metal stage{} invalid rotary_dim {} for head_dim {}",
+            params.stage, params.rotary_dim, params.head_dim
+        )));
+    }
+    if params.stage >= 4 {
+        let cache_k_set = !weights.kv_cache_k.is_null();
+        let cache_v_set = !weights.kv_cache_v.is_null();
+        if cache_k_set != cache_v_set {
+            return Err(GpuError::InvalidArg(
+                "qwen36_moe::attn_step_launch: Metal stage4 requires paired KV cache pointers"
+                    .into(),
+            ));
+        }
+        if cache_k_set {
+            let eff_cache_pos = if params.cache_pos >= 0 {
+                params.cache_pos
+            } else {
+                params.position
+            };
+            if eff_cache_pos < 0 || weights.kv_max_t <= eff_cache_pos {
+                return Err(GpuError::InvalidArg(format!(
+                    "qwen36_moe::attn_step_launch: Metal stage{} invalid cache_pos {} for kv_max_t {}",
+                    params.stage, eff_cache_pos, weights.kv_max_t
+                )));
+            }
+        }
+    }
+    if params.stage >= 5 && weights.o_proj_w.is_null() {
+        return Err(GpuError::InvalidArg(
+            "qwen36_moe::attn_step_launch: Metal stage5 requires o_proj_w".into(),
+        ));
+    }
+
+    let hidden = params.hidden as usize;
+    let num_heads = params.num_heads as usize;
+    let num_kv_heads = params.num_kv_heads as usize;
+    let head_dim = params.head_dim as usize;
+    if hidden == 0 || num_heads == 0 || num_kv_heads == 0 || head_dim == 0 {
+        return Err(GpuError::InvalidArg(
+            "qwen36_moe::attn_step_launch: Metal stage1-5 requires non-zero geometry".into(),
+        ));
+    }
+    if params.stage >= 4 && num_heads % num_kv_heads != 0 {
+        return Err(GpuError::InvalidArg(format!(
+            "qwen36_moe::attn_step_launch: Metal stage{} requires num_heads divisible by num_kv_heads",
+            params.stage
+        )));
+    }
+
+    let q_out_dim = 2 * num_heads * head_dim;
+    let q_normed_dim = num_heads * head_dim;
+    let kv_dim = num_kv_heads * head_dim;
+    let off_q_raw = 0usize;
+    let off_k_raw = q_out_dim;
+    let off_v_raw = off_k_raw + kv_dim;
+    let off_q_normed = off_v_raw + kv_dim;
+    let off_k_normed = off_q_normed + q_normed_dim;
+    let off_q_rot = off_k_normed + kv_dim;
+    let off_k_rot = off_q_rot + q_normed_dim;
+    let off_attn = 4 * num_heads * head_dim + 4 * num_kv_heads * head_dim;
+    let off_gated = off_attn + q_normed_dim;
+    let off_o_out = off_gated + q_normed_dim;
+    let cache_k_set = !weights.kv_cache_k.is_null();
+    let eff_cache_pos = if params.cache_pos >= 0 {
+        params.cache_pos as usize
+    } else {
+        params.position.max(0) as usize
+    };
+    let kv_len = if cache_k_set { eff_cache_pos + 1 } else { 1 };
+    let output_len = if params.stage == 2 {
+        kv_dim
+    } else if params.stage == 3 {
+        q_normed_dim + kv_dim
+    } else if params.stage == 5 {
+        hidden
+    } else {
+        q_normed_dim
+    };
+    let workspace_len = if params.stage >= 5 {
+        off_o_out + hidden
+    } else if params.stage >= 4 {
+        off_attn + q_normed_dim
+    } else if params.stage >= 3 {
+        off_k_rot + kv_dim
+    } else if params.stage >= 2 {
+        off_k_normed + kv_dim
+    } else {
+        off_q_normed + q_normed_dim
+    };
+    let workspace_elems = workspace.shape().iter().product::<usize>();
+    let output_elems = output.shape().iter().product::<usize>();
+    if workspace_elems < workspace_len {
+        return Err(GpuError::InvalidArg(format!(
+            "qwen36_moe::attn_step_launch: Metal stage{} workspace too small: need {}, got {}",
+            params.stage, workspace_len, workspace_elems
+        )));
+    }
+    if output_elems < output_len {
+        return Err(GpuError::InvalidArg(format!(
+            "qwen36_moe::attn_step_launch: Metal stage{} output too small: need {}, got {}",
+            params.stage, output_len, output_elems
+        )));
+    }
+
+    let input = unsafe { std::slice::from_raw_parts(weights.input_hidden as *const u16, hidden) };
+    let input_norm_w =
+        unsafe { std::slice::from_raw_parts(weights.input_norm_w as *const u16, hidden) };
+    let q_norm_w = unsafe { std::slice::from_raw_parts(weights.q_norm_w as *const u16, head_dim) };
+    let output =
+        unsafe { std::slice::from_raw_parts_mut(output.as_mut_ptr() as *mut u16, output_len) };
+    let workspace = unsafe {
+        std::slice::from_raw_parts_mut(workspace.as_mut_ptr() as *mut f32, workspace_len)
+    };
+
+    let mut mean_sq = 0.0f32;
+    for &bits in input {
+        let v = bf16_bits_to_f32(bits);
+        mean_sq += v * v;
+    }
+    let inv_rms = 1.0f32 / (mean_sq / hidden as f32 + params.rms_norm_eps).sqrt();
+    let mut x_norm = vec![0.0f32; hidden];
+    for col in 0..hidden {
+        let v = bf16_bits_to_f32(input[col]);
+        let w = bf16_bits_to_f32(input_norm_w[col]);
+        x_norm[col] = bf16_round_f32(v * inv_rms * (1.0 + w));
+    }
+
+    for row in 0..q_out_dim {
+        let acc = qwen36_dense_or_int4_dot_2d(
+            weights.q_proj_w,
+            int4.q_proj_scale,
+            int4.q_proj_zero,
+            row,
+            hidden,
+            int4.group_size,
+            &x_norm,
+        )?;
+        workspace[off_q_raw + row] = bf16_round_f32(acc);
+    }
+
+    for head in 0..num_heads {
+        let q_in_base = head * 2 * head_dim;
+        let q_out_base = head * head_dim;
+        let mut mean_sq = 0.0f32;
+        for i in 0..head_dim {
+            let v = workspace[off_q_raw + q_in_base + i];
+            mean_sq += v * v;
+        }
+        let inv_head = 1.0f32 / (mean_sq / head_dim as f32 + params.rms_norm_eps).sqrt();
+        for i in 0..head_dim {
+            let v = workspace[off_q_raw + q_in_base + i];
+            let w = bf16_bits_to_f32(q_norm_w[i]);
+            let normed = bf16_round_f32(v * inv_head * (1.0 + w));
+            workspace[off_q_normed + q_out_base + i] = normed;
+            if params.stage == 1 {
+                output[q_out_base + i] = f32_to_bf16_bits(normed);
+            }
+        }
+    }
+
+    if params.stage == 1 {
+        return Ok(());
+    }
+
+    let k_norm_w = unsafe { std::slice::from_raw_parts(weights.k_norm_w as *const u16, head_dim) };
+
+    for row in 0..kv_dim {
+        let k_acc = qwen36_dense_or_int4_dot_2d(
+            weights.k_proj_w,
+            int4.k_proj_scale,
+            int4.k_proj_zero,
+            row,
+            hidden,
+            int4.group_size,
+            &x_norm,
+        )?;
+        let v_acc = qwen36_dense_or_int4_dot_2d(
+            weights.v_proj_w,
+            int4.v_proj_scale,
+            int4.v_proj_zero,
+            row,
+            hidden,
+            int4.group_size,
+            &x_norm,
+        )?;
+        workspace[off_k_raw + row] = bf16_round_f32(k_acc);
+        workspace[off_v_raw + row] = bf16_round_f32(v_acc);
+    }
+
+    for head in 0..num_kv_heads {
+        let base = head * head_dim;
+        let mut mean_sq = 0.0f32;
+        for i in 0..head_dim {
+            let v = workspace[off_k_raw + base + i];
+            mean_sq += v * v;
+        }
+        let inv_head = 1.0f32 / (mean_sq / head_dim as f32 + params.rms_norm_eps).sqrt();
+        for i in 0..head_dim {
+            let v = workspace[off_k_raw + base + i];
+            let w = bf16_bits_to_f32(k_norm_w[i]);
+            let normed = bf16_round_f32(v * inv_head * (1.0 + w));
+            workspace[off_k_normed + base + i] = normed;
+            if params.stage == 2 {
+                output[base + i] = f32_to_bf16_bits(normed);
+            }
+        }
+    }
+
+    if params.stage == 2 {
+        return Ok(());
+    }
+
+    let rotary_dim = params.rotary_dim as usize;
+    let half_rotary = rotary_dim / 2;
+    let theta_log = params.rope_theta.ln();
+    for head_idx in 0..(num_heads + num_kv_heads) {
+        let is_k = head_idx >= num_heads;
+        let head = if is_k { head_idx - num_heads } else { head_idx };
+        let src_off = if is_k { off_k_normed } else { off_q_normed };
+        let dst_off = if is_k { off_k_rot } else { off_q_rot };
+        let pub_off = head_idx * head_dim;
+        for i in 0..half_rotary {
+            let a = workspace[src_off + head * head_dim + i];
+            let b = workspace[src_off + head * head_dim + half_rotary + i];
+            let exponent = (i as f32 / half_rotary as f32) * theta_log;
+            let freq = params.position as f32 * (-exponent).exp();
+            let c = bf16_round_f32(freq.cos());
+            let s = bf16_round_f32(freq.sin());
+            let rot_a = bf16_round_f32(bf16_round_f32(a * c) - bf16_round_f32(b * s));
+            let rot_b = bf16_round_f32(bf16_round_f32(b * c) + bf16_round_f32(a * s));
+            workspace[dst_off + head * head_dim + i] = rot_a;
+            workspace[dst_off + head * head_dim + half_rotary + i] = rot_b;
+            if params.stage == 3 {
+                output[pub_off + i] = f32_to_bf16_bits(rot_a);
+                output[pub_off + half_rotary + i] = f32_to_bf16_bits(rot_b);
+            }
+        }
+        for i in rotary_dim..head_dim {
+            let x = workspace[src_off + head * head_dim + i];
+            workspace[dst_off + head * head_dim + i] = x;
+            if params.stage == 3 {
+                output[pub_off + i] = f32_to_bf16_bits(x);
+            }
+        }
+    }
+
+    if params.stage == 3 {
+        return Ok(());
+    }
+
+    let rep = num_heads / num_kv_heads;
+    let scale = 1.0f32 / (head_dim as f32).sqrt();
+    if cache_k_set {
+        let cache_elems = weights.kv_max_t as usize * kv_dim;
+        let cache_k =
+            unsafe { std::slice::from_raw_parts_mut(weights.kv_cache_k as *mut u16, cache_elems) };
+        let cache_v =
+            unsafe { std::slice::from_raw_parts_mut(weights.kv_cache_v as *mut u16, cache_elems) };
+        let slot_base = eff_cache_pos * kv_dim;
+        for idx in 0..kv_dim {
+            cache_k[slot_base + idx] = f32_to_bf16_bits(workspace[off_k_rot + idx]);
+            cache_v[slot_base + idx] = f32_to_bf16_bits(workspace[off_v_raw + idx]);
+        }
+        for hq in 0..num_heads {
+            let h_kv = hq / rep;
+            let mut scores = vec![0.0f32; kv_len];
+            let mut max_score = f32::NEG_INFINITY;
+            for t in 0..kv_len {
+                let mut dot = 0.0f32;
+                let kv_base = t * kv_dim + h_kv * head_dim;
+                for i in 0..head_dim {
+                    dot += workspace[off_q_rot + hq * head_dim + i]
+                        * bf16_bits_to_f32(cache_k[kv_base + i]);
+                }
+                let score = dot * scale;
+                scores[t] = score;
+                max_score = max_score.max(score);
+            }
+            let mut denom = 0.0f32;
+            for score in scores.iter_mut() {
+                *score = (*score - max_score).exp();
+                denom += *score;
+            }
+            for i in 0..head_dim {
+                let mut acc = 0.0f32;
+                for t in 0..kv_len {
+                    let kv_base = t * kv_dim + h_kv * head_dim;
+                    acc += (scores[t] / denom) * bf16_bits_to_f32(cache_v[kv_base + i]);
+                }
+                workspace[off_attn + hq * head_dim + i] = acc;
+                if params.stage == 4 {
+                    output[hq * head_dim + i] = f32_to_bf16_bits(acc);
+                }
+            }
+        }
+    } else {
+        for hq in 0..num_heads {
+            let h_kv = hq / rep;
+            for i in 0..head_dim {
+                let v = workspace[off_v_raw + h_kv * head_dim + i];
+                workspace[off_attn + hq * head_dim + i] = v;
+                if params.stage == 4 {
+                    output[hq * head_dim + i] = f32_to_bf16_bits(v);
+                }
+            }
+        }
+    }
+
+    if params.stage == 4 {
+        return Ok(());
+    }
+
+    for head in 0..num_heads {
+        for i in 0..head_dim {
+            let out_gate = workspace[off_q_raw + head * 2 * head_dim + head_dim + i];
+            let attn_v = workspace[off_attn + head * head_dim + i];
+            let sig = 1.0f32 / (1.0f32 + (-out_gate).exp());
+            let gated = bf16_round_f32(bf16_round_f32(sig) * attn_v);
+            workspace[off_gated + head * head_dim + i] = gated;
+        }
+    }
+
+    for row in 0..hidden {
+        let acc = qwen36_dense_or_int4_dot_2d(
+            weights.o_proj_w,
+            int4.o_proj_scale,
+            int4.o_proj_zero,
+            row,
+            q_normed_dim,
+            int4.group_size,
+            &workspace[off_gated..off_gated + q_normed_dim],
+        )?;
+        let o_out = bf16_round_f32(acc);
+        let result = bf16_round_f32(bf16_bits_to_f32(input[row]) + o_out);
+        workspace[off_o_out + row] = result;
+        output[row] = f32_to_bf16_bits(result);
+    }
+
     Ok(())
 }
 
@@ -1468,6 +1851,15 @@ pub fn linear_step_launch(
     // All five stages are wired through PR 4b3 step 6.
 
     let backend = output.backend();
+    if backend == Backend::Metal {
+        if params.stage <= 5 {
+            return linear_step_stage1_5_metal_host(params, weights, int4, output, workspace);
+        }
+        return Err(GpuError::InvalidArg(
+            "qwen36_moe::linear_step_launch: Metal backend is wired for stages 1-5 only".into(),
+        ));
+    }
+
     let counters = sync_buf.as_mut_ptr() as *mut c_uint;
     // Layout: 16 u32 work-stealing counter slots at +0..+63 (the FFN
     // concurrent-experts dispatch uses 2*K_top of these; attn/linear/stub
@@ -1527,9 +1919,7 @@ pub fn linear_step_launch(
             }
         }
         Backend::Metal => {
-            return Err(GpuError::InvalidArg(
-                "qwen36_moe::linear_step_launch: Metal backend not yet wired".into(),
-            ));
+            unreachable!("Metal linear_step handled above");
         }
     };
     if status != 0 {
@@ -1538,6 +1928,408 @@ pub fn linear_step_launch(
             format!("qwen36_moe linear_step launch failed with status {status}"),
         ));
     }
+    Ok(())
+}
+
+fn linear_step_stage1_5_metal_host(
+    params: Qwen36MoeLinearStepParams,
+    weights: &Qwen36MoeLinearStepWeights,
+    int4: &Qwen36MoeLinearStepInt4,
+    output: &mut GpuBuffer,
+    workspace: &mut GpuBuffer,
+) -> Result<(), GpuError> {
+    if output.dtype() != ScalarType::BF16 || workspace.dtype() != ScalarType::F32 {
+        return Err(GpuError::InvalidArg(format!(
+            "qwen36_moe::linear_step_launch: Metal stage1-5 expects BF16/F32 \
+             output buffers, got {:?}/{:?}",
+            output.dtype(),
+            workspace.dtype(),
+        )));
+    }
+    if int4.group_size < 0 {
+        return Err(GpuError::InvalidArg(
+            "qwen36_moe::linear_step_launch: Metal stage1-5 does not yet support FP8 sidecars"
+                .into(),
+        ));
+    }
+    if weights.input_hidden.is_null()
+        || weights.input_norm_w.is_null()
+        || weights.in_proj_qkv_w.is_null()
+        || weights.in_proj_z_w.is_null()
+        || weights.in_proj_a_w.is_null()
+        || weights.in_proj_b_w.is_null()
+    {
+        return Err(GpuError::InvalidArg(
+            "qwen36_moe::linear_step_launch: Metal stage1-5 requires input_hidden, \
+             input_norm_w, in_proj_qkv_w, in_proj_z_w, in_proj_a_w, and in_proj_b_w"
+                .into(),
+        ));
+    }
+
+    let hidden = params.hidden as usize;
+    let num_k_heads = params.num_k_heads as usize;
+    let num_v_heads = params.num_v_heads as usize;
+    let head_k_dim = params.head_k_dim as usize;
+    let head_v_dim = params.head_v_dim as usize;
+
+    if params.stage >= 2
+        && (weights.conv1d_w.is_null()
+            || weights.conv_state.is_null()
+            || params.conv_kernel_dim < 1)
+    {
+        return Err(GpuError::InvalidArg(
+            "qwen36_moe::linear_step_launch: Metal stage2 requires conv1d_w, \
+             conv_state, and conv_kernel_dim >= 1"
+                .into(),
+        ));
+    }
+    if params.stage >= 3 && num_v_heads % num_k_heads != 0 {
+        return Err(GpuError::InvalidArg(format!(
+            "qwen36_moe::linear_step_launch: Metal stage{} requires num_v_heads \
+             divisible by num_k_heads, got {num_v_heads}/{num_k_heads}",
+            params.stage
+        )));
+    }
+    if params.stage == 4
+        && (weights.dt_bias.is_null()
+            || weights.a_log.is_null()
+            || weights.recurrent_state.is_null())
+    {
+        return Err(GpuError::InvalidArg(
+            "qwen36_moe::linear_step_launch: Metal stage4 requires dt_bias, \
+             a_log, and recurrent_state"
+                .into(),
+        ));
+    }
+    if params.stage == 5
+        && (weights.dt_bias.is_null()
+            || weights.a_log.is_null()
+            || weights.norm_w.is_null()
+            || weights.out_proj_w.is_null()
+            || weights.recurrent_state.is_null())
+    {
+        return Err(GpuError::InvalidArg(
+            "qwen36_moe::linear_step_launch: Metal stage5 requires dt_bias, \
+             a_log, norm_w, out_proj_w, and recurrent_state"
+                .into(),
+        ));
+    }
+
+    let key_dim = num_k_heads * head_k_dim;
+    let val_dim = num_v_heads * head_v_dim;
+    let qkv_dim = 2 * key_dim + val_dim;
+    let total_rows = qkv_dim + val_dim + 2 * num_v_heads;
+    let off_qkv_raw = 0usize;
+    let off_z_raw = qkv_dim;
+    let off_a_raw = qkv_dim + val_dim;
+    let off_b_raw = qkv_dim + val_dim + num_v_heads;
+    let off_q_normed = total_rows;
+    let off_k_normed = off_q_normed + key_dim;
+    let off_q_rep = off_k_normed + key_dim;
+    let off_k_rep = off_q_rep + num_v_heads * head_k_dim;
+    let stage3_workspace_len = off_k_rep + num_v_heads * head_k_dim;
+    let off_beta = stage3_workspace_len;
+    let off_g = off_beta + num_v_heads;
+    let off_rec_out = off_g + num_v_heads;
+    let stage4_workspace_len = off_rec_out + val_dim;
+    let workspace_len = if params.stage >= 3 {
+        if params.stage >= 4 {
+            stage4_workspace_len
+        } else {
+            stage3_workspace_len
+        }
+    } else {
+        total_rows
+    };
+    let output_len = if params.stage >= 5 {
+        hidden
+    } else if params.stage >= 4 {
+        val_dim
+    } else if params.stage >= 3 {
+        2 * num_v_heads * head_k_dim + val_dim
+    } else {
+        qkv_dim
+    };
+    if workspace.len_bytes() / std::mem::size_of::<f32>() < workspace_len {
+        return Err(GpuError::InvalidArg(format!(
+            "qwen36_moe::linear_step_launch: Metal stage{} workspace too small: \
+             need {workspace_len} f32 entries, got {}",
+            params.stage,
+            workspace.len_bytes() / std::mem::size_of::<f32>(),
+        )));
+    }
+    if output.len_bytes() / std::mem::size_of::<u16>() < output_len {
+        return Err(GpuError::InvalidArg(format!(
+            "qwen36_moe::linear_step_launch: Metal stage{} output too small: \
+             need {output_len} BF16 entries, got {}",
+            params.stage,
+            output.len_bytes() / std::mem::size_of::<u16>(),
+        )));
+    }
+
+    let input = unsafe { std::slice::from_raw_parts(weights.input_hidden as *const u16, hidden) };
+    let input_norm_w =
+        unsafe { std::slice::from_raw_parts(weights.input_norm_w as *const u16, hidden) };
+    let in_proj_a_w = unsafe {
+        std::slice::from_raw_parts(weights.in_proj_a_w as *const u16, num_v_heads * hidden)
+    };
+    let in_proj_b_w = unsafe {
+        std::slice::from_raw_parts(weights.in_proj_b_w as *const u16, num_v_heads * hidden)
+    };
+    let output =
+        unsafe { std::slice::from_raw_parts_mut(output.as_mut_ptr() as *mut u16, output_len) };
+    let workspace = unsafe {
+        std::slice::from_raw_parts_mut(workspace.as_mut_ptr() as *mut f32, workspace_len)
+    };
+
+    let mut mean_sq = 0.0f32;
+    for &bits in input {
+        let v = bf16_bits_to_f32(bits);
+        mean_sq += v * v;
+    }
+    let inv_rms = 1.0f32 / (mean_sq / hidden as f32 + params.rms_norm_eps).sqrt();
+    let mut x_norm = vec![0.0f32; hidden];
+    for col in 0..hidden {
+        let v = bf16_bits_to_f32(input[col]);
+        let w = bf16_bits_to_f32(input_norm_w[col]);
+        x_norm[col] = bf16_round_f32(v * inv_rms * (1.0 + w));
+    }
+
+    for row in 0..qkv_dim {
+        let acc = qwen36_dense_or_int4_dot_2d(
+            weights.in_proj_qkv_w,
+            int4.in_proj_qkv_scale,
+            int4.in_proj_qkv_zero,
+            row,
+            hidden,
+            int4.group_size,
+            &x_norm,
+        )?;
+        let rounded = bf16_round_f32(acc);
+        workspace[off_qkv_raw + row] = rounded;
+        if params.stage == 1 {
+            output[row] = f32_to_bf16_bits(rounded);
+        }
+    }
+    for row in 0..val_dim {
+        let acc = qwen36_dense_or_int4_dot_2d(
+            weights.in_proj_z_w,
+            int4.in_proj_z_scale,
+            int4.in_proj_z_zero,
+            row,
+            hidden,
+            int4.group_size,
+            &x_norm,
+        )?;
+        workspace[off_z_raw + row] = bf16_round_f32(acc);
+    }
+    for row in 0..num_v_heads {
+        let mut acc_a = 0.0f32;
+        let mut acc_b = 0.0f32;
+        let row_base = row * hidden;
+        for col in 0..hidden {
+            let x = x_norm[col];
+            acc_a += bf16_bits_to_f32(in_proj_a_w[row_base + col]) * x;
+            acc_b += bf16_bits_to_f32(in_proj_b_w[row_base + col]) * x;
+        }
+        workspace[off_a_raw + row] = bf16_round_f32(acc_a);
+        workspace[off_b_raw + row] = bf16_round_f32(acc_b);
+    }
+
+    if params.stage == 1 {
+        return Ok(());
+    }
+
+    let kernel = params.conv_kernel_dim as usize;
+    let kstate = kernel - 1;
+    let conv1d_w =
+        unsafe { std::slice::from_raw_parts(weights.conv1d_w as *const u16, qkv_dim * kernel) };
+    let conv1d_bias = if weights.conv1d_bias.is_null() {
+        None
+    } else {
+        Some(unsafe { std::slice::from_raw_parts(weights.conv1d_bias as *const u16, qkv_dim) })
+    };
+    let conv_state =
+        unsafe { std::slice::from_raw_parts_mut(weights.conv_state as *mut u16, qkv_dim * kstate) };
+
+    for ch in 0..qkv_dim {
+        let new_qkv = workspace[off_qkv_raw + ch];
+        let mut acc = 0.0f32;
+        for t in 0..kstate {
+            let state = bf16_bits_to_f32(conv_state[ch * kstate + t]);
+            acc += state * bf16_bits_to_f32(conv1d_w[ch * kernel + t]);
+        }
+        acc += new_qkv * bf16_bits_to_f32(conv1d_w[ch * kernel + kstate]);
+        if let Some(bias) = conv1d_bias {
+            acc += bf16_bits_to_f32(bias[ch]);
+        }
+        let conv_out = bf16_round_f32(acc);
+        let silu = bf16_round_f32(conv_out * (1.0 / (1.0 + (-conv_out).exp())));
+        workspace[off_qkv_raw + ch] = silu;
+        if params.stage == 2 {
+            output[ch] = f32_to_bf16_bits(silu);
+        }
+
+        if kstate > 0 {
+            for t in 0..kstate.saturating_sub(1) {
+                conv_state[ch * kstate + t] = conv_state[ch * kstate + t + 1];
+            }
+            conv_state[ch * kstate + (kstate - 1)] = f32_to_bf16_bits(new_qkv);
+        }
+    }
+
+    if params.stage == 2 {
+        return Ok(());
+    }
+
+    for head in 0..num_k_heads {
+        let q_src = off_qkv_raw + head * head_k_dim;
+        let k_src = off_qkv_raw + key_dim + head * head_k_dim;
+        let q_dst = off_q_normed + head * head_k_dim;
+        let k_dst = off_k_normed + head * head_k_dim;
+
+        let mut q_ss = 0.0f32;
+        let mut k_ss = 0.0f32;
+        for i in 0..head_k_dim {
+            let q = workspace[q_src + i];
+            let k = workspace[k_src + i];
+            q_ss += q * q;
+            k_ss += k * k;
+        }
+        let q_denom = bf16_round_f32(bf16_round_f32(q_ss.sqrt()).max(1e-6));
+        let k_denom = bf16_round_f32(bf16_round_f32(k_ss.sqrt()).max(1e-6));
+        for i in 0..head_k_dim {
+            workspace[q_dst + i] = bf16_round_f32(workspace[q_src + i] / q_denom);
+            workspace[k_dst + i] = bf16_round_f32(workspace[k_src + i] / k_denom);
+        }
+    }
+
+    let rep = num_v_heads / num_k_heads;
+    let q_scale = 1.0f32 / (head_k_dim as f32).sqrt();
+    for vhead in 0..num_v_heads {
+        let src_kh = vhead / rep;
+        let q_src = off_q_normed + src_kh * head_k_dim;
+        let k_src = off_k_normed + src_kh * head_k_dim;
+        let q_dst = off_q_rep + vhead * head_k_dim;
+        let k_dst = off_k_rep + vhead * head_k_dim;
+        for i in 0..head_k_dim {
+            let qs = bf16_round_f32(workspace[q_src + i] * q_scale);
+            let kn = workspace[k_src + i];
+            workspace[q_dst + i] = qs;
+            workspace[k_dst + i] = kn;
+            if params.stage == 3 {
+                output[vhead * head_k_dim + i] = f32_to_bf16_bits(qs);
+                output[num_v_heads * head_k_dim + vhead * head_k_dim + i] = f32_to_bf16_bits(kn);
+            }
+        }
+        let v_src = off_qkv_raw + 2 * key_dim + vhead * head_v_dim;
+        let v_out = 2 * num_v_heads * head_k_dim + vhead * head_v_dim;
+        if params.stage == 3 {
+            for i in 0..head_v_dim {
+                output[v_out + i] = f32_to_bf16_bits(workspace[v_src + i]);
+            }
+        }
+    }
+
+    if params.stage == 3 {
+        return Ok(());
+    }
+
+    let dt_bias = unsafe { std::slice::from_raw_parts(weights.dt_bias as *const u16, num_v_heads) };
+    let a_log = unsafe { std::slice::from_raw_parts(weights.a_log as *const u16, num_v_heads) };
+    let recurrent_state = unsafe {
+        std::slice::from_raw_parts_mut(
+            weights.recurrent_state,
+            num_v_heads * head_k_dim * head_v_dim,
+        )
+    };
+    for head in 0..num_v_heads {
+        let a_v = workspace[off_a_raw + head];
+        let b_v = workspace[off_b_raw + head];
+        let dt_b = bf16_bits_to_f32(dt_bias[head]);
+        let a_log_v = bf16_bits_to_f32(a_log[head]);
+        let softplus = (1.0 + (a_v + dt_b).exp()).ln();
+        workspace[off_beta + head] = 1.0 / (1.0 + (-b_v).exp());
+        workspace[off_g + head] = -softplus * a_log_v.exp();
+    }
+
+    for head in 0..num_v_heads {
+        let beta = workspace[off_beta + head];
+        let gstep = workspace[off_g + head].exp();
+        let state_off = head * head_k_dim * head_v_dim;
+        let kv_off = off_k_rep + head * head_k_dim;
+        let qv_off = off_q_rep + head * head_k_dim;
+        let v_off = off_qkv_raw + 2 * key_dim + head * head_v_dim;
+        for e in 0..head_k_dim * head_v_dim {
+            recurrent_state[state_off + e] *= gstep;
+        }
+        let mut kv_mem = vec![0.0f32; head_v_dim];
+        for j in 0..head_v_dim {
+            let mut acc = 0.0f32;
+            for i in 0..head_k_dim {
+                acc += recurrent_state[state_off + i * head_v_dim + j] * workspace[kv_off + i];
+            }
+            kv_mem[j] = acc;
+        }
+        let mut delta = vec![0.0f32; head_v_dim];
+        for j in 0..head_v_dim {
+            delta[j] = (workspace[v_off + j] - kv_mem[j]) * beta;
+        }
+        for i in 0..head_k_dim {
+            for j in 0..head_v_dim {
+                recurrent_state[state_off + i * head_v_dim + j] += workspace[kv_off + i] * delta[j];
+            }
+        }
+        for j in 0..head_v_dim {
+            let mut acc = 0.0f32;
+            for i in 0..head_k_dim {
+                acc += recurrent_state[state_off + i * head_v_dim + j] * workspace[qv_off + i];
+            }
+            let rec = bf16_round_f32(acc);
+            workspace[off_rec_out + head * head_v_dim + j] = rec;
+            output[head * head_v_dim + j] = f32_to_bf16_bits(rec);
+        }
+    }
+
+    if params.stage == 4 {
+        return Ok(());
+    }
+
+    let norm_w = unsafe { std::slice::from_raw_parts(weights.norm_w as *const u16, head_v_dim) };
+    for head in 0..num_v_heads {
+        let rec_off = off_rec_out + head * head_v_dim;
+        let z_off = off_z_raw + head * head_v_dim;
+        let mut mean_sq = 0.0f32;
+        for j in 0..head_v_dim {
+            let v = workspace[rec_off + j];
+            mean_sq += v * v;
+        }
+        let inv = 1.0f32 / (mean_sq / head_v_dim as f32 + params.rms_norm_eps).sqrt();
+        for j in 0..head_v_dim {
+            let rec = workspace[rec_off + j];
+            let nw = bf16_bits_to_f32(norm_w[j]);
+            let on = bf16_round_f32(rec * inv * nw);
+            let z = workspace[z_off + j];
+            let z_silu = bf16_round_f32(z * (1.0 / (1.0 + (-z).exp())));
+            workspace[rec_off + j] = bf16_round_f32(on * z_silu);
+        }
+    }
+
+    for row in 0..hidden {
+        let acc = qwen36_dense_or_int4_dot_2d(
+            weights.out_proj_w,
+            int4.out_proj_scale,
+            int4.out_proj_zero,
+            row,
+            val_dim,
+            int4.group_size,
+            &workspace[off_rec_out..off_rec_out + val_dim],
+        )?;
+        let o_out = bf16_round_f32(acc);
+        let residual = bf16_round_f32(bf16_bits_to_f32(input[row]) + o_out);
+        output[row] = f32_to_bf16_bits(residual);
+    }
+
     Ok(())
 }
 
@@ -1671,10 +2463,11 @@ pub fn ffn_step_launch(
             params.top_k,
         )));
     }
-    // Only stage 1 is wired through PR 4b4 step 2; stage 2..=5 will land in
-    // follow-up commits to this PR.
-
     let backend = output.backend();
+    if backend == Backend::Metal {
+        return ffn_step_stage1_5_metal_host(params, weights, int4, output, output_idx, workspace);
+    }
+
     let counters = sync_buf.as_mut_ptr() as *mut c_uint;
     // Layout: 16 u32 work-stealing counter slots at +0..+63 (the FFN
     // concurrent-experts dispatch uses 2*K_top of these; attn/linear/stub
@@ -1733,9 +2526,7 @@ pub fn ffn_step_launch(
             }
         }
         Backend::Metal => {
-            return Err(GpuError::InvalidArg(
-                "qwen36_moe::ffn_step_launch: Metal backend not yet wired".into(),
-            ));
+            unreachable!("Metal ffn_step handled above");
         }
     };
     if status != 0 {
@@ -1744,6 +2535,342 @@ pub fn ffn_step_launch(
             format!("qwen36_moe ffn_step launch failed with status {status}"),
         ));
     }
+    Ok(())
+}
+
+fn ffn_step_stage1_5_metal_host(
+    params: Qwen36MoeFfnStepParams,
+    weights: &Qwen36MoeFfnStepWeights,
+    int4: &Qwen36MoeFfnStepInt4,
+    output: &mut GpuBuffer,
+    output_idx: &mut GpuBuffer,
+    workspace: &mut GpuBuffer,
+) -> Result<(), GpuError> {
+    if output.dtype() != ScalarType::BF16
+        || output_idx.dtype() != ScalarType::U32
+        || workspace.dtype() != ScalarType::F32
+    {
+        return Err(GpuError::InvalidArg(format!(
+            "qwen36_moe::ffn_step_launch: Metal stage1-5 expects BF16/U32/F32 \
+             output buffers, got {:?}/{:?}/{:?}",
+            output.dtype(),
+            output_idx.dtype(),
+            workspace.dtype(),
+        )));
+    }
+    if int4.group_size < 0 {
+        return Err(GpuError::InvalidArg(
+            "qwen36_moe::ffn_step_launch: Metal stage1-5 does not yet support FP8 sidecars".into(),
+        ));
+    }
+    if weights.input_hidden.is_null()
+        || weights.post_attn_norm_w.is_null()
+        || weights.gate_w.is_null()
+    {
+        return Err(GpuError::InvalidArg(
+            "qwen36_moe::ffn_step_launch: Metal stage1 requires input_hidden, \
+             post_attn_norm_w, and gate_w"
+                .into(),
+        ));
+    }
+    if params.stage >= 2
+        && (weights.shared_gate_proj_w.is_null()
+            || weights.shared_up_proj_w.is_null()
+            || weights.shared_down_proj_w.is_null()
+            || weights.shared_expert_gate_w.is_null())
+    {
+        return Err(GpuError::InvalidArg(
+            "qwen36_moe::ffn_step_launch: Metal stage2 requires shared expert weights".into(),
+        ));
+    }
+    if params.stage >= 3 && (weights.gate_up_proj_w.is_null() || weights.down_proj_w.is_null()) {
+        return Err(GpuError::InvalidArg(
+            "qwen36_moe::ffn_step_launch: Metal stage3 requires gate_up_proj_w and down_proj_w"
+                .into(),
+        ));
+    }
+
+    let hidden = params.hidden as usize;
+    let num_experts = params.num_experts as usize;
+    let moe_intermediate = params.moe_intermediate as usize;
+    let shared_intermediate = params.shared_intermediate as usize;
+    let top_k = params.top_k as usize;
+    if hidden == 0
+        || num_experts == 0
+        || moe_intermediate == 0
+        || shared_intermediate == 0
+        || top_k == 0
+    {
+        return Err(GpuError::InvalidArg(
+            "qwen36_moe::ffn_step_launch: Metal stage1-5 requires non-zero geometry".into(),
+        ));
+    }
+
+    let off_h_norm = 0usize;
+    let off_router_logits = hidden;
+    let off_router_probs = hidden + num_experts;
+    let off_topk_val = hidden + 2 * num_experts;
+    let off_topk_idx = hidden + 2 * num_experts + top_k;
+    let off_sg_scalar = hidden + 2 * num_experts + 2 * top_k;
+    let off_sgp = off_sg_scalar + 1;
+    let off_sup = off_sgp + shared_intermediate;
+    let off_shared_mid = off_sup + shared_intermediate;
+    let off_shared_out = off_shared_mid + shared_intermediate;
+    let off_expert_gu = off_shared_out + hidden;
+    let off_expert_mid = off_expert_gu + top_k * 2 * moe_intermediate;
+    let off_expert_stack = off_expert_mid + top_k * moe_intermediate;
+    let off_moe_out = off_expert_stack + top_k * hidden;
+    let workspace_len = if params.stage >= 4 {
+        off_moe_out + hidden
+    } else if params.stage >= 3 {
+        off_expert_stack + top_k * hidden
+    } else if params.stage >= 2 {
+        off_shared_out + hidden
+    } else {
+        off_sg_scalar
+    };
+    let output_len = if params.stage == 1 { top_k } else { hidden };
+    if workspace.len_bytes() / std::mem::size_of::<f32>() < workspace_len {
+        return Err(GpuError::InvalidArg(format!(
+            "qwen36_moe::ffn_step_launch: Metal stage{} workspace too small: need {}, got {}",
+            params.stage,
+            workspace_len,
+            workspace.len_bytes() / std::mem::size_of::<f32>()
+        )));
+    }
+    if output.len_bytes() / std::mem::size_of::<u16>() < output_len {
+        return Err(GpuError::InvalidArg(format!(
+            "qwen36_moe::ffn_step_launch: Metal stage{} output too small: need {}, got {}",
+            params.stage,
+            output_len,
+            output.len_bytes() / std::mem::size_of::<u16>()
+        )));
+    }
+    if output_idx.len_bytes() / std::mem::size_of::<i32>() < top_k {
+        return Err(GpuError::InvalidArg(format!(
+            "qwen36_moe::ffn_step_launch: Metal output_idx too small: need {}, got {}",
+            top_k,
+            output_idx.len_bytes() / std::mem::size_of::<i32>()
+        )));
+    }
+
+    let input = unsafe { std::slice::from_raw_parts(weights.input_hidden as *const u16, hidden) };
+    let norm_w =
+        unsafe { std::slice::from_raw_parts(weights.post_attn_norm_w as *const u16, hidden) };
+    let gate_w =
+        unsafe { std::slice::from_raw_parts(weights.gate_w as *const u16, num_experts * hidden) };
+    let output =
+        unsafe { std::slice::from_raw_parts_mut(output.as_mut_ptr() as *mut u16, output_len) };
+    let output_idx =
+        unsafe { std::slice::from_raw_parts_mut(output_idx.as_mut_ptr() as *mut i32, top_k) };
+    let workspace = unsafe {
+        std::slice::from_raw_parts_mut(workspace.as_mut_ptr() as *mut f32, workspace_len)
+    };
+
+    let mut mean_sq = 0.0f32;
+    for &bits in input {
+        let v = bf16_bits_to_f32(bits);
+        mean_sq += v * v;
+    }
+    let inv_rms = 1.0f32 / (mean_sq / hidden as f32 + params.rms_norm_eps).sqrt();
+    for col in 0..hidden {
+        let v = bf16_bits_to_f32(input[col]);
+        let w = bf16_bits_to_f32(norm_w[col]);
+        workspace[off_h_norm + col] = bf16_round_f32(v * inv_rms * (1.0 + w));
+    }
+
+    for expert in 0..num_experts {
+        let mut acc = 0.0f32;
+        let row = expert * hidden;
+        for col in 0..hidden {
+            acc += bf16_bits_to_f32(gate_w[row + col]) * workspace[off_h_norm + col];
+        }
+        workspace[off_router_logits + expert] = bf16_round_f32(acc);
+    }
+
+    let row_max = workspace[off_router_logits..off_router_logits + num_experts]
+        .iter()
+        .copied()
+        .fold(f32::NEG_INFINITY, f32::max);
+    let mut row_sum = 0.0f32;
+    for expert in 0..num_experts {
+        let e = (workspace[off_router_logits + expert] - row_max).exp();
+        workspace[off_router_probs + expert] = e;
+        row_sum += e;
+    }
+    let inv_sum = 1.0f32 / row_sum;
+    for expert in 0..num_experts {
+        workspace[off_router_probs + expert] =
+            bf16_round_f32(workspace[off_router_probs + expert] * inv_sum);
+    }
+
+    for kk in 0..top_k {
+        let mut best_idx = -1i32;
+        let mut best_val = f32::NEG_INFINITY;
+        for expert in 0..num_experts {
+            let v = workspace[off_router_probs + expert];
+            if v > best_val || (v == best_val && best_idx >= 0 && (expert as i32) < best_idx) {
+                best_val = v;
+                best_idx = expert as i32;
+            }
+        }
+        workspace[off_topk_idx + kk] = f32::from_bits(best_idx as u32);
+        workspace[off_topk_val + kk] = best_val;
+        if best_idx >= 0 {
+            workspace[off_router_probs + best_idx as usize] = f32::NEG_INFINITY;
+        }
+    }
+
+    let sum_k: f32 = (0..top_k).map(|kk| workspace[off_topk_val + kk]).sum();
+    let inv_k = 1.0f32 / sum_k;
+    for kk in 0..top_k {
+        let w = bf16_round_f32(workspace[off_topk_val + kk] * inv_k);
+        workspace[off_topk_val + kk] = w;
+        output[kk] = f32_to_bf16_bits(w);
+        output_idx[kk] = f32::to_bits(workspace[off_topk_idx + kk]) as i32;
+    }
+
+    if params.stage == 1 {
+        return Ok(());
+    }
+
+    let shared_expert_gate_w =
+        unsafe { std::slice::from_raw_parts(weights.shared_expert_gate_w as *const u16, hidden) };
+
+    for row in 0..shared_intermediate {
+        let gate_acc = qwen36_dense_or_int4_dot_2d(
+            weights.shared_gate_proj_w,
+            int4.shared_gate_proj_scale,
+            int4.shared_gate_proj_zero,
+            row,
+            hidden,
+            int4.group_size,
+            &workspace[off_h_norm..off_h_norm + hidden],
+        )?;
+        let up_acc = qwen36_dense_or_int4_dot_2d(
+            weights.shared_up_proj_w,
+            int4.shared_up_proj_scale,
+            int4.shared_up_proj_zero,
+            row,
+            hidden,
+            int4.group_size,
+            &workspace[off_h_norm..off_h_norm + hidden],
+        )?;
+        workspace[off_sgp + row] = gate_acc;
+        workspace[off_sup + row] = up_acc;
+    }
+    let mut sg_acc = 0.0f32;
+    for col in 0..hidden {
+        sg_acc += bf16_bits_to_f32(shared_expert_gate_w[col]) * workspace[off_h_norm + col];
+    }
+    workspace[off_sg_scalar] = 1.0f32 / (1.0f32 + (-sg_acc).exp());
+
+    for i in 0..shared_intermediate {
+        let gp = workspace[off_sgp + i];
+        let up = workspace[off_sup + i];
+        let silu = gp * (1.0f32 / (1.0f32 + (-gp).exp()));
+        workspace[off_shared_mid + i] = silu * up;
+    }
+
+    let sg_scalar = workspace[off_sg_scalar];
+    for row in 0..hidden {
+        let acc = qwen36_dense_or_int4_dot_2d(
+            weights.shared_down_proj_w,
+            int4.shared_down_proj_scale,
+            int4.shared_down_proj_zero,
+            row,
+            shared_intermediate,
+            int4.group_size,
+            &workspace[off_shared_mid..off_shared_mid + shared_intermediate],
+        )?;
+        let val = bf16_round_f32(sg_scalar * acc);
+        workspace[off_shared_out + row] = val;
+        if params.stage == 2 {
+            output[row] = f32_to_bf16_bits(val);
+        }
+    }
+
+    if params.stage == 2 {
+        return Ok(());
+    }
+
+    let active_groups = if params.stage == 3 { 1 } else { top_k };
+    for group in 0..active_groups {
+        let expert = f32::to_bits(workspace[off_topk_idx + group]) as i32 as usize;
+        let gu_base = off_expert_gu + group * 2 * moe_intermediate;
+        for row in 0..(2 * moe_intermediate) {
+            let acc = qwen36_expert_dense_or_int4_dot(
+                weights.gate_up_proj_w,
+                int4.gate_up_proj_scale,
+                int4.gate_up_proj_zero,
+                expert,
+                row,
+                2 * moe_intermediate,
+                hidden,
+                int4.group_size,
+                &workspace[off_h_norm..off_h_norm + hidden],
+            )?;
+            workspace[gu_base + row] = acc;
+        }
+
+        let mid_base = off_expert_mid + group * moe_intermediate;
+        for i in 0..moe_intermediate {
+            let gp = workspace[gu_base + i];
+            let up = workspace[gu_base + moe_intermediate + i];
+            let silu = gp * (1.0f32 / (1.0f32 + (-gp).exp()));
+            workspace[mid_base + i] = silu * up;
+        }
+
+        let stack_base = off_expert_stack + group * hidden;
+        for row in 0..hidden {
+            let acc = qwen36_expert_dense_or_int4_dot(
+                weights.down_proj_w,
+                int4.down_proj_scale,
+                int4.down_proj_zero,
+                expert,
+                row,
+                hidden,
+                moe_intermediate,
+                int4.group_size,
+                &workspace[mid_base..mid_base + moe_intermediate],
+            )?;
+            workspace[stack_base + row] = acc;
+            if params.stage == 3 && group == 0 {
+                output[row] = f32_to_bf16_bits(bf16_round_f32(acc));
+            }
+        }
+    }
+
+    if params.stage == 3 {
+        return Ok(());
+    }
+
+    for row in 0..hidden {
+        let mut acc = 0.0f32;
+        for group in 0..top_k {
+            acc += workspace[off_topk_val + group]
+                * workspace[off_expert_stack + group * hidden + row];
+        }
+        let val = bf16_round_f32(acc);
+        workspace[off_moe_out + row] = val;
+        if params.stage == 4 {
+            output[row] = f32_to_bf16_bits(val);
+        }
+    }
+
+    if params.stage == 4 {
+        return Ok(());
+    }
+
+    for row in 0..hidden {
+        let val = bf16_round_f32(
+            bf16_bits_to_f32(input[row])
+                + workspace[off_moe_out + row]
+                + workspace[off_shared_out + row],
+        );
+        output[row] = f32_to_bf16_bits(val);
+    }
+
     Ok(())
 }
 
@@ -1793,6 +2920,19 @@ pub fn int4_dequant_smoke_launch(
     }
 
     let backend = packed_buf.backend();
+    if backend == Backend::Metal {
+        return int4_dequant_smoke_launch_metal_host(
+            packed_buf,
+            scale_buf,
+            zero_buf,
+            out_rows,
+            in_cols,
+            gsz,
+            dq_8_out,
+            dq_scalar_out,
+        );
+    }
+
     let status: c_int = match backend {
         Backend::Hip | Backend::Cuda => {
             #[cfg(any(supersonic_backend_hip, supersonic_backend_cuda))]
@@ -1816,11 +2956,7 @@ pub fn int4_dequant_smoke_launch(
                 ));
             }
         }
-        Backend::Metal => {
-            return Err(GpuError::InvalidArg(
-                "qwen36_moe::int4_dequant_smoke_launch: Metal backend not yet wired".into(),
-            ));
-        }
+        Backend::Metal => unreachable!("Metal int4_dequant_smoke handled above"),
     };
     if status != 0 {
         return Err(GpuError::backend(
@@ -1829,6 +2965,219 @@ pub fn int4_dequant_smoke_launch(
         ));
     }
     Ok(())
+}
+
+fn int4_dequant_smoke_launch_metal_host(
+    packed_buf: &GpuBuffer,
+    scale_buf: &GpuBuffer,
+    zero_buf: &GpuBuffer,
+    out_rows: i32,
+    in_cols: i32,
+    gsz: i32,
+    dq_8_out: &mut GpuBuffer,
+    dq_scalar_out: &mut GpuBuffer,
+) -> Result<(), GpuError> {
+    if packed_buf.dtype() != ScalarType::U8
+        || scale_buf.dtype() != ScalarType::BF16
+        || zero_buf.dtype() != ScalarType::BF16
+        || dq_8_out.dtype() != ScalarType::F32
+        || dq_scalar_out.dtype() != ScalarType::F32
+    {
+        return Err(GpuError::InvalidArg(format!(
+            "qwen36_moe::int4_dequant_smoke_launch: Metal fallback expects \
+             U8/BF16/BF16/F32/F32 buffers, got {:?}/{:?}/{:?}/{:?}/{:?}",
+            packed_buf.dtype(),
+            scale_buf.dtype(),
+            zero_buf.dtype(),
+            dq_8_out.dtype(),
+            dq_scalar_out.dtype(),
+        )));
+    }
+
+    let out_rows = out_rows as usize;
+    let in_cols = in_cols as usize;
+    let gsz = gsz as usize;
+    let total = out_rows * in_cols;
+    let byte_cols = in_cols / 2;
+    let scale_cols = in_cols / gsz;
+    let packed = unsafe {
+        std::slice::from_raw_parts(packed_buf.as_ptr() as *const u8, out_rows * byte_cols)
+    };
+    let scale = unsafe {
+        std::slice::from_raw_parts(
+            scale_buf.as_ptr() as *const u16,
+            (out_rows / gsz) * scale_cols,
+        )
+    };
+    let zero = unsafe {
+        std::slice::from_raw_parts(
+            zero_buf.as_ptr() as *const u16,
+            (out_rows / gsz) * scale_cols,
+        )
+    };
+    let dq_8 = unsafe { std::slice::from_raw_parts_mut(dq_8_out.as_mut_ptr() as *mut f32, total) };
+    let dq_scalar =
+        unsafe { std::slice::from_raw_parts_mut(dq_scalar_out.as_mut_ptr() as *mut f32, total) };
+
+    for row in 0..out_rows {
+        for col in 0..in_cols {
+            let scale_idx = (row / gsz) * scale_cols + col / gsz;
+            let s = f32::from_bits((scale[scale_idx] as u32) << 16);
+            let z = f32::from_bits((zero[scale_idx] as u32) << 16);
+            let byte = packed[row * byte_cols + col / 2];
+            let q = if col & 1 == 0 {
+                byte & 0x0F
+            } else {
+                (byte >> 4) & 0x0F
+            };
+            let v = bf16_round_f32(q as f32 * s - z * s);
+            let idx = row * in_cols + col;
+            dq_8[idx] = v;
+            dq_scalar[idx] = v;
+        }
+    }
+    Ok(())
+}
+
+fn bf16_round_f32(x: f32) -> f32 {
+    let bits = x.to_bits();
+    let rounding_bias = 0x7FFFu32 + ((bits >> 16) & 1);
+    let r = bits.wrapping_add(rounding_bias);
+    f32::from_bits(r & 0xFFFF_0000)
+}
+
+fn f32_to_bf16_bits(x: f32) -> u16 {
+    (bf16_round_f32(x).to_bits() >> 16) as u16
+}
+
+fn bf16_bits_to_f32(bits: u16) -> f32 {
+    f32::from_bits((bits as u32) << 16)
+}
+
+fn qwen36_int4_value_2d(
+    packed: &[u8],
+    scale: &[u16],
+    zero: &[u16],
+    row: usize,
+    col: usize,
+    cols: usize,
+    group_size: usize,
+) -> f32 {
+    let byte_cols = cols.div_ceil(2);
+    let byte = packed[row * byte_cols + col / 2];
+    let nibble = if col & 1 == 0 {
+        byte & 0x0f
+    } else {
+        (byte >> 4) & 0x0f
+    };
+    let scale_cols = cols.div_ceil(group_size);
+    let scale_idx = (row / group_size) * scale_cols + col / group_size;
+    let s = bf16_bits_to_f32(scale[scale_idx]);
+    let z = bf16_bits_to_f32(zero[scale_idx]);
+    bf16_round_f32(nibble as f32 * s - z * s)
+}
+
+fn qwen36_dense_or_int4_dot_2d(
+    weight: *const c_void,
+    scale: *const c_void,
+    zero: *const c_void,
+    row: usize,
+    cols: usize,
+    group_size: i32,
+    x: &[f32],
+) -> Result<f32, GpuError> {
+    if weight.is_null() {
+        return Err(GpuError::InvalidArg(
+            "qwen36_moe: Metal fallback received a null weight pointer".into(),
+        ));
+    }
+    if scale.is_null() && zero.is_null() {
+        let w = unsafe { std::slice::from_raw_parts(weight as *const u16, (row + 1) * cols) };
+        let row_base = row * cols;
+        let mut acc = 0.0f32;
+        for col in 0..cols {
+            acc += bf16_bits_to_f32(w[row_base + col]) * x[col];
+        }
+        return Ok(acc);
+    }
+    if scale.is_null() || zero.is_null() || group_size <= 0 {
+        return Err(GpuError::InvalidArg(
+            "qwen36_moe: Metal INT4 fallback requires paired scale/zero pointers and positive group_size"
+                .into(),
+        ));
+    }
+    let group_size = group_size as usize;
+    let packed_len = (row + 1) * cols.div_ceil(2);
+    let scale_len = (row / group_size + 1) * cols.div_ceil(group_size);
+    let packed = unsafe { std::slice::from_raw_parts(weight as *const u8, packed_len) };
+    let scale = unsafe { std::slice::from_raw_parts(scale as *const u16, scale_len) };
+    let zero = unsafe { std::slice::from_raw_parts(zero as *const u16, scale_len) };
+    let mut acc = 0.0f32;
+    for col in 0..cols {
+        acc += qwen36_int4_value_2d(packed, scale, zero, row, col, cols, group_size) * x[col];
+    }
+    Ok(acc)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn qwen36_expert_dense_or_int4_dot(
+    weight: *const c_void,
+    scale: *const c_void,
+    zero: *const c_void,
+    expert: usize,
+    row: usize,
+    rows: usize,
+    cols: usize,
+    group_size: i32,
+    x: &[f32],
+) -> Result<f32, GpuError> {
+    if weight.is_null() {
+        return Err(GpuError::InvalidArg(
+            "qwen36_moe: Metal expert fallback received a null weight pointer".into(),
+        ));
+    }
+    if scale.is_null() && zero.is_null() {
+        let len = (expert * rows + row + 1) * cols;
+        let w = unsafe { std::slice::from_raw_parts(weight as *const u16, len) };
+        let row_base = (expert * rows + row) * cols;
+        let mut acc = 0.0f32;
+        for col in 0..cols {
+            acc += bf16_bits_to_f32(w[row_base + col]) * x[col];
+        }
+        return Ok(acc);
+    }
+    if scale.is_null() || zero.is_null() || group_size <= 0 {
+        return Err(GpuError::InvalidArg(
+            "qwen36_moe: Metal expert INT4 fallback requires paired scale/zero pointers and positive group_size"
+                .into(),
+        ));
+    }
+    let group_size = group_size as usize;
+    let byte_cols = cols.div_ceil(2);
+    let scale_rows = rows.div_ceil(group_size);
+    let scale_cols = cols.div_ceil(group_size);
+    let packed_len = (expert * rows + row + 1) * byte_cols;
+    let scale_len = (expert * scale_rows + row / group_size + 1) * scale_cols;
+    let packed = unsafe { std::slice::from_raw_parts(weight as *const u8, packed_len) };
+    let scale = unsafe { std::slice::from_raw_parts(scale as *const u16, scale_len) };
+    let zero = unsafe { std::slice::from_raw_parts(zero as *const u16, scale_len) };
+    let packed_base = (expert * rows + row) * byte_cols;
+    let scale_base = (expert * scale_rows + row / group_size) * scale_cols;
+    let mut acc = 0.0f32;
+    for col in 0..cols {
+        let byte = packed[packed_base + col / 2];
+        let nibble = if col & 1 == 0 {
+            byte & 0x0f
+        } else {
+            (byte >> 4) & 0x0f
+        };
+        let scale_idx = scale_base + col / group_size;
+        let s = bf16_bits_to_f32(scale[scale_idx]);
+        let z = bf16_bits_to_f32(zero[scale_idx]);
+        let w = bf16_round_f32(nibble as f32 * s - z * s);
+        acc += w * x[col];
+    }
+    Ok(acc)
 }
 
 /// Safe wrapper for the GPU final RMSNorm + lm_head GEMV.
@@ -1865,6 +3214,21 @@ pub fn lm_head_launch(
              got hidden={hidden} vocab={vocab}"
         )));
     }
+    let backend = lm_head_w_buf.backend();
+    if backend == Backend::Metal {
+        let _ = counter_buf;
+        return lm_head_launch_metal_bf16(
+            ordinal,
+            hidden,
+            vocab,
+            rms_norm_eps,
+            final_hidden_buf,
+            final_norm_w_buf,
+            lm_head_w_buf,
+            logits_buf,
+            x_normed_out_buf,
+        );
+    }
     let block_size: i32 = 256;
     if hidden % block_size != 0 {
         return Err(GpuError::InvalidArg(format!(
@@ -1874,7 +3238,6 @@ pub fn lm_head_launch(
         )));
     }
 
-    let backend = lm_head_w_buf.backend();
     let x_normed_ptr = x_normed_out_buf
         .map(|b| b.as_mut_ptr())
         .unwrap_or(std::ptr::null_mut());
@@ -1904,9 +3267,7 @@ pub fn lm_head_launch(
             }
         }
         Backend::Metal => {
-            return Err(GpuError::InvalidArg(
-                "qwen36_moe::lm_head_launch: Metal backend not yet wired".into(),
-            ));
+            unreachable!("Metal handled above");
         }
     };
     if status != 0 {
@@ -1964,6 +3325,21 @@ pub fn lm_head_batched_launch(
             "qwen36_moe::lm_head_batched_launch: m must be ≥ 1, got {m}"
         )));
     }
+    let backend = lm_head_w_buf.backend();
+    if backend == Backend::Metal {
+        return lm_head_batched_launch_metal_bf16(
+            ordinal,
+            m,
+            hidden,
+            vocab,
+            rms_norm_eps,
+            final_hidden_buf,
+            final_norm_w_buf,
+            lm_head_w_buf,
+            logits_buf,
+            x_normed_out_buf,
+        );
+    }
     // M is bounded by min(16, LDS budget / row size). At hidden=2048 the
     // LDS per row is 4 KiB; with 128 B reduction scratch and a 64 KiB cap
     // the effective ceiling is 15 (not the API's 16). Compute the
@@ -1990,7 +3366,6 @@ pub fn lm_head_batched_launch(
         )));
     }
 
-    let backend = lm_head_w_buf.backend();
     let x_normed_ptr = x_normed_out_buf
         .map(|b| b.as_mut_ptr())
         .unwrap_or(std::ptr::null_mut());
@@ -2020,9 +3395,7 @@ pub fn lm_head_batched_launch(
             }
         }
         Backend::Metal => {
-            return Err(GpuError::InvalidArg(
-                "qwen36_moe::lm_head_batched_launch: Metal backend not yet wired".into(),
-            ));
+            unreachable!("Metal handled above");
         }
     };
     if status == 138 {
@@ -2042,6 +3415,96 @@ pub fn lm_head_batched_launch(
         ));
     }
     Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn lm_head_launch_metal_bf16(
+    ordinal: usize,
+    hidden: i32,
+    vocab: i32,
+    rms_norm_eps: f32,
+    final_hidden_buf: &GpuBuffer,
+    final_norm_w_buf: &GpuBuffer,
+    lm_head_w_buf: &GpuBuffer,
+    logits_buf: &mut GpuBuffer,
+    x_normed_out_buf: Option<&mut GpuBuffer>,
+) -> Result<(), GpuError> {
+    let hidden = hidden as usize;
+    let vocab = vocab as usize;
+    let mut owned_normed;
+    let normed = if let Some(buf) = x_normed_out_buf {
+        buf
+    } else {
+        owned_normed = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[1, hidden])?;
+        &mut owned_normed
+    };
+    crate::prefill_ffi::rms_norm_rows(
+        ordinal,
+        ScalarType::BF16,
+        1,
+        hidden,
+        rms_norm_eps,
+        final_hidden_buf,
+        final_norm_w_buf,
+        normed,
+    )?;
+    crate::prefill_ffi::matmul_rhs_transposed(
+        ordinal,
+        ScalarType::BF16,
+        1,
+        1,
+        vocab,
+        hidden,
+        normed,
+        lm_head_w_buf,
+        logits_buf,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn lm_head_batched_launch_metal_bf16(
+    ordinal: usize,
+    m: i32,
+    hidden: i32,
+    vocab: i32,
+    rms_norm_eps: f32,
+    final_hidden_buf: &GpuBuffer,
+    final_norm_w_buf: &GpuBuffer,
+    lm_head_w_buf: &GpuBuffer,
+    logits_buf: &mut GpuBuffer,
+    x_normed_out_buf: Option<&mut GpuBuffer>,
+) -> Result<(), GpuError> {
+    let m = m as usize;
+    let hidden = hidden as usize;
+    let vocab = vocab as usize;
+    let mut owned_normed;
+    let normed = if let Some(buf) = x_normed_out_buf {
+        buf
+    } else {
+        owned_normed = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[m, hidden])?;
+        &mut owned_normed
+    };
+    crate::prefill_ffi::rms_norm_rows(
+        ordinal,
+        ScalarType::BF16,
+        m,
+        hidden,
+        rms_norm_eps,
+        final_hidden_buf,
+        final_norm_w_buf,
+        normed,
+    )?;
+    crate::prefill_ffi::matmul_rhs_transposed(
+        ordinal,
+        ScalarType::BF16,
+        1,
+        m,
+        vocab,
+        hidden,
+        normed,
+        lm_head_w_buf,
+        logits_buf,
+    )
 }
 
 /// Safe wrapper for the GPU MTP pre-fusion kernel (Phase 6.2c.1).
@@ -2086,6 +3549,24 @@ pub fn mtp_pre_fusion_launch(
             "qwen36_moe::mtp_pre_fusion_launch: positive hidden required, got {hidden}"
         )));
     }
+
+    let backend = fc_w_buf.backend();
+    if backend == Backend::Metal {
+        return mtp_pre_fusion_launch_metal_bf16(
+            ordinal,
+            hidden,
+            rms_norm_eps,
+            e_in_buf,
+            h_base_buf,
+            pre_fc_norm_embedding_w_buf,
+            pre_fc_norm_hidden_w_buf,
+            fc_w_buf,
+            e_norm_out_buf,
+            h_norm_out_buf,
+            fused_out_buf,
+        );
+    }
+
     let block_size: i32 = 256;
     if hidden % block_size != 0 {
         return Err(GpuError::InvalidArg(format!(
@@ -2095,7 +3576,6 @@ pub fn mtp_pre_fusion_launch(
         )));
     }
 
-    let backend = fc_w_buf.backend();
     let status: c_int = match backend {
         Backend::Hip | Backend::Cuda => {
             #[cfg(any(supersonic_backend_hip, supersonic_backend_cuda))]
@@ -2122,11 +3602,7 @@ pub fn mtp_pre_fusion_launch(
                 ));
             }
         }
-        Backend::Metal => {
-            return Err(GpuError::InvalidArg(
-                "qwen36_moe::mtp_pre_fusion_launch: Metal backend not yet wired".into(),
-            ));
-        }
+        Backend::Metal => unreachable!("Metal mtp_pre_fusion handled above"),
     };
     if status != 0 {
         return Err(GpuError::backend(
@@ -2135,6 +3611,70 @@ pub fn mtp_pre_fusion_launch(
         ));
     }
     Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn mtp_pre_fusion_launch_metal_bf16(
+    ordinal: usize,
+    hidden: i32,
+    rms_norm_eps: f32,
+    e_in_buf: &GpuBuffer,
+    h_base_buf: &GpuBuffer,
+    pre_fc_norm_embedding_w_buf: &GpuBuffer,
+    pre_fc_norm_hidden_w_buf: &GpuBuffer,
+    fc_w_buf: &GpuBuffer,
+    e_norm_out_buf: &mut GpuBuffer,
+    h_norm_out_buf: &mut GpuBuffer,
+    fused_out_buf: &mut GpuBuffer,
+) -> Result<(), GpuError> {
+    let hidden = hidden as usize;
+    crate::prefill_ffi::rms_norm_rows(
+        ordinal,
+        ScalarType::BF16,
+        1,
+        hidden,
+        rms_norm_eps,
+        e_in_buf,
+        pre_fc_norm_embedding_w_buf,
+        e_norm_out_buf,
+    )?;
+    crate::prefill_ffi::rms_norm_rows(
+        ordinal,
+        ScalarType::BF16,
+        1,
+        hidden,
+        rms_norm_eps,
+        h_base_buf,
+        pre_fc_norm_hidden_w_buf,
+        h_norm_out_buf,
+    )?;
+
+    let mut concat = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[1, 2 * hidden])?;
+    let half_bytes = hidden * ScalarType::BF16.size_in_bytes();
+    gpu_hal::copy_d2d(
+        ordinal,
+        concat.as_mut_ptr(),
+        e_norm_out_buf.as_ptr(),
+        half_bytes,
+    )?;
+    gpu_hal::copy_d2d(
+        ordinal,
+        concat.offset_ptr(half_bytes) as *mut c_void,
+        h_norm_out_buf.as_ptr(),
+        half_bytes,
+    )?;
+
+    crate::prefill_ffi::matmul_rhs_transposed(
+        ordinal,
+        ScalarType::BF16,
+        1,
+        1,
+        hidden,
+        2 * hidden,
+        &concat,
+        fc_w_buf,
+        fused_out_buf,
+    )
 }
 
 /// Stage A (M3) batched-Q full-attention prefill safe wrapper.
@@ -2194,11 +3734,25 @@ pub fn batched_prefill_attn_full_launch(
             }
             #[cfg(not(any(supersonic_backend_hip, supersonic_backend_cuda)))]
             {
-                let _ = (ordinal, batch_size, q_heads, kv_heads, q_len, kv_len,
-                    head_dim, scale, seqlen_offset, query, key, value, out);
+                let _ = (
+                    ordinal,
+                    batch_size,
+                    q_heads,
+                    kv_heads,
+                    q_len,
+                    kv_len,
+                    head_dim,
+                    scale,
+                    seqlen_offset,
+                    query,
+                    key,
+                    value,
+                    out,
+                );
                 return Err(GpuError::backend(
                     backend,
-                    "qwen36_moe::batched_prefill_attn_full_launch: backend not compiled".to_string(),
+                    "qwen36_moe::batched_prefill_attn_full_launch: backend not compiled"
+                        .to_string(),
                 ));
             }
         }
@@ -2290,9 +3844,7 @@ pub fn batched_prefill_router_permute_launch(
     if status != 0 {
         return Err(GpuError::backend(
             backend,
-            format!(
-                "qwen36_moe batched_prefill_router_permute_launch failed with status {status}"
-            ),
+            format!("qwen36_moe batched_prefill_router_permute_launch failed with status {status}"),
         ));
     }
     Ok(())
@@ -2409,12 +3961,18 @@ pub fn batched_prefill_grouped_expert_launch(
     if status != 0 {
         return Err(GpuError::backend(
             backend,
-            format!(
-                "qwen36_moe batched_prefill_grouped_expert_launch failed with status {status}"
-            ),
+            format!("qwen36_moe batched_prefill_grouped_expert_launch failed with status {status}"),
         ));
     }
-    let _ = (ordinal, n_tokens, top_k, num_experts, hidden, moe_intermediate, group_size);
+    let _ = (
+        ordinal,
+        n_tokens,
+        top_k,
+        num_experts,
+        hidden,
+        moe_intermediate,
+        group_size,
+    );
     Ok(())
 }
 
@@ -2654,6 +4212,2407 @@ mod tests {
         assert!(d.kv_cache_k.is_null());
         assert!(d.linear_recurrent_state.is_null());
         assert!(d.experts_gate_up_w.is_null());
+    }
+
+    #[cfg(all(target_os = "macos", supersonic_backend_metal))]
+    fn bf16_bytes(values: &[f32]) -> Vec<u8> {
+        values
+            .iter()
+            .flat_map(|value| half::bf16::from_f32(*value).to_bits().to_le_bytes())
+            .collect()
+    }
+
+    #[cfg(all(target_os = "macos", supersonic_backend_metal))]
+    fn read_bf16(buffer: &GpuBuffer) -> Vec<f32> {
+        let bytes = buffer.to_host_bytes().expect("download bf16");
+        bytes
+            .chunks_exact(2)
+            .map(|chunk| half::bf16::from_bits(u16::from_le_bytes([chunk[0], chunk[1]])).to_f32())
+            .collect()
+    }
+
+    #[cfg(all(target_os = "macos", supersonic_backend_metal))]
+    fn upload_bf16(ordinal: usize, shape: &[usize], values: &[f32]) -> GpuBuffer {
+        GpuBuffer::from_host_bytes(ordinal, ScalarType::BF16, shape, &bf16_bytes(values))
+            .expect("upload bf16")
+    }
+
+    #[cfg(all(target_os = "macos", supersonic_backend_metal))]
+    fn upload_int4_rows(
+        ordinal: usize,
+        rows: usize,
+        cols: usize,
+        group_size: usize,
+        nibbles: &[Vec<u8>],
+        scale_value: f32,
+    ) -> (GpuBuffer, GpuBuffer, GpuBuffer) {
+        let mut packed = Vec::with_capacity(rows * cols.div_ceil(2));
+        for row in nibbles {
+            for pair in row.chunks(2) {
+                let lo = pair[0] & 0x0f;
+                let hi = pair.get(1).copied().unwrap_or(0) & 0x0f;
+                packed.push(lo | (hi << 4));
+            }
+        }
+        let weights =
+            GpuBuffer::from_host_bytes(ordinal, ScalarType::U8, &[rows, cols.div_ceil(2)], &packed)
+                .expect("upload qwen36 int4 rows");
+        let sidecar_len = rows.div_ceil(group_size) * cols.div_ceil(group_size);
+        let scale = upload_bf16(ordinal, &[sidecar_len], &vec![scale_value; sidecar_len]);
+        let zero = upload_bf16(ordinal, &[sidecar_len], &vec![0.0; sidecar_len]);
+        (weights, scale, zero)
+    }
+
+    #[cfg(all(target_os = "macos", supersonic_backend_metal))]
+    fn f32_bytes(values: &[f32]) -> Vec<u8> {
+        values
+            .iter()
+            .flat_map(|value| value.to_le_bytes())
+            .collect()
+    }
+
+    #[cfg(all(target_os = "macos", supersonic_backend_metal))]
+    fn upload_f32(ordinal: usize, shape: &[usize], values: &[f32]) -> GpuBuffer {
+        GpuBuffer::from_host_bytes(ordinal, ScalarType::F32, shape, &f32_bytes(values))
+            .expect("upload f32")
+    }
+
+    #[cfg(all(target_os = "macos", supersonic_backend_metal))]
+    fn read_f32(buffer: &GpuBuffer) -> Vec<f32> {
+        let bytes = buffer.to_host_bytes().expect("download f32");
+        bytes
+            .chunks_exact(4)
+            .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
+            .collect()
+    }
+
+    #[cfg(all(target_os = "macos", supersonic_backend_metal))]
+    fn qwen36_lm_head_reference(
+        hidden_rows: &[f32],
+        norm_w: &[f32],
+        lm_head: &[f32],
+        rows: usize,
+        hidden: usize,
+        vocab: usize,
+        eps: f32,
+    ) -> (Vec<f32>, Vec<f32>) {
+        let mut normed = vec![0.0f32; rows * hidden];
+        let mut logits = vec![0.0f32; rows * vocab];
+        for row in 0..rows {
+            let hidden_base = row * hidden;
+            let mean_sq = hidden_rows[hidden_base..hidden_base + hidden]
+                .iter()
+                .map(|v| v * v)
+                .sum::<f32>()
+                / hidden as f32;
+            let inv = 1.0 / (mean_sq + eps).sqrt();
+            for col in 0..hidden {
+                normed[hidden_base + col] = half::bf16::from_f32(
+                    hidden_rows[hidden_base + col] * inv * (1.0 + norm_w[col]),
+                )
+                .to_f32();
+            }
+            for tok in 0..vocab {
+                let mut acc = 0.0f32;
+                for col in 0..hidden {
+                    acc += normed[hidden_base + col] * lm_head[tok * hidden + col];
+                }
+                logits[row * vocab + tok] = half::bf16::from_f32(acc).to_f32();
+            }
+        }
+        (normed, logits)
+    }
+
+    #[cfg(all(target_os = "macos", supersonic_backend_metal))]
+    fn bf16_round(value: f32) -> f32 {
+        half::bf16::from_f32(value).to_f32()
+    }
+
+    #[cfg(all(target_os = "macos", supersonic_backend_metal))]
+    fn qwen36_mtp_pre_fusion_reference(
+        e_in: &[f32],
+        h_base: &[f32],
+        e_norm_w: &[f32],
+        h_norm_w: &[f32],
+        fc_w: &[f32],
+        hidden: usize,
+        eps: f32,
+    ) -> (Vec<f32>, Vec<f32>, Vec<f32>) {
+        fn norm(input: &[f32], weight: &[f32], hidden: usize, eps: f32) -> Vec<f32> {
+            let input_bf16: Vec<f32> = input.iter().copied().map(bf16_round).collect();
+            let weight_bf16: Vec<f32> = weight.iter().copied().map(bf16_round).collect();
+            let mean_sq = input_bf16.iter().map(|v| v * v).sum::<f32>() / hidden as f32;
+            let inv = 1.0 / (mean_sq + eps).sqrt();
+            (0..hidden)
+                .map(|idx| bf16_round(input_bf16[idx] * inv * (1.0 + weight_bf16[idx])))
+                .collect()
+        }
+
+        let e_norm = norm(e_in, e_norm_w, hidden, eps);
+        let h_norm = norm(h_base, h_norm_w, hidden, eps);
+        let mut cat = Vec::with_capacity(2 * hidden);
+        cat.extend_from_slice(&e_norm);
+        cat.extend_from_slice(&h_norm);
+        let fc_w_bf16: Vec<f32> = fc_w.iter().copied().map(bf16_round).collect();
+        let mut fused = vec![0.0f32; hidden];
+        for row in 0..hidden {
+            let mut acc = 0.0f32;
+            for col in 0..(2 * hidden) {
+                acc += cat[col] * fc_w_bf16[row * 2 * hidden + col];
+            }
+            fused[row] = bf16_round(acc);
+        }
+        (e_norm, h_norm, fused)
+    }
+
+    #[cfg(all(target_os = "macos", supersonic_backend_metal))]
+    fn qwen36_ffn_stage1_reference(
+        input_hidden: &[f32],
+        norm_w: &[f32],
+        gate_w: &[f32],
+        hidden: usize,
+        num_experts: usize,
+        top_k: usize,
+        eps: f32,
+    ) -> (Vec<f32>, Vec<i32>) {
+        let input_bf16: Vec<f32> = input_hidden.iter().copied().map(bf16_round).collect();
+        let norm_w_bf16: Vec<f32> = norm_w.iter().copied().map(bf16_round).collect();
+        let gate_w_bf16: Vec<f32> = gate_w.iter().copied().map(bf16_round).collect();
+        let mean_sq = input_bf16.iter().map(|v| v * v).sum::<f32>() / hidden as f32;
+        let inv = 1.0 / (mean_sq + eps).sqrt();
+        let h_norm: Vec<f32> = (0..hidden)
+            .map(|idx| bf16_round(input_bf16[idx] * inv * (1.0 + norm_w_bf16[idx])))
+            .collect();
+        let mut logits = vec![0.0f32; num_experts];
+        for expert in 0..num_experts {
+            let mut acc = 0.0f32;
+            for col in 0..hidden {
+                acc += gate_w_bf16[expert * hidden + col] * h_norm[col];
+            }
+            logits[expert] = bf16_round(acc);
+        }
+        let row_max = logits.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+        let exps: Vec<f32> = logits.iter().map(|v| (v - row_max).exp()).collect();
+        let sum = exps.iter().sum::<f32>();
+        let mut probs: Vec<f32> = exps.iter().map(|v| bf16_round(v / sum)).collect();
+        let mut idx = vec![0i32; top_k];
+        let mut weights = vec![0.0f32; top_k];
+        for k in 0..top_k {
+            let mut best_idx = -1i32;
+            let mut best_val = f32::NEG_INFINITY;
+            for (expert, &value) in probs.iter().enumerate() {
+                if value > best_val
+                    || (value == best_val && best_idx >= 0 && (expert as i32) < best_idx)
+                {
+                    best_val = value;
+                    best_idx = expert as i32;
+                }
+            }
+            idx[k] = best_idx;
+            weights[k] = best_val;
+            probs[best_idx as usize] = f32::NEG_INFINITY;
+        }
+        let sum_k = weights.iter().sum::<f32>();
+        for weight in weights.iter_mut() {
+            *weight = bf16_round(*weight / sum_k);
+        }
+        (weights, idx)
+    }
+
+    #[cfg(all(target_os = "macos", supersonic_backend_metal))]
+    fn qwen36_ffn_stage1_5_reference(
+        stage: usize,
+        input_hidden: &[f32],
+        norm_w: &[f32],
+        gate_w: &[f32],
+        gate_up_proj_w: &[f32],
+        down_proj_w: &[f32],
+        shared_gate_proj_w: &[f32],
+        shared_up_proj_w: &[f32],
+        shared_down_proj_w: &[f32],
+        shared_expert_gate_w: &[f32],
+        hidden: usize,
+        num_experts: usize,
+        moe_intermediate: usize,
+        shared_intermediate: usize,
+        top_k: usize,
+        eps: f32,
+    ) -> (Vec<f32>, Vec<i32>) {
+        let input_bf16: Vec<f32> = input_hidden.iter().copied().map(bf16_round).collect();
+        let norm_w_bf16: Vec<f32> = norm_w.iter().copied().map(bf16_round).collect();
+        let gate_w_bf16: Vec<f32> = gate_w.iter().copied().map(bf16_round).collect();
+        let gu_w_bf16: Vec<f32> = gate_up_proj_w.iter().copied().map(bf16_round).collect();
+        let down_w_bf16: Vec<f32> = down_proj_w.iter().copied().map(bf16_round).collect();
+        let sgp_w_bf16: Vec<f32> = shared_gate_proj_w.iter().copied().map(bf16_round).collect();
+        let sup_w_bf16: Vec<f32> = shared_up_proj_w.iter().copied().map(bf16_round).collect();
+        let sd_w_bf16: Vec<f32> = shared_down_proj_w.iter().copied().map(bf16_round).collect();
+        let seg_w_bf16: Vec<f32> = shared_expert_gate_w
+            .iter()
+            .copied()
+            .map(bf16_round)
+            .collect();
+
+        let mean_sq = input_bf16.iter().map(|v| v * v).sum::<f32>() / hidden as f32;
+        let inv = 1.0 / (mean_sq + eps).sqrt();
+        let h_norm: Vec<f32> = (0..hidden)
+            .map(|idx| bf16_round(input_bf16[idx] * inv * (1.0 + norm_w_bf16[idx])))
+            .collect();
+
+        let mut logits = vec![0.0f32; num_experts];
+        for expert in 0..num_experts {
+            let mut acc = 0.0f32;
+            for col in 0..hidden {
+                acc += gate_w_bf16[expert * hidden + col] * h_norm[col];
+            }
+            logits[expert] = bf16_round(acc);
+        }
+        let row_max = logits.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+        let exps: Vec<f32> = logits.iter().map(|v| (v - row_max).exp()).collect();
+        let sum = exps.iter().sum::<f32>();
+        let mut probs: Vec<f32> = exps.iter().map(|v| bf16_round(v / sum)).collect();
+        let mut idx = vec![0i32; top_k];
+        let mut topk_w = vec![0.0f32; top_k];
+        for k in 0..top_k {
+            let mut best_idx = -1i32;
+            let mut best_val = f32::NEG_INFINITY;
+            for (expert, &value) in probs.iter().enumerate() {
+                if value > best_val
+                    || (value == best_val && best_idx >= 0 && (expert as i32) < best_idx)
+                {
+                    best_val = value;
+                    best_idx = expert as i32;
+                }
+            }
+            idx[k] = best_idx;
+            topk_w[k] = best_val;
+            probs[best_idx as usize] = f32::NEG_INFINITY;
+        }
+        let sum_k = topk_w.iter().sum::<f32>();
+        for weight in topk_w.iter_mut() {
+            *weight = bf16_round(*weight / sum_k);
+        }
+        if stage == 1 {
+            return (topk_w, idx);
+        }
+
+        let mut sgp = vec![0.0f32; shared_intermediate];
+        let mut sup = vec![0.0f32; shared_intermediate];
+        for row in 0..shared_intermediate {
+            for col in 0..hidden {
+                sgp[row] += sgp_w_bf16[row * hidden + col] * h_norm[col];
+                sup[row] += sup_w_bf16[row * hidden + col] * h_norm[col];
+            }
+        }
+        let mut sg_scalar = 0.0f32;
+        for col in 0..hidden {
+            sg_scalar += seg_w_bf16[col] * h_norm[col];
+        }
+        sg_scalar = 1.0 / (1.0 + (-sg_scalar).exp());
+        let mut shared_mid = vec![0.0f32; shared_intermediate];
+        for i in 0..shared_intermediate {
+            shared_mid[i] = sgp[i] * (1.0 / (1.0 + (-sgp[i]).exp())) * sup[i];
+        }
+        let mut shared_out = vec![0.0f32; hidden];
+        for row in 0..hidden {
+            let mut acc = 0.0f32;
+            for col in 0..shared_intermediate {
+                acc += sd_w_bf16[row * shared_intermediate + col] * shared_mid[col];
+            }
+            shared_out[row] = bf16_round(sg_scalar * acc);
+        }
+        if stage == 2 {
+            return (shared_out, idx);
+        }
+
+        let active = if stage == 3 { 1 } else { top_k };
+        let mut expert_stack = vec![0.0f32; top_k * hidden];
+        for group in 0..active {
+            let expert = idx[group] as usize;
+            let mut gu = vec![0.0f32; 2 * moe_intermediate];
+            let gu_base = expert * 2 * moe_intermediate * hidden;
+            for row in 0..2 * moe_intermediate {
+                for col in 0..hidden {
+                    gu[row] += gu_w_bf16[gu_base + row * hidden + col] * h_norm[col];
+                }
+            }
+            let mut mid = vec![0.0f32; moe_intermediate];
+            for i in 0..moe_intermediate {
+                mid[i] = gu[i] * (1.0 / (1.0 + (-gu[i]).exp())) * gu[moe_intermediate + i];
+            }
+            let down_base = expert * hidden * moe_intermediate;
+            for row in 0..hidden {
+                let mut acc = 0.0f32;
+                for col in 0..moe_intermediate {
+                    acc += down_w_bf16[down_base + row * moe_intermediate + col] * mid[col];
+                }
+                expert_stack[group * hidden + row] = acc;
+            }
+        }
+        if stage == 3 {
+            return (
+                expert_stack[..hidden]
+                    .iter()
+                    .copied()
+                    .map(bf16_round)
+                    .collect(),
+                idx,
+            );
+        }
+
+        let mut moe_out = vec![0.0f32; hidden];
+        for row in 0..hidden {
+            let mut acc = 0.0f32;
+            for group in 0..top_k {
+                acc += topk_w[group] * expert_stack[group * hidden + row];
+            }
+            moe_out[row] = bf16_round(acc);
+        }
+        if stage == 4 {
+            return (moe_out, idx);
+        }
+
+        let mut out = vec![0.0f32; hidden];
+        for row in 0..hidden {
+            out[row] = bf16_round(input_bf16[row] + moe_out[row] + shared_out[row]);
+        }
+        (out, idx)
+    }
+
+    #[cfg(all(target_os = "macos", supersonic_backend_metal))]
+    fn qwen36_attn_stage1_reference(
+        input_hidden: &[f32],
+        input_norm_w: &[f32],
+        q_proj_w: &[f32],
+        q_norm_w: &[f32],
+        hidden: usize,
+        num_heads: usize,
+        head_dim: usize,
+        eps: f32,
+    ) -> Vec<f32> {
+        let input_bf16: Vec<f32> = input_hidden.iter().copied().map(bf16_round).collect();
+        let norm_w_bf16: Vec<f32> = input_norm_w.iter().copied().map(bf16_round).collect();
+        let q_proj_w_bf16: Vec<f32> = q_proj_w.iter().copied().map(bf16_round).collect();
+        let q_norm_w_bf16: Vec<f32> = q_norm_w.iter().copied().map(bf16_round).collect();
+        let mean_sq = input_bf16.iter().map(|v| v * v).sum::<f32>() / hidden as f32;
+        let inv = 1.0 / (mean_sq + eps).sqrt();
+        let x_norm: Vec<f32> = (0..hidden)
+            .map(|idx| bf16_round(input_bf16[idx] * inv * (1.0 + norm_w_bf16[idx])))
+            .collect();
+        let q_out_dim = 2 * num_heads * head_dim;
+        let mut q_raw = vec![0.0f32; q_out_dim];
+        for row in 0..q_out_dim {
+            let mut acc = 0.0f32;
+            for col in 0..hidden {
+                acc += q_proj_w_bf16[row * hidden + col] * x_norm[col];
+            }
+            q_raw[row] = bf16_round(acc);
+        }
+        let mut q_normed = vec![0.0f32; num_heads * head_dim];
+        for head in 0..num_heads {
+            let q_in_base = head * 2 * head_dim;
+            let q_out_base = head * head_dim;
+            let mean_sq = (0..head_dim)
+                .map(|i| q_raw[q_in_base + i].powi(2))
+                .sum::<f32>()
+                / head_dim as f32;
+            let inv = 1.0 / (mean_sq + eps).sqrt();
+            for i in 0..head_dim {
+                q_normed[q_out_base + i] =
+                    bf16_round(q_raw[q_in_base + i] * inv * (1.0 + q_norm_w_bf16[i]));
+            }
+        }
+        q_normed
+    }
+
+    #[cfg(all(target_os = "macos", supersonic_backend_metal))]
+    fn qwen36_attn_stage1_5_reference(
+        stage: usize,
+        input_hidden: &[f32],
+        input_norm_w: &[f32],
+        q_proj_w: &[f32],
+        k_proj_w: &[f32],
+        v_proj_w: &[f32],
+        q_norm_w: &[f32],
+        k_norm_w: &[f32],
+        o_proj_w: &[f32],
+        hidden: usize,
+        num_heads: usize,
+        num_kv_heads: usize,
+        head_dim: usize,
+        rotary_dim: usize,
+        rope_theta: f32,
+        position: i32,
+        eps: f32,
+    ) -> Vec<f32> {
+        let input_bf16: Vec<f32> = input_hidden.iter().copied().map(bf16_round).collect();
+        let norm_w_bf16: Vec<f32> = input_norm_w.iter().copied().map(bf16_round).collect();
+        let q_proj_w_bf16: Vec<f32> = q_proj_w.iter().copied().map(bf16_round).collect();
+        let k_proj_w_bf16: Vec<f32> = k_proj_w.iter().copied().map(bf16_round).collect();
+        let v_proj_w_bf16: Vec<f32> = v_proj_w.iter().copied().map(bf16_round).collect();
+        let q_norm_w_bf16: Vec<f32> = q_norm_w.iter().copied().map(bf16_round).collect();
+        let k_norm_w_bf16: Vec<f32> = k_norm_w.iter().copied().map(bf16_round).collect();
+        let o_proj_w_bf16: Vec<f32> = o_proj_w.iter().copied().map(bf16_round).collect();
+
+        let mean_sq = input_bf16.iter().map(|v| v * v).sum::<f32>() / hidden as f32;
+        let inv = 1.0 / (mean_sq + eps).sqrt();
+        let x_norm: Vec<f32> = (0..hidden)
+            .map(|idx| bf16_round(input_bf16[idx] * inv * (1.0 + norm_w_bf16[idx])))
+            .collect();
+
+        let q_out_dim = 2 * num_heads * head_dim;
+        let kv_dim = num_kv_heads * head_dim;
+        let mut q_raw = vec![0.0f32; q_out_dim];
+        for row in 0..q_out_dim {
+            let mut acc = 0.0f32;
+            for col in 0..hidden {
+                acc += q_proj_w_bf16[row * hidden + col] * x_norm[col];
+            }
+            q_raw[row] = bf16_round(acc);
+        }
+        let mut q_normed = vec![0.0f32; num_heads * head_dim];
+        for head in 0..num_heads {
+            let q_in_base = head * 2 * head_dim;
+            let q_out_base = head * head_dim;
+            let mean_sq = (0..head_dim)
+                .map(|i| q_raw[q_in_base + i].powi(2))
+                .sum::<f32>()
+                / head_dim as f32;
+            let inv = 1.0 / (mean_sq + eps).sqrt();
+            for i in 0..head_dim {
+                q_normed[q_out_base + i] =
+                    bf16_round(q_raw[q_in_base + i] * inv * (1.0 + q_norm_w_bf16[i]));
+            }
+        }
+        if stage == 1 {
+            return q_normed;
+        }
+
+        let mut k_raw = vec![0.0f32; kv_dim];
+        let mut v_raw = vec![0.0f32; kv_dim];
+        for row in 0..kv_dim {
+            let mut k_acc = 0.0f32;
+            let mut v_acc = 0.0f32;
+            for col in 0..hidden {
+                k_acc += k_proj_w_bf16[row * hidden + col] * x_norm[col];
+                v_acc += v_proj_w_bf16[row * hidden + col] * x_norm[col];
+            }
+            k_raw[row] = bf16_round(k_acc);
+            v_raw[row] = bf16_round(v_acc);
+        }
+        let mut k_normed = vec![0.0f32; kv_dim];
+        for head in 0..num_kv_heads {
+            let base = head * head_dim;
+            let mean_sq =
+                (0..head_dim).map(|i| k_raw[base + i].powi(2)).sum::<f32>() / head_dim as f32;
+            let inv = 1.0 / (mean_sq + eps).sqrt();
+            for i in 0..head_dim {
+                k_normed[base + i] = bf16_round(k_raw[base + i] * inv * (1.0 + k_norm_w_bf16[i]));
+            }
+        }
+        if stage == 2 {
+            return k_normed;
+        }
+
+        fn rope(
+            input: &[f32],
+            num_heads: usize,
+            head_dim: usize,
+            rotary_dim: usize,
+            rope_theta: f32,
+            position: i32,
+        ) -> Vec<f32> {
+            let mut out = input.to_vec();
+            let half = rotary_dim / 2;
+            let theta_log = rope_theta.ln();
+            for head in 0..num_heads {
+                let base = head * head_dim;
+                for i in 0..half {
+                    let a = input[base + i];
+                    let b = input[base + half + i];
+                    let freq = position as f32 * (-((i as f32 / half as f32) * theta_log)).exp();
+                    let c = bf16_round(freq.cos());
+                    let s = bf16_round(freq.sin());
+                    out[base + i] = bf16_round(bf16_round(a * c) - bf16_round(b * s));
+                    out[base + half + i] = bf16_round(bf16_round(b * c) + bf16_round(a * s));
+                }
+            }
+            out
+        }
+
+        let q_rot = rope(
+            &q_normed, num_heads, head_dim, rotary_dim, rope_theta, position,
+        );
+        let k_rot = rope(
+            &k_normed,
+            num_kv_heads,
+            head_dim,
+            rotary_dim,
+            rope_theta,
+            position,
+        );
+        if stage == 3 {
+            let mut out = q_rot;
+            out.extend_from_slice(&k_rot);
+            return out;
+        }
+
+        let rep = num_heads / num_kv_heads;
+        let mut attn = vec![0.0f32; num_heads * head_dim];
+        for hq in 0..num_heads {
+            let h_kv = hq / rep;
+            for i in 0..head_dim {
+                attn[hq * head_dim + i] = v_raw[h_kv * head_dim + i];
+            }
+        }
+        if stage == 4 {
+            return attn;
+        }
+
+        let mut gated = vec![0.0f32; num_heads * head_dim];
+        for h in 0..num_heads {
+            for i in 0..head_dim {
+                let out_gate = q_raw[h * 2 * head_dim + head_dim + i];
+                let sig = bf16_round(1.0 / (1.0 + (-out_gate).exp()));
+                gated[h * head_dim + i] = bf16_round(sig * attn[h * head_dim + i]);
+            }
+        }
+        let qd = num_heads * head_dim;
+        let mut out = vec![0.0f32; hidden];
+        for row in 0..hidden {
+            let mut acc = 0.0f32;
+            for col in 0..qd {
+                acc += o_proj_w_bf16[row * qd + col] * gated[col];
+            }
+            out[row] = bf16_round(input_bf16[row] + bf16_round(acc));
+        }
+        out
+    }
+
+    #[cfg(all(target_os = "macos", supersonic_backend_metal))]
+    fn qwen36_linear_stage1_reference(
+        input_hidden: &[f32],
+        input_norm_w: &[f32],
+        in_proj_qkv_w: &[f32],
+        hidden: usize,
+        qkv_dim: usize,
+        eps: f32,
+    ) -> Vec<f32> {
+        let input_bf16: Vec<f32> = input_hidden.iter().copied().map(bf16_round).collect();
+        let norm_w_bf16: Vec<f32> = input_norm_w.iter().copied().map(bf16_round).collect();
+        let qkv_w_bf16: Vec<f32> = in_proj_qkv_w.iter().copied().map(bf16_round).collect();
+        let mean_sq = input_bf16.iter().map(|v| v * v).sum::<f32>() / hidden as f32;
+        let inv = 1.0 / (mean_sq + eps).sqrt();
+        let x_norm: Vec<f32> = (0..hidden)
+            .map(|idx| bf16_round(input_bf16[idx] * inv * (1.0 + norm_w_bf16[idx])))
+            .collect();
+        let mut qkv_raw = vec![0.0f32; qkv_dim];
+        for row in 0..qkv_dim {
+            let mut acc = 0.0f32;
+            for col in 0..hidden {
+                acc += qkv_w_bf16[row * hidden + col] * x_norm[col];
+            }
+            qkv_raw[row] = bf16_round(acc);
+        }
+        qkv_raw
+    }
+
+    #[cfg(all(target_os = "macos", supersonic_backend_metal))]
+    fn qwen36_linear_stage2_reference(
+        qkv_raw: &[f32],
+        conv_state: &[f32],
+        conv1d_w: &[f32],
+        conv1d_bias: Option<&[f32]>,
+        qkv_dim: usize,
+        kernel: usize,
+    ) -> (Vec<f32>, Vec<f32>) {
+        let qkv_bf16: Vec<f32> = qkv_raw.iter().copied().map(bf16_round).collect();
+        let state_bf16: Vec<f32> = conv_state.iter().copied().map(bf16_round).collect();
+        let weight_bf16: Vec<f32> = conv1d_w.iter().copied().map(bf16_round).collect();
+        let bias_bf16 = conv1d_bias.map(|b| b.iter().copied().map(bf16_round).collect::<Vec<_>>());
+        let kstate = kernel - 1;
+        let mut silu_out = vec![0.0f32; qkv_dim];
+        let mut next_state = state_bf16.clone();
+        for ch in 0..qkv_dim {
+            let mut acc = 0.0f32;
+            for t in 0..kstate {
+                acc += state_bf16[ch * kstate + t] * weight_bf16[ch * kernel + t];
+            }
+            acc += qkv_bf16[ch] * weight_bf16[ch * kernel + kstate];
+            if let Some(bias) = bias_bf16.as_ref() {
+                acc += bias[ch];
+            }
+            let conv_out = bf16_round(acc);
+            silu_out[ch] = bf16_round(conv_out * (1.0 / (1.0 + (-conv_out).exp())));
+            for t in 0..kstate.saturating_sub(1) {
+                next_state[ch * kstate + t] = state_bf16[ch * kstate + t + 1];
+            }
+            if kstate > 0 {
+                next_state[ch * kstate + (kstate - 1)] = qkv_bf16[ch];
+            }
+        }
+        (silu_out, next_state)
+    }
+
+    #[cfg(all(target_os = "macos", supersonic_backend_metal))]
+    fn qwen36_linear_stage3_reference(
+        silu_out: &[f32],
+        num_k_heads: usize,
+        num_v_heads: usize,
+        head_k_dim: usize,
+        head_v_dim: usize,
+    ) -> Vec<f32> {
+        let key_dim = num_k_heads * head_k_dim;
+        let val_dim = num_v_heads * head_v_dim;
+        let mut q_normed = vec![0.0f32; key_dim];
+        let mut k_normed = vec![0.0f32; key_dim];
+        for head in 0..num_k_heads {
+            let q_base = head * head_k_dim;
+            let k_base = key_dim + head * head_k_dim;
+            let q_ss = (0..head_k_dim)
+                .map(|i| silu_out[q_base + i] * silu_out[q_base + i])
+                .sum::<f32>();
+            let k_ss = (0..head_k_dim)
+                .map(|i| silu_out[k_base + i] * silu_out[k_base + i])
+                .sum::<f32>();
+            let q_denom = bf16_round(bf16_round(q_ss.sqrt()).max(1e-6));
+            let k_denom = bf16_round(bf16_round(k_ss.sqrt()).max(1e-6));
+            for i in 0..head_k_dim {
+                q_normed[q_base + i] = bf16_round(silu_out[q_base + i] / q_denom);
+                k_normed[head * head_k_dim + i] = bf16_round(silu_out[k_base + i] / k_denom);
+            }
+        }
+
+        let mut out = vec![0.0f32; 2 * num_v_heads * head_k_dim + val_dim];
+        let rep = num_v_heads / num_k_heads;
+        let q_scale = 1.0f32 / (head_k_dim as f32).sqrt();
+        for vhead in 0..num_v_heads {
+            let src_kh = vhead / rep;
+            for i in 0..head_k_dim {
+                out[vhead * head_k_dim + i] =
+                    bf16_round(q_normed[src_kh * head_k_dim + i] * q_scale);
+                out[num_v_heads * head_k_dim + vhead * head_k_dim + i] =
+                    k_normed[src_kh * head_k_dim + i];
+            }
+            let v_src = 2 * key_dim + vhead * head_v_dim;
+            let v_dst = 2 * num_v_heads * head_k_dim + vhead * head_v_dim;
+            for i in 0..head_v_dim {
+                out[v_dst + i] = silu_out[v_src + i];
+            }
+        }
+        out
+    }
+
+    #[cfg(all(target_os = "macos", supersonic_backend_metal))]
+    fn qwen36_linear_stage4_reference(
+        stage3_out: &[f32],
+        a_raw: &[f32],
+        b_raw: &[f32],
+        dt_bias: &[f32],
+        a_log: &[f32],
+        recurrent_state: &[f32],
+        num_v_heads: usize,
+        head_k_dim: usize,
+        head_v_dim: usize,
+    ) -> (Vec<f32>, Vec<f32>) {
+        let val_dim = num_v_heads * head_v_dim;
+        let q_scaled = &stage3_out[..num_v_heads * head_k_dim];
+        let k_rep = &stage3_out[num_v_heads * head_k_dim..2 * num_v_heads * head_k_dim];
+        let v_heads =
+            &stage3_out[2 * num_v_heads * head_k_dim..2 * num_v_heads * head_k_dim + val_dim];
+        let a_bf16: Vec<f32> = a_raw.iter().copied().map(bf16_round).collect();
+        let b_bf16: Vec<f32> = b_raw.iter().copied().map(bf16_round).collect();
+        let dt_bf16: Vec<f32> = dt_bias.iter().copied().map(bf16_round).collect();
+        let alog_bf16: Vec<f32> = a_log.iter().copied().map(bf16_round).collect();
+        let mut state = recurrent_state.to_vec();
+        let mut rec_out = vec![0.0f32; val_dim];
+
+        for head in 0..num_v_heads {
+            let beta = 1.0 / (1.0 + (-b_bf16[head]).exp());
+            let softplus = (1.0 + (a_bf16[head] + dt_bf16[head]).exp()).ln();
+            let gstep = (-softplus * alog_bf16[head].exp()).exp();
+            let state_off = head * head_k_dim * head_v_dim;
+            let q_off = head * head_k_dim;
+            let v_off = head * head_v_dim;
+
+            for e in 0..head_k_dim * head_v_dim {
+                state[state_off + e] *= gstep;
+            }
+            let mut kv_mem = vec![0.0f32; head_v_dim];
+            for j in 0..head_v_dim {
+                for i in 0..head_k_dim {
+                    kv_mem[j] += state[state_off + i * head_v_dim + j] * k_rep[q_off + i];
+                }
+            }
+            let mut delta = vec![0.0f32; head_v_dim];
+            for j in 0..head_v_dim {
+                delta[j] = (v_heads[v_off + j] - kv_mem[j]) * beta;
+            }
+            for i in 0..head_k_dim {
+                for j in 0..head_v_dim {
+                    state[state_off + i * head_v_dim + j] += k_rep[q_off + i] * delta[j];
+                }
+            }
+            for j in 0..head_v_dim {
+                let mut acc = 0.0f32;
+                for i in 0..head_k_dim {
+                    acc += state[state_off + i * head_v_dim + j] * q_scaled[q_off + i];
+                }
+                rec_out[v_off + j] = bf16_round(acc);
+            }
+        }
+
+        (rec_out, state)
+    }
+
+    #[cfg(all(target_os = "macos", supersonic_backend_metal))]
+    fn qwen36_linear_stage5_reference(
+        input_hidden: &[f32],
+        rec_out: &[f32],
+        z_raw: &[f32],
+        norm_w: &[f32],
+        out_proj_w: &[f32],
+        hidden: usize,
+        num_v_heads: usize,
+        head_v_dim: usize,
+        eps: f32,
+    ) -> Vec<f32> {
+        let val_dim = num_v_heads * head_v_dim;
+        let rec_bf16: Vec<f32> = rec_out.iter().copied().map(bf16_round).collect();
+        let z_bf16: Vec<f32> = z_raw.iter().copied().map(bf16_round).collect();
+        let norm_w_bf16: Vec<f32> = norm_w.iter().copied().map(bf16_round).collect();
+        let out_w_bf16: Vec<f32> = out_proj_w.iter().copied().map(bf16_round).collect();
+        let input_bf16: Vec<f32> = input_hidden.iter().copied().map(bf16_round).collect();
+        let mut gated = vec![0.0f32; val_dim];
+        for head in 0..num_v_heads {
+            let rec_off = head * head_v_dim;
+            let mean_sq = (0..head_v_dim)
+                .map(|j| rec_bf16[rec_off + j] * rec_bf16[rec_off + j])
+                .sum::<f32>()
+                / head_v_dim as f32;
+            let inv = 1.0 / (mean_sq + eps).sqrt();
+            for j in 0..head_v_dim {
+                let on = bf16_round(rec_bf16[rec_off + j] * inv * norm_w_bf16[j]);
+                let z = z_bf16[rec_off + j];
+                let z_silu = bf16_round(z * (1.0 / (1.0 + (-z).exp())));
+                gated[rec_off + j] = bf16_round(on * z_silu);
+            }
+        }
+        let mut out = vec![0.0f32; hidden];
+        for row in 0..hidden {
+            let mut acc = 0.0f32;
+            for col in 0..val_dim {
+                acc += out_w_bf16[row * val_dim + col] * gated[col];
+            }
+            out[row] = bf16_round(input_bf16[row] + bf16_round(acc));
+        }
+        out
+    }
+
+    #[cfg(all(target_os = "macos", supersonic_backend_metal))]
+    #[test]
+    fn metal_lm_head_fallback_runs_and_captures_normed() {
+        use gpu_hal::{set_backend, Backend};
+
+        set_backend(Backend::Metal);
+        let ordinal = 0usize;
+        let hidden = 4usize;
+        let vocab = 4usize;
+        let eps = 0.0f32;
+        let hidden_vals = [1.0, 0.5, -1.0, 2.0];
+        let norm_vals = [0.0, 0.25, -0.5, 1.0];
+        let lm_vals = [
+            1.0, 0.0, 0.0, 0.0, //
+            0.0, 1.0, 0.0, 0.0, //
+            0.0, 0.0, 1.0, 0.0, //
+            0.0, 0.0, 0.0, 1.0, //
+        ];
+        let hidden_buf = upload_bf16(ordinal, &[hidden], &hidden_vals);
+        let norm_buf = upload_bf16(ordinal, &[hidden], &norm_vals);
+        let lm_buf = upload_bf16(ordinal, &[vocab, hidden], &lm_vals);
+        let mut logits = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[vocab])
+            .expect("alloc qwen36 metal logits");
+        let mut normed = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[hidden])
+            .expect("alloc qwen36 metal normed");
+        let mut counter = GpuBuffer::zeros(ordinal, ScalarType::U32, &[1]).expect("alloc counter");
+
+        lm_head_launch(
+            ordinal,
+            hidden as i32,
+            vocab as i32,
+            eps,
+            &hidden_buf,
+            &norm_buf,
+            &lm_buf,
+            &mut logits,
+            Some(&mut normed),
+            &mut counter,
+        )
+        .expect("run Qwen3.6-MoE Metal lm_head fallback");
+
+        let (expected_normed, expected_logits) =
+            qwen36_lm_head_reference(&hidden_vals, &norm_vals, &lm_vals, 1, hidden, vocab, eps);
+        for (idx, (a, e)) in read_bf16(&normed)
+            .iter()
+            .zip(expected_normed.iter())
+            .enumerate()
+        {
+            assert!(
+                (a - e).abs() <= 0.01,
+                "normed idx {idx}: expected {e}, got {a}"
+            );
+        }
+        for (idx, (a, e)) in read_bf16(&logits)
+            .iter()
+            .zip(expected_logits.iter())
+            .enumerate()
+        {
+            assert!(
+                (a - e).abs() <= 0.01,
+                "logit idx {idx}: expected {e}, got {a}"
+            );
+        }
+    }
+
+    #[cfg(all(target_os = "macos", supersonic_backend_metal))]
+    #[test]
+    fn metal_lm_head_batched_fallback_matches_rows() {
+        use gpu_hal::{set_backend, Backend};
+
+        set_backend(Backend::Metal);
+        let ordinal = 0usize;
+        let rows = 2usize;
+        let hidden = 4usize;
+        let vocab = 3usize;
+        let eps = 1e-5f32;
+        let hidden_vals = [1.0, 0.5, -1.0, 2.0, -0.25, 0.75, 1.5, -2.0];
+        let norm_vals = [0.0, 0.25, -0.5, 1.0];
+        let lm_vals = [
+            1.0, 0.0, 0.0, 0.0, //
+            0.0, 1.0, 0.0, 0.0, //
+            0.25, -0.5, 0.75, 1.0, //
+        ];
+        let hidden_buf = upload_bf16(ordinal, &[rows, hidden], &hidden_vals);
+        let norm_buf = upload_bf16(ordinal, &[hidden], &norm_vals);
+        let lm_buf = upload_bf16(ordinal, &[vocab, hidden], &lm_vals);
+        let mut logits = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[rows, vocab])
+            .expect("alloc qwen36 metal batched logits");
+        let mut normed = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[rows, hidden])
+            .expect("alloc qwen36 metal batched normed");
+
+        lm_head_batched_launch(
+            ordinal,
+            rows as i32,
+            hidden as i32,
+            vocab as i32,
+            eps,
+            &hidden_buf,
+            &norm_buf,
+            &lm_buf,
+            &mut logits,
+            Some(&mut normed),
+        )
+        .expect("run Qwen3.6-MoE Metal batched lm_head fallback");
+
+        let (expected_normed, expected_logits) =
+            qwen36_lm_head_reference(&hidden_vals, &norm_vals, &lm_vals, rows, hidden, vocab, eps);
+        for (idx, (a, e)) in read_bf16(&normed)
+            .iter()
+            .zip(expected_normed.iter())
+            .enumerate()
+        {
+            assert!(
+                (a - e).abs() <= 0.01,
+                "normed idx {idx}: expected {e}, got {a}"
+            );
+        }
+        for (idx, (a, e)) in read_bf16(&logits)
+            .iter()
+            .zip(expected_logits.iter())
+            .enumerate()
+        {
+            assert!(
+                (a - e).abs() <= 0.02,
+                "logit idx {idx}: expected {e}, got {a}"
+            );
+        }
+    }
+
+    #[cfg(all(target_os = "macos", supersonic_backend_metal))]
+    #[test]
+    fn metal_mtp_pre_fusion_fallback_matches_reference() {
+        use gpu_hal::{set_backend, Backend};
+
+        set_backend(Backend::Metal);
+        let ordinal = 0usize;
+        let hidden = 4usize;
+        let eps = 1e-5f32;
+        let e_in_vals = [1.0, 0.5, -1.0, 2.0];
+        let h_base_vals = [-0.25, 0.75, 1.5, -2.0];
+        let e_norm_w_vals = [0.0, 0.25, -0.5, 1.0];
+        let h_norm_w_vals = [0.5, -0.25, 0.0, 0.75];
+        let fc_w_vals = [
+            1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, //
+            0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, //
+            0.25, -0.5, 0.0, 0.0, 0.0, 0.0, 0.75, 1.0, //
+            0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, //
+        ];
+        let e_in = upload_bf16(ordinal, &[hidden], &e_in_vals);
+        let h_base = upload_bf16(ordinal, &[hidden], &h_base_vals);
+        let e_norm_w = upload_bf16(ordinal, &[hidden], &e_norm_w_vals);
+        let h_norm_w = upload_bf16(ordinal, &[hidden], &h_norm_w_vals);
+        let fc_w = upload_bf16(ordinal, &[hidden, 2 * hidden], &fc_w_vals);
+        let mut e_norm = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[hidden])
+            .expect("alloc qwen36 metal mtp e_norm");
+        let mut h_norm = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[hidden])
+            .expect("alloc qwen36 metal mtp h_norm");
+        let mut fused = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[hidden])
+            .expect("alloc qwen36 metal mtp fused");
+
+        mtp_pre_fusion_launch(
+            ordinal,
+            hidden as i32,
+            eps,
+            &e_in,
+            &h_base,
+            &e_norm_w,
+            &h_norm_w,
+            &fc_w,
+            &mut e_norm,
+            &mut h_norm,
+            &mut fused,
+        )
+        .expect("run Qwen3.6-MoE Metal MTP pre-fusion fallback");
+
+        let (expected_e_norm, expected_h_norm, expected_fused) = qwen36_mtp_pre_fusion_reference(
+            &e_in_vals,
+            &h_base_vals,
+            &e_norm_w_vals,
+            &h_norm_w_vals,
+            &fc_w_vals,
+            hidden,
+            eps,
+        );
+        for (idx, (a, e)) in read_bf16(&e_norm)
+            .iter()
+            .zip(expected_e_norm.iter())
+            .enumerate()
+        {
+            assert!(
+                (a - e).abs() <= 0.01,
+                "e_norm idx {idx}: expected {e}, got {a}"
+            );
+        }
+        for (idx, (a, e)) in read_bf16(&h_norm)
+            .iter()
+            .zip(expected_h_norm.iter())
+            .enumerate()
+        {
+            assert!(
+                (a - e).abs() <= 0.01,
+                "h_norm idx {idx}: expected {e}, got {a}"
+            );
+        }
+        for (idx, (a, e)) in read_bf16(&fused)
+            .iter()
+            .zip(expected_fused.iter())
+            .enumerate()
+        {
+            assert!(
+                (a - e).abs() <= 0.02,
+                "fused idx {idx}: expected {e}, got {a}"
+            );
+        }
+    }
+
+    #[cfg(all(target_os = "macos", supersonic_backend_metal))]
+    #[test]
+    fn metal_ffn_stage1_fallback_matches_reference() {
+        use gpu_hal::{set_backend, Backend};
+
+        set_backend(Backend::Metal);
+        let ordinal = 0usize;
+        let hidden = 4usize;
+        let num_experts = 4usize;
+        let top_k = 2usize;
+        let eps = 1e-5f32;
+        let input_vals = [1.0, 0.5, -1.0, 2.0];
+        let norm_vals = [0.0, 0.25, -0.5, 1.0];
+        let gate_vals = [
+            1.0, 0.0, 0.0, 0.0, //
+            0.0, 1.0, 0.0, 0.0, //
+            0.25, -0.5, 0.75, 1.0, //
+            -0.5, 0.25, 0.5, -0.25, //
+        ];
+        let input_hidden = upload_bf16(ordinal, &[hidden], &input_vals);
+        let norm_w = upload_bf16(ordinal, &[hidden], &norm_vals);
+        let gate_w = upload_bf16(ordinal, &[num_experts, hidden], &gate_vals);
+        let mut output = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[hidden])
+            .expect("alloc qwen36 metal ffn output");
+        let mut output_idx = GpuBuffer::zeros(ordinal, ScalarType::U32, &[top_k])
+            .expect("alloc qwen36 metal ffn output_idx");
+        let workspace_len = hidden + 2 * num_experts + 2 * top_k;
+        let mut workspace = GpuBuffer::zeros(ordinal, ScalarType::F32, &[workspace_len])
+            .expect("alloc qwen36 metal ffn workspace");
+        let mut sync_buf =
+            GpuBuffer::zeros(ordinal, ScalarType::U8, &[96]).expect("alloc sync buf");
+
+        let params = Qwen36MoeFfnStepParams {
+            stage: 1,
+            hidden: hidden as i32,
+            num_experts: num_experts as i32,
+            moe_intermediate: 4,
+            shared_intermediate: 4,
+            top_k: top_k as i32,
+            rms_norm_eps: eps,
+        };
+        let weights = Qwen36MoeFfnStepWeights {
+            input_hidden: input_hidden.as_ptr(),
+            post_attn_norm_w: norm_w.as_ptr(),
+            gate_w: gate_w.as_ptr(),
+            gate_up_proj_w: std::ptr::null(),
+            down_proj_w: std::ptr::null(),
+            shared_gate_proj_w: std::ptr::null(),
+            shared_up_proj_w: std::ptr::null(),
+            shared_down_proj_w: std::ptr::null(),
+            shared_expert_gate_w: std::ptr::null(),
+        };
+
+        ffn_step_launch(
+            ordinal,
+            ScalarType::BF16,
+            params,
+            &weights,
+            &Qwen36MoeFfnStepInt4::disabled(),
+            &mut output,
+            &mut output_idx,
+            &mut workspace,
+            &mut sync_buf,
+        )
+        .expect("run Qwen3.6-MoE Metal FFN stage1 fallback");
+
+        let (expected_weights, expected_idx) = qwen36_ffn_stage1_reference(
+            &input_vals,
+            &norm_vals,
+            &gate_vals,
+            hidden,
+            num_experts,
+            top_k,
+            eps,
+        );
+        let got_idx_bytes = output_idx.to_host_bytes().expect("download output_idx");
+        let got_idx: Vec<i32> = got_idx_bytes
+            .chunks_exact(4)
+            .map(|chunk| i32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
+            .collect();
+        assert_eq!(got_idx, expected_idx);
+        for (idx, (a, e)) in read_bf16(&output)[..top_k]
+            .iter()
+            .zip(expected_weights.iter())
+            .enumerate()
+        {
+            assert!(
+                (a - e).abs() <= 0.01,
+                "topk weight idx {idx}: expected {e}, got {a}"
+            );
+        }
+    }
+
+    #[cfg(all(target_os = "macos", supersonic_backend_metal))]
+    #[test]
+    fn metal_ffn_stage2_5_fallbacks_match_reference() {
+        use gpu_hal::{set_backend, Backend};
+
+        set_backend(Backend::Metal);
+        let ordinal = 0usize;
+        let hidden = 4usize;
+        let num_experts = 4usize;
+        let moe_intermediate = 3usize;
+        let shared_intermediate = 3usize;
+        let top_k = 2usize;
+        let eps = 1e-5f32;
+        let input_vals = [1.0, 0.5, -1.0, 2.0];
+        let norm_vals = [0.0, 0.25, -0.5, 1.0];
+        let gate_vals = [
+            1.0, 0.0, 0.0, 0.0, //
+            0.0, 1.0, 0.0, 0.0, //
+            0.25, -0.5, 0.75, 1.0, //
+            -0.5, 0.25, 0.5, -0.25, //
+        ];
+        let shared_gate_vals = [
+            0.25, -0.5, 0.75, 0.125, //
+            -0.25, 0.5, -0.75, 1.0, //
+            0.5, 0.25, -0.25, 0.75, //
+        ];
+        let shared_up_vals = [
+            -0.5, 0.25, 1.0, -0.25, //
+            0.75, -0.75, 0.5, 0.125, //
+            0.25, 0.5, -0.5, 1.0, //
+        ];
+        let shared_down_vals = [
+            0.5, -0.25, 0.75, //
+            -0.5, 0.25, 1.0, //
+            0.125, -0.75, 0.5, //
+            0.75, 0.5, -0.25, //
+        ];
+        let shared_gate_scalar_vals = [0.25, -0.5, 0.75, 1.0];
+        let mut gate_up_vals = vec![0.0f32; num_experts * 2 * moe_intermediate * hidden];
+        for (idx, v) in gate_up_vals.iter_mut().enumerate() {
+            *v = ((idx % 11) as f32 - 5.0) * 0.125;
+        }
+        let mut down_vals = vec![0.0f32; num_experts * hidden * moe_intermediate];
+        for (idx, v) in down_vals.iter_mut().enumerate() {
+            *v = ((idx % 13) as f32 - 6.0) * 0.1;
+        }
+
+        let input_hidden = upload_bf16(ordinal, &[hidden], &input_vals);
+        let norm_w = upload_bf16(ordinal, &[hidden], &norm_vals);
+        let gate_w = upload_bf16(ordinal, &[num_experts, hidden], &gate_vals);
+        let gate_up_proj_w = upload_bf16(
+            ordinal,
+            &[num_experts, 2 * moe_intermediate, hidden],
+            &gate_up_vals,
+        );
+        let down_proj_w = upload_bf16(
+            ordinal,
+            &[num_experts, hidden, moe_intermediate],
+            &down_vals,
+        );
+        let shared_gate_proj_w =
+            upload_bf16(ordinal, &[shared_intermediate, hidden], &shared_gate_vals);
+        let shared_up_proj_w =
+            upload_bf16(ordinal, &[shared_intermediate, hidden], &shared_up_vals);
+        let shared_down_proj_w =
+            upload_bf16(ordinal, &[hidden, shared_intermediate], &shared_down_vals);
+        let shared_expert_gate_w = upload_bf16(ordinal, &[1, hidden], &shared_gate_scalar_vals);
+
+        let weights = Qwen36MoeFfnStepWeights {
+            input_hidden: input_hidden.as_ptr(),
+            post_attn_norm_w: norm_w.as_ptr(),
+            gate_w: gate_w.as_ptr(),
+            gate_up_proj_w: gate_up_proj_w.as_ptr(),
+            down_proj_w: down_proj_w.as_ptr(),
+            shared_gate_proj_w: shared_gate_proj_w.as_ptr(),
+            shared_up_proj_w: shared_up_proj_w.as_ptr(),
+            shared_down_proj_w: shared_down_proj_w.as_ptr(),
+            shared_expert_gate_w: shared_expert_gate_w.as_ptr(),
+        };
+
+        for stage in 2..=5 {
+            let mut output = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[hidden])
+                .expect("alloc qwen36 metal ffn output");
+            let mut output_idx = GpuBuffer::zeros(ordinal, ScalarType::U32, &[top_k])
+                .expect("alloc qwen36 metal ffn output_idx");
+            let workspace_len = 3 * hidden
+                + 2 * num_experts
+                + 2 * top_k
+                + 1
+                + 3 * shared_intermediate
+                + top_k * 3 * moe_intermediate
+                + top_k * hidden;
+            let mut workspace = GpuBuffer::zeros(ordinal, ScalarType::F32, &[workspace_len])
+                .expect("alloc qwen36 metal ffn workspace");
+            let mut sync_buf =
+                GpuBuffer::zeros(ordinal, ScalarType::U8, &[96]).expect("alloc sync buf");
+
+            let params = Qwen36MoeFfnStepParams {
+                stage,
+                hidden: hidden as i32,
+                num_experts: num_experts as i32,
+                moe_intermediate: moe_intermediate as i32,
+                shared_intermediate: shared_intermediate as i32,
+                top_k: top_k as i32,
+                rms_norm_eps: eps,
+            };
+            ffn_step_launch(
+                ordinal,
+                ScalarType::BF16,
+                params,
+                &weights,
+                &Qwen36MoeFfnStepInt4::disabled(),
+                &mut output,
+                &mut output_idx,
+                &mut workspace,
+                &mut sync_buf,
+            )
+            .expect("run Qwen3.6-MoE Metal FFN fallback");
+
+            let (expected, expected_idx) = qwen36_ffn_stage1_5_reference(
+                stage as usize,
+                &input_vals,
+                &norm_vals,
+                &gate_vals,
+                &gate_up_vals,
+                &down_vals,
+                &shared_gate_vals,
+                &shared_up_vals,
+                &shared_down_vals,
+                &shared_gate_scalar_vals,
+                hidden,
+                num_experts,
+                moe_intermediate,
+                shared_intermediate,
+                top_k,
+                eps,
+            );
+            let got_idx_bytes = output_idx.to_host_bytes().expect("download output_idx");
+            let got_idx: Vec<i32> = got_idx_bytes
+                .chunks_exact(4)
+                .map(|chunk| i32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
+                .collect();
+            assert_eq!(got_idx, expected_idx, "stage {stage} topk idx mismatch");
+            for (idx, (a, e)) in read_bf16(&output).iter().zip(expected.iter()).enumerate() {
+                assert!(
+                    (a - e).abs() <= 0.02,
+                    "stage {stage} output idx {idx}: expected {e}, got {a}"
+                );
+            }
+        }
+    }
+
+    #[cfg(all(target_os = "macos", supersonic_backend_metal))]
+    #[test]
+    fn metal_attn_stage1_fallback_matches_reference() {
+        use gpu_hal::{set_backend, Backend};
+
+        set_backend(Backend::Metal);
+        let ordinal = 0usize;
+        let hidden = 4usize;
+        let num_heads = 2usize;
+        let num_kv_heads = 1usize;
+        let head_dim = 2usize;
+        let eps = 1e-5f32;
+        let input_vals = [1.0, 0.5, -1.0, 2.0];
+        let norm_vals = [0.0, 0.25, -0.5, 1.0];
+        let q_norm_vals = [0.0, 0.5];
+        let q_proj_vals = [
+            1.0, 0.0, 0.0, 0.0, //
+            0.0, 1.0, 0.0, 0.0, //
+            0.25, -0.5, 0.75, 1.0, //
+            -0.5, 0.25, 0.5, -0.25, //
+            0.0, 0.0, 1.0, 0.0, //
+            0.0, 0.0, 0.0, 1.0, //
+            0.5, 0.5, -0.25, 0.25, //
+            -0.25, 0.75, 0.25, -0.5, //
+        ];
+        let input_hidden = upload_bf16(ordinal, &[hidden], &input_vals);
+        let input_norm_w = upload_bf16(ordinal, &[hidden], &norm_vals);
+        let q_proj_w = upload_bf16(ordinal, &[2 * num_heads * head_dim, hidden], &q_proj_vals);
+        let q_norm_w = upload_bf16(ordinal, &[head_dim], &q_norm_vals);
+        let mut output = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[num_heads * head_dim])
+            .expect("alloc qwen36 metal attn output");
+        let workspace_len =
+            2 * num_heads * head_dim + 2 * num_kv_heads * head_dim + num_heads * head_dim;
+        let mut workspace = GpuBuffer::zeros(ordinal, ScalarType::F32, &[workspace_len])
+            .expect("alloc qwen36 metal attn workspace");
+        let mut sync_buf =
+            GpuBuffer::zeros(ordinal, ScalarType::U8, &[96]).expect("alloc sync buf");
+
+        let params = Qwen36MoeAttnStepParams {
+            stage: 1,
+            hidden: hidden as i32,
+            num_heads: num_heads as i32,
+            num_kv_heads: num_kv_heads as i32,
+            head_dim: head_dim as i32,
+            rotary_dim: head_dim as i32,
+            rope_theta: 1_000_000.0,
+            rms_norm_eps: eps,
+            position: 0,
+            cache_pos: Qwen36MoeAttnStepParams::CACHE_POS_INHERIT,
+        };
+        let weights = Qwen36MoeAttnStepWeights {
+            input_hidden: input_hidden.as_ptr(),
+            input_norm_w: input_norm_w.as_ptr(),
+            q_proj_w: q_proj_w.as_ptr(),
+            k_proj_w: std::ptr::null(),
+            v_proj_w: std::ptr::null(),
+            q_norm_w: q_norm_w.as_ptr(),
+            k_norm_w: std::ptr::null(),
+            o_proj_w: std::ptr::null(),
+            kv_cache_k: std::ptr::null_mut(),
+            kv_cache_v: std::ptr::null_mut(),
+            kv_max_t: 0,
+        };
+
+        attn_step_launch(
+            ordinal,
+            ScalarType::BF16,
+            params,
+            &weights,
+            &Qwen36MoeAttnStepInt4::disabled(),
+            &mut output,
+            &mut workspace,
+            &mut sync_buf,
+        )
+        .expect("run Qwen3.6-MoE Metal attention stage1 fallback");
+
+        let expected = qwen36_attn_stage1_reference(
+            &input_vals,
+            &norm_vals,
+            &q_proj_vals,
+            &q_norm_vals,
+            hidden,
+            num_heads,
+            head_dim,
+            eps,
+        );
+        for (idx, (a, e)) in read_bf16(&output).iter().zip(expected.iter()).enumerate() {
+            assert!(
+                (a - e).abs() <= 0.01,
+                "q_normed idx {idx}: expected {e}, got {a}"
+            );
+        }
+    }
+
+    #[cfg(all(target_os = "macos", supersonic_backend_metal))]
+    #[test]
+    fn metal_attn_stage1_int4_sidecar_matches_reference() {
+        use gpu_hal::{set_backend, Backend};
+
+        set_backend(Backend::Metal);
+        let ordinal = 0usize;
+        let hidden = 4usize;
+        let num_heads = 2usize;
+        let num_kv_heads = 1usize;
+        let head_dim = 2usize;
+        let group_size = 2usize;
+        let eps = 1e-5f32;
+        let input_vals = [1.0, 0.5, -1.0, 2.0];
+        let norm_vals = [0.0, 0.25, -0.5, 1.0];
+        let q_norm_vals = [0.0, 0.5];
+        let nibbles = vec![
+            vec![4, 0, 0, 0],
+            vec![0, 4, 0, 0],
+            vec![1, 2, 0, 0],
+            vec![0, 0, 2, 1],
+            vec![0, 0, 4, 0],
+            vec![0, 0, 0, 4],
+            vec![2, 0, 1, 0],
+            vec![0, 1, 0, 2],
+        ];
+        let q_proj_vals = nibbles
+            .iter()
+            .flat_map(|row| row.iter().map(|v| *v as f32 * 0.25))
+            .collect::<Vec<_>>();
+
+        let input_hidden = upload_bf16(ordinal, &[hidden], &input_vals);
+        let input_norm_w = upload_bf16(ordinal, &[hidden], &norm_vals);
+        let (q_proj_w, q_proj_scale, q_proj_zero) = upload_int4_rows(
+            ordinal,
+            2 * num_heads * head_dim,
+            hidden,
+            group_size,
+            &nibbles,
+            0.25,
+        );
+        let q_norm_w = upload_bf16(ordinal, &[head_dim], &q_norm_vals);
+        let mut output = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[num_heads * head_dim])
+            .expect("alloc qwen36 metal attn int4 output");
+        let workspace_len =
+            2 * num_heads * head_dim + 2 * num_kv_heads * head_dim + num_heads * head_dim;
+        let mut workspace = GpuBuffer::zeros(ordinal, ScalarType::F32, &[workspace_len])
+            .expect("alloc qwen36 metal attn int4 workspace");
+        let mut sync_buf =
+            GpuBuffer::zeros(ordinal, ScalarType::U8, &[96]).expect("alloc sync buf");
+
+        let params = Qwen36MoeAttnStepParams {
+            stage: 1,
+            hidden: hidden as i32,
+            num_heads: num_heads as i32,
+            num_kv_heads: num_kv_heads as i32,
+            head_dim: head_dim as i32,
+            rotary_dim: head_dim as i32,
+            rope_theta: 1_000_000.0,
+            rms_norm_eps: eps,
+            position: 0,
+            cache_pos: Qwen36MoeAttnStepParams::CACHE_POS_INHERIT,
+        };
+        let weights = Qwen36MoeAttnStepWeights {
+            input_hidden: input_hidden.as_ptr(),
+            input_norm_w: input_norm_w.as_ptr(),
+            q_proj_w: q_proj_w.as_ptr(),
+            k_proj_w: std::ptr::null(),
+            v_proj_w: std::ptr::null(),
+            q_norm_w: q_norm_w.as_ptr(),
+            k_norm_w: std::ptr::null(),
+            o_proj_w: std::ptr::null(),
+            kv_cache_k: std::ptr::null_mut(),
+            kv_cache_v: std::ptr::null_mut(),
+            kv_max_t: 0,
+        };
+        let int4 = Qwen36MoeAttnStepInt4 {
+            q_proj_scale: q_proj_scale.as_ptr(),
+            q_proj_zero: q_proj_zero.as_ptr(),
+            k_proj_scale: std::ptr::null(),
+            k_proj_zero: std::ptr::null(),
+            v_proj_scale: std::ptr::null(),
+            v_proj_zero: std::ptr::null(),
+            o_proj_scale: std::ptr::null(),
+            o_proj_zero: std::ptr::null(),
+            group_size: group_size as i32,
+        };
+
+        attn_step_launch(
+            ordinal,
+            ScalarType::BF16,
+            params,
+            &weights,
+            &int4,
+            &mut output,
+            &mut workspace,
+            &mut sync_buf,
+        )
+        .expect("run Qwen3.6-MoE Metal attention stage1 INT4 fallback");
+
+        let expected = qwen36_attn_stage1_reference(
+            &input_vals,
+            &norm_vals,
+            &q_proj_vals,
+            &q_norm_vals,
+            hidden,
+            num_heads,
+            head_dim,
+            eps,
+        );
+        for (idx, (a, e)) in read_bf16(&output).iter().zip(expected.iter()).enumerate() {
+            assert!(
+                (a - e).abs() <= 0.01,
+                "int4 q_normed idx {idx}: expected {e}, got {a}"
+            );
+        }
+    }
+
+    #[cfg(all(target_os = "macos", supersonic_backend_metal))]
+    #[test]
+    fn metal_attn_stage2_5_fallbacks_match_reference() {
+        use gpu_hal::{set_backend, Backend};
+
+        set_backend(Backend::Metal);
+        let ordinal = 0usize;
+        let hidden = 4usize;
+        let num_heads = 2usize;
+        let num_kv_heads = 1usize;
+        let head_dim = 2usize;
+        let eps = 1e-5f32;
+        let input_vals = [1.0, 0.5, -1.0, 2.0];
+        let norm_vals = [0.0, 0.25, -0.5, 1.0];
+        let q_norm_vals = [0.0, 0.5];
+        let k_norm_vals = [0.25, -0.25];
+        let q_proj_vals = [
+            1.0, 0.0, 0.0, 0.0, //
+            0.0, 1.0, 0.0, 0.0, //
+            0.25, -0.5, 0.75, 1.0, //
+            -0.5, 0.25, 0.5, -0.25, //
+            0.0, 0.0, 1.0, 0.0, //
+            0.0, 0.0, 0.0, 1.0, //
+            0.5, 0.5, -0.25, 0.25, //
+            -0.25, 0.75, 0.25, -0.5, //
+        ];
+        let k_proj_vals = [
+            0.5, -0.25, 1.0, 0.25, //
+            -0.75, 0.5, 0.25, -0.5, //
+        ];
+        let v_proj_vals = [
+            0.25, 0.75, -0.5, 0.5, //
+            -0.5, 0.25, 0.75, 1.0, //
+        ];
+        let o_proj_vals = [
+            0.25, -0.5, 0.75, 1.0, //
+            -0.25, 0.5, -0.75, 0.125, //
+            0.5, 0.25, 0.25, -0.5, //
+            -1.0, 0.75, 0.5, 0.25, //
+        ];
+        let input_hidden = upload_bf16(ordinal, &[hidden], &input_vals);
+        let input_norm_w = upload_bf16(ordinal, &[hidden], &norm_vals);
+        let q_proj_w = upload_bf16(ordinal, &[2 * num_heads * head_dim, hidden], &q_proj_vals);
+        let k_proj_w = upload_bf16(ordinal, &[num_kv_heads * head_dim, hidden], &k_proj_vals);
+        let v_proj_w = upload_bf16(ordinal, &[num_kv_heads * head_dim, hidden], &v_proj_vals);
+        let q_norm_w = upload_bf16(ordinal, &[head_dim], &q_norm_vals);
+        let k_norm_w = upload_bf16(ordinal, &[head_dim], &k_norm_vals);
+        let o_proj_w = upload_bf16(ordinal, &[hidden, num_heads * head_dim], &o_proj_vals);
+
+        let weights = Qwen36MoeAttnStepWeights {
+            input_hidden: input_hidden.as_ptr(),
+            input_norm_w: input_norm_w.as_ptr(),
+            q_proj_w: q_proj_w.as_ptr(),
+            k_proj_w: k_proj_w.as_ptr(),
+            v_proj_w: v_proj_w.as_ptr(),
+            q_norm_w: q_norm_w.as_ptr(),
+            k_norm_w: k_norm_w.as_ptr(),
+            o_proj_w: o_proj_w.as_ptr(),
+            kv_cache_k: std::ptr::null_mut(),
+            kv_cache_v: std::ptr::null_mut(),
+            kv_max_t: 0,
+        };
+
+        for stage in 2..=5 {
+            let mut output = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[6])
+                .expect("alloc qwen36 metal attn output");
+            let mut workspace = GpuBuffer::zeros(ordinal, ScalarType::F32, &[36])
+                .expect("alloc qwen36 metal attn workspace");
+            let mut sync_buf =
+                GpuBuffer::zeros(ordinal, ScalarType::U8, &[96]).expect("alloc sync buf");
+            let params = Qwen36MoeAttnStepParams {
+                stage,
+                hidden: hidden as i32,
+                num_heads: num_heads as i32,
+                num_kv_heads: num_kv_heads as i32,
+                head_dim: head_dim as i32,
+                rotary_dim: head_dim as i32,
+                rope_theta: 1_000_000.0,
+                rms_norm_eps: eps,
+                position: 3,
+                cache_pos: Qwen36MoeAttnStepParams::CACHE_POS_INHERIT,
+            };
+
+            attn_step_launch(
+                ordinal,
+                ScalarType::BF16,
+                params,
+                &weights,
+                &Qwen36MoeAttnStepInt4::disabled(),
+                &mut output,
+                &mut workspace,
+                &mut sync_buf,
+            )
+            .expect("run Qwen3.6-MoE Metal attention fallback");
+
+            let expected = qwen36_attn_stage1_5_reference(
+                stage as usize,
+                &input_vals,
+                &norm_vals,
+                &q_proj_vals,
+                &k_proj_vals,
+                &v_proj_vals,
+                &q_norm_vals,
+                &k_norm_vals,
+                &o_proj_vals,
+                hidden,
+                num_heads,
+                num_kv_heads,
+                head_dim,
+                head_dim,
+                1_000_000.0,
+                3,
+                eps,
+            );
+            let got = read_bf16(&output);
+            for (idx, (a, e)) in got.iter().zip(expected.iter()).enumerate() {
+                assert!(
+                    (a - e).abs() <= 0.02,
+                    "stage {stage} idx {idx}: expected {e}, got {a}"
+                );
+            }
+        }
+    }
+
+    #[cfg(all(target_os = "macos", supersonic_backend_metal))]
+    #[test]
+    fn metal_linear_stage1_fallback_matches_reference() {
+        use gpu_hal::{set_backend, Backend};
+
+        set_backend(Backend::Metal);
+        let ordinal = 0usize;
+        let hidden = 4usize;
+        let num_k_heads = 1usize;
+        let num_v_heads = 2usize;
+        let head_k_dim = 2usize;
+        let head_v_dim = 1usize;
+        let key_dim = num_k_heads * head_k_dim;
+        let val_dim = num_v_heads * head_v_dim;
+        let qkv_dim = 2 * key_dim + val_dim;
+        let eps = 1e-5f32;
+        let input_vals = [1.0, 0.5, -1.0, 2.0];
+        let norm_vals = [0.0, 0.25, -0.5, 1.0];
+        let qkv_vals = [
+            1.0, 0.0, 0.0, 0.0, //
+            0.0, 1.0, 0.0, 0.0, //
+            0.25, -0.5, 0.75, 1.0, //
+            -0.5, 0.25, 0.5, -0.25, //
+            0.0, 0.0, 1.0, 0.0, //
+            0.0, 0.0, 0.0, 1.0, //
+        ];
+        let z_vals = [
+            0.5, 0.0, -0.5, 1.0, //
+            -0.25, 0.75, 0.25, -0.5, //
+        ];
+        let a_vals = [
+            1.0, -0.5, 0.0, 0.25, //
+            0.0, 0.25, 0.5, -1.0, //
+        ];
+        let b_vals = [
+            -0.5, 0.5, 1.0, 0.0, //
+            0.25, 0.0, -0.25, 0.75, //
+        ];
+        let input_hidden = upload_bf16(ordinal, &[hidden], &input_vals);
+        let input_norm_w = upload_bf16(ordinal, &[hidden], &norm_vals);
+        let in_proj_qkv_w = upload_bf16(ordinal, &[qkv_dim, hidden], &qkv_vals);
+        let in_proj_z_w = upload_bf16(ordinal, &[val_dim, hidden], &z_vals);
+        let in_proj_a_w = upload_bf16(ordinal, &[num_v_heads, hidden], &a_vals);
+        let in_proj_b_w = upload_bf16(ordinal, &[num_v_heads, hidden], &b_vals);
+        let mut output = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[qkv_dim])
+            .expect("alloc qwen36 metal linear output");
+        let workspace_len = qkv_dim + val_dim + 2 * num_v_heads;
+        let mut workspace = GpuBuffer::zeros(ordinal, ScalarType::F32, &[workspace_len])
+            .expect("alloc qwen36 metal linear workspace");
+        let mut sync_buf =
+            GpuBuffer::zeros(ordinal, ScalarType::U8, &[96]).expect("alloc sync buf");
+
+        let params = Qwen36MoeLinearStepParams {
+            stage: 1,
+            hidden: hidden as i32,
+            num_k_heads: num_k_heads as i32,
+            num_v_heads: num_v_heads as i32,
+            head_k_dim: head_k_dim as i32,
+            head_v_dim: head_v_dim as i32,
+            conv_kernel_dim: 4,
+            rms_norm_eps: eps,
+        };
+        let weights = Qwen36MoeLinearStepWeights {
+            input_hidden: input_hidden.as_ptr(),
+            input_norm_w: input_norm_w.as_ptr(),
+            in_proj_qkv_w: in_proj_qkv_w.as_ptr(),
+            in_proj_z_w: in_proj_z_w.as_ptr(),
+            in_proj_a_w: in_proj_a_w.as_ptr(),
+            in_proj_b_w: in_proj_b_w.as_ptr(),
+            conv1d_w: std::ptr::null(),
+            conv1d_bias: std::ptr::null(),
+            dt_bias: std::ptr::null(),
+            a_log: std::ptr::null(),
+            norm_w: std::ptr::null(),
+            out_proj_w: std::ptr::null(),
+            conv_state: std::ptr::null_mut(),
+            recurrent_state: std::ptr::null_mut(),
+        };
+
+        linear_step_launch(
+            ordinal,
+            ScalarType::BF16,
+            params,
+            &weights,
+            &Qwen36MoeLinearStepInt4::disabled(),
+            &mut output,
+            &mut workspace,
+            &mut sync_buf,
+        )
+        .expect("run Qwen3.6-MoE Metal linear stage1 fallback");
+
+        let expected = qwen36_linear_stage1_reference(
+            &input_vals,
+            &norm_vals,
+            &qkv_vals,
+            hidden,
+            qkv_dim,
+            eps,
+        );
+        for (idx, (a, e)) in read_bf16(&output).iter().zip(expected.iter()).enumerate() {
+            assert!(
+                (a - e).abs() <= 0.01,
+                "qkv_raw idx {idx}: expected {e}, got {a}"
+            );
+        }
+    }
+
+    #[cfg(all(target_os = "macos", supersonic_backend_metal))]
+    #[test]
+    fn metal_linear_stage2_fallback_matches_reference_and_updates_state() {
+        use gpu_hal::{set_backend, Backend};
+
+        set_backend(Backend::Metal);
+        let ordinal = 0usize;
+        let hidden = 4usize;
+        let num_k_heads = 1usize;
+        let num_v_heads = 2usize;
+        let head_k_dim = 2usize;
+        let head_v_dim = 1usize;
+        let key_dim = num_k_heads * head_k_dim;
+        let val_dim = num_v_heads * head_v_dim;
+        let qkv_dim = 2 * key_dim + val_dim;
+        let kernel = 3usize;
+        let kstate = kernel - 1;
+        let eps = 1e-5f32;
+        let input_vals = [1.0, 0.5, -1.0, 2.0];
+        let norm_vals = [0.0, 0.25, -0.5, 1.0];
+        let qkv_vals = [
+            1.0, 0.0, 0.0, 0.0, //
+            0.0, 1.0, 0.0, 0.0, //
+            0.25, -0.5, 0.75, 1.0, //
+            -0.5, 0.25, 0.5, -0.25, //
+            0.0, 0.0, 1.0, 0.0, //
+            0.0, 0.0, 0.0, 1.0, //
+        ];
+        let z_vals = [
+            0.5, 0.0, -0.5, 1.0, //
+            -0.25, 0.75, 0.25, -0.5, //
+        ];
+        let a_vals = [
+            1.0, -0.5, 0.0, 0.25, //
+            0.0, 0.25, 0.5, -1.0, //
+        ];
+        let b_vals = [
+            -0.5, 0.5, 1.0, 0.0, //
+            0.25, 0.0, -0.25, 0.75, //
+        ];
+        let conv_w_vals = [
+            0.5, -0.25, 1.0, //
+            0.25, 0.5, -0.5, //
+            -0.5, 1.0, 0.25, //
+            1.0, 0.0, -0.25, //
+            0.75, -0.5, 0.5, //
+            -0.25, 0.25, 1.0, //
+        ];
+        let conv_bias_vals = [0.0, 0.25, -0.25, 0.5, -0.5, 0.125];
+        let conv_state_vals = [
+            0.25, -0.5, //
+            0.0, 0.5, //
+            -0.25, 0.75, //
+            1.0, -1.0, //
+            0.125, -0.375, //
+            -0.75, 0.25, //
+        ];
+        let input_hidden = upload_bf16(ordinal, &[hidden], &input_vals);
+        let input_norm_w = upload_bf16(ordinal, &[hidden], &norm_vals);
+        let in_proj_qkv_w = upload_bf16(ordinal, &[qkv_dim, hidden], &qkv_vals);
+        let in_proj_z_w = upload_bf16(ordinal, &[val_dim, hidden], &z_vals);
+        let in_proj_a_w = upload_bf16(ordinal, &[num_v_heads, hidden], &a_vals);
+        let in_proj_b_w = upload_bf16(ordinal, &[num_v_heads, hidden], &b_vals);
+        let conv1d_w = upload_bf16(ordinal, &[qkv_dim, kernel], &conv_w_vals);
+        let conv1d_bias = upload_bf16(ordinal, &[qkv_dim], &conv_bias_vals);
+        let mut conv_state = upload_bf16(ordinal, &[qkv_dim, kstate], &conv_state_vals);
+        let mut output = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[qkv_dim])
+            .expect("alloc qwen36 metal linear stage2 output");
+        let workspace_len = qkv_dim + val_dim + 2 * num_v_heads;
+        let mut workspace = GpuBuffer::zeros(ordinal, ScalarType::F32, &[workspace_len])
+            .expect("alloc qwen36 metal linear stage2 workspace");
+        let mut sync_buf =
+            GpuBuffer::zeros(ordinal, ScalarType::U8, &[96]).expect("alloc sync buf");
+
+        let params = Qwen36MoeLinearStepParams {
+            stage: 2,
+            hidden: hidden as i32,
+            num_k_heads: num_k_heads as i32,
+            num_v_heads: num_v_heads as i32,
+            head_k_dim: head_k_dim as i32,
+            head_v_dim: head_v_dim as i32,
+            conv_kernel_dim: kernel as i32,
+            rms_norm_eps: eps,
+        };
+        let weights = Qwen36MoeLinearStepWeights {
+            input_hidden: input_hidden.as_ptr(),
+            input_norm_w: input_norm_w.as_ptr(),
+            in_proj_qkv_w: in_proj_qkv_w.as_ptr(),
+            in_proj_z_w: in_proj_z_w.as_ptr(),
+            in_proj_a_w: in_proj_a_w.as_ptr(),
+            in_proj_b_w: in_proj_b_w.as_ptr(),
+            conv1d_w: conv1d_w.as_ptr(),
+            conv1d_bias: conv1d_bias.as_ptr(),
+            dt_bias: std::ptr::null(),
+            a_log: std::ptr::null(),
+            norm_w: std::ptr::null(),
+            out_proj_w: std::ptr::null(),
+            conv_state: conv_state.as_mut_ptr(),
+            recurrent_state: std::ptr::null_mut(),
+        };
+
+        linear_step_launch(
+            ordinal,
+            ScalarType::BF16,
+            params,
+            &weights,
+            &Qwen36MoeLinearStepInt4::disabled(),
+            &mut output,
+            &mut workspace,
+            &mut sync_buf,
+        )
+        .expect("run Qwen3.6-MoE Metal linear stage2 fallback");
+
+        let qkv_raw = qwen36_linear_stage1_reference(
+            &input_vals,
+            &norm_vals,
+            &qkv_vals,
+            hidden,
+            qkv_dim,
+            eps,
+        );
+        let (expected_silu, expected_state) = qwen36_linear_stage2_reference(
+            &qkv_raw,
+            &conv_state_vals,
+            &conv_w_vals,
+            Some(&conv_bias_vals),
+            qkv_dim,
+            kernel,
+        );
+        for (idx, (a, e)) in read_bf16(&output)
+            .iter()
+            .zip(expected_silu.iter())
+            .enumerate()
+        {
+            assert!(
+                (a - e).abs() <= 0.01,
+                "silu_out idx {idx}: expected {e}, got {a}"
+            );
+        }
+        for (idx, (a, e)) in read_bf16(&conv_state)
+            .iter()
+            .zip(expected_state.iter())
+            .enumerate()
+        {
+            assert!(
+                (a - e).abs() <= 0.01,
+                "conv_state idx {idx}: expected {e}, got {a}"
+            );
+        }
+    }
+
+    #[cfg(all(target_os = "macos", supersonic_backend_metal))]
+    #[test]
+    fn metal_linear_stage3_fallback_matches_reference() {
+        use gpu_hal::{set_backend, Backend};
+
+        set_backend(Backend::Metal);
+        let ordinal = 0usize;
+        let hidden = 4usize;
+        let num_k_heads = 1usize;
+        let num_v_heads = 2usize;
+        let head_k_dim = 2usize;
+        let head_v_dim = 1usize;
+        let key_dim = num_k_heads * head_k_dim;
+        let val_dim = num_v_heads * head_v_dim;
+        let qkv_dim = 2 * key_dim + val_dim;
+        let kernel = 3usize;
+        let kstate = kernel - 1;
+        let eps = 1e-5f32;
+        let input_vals = [1.0, 0.5, -1.0, 2.0];
+        let norm_vals = [0.0, 0.25, -0.5, 1.0];
+        let qkv_vals = [
+            1.0, 0.0, 0.0, 0.0, //
+            0.0, 1.0, 0.0, 0.0, //
+            0.25, -0.5, 0.75, 1.0, //
+            -0.5, 0.25, 0.5, -0.25, //
+            0.0, 0.0, 1.0, 0.0, //
+            0.0, 0.0, 0.0, 1.0, //
+        ];
+        let z_vals = [
+            0.5, 0.0, -0.5, 1.0, //
+            -0.25, 0.75, 0.25, -0.5, //
+        ];
+        let a_vals = [
+            1.0, -0.5, 0.0, 0.25, //
+            0.0, 0.25, 0.5, -1.0, //
+        ];
+        let b_vals = [
+            -0.5, 0.5, 1.0, 0.0, //
+            0.25, 0.0, -0.25, 0.75, //
+        ];
+        let conv_w_vals = [
+            0.5, -0.25, 1.0, //
+            0.25, 0.5, -0.5, //
+            -0.5, 1.0, 0.25, //
+            1.0, 0.0, -0.25, //
+            0.75, -0.5, 0.5, //
+            -0.25, 0.25, 1.0, //
+        ];
+        let conv_state_vals = [
+            0.25, -0.5, //
+            0.0, 0.5, //
+            -0.25, 0.75, //
+            1.0, -1.0, //
+            0.125, -0.375, //
+            -0.75, 0.25, //
+        ];
+        let input_hidden = upload_bf16(ordinal, &[hidden], &input_vals);
+        let input_norm_w = upload_bf16(ordinal, &[hidden], &norm_vals);
+        let in_proj_qkv_w = upload_bf16(ordinal, &[qkv_dim, hidden], &qkv_vals);
+        let in_proj_z_w = upload_bf16(ordinal, &[val_dim, hidden], &z_vals);
+        let in_proj_a_w = upload_bf16(ordinal, &[num_v_heads, hidden], &a_vals);
+        let in_proj_b_w = upload_bf16(ordinal, &[num_v_heads, hidden], &b_vals);
+        let conv1d_w = upload_bf16(ordinal, &[qkv_dim, kernel], &conv_w_vals);
+        let mut conv_state = upload_bf16(ordinal, &[qkv_dim, kstate], &conv_state_vals);
+        let output_len = 2 * num_v_heads * head_k_dim + val_dim;
+        let mut output = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[output_len])
+            .expect("alloc qwen36 metal linear stage3 output");
+        let stage3_workspace_len =
+            qkv_dim + val_dim + 2 * num_v_heads + 2 * key_dim + 2 * num_v_heads * head_k_dim;
+        let mut workspace = GpuBuffer::zeros(ordinal, ScalarType::F32, &[stage3_workspace_len])
+            .expect("alloc qwen36 metal linear stage3 workspace");
+        let mut sync_buf =
+            GpuBuffer::zeros(ordinal, ScalarType::U8, &[96]).expect("alloc sync buf");
+
+        let params = Qwen36MoeLinearStepParams {
+            stage: 3,
+            hidden: hidden as i32,
+            num_k_heads: num_k_heads as i32,
+            num_v_heads: num_v_heads as i32,
+            head_k_dim: head_k_dim as i32,
+            head_v_dim: head_v_dim as i32,
+            conv_kernel_dim: kernel as i32,
+            rms_norm_eps: eps,
+        };
+        let weights = Qwen36MoeLinearStepWeights {
+            input_hidden: input_hidden.as_ptr(),
+            input_norm_w: input_norm_w.as_ptr(),
+            in_proj_qkv_w: in_proj_qkv_w.as_ptr(),
+            in_proj_z_w: in_proj_z_w.as_ptr(),
+            in_proj_a_w: in_proj_a_w.as_ptr(),
+            in_proj_b_w: in_proj_b_w.as_ptr(),
+            conv1d_w: conv1d_w.as_ptr(),
+            conv1d_bias: std::ptr::null(),
+            dt_bias: std::ptr::null(),
+            a_log: std::ptr::null(),
+            norm_w: std::ptr::null(),
+            out_proj_w: std::ptr::null(),
+            conv_state: conv_state.as_mut_ptr(),
+            recurrent_state: std::ptr::null_mut(),
+        };
+
+        linear_step_launch(
+            ordinal,
+            ScalarType::BF16,
+            params,
+            &weights,
+            &Qwen36MoeLinearStepInt4::disabled(),
+            &mut output,
+            &mut workspace,
+            &mut sync_buf,
+        )
+        .expect("run Qwen3.6-MoE Metal linear stage3 fallback");
+
+        let qkv_raw = qwen36_linear_stage1_reference(
+            &input_vals,
+            &norm_vals,
+            &qkv_vals,
+            hidden,
+            qkv_dim,
+            eps,
+        );
+        let (silu_out, _) = qwen36_linear_stage2_reference(
+            &qkv_raw,
+            &conv_state_vals,
+            &conv_w_vals,
+            None,
+            qkv_dim,
+            kernel,
+        );
+        let expected = qwen36_linear_stage3_reference(
+            &silu_out,
+            num_k_heads,
+            num_v_heads,
+            head_k_dim,
+            head_v_dim,
+        );
+        for (idx, (a, e)) in read_bf16(&output).iter().zip(expected.iter()).enumerate() {
+            assert!(
+                (a - e).abs() <= 0.01,
+                "stage3 output idx {idx}: expected {e}, got {a}"
+            );
+        }
+    }
+
+    #[cfg(all(target_os = "macos", supersonic_backend_metal))]
+    #[test]
+    fn metal_linear_stage4_fallback_matches_reference_and_updates_recurrent_state() {
+        use gpu_hal::{set_backend, Backend};
+
+        set_backend(Backend::Metal);
+        let ordinal = 0usize;
+        let hidden = 4usize;
+        let num_k_heads = 1usize;
+        let num_v_heads = 2usize;
+        let head_k_dim = 2usize;
+        let head_v_dim = 1usize;
+        let key_dim = num_k_heads * head_k_dim;
+        let val_dim = num_v_heads * head_v_dim;
+        let qkv_dim = 2 * key_dim + val_dim;
+        let kernel = 3usize;
+        let kstate = kernel - 1;
+        let eps = 1e-5f32;
+        let input_vals = [1.0, 0.5, -1.0, 2.0];
+        let norm_vals = [0.0, 0.25, -0.5, 1.0];
+        let qkv_vals = [
+            1.0, 0.0, 0.0, 0.0, //
+            0.0, 1.0, 0.0, 0.0, //
+            0.25, -0.5, 0.75, 1.0, //
+            -0.5, 0.25, 0.5, -0.25, //
+            0.0, 0.0, 1.0, 0.0, //
+            0.0, 0.0, 0.0, 1.0, //
+        ];
+        let z_vals = [
+            0.5, 0.0, -0.5, 1.0, //
+            -0.25, 0.75, 0.25, -0.5, //
+        ];
+        let a_vals = [
+            1.0, -0.5, 0.0, 0.25, //
+            0.0, 0.25, 0.5, -1.0, //
+        ];
+        let b_vals = [
+            -0.5, 0.5, 1.0, 0.0, //
+            0.25, 0.0, -0.25, 0.75, //
+        ];
+        let conv_w_vals = [
+            0.5, -0.25, 1.0, //
+            0.25, 0.5, -0.5, //
+            -0.5, 1.0, 0.25, //
+            1.0, 0.0, -0.25, //
+            0.75, -0.5, 0.5, //
+            -0.25, 0.25, 1.0, //
+        ];
+        let conv_state_vals = [
+            0.25, -0.5, //
+            0.0, 0.5, //
+            -0.25, 0.75, //
+            1.0, -1.0, //
+            0.125, -0.375, //
+            -0.75, 0.25, //
+        ];
+        let dt_bias_vals = [0.125, -0.25];
+        let a_log_vals = [-0.5, 0.25];
+        let recurrent_vals = [0.25, -0.5, 0.75, -1.0];
+
+        let input_hidden = upload_bf16(ordinal, &[hidden], &input_vals);
+        let input_norm_w = upload_bf16(ordinal, &[hidden], &norm_vals);
+        let in_proj_qkv_w = upload_bf16(ordinal, &[qkv_dim, hidden], &qkv_vals);
+        let in_proj_z_w = upload_bf16(ordinal, &[val_dim, hidden], &z_vals);
+        let in_proj_a_w = upload_bf16(ordinal, &[num_v_heads, hidden], &a_vals);
+        let in_proj_b_w = upload_bf16(ordinal, &[num_v_heads, hidden], &b_vals);
+        let conv1d_w = upload_bf16(ordinal, &[qkv_dim, kernel], &conv_w_vals);
+        let mut conv_state = upload_bf16(ordinal, &[qkv_dim, kstate], &conv_state_vals);
+        let dt_bias = upload_bf16(ordinal, &[num_v_heads], &dt_bias_vals);
+        let a_log = upload_bf16(ordinal, &[num_v_heads], &a_log_vals);
+        let mut recurrent_state = upload_f32(
+            ordinal,
+            &[num_v_heads, head_k_dim, head_v_dim],
+            &recurrent_vals,
+        );
+        let mut output = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[val_dim])
+            .expect("alloc qwen36 metal linear stage4 output");
+        let stage4_workspace_len = qkv_dim
+            + val_dim
+            + 2 * num_v_heads
+            + 2 * key_dim
+            + 2 * num_v_heads * head_k_dim
+            + 2 * num_v_heads
+            + val_dim;
+        let mut workspace = GpuBuffer::zeros(ordinal, ScalarType::F32, &[stage4_workspace_len])
+            .expect("alloc qwen36 metal linear stage4 workspace");
+        let mut sync_buf =
+            GpuBuffer::zeros(ordinal, ScalarType::U8, &[96]).expect("alloc sync buf");
+
+        let params = Qwen36MoeLinearStepParams {
+            stage: 4,
+            hidden: hidden as i32,
+            num_k_heads: num_k_heads as i32,
+            num_v_heads: num_v_heads as i32,
+            head_k_dim: head_k_dim as i32,
+            head_v_dim: head_v_dim as i32,
+            conv_kernel_dim: kernel as i32,
+            rms_norm_eps: eps,
+        };
+        let weights = Qwen36MoeLinearStepWeights {
+            input_hidden: input_hidden.as_ptr(),
+            input_norm_w: input_norm_w.as_ptr(),
+            in_proj_qkv_w: in_proj_qkv_w.as_ptr(),
+            in_proj_z_w: in_proj_z_w.as_ptr(),
+            in_proj_a_w: in_proj_a_w.as_ptr(),
+            in_proj_b_w: in_proj_b_w.as_ptr(),
+            conv1d_w: conv1d_w.as_ptr(),
+            conv1d_bias: std::ptr::null(),
+            dt_bias: dt_bias.as_ptr(),
+            a_log: a_log.as_ptr(),
+            norm_w: std::ptr::null(),
+            out_proj_w: std::ptr::null(),
+            conv_state: conv_state.as_mut_ptr(),
+            recurrent_state: recurrent_state.as_mut_ptr() as *mut f32,
+        };
+
+        linear_step_launch(
+            ordinal,
+            ScalarType::BF16,
+            params,
+            &weights,
+            &Qwen36MoeLinearStepInt4::disabled(),
+            &mut output,
+            &mut workspace,
+            &mut sync_buf,
+        )
+        .expect("run Qwen3.6-MoE Metal linear stage4 fallback");
+
+        let qkv_raw = qwen36_linear_stage1_reference(
+            &input_vals,
+            &norm_vals,
+            &qkv_vals,
+            hidden,
+            qkv_dim,
+            eps,
+        );
+        let a_raw = qwen36_linear_stage1_reference(
+            &input_vals,
+            &norm_vals,
+            &a_vals,
+            hidden,
+            num_v_heads,
+            eps,
+        );
+        let b_raw = qwen36_linear_stage1_reference(
+            &input_vals,
+            &norm_vals,
+            &b_vals,
+            hidden,
+            num_v_heads,
+            eps,
+        );
+        let (silu_out, _) = qwen36_linear_stage2_reference(
+            &qkv_raw,
+            &conv_state_vals,
+            &conv_w_vals,
+            None,
+            qkv_dim,
+            kernel,
+        );
+        let stage3_out = qwen36_linear_stage3_reference(
+            &silu_out,
+            num_k_heads,
+            num_v_heads,
+            head_k_dim,
+            head_v_dim,
+        );
+        let (expected_rec, expected_state) = qwen36_linear_stage4_reference(
+            &stage3_out,
+            &a_raw,
+            &b_raw,
+            &dt_bias_vals,
+            &a_log_vals,
+            &recurrent_vals,
+            num_v_heads,
+            head_k_dim,
+            head_v_dim,
+        );
+        for (idx, (a, e)) in read_bf16(&output)
+            .iter()
+            .zip(expected_rec.iter())
+            .enumerate()
+        {
+            assert!(
+                (a - e).abs() <= 0.01,
+                "stage4 output idx {idx}: expected {e}, got {a}"
+            );
+        }
+        for (idx, (a, e)) in read_f32(&recurrent_state)
+            .iter()
+            .zip(expected_state.iter())
+            .enumerate()
+        {
+            assert!(
+                (a - e).abs() <= 0.0005,
+                "recurrent_state idx {idx}: expected {e}, got {a}"
+            );
+        }
+    }
+
+    #[cfg(all(target_os = "macos", supersonic_backend_metal))]
+    #[test]
+    fn metal_linear_stage5_fallback_matches_reference() {
+        use gpu_hal::{set_backend, Backend};
+
+        set_backend(Backend::Metal);
+        let ordinal = 0usize;
+        let hidden = 4usize;
+        let num_k_heads = 1usize;
+        let num_v_heads = 2usize;
+        let head_k_dim = 2usize;
+        let head_v_dim = 1usize;
+        let key_dim = num_k_heads * head_k_dim;
+        let val_dim = num_v_heads * head_v_dim;
+        let qkv_dim = 2 * key_dim + val_dim;
+        let kernel = 3usize;
+        let kstate = kernel - 1;
+        let eps = 1e-5f32;
+        let input_vals = [1.0, 0.5, -1.0, 2.0];
+        let norm_vals = [0.0, 0.25, -0.5, 1.0];
+        let qkv_vals = [
+            1.0, 0.0, 0.0, 0.0, //
+            0.0, 1.0, 0.0, 0.0, //
+            0.25, -0.5, 0.75, 1.0, //
+            -0.5, 0.25, 0.5, -0.25, //
+            0.0, 0.0, 1.0, 0.0, //
+            0.0, 0.0, 0.0, 1.0, //
+        ];
+        let z_vals = [
+            0.5, 0.0, -0.5, 1.0, //
+            -0.25, 0.75, 0.25, -0.5, //
+        ];
+        let a_vals = [
+            1.0, -0.5, 0.0, 0.25, //
+            0.0, 0.25, 0.5, -1.0, //
+        ];
+        let b_vals = [
+            -0.5, 0.5, 1.0, 0.0, //
+            0.25, 0.0, -0.25, 0.75, //
+        ];
+        let conv_w_vals = [
+            0.5, -0.25, 1.0, //
+            0.25, 0.5, -0.5, //
+            -0.5, 1.0, 0.25, //
+            1.0, 0.0, -0.25, //
+            0.75, -0.5, 0.5, //
+            -0.25, 0.25, 1.0, //
+        ];
+        let conv_state_vals = [
+            0.25, -0.5, //
+            0.0, 0.5, //
+            -0.25, 0.75, //
+            1.0, -1.0, //
+            0.125, -0.375, //
+            -0.75, 0.25, //
+        ];
+        let dt_bias_vals = [0.125, -0.25];
+        let a_log_vals = [-0.5, 0.25];
+        let recurrent_vals = [0.25, -0.5, 0.75, -1.0];
+        let out_norm_vals = [1.25];
+        let out_proj_vals = [
+            1.0, 0.0, //
+            0.0, 1.0, //
+            0.5, -0.25, //
+            -0.75, 0.25, //
+        ];
+
+        let input_hidden = upload_bf16(ordinal, &[hidden], &input_vals);
+        let input_norm_w = upload_bf16(ordinal, &[hidden], &norm_vals);
+        let in_proj_qkv_w = upload_bf16(ordinal, &[qkv_dim, hidden], &qkv_vals);
+        let in_proj_z_w = upload_bf16(ordinal, &[val_dim, hidden], &z_vals);
+        let in_proj_a_w = upload_bf16(ordinal, &[num_v_heads, hidden], &a_vals);
+        let in_proj_b_w = upload_bf16(ordinal, &[num_v_heads, hidden], &b_vals);
+        let conv1d_w = upload_bf16(ordinal, &[qkv_dim, kernel], &conv_w_vals);
+        let mut conv_state = upload_bf16(ordinal, &[qkv_dim, kstate], &conv_state_vals);
+        let dt_bias = upload_bf16(ordinal, &[num_v_heads], &dt_bias_vals);
+        let a_log = upload_bf16(ordinal, &[num_v_heads], &a_log_vals);
+        let norm_w = upload_bf16(ordinal, &[head_v_dim], &out_norm_vals);
+        let out_proj_w = upload_bf16(ordinal, &[hidden, val_dim], &out_proj_vals);
+        let mut recurrent_state = upload_f32(
+            ordinal,
+            &[num_v_heads, head_k_dim, head_v_dim],
+            &recurrent_vals,
+        );
+        let mut output = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[hidden])
+            .expect("alloc qwen36 metal linear stage5 output");
+        let stage4_workspace_len = qkv_dim
+            + val_dim
+            + 2 * num_v_heads
+            + 2 * key_dim
+            + 2 * num_v_heads * head_k_dim
+            + 2 * num_v_heads
+            + val_dim;
+        let mut workspace = GpuBuffer::zeros(ordinal, ScalarType::F32, &[stage4_workspace_len])
+            .expect("alloc qwen36 metal linear stage5 workspace");
+        let mut sync_buf =
+            GpuBuffer::zeros(ordinal, ScalarType::U8, &[96]).expect("alloc sync buf");
+
+        let params = Qwen36MoeLinearStepParams {
+            stage: 5,
+            hidden: hidden as i32,
+            num_k_heads: num_k_heads as i32,
+            num_v_heads: num_v_heads as i32,
+            head_k_dim: head_k_dim as i32,
+            head_v_dim: head_v_dim as i32,
+            conv_kernel_dim: kernel as i32,
+            rms_norm_eps: eps,
+        };
+        let weights = Qwen36MoeLinearStepWeights {
+            input_hidden: input_hidden.as_ptr(),
+            input_norm_w: input_norm_w.as_ptr(),
+            in_proj_qkv_w: in_proj_qkv_w.as_ptr(),
+            in_proj_z_w: in_proj_z_w.as_ptr(),
+            in_proj_a_w: in_proj_a_w.as_ptr(),
+            in_proj_b_w: in_proj_b_w.as_ptr(),
+            conv1d_w: conv1d_w.as_ptr(),
+            conv1d_bias: std::ptr::null(),
+            dt_bias: dt_bias.as_ptr(),
+            a_log: a_log.as_ptr(),
+            norm_w: norm_w.as_ptr(),
+            out_proj_w: out_proj_w.as_ptr(),
+            conv_state: conv_state.as_mut_ptr(),
+            recurrent_state: recurrent_state.as_mut_ptr() as *mut f32,
+        };
+
+        linear_step_launch(
+            ordinal,
+            ScalarType::BF16,
+            params,
+            &weights,
+            &Qwen36MoeLinearStepInt4::disabled(),
+            &mut output,
+            &mut workspace,
+            &mut sync_buf,
+        )
+        .expect("run Qwen3.6-MoE Metal linear stage5 fallback");
+
+        let qkv_raw = qwen36_linear_stage1_reference(
+            &input_vals,
+            &norm_vals,
+            &qkv_vals,
+            hidden,
+            qkv_dim,
+            eps,
+        );
+        let z_raw =
+            qwen36_linear_stage1_reference(&input_vals, &norm_vals, &z_vals, hidden, val_dim, eps);
+        let a_raw = qwen36_linear_stage1_reference(
+            &input_vals,
+            &norm_vals,
+            &a_vals,
+            hidden,
+            num_v_heads,
+            eps,
+        );
+        let b_raw = qwen36_linear_stage1_reference(
+            &input_vals,
+            &norm_vals,
+            &b_vals,
+            hidden,
+            num_v_heads,
+            eps,
+        );
+        let (silu_out, _) = qwen36_linear_stage2_reference(
+            &qkv_raw,
+            &conv_state_vals,
+            &conv_w_vals,
+            None,
+            qkv_dim,
+            kernel,
+        );
+        let stage3_out = qwen36_linear_stage3_reference(
+            &silu_out,
+            num_k_heads,
+            num_v_heads,
+            head_k_dim,
+            head_v_dim,
+        );
+        let (rec_out, _) = qwen36_linear_stage4_reference(
+            &stage3_out,
+            &a_raw,
+            &b_raw,
+            &dt_bias_vals,
+            &a_log_vals,
+            &recurrent_vals,
+            num_v_heads,
+            head_k_dim,
+            head_v_dim,
+        );
+        let expected = qwen36_linear_stage5_reference(
+            &input_vals,
+            &rec_out,
+            &z_raw,
+            &out_norm_vals,
+            &out_proj_vals,
+            hidden,
+            num_v_heads,
+            head_v_dim,
+            eps,
+        );
+        for (idx, (a, e)) in read_bf16(&output).iter().zip(expected.iter()).enumerate() {
+            assert!(
+                (a - e).abs() <= 0.01,
+                "stage5 output idx {idx}: expected {e}, got {a}"
+            );
+        }
     }
 
     /// HIP smoke test: launch the stub kernel against a synthetic 40-layer
@@ -7021,7 +10980,11 @@ mod tests {
     /// BF16 round-to-nearest-even of an F32 value, returning the 16-bit
     /// big-end-of-F32 representation. Same math as the kernel's
     /// `bf16_round_rne_f32`.
-    #[cfg(any(supersonic_backend_hip, supersonic_backend_cuda))]
+    #[cfg(any(
+        supersonic_backend_hip,
+        supersonic_backend_cuda,
+        supersonic_backend_metal
+    ))]
     fn bf16_round_bits(x: f32) -> u16 {
         let bits = x.to_bits();
         let rounding_bias = 0x7FFFu32 + ((bits >> 16) & 1);
@@ -7030,7 +10993,11 @@ mod tests {
     }
 
     /// Reverse: F32 from a BF16 bit pattern.
-    #[cfg(any(supersonic_backend_hip, supersonic_backend_cuda))]
+    #[cfg(any(
+        supersonic_backend_hip,
+        supersonic_backend_cuda,
+        supersonic_backend_metal
+    ))]
     fn f32_from_bf16(b: u16) -> f32 {
         f32::from_bits((b as u32) << 16)
     }
@@ -7039,7 +11006,11 @@ mod tests {
     /// of `minmax_int4_packed_and_recon` in the FFN oracle. Returns
     /// `(packed [out, in/2] u8, scale [out/gs, in/gs] u16-as-BF16,
     /// zero [out/gs, in/gs] u16-as-BF16)`.
-    #[cfg(any(supersonic_backend_hip, supersonic_backend_cuda))]
+    #[cfg(any(
+        supersonic_backend_hip,
+        supersonic_backend_cuda,
+        supersonic_backend_metal
+    ))]
     fn host_minmax_int4(
         w: &[f32],
         out_rows: usize,
@@ -7099,7 +11070,11 @@ mod tests {
 
     /// Reference reconstruction: `bf16(q*s - z*s)` per element. Returns
     /// F32 values whose lower 16 bits are zero (i.e. exactly BF16-precision).
-    #[cfg(any(supersonic_backend_hip, supersonic_backend_cuda))]
+    #[cfg(any(
+        supersonic_backend_hip,
+        supersonic_backend_cuda,
+        supersonic_backend_metal
+    ))]
     fn host_dequant_recon(
         packed: &[u8],
         scale: &[u16],
@@ -7129,7 +11104,11 @@ mod tests {
     }
 
     /// Encode a slice of BF16 16-bit values to LE bytes for `from_host_bytes`.
-    #[cfg(any(supersonic_backend_hip, supersonic_backend_cuda))]
+    #[cfg(any(
+        supersonic_backend_hip,
+        supersonic_backend_cuda,
+        supersonic_backend_metal
+    ))]
     fn bf16_bits_to_bytes(bits: &[u16]) -> Vec<u8> {
         let mut bytes = Vec::with_capacity(bits.len() * 2);
         for b in bits {
@@ -7141,10 +11120,16 @@ mod tests {
     /// Drives one (out_rows, in_cols, gsz) configuration through the smoke
     /// kernel and asserts both helper outputs match the host reference
     /// exactly.
-    #[cfg(any(supersonic_backend_hip, supersonic_backend_cuda))]
+    #[cfg(any(
+        supersonic_backend_hip,
+        supersonic_backend_cuda,
+        supersonic_backend_metal
+    ))]
     fn run_int4_dequant_smoke(out_rows: usize, in_cols: usize, gsz: usize, label: &str) {
         use gpu_hal::{is_backend_compiled, set_backend, Backend, GpuBuffer, ScalarType};
-        let backend = if is_backend_compiled(Backend::Cuda) {
+        let backend = if is_backend_compiled(Backend::Metal) {
+            Backend::Metal
+        } else if is_backend_compiled(Backend::Cuda) {
             Backend::Cuda
         } else {
             Backend::Hip
@@ -7234,7 +11219,11 @@ mod tests {
         }
     }
 
-    #[cfg(any(supersonic_backend_hip, supersonic_backend_cuda))]
+    #[cfg(any(
+        supersonic_backend_hip,
+        supersonic_backend_cuda,
+        supersonic_backend_metal
+    ))]
     #[test]
     fn qwen36_moe_int4_dequant_smoke_fast_path() {
         // gsz=8, in_cols=16 → every 8-col span lies in one group, so
@@ -7242,7 +11231,11 @@ mod tests {
         run_int4_dequant_smoke(8, 16, 8, "fast (gsz=8)");
     }
 
-    #[cfg(any(supersonic_backend_hip, supersonic_backend_cuda))]
+    #[cfg(any(
+        supersonic_backend_hip,
+        supersonic_backend_cuda,
+        supersonic_backend_metal
+    ))]
     #[test]
     fn qwen36_moe_int4_dequant_smoke_slow_path() {
         // gsz=4, in_cols=16 → 8-col spans starting at col=0 cross from

--- a/crates/kernel-ffi/src/qwen3_moe.rs
+++ b/crates/kernel-ffi/src/qwen3_moe.rs
@@ -4,12 +4,14 @@
 //! pure-attention MoE model with different geometry and no Qwen3.6 hybrid
 //! linear-attention/shared-expert path.
 
-#![cfg_attr(not(supersonic_backend_hip), allow(unused_variables))]
+#![cfg_attr(not(supersonic_backend_hip), allow(unused_imports, unused_variables))]
 
 use std::ffi::{c_int, c_void};
 use std::os::raw::c_uint;
 
 use gpu_hal::{Backend, GpuBuffer, GpuError, ScalarType};
+
+const LOWBIT_NATIVE_INT4: i32 = 4;
 
 #[repr(C)]
 #[derive(Debug, Clone)]
@@ -215,6 +217,17 @@ pub fn decode_layer_launch(
         )));
     }
     let backend = input_hidden.backend();
+    if backend == Backend::Metal {
+        return decode_layer_launch_metal_host(
+            hidden,
+            position,
+            layer,
+            int4,
+            input_hidden,
+            output_hidden,
+            workspace,
+        );
+    }
     let status: c_int = match backend {
         Backend::Hip => {
             #[cfg(supersonic_backend_hip)]
@@ -262,6 +275,338 @@ pub fn decode_layer_launch(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
+fn decode_layer_launch_metal_host(
+    hidden: i32,
+    position: i32,
+    layer: &Qwen3MoeDecodeLayerDesc,
+    int4: &Qwen3MoeInt4ScaleDesc,
+    input_hidden: &GpuBuffer,
+    output_hidden: &mut GpuBuffer,
+    workspace: &mut GpuBuffer,
+) -> Result<(), GpuError> {
+    if input_hidden.dtype() != ScalarType::BF16
+        || output_hidden.dtype() != ScalarType::BF16
+        || workspace.dtype() != ScalarType::F32
+    {
+        return Err(GpuError::InvalidArg(format!(
+            "qwen3_moe::decode_layer_launch: Metal fallback expects BF16/BF16/F32 buffers, got {:?}/{:?}/{:?}",
+            input_hidden.dtype(),
+            output_hidden.dtype(),
+            workspace.dtype()
+        )));
+    }
+    let hidden = checked_positive("hidden", hidden)?;
+    let head_dim = checked_positive("head_dim", layer.head_dim)?;
+    let num_heads = checked_positive("num_heads", layer.num_heads)?;
+    let num_kv_heads = checked_positive("num_kv_heads", layer.num_kv_heads)?;
+    let experts = checked_positive("num_experts", layer.num_experts)?;
+    let top_k = checked_positive("top_k", layer.top_k)?;
+    let moe_i = checked_positive("moe_intermediate_size", layer.moe_intermediate_size)?;
+    let group_size = checked_positive("group_size", int4.group_size)?;
+    if num_heads % num_kv_heads != 0 {
+        return Err(GpuError::InvalidArg(format!(
+            "qwen3_moe::decode_layer_launch: Metal fallback requires num_heads divisible by num_kv_heads, got {num_heads}/{num_kv_heads}"
+        )));
+    }
+    if head_dim % 2 != 0 {
+        return Err(GpuError::InvalidArg(format!(
+            "qwen3_moe::decode_layer_launch: Metal fallback requires even head_dim, got {head_dim}"
+        )));
+    }
+    if top_k > experts {
+        return Err(GpuError::InvalidArg(format!(
+            "qwen3_moe::decode_layer_launch: Metal fallback top_k {top_k} exceeds experts {experts}"
+        )));
+    }
+    require_ptrs(
+        layer,
+        int4,
+        &[
+            layer.input_norm_w,
+            layer.post_attn_norm_w,
+            layer.q_proj_w,
+            layer.k_proj_w,
+            layer.v_proj_w,
+            layer.o_proj_w,
+            layer.q_norm_w,
+            layer.k_norm_w,
+            layer.router_w,
+            layer.experts_gate_up_w,
+            layer.experts_down_w,
+            int4.q_proj_scale,
+            int4.q_proj_zero,
+            int4.k_proj_scale,
+            int4.k_proj_zero,
+            int4.v_proj_scale,
+            int4.v_proj_zero,
+            int4.o_proj_scale,
+            int4.o_proj_zero,
+            int4.experts_gate_up_scale,
+            int4.experts_gate_up_zero,
+            int4.experts_down_scale,
+            int4.experts_down_zero,
+        ],
+    )?;
+
+    let q_dim = num_heads * head_dim;
+    let kv_dim = num_kv_heads * head_dim;
+    let needed_workspace = hidden
+        + q_dim
+        + kv_dim
+        + kv_dim
+        + q_dim
+        + hidden
+        + experts
+        + experts
+        + top_k
+        + top_k
+        + 2 * moe_i
+        + moe_i
+        + hidden
+        + hidden;
+    let workspace_elems = workspace.shape().iter().product::<usize>();
+    if workspace_elems < needed_workspace {
+        return Err(GpuError::InvalidArg(format!(
+            "qwen3_moe::decode_layer_launch: Metal fallback workspace too small: need {needed_workspace}, got {workspace_elems}"
+        )));
+    }
+    let input_elems = input_hidden.shape().iter().product::<usize>();
+    let output_elems = output_hidden.shape().iter().product::<usize>();
+    if input_elems < hidden || output_elems < hidden {
+        return Err(GpuError::InvalidArg(format!(
+            "qwen3_moe::decode_layer_launch: Metal fallback hidden buffers too small: input {input_elems}, output {output_elems}, hidden {hidden}"
+        )));
+    }
+
+    let input = unsafe { std::slice::from_raw_parts(input_hidden.as_ptr() as *const u16, hidden) };
+    let output =
+        unsafe { std::slice::from_raw_parts_mut(output_hidden.as_mut_ptr() as *mut u16, hidden) };
+
+    let mut x = input
+        .iter()
+        .map(|bits| bf16_bits_to_f32(*bits))
+        .collect::<Vec<_>>();
+    let mut hnorm = vec![0.0f32; hidden];
+    q3_rms_norm_host(
+        &x,
+        layer.input_norm_w as *const u16,
+        layer.input_norm_eps,
+        &mut hnorm,
+    );
+
+    let mut q = vec![0.0f32; q_dim];
+    let mut k = vec![0.0f32; kv_dim];
+    let mut v = vec![0.0f32; kv_dim];
+    q3_int4_matvec_host(
+        layer.q_proj_w as *const u8,
+        int4.q_proj_scale as *const u16,
+        int4.q_proj_zero as *const u16,
+        q_dim,
+        hidden,
+        group_size,
+        &hnorm,
+        &mut q,
+    );
+    q3_int4_matvec_host(
+        layer.k_proj_w as *const u8,
+        int4.k_proj_scale as *const u16,
+        int4.k_proj_zero as *const u16,
+        kv_dim,
+        hidden,
+        group_size,
+        &hnorm,
+        &mut k,
+    );
+    q3_int4_matvec_host(
+        layer.v_proj_w as *const u8,
+        int4.v_proj_scale as *const u16,
+        int4.v_proj_zero as *const u16,
+        kv_dim,
+        hidden,
+        group_size,
+        &hnorm,
+        &mut v,
+    );
+
+    q3_head_rms_norm_host(
+        &mut q,
+        num_heads,
+        head_dim,
+        layer.q_norm_w as *const u16,
+        layer.input_norm_eps,
+    );
+    q3_head_rms_norm_host(
+        &mut k,
+        num_kv_heads,
+        head_dim,
+        layer.k_norm_w as *const u16,
+        layer.input_norm_eps,
+    );
+    q3_rope_half_host(&mut q, num_heads, head_dim, position, layer.rope_theta);
+    q3_rope_half_host(&mut k, num_kv_heads, head_dim, position, layer.rope_theta);
+
+    let cache_k_set = !layer.kv_cache_k.is_null();
+    let cache_v_set = !layer.kv_cache_v.is_null();
+    if cache_k_set != cache_v_set {
+        return Err(GpuError::InvalidArg(
+            "qwen3_moe::decode_layer_launch: Metal fallback requires paired KV cache pointers"
+                .into(),
+        ));
+    }
+    let kv_len = if cache_k_set {
+        if layer.kv_len < 0 || layer.kv_len >= layer.kv_max_t {
+            return Err(GpuError::InvalidArg(format!(
+                "qwen3_moe::decode_layer_launch: Metal fallback invalid kv_len {} for kv_max_t {}",
+                layer.kv_len, layer.kv_max_t
+            )));
+        }
+        let base = layer.kv_len as usize * kv_dim;
+        let cache_elems = layer.kv_max_t as usize * kv_dim;
+        let cache_k =
+            unsafe { std::slice::from_raw_parts_mut(layer.kv_cache_k as *mut u16, cache_elems) };
+        let cache_v =
+            unsafe { std::slice::from_raw_parts_mut(layer.kv_cache_v as *mut u16, cache_elems) };
+        for idx in 0..kv_dim {
+            cache_k[base + idx] = f32_to_bf16_bits(k[idx]);
+            cache_v[base + idx] = f32_to_bf16_bits(v[idx]);
+        }
+        layer.kv_len as usize + 1
+    } else {
+        1
+    };
+
+    let mut attn = vec![0.0f32; q_dim];
+    let rep = num_heads / num_kv_heads;
+    let scale = 1.0f32 / (head_dim as f32).sqrt();
+    let cache_k = if cache_k_set {
+        Some(unsafe {
+            std::slice::from_raw_parts(
+                layer.kv_cache_k as *const u16,
+                layer.kv_max_t as usize * kv_dim,
+            )
+        })
+    } else {
+        None
+    };
+    let cache_v = if cache_v_set {
+        Some(unsafe {
+            std::slice::from_raw_parts(
+                layer.kv_cache_v as *const u16,
+                layer.kv_max_t as usize * kv_dim,
+            )
+        })
+    } else {
+        None
+    };
+    for head in 0..num_heads {
+        let kv_head = head / rep;
+        let mut scores = vec![0.0f32; kv_len];
+        let mut max_score = f32::NEG_INFINITY;
+        for t in 0..kv_len {
+            let mut dot = 0.0f32;
+            for i in 0..head_dim {
+                let kval = cache_k
+                    .map(|cache| bf16_bits_to_f32(cache[t * kv_dim + kv_head * head_dim + i]))
+                    .unwrap_or_else(|| k[kv_head * head_dim + i]);
+                dot += q[head * head_dim + i] * kval;
+            }
+            let score = dot * scale;
+            scores[t] = score;
+            max_score = max_score.max(score);
+        }
+        let mut denom = 0.0f32;
+        for score in scores.iter_mut() {
+            *score = (*score - max_score).exp();
+            denom += *score;
+        }
+        for i in 0..head_dim {
+            let mut acc = 0.0f32;
+            for t in 0..kv_len {
+                let vv = cache_v
+                    .map(|cache| bf16_bits_to_f32(cache[t * kv_dim + kv_head * head_dim + i]))
+                    .unwrap_or_else(|| v[kv_head * head_dim + i]);
+                acc += (scores[t] / denom) * vv;
+            }
+            attn[head * head_dim + i] = bf16_round_f32(acc);
+        }
+    }
+
+    let mut attn_out = vec![0.0f32; hidden];
+    q3_int4_matvec_host(
+        layer.o_proj_w as *const u8,
+        int4.o_proj_scale as *const u16,
+        int4.o_proj_zero as *const u16,
+        hidden,
+        q_dim,
+        group_size,
+        &attn,
+        &mut attn_out,
+    );
+    for i in 0..hidden {
+        x[i] = bf16_round_f32(x[i] + bf16_round_f32(attn_out[i]));
+    }
+
+    q3_rms_norm_host(
+        &x,
+        layer.post_attn_norm_w as *const u16,
+        layer.post_attn_norm_eps,
+        &mut hnorm,
+    );
+    let mut router = vec![0.0f32; experts];
+    q3_bf16_matvec_host(
+        layer.router_w as *const u16,
+        experts,
+        hidden,
+        &hnorm,
+        &mut router,
+    );
+    let (topk_val, topk_idx) = q3_router_topk_host(&router, top_k, layer.norm_topk_prob != 0);
+
+    let mut moe_out = vec![0.0f32; hidden];
+    let mut gu = vec![0.0f32; 2 * moe_i];
+    let mut mid = vec![0.0f32; moe_i];
+    let mut expert_out = vec![0.0f32; hidden];
+    for kpos in 0..top_k {
+        let expert = topk_idx[kpos];
+        q3_expert_int4_matvec_host(
+            layer.experts_gate_up_w as *const u8,
+            int4.experts_gate_up_scale as *const u16,
+            int4.experts_gate_up_zero as *const u16,
+            expert,
+            2 * moe_i,
+            hidden,
+            group_size,
+            &hnorm,
+            &mut gu,
+        );
+        for i in 0..moe_i {
+            let g = gu[i];
+            let u = gu[moe_i + i];
+            mid[i] = bf16_round_f32((g / (1.0 + (-g).exp())) * u);
+        }
+        q3_expert_int4_matvec_host(
+            layer.experts_down_w as *const u8,
+            int4.experts_down_scale as *const u16,
+            int4.experts_down_zero as *const u16,
+            expert,
+            hidden,
+            moe_i,
+            group_size,
+            &mid,
+            &mut expert_out,
+        );
+        for i in 0..hidden {
+            moe_out[i] += topk_val[kpos] * expert_out[i];
+        }
+    }
+
+    for i in 0..hidden {
+        output[i] = f32_to_bf16_bits(bf16_round_f32(x[i] + bf16_round_f32(moe_out[i])));
+    }
+    Ok(())
+}
+
 pub fn lm_head_launch(
     ordinal: usize,
     dtype: ScalarType,
@@ -280,6 +625,19 @@ pub fn lm_head_launch(
         )));
     }
     let backend = final_hidden.backend();
+    if backend == Backend::Metal {
+        let _ = counter;
+        return lm_head_launch_metal_bf16(
+            ordinal,
+            hidden,
+            vocab,
+            rms_norm_eps,
+            final_hidden,
+            final_norm_w,
+            lm_head_w,
+            logits,
+        );
+    }
     let status: c_int = match backend {
         Backend::Hip => {
             #[cfg(supersonic_backend_hip)]
@@ -428,6 +786,22 @@ pub fn lm_head_int4_launch(
         )));
     }
     let backend = final_hidden.backend();
+    if backend == Backend::Metal {
+        let _ = counter;
+        return lm_head_int4_launch_metal_bf16(
+            ordinal,
+            hidden,
+            vocab,
+            rms_norm_eps,
+            final_hidden,
+            final_norm_w,
+            lm_head_w,
+            lm_head_scale,
+            lm_head_zero,
+            group_size,
+            logits,
+        );
+    }
     let status: c_int = match backend {
         Backend::Hip => {
             #[cfg(supersonic_backend_hip)]
@@ -483,6 +857,370 @@ pub fn lm_head_int4_launch(
     Ok(())
 }
 
+fn checked_lm_head_dims(
+    hidden: i32,
+    vocab: i32,
+    group_size: Option<i32>,
+) -> Result<(usize, usize, usize), GpuError> {
+    if hidden <= 0 || vocab <= 0 {
+        return Err(GpuError::InvalidArg(format!(
+            "qwen3_moe lm_head Metal fallback requires positive hidden/vocab, got {hidden}/{vocab}"
+        )));
+    }
+    let group_size = match group_size {
+        Some(g) if g > 0 => g as usize,
+        Some(g) => {
+            return Err(GpuError::InvalidArg(format!(
+                "qwen3_moe INT4 lm_head Metal fallback requires positive group_size, got {g}"
+            )));
+        }
+        None => 0,
+    };
+    Ok((hidden as usize, vocab as usize, group_size))
+}
+
+fn checked_positive(name: &str, value: i32) -> Result<usize, GpuError> {
+    if value <= 0 {
+        return Err(GpuError::InvalidArg(format!(
+            "qwen3_moe::decode_layer_launch: Metal fallback requires positive {name}, got {value}"
+        )));
+    }
+    Ok(value as usize)
+}
+
+fn require_ptrs(
+    _layer: &Qwen3MoeDecodeLayerDesc,
+    _int4: &Qwen3MoeInt4ScaleDesc,
+    ptrs: &[*const c_void],
+) -> Result<(), GpuError> {
+    if ptrs.iter().any(|ptr| ptr.is_null()) {
+        return Err(GpuError::InvalidArg(
+            "qwen3_moe::decode_layer_launch: Metal fallback requires all layer and INT4 pointers"
+                .into(),
+        ));
+    }
+    Ok(())
+}
+
+fn bf16_bits_to_f32(bits: u16) -> f32 {
+    f32::from_bits((bits as u32) << 16)
+}
+
+fn f32_to_bf16_bits(x: f32) -> u16 {
+    let mut bits = x.to_bits();
+    let bias = 0x7FFFu32 + ((bits >> 16) & 1);
+    bits = bits.wrapping_add(bias) & 0xFFFF_0000;
+    (bits >> 16) as u16
+}
+
+fn bf16_round_f32(x: f32) -> f32 {
+    bf16_bits_to_f32(f32_to_bf16_bits(x))
+}
+
+fn q3_rms_norm_host(input: &[f32], weight: *const u16, eps: f32, output: &mut [f32]) {
+    let mean_sq = input.iter().map(|v| v * v).sum::<f32>() / input.len() as f32;
+    let inv = 1.0f32 / (mean_sq + eps).sqrt();
+    let weight = unsafe { std::slice::from_raw_parts(weight, input.len()) };
+    for (i, out) in output.iter_mut().enumerate() {
+        *out = bf16_round_f32(input[i] * inv * bf16_bits_to_f32(weight[i]));
+    }
+}
+
+fn q3_head_rms_norm_host(
+    x: &mut [f32],
+    heads: usize,
+    head_dim: usize,
+    weight: *const u16,
+    eps: f32,
+) {
+    let weight = unsafe { std::slice::from_raw_parts(weight, head_dim) };
+    for head in 0..heads {
+        let base = head * head_dim;
+        let mean_sq = x[base..base + head_dim].iter().map(|v| v * v).sum::<f32>() / head_dim as f32;
+        let inv = 1.0f32 / (mean_sq + eps).sqrt();
+        for i in 0..head_dim {
+            x[base + i] = bf16_round_f32(x[base + i] * inv * bf16_bits_to_f32(weight[i]));
+        }
+    }
+}
+
+fn q3_rope_half_host(x: &mut [f32], heads: usize, head_dim: usize, position: i32, theta: f32) {
+    let half = head_dim / 2;
+    let theta_log = theta.ln();
+    for head in 0..heads {
+        let base = head * head_dim;
+        for i in 0..half {
+            let a = x[base + i];
+            let b = x[base + half + i];
+            let freq = position as f32 * (-(i as f32 / half as f32) * theta_log).exp();
+            let c = bf16_round_f32(freq.cos());
+            let s = bf16_round_f32(freq.sin());
+            x[base + i] = bf16_round_f32(bf16_round_f32(a * c) - bf16_round_f32(b * s));
+            x[base + half + i] = bf16_round_f32(bf16_round_f32(b * c) + bf16_round_f32(a * s));
+        }
+    }
+}
+
+fn q3_int4_value(
+    packed: &[u8],
+    scale: &[u16],
+    zero: &[u16],
+    row: usize,
+    col: usize,
+    rows: usize,
+    cols: usize,
+    group_size: usize,
+) -> f32 {
+    let _ = rows;
+    let byte_cols = cols.div_ceil(2);
+    let byte = packed[row * byte_cols + col / 2];
+    let nibble = if col & 1 == 0 {
+        byte & 0x0f
+    } else {
+        (byte >> 4) & 0x0f
+    };
+    let scale_cols = cols.div_ceil(group_size);
+    let scale_idx = (row / group_size) * scale_cols + col / group_size;
+    let s = bf16_bits_to_f32(scale[scale_idx]);
+    let z = bf16_bits_to_f32(zero[scale_idx]);
+    bf16_round_f32(nibble as f32 * s - z * s)
+}
+
+fn q3_int4_matvec_host(
+    weight: *const u8,
+    scale: *const u16,
+    zero: *const u16,
+    rows: usize,
+    cols: usize,
+    group_size: usize,
+    x: &[f32],
+    out: &mut [f32],
+) {
+    let packed = unsafe { std::slice::from_raw_parts(weight, rows * cols.div_ceil(2)) };
+    let scale_len = rows.div_ceil(group_size) * cols.div_ceil(group_size);
+    let scale = unsafe { std::slice::from_raw_parts(scale, scale_len) };
+    let zero = unsafe { std::slice::from_raw_parts(zero, scale_len) };
+    for row in 0..rows {
+        let mut acc = 0.0f32;
+        for col in 0..cols {
+            acc += q3_int4_value(packed, scale, zero, row, col, rows, cols, group_size) * x[col];
+        }
+        out[row] = bf16_round_f32(acc);
+    }
+}
+
+fn q3_bf16_matvec_host(weight: *const u16, rows: usize, cols: usize, x: &[f32], out: &mut [f32]) {
+    let weight = unsafe { std::slice::from_raw_parts(weight, rows * cols) };
+    for row in 0..rows {
+        let mut acc = 0.0f32;
+        let row_base = row * cols;
+        for col in 0..cols {
+            acc += bf16_bits_to_f32(weight[row_base + col]) * x[col];
+        }
+        out[row] = bf16_round_f32(acc);
+    }
+}
+
+fn q3_expert_int4_value(
+    packed: &[u8],
+    scale: &[u16],
+    zero: &[u16],
+    expert: usize,
+    row: usize,
+    col: usize,
+    rows: usize,
+    cols: usize,
+    group_size: usize,
+) -> f32 {
+    let byte_cols = cols.div_ceil(2);
+    let packed_base = (expert * rows + row) * byte_cols;
+    let byte = packed[packed_base + col / 2];
+    let nibble = if col & 1 == 0 {
+        byte & 0x0f
+    } else {
+        (byte >> 4) & 0x0f
+    };
+    let scale_rows = rows.div_ceil(group_size);
+    let scale_cols = cols.div_ceil(group_size);
+    let scale_idx = (expert * scale_rows + row / group_size) * scale_cols + col / group_size;
+    let s = bf16_bits_to_f32(scale[scale_idx]);
+    let z = bf16_bits_to_f32(zero[scale_idx]);
+    bf16_round_f32(nibble as f32 * s - z * s)
+}
+
+fn q3_expert_int4_matvec_host(
+    weight: *const u8,
+    scale: *const u16,
+    zero: *const u16,
+    expert: usize,
+    rows: usize,
+    cols: usize,
+    group_size: usize,
+    x: &[f32],
+    out: &mut [f32],
+) {
+    let expert_count = expert + 1;
+    let packed =
+        unsafe { std::slice::from_raw_parts(weight, expert_count * rows * cols.div_ceil(2)) };
+    let scale_len = expert_count * rows.div_ceil(group_size) * cols.div_ceil(group_size);
+    let scale = unsafe { std::slice::from_raw_parts(scale, scale_len) };
+    let zero = unsafe { std::slice::from_raw_parts(zero, scale_len) };
+    for row in 0..rows {
+        let mut acc = 0.0f32;
+        for col in 0..cols {
+            acc += q3_expert_int4_value(
+                packed, scale, zero, expert, row, col, rows, cols, group_size,
+            ) * x[col];
+        }
+        out[row] = bf16_round_f32(acc);
+    }
+}
+
+fn q3_router_topk_host(
+    router: &[f32],
+    top_k: usize,
+    norm_topk_prob: bool,
+) -> (Vec<f32>, Vec<usize>) {
+    let experts = router.len();
+    let mut probs = vec![0.0f32; experts];
+    let mut vals = vec![0.0f32; top_k];
+    let mut idxs = vec![0usize; top_k];
+    if norm_topk_prob {
+        let mut scratch = router.to_vec();
+        for kpos in 0..top_k {
+            let mut best_i = 0usize;
+            let mut best_v = f32::NEG_INFINITY;
+            for (idx, &value) in scratch.iter().enumerate() {
+                if value > best_v {
+                    best_i = idx;
+                    best_v = value;
+                }
+            }
+            idxs[kpos] = best_i;
+            vals[kpos] = best_v;
+            scratch[best_i] = f32::NEG_INFINITY;
+        }
+        let maxv = vals[0];
+        let mut denom = 0.0f32;
+        for expert in 0..experts {
+            probs[expert] = (router[expert] - maxv).exp();
+            denom += probs[expert];
+        }
+        for kpos in 0..top_k {
+            vals[kpos] = bf16_round_f32(probs[idxs[kpos]] / denom);
+        }
+        let sum = vals.iter().sum::<f32>();
+        for val in vals.iter_mut() {
+            *val = bf16_round_f32(*val / sum);
+        }
+    } else {
+        let maxv = router
+            .iter()
+            .copied()
+            .fold(f32::NEG_INFINITY, |acc, value| acc.max(value));
+        let mut denom = 0.0f32;
+        for expert in 0..experts {
+            probs[expert] = (router[expert] - maxv).exp();
+            denom += probs[expert];
+        }
+        for prob in probs.iter_mut() {
+            *prob = bf16_round_f32(*prob / denom);
+        }
+        for kpos in 0..top_k {
+            let mut best_i = 0usize;
+            let mut best_v = f32::NEG_INFINITY;
+            for (idx, &value) in probs.iter().enumerate() {
+                if value > best_v {
+                    best_i = idx;
+                    best_v = value;
+                }
+            }
+            idxs[kpos] = best_i;
+            vals[kpos] = best_v;
+            probs[best_i] = f32::NEG_INFINITY;
+        }
+    }
+    (vals, idxs)
+}
+
+fn lm_head_launch_metal_bf16(
+    ordinal: usize,
+    hidden: i32,
+    vocab: i32,
+    rms_norm_eps: f32,
+    final_hidden: &GpuBuffer,
+    final_norm_w: &GpuBuffer,
+    lm_head_w: &GpuBuffer,
+    logits: &mut GpuBuffer,
+) -> Result<(), GpuError> {
+    let (hidden, vocab, _) = checked_lm_head_dims(hidden, vocab, None)?;
+    let mut normed = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[1, hidden])?;
+    crate::prefill_ffi::rms_norm_rows_plain(
+        ordinal,
+        ScalarType::BF16,
+        1,
+        hidden,
+        rms_norm_eps,
+        final_hidden,
+        final_norm_w,
+        &mut normed,
+    )?;
+    crate::prefill_ffi::matmul_rhs_transposed(
+        ordinal,
+        ScalarType::BF16,
+        1,
+        1,
+        vocab,
+        hidden,
+        &normed,
+        lm_head_w,
+        logits,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn lm_head_int4_launch_metal_bf16(
+    ordinal: usize,
+    hidden: i32,
+    vocab: i32,
+    rms_norm_eps: f32,
+    final_hidden: &GpuBuffer,
+    final_norm_w: &GpuBuffer,
+    lm_head_w: &GpuBuffer,
+    lm_head_scale: &GpuBuffer,
+    lm_head_zero: &GpuBuffer,
+    group_size: i32,
+    logits: &mut GpuBuffer,
+) -> Result<(), GpuError> {
+    let (hidden, vocab, group_size) = checked_lm_head_dims(hidden, vocab, Some(group_size))?;
+    let mut normed = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[1, hidden])?;
+    crate::prefill_ffi::rms_norm_rows_plain(
+        ordinal,
+        ScalarType::BF16,
+        1,
+        hidden,
+        rms_norm_eps,
+        final_hidden,
+        final_norm_w,
+        &mut normed,
+    )?;
+    crate::prefill_ffi::matmul_rhs_transposed_int4(
+        ordinal,
+        1,
+        1,
+        vocab,
+        hidden,
+        &normed,
+        lm_head_w,
+        lm_head_scale,
+        lm_head_zero,
+        None,
+        group_size,
+        LOWBIT_NATIVE_INT4,
+        logits,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -491,5 +1229,408 @@ mod tests {
     fn descriptor_sizes_match_bridge_static_asserts() {
         assert_eq!(std::mem::size_of::<Qwen3MoeDecodeLayerDesc>(), 168);
         assert_eq!(std::mem::size_of::<Qwen3MoeInt4ScaleDesc>(), 104);
+    }
+
+    #[cfg(all(target_os = "macos", supersonic_backend_metal))]
+    fn bf16_bytes(values: &[f32]) -> Vec<u8> {
+        values
+            .iter()
+            .flat_map(|value| half::bf16::from_f32(*value).to_bits().to_le_bytes())
+            .collect()
+    }
+
+    #[cfg(all(target_os = "macos", supersonic_backend_metal))]
+    fn read_bf16(buffer: &GpuBuffer) -> Vec<f32> {
+        let bytes = buffer.to_host_bytes().expect("download bf16");
+        bytes
+            .chunks_exact(2)
+            .map(|chunk| half::bf16::from_bits(u16::from_le_bytes([chunk[0], chunk[1]])).to_f32())
+            .collect()
+    }
+
+    #[cfg(all(target_os = "macos", supersonic_backend_metal))]
+    fn upload_bf16(ordinal: usize, shape: &[usize], values: &[f32]) -> GpuBuffer {
+        GpuBuffer::from_host_bytes(ordinal, ScalarType::BF16, shape, &bf16_bytes(values))
+            .expect("upload bf16")
+    }
+
+    #[cfg(all(target_os = "macos", supersonic_backend_metal))]
+    fn pack_int4_rows(rows: &[Vec<u8>]) -> Vec<u8> {
+        let mut out = Vec::new();
+        for row in rows {
+            for pair in row.chunks(2) {
+                let lo = pair[0] & 0x0f;
+                let hi = pair.get(1).copied().unwrap_or(0) & 0x0f;
+                out.push(lo | (hi << 4));
+            }
+        }
+        out
+    }
+
+    #[cfg(all(target_os = "macos", supersonic_backend_metal))]
+    fn upload_int4_matrix(
+        ordinal: usize,
+        rows: usize,
+        cols: usize,
+        group_size: usize,
+        nibbles: Vec<Vec<u8>>,
+        scale: f32,
+    ) -> (GpuBuffer, GpuBuffer, GpuBuffer) {
+        let packed = pack_int4_rows(&nibbles);
+        let weight =
+            GpuBuffer::from_host_bytes(ordinal, ScalarType::U8, &[rows, cols.div_ceil(2)], &packed)
+                .expect("upload int4 matrix");
+        let scale_len = rows.div_ceil(group_size) * cols.div_ceil(group_size);
+        let scale_vals = vec![scale; scale_len];
+        let zero_vals = vec![0.0; scale_len];
+        (
+            weight,
+            upload_bf16(ordinal, &[scale_len], &scale_vals),
+            upload_bf16(ordinal, &[scale_len], &zero_vals),
+        )
+    }
+
+    #[cfg(all(target_os = "macos", supersonic_backend_metal))]
+    fn upload_int4_experts(
+        ordinal: usize,
+        experts: usize,
+        rows: usize,
+        cols: usize,
+        group_size: usize,
+        nibbles: Vec<Vec<Vec<u8>>>,
+        scale: f32,
+    ) -> (GpuBuffer, GpuBuffer, GpuBuffer) {
+        let mut flat_rows = Vec::new();
+        for expert in nibbles {
+            for row in expert {
+                flat_rows.push(row);
+            }
+        }
+        let packed = pack_int4_rows(&flat_rows);
+        let weight = GpuBuffer::from_host_bytes(
+            ordinal,
+            ScalarType::U8,
+            &[experts, rows, cols.div_ceil(2)],
+            &packed,
+        )
+        .expect("upload int4 experts");
+        let scale_len = experts * rows.div_ceil(group_size) * cols.div_ceil(group_size);
+        let scale_vals = vec![scale; scale_len];
+        let zero_vals = vec![0.0; scale_len];
+        (
+            weight,
+            upload_bf16(ordinal, &[scale_len], &scale_vals),
+            upload_bf16(ordinal, &[scale_len], &zero_vals),
+        )
+    }
+
+    #[cfg(all(target_os = "macos", supersonic_backend_metal))]
+    fn rms_norm_reference(hidden: &[f32], weight: &[f32], eps: f32) -> Vec<f32> {
+        let mean_sq = hidden.iter().map(|v| v * v).sum::<f32>() / hidden.len() as f32;
+        let inv = 1.0 / (mean_sq + eps).sqrt();
+        hidden
+            .iter()
+            .zip(weight.iter())
+            .map(|(h, w)| half::bf16::from_f32(h * inv * w).to_f32())
+            .collect()
+    }
+
+    #[cfg(all(target_os = "macos", supersonic_backend_metal))]
+    #[test]
+    fn metal_lm_head_bf16_fallback_runs() {
+        gpu_hal::set_backend(Backend::Metal);
+        let ordinal = 0usize;
+        let hidden_vals = [1.0, 0.5, -1.0, 2.0];
+        let norm_vals = [1.0, 1.0, 1.0, 1.0];
+        let lm_vals = [
+            1.0, 0.0, 0.0, 0.0, //
+            0.0, 1.0, 0.0, 0.0, //
+            0.0, 0.0, 1.0, 0.0, //
+            0.0, 0.0, 0.0, 1.0, //
+        ];
+        let hidden = upload_bf16(ordinal, &[4], &hidden_vals);
+        let norm = upload_bf16(ordinal, &[4], &norm_vals);
+        let lm = upload_bf16(ordinal, &[4, 4], &lm_vals);
+        let mut logits = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[4]).expect("alloc logits");
+        let mut counter = GpuBuffer::zeros(ordinal, ScalarType::U32, &[1]).expect("alloc counter");
+
+        lm_head_launch(
+            ordinal,
+            ScalarType::BF16,
+            4,
+            4,
+            0.0,
+            &hidden,
+            &norm,
+            &lm,
+            &mut logits,
+            &mut counter,
+        )
+        .expect("run Qwen3-MoE Metal BF16 lm_head fallback");
+
+        let actual = read_bf16(&logits);
+        let expected = rms_norm_reference(&hidden_vals, &norm_vals, 0.0);
+        for (idx, (a, e)) in actual.iter().zip(expected.iter()).enumerate() {
+            assert!((a - e).abs() <= 0.01, "idx {idx}: expected {e}, got {a}");
+        }
+    }
+
+    #[cfg(all(target_os = "macos", supersonic_backend_metal))]
+    #[test]
+    fn metal_lm_head_int4_fallback_runs() {
+        gpu_hal::set_backend(Backend::Metal);
+        let ordinal = 0usize;
+        let hidden_vals = [1.0, 0.5, -1.0, 2.0];
+        let norm_vals = [1.0, 1.0, 1.0, 1.0];
+        let hidden = upload_bf16(ordinal, &[4], &hidden_vals);
+        let norm = upload_bf16(ordinal, &[4], &norm_vals);
+
+        let nibbles: [[u8; 4]; 4] = [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 0]];
+        let mut rhs_bytes = Vec::with_capacity(8);
+        for row in &nibbles {
+            rhs_bytes.push(row[0] | (row[1] << 4));
+            rhs_bytes.push(row[2] | (row[3] << 4));
+        }
+        let lm_int4 = GpuBuffer::from_host_bytes(ordinal, ScalarType::U8, &[1, 4, 2], &rhs_bytes)
+            .expect("upload int4 lm_head");
+        let scale_vals = [0.5, 0.25, 0.125, 1.0];
+        let zero_vals = [2.0, 1.0, 4.0, 0.5];
+        let scale = upload_bf16(ordinal, &[2, 2], &scale_vals);
+        let zero = upload_bf16(ordinal, &[2, 2], &zero_vals);
+        let mut logits = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[4]).expect("alloc logits");
+        let mut counter = GpuBuffer::zeros(ordinal, ScalarType::U32, &[1]).expect("alloc counter");
+
+        lm_head_int4_launch(
+            ordinal,
+            ScalarType::BF16,
+            4,
+            4,
+            0.0,
+            &hidden,
+            &norm,
+            &lm_int4,
+            &scale,
+            &zero,
+            2,
+            &mut logits,
+            &mut counter,
+        )
+        .expect("run Qwen3-MoE Metal INT4 lm_head fallback");
+
+        let normed = rms_norm_reference(&hidden_vals, &norm_vals, 0.0);
+        let bf16_round = |x: f32| -> f32 { half::bf16::from_f32(x).to_f32() };
+        let mut expected = [0.0f32; 4];
+        for col in 0..4usize {
+            let scale_row = col / 2;
+            let mut acc = 0.0f32;
+            for kk in 0..4usize {
+                let si = scale_row * 2 + (kk / 2);
+                let w = bf16_round(
+                    nibbles[col][kk] as f32 * scale_vals[si] - zero_vals[si] * scale_vals[si],
+                );
+                acc += normed[kk] * w;
+            }
+            expected[col] = acc;
+        }
+
+        let actual = read_bf16(&logits);
+        for (idx, (a, e)) in actual.iter().zip(expected.iter()).enumerate() {
+            assert!((a - e).abs() <= 0.05, "idx {idx}: expected {e}, got {a}");
+        }
+    }
+
+    #[cfg(all(target_os = "macos", supersonic_backend_metal))]
+    #[test]
+    fn metal_decode_layer_int4_fallback_runs_and_updates_kv() {
+        gpu_hal::set_backend(Backend::Metal);
+        let ordinal = 0usize;
+        let hidden = 4usize;
+        let head_dim = 2usize;
+        let num_heads = 2usize;
+        let num_kv_heads = 1usize;
+        let q_dim = num_heads * head_dim;
+        let kv_dim = num_kv_heads * head_dim;
+        let experts = 2usize;
+        let top_k = 1usize;
+        let moe_i = 2usize;
+        let group_size = 2usize;
+
+        let input = upload_bf16(ordinal, &[hidden], &[1.0, -0.5, 0.25, 0.75]);
+        let input_norm = upload_bf16(ordinal, &[hidden], &[1.0, 1.0, 1.0, 1.0]);
+        let post_norm = upload_bf16(ordinal, &[hidden], &[1.0, 1.0, 1.0, 1.0]);
+        let q_norm = upload_bf16(ordinal, &[head_dim], &[1.0, 1.0]);
+        let k_norm = upload_bf16(ordinal, &[head_dim], &[1.0, 1.0]);
+        let router = upload_bf16(
+            ordinal,
+            &[experts, hidden],
+            &[1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0],
+        );
+
+        let (q_w, q_s, q_z) = upload_int4_matrix(
+            ordinal,
+            q_dim,
+            hidden,
+            group_size,
+            vec![
+                vec![4, 0, 0, 0],
+                vec![0, 4, 0, 0],
+                vec![0, 0, 4, 0],
+                vec![0, 0, 0, 4],
+            ],
+            0.25,
+        );
+        let (k_w, k_s, k_z) = upload_int4_matrix(
+            ordinal,
+            kv_dim,
+            hidden,
+            group_size,
+            vec![vec![4, 0, 0, 0], vec![0, 4, 0, 0]],
+            0.25,
+        );
+        let (v_w, v_s, v_z) = upload_int4_matrix(
+            ordinal,
+            kv_dim,
+            hidden,
+            group_size,
+            vec![vec![0, 0, 4, 0], vec![0, 0, 0, 4]],
+            0.25,
+        );
+        let (o_w, o_s, o_z) = upload_int4_matrix(
+            ordinal,
+            hidden,
+            q_dim,
+            group_size,
+            vec![
+                vec![4, 0, 0, 0],
+                vec![0, 4, 0, 0],
+                vec![0, 0, 4, 0],
+                vec![0, 0, 0, 4],
+            ],
+            0.25,
+        );
+        let (gate_up_w, gate_up_s, gate_up_z) = upload_int4_experts(
+            ordinal,
+            experts,
+            2 * moe_i,
+            hidden,
+            group_size,
+            vec![
+                vec![
+                    vec![4, 0, 0, 0],
+                    vec![0, 4, 0, 0],
+                    vec![0, 0, 4, 0],
+                    vec![0, 0, 0, 4],
+                ],
+                vec![
+                    vec![0, 4, 0, 0],
+                    vec![4, 0, 0, 0],
+                    vec![0, 0, 0, 4],
+                    vec![0, 0, 4, 0],
+                ],
+            ],
+            0.25,
+        );
+        let (down_w, down_s, down_z) = upload_int4_experts(
+            ordinal,
+            experts,
+            hidden,
+            moe_i,
+            group_size,
+            vec![
+                vec![vec![4, 0], vec![0, 4], vec![4, 0], vec![0, 4]],
+                vec![vec![0, 4], vec![4, 0], vec![0, 4], vec![4, 0]],
+            ],
+            0.25,
+        );
+
+        let mut kv_k = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[2, kv_dim]).expect("kv k");
+        let mut kv_v = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[2, kv_dim]).expect("kv v");
+        let mut output = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[hidden]).expect("output");
+        let workspace_len = hidden
+            + q_dim
+            + kv_dim
+            + kv_dim
+            + q_dim
+            + hidden
+            + experts
+            + experts
+            + top_k
+            + top_k
+            + 2 * moe_i
+            + moe_i
+            + hidden
+            + hidden;
+        let mut workspace =
+            GpuBuffer::zeros(ordinal, ScalarType::F32, &[workspace_len]).expect("workspace");
+
+        let layer = Qwen3MoeDecodeLayerDesc {
+            layer_idx: 0,
+            input_norm_w: input_norm.as_ptr(),
+            input_norm_eps: 1e-5,
+            post_attn_norm_w: post_norm.as_ptr(),
+            post_attn_norm_eps: 1e-5,
+            q_proj_w: q_w.as_ptr(),
+            k_proj_w: k_w.as_ptr(),
+            v_proj_w: v_w.as_ptr(),
+            o_proj_w: o_w.as_ptr(),
+            q_norm_w: q_norm.as_ptr(),
+            k_norm_w: k_norm.as_ptr(),
+            rope_theta: 10_000.0,
+            head_dim: head_dim as i32,
+            num_heads: num_heads as i32,
+            num_kv_heads: num_kv_heads as i32,
+            kv_cache_k: kv_k.as_mut_ptr(),
+            kv_cache_v: kv_v.as_mut_ptr(),
+            kv_len: 0,
+            kv_max_t: 2,
+            router_w: router.as_ptr(),
+            experts_gate_up_w: gate_up_w.as_ptr(),
+            experts_down_w: down_w.as_ptr(),
+            num_experts: experts as i32,
+            top_k: top_k as i32,
+            moe_intermediate_size: moe_i as i32,
+            norm_topk_prob: 1,
+        };
+        let int4 = Qwen3MoeInt4ScaleDesc {
+            q_proj_scale: q_s.as_ptr(),
+            q_proj_zero: q_z.as_ptr(),
+            k_proj_scale: k_s.as_ptr(),
+            k_proj_zero: k_z.as_ptr(),
+            v_proj_scale: v_s.as_ptr(),
+            v_proj_zero: v_z.as_ptr(),
+            o_proj_scale: o_s.as_ptr(),
+            o_proj_zero: o_z.as_ptr(),
+            experts_gate_up_scale: gate_up_s.as_ptr(),
+            experts_gate_up_zero: gate_up_z.as_ptr(),
+            experts_down_scale: down_s.as_ptr(),
+            experts_down_zero: down_z.as_ptr(),
+            group_size: group_size as i32,
+        };
+
+        decode_layer_launch(
+            ordinal,
+            ScalarType::BF16,
+            &layer,
+            &int4,
+            hidden as i32,
+            0,
+            &input,
+            &mut output,
+            &mut workspace,
+        )
+        .expect("run Qwen3-MoE Metal decode-layer INT4 fallback");
+
+        let actual = read_bf16(&output);
+        assert!(
+            actual.iter().all(|v| v.is_finite()) && actual.iter().any(|v| v.abs() > 0.001),
+            "decode output should be finite and non-zero: {actual:?}"
+        );
+        let cached_k = read_bf16(&kv_k);
+        let cached_v = read_bf16(&kv_v);
+        assert!(
+            cached_k.iter().take(kv_dim).any(|v| v.abs() > 0.001)
+                && cached_v.iter().take(kv_dim).any(|v| v.abs() > 0.001),
+            "KV cache should be updated: k={cached_k:?} v={cached_v:?}"
+        );
     }
 }

--- a/crates/machine-profile/src/cpu/vector_kernels.rs
+++ b/crates/machine-profile/src/cpu/vector_kernels.rs
@@ -16,20 +16,27 @@ fn measure_fp32(num_p_cores: u32) -> MeasuredVsTheoretical {
     // peak_fp32_avx2 is compiled with target_feature = "avx2,fma" and uses
     // _mm256_fmadd_ps. AVX2 does not imply FMA on x86_64 — early Haswell-era
     // and a few low-power lines have one without the other, so gate on both.
-    let per_core_gflops = if cfg!(target_arch = "x86_64")
-        && std::is_x86_feature_detected!("avx2")
-        && std::is_x86_feature_detected!("fma")
-    {
-        unsafe { peak_fp32_avx2() }
-    } else {
-        peak_fp32_scalar()
-    };
+    let per_core_gflops = measure_fp32_impl();
     MeasuredVsTheoretical {
         measured_per_unit: Some(per_core_gflops),
         measured_aggregate: per_core_gflops * num_p_cores as f64,
         theoretical_aggregate: None,
         ratio: None,
     }
+}
+
+#[cfg(target_arch = "x86_64")]
+fn measure_fp32_impl() -> f64 {
+    if std::is_x86_feature_detected!("avx2") && std::is_x86_feature_detected!("fma") {
+        unsafe { peak_fp32_avx2() }
+    } else {
+        peak_fp32_scalar()
+    }
+}
+
+#[cfg(not(target_arch = "x86_64"))]
+fn measure_fp32_impl() -> f64 {
+    peak_fp32_scalar()
 }
 
 // NOTE: On stable Rust 1.95.0, `_mm512_castsi512_bf16` and `_mm512_dpbf16_ps`
@@ -39,15 +46,27 @@ fn measure_fp32(num_p_cores: u32) -> MeasuredVsTheoretical {
 // this toolchain — catalog consumers should treat it as a lower bound until the
 // AVX-512 BF16 intrinsics land on stable.
 fn measure_bf16(num_p_cores: u32) -> Option<MeasuredVsTheoretical> {
-    if !cfg!(target_arch = "x86_64") { return None; }
-    if !std::is_x86_feature_detected!("avx512bf16") { return None; }
-    let per_core_gflops = unsafe { peak_bf16_avx512() };
-    Some(MeasuredVsTheoretical {
-        measured_per_unit: Some(per_core_gflops),
-        measured_aggregate: per_core_gflops * num_p_cores as f64,
-        theoretical_aggregate: None,
-        ratio: None,
-    })
+    measure_bf16_impl(num_p_cores)
+}
+
+#[cfg(target_arch = "x86_64")]
+fn measure_bf16_impl(num_p_cores: u32) -> Option<MeasuredVsTheoretical> {
+    if std::is_x86_feature_detected!("avx512bf16") {
+        let per_core_gflops = unsafe { peak_bf16_avx512() };
+        Some(MeasuredVsTheoretical {
+            measured_per_unit: Some(per_core_gflops),
+            measured_aggregate: per_core_gflops * num_p_cores as f64,
+            theoretical_aggregate: None,
+            ratio: None,
+        })
+    } else {
+        None
+    }
+}
+
+#[cfg(not(target_arch = "x86_64"))]
+fn measure_bf16_impl(_num_p_cores: u32) -> Option<MeasuredVsTheoretical> {
+    None
 }
 
 fn peak_fp32_scalar() -> f64 {
@@ -83,7 +102,9 @@ unsafe fn peak_fp32_avx2() -> f64 {
         }
     }
     let mut acc = a[0];
-    for k in 1..8 { acc = _mm256_add_ps(acc, a[k]); }
+    for k in 1..8 {
+        acc = _mm256_add_ps(acc, a[k]);
+    }
     let mut tmp = [0f32; 8];
     _mm256_storeu_ps(tmp.as_mut_ptr(), acc);
     black_box(tmp);
@@ -91,7 +112,9 @@ unsafe fn peak_fp32_avx2() -> f64 {
 }
 
 #[cfg(not(target_arch = "x86_64"))]
-unsafe fn peak_fp32_avx2() -> f64 { peak_fp32_scalar() }
+unsafe fn peak_fp32_avx2() -> f64 {
+    peak_fp32_scalar()
+}
 
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "avx512bf16")]
@@ -105,7 +128,9 @@ unsafe fn peak_bf16_avx512() -> f64 {
 }
 
 #[cfg(not(target_arch = "x86_64"))]
-unsafe fn peak_bf16_avx512() -> f64 { 0.0 }
+unsafe fn peak_bf16_avx512() -> f64 {
+    0.0
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/runner/src/bin/qwen35_bughunt.rs
+++ b/crates/runner/src/bin/qwen35_bughunt.rs
@@ -57,6 +57,10 @@ struct Cli {
 
     #[arg(long)]
     profile_layers: bool,
+
+    /// Run on an arch without a registry entry by reusing another arch's kernel.
+    #[arg(long)]
+    allow_untested_gpu: Option<String>,
 }
 
 fn main() -> Result<()> {
@@ -94,6 +98,7 @@ fn main() -> Result<()> {
         bench_warmup: cli.warmup,
         bench_decode_tokens: cli.decode_tokens,
         bench_profile_ops: cli.profile_ops,
+        allow_untested_gpu: cli.allow_untested_gpu,
     })?;
 
     let exit_code = report.exit_code();

--- a/crates/runner/src/bughunt.rs
+++ b/crates/runner/src/bughunt.rs
@@ -17,20 +17,18 @@ mod profile;
 mod report;
 mod runtime;
 mod util;
-pub use args::*;
-use args::validate_args;
-use manifest::{load_prompt_manifest, select_prompts};
-use output::{print_report_summary, write_report_json};
-use profile::{
-    collect_profiles, reset_profiles, snapshot_profiles, ProfileGuard, ProfileReports,
-};
-pub use report::*;
-use runtime::QwenBughuntRuntime;
 use adapter::{
     compute_qwen_logits_from_hidden_row, run_native_prefill,
     run_native_prefill_greedy_token_with_state, run_native_prefill_with_trace,
     run_tail_replay_with_trace, run_trace_oracle,
 };
+use args::validate_args;
+pub use args::*;
+use manifest::{load_prompt_manifest, select_prompts};
+use output::{print_report_summary, write_report_json};
+use profile::{collect_profiles, reset_profiles, snapshot_profiles, ProfileGuard, ProfileReports};
+pub use report::*;
+use runtime::QwenBughuntRuntime;
 use util::{
     bench_stats, decode_bf16_le, encode_bf16_le, extract_causal_conv_window_bsd, flatten_bsh,
     flatten_token_bsd, max_abs_delta_details, mean_abs_delta, mean_square, mean_square_delta,
@@ -50,6 +48,7 @@ pub fn run(args: BughuntArgs) -> Result<BughuntReport> {
         args.backend,
         args.ordinal,
         &args.oracle_device,
+        args.allow_untested_gpu.as_deref(),
     )?;
     let metadata = runtime.metadata(args.mode);
     let report = match args.mode {

--- a/crates/runner/src/bughunt/args.rs
+++ b/crates/runner/src/bughunt/args.rs
@@ -97,6 +97,7 @@ pub struct BughuntArgs {
     pub bench_warmup: usize,
     pub bench_decode_tokens: usize,
     pub bench_profile_ops: bool,
+    pub allow_untested_gpu: Option<String>,
 }
 
 pub(crate) fn validate_args(args: &BughuntArgs) -> Result<()> {

--- a/crates/runner/src/bughunt/runtime.rs
+++ b/crates/runner/src/bughunt/runtime.rs
@@ -39,14 +39,19 @@ impl QwenBughuntRuntime {
         backend_choice: BackendArg,
         ordinal: usize,
         oracle_device_spec: &str,
+        allow_untested_gpu: Option<&str>,
     ) -> Result<Self> {
         let backend = backend_runtime::resolve_backend(backend_choice.into(), ordinal)?;
         gpu_hal::set_backend(backend);
 
         let gpu = backend_runtime::query_gpu_info(backend, ordinal)?;
         let model_variant = ModelVariant::Qwen3_5_0_8B;
-        let entry =
-            backend_runtime::lookup_registry_entry(&model_variant, backend, &gpu.gpu_arch, None)?;
+        let entry = backend_runtime::lookup_registry_entry(
+            &model_variant,
+            backend,
+            &gpu.gpu_arch,
+            allow_untested_gpu,
+        )?;
         let params = match entry.params {
             FamilyParams::Qwen35(params) => params,
             _ => bail!("bughunt harness only supports Qwen3.5"),

--- a/crates/runner/src/gemma4_engine.rs
+++ b/crates/runner/src/gemma4_engine.rs
@@ -331,6 +331,29 @@ fn copy_kv_slots_range(
     Ok(())
 }
 
+fn copy_kv_slots_range_to_compact(
+    device: usize,
+    src: &GpuBuffer,
+    dst: &mut GpuBuffer,
+    num_kv_heads: usize,
+    src_max_t: usize,
+    head_dim: usize,
+    t_start: usize,
+    count: usize,
+) -> Result<()> {
+    let row_bytes = head_dim * 2;
+    for h in 0..num_kv_heads {
+        let src_byte_off = ((h * src_max_t) + t_start) * row_bytes;
+        let dst_byte_off = h * count * row_bytes;
+        let bytes = count * row_bytes;
+        let src_ptr = src.offset_ptr(src_byte_off);
+        let dst_ptr = unsafe { (dst.as_mut_ptr() as *mut u8).add(dst_byte_off) as *mut c_void };
+        gpu_hal::copy_d2d(device, dst_ptr, src_ptr, bytes)
+            .map_err(|e| anyhow!("copy_kv_slots_range_to_compact: {e}"))?;
+    }
+    Ok(())
+}
+
 struct LayerWeights {
     kind: AttnKind,
     head_dim: usize,
@@ -1884,6 +1907,14 @@ impl Gemma4Engine {
         let num_layers = self.tcfg.num_hidden_layers;
         let vocab_size = self.tcfg.vocab_size;
 
+        if gpu_hal::current_backend() == Backend::Metal {
+            if self.kv_fp8_descs_gpu.is_some() || self.fp8_scale_descs_gpu.is_some() {
+                bail!("Gemma 4 Metal component decode currently supports BF16 weights and BF16 KV only");
+            }
+            self.prepare_single_decode_inputs(input_token_id)?;
+            return self.run_decode_body_seq_metal_component(seq_idx, pos);
+        }
+
         if let Some(embed_tokens_per_layer_w) = self.embed_tokens_per_layer_w.as_ref() {
             let embed_scale = bf16::from_f32((hidden_size as f32).sqrt()).to_f32();
             let proj_scale = bf16::from_f32((hidden_size as f32).powf(-0.5)).to_f32();
@@ -1942,6 +1973,385 @@ impl Gemma4Engine {
                 pos,
                 eps,
                 1.0f32,
+            )?;
+        }
+        Ok(())
+    }
+
+    fn run_decode_body_seq_metal_component(&mut self, seq_idx: usize, pos: usize) -> Result<()> {
+        let device = self.device;
+        let dtype = ScalarType::BF16;
+        let hidden_size = self.tcfg.hidden_size;
+        let num_q_heads = self.tcfg.num_attention_heads;
+        let num_kv_heads = self.tcfg.num_key_value_heads;
+        let eps = self.tcfg.rms_norm_eps as f32;
+        let ple_hidden = self.tcfg.hidden_size_per_layer_input;
+        let num_layers = self.tcfg.num_hidden_layers;
+        let max_t = self.max_t;
+        let kv_len = pos + 1;
+
+        for layer_idx in 0..num_layers {
+            let w = &self.layers[layer_idx];
+            let head_dim = w.head_dim;
+            let q_dim = num_q_heads * head_dim;
+            let kv_dim = num_kv_heads * head_dim;
+            let sliding_window = match w.kind {
+                AttnKind::Sliding => self.tcfg.sliding_window,
+                AttnKind::Full => 0,
+            };
+            let (cos_table, sin_table) = match w.kind {
+                AttnKind::Sliding => (&self.sliding_cos, &self.sliding_sin),
+                AttnKind::Full => (&self.full_cos, &self.full_sin),
+            };
+            let shared_kv = w.shared_kv;
+            let kv_source = w.kv_source;
+            let intermediate = w.intermediate_size;
+
+            let residual = self.decode_hidden_io.clone_device()?;
+            let mut x = GpuBuffer::zeros(device, dtype, &[1, hidden_size])?;
+            g4::rms_norm_rows(
+                device,
+                dtype,
+                &mut x,
+                &self.decode_hidden_io,
+                Some(&w.input_norm),
+                eps,
+                1,
+                hidden_size,
+            )?;
+
+            let mut q = GpuBuffer::zeros(device, dtype, &[1, num_q_heads, head_dim])?;
+            g4::matvec_batched(
+                device,
+                dtype,
+                &mut q,
+                &x,
+                &w.q_proj,
+                1,
+                hidden_size,
+                q_dim,
+                &mut self.counter,
+            )?;
+            let mut q_normed = GpuBuffer::zeros(device, dtype, &[1, num_q_heads, head_dim])?;
+            g4::rms_norm_rows(
+                device,
+                dtype,
+                &mut q_normed,
+                &q,
+                Some(&w.q_norm),
+                eps,
+                num_q_heads,
+                head_dim,
+            )?;
+            g4::rope_prefill(
+                device,
+                dtype,
+                &mut q_normed,
+                cos_table,
+                sin_table,
+                1,
+                num_q_heads,
+                head_dim,
+                head_dim,
+                pos,
+            )?;
+
+            if !shared_kv {
+                let k_proj = w.k_proj.as_ref().expect("k_proj on non-shared Gemma layer");
+                let v_proj = w.v_proj.as_ref().expect("v_proj on non-shared Gemma layer");
+                let k_norm = w.k_norm.as_ref().expect("k_norm on non-shared Gemma layer");
+
+                let mut k = GpuBuffer::zeros(device, dtype, &[1, num_kv_heads, head_dim])?;
+                g4::matvec_batched(
+                    device,
+                    dtype,
+                    &mut k,
+                    &x,
+                    k_proj,
+                    1,
+                    hidden_size,
+                    kv_dim,
+                    &mut self.counter,
+                )?;
+                let mut v = GpuBuffer::zeros(device, dtype, &[1, num_kv_heads, head_dim])?;
+                g4::matvec_batched(
+                    device,
+                    dtype,
+                    &mut v,
+                    &x,
+                    v_proj,
+                    1,
+                    hidden_size,
+                    kv_dim,
+                    &mut self.counter,
+                )?;
+                let mut k_normed = GpuBuffer::zeros(device, dtype, &[1, num_kv_heads, head_dim])?;
+                g4::rms_norm_rows(
+                    device,
+                    dtype,
+                    &mut k_normed,
+                    &k,
+                    Some(k_norm),
+                    eps,
+                    num_kv_heads,
+                    head_dim,
+                )?;
+                let mut v_normed = GpuBuffer::zeros(device, dtype, &[1, num_kv_heads, head_dim])?;
+                g4::rms_norm_rows(
+                    device,
+                    dtype,
+                    &mut v_normed,
+                    &v,
+                    None,
+                    eps,
+                    num_kv_heads,
+                    head_dim,
+                )?;
+                g4::rope_prefill(
+                    device,
+                    dtype,
+                    &mut k_normed,
+                    cos_table,
+                    sin_table,
+                    1,
+                    num_kv_heads,
+                    head_dim,
+                    head_dim,
+                    pos,
+                )?;
+                g4::kv_append(
+                    device,
+                    dtype,
+                    &k_normed,
+                    &v_normed,
+                    &mut self.k_caches[seq_idx][layer_idx],
+                    &mut self.v_caches[seq_idx][layer_idx],
+                    num_kv_heads,
+                    head_dim,
+                    pos,
+                    max_t,
+                )?;
+            }
+
+            let src_layer = if shared_kv { kv_source } else { layer_idx };
+            let mut attn_out = GpuBuffer::zeros(device, dtype, &[1, num_q_heads, head_dim])?;
+            let mut scores = GpuBuffer::zeros(device, ScalarType::F32, &[1, num_q_heads, max_t])?;
+            if sliding_window > 0 && kv_len > sliding_window {
+                let window_start = kv_len - sliding_window;
+                let mut k_window =
+                    GpuBuffer::zeros(device, dtype, &[num_kv_heads, sliding_window, head_dim])?;
+                let mut v_window =
+                    GpuBuffer::zeros(device, dtype, &[num_kv_heads, sliding_window, head_dim])?;
+                copy_kv_slots_range_to_compact(
+                    device,
+                    &self.k_caches[seq_idx][src_layer],
+                    &mut k_window,
+                    num_kv_heads,
+                    max_t,
+                    head_dim,
+                    window_start,
+                    sliding_window,
+                )?;
+                copy_kv_slots_range_to_compact(
+                    device,
+                    &self.v_caches[seq_idx][src_layer],
+                    &mut v_window,
+                    num_kv_heads,
+                    max_t,
+                    head_dim,
+                    window_start,
+                    sliding_window,
+                )?;
+                g4::attn_prefill(
+                    device,
+                    dtype,
+                    &q_normed,
+                    &k_window,
+                    &v_window,
+                    &mut scores,
+                    &mut attn_out,
+                    1,
+                    num_q_heads,
+                    num_kv_heads,
+                    head_dim,
+                    sliding_window - 1,
+                    sliding_window,
+                    0,
+                    1.0,
+                )?;
+            } else {
+                g4::attn_prefill(
+                    device,
+                    dtype,
+                    &q_normed,
+                    &self.k_caches[seq_idx][src_layer],
+                    &self.v_caches[seq_idx][src_layer],
+                    &mut scores,
+                    &mut attn_out,
+                    1,
+                    num_q_heads,
+                    num_kv_heads,
+                    head_dim,
+                    pos,
+                    max_t,
+                    sliding_window as i32,
+                    1.0,
+                )?;
+            }
+
+            let mut o = GpuBuffer::zeros(device, dtype, &[1, hidden_size])?;
+            g4::matvec_batched(
+                device,
+                dtype,
+                &mut o,
+                &attn_out,
+                &w.o_proj,
+                1,
+                q_dim,
+                hidden_size,
+                &mut self.counter,
+            )?;
+            let mut x2 = GpuBuffer::zeros(device, dtype, &[1, hidden_size])?;
+            g4::rms_norm_rows(
+                device,
+                dtype,
+                &mut x2,
+                &o,
+                Some(&w.post_attn_norm),
+                eps,
+                1,
+                hidden_size,
+            )?;
+            let mut h_mid = GpuBuffer::zeros(device, dtype, &[1, hidden_size])?;
+            g4::add_residual(device, dtype, &mut h_mid, &residual, &x2, hidden_size)?;
+
+            let residual2 = h_mid.clone_device()?;
+            let mut x3 = GpuBuffer::zeros(device, dtype, &[1, hidden_size])?;
+            g4::rms_norm_rows(
+                device,
+                dtype,
+                &mut x3,
+                &h_mid,
+                Some(&w.pre_ff_norm),
+                eps,
+                1,
+                hidden_size,
+            )?;
+            let mut gate = GpuBuffer::zeros(device, dtype, &[1, intermediate])?;
+            g4::matvec_batched(
+                device,
+                dtype,
+                &mut gate,
+                &x3,
+                &w.gate_proj,
+                1,
+                hidden_size,
+                intermediate,
+                &mut self.counter,
+            )?;
+            let mut up_buf = GpuBuffer::zeros(device, dtype, &[1, intermediate])?;
+            g4::matvec_batched(
+                device,
+                dtype,
+                &mut up_buf,
+                &x3,
+                &w.up_proj,
+                1,
+                hidden_size,
+                intermediate,
+                &mut self.counter,
+            )?;
+            let mut y = GpuBuffer::zeros(device, dtype, &[1, intermediate])?;
+            g4::gelu_tanh_gate_mul(device, dtype, &mut y, &gate, &up_buf, intermediate)?;
+            let mut m = GpuBuffer::zeros(device, dtype, &[1, hidden_size])?;
+            g4::matvec_batched(
+                device,
+                dtype,
+                &mut m,
+                &y,
+                &w.down_proj,
+                1,
+                intermediate,
+                hidden_size,
+                &mut self.counter,
+            )?;
+            let mut x4 = GpuBuffer::zeros(device, dtype, &[1, hidden_size])?;
+            g4::rms_norm_rows(
+                device,
+                dtype,
+                &mut x4,
+                &m,
+                Some(&w.post_ff_norm),
+                eps,
+                1,
+                hidden_size,
+            )?;
+            let mut h_pre_ple = GpuBuffer::zeros(device, dtype, &[1, hidden_size])?;
+            g4::add_residual(device, dtype, &mut h_pre_ple, &residual2, &x4, hidden_size)?;
+
+            let mut pli_slice = GpuBuffer::zeros(device, dtype, &[1, ple_hidden])?;
+            g4::gather_layer_slice(
+                device,
+                dtype,
+                &mut pli_slice,
+                &self.decode_pli,
+                1,
+                num_layers,
+                ple_hidden,
+                layer_idx,
+            )?;
+            let mut gated = GpuBuffer::zeros(device, dtype, &[1, ple_hidden])?;
+            g4::matvec_batched(
+                device,
+                dtype,
+                &mut gated,
+                &h_pre_ple,
+                &w.per_layer_input_gate_w,
+                1,
+                hidden_size,
+                ple_hidden,
+                &mut self.counter,
+            )?;
+            let mut gated_act = GpuBuffer::zeros(device, dtype, &[1, ple_hidden])?;
+            g4::gelu_tanh_gate_mul(device, dtype, &mut gated_act, &gated, &pli_slice, ple_hidden)?;
+            let mut projected = GpuBuffer::zeros(device, dtype, &[1, hidden_size])?;
+            g4::matvec_batched(
+                device,
+                dtype,
+                &mut projected,
+                &gated_act,
+                &w.per_layer_projection_w,
+                1,
+                ple_hidden,
+                hidden_size,
+                &mut self.counter,
+            )?;
+            let mut normed = GpuBuffer::zeros(device, dtype, &[1, hidden_size])?;
+            g4::rms_norm_rows(
+                device,
+                dtype,
+                &mut normed,
+                &projected,
+                Some(&w.post_per_layer_input_norm_w),
+                eps,
+                1,
+                hidden_size,
+            )?;
+            let mut h_new = GpuBuffer::zeros(device, dtype, &[1, hidden_size])?;
+            g4::add_scaled_residual(
+                device,
+                dtype,
+                &mut h_new,
+                &h_pre_ple,
+                &normed,
+                w.layer_scalar,
+                hidden_size,
+            )?;
+            gpu_hal::copy_d2d(
+                device,
+                self.decode_hidden_io.as_mut_ptr(),
+                h_new.as_ptr(),
+                self.decode_hidden_io.len_bytes(),
             )?;
         }
         Ok(())

--- a/crates/runner/src/gemma4_int4_engine.rs
+++ b/crates/runner/src/gemma4_int4_engine.rs
@@ -19,10 +19,10 @@
 use std::ffi::{c_int, c_void};
 use std::path::{Path, PathBuf};
 
-use ::gemma4::config::{AttnKind, Config, TextConfig};
-use ::gemma4::weight_spec as g4_spec;
 use anyhow::{anyhow, bail, Context, Result};
-use gpu_hal::{GpuBuffer, ScalarType};
+use gemma4::config::{AttnKind, Config, TextConfig};
+use gemma4::weight_spec as g4_spec;
+use gpu_hal::{Backend, GpuBuffer, ScalarType};
 use half::bf16;
 use kernel_ffi::gemma4 as g4;
 use kernel_ffi::gemma4::{Gemma4BatchSeqDesc, Gemma4DecodeLayerDesc, Gemma4Int4ScaleDesc};
@@ -356,6 +356,29 @@ fn copy_kv_slots_range(
         let dst_ptr = unsafe { (dst.as_mut_ptr() as *mut u8).add(byte_off) as *mut c_void };
         gpu_hal::copy_d2d(device, dst_ptr, src_ptr, bytes)
             .map_err(|e| anyhow!("copy_kv_slots_range: {e}"))?;
+    }
+    Ok(())
+}
+
+fn copy_kv_slots_range_to_compact(
+    device: usize,
+    src: &GpuBuffer,
+    dst: &mut GpuBuffer,
+    num_kv_heads: usize,
+    src_max_t: usize,
+    head_dim: usize,
+    t_start: usize,
+    count: usize,
+) -> Result<()> {
+    let row_bytes = head_dim * 2;
+    for h in 0..num_kv_heads {
+        let src_byte_off = ((h * src_max_t) + t_start) * row_bytes;
+        let dst_byte_off = h * count * row_bytes;
+        let bytes = count * row_bytes;
+        let src_ptr = src.offset_ptr(src_byte_off);
+        let dst_ptr = unsafe { (dst.as_mut_ptr() as *mut u8).add(dst_byte_off) as *mut c_void };
+        gpu_hal::copy_d2d(device, dst_ptr, src_ptr, bytes)
+            .map_err(|e| anyhow!("copy_kv_slots_range_to_compact: {e}"))?;
     }
     Ok(())
 }
@@ -1766,6 +1789,9 @@ impl Gemma4Int4Engine {
     /// (small matmul + norm over the token's row) and the lm-head epilogue
     /// runs after. Returns softcapped logits.
     pub fn decode_step(&mut self, input_token_id: u32, pos: usize) -> Result<Vec<f32>> {
+        if gpu_hal::current_backend() == Backend::Metal {
+            return self.decode_step_primitive(input_token_id, pos);
+        }
         if pos >= self.max_t {
             bail!("decode_step: pos {pos} >= max_t {}", self.max_t);
         }
@@ -2485,22 +2511,94 @@ impl Gemma4Int4Engine {
             let kv_len = pos + 1;
             let mut attn_out = GpuBuffer::zeros(device, dtype, &[num_q_heads, head_dim])?;
             let mut scores = GpuBuffer::zeros(device, ScalarType::F32, &[num_q_heads, max_t])?;
-            g4::swa_attn_decode(
-                device,
-                dtype,
-                &q_normed,
-                &self.k_caches[layer_idx],
-                &self.v_caches[layer_idx],
-                &mut scores,
-                &mut attn_out,
-                num_q_heads,
-                num_kv_heads,
-                head_dim,
-                kv_len,
-                max_t,
-                sliding_window,
-                1.0,
-            )?;
+            if gpu_hal::current_backend() == Backend::Metal {
+                let sliding_window_usize = sliding_window.max(0) as usize;
+                if sliding_window_usize > 0 && kv_len > sliding_window_usize {
+                    let window_start = kv_len - sliding_window_usize;
+                    let mut k_window = GpuBuffer::zeros(
+                        device,
+                        dtype,
+                        &[num_kv_heads, sliding_window_usize, head_dim],
+                    )?;
+                    let mut v_window = GpuBuffer::zeros(
+                        device,
+                        dtype,
+                        &[num_kv_heads, sliding_window_usize, head_dim],
+                    )?;
+                    copy_kv_slots_range_to_compact(
+                        device,
+                        &self.k_caches[layer_idx],
+                        &mut k_window,
+                        num_kv_heads,
+                        max_t,
+                        head_dim,
+                        window_start,
+                        sliding_window_usize,
+                    )?;
+                    copy_kv_slots_range_to_compact(
+                        device,
+                        &self.v_caches[layer_idx],
+                        &mut v_window,
+                        num_kv_heads,
+                        max_t,
+                        head_dim,
+                        window_start,
+                        sliding_window_usize,
+                    )?;
+                    g4::attn_prefill(
+                        device,
+                        dtype,
+                        &q_normed,
+                        &k_window,
+                        &v_window,
+                        &mut scores,
+                        &mut attn_out,
+                        1,
+                        num_q_heads,
+                        num_kv_heads,
+                        head_dim,
+                        sliding_window_usize - 1,
+                        sliding_window_usize,
+                        0,
+                        1.0,
+                    )?;
+                } else {
+                    g4::attn_prefill(
+                        device,
+                        dtype,
+                        &q_normed,
+                        &self.k_caches[layer_idx],
+                        &self.v_caches[layer_idx],
+                        &mut scores,
+                        &mut attn_out,
+                        1,
+                        num_q_heads,
+                        num_kv_heads,
+                        head_dim,
+                        pos,
+                        max_t,
+                        sliding_window,
+                        1.0,
+                    )?;
+                }
+            } else {
+                g4::swa_attn_decode(
+                    device,
+                    dtype,
+                    &q_normed,
+                    &self.k_caches[layer_idx],
+                    &self.v_caches[layer_idx],
+                    &mut scores,
+                    &mut attn_out,
+                    num_q_heads,
+                    num_kv_heads,
+                    head_dim,
+                    kv_len,
+                    max_t,
+                    sliding_window,
+                    1.0,
+                )?;
+            }
 
             let attn_flat = {
                 let bytes = attn_out.to_host_bytes()?;

--- a/crates/runner/src/gemma4_runtime.rs
+++ b/crates/runner/src/gemma4_runtime.rs
@@ -425,6 +425,18 @@ pub(crate) fn validate_gemma4_startup(
         if cli.batch_size != 1 {
             anyhow::bail!("Gemma 4 CUDA v1 supports only --batch-size=1");
         }
+    } else if backend == Backend::Metal {
+        if cli.fp8_runtime {
+            anyhow::bail!(
+                "Gemma 4 Metal currently supports BF16 and INT4 only; --fp8-runtime is not wired"
+            );
+        }
+        if cli.kv_fp8 {
+            anyhow::bail!("Gemma 4 Metal currently supports BF16 KV only; --kv-fp8 is not wired");
+        }
+        if cli.batch_size != 1 {
+            anyhow::bail!("Gemma 4 Metal currently supports only --batch-size=1");
+        }
     }
 
     if cli.fp8_runtime && cli.int4 {

--- a/crates/runner/src/phi4_engine.rs
+++ b/crates/runner/src/phi4_engine.rs
@@ -12,16 +12,67 @@ use std::time::Instant;
 
 use anyhow::{anyhow, bail, Result};
 use gpu_hal::{Backend, GpuBuffer, ScalarType};
-use kernel_ffi::phi4 as phi4_ffi;
+use kernel_ffi::{phi4 as phi4_ffi, prefill_ffi};
 
+use crate::model_files::model_dir_has_raw_safetensors;
 use crate::oracle::OracleOutput;
 use crate::registry::{FamilyParams, ModelVariant, RegistryEntry};
 use crate::{oracle as oracle_mod, should_fetch_exact_bake, try_download_bake, validate};
-use crate::model_files::model_dir_has_raw_safetensors;
 use phi4::config::{load_config, Phi4Config};
 use phi4::rope::Phi4LongRope;
 use phi4::state::Phi4ModelState;
 use phi4::weights::Phi4Weights;
+
+struct Phi4MetalDecodeScratch {
+    input_normed: GpuBuffer,
+    q: GpuBuffer,
+    k: GpuBuffer,
+    v: GpuBuffer,
+    attn_out_f32: GpuBuffer,
+    attn_out_bf16: GpuBuffer,
+    attn_proj: GpuBuffer,
+    post_attn_normed: GpuBuffer,
+    gate: GpuBuffer,
+    up: GpuBuffer,
+    swiglu: GpuBuffer,
+    mlp_out: GpuBuffer,
+}
+
+impl Phi4MetalDecodeScratch {
+    fn new(config: &Phi4Config, ordinal: usize) -> Result<Self> {
+        let hidden = config.hidden_size;
+        let head_dim = config.head_dim();
+        let q_dim = config.num_attention_heads * head_dim;
+        let kv_dim = config.num_key_value_heads * head_dim;
+        let intermediate = config.intermediate_size;
+        Ok(Self {
+            input_normed: GpuBuffer::zeros(ordinal, ScalarType::BF16, &[1, hidden])
+                .map_err(|e| anyhow!("alloc Phi-4 Metal input_normed: {e}"))?,
+            q: GpuBuffer::zeros(ordinal, ScalarType::BF16, &[1, q_dim])
+                .map_err(|e| anyhow!("alloc Phi-4 Metal q: {e}"))?,
+            k: GpuBuffer::zeros(ordinal, ScalarType::BF16, &[1, kv_dim])
+                .map_err(|e| anyhow!("alloc Phi-4 Metal k: {e}"))?,
+            v: GpuBuffer::zeros(ordinal, ScalarType::BF16, &[1, kv_dim])
+                .map_err(|e| anyhow!("alloc Phi-4 Metal v: {e}"))?,
+            attn_out_f32: GpuBuffer::zeros(ordinal, ScalarType::F32, &[q_dim])
+                .map_err(|e| anyhow!("alloc Phi-4 Metal attn_out_f32: {e}"))?,
+            attn_out_bf16: GpuBuffer::zeros(ordinal, ScalarType::BF16, &[1, q_dim])
+                .map_err(|e| anyhow!("alloc Phi-4 Metal attn_out_bf16: {e}"))?,
+            attn_proj: GpuBuffer::zeros(ordinal, ScalarType::BF16, &[1, hidden])
+                .map_err(|e| anyhow!("alloc Phi-4 Metal attn_proj: {e}"))?,
+            post_attn_normed: GpuBuffer::zeros(ordinal, ScalarType::BF16, &[1, hidden])
+                .map_err(|e| anyhow!("alloc Phi-4 Metal post_attn_normed: {e}"))?,
+            gate: GpuBuffer::zeros(ordinal, ScalarType::BF16, &[1, intermediate])
+                .map_err(|e| anyhow!("alloc Phi-4 Metal gate: {e}"))?,
+            up: GpuBuffer::zeros(ordinal, ScalarType::BF16, &[1, intermediate])
+                .map_err(|e| anyhow!("alloc Phi-4 Metal up: {e}"))?,
+            swiglu: GpuBuffer::zeros(ordinal, ScalarType::BF16, &[1, intermediate])
+                .map_err(|e| anyhow!("alloc Phi-4 Metal swiglu: {e}"))?,
+            mlp_out: GpuBuffer::zeros(ordinal, ScalarType::BF16, &[1, hidden])
+                .map_err(|e| anyhow!("alloc Phi-4 Metal mlp_out: {e}"))?,
+        })
+    }
+}
 
 fn resolve_phi4_oracle_model_id(
     explicit_model_id: Option<&str>,
@@ -80,6 +131,12 @@ pub fn run_phi4(
     }
     if cli.batch_size != 1 {
         bail!("Phi-4 engine is single-sequence at launch (--batch-size must be 1)");
+    }
+    if entry.backend == Backend::Metal && cli.kv_fp8 {
+        bail!("Phi-4 Metal currently supports BF16 KV cache only; --kv-fp8 is not wired");
+    }
+    if entry.backend == Backend::Metal && cli.teacher_forced {
+        bail!("Phi-4 Metal teacher-forced scoring is not wired yet");
     }
     if cli.oracle_prefill || cli.gpu_validate {
         bail!("Phi-4 engine has no --oracle-prefill / --gpu-validate path yet");
@@ -453,6 +510,11 @@ pub fn run_phi4(
         .map_err(|e| anyhow!("alloc lm_argmax_idxs: {e}"))?;
     let mut lm_argmax_out = GpuBuffer::zeros(ordinal, ScalarType::U32, &[1])
         .map_err(|e| anyhow!("alloc lm_argmax_out: {e}"))?;
+    let mut metal_scratch = if entry.backend == Backend::Metal {
+        Some(Phi4MetalDecodeScratch::new(&config, ordinal)?)
+    } else {
+        None
+    };
 
     let mut hidden_io = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[1, hidden_size])
         .map_err(|e| anyhow!("alloc hidden_io: {e}"))?;
@@ -664,35 +726,53 @@ pub fn run_phi4(
         // 5. Pick LongRoPE table for this position (short vs long).
         let (cos_table, sin_table) = rope.tables_for_kv_len(pos);
 
-        // 6. Launch persistent decode megakernel.
-        phi4_ffi::persistent_decode(
-            ordinal,
-            ScalarType::BF16,
-            launch_layers,
-            hidden_size,
-            intermediate_size,
-            pos,
-            &desc_device,
-            &mut hidden_io,
-            &mut workspace,
-            &mut sync_buf,
-            cos_table,
-            sin_table,
-            proj_buf_floats,
-            attn_scratch_floats,
-            fp8_scale_device.as_ref(),
-            kv_fp8_desc_device.as_ref(),
-            1,
-            None,
-            int4_scale_device.as_ref(),
-            if debug_dump_layer_trace.is_some() && step == prompt_ids.len() - 1 {
-                layer_trace_buf.as_mut()
-            } else {
-                None
-            },
-            PHI4_TRACE_COMPONENTS,
-        )
-        .map_err(|e| anyhow!("phi4 persistent_decode at step {step}: {e}"))?;
+        // 6. Run the decoder stack. HIP/CUDA use the persistent megakernel;
+        // Metal uses a BF16 component path built from the existing Metal
+        // primitives until a Phi-specific Metal persistent kernel lands.
+        if let Some(scratch) = metal_scratch.as_mut() {
+            phi4_decode_step_metal_bf16(
+                &config,
+                &weights,
+                &mut state,
+                &rope,
+                ordinal,
+                launch_layers,
+                hidden_size,
+                &mut hidden_io,
+                pos,
+                scratch,
+            )
+            .map_err(|e| anyhow!("phi4 Metal component decode at step {step}: {e}"))?;
+        } else {
+            phi4_ffi::persistent_decode(
+                ordinal,
+                ScalarType::BF16,
+                launch_layers,
+                hidden_size,
+                intermediate_size,
+                pos,
+                &desc_device,
+                &mut hidden_io,
+                &mut workspace,
+                &mut sync_buf,
+                cos_table,
+                sin_table,
+                proj_buf_floats,
+                attn_scratch_floats,
+                fp8_scale_device.as_ref(),
+                kv_fp8_desc_device.as_ref(),
+                1,
+                None,
+                int4_scale_device.as_ref(),
+                if debug_dump_layer_trace.is_some() && step == prompt_ids.len() - 1 {
+                    layer_trace_buf.as_mut()
+                } else {
+                    None
+                },
+                PHI4_TRACE_COMPONENTS,
+            )
+            .map_err(|e| anyhow!("phi4 persistent_decode at step {step}: {e}"))?;
+        }
 
         if let (Some(ref path), Some(trace_buf)) =
             (&debug_dump_layer_trace, layer_trace_buf.as_ref())
@@ -1084,6 +1164,332 @@ pub fn run_phi4(
     }
 
     Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn phi4_decode_step_metal_bf16(
+    config: &Phi4Config,
+    weights: &Phi4Weights,
+    state: &mut Phi4ModelState,
+    rope: &Phi4LongRope,
+    ordinal: usize,
+    launch_layers: usize,
+    hidden_size: usize,
+    hidden_io: &mut GpuBuffer,
+    pos: usize,
+    scratch: &mut Phi4MetalDecodeScratch,
+) -> Result<()> {
+    let head_dim = config.head_dim();
+    let num_heads = config.num_attention_heads;
+    let num_kv_heads = config.num_key_value_heads;
+    let q_dim = num_heads * head_dim;
+    let kv_dim = num_kv_heads * head_dim;
+    let intermediate = config.intermediate_size;
+    let rms_eps = config.rms_norm_eps as f32;
+    let scale = 1.0f32 / (head_dim as f32).sqrt();
+    let (cos_table, sin_table) = rope.tables_for_kv_len(pos);
+
+    for layer_idx in 0..launch_layers {
+        let lw = &weights.layers[layer_idx];
+        let ls = &mut state.layers[layer_idx];
+        let kv_cap = ls.kv_capacity();
+        let cache_k = ls
+            .kv_cache_k
+            .as_mut()
+            .ok_or_else(|| anyhow!("Phi-4 Metal layer {layer_idx}: missing K cache"))?;
+        let cache_v = ls
+            .kv_cache_v
+            .as_mut()
+            .ok_or_else(|| anyhow!("Phi-4 Metal layer {layer_idx}: missing V cache"))?;
+
+        prefill_ffi::rms_norm_rows_plain(
+            ordinal,
+            ScalarType::BF16,
+            1,
+            hidden_size,
+            rms_eps,
+            hidden_io,
+            &lw.input_norm_w,
+            &mut scratch.input_normed,
+        )
+        .map_err(|e| anyhow!("layer {layer_idx} input RMSNorm: {e}"))?;
+
+        phi4_metal_matmul_projection(
+            ordinal,
+            weights,
+            q_dim,
+            hidden_size,
+            &scratch.input_normed,
+            &lw.q_proj_w,
+            lw.q_proj_int4_scale.as_ref(),
+            lw.q_proj_int4_zero.as_ref(),
+            lw.q_proj_fp8_scale.as_ref(),
+            &mut scratch.q,
+        )
+        .map_err(|e| anyhow!("layer {layer_idx} q_proj: {e}"))?;
+        phi4_metal_matmul_projection(
+            ordinal,
+            weights,
+            kv_dim,
+            hidden_size,
+            &scratch.input_normed,
+            &lw.k_proj_w,
+            lw.k_proj_int4_scale.as_ref(),
+            lw.k_proj_int4_zero.as_ref(),
+            lw.k_proj_fp8_scale.as_ref(),
+            &mut scratch.k,
+        )
+        .map_err(|e| anyhow!("layer {layer_idx} k_proj: {e}"))?;
+        phi4_metal_matmul_projection(
+            ordinal,
+            weights,
+            kv_dim,
+            hidden_size,
+            &scratch.input_normed,
+            &lw.v_proj_w,
+            lw.v_proj_int4_scale.as_ref(),
+            lw.v_proj_int4_zero.as_ref(),
+            lw.v_proj_fp8_scale.as_ref(),
+            &mut scratch.v,
+        )
+        .map_err(|e| anyhow!("layer {layer_idx} v_proj: {e}"))?;
+
+        prefill_ffi::apply_rope_prefill(
+            ordinal,
+            ScalarType::BF16,
+            1,
+            num_heads,
+            head_dim,
+            config.rotary_dim(),
+            cos_table,
+            sin_table,
+            pos,
+            &mut scratch.q,
+        )
+        .map_err(|e| anyhow!("layer {layer_idx} q RoPE: {e}"))?;
+        prefill_ffi::apply_rope_prefill(
+            ordinal,
+            ScalarType::BF16,
+            1,
+            num_kv_heads,
+            head_dim,
+            config.rotary_dim(),
+            cos_table,
+            sin_table,
+            pos,
+            &mut scratch.k,
+        )
+        .map_err(|e| anyhow!("layer {layer_idx} k RoPE: {e}"))?;
+
+        let elem_bytes = ScalarType::BF16.size_in_bytes();
+        let head_bytes = head_dim * elem_bytes;
+        for h in 0..num_kv_heads {
+            let src_off = h * head_bytes;
+            let dst_off = ((h * kv_cap + pos) * head_dim) * elem_bytes;
+            gpu_hal::copy_d2d(
+                ordinal,
+                cache_k.offset_ptr(dst_off) as *mut c_void,
+                scratch.k.offset_ptr(src_off),
+                head_bytes,
+            )
+            .map_err(|e| anyhow!("layer {layer_idx} append K head {h}: {e}"))?;
+            gpu_hal::copy_d2d(
+                ordinal,
+                cache_v.offset_ptr(dst_off) as *mut c_void,
+                scratch.v.offset_ptr(src_off),
+                head_bytes,
+            )
+            .map_err(|e| anyhow!("layer {layer_idx} append V head {h}: {e}"))?;
+        }
+
+        prefill_ffi::metal_full_attention_decode_bf16_f32(
+            num_heads,
+            num_kv_heads,
+            pos + 1,
+            kv_cap,
+            head_dim,
+            scale,
+            &scratch.q,
+            &*cache_k,
+            &*cache_v,
+            &mut scratch.attn_out_f32,
+        )
+        .map_err(|e| anyhow!("layer {layer_idx} full attention: {e}"))?;
+        prefill_ffi::cast(
+            ordinal,
+            ScalarType::F32,
+            ScalarType::BF16,
+            q_dim,
+            &scratch.attn_out_f32,
+            &mut scratch.attn_out_bf16,
+        )
+        .map_err(|e| anyhow!("layer {layer_idx} attention cast: {e}"))?;
+        phi4_metal_matmul_projection(
+            ordinal,
+            weights,
+            hidden_size,
+            q_dim,
+            &scratch.attn_out_bf16,
+            &lw.o_proj_w,
+            lw.o_proj_int4_scale.as_ref(),
+            lw.o_proj_int4_zero.as_ref(),
+            lw.o_proj_fp8_scale.as_ref(),
+            &mut scratch.attn_proj,
+        )
+        .map_err(|e| anyhow!("layer {layer_idx} o_proj: {e}"))?;
+        prefill_ffi::element_add(
+            ordinal,
+            ScalarType::BF16,
+            hidden_size,
+            hidden_io,
+            &scratch.attn_proj,
+            &mut scratch.mlp_out,
+        )
+        .map_err(|e| anyhow!("layer {layer_idx} attention residual: {e}"))?;
+        gpu_hal::copy_d2d(
+            ordinal,
+            hidden_io.as_mut_ptr(),
+            scratch.mlp_out.as_ptr(),
+            hidden_io.len_bytes(),
+        )
+        .map_err(|e| anyhow!("layer {layer_idx} attention residual copy: {e}"))?;
+
+        prefill_ffi::rms_norm_rows_plain(
+            ordinal,
+            ScalarType::BF16,
+            1,
+            hidden_size,
+            rms_eps,
+            hidden_io,
+            &lw.post_attn_norm_w,
+            &mut scratch.post_attn_normed,
+        )
+        .map_err(|e| anyhow!("layer {layer_idx} post-attn RMSNorm: {e}"))?;
+        phi4_metal_matmul_projection(
+            ordinal,
+            weights,
+            intermediate,
+            hidden_size,
+            &scratch.post_attn_normed,
+            &lw.gate_proj_w,
+            lw.gate_proj_int4_scale.as_ref(),
+            lw.gate_proj_int4_zero.as_ref(),
+            lw.gate_proj_fp8_scale.as_ref(),
+            &mut scratch.gate,
+        )
+        .map_err(|e| anyhow!("layer {layer_idx} gate_proj: {e}"))?;
+        phi4_metal_matmul_projection(
+            ordinal,
+            weights,
+            intermediate,
+            hidden_size,
+            &scratch.post_attn_normed,
+            &lw.up_proj_w,
+            lw.up_proj_int4_scale.as_ref(),
+            lw.up_proj_int4_zero.as_ref(),
+            lw.up_proj_fp8_scale.as_ref(),
+            &mut scratch.up,
+        )
+        .map_err(|e| anyhow!("layer {layer_idx} up_proj: {e}"))?;
+        prefill_ffi::swiglu_mul(
+            ordinal,
+            ScalarType::BF16,
+            intermediate,
+            &scratch.gate,
+            &scratch.up,
+            &mut scratch.swiglu,
+        )
+        .map_err(|e| anyhow!("layer {layer_idx} swiglu: {e}"))?;
+        phi4_metal_matmul_projection(
+            ordinal,
+            weights,
+            hidden_size,
+            intermediate,
+            &scratch.swiglu,
+            &lw.down_proj_w,
+            lw.down_proj_int4_scale.as_ref(),
+            lw.down_proj_int4_zero.as_ref(),
+            lw.down_proj_fp8_scale.as_ref(),
+            &mut scratch.mlp_out,
+        )
+        .map_err(|e| anyhow!("layer {layer_idx} down_proj: {e}"))?;
+        prefill_ffi::element_add(
+            ordinal,
+            ScalarType::BF16,
+            hidden_size,
+            hidden_io,
+            &scratch.mlp_out,
+            &mut scratch.attn_proj,
+        )
+        .map_err(|e| anyhow!("layer {layer_idx} MLP residual: {e}"))?;
+        gpu_hal::copy_d2d(
+            ordinal,
+            hidden_io.as_mut_ptr(),
+            scratch.attn_proj.as_ptr(),
+            hidden_io.len_bytes(),
+        )
+        .map_err(|e| anyhow!("layer {layer_idx} MLP residual copy: {e}"))?;
+    }
+    Ok(())
+}
+
+fn phi4_metal_matmul_projection(
+    ordinal: usize,
+    weights: &Phi4Weights,
+    out_dim: usize,
+    in_dim: usize,
+    input: &GpuBuffer,
+    weight: &GpuBuffer,
+    int4_scale: Option<&GpuBuffer>,
+    int4_zero: Option<&GpuBuffer>,
+    fp8_scale: Option<&GpuBuffer>,
+    output: &mut GpuBuffer,
+) -> Result<()> {
+    if weights.is_int4 {
+        let scale = int4_scale.ok_or_else(|| anyhow!("missing INT4 scale tensor"))?;
+        let zero = int4_zero.ok_or_else(|| anyhow!("missing INT4 zero tensor"))?;
+        Ok(prefill_ffi::matmul_rhs_transposed_int4(
+            ordinal,
+            1,
+            1,
+            out_dim,
+            in_dim,
+            input,
+            weight,
+            scale,
+            zero,
+            None,
+            weights.int4_group_size,
+            4,
+            output,
+        )?)
+    } else if weights.is_fp8 {
+        let scale = fp8_scale.ok_or_else(|| anyhow!("missing FP8 scale tensor"))?;
+        Ok(prefill_ffi::matmul_rhs_transposed_fp8(
+            ordinal,
+            1,
+            1,
+            out_dim,
+            in_dim,
+            input,
+            weight,
+            scale,
+            weights.fp8_block_size,
+            output,
+        )?)
+    } else {
+        Ok(prefill_ffi::matmul_rhs_transposed(
+            ordinal,
+            ScalarType::BF16,
+            1,
+            1,
+            out_dim,
+            in_dim,
+            input,
+            weight,
+            output,
+        )?)
+    }
 }
 
 /// Compute the negative log-likelihood of `target_token` under the distribution
@@ -1515,6 +1921,301 @@ mod oracle_tests {
             .unwrap()
             .as_nanos();
         std::env::temp_dir().join(format!("{prefix}-{}-{nanos}", std::process::id()))
+    }
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod metal_component_tests {
+    use std::sync::Arc;
+
+    use gpu_hal::{set_backend, Backend};
+    use half::bf16;
+    use phi4::config::Phi4Config;
+    use phi4::state::Phi4ModelState;
+    use phi4::weights::{Phi4LayerWeights, Phi4Weights};
+
+    use super::*;
+
+    fn bf16_bytes(values: &[f32]) -> Vec<u8> {
+        values
+            .iter()
+            .flat_map(|value| bf16::from_f32(*value).to_bits().to_le_bytes())
+            .collect()
+    }
+
+    fn read_bf16(buffer: &GpuBuffer) -> Vec<f32> {
+        let bytes = buffer.to_host_bytes().expect("download bf16 buffer");
+        bytes
+            .chunks_exact(2)
+            .map(|chunk| bf16::from_bits(u16::from_le_bytes([chunk[0], chunk[1]])).to_f32())
+            .collect()
+    }
+
+    fn upload(ordinal: usize, shape: &[usize], values: &[f32]) -> GpuBuffer {
+        GpuBuffer::from_host_bytes(ordinal, ScalarType::BF16, shape, &bf16_bytes(values))
+            .expect("upload bf16 test tensor")
+    }
+
+    fn fp8_e4m3_byte(value: f32) -> u8 {
+        if value == 0.0 {
+            0x00
+        } else if value == 1.0 {
+            0x38
+        } else {
+            panic!("test FP8 helper only encodes exact 0.0 and 1.0, got {value}");
+        }
+    }
+
+    fn upload_fp8(ordinal: usize, shape: &[usize], values: &[f32]) -> GpuBuffer {
+        let bytes = values
+            .iter()
+            .map(|value| fp8_e4m3_byte(*value))
+            .collect::<Vec<_>>();
+        GpuBuffer::from_host_bytes(ordinal, ScalarType::F8E4M3, shape, &bytes)
+            .expect("upload fp8 test tensor")
+    }
+
+    fn upload_fp8_scale(ordinal: usize) -> GpuBuffer {
+        GpuBuffer::from_host_bytes(
+            ordinal,
+            ScalarType::BF16,
+            &[1, 1],
+            &bf16::from_f32(1.0).to_bits().to_le_bytes(),
+        )
+        .expect("upload fp8 scale")
+    }
+
+    fn identity(size: usize) -> Vec<f32> {
+        let mut values = vec![0.0; size * size];
+        for i in 0..size {
+            values[i * size + i] = 1.0;
+        }
+        values
+    }
+
+    #[test]
+    fn phi4_metal_component_decode_smoke_appends_kv_and_updates_hidden() {
+        set_backend(Backend::Metal);
+        let ordinal = 0usize;
+        let config = Phi4Config {
+            vocab_size: 8,
+            hidden_size: 4,
+            intermediate_size: 4,
+            num_hidden_layers: 1,
+            num_attention_heads: 1,
+            num_key_value_heads: 1,
+            max_position_embeddings: 8,
+            original_max_position_embeddings: 8,
+            rope_theta: 10000.0,
+            partial_rotary_factor: 0.5,
+            rms_norm_eps: 1e-5,
+            tie_word_embeddings: true,
+            rope_scaling: None,
+            eos_token_id: None,
+            bos_token_id: None,
+        };
+        let hidden = config.hidden_size;
+        let intermediate = config.intermediate_size;
+        let ident = identity(hidden);
+        let ones = vec![1.0; hidden];
+        let zeros = vec![0.0; hidden * hidden];
+        let layer = Phi4LayerWeights {
+            input_norm_w: upload(ordinal, &[hidden], &ones),
+            post_attn_norm_w: upload(ordinal, &[hidden], &ones),
+            q_proj_w: upload(ordinal, &[hidden, hidden], &ident),
+            k_proj_w: upload(ordinal, &[hidden, hidden], &ident),
+            v_proj_w: upload(ordinal, &[hidden, hidden], &ident),
+            o_proj_w: upload(ordinal, &[hidden, hidden], &ident),
+            gate_proj_w: upload(ordinal, &[intermediate, hidden], &zeros),
+            up_proj_w: upload(ordinal, &[intermediate, hidden], &zeros),
+            down_proj_w: upload(ordinal, &[hidden, intermediate], &zeros),
+            q_proj_int4_scale: None,
+            q_proj_int4_zero: None,
+            k_proj_int4_scale: None,
+            k_proj_int4_zero: None,
+            v_proj_int4_scale: None,
+            v_proj_int4_zero: None,
+            o_proj_int4_scale: None,
+            o_proj_int4_zero: None,
+            gate_proj_int4_scale: None,
+            gate_proj_int4_zero: None,
+            up_proj_int4_scale: None,
+            up_proj_int4_zero: None,
+            down_proj_int4_scale: None,
+            down_proj_int4_zero: None,
+            q_proj_fp8_scale: None,
+            k_proj_fp8_scale: None,
+            v_proj_fp8_scale: None,
+            o_proj_fp8_scale: None,
+            gate_proj_fp8_scale: None,
+            up_proj_fp8_scale: None,
+            down_proj_fp8_scale: None,
+        };
+        let dummy = Arc::new(upload(
+            ordinal,
+            &[config.vocab_size, hidden],
+            &vec![0.0; 8 * hidden],
+        ));
+        let weights = Phi4Weights {
+            config: config.clone(),
+            embed_tokens: dummy.clone(),
+            lm_head: dummy,
+            norm_weight: upload(ordinal, &[hidden], &ones),
+            layers: vec![layer],
+            is_int4: false,
+            int4_group_size: 0,
+            is_fp8: false,
+            fp8_block_size: 0,
+        };
+        let rope = Phi4LongRope::build(&config, ordinal).expect("build tiny Phi-4 rope");
+        let mut state = Phi4ModelState::new(&config);
+        state.layers[0]
+            .ensure_kv_capacity(0, ordinal, &config, 4, false)
+            .expect("alloc tiny KV");
+        let mut hidden_io = upload(ordinal, &[1, hidden], &[1.0, 0.5, -0.25, 0.125]);
+        let before = read_bf16(&hidden_io);
+        let mut scratch = Phi4MetalDecodeScratch::new(&config, ordinal).expect("alloc scratch");
+
+        phi4_decode_step_metal_bf16(
+            &config,
+            &weights,
+            &mut state,
+            &rope,
+            ordinal,
+            1,
+            hidden,
+            &mut hidden_io,
+            0,
+            &mut scratch,
+        )
+        .expect("run Phi-4 Metal component decode");
+
+        let after = read_bf16(&hidden_io);
+        assert!(after.iter().all(|v| v.is_finite()));
+        assert!(
+            after
+                .iter()
+                .zip(before.iter())
+                .any(|(a, b)| (a - b).abs() > 0.01),
+            "component decode should update hidden state: before={before:?} after={after:?}"
+        );
+        let cache_k = state.layers[0]
+            .kv_cache_k
+            .as_ref()
+            .expect("K cache after decode");
+        let cache = read_bf16(cache_k);
+        assert!(
+            cache.iter().take(hidden).any(|v| v.abs() > 0.01),
+            "component decode should append non-zero K cache, cache={cache:?}"
+        );
+    }
+
+    #[test]
+    fn phi4_metal_component_decode_accepts_fp8_projection_weights() {
+        set_backend(Backend::Metal);
+        let ordinal = 0usize;
+        let config = Phi4Config {
+            vocab_size: 8,
+            hidden_size: 4,
+            intermediate_size: 4,
+            num_hidden_layers: 1,
+            num_attention_heads: 1,
+            num_key_value_heads: 1,
+            max_position_embeddings: 8,
+            original_max_position_embeddings: 8,
+            rope_theta: 10000.0,
+            partial_rotary_factor: 0.5,
+            rms_norm_eps: 1e-5,
+            tie_word_embeddings: true,
+            rope_scaling: None,
+            eos_token_id: None,
+            bos_token_id: None,
+        };
+        let hidden = config.hidden_size;
+        let intermediate = config.intermediate_size;
+        let ident = identity(hidden);
+        let ones = vec![1.0; hidden];
+        let zeros = vec![0.0; hidden * hidden];
+        let layer = Phi4LayerWeights {
+            input_norm_w: upload(ordinal, &[hidden], &ones),
+            post_attn_norm_w: upload(ordinal, &[hidden], &ones),
+            q_proj_w: upload_fp8(ordinal, &[hidden, hidden], &ident),
+            k_proj_w: upload_fp8(ordinal, &[hidden, hidden], &ident),
+            v_proj_w: upload_fp8(ordinal, &[hidden, hidden], &ident),
+            o_proj_w: upload_fp8(ordinal, &[hidden, hidden], &ident),
+            gate_proj_w: upload_fp8(ordinal, &[intermediate, hidden], &zeros),
+            up_proj_w: upload_fp8(ordinal, &[intermediate, hidden], &zeros),
+            down_proj_w: upload_fp8(ordinal, &[hidden, intermediate], &zeros),
+            q_proj_int4_scale: None,
+            q_proj_int4_zero: None,
+            k_proj_int4_scale: None,
+            k_proj_int4_zero: None,
+            v_proj_int4_scale: None,
+            v_proj_int4_zero: None,
+            o_proj_int4_scale: None,
+            o_proj_int4_zero: None,
+            gate_proj_int4_scale: None,
+            gate_proj_int4_zero: None,
+            up_proj_int4_scale: None,
+            up_proj_int4_zero: None,
+            down_proj_int4_scale: None,
+            down_proj_int4_zero: None,
+            q_proj_fp8_scale: Some(upload_fp8_scale(ordinal)),
+            k_proj_fp8_scale: Some(upload_fp8_scale(ordinal)),
+            v_proj_fp8_scale: Some(upload_fp8_scale(ordinal)),
+            o_proj_fp8_scale: Some(upload_fp8_scale(ordinal)),
+            gate_proj_fp8_scale: Some(upload_fp8_scale(ordinal)),
+            up_proj_fp8_scale: Some(upload_fp8_scale(ordinal)),
+            down_proj_fp8_scale: Some(upload_fp8_scale(ordinal)),
+        };
+        let dummy = Arc::new(upload(
+            ordinal,
+            &[config.vocab_size, hidden],
+            &vec![0.0; 8 * hidden],
+        ));
+        let weights = Phi4Weights {
+            config: config.clone(),
+            embed_tokens: dummy.clone(),
+            lm_head: dummy,
+            norm_weight: upload(ordinal, &[hidden], &ones),
+            layers: vec![layer],
+            is_int4: false,
+            int4_group_size: 0,
+            is_fp8: true,
+            fp8_block_size: 128,
+        };
+        let rope = Phi4LongRope::build(&config, ordinal).expect("build tiny Phi-4 rope");
+        let mut state = Phi4ModelState::new(&config);
+        state.layers[0]
+            .ensure_kv_capacity(0, ordinal, &config, 4, false)
+            .expect("alloc tiny KV");
+        let mut hidden_io = upload(ordinal, &[1, hidden], &[1.0, 0.5, -0.25, 0.125]);
+        let before = read_bf16(&hidden_io);
+        let mut scratch = Phi4MetalDecodeScratch::new(&config, ordinal).expect("alloc scratch");
+
+        phi4_decode_step_metal_bf16(
+            &config,
+            &weights,
+            &mut state,
+            &rope,
+            ordinal,
+            1,
+            hidden,
+            &mut hidden_io,
+            0,
+            &mut scratch,
+        )
+        .expect("run Phi-4 Metal FP8 component decode");
+
+        let after = read_bf16(&hidden_io);
+        assert!(after.iter().all(|v| v.is_finite()));
+        assert!(
+            after
+                .iter()
+                .zip(before.iter())
+                .any(|(a, b)| (a - b).abs() > 0.01),
+            "FP8 component decode should update hidden state: before={before:?} after={after:?}"
+        );
     }
 }
 

--- a/crates/runner/src/policy.rs
+++ b/crates/runner/src/policy.rs
@@ -40,8 +40,8 @@ pub(crate) fn validate_global_flags(
         if !cli.int4 || profile != QuantProfile::Int4Gptq {
             anyhow::bail!("qwen3-30b-a3b v1 requires --int4 / int4-gptq");
         }
-        if backend != Backend::Hip {
-            anyhow::bail!("qwen3-30b-a3b v1 is supported only on HIP");
+        if !matches!(backend, Backend::Hip | Backend::Metal) {
+            anyhow::bail!("qwen3-30b-a3b v1 is supported only on HIP and Metal");
         }
     }
     if cli.gguf_file.is_some() && profile != QuantProfile::Q4Km {

--- a/crates/runner/src/qwen35_startup.rs
+++ b/crates/runner/src/qwen35_startup.rs
@@ -153,9 +153,14 @@ pub(crate) fn validate_qwen35_startup(
     } else if backend == Backend::Metal {
         if !matches!(
             model_variant,
-            ModelVariant::Qwen3_5_0_8B | ModelVariant::Qwen3_5_2B
+            ModelVariant::Qwen3_5_0_8B
+                | ModelVariant::Qwen3_5_2B
+                | ModelVariant::Qwen3_5_4B
+                | ModelVariant::Qwen3_5_9B
         ) {
-            anyhow::bail!("Metal only supports --model qwen3.5-0.8b or qwen3.5-2b");
+            anyhow::bail!(
+                "Metal only supports --model qwen3.5-0.8b, qwen3.5-2b, qwen3.5-4b, or qwen3.5-9b"
+            );
         }
         if q4km_like {
             anyhow::bail!("Metal does not support --q4km/--q4km-gptq on Qwen3.5 yet");

--- a/crates/runner/src/qwen36_moe/engine.rs
+++ b/crates/runner/src/qwen36_moe/engine.rs
@@ -25,7 +25,7 @@ use crate::qwen36_moe_cli::output::{
     print_sampling_summary,
 };
 use crate::qwen36_moe_cli::policy::{
-    resolve_context_size, validate_cuda_v1_flags, validate_decode_backend,
+    resolve_context_size, validate_cuda_v1_flags, validate_decode_backend, validate_metal_v1_flags,
     validate_persistent_kv_fp8_flags,
 };
 use crate::qwen36_moe_cli::prompt::{
@@ -105,6 +105,7 @@ fn run_inner(
     let (context_size, context_size_source) = resolve_context_size(cli);
     validate_persistent_kv_fp8_flags(cli)?;
     validate_cuda_v1_flags(cli, entry)?;
+    validate_metal_v1_flags(cli, entry)?;
 
     let report = run_qwen36_moe_dry_run(
         &cli.model_dir,
@@ -148,7 +149,7 @@ fn run_inner(
         // `--persistent-decode` flag is a hidden no-op (kept for harness
         // back-compat); `--no-persistent-decode` is the documented
         // opt-out for A/B comparison or bisecting megakernel regressions.
-        !cli.no_persistent_decode,
+        entry.backend != Backend::Metal && !cli.no_persistent_decode,
         cli.kv_fp8,
         cli.dump_last_logits,
         cli.profile_prefill,

--- a/crates/runner/src/qwen36_moe/policy.rs
+++ b/crates/runner/src/qwen36_moe/policy.rs
@@ -30,12 +30,33 @@ pub fn validate_persistent_kv_fp8_flags(cli: &crate::Cli) -> Result<()> {
 }
 
 pub fn validate_decode_backend(entry: &RegistryEntry) -> Result<()> {
-    if !matches!(entry.backend, Backend::Hip | Backend::Cuda) {
+    if !matches!(entry.backend, Backend::Hip | Backend::Cuda | Backend::Metal) {
         anyhow::bail!(
-            "qwen3.6-35b-a3b decode kernels are wired for HIP and CUDA sm86; \
-             registry-selected backend was {:?}. Re-run with --backend hip/cuda, \
+            "qwen3.6-35b-a3b decode kernels are wired for HIP, CUDA sm86, and \
+             the Metal chained fallback path; registry-selected backend was {:?}. \
+             Re-run with --backend hip/cuda/metal, \
              or use --dry-run for analytic accounting.",
             entry.backend,
+        );
+    }
+    Ok(())
+}
+
+pub fn validate_metal_v1_flags(cli: &crate::Cli, entry: &RegistryEntry) -> Result<()> {
+    if entry.backend != Backend::Metal {
+        return Ok(());
+    }
+    if cli.fp8_runtime {
+        anyhow::bail!(
+            "Qwen3.6-35B-A3B Metal v1 supports INT4 chained decode only; --fp8-runtime is not wired."
+        );
+    }
+    if cli.kv_fp8 {
+        anyhow::bail!("Qwen3.6-35B-A3B Metal v1 keeps BF16 KV cache; --kv-fp8 is not wired.");
+    }
+    if cli.speculative_decode || cli.batched_spec_verify {
+        anyhow::bail!(
+            "Qwen3.6-35B-A3B Metal v1 does not wire the MTP/speculative decode path yet."
         );
     }
     Ok(())

--- a/crates/runner/src/qwen3_moe.rs
+++ b/crates/runner/src/qwen3_moe.rs
@@ -116,8 +116,8 @@ pub(crate) fn run(cli: &Cli, entry: &RegistryEntry, total_vram: u64) -> Result<(
 }
 
 fn validate_policy(cli: &Cli, entry: &RegistryEntry) -> Result<()> {
-    if entry.backend != Backend::Hip {
-        anyhow::bail!("Qwen3-30B-A3B v1 is HIP-only");
+    if !matches!(entry.backend, Backend::Hip | Backend::Metal) {
+        anyhow::bail!("Qwen3-30B-A3B v1 is supported only on HIP and Metal");
     }
     if !cli.int4 {
         anyhow::bail!("Qwen3-30B-A3B v1 requires --int4; BF16 weights do not fit gfx1100 24 GB");
@@ -249,10 +249,14 @@ fn decode_text(
     let mut lm_head_elapsed = std::time::Duration::ZERO;
     let mut sample_elapsed = std::time::Duration::ZERO;
     let mut gen_steps = 0usize;
-    let use_persistent = !cli.no_persistent_decode;
+    let use_persistent = entry.backend != Backend::Metal && !cli.no_persistent_decode;
     if use_persistent {
         eprintln!(
             "[qwen3-moe] persistent decode enabled; pass --no-persistent-decode for chained A/B"
+        );
+    } else if entry.backend == Backend::Metal {
+        eprintln!(
+            "[qwen3-moe] Metal decode uses chained layer fallbacks; persistent decode is HIP-only"
         );
     }
 
@@ -556,7 +560,9 @@ fn qwen3_workspace_floats(text: &qwen3_moe::config::TextConfig, context: usize) 
 }
 
 fn print_decode_phase_profile(step: usize, num_layers: usize, profile: &GpuBuffer) -> Result<()> {
-    let bytes = profile.to_host_bytes().context("d2h Qwen3 decode phase profile")?;
+    let bytes = profile
+        .to_host_bytes()
+        .context("d2h Qwen3 decode phase profile")?;
     let mut phase_totals = [0u64; QWEN3_PROFILE_PHASES];
     let mut layer_totals = vec![0u64; num_layers];
     for (idx, chunk) in bytes.chunks_exact(std::mem::size_of::<u64>()).enumerate() {

--- a/crates/runner/tests/metal_qwen_smoke.rs
+++ b/crates/runner/tests/metal_qwen_smoke.rs
@@ -40,6 +40,9 @@ fn metal_qwen_smoke_runs_end_to_end() {
         "--max-new-tokens",
         "1",
     ]);
+    if let Some(allow_untested_gpu) = std::env::var_os("SUPERSONIC_TEST_ALLOW_UNTESTED_GPU") {
+        cmd.arg("--allow-untested-gpu").arg(allow_untested_gpu);
+    }
 
     if repo_root.join(".venv/bin/python3").exists() {
         cmd.args(["--validate", "--oracle-device", "cpu"]);

--- a/docs/build-and-run.md
+++ b/docs/build-and-run.md
@@ -258,13 +258,24 @@ Detailed CUDA `sm86` history for both the `0.8B` and `4B` hero lanes lives in
 
 ## Metal
 
-Metal support is currently a Qwen3.5 0.8B Apple-silicon lane validated on Apple M4.
+Metal support is currently a Qwen3.5 Apple-silicon lane validated on Apple M4
+and Apple M5 Max.
 The core decode path is now O(N) incremental decode — no replay overhead.
 
-Validated Metal scope:
+Supported Metal scope:
 
 - `qwen3.5-0.8b`, `qwen3.5-2b`
+- `qwen3.5-4b`, `qwen3.5-9b` on Apple M5 Max
+- `qwen3-30b-a3b` INT4 on Apple M5 Max is wired through a correctness-first
+  chained Metal fallback; a local full-model smoke is still pending
+- `qwen3.6-35b-a3b` INT4 on Apple M5 Max is wired through the chained Metal
+  decode route; a local full-model smoke is still pending
+- `gemma4-e2b`, `gemma4-e4b` BF16 and INT4 on Apple M5 Max are wired through a
+  component Metal decode path; a local model smoke is still pending
+- `phi4-mini` BF16, INT4, and FP8-runtime on Apple M5 Max are wired through a
+  component Metal decode path; a local model smoke is still pending
 - Apple M4 / `apple-m4`
+- Apple M5 Max / `apple-m5-max`
 - BF16 prefill parity against the Python CPU oracle
 - CLI and `supersonic-serve` HTTP server
 - native Metal greedy prefill
@@ -273,15 +284,29 @@ Validated Metal scope:
 
 Metal currently rejects or defers:
 
-- models other than `qwen3.5-0.8b` and `qwen3.5-2b`
-- `--fp8-runtime`
+- `--fp8-runtime` outside the Phi4 component path
 - `--kv-fp8`
 - batched decode
 - persistent megakernel decode (all ops fused into one dispatch)
+- `qwen3-30b-a3b` INT4 on Apple M5 Max has a correctness-first chained Metal
+  fallback for decode-layer attention, MoE routing, expert matmul, KV updates,
+  and the final INT4 lm-head. The persistent Qwen3-MoE megakernel remains
+  HIP-only, and a local full-model smoke is still pending.
+- `qwen3.6-35b-a3b` INT4 on Apple M5 Max uses the host-orchestrated chained
+  decode route with Metal fallbacks for BF16 full-attention, linear-attention,
+  and FFN stages, plus INT4 sidecars for projection and expert matvecs.
+  FP8-runtime, KV-FP8, speculative decode, persistent decode, and the local
+  full-model smoke are still pending.
+- `phi4-mini` INT4 and FP8-runtime are build-checked through the component
+  Metal route; KV-FP8 and local model smokes are still pending
+- `gemma4-e2b` and `gemma4-e4b` INT4 are build-checked through the component
+  Metal route, but still need a local INT4 bake/model smoke
 
 Native Metal kernels used in the hot path:
 
 - matmul RHS-transposed (BF16 + INT4 GPTQ dequant)
+- FP8 runtime-dequant matmul has a correctness-first Metal host fallback for
+  Phi4 component decode
 - full-attention prefill core
 - lm-head argmax
 - RMSNorm rows
@@ -293,13 +318,17 @@ Native Metal kernels used in the hot path:
 - QKV split
 - Q-gate split
 
-Current Apple M4 checkpoint on this machine:
+Current Apple M4 / Apple M5 Max checkpoint:
 
 - `qwen35_bughunt --mode gate`: PASS for `hello_world`, `forest_prompt`, and `code_prompt`
 - `supersonic --backend metal --model qwen3.5-0.8b --prompt "Hello, world" --max-new-tokens 8`:
   - prefill about `112 ms`
   - incremental decode about `34 ms/token` (constant across context lengths)
 - `--gpu-validate` on 16-token sequence: `gpu_oracle_max_delta=0.0000` every step
+- Apple M5 Max validation also covers `qwen3.5-0.8b --validate --oracle-device cpu`
+  and the checked-in bughunt gate.
+- Apple M5 Max validation also covers one-token `qwen3.5-4b` and `qwen3.5-9b`
+  `--validate --oracle-device cpu` smokes through Metal v2 incremental decode.
 
 The next optimization target is a persistent Metal megakernel — collapsing the
 per-token command-buffer round-trips into a single dispatch, equivalent to the

--- a/docs/supported-matrix.md
+++ b/docs/supported-matrix.md
@@ -13,7 +13,8 @@ Six backend surfaces are validated or in bring-up today:
 - **HIP / `gfx942`** — AMD Instinct MI300X-class (CDNA 3, wave64 bring-up)
 - **CUDA / `sm86`** — NVIDIA RTX 3090-class (Ampere)
 - **CUDA / `sm90`** — NVIDIA H100 80GB HBM3 (Hopper)
-- **Metal / `apple-m4`** — Apple M4, BF16 Qwen3.5 0.8B (CLI + `supersonic-serve`)
+- **Metal / `apple-m4`, `apple-m5-max`** — Apple silicon, BF16 Qwen3.5
+  (CLI + `supersonic-serve` on M4; CLI + bughunt gate on M5 Max)
 
 ### HIP on `gfx1100`
 
@@ -197,16 +198,50 @@ lane, not a Hopper-specific retune.
   certification for one of these inherited lanes, run the matching `tests/sm86`
   validation script on the H100 and record the result here.
 
-### Metal on `apple-m4`
+### Metal on `apple-m4` / `apple-m5-max`
 
 | Model            | BF16 | INT4 | FP8 runtime | FP8 KV |
 |------------------|:----:|:----:|:-----------:|:------:|
 | qwen3.5-0.8b     |  ✅  |  —   |      —      |    —   |
 | qwen3.5-2b       |  ✅  |  —   |      —      |    —   |
+| qwen3.5-4b       |  ✅¹ |  —   |      —      |    —   |
+| qwen3.5-9b       |  ✅¹ |  —   |      —      |    —   |
+| qwen3-30b-a3b    |  —   | ⏳²  |      —      |    —   |
+| qwen3.6-35b-a3b  |  —   | ⏳²  |      —      |    —   |
+| gemma4-e2b       |  ⏳² | ⏳²  |      —      |    —   |
+| gemma4-e4b       |  ⏳² | ⏳²  |      —      |    —   |
+| phi4-mini        |  ⏳² | ⏳²  |     ⏳²     |    —   |
 
 Metal v2 is a single supported surface:
 
-- BF16 single-sequence decode for `qwen3.5-0.8b` and `qwen3.5-2b`
+- BF16 single-sequence decode for `qwen3.5-0.8b`, `qwen3.5-2b`, `qwen3.5-4b`,
+  and `qwen3.5-9b`
+- Apple M5 Max is validated on the `qwen3.5-0.8b` CLI + bughunt gate path;
+  it uses the same Metal v2 path as Apple M4.
+- `qwen3.5-4b` and `qwen3.5-9b` are validated on Apple M5 Max with one-token
+  `--validate --oracle-device cpu` smokes through Metal v2 incremental decode.
+- `qwen3-30b-a3b` INT4 has an Apple M5 Max registry row and uses a
+  correctness-first chained Metal fallback for decode-layer attention, MoE
+  routing, expert matmul, KV updates, and the final INT4 lm-head. The
+  persistent Qwen3-MoE megakernel remains HIP-only; a local full-model smoke is
+  still pending.
+- `qwen3.6-35b-a3b` INT4 has an Apple M5 Max registry row and uses the
+  host-orchestrated chained decode route with Metal fallbacks for BF16
+  full-attention stages 1-5, linear-attention stages 1-5, FFN stages 1-5,
+  the final lm-head helpers, MTP pre-fusion helper, and INT4 sidecars for the
+  projection/expert matvecs. Persistent decode, FP8-runtime, KV-FP8, and
+  speculative decode remain HIP/CUDA-only; a local full-model smoke is still
+  pending.
+- `phi4-mini` has an Apple M5 Max registry row and uses a component Metal decode
+  path assembled from existing RMSNorm, GEMV, INT4 runtime-dequant matvec,
+  FP8 runtime-dequant host fallback matvec, RoPE, attention, SwiGLU, and
+  residual kernels. A local model smoke is still pending.
+- `gemma4-e2b` and `gemma4-e4b` have Apple M5 Max registry rows. BF16 uses a
+  runner-level Metal component path for RMSNorm, BF16 matvec, RoPE, attention,
+  residual, MLP, PLE, K/V append, and sliding-window cache slicing. INT4 uses
+  the same component decode route with Metal INT4 matvec fallbacks.
+  A local model smoke is still pending.
+- Apple M4 remains limited to the smaller Metal validation lane.
 - both the `supersonic` CLI and `supersonic-serve` HTTP server work; `/v1/completions`
   and `/v1/chat/completions` (streaming and non-streaming) are exercised end-to-end
 - decode is implemented as **incremental per-token decode**: each generated token runs
@@ -216,3 +251,11 @@ Metal v2 is a single supported surface:
   validation against a baked INT4 model is pending hardware time
 - `--fp8-runtime`, `--kv-fp8`, `--batch-size > 1`, `--force-kernel-decode`,
   and `--force-component-decode` are all rejected at startup
+
+¹ Apple M5 Max only.
+² Apple M5 Max component path is wired and build-checked; end-to-end
+  validation is pending a local model checkout.
+
+Metal is not yet at mode-level HIP parity: persistent megakernel decode,
+Qwen3.6 FP8-runtime, Qwen3.6 KV-FP8, speculative decode, and the local
+full-model smokes for the large Apple M5 Max rows remain pending.

--- a/tests/metal/qwen35_bughunt_gate.sh
+++ b/tests/metal/qwen35_bughunt_gate.sh
@@ -18,7 +18,7 @@ fi
 
 cd "$repo_root"
 
-cargo build -p runner --bin qwen35_bughunt
+cargo build -p runner --bin qwen35_bughunt --features bughunt
 
 cmd=(
   "$repo_root/target/debug/qwen35_bughunt"
@@ -32,6 +32,10 @@ cmd=(
 
 if [[ -n "${QWEN35_BUGHUNT_PROMPT:-}" ]]; then
   cmd+=(--prompt "$QWEN35_BUGHUNT_PROMPT")
+fi
+
+if [[ -n "${QWEN35_BUGHUNT_ALLOW_UNTESTED_GPU:-}" ]]; then
+  cmd+=(--allow-untested-gpu "$QWEN35_BUGHUNT_ALLOW_UNTESTED_GPU")
 fi
 
 if [[ -d "$repo_root/.venv/bin" ]]; then


### PR DESCRIPTION
## Summary

Adds Apple M5 Max / Metal execution paths across the SuperSonic runtime surface. The change wires Metal support through the model/backend registry, kernel FFI host dispatch, and runner engines for Qwen, Gemma 4, Phi 4, and Qwen MoE flows.

It also extends the Metal smoke and bughunt surfaces and updates the build/run and supported matrix docs so Apple Metal support is visible to users.

## Impact

- Registers Apple M5 Max Metal combinations and policy handling.
- Adds Metal host paths and FFI dispatch for affected kernels and prefill/decode helpers.
- Extends runner engine support for Gemma 4, Phi 4, Qwen3.5, and Qwen MoE Metal paths.
- Updates docs and Metal smoke coverage.

## Validation

- `git diff --check main...HEAD`
- `cargo check --workspace`

Note: `cargo check` passed on macOS with existing warning noise, including `hipcc not found; machine-profile GPU kernels disabled`.