### PR TITLE
[codex] Validate large Apple M5 Max Metal models

### DIFF
--- a/crates/runner/src/qwen3_moe.rs
+++ b/crates/runner/src/qwen3_moe.rs
@@ -398,6 +398,17 @@ fn decode_text(
         elapsed,
         generated.len() as f64 / elapsed.max(1e-9)
     );
+    let decode_ms = decode_elapsed.as_secs_f64() * 1000.0;
+    let ms_per_step = if generated.is_empty() {
+        0.0
+    } else {
+        decode_ms / generated.len() as f64
+    };
+    eprintln!(
+        "[result] prompt_tokens={} generated_tokens={} decode_ms={decode_ms:.0} ms_per_step={ms_per_step:.1}",
+        prompt.prompt_ids.len(),
+        generated.len(),
+    );
     if cli.emit_stage_timings && gen_steps > 0 {
         let n = gen_steps as f64;
         eprintln!(

--- a/crates/runner/tests/metal_large_model_smoke.rs
+++ b/crates/runner/tests/metal_large_model_smoke.rs
@@ -97,13 +97,12 @@ fn metal_large_model_smokes_run_end_to_end() {
 
 #[cfg(target_os = "macos")]
 fn run_case(case: SmokeCase) {
-    let Some(model_dir) = support::resolve_model_dir(case.model_dir) else {
-        eprintln!(
-            "skipping {}: set SUPERSONIC_TEST_MODEL_ROOT with {} or {}",
+    let model_dir = support::resolve_model_dir(case.model_dir).unwrap_or_else(|| {
+        panic!(
+            "missing model for {}: set SUPERSONIC_TEST_MODEL_ROOT with {} or set {}",
             case.name, case.model_dir.canonical_subdir, case.model_dir.override_env
-        );
-        return;
-    };
+        )
+    });
 
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_supersonic"));
     cmd.env("PATH", support::path_with_repo_venv()).args([

--- a/crates/runner/tests/metal_large_model_smoke.rs
+++ b/crates/runner/tests/metal_large_model_smoke.rs
@@ -1,0 +1,166 @@
+#[cfg(target_os = "macos")]
+mod support;
+
+#[cfg(target_os = "macos")]
+use std::process::Command;
+
+#[cfg(target_os = "macos")]
+use support::{GEMMA4_E2B, GEMMA4_E4B, PHI4_MINI, QWEN3_30B_A3B};
+
+#[cfg(target_os = "macos")]
+#[derive(Clone, Copy)]
+struct SmokeCase {
+    name: &'static str,
+    model: &'static str,
+    model_dir: support::TestModel,
+    quant_flag: Option<&'static str>,
+    family_marker: &'static str,
+    quant_marker: Option<&'static str>,
+}
+
+#[cfg(target_os = "macos")]
+const CASES: &[SmokeCase] = &[
+    SmokeCase {
+        name: "qwen3_30b_a3b_int4",
+        model: "qwen3-30b-a3b",
+        model_dir: QWEN3_30B_A3B,
+        quant_flag: Some("--int4"),
+        family_marker: "[qwen3-moe]",
+        quant_marker: Some("INT4"),
+    },
+    SmokeCase {
+        name: "gemma4_e2b_bf16",
+        model: "gemma4-e2b",
+        model_dir: GEMMA4_E2B,
+        quant_flag: None,
+        family_marker: "[gemma4]",
+        quant_marker: None,
+    },
+    SmokeCase {
+        name: "gemma4_e2b_int4",
+        model: "gemma4-e2b",
+        model_dir: GEMMA4_E2B,
+        quant_flag: Some("--int4"),
+        family_marker: "[gemma4]",
+        quant_marker: Some("INT4 GPTQ"),
+    },
+    SmokeCase {
+        name: "gemma4_e4b_bf16",
+        model: "gemma4-e4b",
+        model_dir: GEMMA4_E4B,
+        quant_flag: None,
+        family_marker: "[gemma4]",
+        quant_marker: None,
+    },
+    SmokeCase {
+        name: "gemma4_e4b_int4",
+        model: "gemma4-e4b",
+        model_dir: GEMMA4_E4B,
+        quant_flag: Some("--int4"),
+        family_marker: "[gemma4]",
+        quant_marker: Some("INT4 GPTQ"),
+    },
+    SmokeCase {
+        name: "phi4_mini_bf16",
+        model: "phi4-mini",
+        model_dir: PHI4_MINI,
+        quant_flag: None,
+        family_marker: "[phi4]",
+        quant_marker: None,
+    },
+    SmokeCase {
+        name: "phi4_mini_int4",
+        model: "phi4-mini",
+        model_dir: PHI4_MINI,
+        quant_flag: Some("--int4"),
+        family_marker: "[phi4]",
+        quant_marker: Some("INT4 runtime dequant"),
+    },
+    SmokeCase {
+        name: "phi4_mini_fp8_runtime",
+        model: "phi4-mini",
+        model_dir: PHI4_MINI,
+        quant_flag: Some("--fp8-runtime"),
+        family_marker: "[phi4]",
+        quant_marker: Some("FP8 runtime dequant"),
+    },
+];
+
+#[cfg(target_os = "macos")]
+#[test]
+#[ignore = "requires Apple M5 Max Metal and local models via SUPERSONIC_TEST_MODEL_ROOT"]
+fn metal_large_model_smokes_run_end_to_end() {
+    for case in CASES {
+        run_case(*case);
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn run_case(case: SmokeCase) {
+    let Some(model_dir) = support::resolve_model_dir(case.model_dir) else {
+        eprintln!(
+            "skipping {}: set SUPERSONIC_TEST_MODEL_ROOT with {} or {}",
+            case.name, case.model_dir.canonical_subdir, case.model_dir.override_env
+        );
+        return;
+    };
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_supersonic"));
+    cmd.env("PATH", support::path_with_repo_venv()).args([
+        "--backend",
+        "metal",
+        "--model",
+        case.model,
+        "--model-dir",
+        model_dir.to_str().expect("model dir must be valid UTF-8"),
+        "--prompt",
+        "Hello",
+        "--max-new-tokens",
+        "1",
+        "--emit-stage-timings",
+    ]);
+    if let Some(flag) = case.quant_flag {
+        cmd.arg(flag);
+    }
+
+    let output = cmd.output().unwrap_or_else(|e| {
+        panic!("run {} Metal smoke: {e}", case.name);
+    });
+    let combined = support::combined_output(&output);
+
+    assert!(
+        output.status.success(),
+        "{} Metal smoke failed with status {:?}:\n{}",
+        case.name,
+        output.status.code(),
+        combined
+    );
+    assert!(
+        combined.contains("backend=Metal"),
+        "{} expected Metal backend selection:\n{}",
+        case.name,
+        combined
+    );
+    assert!(
+        combined.contains(case.family_marker),
+        "{} expected family marker {}:\n{}",
+        case.name,
+        case.family_marker,
+        combined
+    );
+    if let Some(marker) = case.quant_marker {
+        assert!(
+            combined.contains(marker),
+            "{} expected quant marker {}:\n{}",
+            case.name,
+            marker,
+            combined
+        );
+    }
+    assert!(
+        combined.contains("[result]"),
+        "{} expected result summary:\n{}",
+        case.name,
+        combined
+    );
+}

--- a/crates/runner/tests/support/mod.rs
+++ b/crates/runner/tests/support/mod.rs
@@ -1,0 +1,129 @@
+use std::path::{Path, PathBuf};
+
+#[derive(Clone, Copy, Debug)]
+pub struct TestModel {
+    pub canonical_subdir: &'static str,
+    pub override_env: &'static str,
+    pub hf_cache_repos: &'static [&'static str],
+}
+
+impl TestModel {
+    pub const fn new(
+        canonical_subdir: &'static str,
+        override_env: &'static str,
+        hf_cache_repos: &'static [&'static str],
+    ) -> Self {
+        Self {
+            canonical_subdir,
+            override_env,
+            hf_cache_repos,
+        }
+    }
+}
+
+pub const QWEN3_30B_A3B: TestModel = TestModel::new(
+    "qwen3-30b-a3b",
+    "SUPERSONIC_TEST_QWEN3_30B_A3B_MODEL_DIR",
+    &["models--Qwen--Qwen3-30B-A3B"],
+);
+
+pub const GEMMA4_E2B: TestModel = TestModel::new(
+    "gemma4-e2b",
+    "SUPERSONIC_TEST_GEMMA4_E2B_MODEL_DIR",
+    &["models--google--gemma-4-E2B"],
+);
+
+pub const GEMMA4_E4B: TestModel = TestModel::new(
+    "gemma4-e4b",
+    "SUPERSONIC_TEST_GEMMA4_E4B_MODEL_DIR",
+    &["models--google--gemma-4-E4B"],
+);
+
+pub const PHI4_MINI: TestModel = TestModel::new(
+    "phi4-mini",
+    "SUPERSONIC_TEST_PHI4_MINI_MODEL_DIR",
+    &["models--microsoft--Phi-4-mini-instruct"],
+);
+
+pub fn resolve_model_dir(model: TestModel) -> Option<PathBuf> {
+    if let Some(dir) = valid_model_dir_from_env(model.override_env) {
+        return Some(dir);
+    }
+
+    if let Some(root) = std::env::var_os("SUPERSONIC_TEST_MODEL_ROOT") {
+        let dir = PathBuf::from(root).join(model.canonical_subdir);
+        if is_model_dir(&dir) {
+            return Some(dir);
+        }
+    }
+
+    discover_hf_cache_snapshot(model)
+}
+
+pub fn repo_root() -> PathBuf {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest_dir
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("runner crate should live under <repo>/crates/runner")
+        .to_path_buf()
+}
+
+pub fn path_with_repo_venv() -> std::ffi::OsString {
+    let venv_bin = repo_root().join(".venv/bin");
+    let mut path_entries = Vec::new();
+    if venv_bin.exists() {
+        path_entries.push(venv_bin);
+    }
+    path_entries.extend(std::env::split_paths(
+        &std::env::var_os("PATH").unwrap_or_default(),
+    ));
+    std::env::join_paths(path_entries).expect("join PATH entries")
+}
+
+pub fn combined_output(output: &std::process::Output) -> String {
+    format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn valid_model_dir_from_env(env_name: &str) -> Option<PathBuf> {
+    let dir = std::env::var_os(env_name).map(PathBuf::from)?;
+    if is_model_dir(&dir) {
+        Some(dir)
+    } else {
+        eprintln!("skipping {env_name}: {} is not a model dir", dir.display());
+        None
+    }
+}
+
+fn discover_hf_cache_snapshot(model: TestModel) -> Option<PathBuf> {
+    let home = std::env::var_os("HOME").map(PathBuf::from)?;
+    for base in [
+        home.join(".cache/huggingface"),
+        home.join(".cache/huggingface/hub"),
+    ] {
+        for repo in model.hf_cache_repos {
+            let snapshots = base.join(repo).join("snapshots");
+            let Ok(entries) = std::fs::read_dir(&snapshots) else {
+                continue;
+            };
+            let mut candidates: Vec<PathBuf> =
+                entries.flatten().map(|entry| entry.path()).collect();
+            candidates.sort();
+            candidates.reverse();
+            for candidate in candidates {
+                if is_model_dir(&candidate) {
+                    return Some(candidate);
+                }
+            }
+        }
+    }
+    None
+}
+
+fn is_model_dir(path: &Path) -> bool {
+    path.join("config.json").is_file() && path.join("tokenizer.json").is_file()
+}

--- a/docs/build-and-run.md
+++ b/docs/build-and-run.md
@@ -259,22 +259,22 @@ Detailed CUDA `sm86` history for both the `0.8B` and `4B` hero lanes lives in
 ## Metal
 
 Metal support is currently an Apple-silicon lane validated on Apple M4 and
-Apple M5 Max, with Qwen3.5 BF16 coverage and a supported Qwen3.6-35B-A3B INT4
-Apple M5 Max path.
+Apple M5 Max, with Qwen3.5 BF16 coverage, Qwen3.6-35B-A3B INT4 coverage, and
+large Apple M5 Max component/chained-path coverage.
 The core decode path is now O(N) incremental decode — no replay overhead.
 
 Supported Metal scope:
 
 - `qwen3.5-0.8b`, `qwen3.5-2b`
 - `qwen3.5-4b`, `qwen3.5-9b` on Apple M5 Max
-- `qwen3-30b-a3b` INT4 on Apple M5 Max is wired through a correctness-first
-  chained Metal fallback; a local full-model smoke is still pending
+- `qwen3-30b-a3b` INT4 on Apple M5 Max is supported through a correctness-first
+  chained Metal fallback
 - `qwen3.6-35b-a3b` INT4 on Apple M5 Max is supported through the
   correctness-first chained Metal decode route
-- `gemma4-e2b`, `gemma4-e4b` BF16 and INT4 on Apple M5 Max are wired through a
-  component Metal decode path; a local model smoke is still pending
-- `phi4-mini` BF16, INT4, and FP8-runtime on Apple M5 Max are wired through a
-  component Metal decode path; a local model smoke is still pending
+- `gemma4-e2b`, `gemma4-e4b` BF16 and INT4 on Apple M5 Max are supported
+  through a component Metal decode path
+- `phi4-mini` BF16, INT4, and FP8-runtime on Apple M5 Max are supported through
+  a component Metal decode path
 - Apple M4 / `apple-m4`
 - Apple M5 Max / `apple-m5-max`
 - BF16 prefill parity against the Python CPU oracle
@@ -292,7 +292,7 @@ Metal currently rejects or defers:
 - `qwen3-30b-a3b` INT4 on Apple M5 Max has a correctness-first chained Metal
   fallback for decode-layer attention, MoE routing, expert matmul, KV updates,
   and the final INT4 lm-head. The persistent Qwen3-MoE megakernel remains
-  HIP-only, and a local full-model smoke is still pending.
+  HIP-only.
 - `qwen3.6-35b-a3b` INT4 on Apple M5 Max uses the host-orchestrated chained
   decode route with Metal fallbacks for BF16 full-attention, linear-attention,
   and FFN stages, plus INT4 sidecars for projection and expert matvecs. The
@@ -300,10 +300,10 @@ Metal currently rejects or defers:
   `cargo run --release --bin supersonic -- --backend metal --model qwen3.6-35b-a3b --model-dir /path/to/Qwen3.6-35B-A3B --int4 --prompt "Hello" --max-new-tokens 1 --emit-stage-timings`.
   FP8-runtime, KV-FP8, speculative decode, and persistent decode remain
   unsupported on this Metal path.
-- `phi4-mini` INT4 and FP8-runtime are build-checked through the component
-  Metal route; KV-FP8 and local model smokes are still pending
-- `gemma4-e2b` and `gemma4-e4b` INT4 are build-checked through the component
-  Metal route, but still need a local INT4 bake/model smoke
+- `phi4-mini` INT4 and FP8-runtime use the component Metal route; KV-FP8 is
+  still unsupported
+- `gemma4-e2b` and `gemma4-e4b` INT4 use the component Metal route with
+  release-hosted INT4 GPTQ bakes
 
 Native Metal kernels used in the hot path:
 
@@ -332,10 +332,41 @@ Current Apple M4 / Apple M5 Max checkpoint:
   and the checked-in bughunt gate.
 - Apple M5 Max validation also covers one-token `qwen3.5-4b` and `qwen3.5-9b`
   `--validate --oracle-device cpu` smokes through Metal v2 incremental decode.
+- Apple M5 Max validation also covers one-token large-model smokes for
+  `qwen3-30b-a3b` INT4, `gemma4-e2b` BF16/INT4, `gemma4-e4b` BF16/INT4, and
+  `phi4-mini` BF16/INT4/FP8-runtime.
 
 The next optimization target is a persistent Metal megakernel — collapsing the
 per-token command-buffer round-trips into a single dispatch, equivalent to the
 HIP persistent decode path.
+
+### Large model setup
+
+The large Apple M5 Max Metal smoke suite uses one canonical model root:
+
+```bash
+export SUPERSONIC_TEST_MODEL_ROOT="$HOME/.cache/supersonic-metal-models"
+mkdir -p "$SUPERSONIC_TEST_MODEL_ROOT"
+
+hf download Qwen/Qwen3-30B-A3B --local-dir "$SUPERSONIC_TEST_MODEL_ROOT/qwen3-30b-a3b"
+hf download google/gemma-4-E2B --local-dir "$SUPERSONIC_TEST_MODEL_ROOT/gemma4-e2b"
+hf download google/gemma-4-E4B --local-dir "$SUPERSONIC_TEST_MODEL_ROOT/gemma4-e4b"
+hf download microsoft/Phi-4-mini-instruct --local-dir "$SUPERSONIC_TEST_MODEL_ROOT/phi4-mini"
+```
+
+Quantized lanes use release-hosted bakes and install them under each model's
+`.supersonic/` directory on first run:
+
+- `v2-int4-gptq` for `qwen3-30b-a3b`, `gemma4-e2b`, `gemma4-e4b`, and
+  `phi4-mini --int4`
+- `v2-fp8` for `phi4-mini --fp8-runtime`
+
+The ignored large-model gate is:
+
+```bash
+SUPERSONIC_TEST_MODEL_ROOT="$HOME/.cache/supersonic-metal-models" \
+  cargo test --release -p runner --test metal_large_model_smoke -- --ignored --nocapture
+```
 
 ### Metal validation
 

--- a/docs/supported-matrix.md
+++ b/docs/supported-matrix.md
@@ -206,11 +206,11 @@ lane, not a Hopper-specific retune.
 | qwen3.5-2b       |  ✅  |  —   |      —      |    —   |
 | qwen3.5-4b       |  ✅¹ |  —   |      —      |    —   |
 | qwen3.5-9b       |  ✅¹ |  —   |      —      |    —   |
-| qwen3-30b-a3b    |  —   | ⏳²  |      —      |    —   |
+| qwen3-30b-a3b    |  —   |  ✅¹ |      —      |    —   |
 | qwen3.6-35b-a3b  |  —   |  ✅¹ |      —      |    —   |
-| gemma4-e2b       |  ⏳² | ⏳²  |      —      |    —   |
-| gemma4-e4b       |  ⏳² | ⏳²  |      —      |    —   |
-| phi4-mini        |  ⏳² | ⏳²  |     ⏳²     |    —   |
+| gemma4-e2b       |  ✅¹ |  ✅¹ |      —      |    —   |
+| gemma4-e4b       |  ✅¹ |  ✅¹ |      —      |    —   |
+| phi4-mini        |  ✅¹ |  ✅¹ |     ✅¹     |    —   |
 
 Metal v2 is a single supported surface:
 
@@ -223,8 +223,7 @@ Metal v2 is a single supported surface:
 - `qwen3-30b-a3b` INT4 has an Apple M5 Max registry row and uses a
   correctness-first chained Metal fallback for decode-layer attention, MoE
   routing, expert matmul, KV updates, and the final INT4 lm-head. The
-  persistent Qwen3-MoE megakernel remains HIP-only; a local full-model smoke is
-  still pending.
+  persistent Qwen3-MoE megakernel remains HIP-only.
 - `qwen3.6-35b-a3b` INT4 is supported on Apple M5 Max through the
   host-orchestrated chained decode route with Metal fallbacks for BF16
   full-attention stages 1-5, linear-attention stages 1-5, FFN stages 1-5,
@@ -236,28 +235,32 @@ Metal v2 is a single supported surface:
 - `phi4-mini` has an Apple M5 Max registry row and uses a component Metal decode
   path assembled from existing RMSNorm, GEMV, INT4 runtime-dequant matvec,
   FP8 runtime-dequant host fallback matvec, RoPE, attention, SwiGLU, and
-  residual kernels. A local model smoke is still pending.
+  residual kernels.
 - `gemma4-e2b` and `gemma4-e4b` have Apple M5 Max registry rows. BF16 uses a
   runner-level Metal component path for RMSNorm, BF16 matvec, RoPE, attention,
   residual, MLP, PLE, K/V append, and sliding-window cache slicing. INT4 uses
   the same component decode route with Metal INT4 matvec fallbacks.
-  A local model smoke is still pending.
 - Apple M4 remains limited to the smaller Metal validation lane.
 - both the `supersonic` CLI and `supersonic-serve` HTTP server work; `/v1/completions`
   and `/v1/chat/completions` (streaming and non-streaming) are exercised end-to-end
 - decode is implemented as **incremental per-token decode**: each generated token runs
   a single length-1 forward pass (O(N) per step). Conv and recurrent state are carried
   across tokens in persistent GPU buffers; KV cache grows with the sequence
-- INT4 GPTQ kernel coverage includes the supported `qwen3.6-35b-a3b` Apple M5
-  Max smoke; other large INT4 Metal rows remain pending local model validation
+- INT4 GPTQ kernel coverage includes the supported `qwen3.6-35b-a3b`,
+  `qwen3-30b-a3b`, `gemma4-e2b`, `gemma4-e4b`, and `phi4-mini` Apple M5 Max
+  smokes.
 - `--fp8-runtime`, `--kv-fp8`, `--batch-size > 1`, `--force-kernel-decode`,
   and `--force-component-decode` are all rejected at startup
 
 ¹ Apple M5 Max only.
-² Apple M5 Max component path is wired and build-checked; end-to-end
-  validation is pending a local model checkout.
 
 Metal is not yet at mode-level HIP parity: persistent megakernel decode,
-Qwen3.6 FP8-runtime, Qwen3.6 KV-FP8, speculative decode, and the remaining
-large Apple M5 Max model smokes outside the supported Qwen3.6 INT4 lane remain
-pending.
+Qwen3.6 FP8-runtime, Qwen3.6 KV-FP8, speculative decode, Metal VMM, and
+batching remain unsupported.
+
+The Apple M5 Max large-model smoke is:
+
+```bash
+SUPERSONIC_TEST_MODEL_ROOT=/path/to/supersonic-metal-models \
+  cargo test --release -p runner --test metal_large_model_smoke -- --ignored --nocapture
+```


### PR DESCRIPTION
## Summary

- adds an ignored large Apple M5 Max Metal smoke suite for qwen3-30b-a3b, gemma4-e2b/e4b, and phi4-mini
- adds a shared integration-test model resolver for SUPERSONIC_TEST_MODEL_ROOT with per-model overrides and Hugging Face cache fallback
- promotes validated Apple M5 Max Metal rows in the support matrix and documents the cache/model setup
- emits a standardized [result] marker from the Qwen3 MoE runner path

## Validation

- rustfmt --edition 2021 --check crates/runner/src/qwen3_moe.rs crates/runner/tests/metal_large_model_smoke.rs crates/runner/tests/support/mod.rs
- git diff --check
- SUPERSONIC_TEST_MODEL_ROOT="$HOME/.cache/supersonic-metal-models" cargo test --release -p runner --test metal_large_model_smoke -- --ignored --nocapture
- cargo check --workspace

## Notes

- cargo fmt --check still reports pre-existing workspace formatting drift outside this PR scope, so the PR avoids committing that unrelated rustfmt churn.
- hf CLI is installed at ~/.local/bin/hf; local HF auth is not configured yet.
