### PR TITLE
Support Qwen3.6 Metal INT4 smoke

### DIFF
--- a/crates/core/src/registry.rs
+++ b/crates/core/src/registry.rs
@@ -1382,11 +1382,17 @@ mod tests {
             &Backend::Metal,
             &GpuArch::AppleM5Max,
         );
+        let qwen36_moe_m5 = lookup(
+            &ModelVariant::Qwen3_6_35B_A3B,
+            &Backend::Metal,
+            &GpuArch::AppleM5Max,
+        );
         assert!(e08b_m5.is_some());
         assert!(e2b_m5.is_some());
         assert!(e4b_m5.is_some());
         assert!(e9b_m5.is_some());
         assert!(qwen3_moe_m5.is_some());
+        assert!(qwen36_moe_m5.is_some());
         assert!(phi4_m5.is_some());
         assert!(gemma_e2b_m5.is_some());
         assert!(gemma_e4b_m5.is_some());
@@ -1412,6 +1418,11 @@ mod tests {
         );
         assert!(
             supported_archs_for(&ModelVariant::Qwen3_30B_A3B, &Backend::Metal)
+                .iter()
+                .any(|arch| arch == "apple-m5-max")
+        );
+        assert!(
+            supported_archs_for(&ModelVariant::Qwen3_6_35B_A3B, &Backend::Metal)
                 .iter()
                 .any(|arch| arch == "apple-m5-max")
         );

--- a/crates/kernel-ffi/src/qwen36_moe.rs
+++ b/crates/kernel-ffi/src/qwen36_moe.rs
@@ -2287,7 +2287,9 @@ fn linear_step_stage1_5_metal_host(
             }
             let rec = bf16_round_f32(acc);
             workspace[off_rec_out + head * head_v_dim + j] = rec;
-            output[head * head_v_dim + j] = f32_to_bf16_bits(rec);
+            if params.stage == 4 {
+                output[head * head_v_dim + j] = f32_to_bf16_bits(rec);
+            }
         }
     }
 

--- a/crates/runner/src/qwen36_moe/bake.rs
+++ b/crates/runner/src/qwen36_moe/bake.rs
@@ -95,3 +95,37 @@ pub(crate) fn select_decode_bake(
         weight_mode,
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_model_dir(name: &str) -> PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock before unix epoch")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "supersonic-qwen36-bake-{name}-{}-{nonce}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&dir).expect("create temp model dir");
+        dir
+    }
+
+    #[test]
+    fn select_decode_bake_rejects_bf16_when_int4_required() {
+        let model_dir = temp_model_dir("int4-required");
+        fs::create_dir_all(model_store::bake_dir(&model_dir)).expect("create bf16 bake dir");
+
+        let err = match select_decode_bake(&model_dir, false, true) {
+            Ok(_) => panic!("int4 requirement must not fall back to bf16"),
+            Err(err) => err.to_string(),
+        };
+
+        assert!(err.contains("--int4 requested but no INT4-GPTQ bake exists"));
+        let _ = fs::remove_dir_all(model_dir);
+    }
+}

--- a/crates/runner/src/qwen36_moe/bake.rs
+++ b/crates/runner/src/qwen36_moe/bake.rs
@@ -50,6 +50,7 @@ pub(crate) fn ensure_qwen36_bake(cli: &crate::Cli, entry: &RegistryEntry) -> Res
 pub(crate) fn select_decode_bake(
     model_dir: &Path,
     fp8_runtime: bool,
+    int4_runtime: bool,
 ) -> Result<DecodeBakeSelection> {
     // INT4 remains the default small-VRAM path; explicit --fp8-runtime
     // selects the native FP8 bake.
@@ -68,6 +69,14 @@ pub(crate) fn select_decode_bake(
         (fp8_dir, Qwen36WeightMode::Fp8)
     } else if int4_dir.exists() {
         (int4_dir, Qwen36WeightMode::Int4)
+    } else if int4_runtime {
+        return Err(anyhow!(
+            "--int4 requested but no INT4-GPTQ bake exists at {}. \
+             Create one with `python3 oracle/bake_int4.py --model-dir {}` \
+             or allow the release bake download.",
+            int4_dir.display(),
+            model_dir.display()
+        ));
     } else if bf16_dir.exists() {
         (bf16_dir, Qwen36WeightMode::Bf16)
     } else {

--- a/crates/runner/src/qwen36_moe/engine.rs
+++ b/crates/runner/src/qwen36_moe/engine.rs
@@ -132,6 +132,7 @@ fn run_inner(
         top_p: cli.top_p,
         seed: cli.sampling_seed,
     };
+    let requires_int4_bake = cli.int4 || matches!(entry.backend, Backend::Cuda | Backend::Metal);
     decode_text(
         &cli.model_dir,
         &report,
@@ -141,7 +142,7 @@ fn run_inner(
         cli.emit_stage_timings,
         cli.speculative_decode,
         cli.fp8_runtime,
-        cli.int4,
+        requires_int4_bake,
         cli.batched_spec_verify,
         entry.backend,
         cli.device,
@@ -221,12 +222,20 @@ fn decode_text(
 
     let bake_open_start = std::time::Instant::now();
     let bake = select_decode_bake(model_dir, fp8_runtime, int4_runtime)?;
-    if backend == Backend::Cuda && !bake.weight_mode.is_int4() {
-        anyhow::bail!(
-            "Qwen3.6-35B-A3B CUDA v1 requires an INT4/q4km bake; selected {} from {}",
-            bake.weight_mode.display_name(),
-            bake.bake_dir.display(),
-        );
+    if !bake.weight_mode.is_int4() {
+        match backend {
+            Backend::Cuda => anyhow::bail!(
+                "Qwen3.6-35B-A3B CUDA v1 requires an INT4/q4km bake; selected {} from {}",
+                bake.weight_mode.display_name(),
+                bake.bake_dir.display(),
+            ),
+            Backend::Metal => anyhow::bail!(
+                "Qwen3.6-35B-A3B Metal v1 requires an INT4-GPTQ bake; selected {} from {}",
+                bake.weight_mode.display_name(),
+                bake.bake_dir.display(),
+            ),
+            _ => {}
+        }
     }
     println!(
         "  loading from bake: {} ({})",

--- a/crates/runner/src/qwen36_moe/engine.rs
+++ b/crates/runner/src/qwen36_moe/engine.rs
@@ -100,12 +100,11 @@ fn run_inner(
     total_vram: u64,
     keep_mask: Option<Vec<bool>>,
 ) -> Result<()> {
-    ensure_qwen36_bake(cli, entry)?;
-
     let (context_size, context_size_source) = resolve_context_size(cli);
     validate_persistent_kv_fp8_flags(cli)?;
     validate_cuda_v1_flags(cli, entry)?;
     validate_metal_v1_flags(cli, entry)?;
+    ensure_qwen36_bake(cli, entry)?;
 
     let report = run_qwen36_moe_dry_run(
         &cli.model_dir,
@@ -142,6 +141,7 @@ fn run_inner(
         cli.emit_stage_timings,
         cli.speculative_decode,
         cli.fp8_runtime,
+        cli.int4,
         cli.batched_spec_verify,
         entry.backend,
         cli.device,
@@ -186,6 +186,7 @@ fn decode_text(
     emit_stage_timings: bool,
     speculative_decode: bool,
     fp8_runtime: bool,
+    int4_runtime: bool,
     batched_spec_verify: bool,
     backend: Backend,
     ordinal: usize,
@@ -219,7 +220,7 @@ fn decode_text(
     print_prompt_summary(prompt, &prompt_ids);
 
     let bake_open_start = std::time::Instant::now();
-    let bake = select_decode_bake(model_dir, fp8_runtime)?;
+    let bake = select_decode_bake(model_dir, fp8_runtime, int4_runtime)?;
     if backend == Backend::Cuda && !bake.weight_mode.is_int4() {
         anyhow::bail!(
             "Qwen3.6-35B-A3B CUDA v1 requires an INT4/q4km bake; selected {} from {}",

--- a/crates/runner/src/qwen36_moe/output.rs
+++ b/crates/runner/src/qwen36_moe/output.rs
@@ -117,4 +117,9 @@ pub(crate) fn print_generation_summary(
     if !generated_ids.is_empty() {
         println!("  Generated ids: {generated_ids:?}");
     }
+    println!(
+        "[result] prompt_tokens={} generated_tokens={}",
+        prompt_len,
+        generated_ids.len()
+    );
 }

--- a/crates/runner/src/qwen36_moe/policy.rs
+++ b/crates/runner/src/qwen36_moe/policy.rs
@@ -106,6 +106,15 @@ mod tests {
         .expect("qwen3.6-35b-a3b CUDA sm86 registry entry")
     }
 
+    fn metal_entry() -> &'static RegistryEntry {
+        lookup(
+            &ModelVariant::Qwen3_6_35B_A3B,
+            &Backend::Metal,
+            &GpuArch::AppleM5Max,
+        )
+        .expect("qwen3.6-35b-a3b Metal apple-m5-max registry entry")
+    }
+
     fn cli(extra: &[&str]) -> crate::Cli {
         let mut args = vec![
             "supersonic",
@@ -122,6 +131,12 @@ mod tests {
     fn cuda_v1_error(extra: &[&str]) -> String {
         validate_cuda_v1_flags(&cli(extra), cuda_entry())
             .expect_err("CUDA v1 policy should reject this flag set")
+            .to_string()
+    }
+
+    fn metal_v1_error(extra: &[&str]) -> String {
+        validate_metal_v1_flags(&cli(extra), metal_entry())
+            .expect_err("Metal v1 policy should reject this flag set")
             .to_string()
     }
 
@@ -153,5 +168,18 @@ mod tests {
         std::env::remove_var("SUPERSONIC_VMM_KV");
 
         assert!(err.contains("SUPERSONIC_VMM_KV=1"));
+    }
+
+    #[test]
+    fn metal_v1_accepts_default_int4_path() {
+        validate_metal_v1_flags(&cli(&["--int4"]), metal_entry()).expect("Metal INT4 v1 flags");
+    }
+
+    #[test]
+    fn metal_v1_rejects_unsupported_weight_kv_and_speculative_modes() {
+        assert!(metal_v1_error(&["--fp8-runtime"]).contains("--fp8-runtime"));
+        assert!(metal_v1_error(&["--kv-fp8"]).contains("--kv-fp8"));
+        assert!(metal_v1_error(&["--speculative-decode"]).contains("speculative"));
+        assert!(metal_v1_error(&["--batched-spec-verify"]).contains("speculative"));
     }
 }

--- a/crates/runner/tests/qwen36_moe_metal_smoke.rs
+++ b/crates/runner/tests/qwen36_moe_metal_smoke.rs
@@ -1,0 +1,92 @@
+#[cfg(target_os = "macos")]
+use std::path::PathBuf;
+#[cfg(target_os = "macos")]
+use std::process::Command;
+
+#[cfg(target_os = "macos")]
+fn combined_output(output: &std::process::Output) -> String {
+    format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+#[cfg(target_os = "macos")]
+fn model_dir() -> Option<std::ffi::OsString> {
+    std::env::var_os("SUPERSONIC_TEST_QWEN36_MOE_MODEL_DIR")
+        .or_else(|| std::env::var_os("SUPERSONIC_TEST_MODEL_DIR"))
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+#[ignore = "requires Apple M5 Max Metal and a local Qwen3.6-35B-A3B dir via SUPERSONIC_TEST_QWEN36_MOE_MODEL_DIR or SUPERSONIC_TEST_MODEL_DIR"]
+fn qwen36_moe_metal_int4_smoke_runs_end_to_end() {
+    let Some(model_dir) = model_dir() else {
+        eprintln!(
+            "skipping: SUPERSONIC_TEST_QWEN36_MOE_MODEL_DIR/SUPERSONIC_TEST_MODEL_DIR is not set"
+        );
+        return;
+    };
+
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let repo_root = manifest_dir
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("runner crate should live under <repo>/crates/runner");
+    let venv_bin = repo_root.join(".venv/bin");
+    let mut path_entries = Vec::new();
+    if venv_bin.exists() {
+        path_entries.push(venv_bin);
+    }
+    path_entries.extend(std::env::split_paths(
+        &std::env::var_os("PATH").unwrap_or_default(),
+    ));
+    let path_value = std::env::join_paths(path_entries).expect("join PATH entries");
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_supersonic"));
+    cmd.env("PATH", path_value).args([
+        "--backend",
+        "metal",
+        "--model",
+        "qwen3.6-35b-a3b",
+        "--model-dir",
+        model_dir.to_str().expect("model dir must be valid UTF-8"),
+        "--int4",
+        "--prompt",
+        "Hello",
+        "--max-new-tokens",
+        "1",
+        "--emit-stage-timings",
+    ]);
+
+    let output = cmd.output().expect("run Qwen3.6-MoE Metal INT4 smoke test");
+    let combined = combined_output(&output);
+
+    assert!(
+        output.status.success(),
+        "Qwen3.6-MoE Metal INT4 smoke failed with status {:?}:\n{}",
+        output.status.code(),
+        combined
+    );
+    assert!(
+        combined.contains("backend=Metal"),
+        "expected Metal backend selection:\n{}",
+        combined
+    );
+    assert!(
+        combined.contains("=== Decode (Qwen3.6-MoE) ==="),
+        "expected Qwen3.6-MoE decode marker:\n{}",
+        combined
+    );
+    assert!(
+        combined.contains("INT4 GPTQ") || combined.contains("INT4 sidecar"),
+        "expected INT4 bake/sidecar marker:\n{}",
+        combined
+    );
+    assert!(
+        combined.contains("[result]"),
+        "expected result summary in output:\n{}",
+        combined
+    );
+}

--- a/crates/runner/tests/qwen36_moe_mtp_parity.rs
+++ b/crates/runner/tests/qwen36_moe_mtp_parity.rs
@@ -12,7 +12,8 @@
 //! the oracle JSON (the existing `prefusion_weights` block is already
 //! 16 MiB). The test loads `mtp.*` tensors from the INT4 bake's raw BF16
 //! MTP pass-through tensors at the path given by
-//! `SUPERSONIC_QWEN36_MTP_MODEL_DIR`, matching the runtime path.
+//! `SUPERSONIC_QWEN36_MTP_MODEL_DIR` or `SUPERSONIC_TEST_MODEL_DIR`,
+//! matching the runtime path.
 //!
 //! Skipped silently when either env var isn't set so CI / non-HIP
 //! machines stay green. To run locally:
@@ -23,7 +24,7 @@
 //!     --num-speculative-tokens 1 --seed 42 \
 //!     --out /tmp/qwen36_mtp.json
 //! SUPERSONIC_QWEN36_MTP_ORACLE_JSON=/tmp/qwen36_mtp.json \
-//!   SUPERSONIC_QWEN36_MTP_MODEL_DIR=/path/to/Qwen3.6-35B-A3B \
+//!   SUPERSONIC_TEST_MODEL_DIR=/path/to/Qwen3.6-35B-A3B \
 //!   cargo test --release -p runner --test qwen36_moe_mtp_parity \
 //!     -- --nocapture
 //! ```
@@ -47,6 +48,13 @@ use runner::qwen36_moe_speculative::{
 use runner::qwen36_moe_types::{FullAttnKvCache, MtpLayerBuffers, MultiLayerGeom, PositionPair};
 use safetensors::SafeTensors;
 use serde_json::Value;
+
+fn qwen36_model_dir() -> Option<String> {
+    std::env::var("SUPERSONIC_QWEN36_MTP_MODEL_DIR")
+        .or_else(|_| std::env::var("SUPERSONIC_TEST_QWEN36_MOE_MODEL_DIR"))
+        .or_else(|_| std::env::var("SUPERSONIC_TEST_MODEL_DIR"))
+        .ok()
+}
 
 fn b64(input: &str) -> Vec<u8> {
     base64::engine::general_purpose::STANDARD
@@ -247,9 +255,9 @@ fn qwen36_moe_mtp_layer_forward_matches_oracle() {
         );
         return;
     };
-    let Ok(model_dir) = std::env::var("SUPERSONIC_QWEN36_MTP_MODEL_DIR") else {
+    let Some(model_dir) = qwen36_model_dir() else {
         eprintln!(
-            "skip: SUPERSONIC_QWEN36_MTP_MODEL_DIR not set. Point this at the \
+            "skip: SUPERSONIC_QWEN36_MTP_MODEL_DIR/SUPERSONIC_TEST_MODEL_DIR not set. Point this at the \
              same model_dir the oracle used (the test loads `mtp.*` tensors \
              directly from safetensors — they're too big to round-trip through \
              the oracle JSON)."
@@ -407,8 +415,8 @@ fn qwen36_moe_mtp_draft_step_matches_oracle() {
         eprintln!("skip: SUPERSONIC_QWEN36_MTP_ORACLE_JSON not set");
         return;
     };
-    let Ok(model_dir) = std::env::var("SUPERSONIC_QWEN36_MTP_MODEL_DIR") else {
-        eprintln!("skip: SUPERSONIC_QWEN36_MTP_MODEL_DIR not set");
+    let Some(model_dir) = qwen36_model_dir() else {
+        eprintln!("skip: SUPERSONIC_QWEN36_MTP_MODEL_DIR/SUPERSONIC_TEST_MODEL_DIR not set");
         return;
     };
     let model_dir = PathBuf::from(model_dir);
@@ -531,8 +539,8 @@ fn qwen36_moe_mtp_draft_chain_matches_oracle() {
         eprintln!("skip: SUPERSONIC_QWEN36_MTP_ORACLE_JSON not set");
         return;
     };
-    let Ok(model_dir) = std::env::var("SUPERSONIC_QWEN36_MTP_MODEL_DIR") else {
-        eprintln!("skip: SUPERSONIC_QWEN36_MTP_MODEL_DIR not set");
+    let Some(model_dir) = qwen36_model_dir() else {
+        eprintln!("skip: SUPERSONIC_QWEN36_MTP_MODEL_DIR/SUPERSONIC_TEST_MODEL_DIR not set");
         return;
     };
     let model_dir = PathBuf::from(model_dir);
@@ -707,8 +715,8 @@ fn qwen36_moe_speculative_driver_orchestration() {
         eprintln!("skip: SUPERSONIC_QWEN36_MTP_ORACLE_JSON not set");
         return;
     };
-    let Ok(model_dir) = std::env::var("SUPERSONIC_QWEN36_MTP_MODEL_DIR") else {
-        eprintln!("skip: SUPERSONIC_QWEN36_MTP_MODEL_DIR not set");
+    let Some(model_dir) = qwen36_model_dir() else {
+        eprintln!("skip: SUPERSONIC_QWEN36_MTP_MODEL_DIR/SUPERSONIC_TEST_MODEL_DIR not set");
         return;
     };
     let model_dir = PathBuf::from(model_dir);
@@ -797,11 +805,12 @@ fn qwen36_moe_speculative_driver_orchestration() {
         let mut step_idx = 0usize;
         let first_match = want_drafts[0];
         let synth_fh_p2 = synth_fh.clone();
-        let base_step_p2 = move |_pos: PositionPair, _input: u32| -> anyhow::Result<(u32, Vec<u8>)> {
-            let predicted = if step_idx == 0 { first_match } else { bad_pred };
-            step_idx += 1;
-            Ok((predicted, synth_fh_p2.clone()))
-        };
+        let base_step_p2 =
+            move |_pos: PositionPair, _input: u32| -> anyhow::Result<(u32, Vec<u8>)> {
+                let predicted = if step_idx == 0 { first_match } else { bad_pred };
+                step_idx += 1;
+                Ok((predicted, synth_fh_p2.clone()))
+            };
         eprintln!("[spec] pass 2 (reject at k=1)");
         let r2 = run_speculative_decode_step(
             ordinal,
@@ -930,8 +939,8 @@ fn qwen36_moe_speculative_driver_orchestration_batched() {
         eprintln!("skip: SUPERSONIC_QWEN36_MTP_ORACLE_JSON not set");
         return;
     };
-    let Ok(model_dir) = std::env::var("SUPERSONIC_QWEN36_MTP_MODEL_DIR") else {
-        eprintln!("skip: SUPERSONIC_QWEN36_MTP_MODEL_DIR not set");
+    let Some(model_dir) = qwen36_model_dir() else {
+        eprintln!("skip: SUPERSONIC_QWEN36_MTP_MODEL_DIR/SUPERSONIC_TEST_MODEL_DIR not set");
         return;
     };
     let model_dir = PathBuf::from(model_dir);
@@ -974,16 +983,17 @@ fn qwen36_moe_speculative_driver_orchestration_batched() {
     let bonus_token: u32 = 999;
     let want_drafts_p1 = want_drafts.clone();
     let synth_fh_p1 = synth_fh.clone();
-    let base_step_batched_p1 = move |inputs: &[(PositionPair, u32)]| -> anyhow::Result<Vec<(u32, Vec<u8>)>> {
-        assert_eq!(inputs.len(), k + 1, "expected K+1 inputs");
-        // Predictions: drafts[0..K] match, then bonus for K-th.
-        let mut out: Vec<(u32, Vec<u8>)> = Vec::with_capacity(k + 1);
-        for i in 0..k {
-            out.push((want_drafts_p1[i], synth_fh_p1.clone()));
-        }
-        out.push((bonus_token, synth_fh_p1.clone()));
-        Ok(out)
-    };
+    let base_step_batched_p1 =
+        move |inputs: &[(PositionPair, u32)]| -> anyhow::Result<Vec<(u32, Vec<u8>)>> {
+            assert_eq!(inputs.len(), k + 1, "expected K+1 inputs");
+            // Predictions: drafts[0..K] match, then bonus for K-th.
+            let mut out: Vec<(u32, Vec<u8>)> = Vec::with_capacity(k + 1);
+            for i in 0..k {
+                out.push((want_drafts_p1[i], synth_fh_p1.clone()));
+            }
+            out.push((bonus_token, synth_fh_p1.clone()));
+            Ok(out)
+        };
     let r1 = run_speculative_decode_step_batched(
         ordinal,
         &geom,
@@ -1060,15 +1070,16 @@ fn qwen36_moe_speculative_driver_orchestration_batched() {
     // ---- Pass 3: zero-accept (immediate reject at k=0) ----
     let bad_pred: u32 = 67890;
     let synth_fh_p3 = synth_fh.clone();
-    let base_step_batched_p3 = move |inputs: &[(PositionPair, u32)]| -> anyhow::Result<Vec<(u32, Vec<u8>)>> {
-        assert_eq!(inputs.len(), k + 1);
-        let mut out: Vec<(u32, Vec<u8>)> = Vec::with_capacity(k + 1);
-        out.push((bad_pred, synth_fh_p3.clone())); // immediate reject
-        for _ in 1..(k + 1) {
-            out.push((0u32, synth_fh_p3.clone()));
-        }
-        Ok(out)
-    };
+    let base_step_batched_p3 =
+        move |inputs: &[(PositionPair, u32)]| -> anyhow::Result<Vec<(u32, Vec<u8>)>> {
+            assert_eq!(inputs.len(), k + 1);
+            let mut out: Vec<(u32, Vec<u8>)> = Vec::with_capacity(k + 1);
+            out.push((bad_pred, synth_fh_p3.clone())); // immediate reject
+            for _ in 1..(k + 1) {
+                out.push((0u32, synth_fh_p3.clone()));
+            }
+            Ok(out)
+        };
     let r3 = run_speculative_decode_step_batched(
         ordinal,
         &geom,
@@ -1095,10 +1106,11 @@ fn qwen36_moe_speculative_driver_orchestration_batched() {
     // ---- Pass 4: K=0 fallback ----
     let k0_pred: u32 = 4242;
     let synth_fh_p4 = synth_fh.clone();
-    let base_step_batched_p4 = move |inputs: &[(PositionPair, u32)]| -> anyhow::Result<Vec<(u32, Vec<u8>)>> {
-        assert_eq!(inputs.len(), 1, "K=0 fallback runs exactly one base step");
-        Ok(vec![(k0_pred, synth_fh_p4.clone())])
-    };
+    let base_step_batched_p4 =
+        move |inputs: &[(PositionPair, u32)]| -> anyhow::Result<Vec<(u32, Vec<u8>)>> {
+            assert_eq!(inputs.len(), 1, "K=0 fallback runs exactly one base step");
+            Ok(vec![(k0_pred, synth_fh_p4.clone())])
+        };
     let r4 = run_speculative_decode_step_batched(
         ordinal,
         &geom,
@@ -1144,8 +1156,8 @@ fn qwen36_moe_speculative_driver_batched_reject_at_last_index() {
         eprintln!("skip: SUPERSONIC_QWEN36_MTP_ORACLE_JSON not set");
         return;
     };
-    let Ok(model_dir) = std::env::var("SUPERSONIC_QWEN36_MTP_MODEL_DIR") else {
-        eprintln!("skip: SUPERSONIC_QWEN36_MTP_MODEL_DIR not set");
+    let Some(model_dir) = qwen36_model_dir() else {
+        eprintln!("skip: SUPERSONIC_QWEN36_MTP_MODEL_DIR/SUPERSONIC_TEST_MODEL_DIR not set");
         return;
     };
     let model_dir = PathBuf::from(model_dir);
@@ -1179,15 +1191,16 @@ fn qwen36_moe_speculative_driver_batched_reject_at_last_index() {
     // Post-fix: n_accepted=0 != K → no bonus, emitted=[bad_pred].
     let bad_pred_k1: u32 = 7777;
     let synth_fh_k1 = synth_fh.clone();
-    let base_step_k1 = move |inputs: &[(PositionPair, u32)]| -> anyhow::Result<Vec<(u32, Vec<u8>)>> {
-        assert_eq!(inputs.len(), 2, "K=1 → K+1=2 verify inputs");
-        // K+1 = 2 predictions: index 0 mismatches drafts[0],
-        // index 1 (bonus) is filler — must NOT appear in emitted.
-        Ok(vec![
-            (bad_pred_k1, synth_fh_k1.clone()),
-            (99999, synth_fh_k1.clone()),
-        ])
-    };
+    let base_step_k1 =
+        move |inputs: &[(PositionPair, u32)]| -> anyhow::Result<Vec<(u32, Vec<u8>)>> {
+            assert_eq!(inputs.len(), 2, "K=1 → K+1=2 verify inputs");
+            // K+1 = 2 predictions: index 0 mismatches drafts[0],
+            // index 1 (bonus) is filler — must NOT appear in emitted.
+            Ok(vec![
+                (bad_pred_k1, synth_fh_k1.clone()),
+                (99999, synth_fh_k1.clone()),
+            ])
+        };
     let r_k1 = run_speculative_decode_step_batched(
         ordinal,
         &geom,
@@ -1230,14 +1243,15 @@ fn qwen36_moe_speculative_driver_batched_reject_at_last_index() {
     let first_match = oracle_drafts[0];
     let bad_pred_k2: u32 = 8888;
     let synth_fh_k2 = synth_fh.clone();
-    let base_step_k2 = move |inputs: &[(PositionPair, u32)]| -> anyhow::Result<Vec<(u32, Vec<u8>)>> {
-        assert_eq!(inputs.len(), 3, "K=2 → K+1=3 verify inputs");
-        Ok(vec![
-            (first_match, synth_fh_k2.clone()), // accepts drafts[0]
-            (bad_pred_k2, synth_fh_k2.clone()), // rejects drafts[1]
-            (99999, synth_fh_k2.clone()),       // bonus filler
-        ])
-    };
+    let base_step_k2 =
+        move |inputs: &[(PositionPair, u32)]| -> anyhow::Result<Vec<(u32, Vec<u8>)>> {
+            assert_eq!(inputs.len(), 3, "K=2 → K+1=3 verify inputs");
+            Ok(vec![
+                (first_match, synth_fh_k2.clone()), // accepts drafts[0]
+                (bad_pred_k2, synth_fh_k2.clone()), // rejects drafts[1]
+                (99999, synth_fh_k2.clone()),       // bonus filler
+            ])
+        };
     let r_k2 = run_speculative_decode_step_batched(
         ordinal,
         &geom,

--- a/crates/runner/tests/qwen36_moe_sparse_vmm_smoke.rs
+++ b/crates/runner/tests/qwen36_moe_sparse_vmm_smoke.rs
@@ -7,6 +7,7 @@ use std::process::Command;
 fn model_dir() -> Option<String> {
     std::env::var("SUPERSONIC_TEST_QWEN36_MOE_MODEL_DIR")
         .or_else(|_| std::env::var("SUPERSONIC_QWEN36_MTP_MODEL_DIR"))
+        .or_else(|_| std::env::var("SUPERSONIC_TEST_MODEL_DIR"))
         .ok()
 }
 
@@ -96,7 +97,7 @@ fn qwen36_moe_sparse_vmm_matches_dense_virtual_slabs() {
 
     let Some(model_dir) = model_dir() else {
         eprintln!(
-            "skipping: SUPERSONIC_TEST_QWEN36_MOE_MODEL_DIR/SUPERSONIC_QWEN36_MTP_MODEL_DIR not set"
+            "skipping: SUPERSONIC_TEST_QWEN36_MOE_MODEL_DIR/SUPERSONIC_QWEN36_MTP_MODEL_DIR/SUPERSONIC_TEST_MODEL_DIR not set"
         );
         return;
     };

--- a/docs/build-and-run.md
+++ b/docs/build-and-run.md
@@ -258,8 +258,9 @@ Detailed CUDA `sm86` history for both the `0.8B` and `4B` hero lanes lives in
 
 ## Metal
 
-Metal support is currently a Qwen3.5 Apple-silicon lane validated on Apple M4
-and Apple M5 Max.
+Metal support is currently an Apple-silicon lane validated on Apple M4 and
+Apple M5 Max, with Qwen3.5 BF16 coverage and a supported Qwen3.6-35B-A3B INT4
+Apple M5 Max path.
 The core decode path is now O(N) incremental decode — no replay overhead.
 
 Supported Metal scope:
@@ -268,8 +269,8 @@ Supported Metal scope:
 - `qwen3.5-4b`, `qwen3.5-9b` on Apple M5 Max
 - `qwen3-30b-a3b` INT4 on Apple M5 Max is wired through a correctness-first
   chained Metal fallback; a local full-model smoke is still pending
-- `qwen3.6-35b-a3b` INT4 on Apple M5 Max is wired through the chained Metal
-  decode route; a local full-model smoke is still pending
+- `qwen3.6-35b-a3b` INT4 on Apple M5 Max is supported through the
+  correctness-first chained Metal decode route
 - `gemma4-e2b`, `gemma4-e4b` BF16 and INT4 on Apple M5 Max are wired through a
   component Metal decode path; a local model smoke is still pending
 - `phi4-mini` BF16, INT4, and FP8-runtime on Apple M5 Max are wired through a
@@ -294,9 +295,11 @@ Metal currently rejects or defers:
   HIP-only, and a local full-model smoke is still pending.
 - `qwen3.6-35b-a3b` INT4 on Apple M5 Max uses the host-orchestrated chained
   decode route with Metal fallbacks for BF16 full-attention, linear-attention,
-  and FFN stages, plus INT4 sidecars for projection and expert matvecs.
-  FP8-runtime, KV-FP8, speculative decode, persistent decode, and the local
-  full-model smoke are still pending.
+  and FFN stages, plus INT4 sidecars for projection and expert matvecs. The
+  one-token local smoke is:
+  `cargo run --release --bin supersonic -- --backend metal --model qwen3.6-35b-a3b --model-dir /path/to/Qwen3.6-35B-A3B --int4 --prompt "Hello" --max-new-tokens 1 --emit-stage-timings`.
+  FP8-runtime, KV-FP8, speculative decode, and persistent decode remain
+  unsupported on this Metal path.
 - `phi4-mini` INT4 and FP8-runtime are build-checked through the component
   Metal route; KV-FP8 and local model smokes are still pending
 - `gemma4-e2b` and `gemma4-e4b` INT4 are build-checked through the component

--- a/docs/lowlevel-memory.md
+++ b/docs/lowlevel-memory.md
@@ -188,7 +188,7 @@ on CUDA devices with `SUPERSONIC_VMM_KV=1`:
   expert VA reservation after the run. With persistent decode left at its
   default, the run reports segmented persistent sparse decode.
 - Qwen3.6-MoE sparse-vs-dense VMM e2e gate:
-  `SUPERSONIC_BACKENDS=hip SUPERSONIC_TEST_QWEN36_MOE_MODEL_DIR=/mnt/data/models/Qwen3.6-35B-A3B cargo test --release -p runner --test qwen36_moe_sparse_vmm_smoke -- --ignored --nocapture`
+  `SUPERSONIC_BACKENDS=hip SUPERSONIC_TEST_MODEL_DIR=/mnt/data/models/Qwen3.6-35B-A3B cargo test --release -p runner --test qwen36_moe_sparse_vmm_smoke -- --ignored --nocapture`
   compares dense virtual expert slabs with sparse router-prefetched slabs over
   multiple generated tokens and validates the telemetry JSON cap/peak fields.
   The default test cap is 256 experts; override with

--- a/docs/supported-matrix.md
+++ b/docs/supported-matrix.md
@@ -207,7 +207,7 @@ lane, not a Hopper-specific retune.
 | qwen3.5-4b       |  ✅¹ |  —   |      —      |    —   |
 | qwen3.5-9b       |  ✅¹ |  —   |      —      |    —   |
 | qwen3-30b-a3b    |  —   | ⏳²  |      —      |    —   |
-| qwen3.6-35b-a3b  |  —   | ⏳²  |      —      |    —   |
+| qwen3.6-35b-a3b  |  —   |  ✅¹ |      —      |    —   |
 | gemma4-e2b       |  ⏳² | ⏳²  |      —      |    —   |
 | gemma4-e4b       |  ⏳² | ⏳²  |      —      |    —   |
 | phi4-mini        |  ⏳² | ⏳²  |     ⏳²     |    —   |
@@ -225,13 +225,14 @@ Metal v2 is a single supported surface:
   routing, expert matmul, KV updates, and the final INT4 lm-head. The
   persistent Qwen3-MoE megakernel remains HIP-only; a local full-model smoke is
   still pending.
-- `qwen3.6-35b-a3b` INT4 has an Apple M5 Max registry row and uses the
+- `qwen3.6-35b-a3b` INT4 is supported on Apple M5 Max through the
   host-orchestrated chained decode route with Metal fallbacks for BF16
   full-attention stages 1-5, linear-attention stages 1-5, FFN stages 1-5,
   the final lm-head helpers, MTP pre-fusion helper, and INT4 sidecars for the
-  projection/expert matvecs. Persistent decode, FP8-runtime, KV-FP8, and
-  speculative decode remain HIP/CUDA-only; a local full-model smoke is still
-  pending.
+  projection/expert matvecs. The validation smoke is:
+  `SUPERSONIC_TEST_MODEL_DIR=/path/to/Qwen3.6-35B-A3B cargo test --release -p runner --test qwen36_moe_metal_smoke -- --ignored --nocapture`.
+  Persistent decode, FP8-runtime, KV-FP8, and speculative decode remain
+  unsupported on this Metal path.
 - `phi4-mini` has an Apple M5 Max registry row and uses a component Metal decode
   path assembled from existing RMSNorm, GEMV, INT4 runtime-dequant matvec,
   FP8 runtime-dequant host fallback matvec, RoPE, attention, SwiGLU, and
@@ -247,8 +248,8 @@ Metal v2 is a single supported surface:
 - decode is implemented as **incremental per-token decode**: each generated token runs
   a single length-1 forward pass (O(N) per step). Conv and recurrent state are carried
   across tokens in persistent GPU buffers; KV cache grows with the sequence
-- INT4 GPTQ kernel is wired in (bit-exact CPU reference unit test passes); end-to-end
-  validation against a baked INT4 model is pending hardware time
+- INT4 GPTQ kernel coverage includes the supported `qwen3.6-35b-a3b` Apple M5
+  Max smoke; other large INT4 Metal rows remain pending local model validation
 - `--fp8-runtime`, `--kv-fp8`, `--batch-size > 1`, `--force-kernel-decode`,
   and `--force-component-decode` are all rejected at startup
 
@@ -257,5 +258,6 @@ Metal v2 is a single supported surface:
   validation is pending a local model checkout.
 
 Metal is not yet at mode-level HIP parity: persistent megakernel decode,
-Qwen3.6 FP8-runtime, Qwen3.6 KV-FP8, speculative decode, and the local
-full-model smokes for the large Apple M5 Max rows remain pending.
+Qwen3.6 FP8-runtime, Qwen3.6 KV-FP8, speculative decode, and the remaining
+large Apple M5 Max model smokes outside the supported Qwen3.6 INT4 lane remain
+pending.


### PR DESCRIPTION
## Summary
- add an ignored Qwen3.6-35B-A3B Metal INT4 runner smoke using SUPERSONIC_TEST_MODEL_DIR or SUPERSONIC_TEST_QWEN36_MOE_MODEL_DIR
- mark Apple M5 Max Metal INT4 support in docs with the tested chained decode constraints
- fix the Qwen3.6 Metal linear fallback stage-5 intermediate publish bug and tighten unsupported Metal flag policy ordering

## Verification
- SUPERSONIC_TEST_MODEL_DIR=/Users/deano/.cache/huggingface/models--Qwen--Qwen3.6-35B-A3B-FP8/snapshots/95a723d08a9490559dae23d0cff1d9466213d989 cargo test --release -p runner --test qwen36_moe_metal_smoke -- --ignored --nocapture
- cargo test -p runner qwen36_moe
- cargo test -p supersonic-core registry
- cargo check --workspace
- checked Metal policy rejections for --fp8-runtime, --kv-fp8, and --speculative-decode