### PR TITLE
[codex] add M5 Metal Qwen3.6 perf harness

### DIFF
--- a/crates/bench/src/bin/bench_perf.rs
+++ b/crates/bench/src/bin/bench_perf.rs
@@ -1,5 +1,6 @@
 use anyhow::{anyhow, Result};
 use clap::Parser;
+use std::collections::HashMap;
 use std::path::PathBuf;
 use supersonic_bench::matrix::{run_matrix, BenchArch, MatrixConfig};
 use supersonic_bench::runs::{allocate_run_dir, RunDir};
@@ -27,9 +28,10 @@ struct Cli {
     binary: PathBuf,
     #[arg(long, default_value = "./target/bench-runs")]
     run_root: PathBuf,
-    /// Model dir override: KEY=PATH, repeatable. KEY is e.g. "qwen3.5-0.8b".
-    #[arg(long = "model-dir", value_parser = parse_kv)]
-    model_dirs: Vec<(String, PathBuf)>,
+    /// Model dir override. Use KEY=PATH for a specific model, or PATH when a
+    /// single model is selected.
+    #[arg(long = "model-dir", value_parser = parse_model_dir)]
+    model_dirs: Vec<ModelDirArg>,
     /// SpecPrefill draft dir override: KEY=PATH, repeatable. KEY is the target
     /// model, e.g. "qwen3.6-35b-a3b=/models/Qwen3.5-0.8B".
     #[arg(long = "specprefill-draft-dir", value_parser = parse_kv)]
@@ -41,6 +43,20 @@ fn parse_kv(s: &str) -> Result<(String, PathBuf), String> {
         .split_once('=')
         .ok_or_else(|| "expected KEY=PATH".to_string())?;
     Ok((k.to_string(), PathBuf::from(v)))
+}
+
+#[derive(Debug, Clone)]
+enum ModelDirArg {
+    Exact(String, PathBuf),
+    Bare(PathBuf),
+}
+
+fn parse_model_dir(s: &str) -> Result<ModelDirArg, String> {
+    if let Some((k, v)) = s.split_once('=') {
+        Ok(ModelDirArg::Exact(k.to_string(), PathBuf::from(v)))
+    } else {
+        Ok(ModelDirArg::Bare(PathBuf::from(s)))
+    }
 }
 
 fn main() -> Result<()> {
@@ -56,15 +72,29 @@ fn main() -> Result<()> {
     let run_path = allocate_run_dir(&cli.run_root, &git_sha, &today);
     let rd = RunDir::new(run_path.clone());
 
-    let dir_map: std::collections::HashMap<_, _> = cli.model_dirs.into_iter().collect();
-    let resolver: Box<dyn Fn(&str) -> PathBuf> = Box::new(move |m: &str| {
-        dir_map
+    let selected_models = models.clone();
+    let model_root = std::env::var_os("SUPERSONIC_TEST_MODEL_ROOT").map(PathBuf::from);
+    let (dir_map, bare_model_dir) = normalize_model_dirs(cli.model_dirs, &selected_models)?;
+    let resolver: Box<dyn Fn(&str) -> Result<PathBuf>> = Box::new(move |m: &str| {
+        let candidate = dir_map
             .get(m)
             .cloned()
-            .unwrap_or_else(|| PathBuf::from(format!("/mnt/data/models/{m}")))
+            .or_else(|| bare_model_dir.clone())
+            .or_else(|| model_root.as_ref().map(|root| root.join(m)));
+        let Some(path) = candidate else {
+            return Err(anyhow!(
+                "missing model dir for {m}; pass --model-dir {m}=PATH or set SUPERSONIC_TEST_MODEL_ROOT"
+            ));
+        };
+        if !path.exists() {
+            return Err(anyhow!(
+                "model dir for {m} does not exist: {}; pass --model-dir {m}=PATH or set SUPERSONIC_TEST_MODEL_ROOT",
+                path.display()
+            ));
+        }
+        Ok(path)
     });
-    let draft_dir_map: std::collections::HashMap<_, _> =
-        cli.specprefill_draft_dirs.into_iter().collect();
+    let draft_dir_map: HashMap<_, _> = cli.specprefill_draft_dirs.into_iter().collect();
     let draft_resolver: Box<dyn Fn(&str) -> Option<PathBuf>> =
         Box::new(move |m: &str| draft_dir_map.get(m).cloned());
 
@@ -88,6 +118,30 @@ fn main() -> Result<()> {
     run_matrix(&cfg, &rd)?;
     println!("[bench-perf] wrote {}", run_path.display());
     Ok(())
+}
+
+fn normalize_model_dirs(
+    args: Vec<ModelDirArg>,
+    selected_models: &[String],
+) -> Result<(HashMap<String, PathBuf>, Option<PathBuf>)> {
+    let mut exact = HashMap::new();
+    let mut bare = None;
+    for arg in args {
+        match arg {
+            ModelDirArg::Exact(model, path) => {
+                exact.insert(model, path);
+            }
+            ModelDirArg::Bare(path) => {
+                if selected_models.len() != 1 {
+                    return Err(anyhow!(
+                        "--model-dir PATH is only valid when exactly one model is selected; use --model-dir KEY=PATH for matrix runs"
+                    ));
+                }
+                bare = Some(path);
+            }
+        }
+    }
+    Ok((exact, bare))
 }
 
 fn filter_csv<'a>(spec: &str, available: impl IntoIterator<Item = &'a str>) -> Vec<String> {

--- a/crates/bench/src/bin/bench_perf.rs
+++ b/crates/bench/src/bin/bench_perf.rs
@@ -76,16 +76,20 @@ fn main() -> Result<()> {
     let model_root = std::env::var_os("SUPERSONIC_TEST_MODEL_ROOT").map(PathBuf::from);
     let (dir_map, bare_model_dir) = normalize_model_dirs(cli.model_dirs, &selected_models)?;
     let resolver: Box<dyn Fn(&str) -> Result<PathBuf>> = Box::new(move |m: &str| {
-        let candidate = dir_map
-            .get(m)
-            .cloned()
-            .or_else(|| bare_model_dir.clone())
-            .or_else(|| model_root.as_ref().map(|root| root.join(m)));
-        let Some(path) = candidate else {
-            return Err(anyhow!(
-                "missing model dir for {m}; pass --model-dir {m}=PATH or set SUPERSONIC_TEST_MODEL_ROOT"
-            ));
+        let candidate = dir_map.get(m).cloned().or_else(|| bare_model_dir.clone());
+        if let Some(path) = candidate {
+            if !path.exists() {
+                return Err(anyhow!(
+                    "model dir for {m} does not exist: {}; pass --model-dir {m}=PATH or set SUPERSONIC_TEST_MODEL_ROOT",
+                    path.display()
+                ));
+            }
+            return Ok(path);
+        }
+        let Some(root) = model_root.as_ref() else {
+            return Ok(PathBuf::from(format!("/mnt/data/models/{m}")));
         };
+        let path = root.join(m);
         if !path.exists() {
             return Err(anyhow!(
                 "model dir for {m} does not exist: {}; pass --model-dir {m}=PATH or set SUPERSONIC_TEST_MODEL_ROOT",

--- a/crates/bench/src/matrix.rs
+++ b/crates/bench/src/matrix.rs
@@ -18,6 +18,7 @@ pub enum BenchArch {
     Gfx1150,
     Sm86,
     AppleM4,
+    AppleM5Max,
 }
 
 impl BenchArch {
@@ -27,6 +28,7 @@ impl BenchArch {
             "gfx1150" => Self::Gfx1150,
             "sm86" => Self::Sm86,
             "apple-m4" => Self::AppleM4,
+            "apple-m5-max" => Self::AppleM5Max,
             _ => return None,
         })
     }
@@ -36,6 +38,7 @@ impl BenchArch {
             Self::Gfx1150 => "gfx1150",
             Self::Sm86 => "sm86",
             Self::AppleM4 => "apple-m4",
+            Self::AppleM5Max => "apple-m5-max",
         }
     }
 
@@ -43,7 +46,7 @@ impl BenchArch {
         match self {
             Self::Gfx1100 | Self::Gfx1150 => Some("hip"),
             Self::Sm86 => Some("cuda"),
-            Self::AppleM4 => None,
+            Self::AppleM4 | Self::AppleM5Max => Some("metal"),
         }
     }
 }
@@ -246,6 +249,15 @@ pub static SUPPORTED_COMBOS: &[ComboDescriptor] = &[
         arch: BenchArch::Gfx1100,
         min_vram_gib: 21.0,
     },
+    // Apple M5 Max Metal v1: Qwen3.6 INT4 chained decode only. This is the
+    // main-target harness lane; persistent decode, KV-FP8, speculative decode,
+    // batching, and Metal VMM stay explicitly out of scope for this row.
+    ComboDescriptor {
+        model: "qwen3.6-35b-a3b",
+        quant: "int4",
+        arch: BenchArch::AppleM5Max,
+        min_vram_gib: 21.0,
+    },
     // CUDA sm86 Qwen3.6-MoE prefill lanes. `int4-specNNN` is INT4 plus
     // Qwen3.5-0.8B cross-family SpecPrefill cosine keep ratio NNN/100.
     ComboDescriptor {
@@ -309,7 +321,7 @@ pub struct MatrixConfig {
     pub models: Vec<String>,
     pub quants: Vec<String>,
     pub binary: PathBuf,
-    pub model_dir_resolver: Box<dyn Fn(&str) -> PathBuf>,
+    pub model_dir_resolver: Box<dyn Fn(&str) -> Result<PathBuf>>,
     pub specprefill_draft_dir_resolver: Box<dyn Fn(&str) -> Option<PathBuf>>,
     pub prompt: String,
     pub max_new_tokens: u32,
@@ -355,6 +367,8 @@ pub fn run_matrix(cfg: &MatrixConfig, rd: &RunDir) -> Result<()> {
                     schema_version: SCHEMA_VERSION,
                     model: model.clone(),
                     quant: quant.clone(),
+                    arch: cfg.arch.as_str().to_string(),
+                    backend: cfg.arch.backend().unwrap_or("auto").to_string(),
                     prompt: cfg.prompt.clone(),
                     max_new_tokens: cfg.max_new_tokens,
                     status: PerfStatus::Skipped {
@@ -365,6 +379,9 @@ pub fn run_matrix(cfg: &MatrixConfig, rd: &RunDir) -> Result<()> {
                             quant
                         ),
                     },
+                    stage_timings: None,
+                    chain_breakdown: None,
+                    lifecycle_timings: None,
                     gpu_temp_c_end: None,
                 };
                 rd.write_perf(&cell)?;
@@ -374,8 +391,9 @@ pub fn run_matrix(cfg: &MatrixConfig, rd: &RunDir) -> Result<()> {
             let invocation = ComboInvocation {
                 binary: cfg.binary.clone(),
                 backend: cfg.arch.backend().map(str::to_string),
+                arch: cfg.arch.as_str().to_string(),
                 model: model.clone(),
-                model_dir: (cfg.model_dir_resolver)(model),
+                model_dir: (cfg.model_dir_resolver)(model)?,
                 quant: quant.clone(),
                 specprefill_draft_dir: (cfg.specprefill_draft_dir_resolver)(model),
                 prompt: cfg.prompt.clone(),

--- a/crates/bench/src/perf.rs
+++ b/crates/bench/src/perf.rs
@@ -1,6 +1,7 @@
 use crate::runs::{PerfCellJson, PerfStatus, SCHEMA_VERSION};
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::process::Command;
 use std::time::Duration;
@@ -9,6 +10,19 @@ use std::time::Duration;
 pub struct ExtractedMetrics {
     pub ms_per_step: f64,
     pub ms_per_tok: Option<f64>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AttributionTimings {
+    pub stage_timings: Option<BTreeMap<String, f64>>,
+    pub chain_breakdown: Option<BTreeMap<String, f64>>,
+    pub lifecycle_timings: Option<BTreeMap<String, f64>>,
+}
+
+#[derive(Debug, Clone)]
+struct ExtractedRun {
+    metrics: ExtractedMetrics,
+    attribution: AttributionTimings,
 }
 
 /// Parse the last `[result] ms_per_step=N ...` line from the combined
@@ -66,6 +80,26 @@ pub fn extract_metrics(output: &str) -> Option<ExtractedMetrics> {
     None
 }
 
+pub fn extract_attribution_timings(output: &str) -> AttributionTimings {
+    AttributionTimings {
+        stage_timings: output
+            .lines()
+            .rev()
+            .find(|l| l.starts_with("[qwen36-moe stage-timings]"))
+            .map(parse_numeric_fields),
+        chain_breakdown: output
+            .lines()
+            .rev()
+            .find(|l| l.starts_with("[qwen36-moe chain-breakdown]"))
+            .map(parse_numeric_fields),
+        lifecycle_timings: output
+            .lines()
+            .rev()
+            .find(|l| l.starts_with("[qwen36-moe lifecycle-timings]"))
+            .map(parse_numeric_fields),
+    }
+}
+
 fn parse_field(line: &str, key: &str) -> Option<f64> {
     // Assumes runner emits space-delimited key=value pairs (no trailing punctuation).
     let needle = format!("{key}=");
@@ -75,10 +109,25 @@ fn parse_field(line: &str, key: &str) -> Option<f64> {
     rest[..end].parse().ok()
 }
 
+fn parse_numeric_fields(line: &str) -> BTreeMap<String, f64> {
+    line.split_whitespace()
+        .filter_map(|part| {
+            let part = part.trim_matches(|c| c == '(' || c == ')');
+            let (key, raw) = part.split_once('=')?;
+            let value = raw
+                .trim_end_matches(|c: char| c == ',' || c == ')')
+                .parse::<f64>()
+                .ok()?;
+            Some((key.to_string(), value))
+        })
+        .collect()
+}
+
 #[derive(Debug, Clone)]
 pub struct ComboInvocation {
     pub binary: PathBuf,
     pub backend: Option<String>,
+    pub arch: String,
     pub model: String,
     pub model_dir: PathBuf,
     pub quant: String,
@@ -100,39 +149,56 @@ pub fn run_one_combo(invocation: &ComboInvocation, policy: &RunPolicy) -> Result
     }
 
     // Warmup pass — discard.
-    let _ = invoke_supersonic(invocation, invocation.warmup_tokens);
+    let _ = invoke_supersonic(invocation, invocation.warmup_tokens, false);
 
     let mut samples = Vec::new();
     let mut last_err: Option<String> = None;
     for _ in 0..policy.measurement_runs {
-        match invoke_supersonic(invocation, invocation.max_new_tokens) {
-            Ok(m) => samples.push(m.ms_per_step),
+        match invoke_supersonic(invocation, invocation.max_new_tokens, false) {
+            Ok(run) => samples.push(run.metrics.ms_per_step),
             Err(e) => last_err = Some(e),
         }
     }
 
-    let status = if samples.is_empty() {
-        PerfStatus::Error {
-            stderr_tail: last_err.unwrap_or_else(|| "no samples".into()),
-        }
+    let (status, attribution) = if samples.is_empty() {
+        (
+            PerfStatus::Error {
+                stderr_tail: last_err.unwrap_or_else(|| "no samples".into()),
+            },
+            AttributionTimings::default(),
+        )
     } else {
         let mut sorted = samples.clone();
         sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
         let median = sorted[sorted.len() / 2];
-        PerfStatus::Ok {
-            ms_per_step: median,
-            ms_per_tok: median,
-            samples,
-        }
+        let attribution = invoke_supersonic(invocation, invocation.max_new_tokens, true)
+            .map(|run| run.attribution)
+            .unwrap_or_default();
+        (
+            PerfStatus::Ok {
+                ms_per_step: median,
+                ms_per_tok: median,
+                samples,
+            },
+            attribution,
+        )
     };
 
     Ok(PerfCellJson {
         schema_version: SCHEMA_VERSION,
         model: invocation.model.clone(),
         quant: invocation.quant.clone(),
+        arch: invocation.arch.clone(),
+        backend: invocation
+            .backend
+            .clone()
+            .unwrap_or_else(|| "auto".to_string()),
         prompt: invocation.prompt.clone(),
         max_new_tokens: invocation.max_new_tokens,
         status,
+        stage_timings: attribution.stage_timings,
+        chain_breakdown: attribution.chain_breakdown,
+        lifecycle_timings: attribution.lifecycle_timings,
         gpu_temp_c_end: None,
     })
 }
@@ -140,10 +206,15 @@ pub fn run_one_combo(invocation: &ComboInvocation, policy: &RunPolicy) -> Result
 fn invoke_supersonic(
     invocation: &ComboInvocation,
     max_new: u32,
-) -> std::result::Result<ExtractedMetrics, String> {
+    emit_stage_timings: bool,
+) -> std::result::Result<ExtractedRun, String> {
     let mut cmd = Command::new(&invocation.binary);
     if let Some(backend) = &invocation.backend {
         cmd.arg("--backend").arg(backend);
+    }
+    if invocation.arch == "apple-m5-max" && invocation.model == "qwen3.6-35b-a3b" {
+        cmd.env("SUPERSONIC_QWEN36_MOE_BATCHED_PREFILL", "0")
+            .env("SUPERSONIC_QWEN36_DENSE_PREFILL_TOKEN_LOOP", "1");
     }
     cmd.arg("--model")
         .arg(&invocation.model)
@@ -153,6 +224,9 @@ fn invoke_supersonic(
         .arg(&invocation.prompt)
         .arg("--max-new-tokens")
         .arg(max_new.to_string());
+    if emit_stage_timings {
+        cmd.arg("--emit-stage-timings");
+    }
     apply_quant_flag(
         &mut cmd,
         &invocation.quant,
@@ -162,7 +236,7 @@ fn invoke_supersonic(
     let stdout = String::from_utf8_lossy(&out.stdout);
     let stderr = String::from_utf8_lossy(&out.stderr);
     let combined = format!("{stdout}\n{stderr}");
-    extract_metrics(&combined).ok_or_else(|| {
+    let metrics = extract_metrics(&combined).ok_or_else(|| {
         let tail: String = combined
             .lines()
             .rev()
@@ -173,6 +247,10 @@ fn invoke_supersonic(
             .collect::<Vec<_>>()
             .join("\n");
         format!("no recognized metric line; tail:\n{tail}")
+    })?;
+    Ok(ExtractedRun {
+        metrics,
+        attribution: extract_attribution_timings(&combined),
     })
 }
 

--- a/crates/bench/src/runs.rs
+++ b/crates/bench/src/runs.rs
@@ -1,8 +1,9 @@
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use std::io;
 use std::path::{Path, PathBuf};
 
-pub const SCHEMA_VERSION: u32 = 1;
+pub const SCHEMA_VERSION: u32 = 2;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MetaJson {
@@ -40,10 +41,18 @@ pub struct PerfCellJson {
     pub schema_version: u32,
     pub model: String,
     pub quant: String,
+    pub arch: String,
+    pub backend: String,
     pub prompt: String,
     pub max_new_tokens: u32,
     #[serde(flatten)]
     pub status: PerfStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stage_timings: Option<BTreeMap<String, f64>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub chain_breakdown: Option<BTreeMap<String, f64>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lifecycle_timings: Option<BTreeMap<String, f64>>,
     pub gpu_temp_c_end: Option<f64>,
 }
 

--- a/crates/bench/tests/extract_metrics.rs
+++ b/crates/bench/tests/extract_metrics.rs
@@ -1,5 +1,5 @@
 #[allow(unused_imports)]
-use supersonic_bench::perf::{extract_metrics, ExtractedMetrics};
+use supersonic_bench::perf::{extract_attribution_timings, extract_metrics, ExtractedMetrics};
 
 const MODERN: &str = include_str!("fixtures/runner_output_modern.txt");
 const PHI4: &str = include_str!("fixtures/runner_output_phi4.txt");
@@ -63,4 +63,27 @@ fn extracts_qwen36_batched_prefill_lines_when_result_line_is_absent() {
 ";
     let m = extract_metrics(s).unwrap();
     assert!((m.ms_per_step - 3514.6).abs() < 1e-6);
+}
+
+#[test]
+fn extracts_qwen36_attribution_timing_maps() {
+    let s = "\
+[result] prompt_tokens=6 generated_tokens=16
+[qwen36-moe stage-timings] gen_steps=16 embed_ms_avg=0.123 chain_ms_avg=25.456 lm_head_ms_avg=2.000 sample_ms_avg=0.010 detok_ms_avg=0.001 total_ms_avg=27.590 (chain_total_ms=407.3 lm_head_total_ms=32.0)
+[qwen36-moe chain-breakdown] gen_steps=16 full_attn_ms_avg=8.000 linear_attn_ms_avg=4.000 ffn_ms_avg=13.456 (full_attn_total_ms=128.0 linear_attn_total_ms=64.0 ffn_total_ms=215.3)
+[qwen36-moe lifecycle-timings] prompt_setup_ms=1.000 bake_open_ms=2.000 layer_load_ms=3.000 session_ms=4.000 prefill_steps=1 prefill_embed_ms=5.000 prefill_chain_ms=6.000 prefill_total_ms=11.000 generation_wall_ms=441.0 total_wall_ms=452.0
+";
+    let timings = extract_attribution_timings(s);
+    assert_eq!(
+        timings.stage_timings.unwrap().get("chain_ms_avg"),
+        Some(&25.456)
+    );
+    assert_eq!(
+        timings.chain_breakdown.unwrap().get("ffn_total_ms"),
+        Some(&215.3)
+    );
+    assert_eq!(
+        timings.lifecycle_timings.unwrap().get("prefill_total_ms"),
+        Some(&11.0)
+    );
 }

--- a/crates/bench/tests/matrix_writes_run_dir.rs
+++ b/crates/bench/tests/matrix_writes_run_dir.rs
@@ -10,7 +10,7 @@ fn matrix_writes_meta_and_at_least_one_perf_cell() {
         models: vec!["qwen3.5-0.8b".into()],
         quants: vec!["bf16".into()],
         binary: PathBuf::from("/bin/echo"), // will produce no [result], so cells will be Error
-        model_dir_resolver: Box::new(|_| PathBuf::from("/nonexistent")),
+        model_dir_resolver: Box::new(|_| Ok(PathBuf::from("/nonexistent"))),
         specprefill_draft_dir_resolver: Box::new(|_| None),
         prompt: "x".into(),
         max_new_tokens: 1,
@@ -41,7 +41,7 @@ fn matrix_skips_unsupported_combo_with_skipped_status() {
         // /bin/false would produce an Error cell if the supported-combo guard
         // weren't there; the test asserts the guard runs first.
         binary: PathBuf::from("/bin/false"),
-        model_dir_resolver: Box::new(|_| PathBuf::from("/nonexistent")),
+        model_dir_resolver: Box::new(|_| Ok(PathBuf::from("/nonexistent"))),
         specprefill_draft_dir_resolver: Box::new(|_| None),
         prompt: "x".into(),
         max_new_tokens: 1,
@@ -80,7 +80,7 @@ fn matrix_runs_ad_hoc_sm86_specprefill_lane() {
         models: vec!["qwen3.6-35b-a3b".into()],
         quants: vec!["int4-spec070".into()],
         binary: PathBuf::from("/bin/echo"),
-        model_dir_resolver: Box::new(|_| PathBuf::from("/nonexistent")),
+        model_dir_resolver: Box::new(|_| Ok(PathBuf::from("/nonexistent"))),
         specprefill_draft_dir_resolver: Box::new(|_| Some(PathBuf::from("/draft"))),
         prompt: "x".into(),
         max_new_tokens: 1,

--- a/crates/bench/tests/registry_filter.rs
+++ b/crates/bench/tests/registry_filter.rs
@@ -18,11 +18,21 @@ fn gfx1100_includes_shipping_models() {
 
 #[test]
 fn min_vram_set_for_every_combo() {
-    for arch in [BenchArch::Gfx1100, BenchArch::Sm86] {
+    for arch in [BenchArch::Gfx1100, BenchArch::Sm86, BenchArch::AppleM5Max] {
         for c in combos_for_arch(arch) {
             assert!(c.min_vram_gib > 0.0, "combo {c:?} has zero min_vram_gib");
         }
     }
+}
+
+#[test]
+fn apple_m5_max_includes_qwen36_int4_metal_lane() {
+    let combos = combos_for_arch(BenchArch::AppleM5Max);
+    let model_quants: Vec<(&str, &str)> = combos.iter().map(|c| (c.model, c.quant)).collect();
+
+    assert_eq!(BenchArch::AppleM5Max.backend(), Some("metal"));
+    assert!(model_quants.contains(&("qwen3.6-35b-a3b", "int4")));
+    assert!(!model_quants.contains(&("qwen3.6-35b-a3b", "kv-fp8")));
 }
 
 #[test]

--- a/crates/bench/tests/run_dir_layout.rs
+++ b/crates/bench/tests/run_dir_layout.rs
@@ -4,7 +4,7 @@ use supersonic_bench::runs::{MetaJson, PerfCellJson, PerfStatus, RunDir};
 #[test]
 fn meta_json_round_trip() {
     let meta = MetaJson {
-        schema_version: 1,
+        schema_version: 2,
         run_id: "2026-05-05-abc1234".to_string(),
         timestamp_utc: "2026-05-05T12:00:00Z".to_string(),
         git_sha: "abc1234".to_string(),
@@ -26,9 +26,11 @@ fn meta_json_round_trip() {
 #[test]
 fn perf_cell_json_status_variants() {
     let ok = PerfCellJson {
-        schema_version: 1,
+        schema_version: 2,
         model: "qwen3.5-0.8b".into(),
         quant: "bf16".into(),
+        arch: "gfx1100".into(),
+        backend: "hip".into(),
         prompt: "The quick brown fox jumps over".into(),
         max_new_tokens: 16,
         status: PerfStatus::Ok {
@@ -36,6 +38,9 @@ fn perf_cell_json_status_variants() {
             ms_per_tok: 8.0,
             samples: vec![8.1, 8.0, 7.9],
         },
+        stage_timings: None,
+        chain_breakdown: None,
+        lifecycle_timings: None,
         gpu_temp_c_end: Some(60.0),
     };
     let s = serde_json::to_string(&ok).unwrap();

--- a/crates/bench/tests/run_one_combo.rs
+++ b/crates/bench/tests/run_one_combo.rs
@@ -23,6 +23,7 @@ fn run_one_combo_takes_median_of_three() {
     let invocation = ComboInvocation {
         binary: bin,
         backend: None,
+        arch: "gfx1100".into(),
         model: "qwen3.5-0.8b".into(),
         model_dir: PathBuf::from("/nonexistent"),
         quant: "bf16".into(),
@@ -55,6 +56,7 @@ fn run_one_combo_records_error_on_missing_binary() {
     let invocation = ComboInvocation {
         binary: PathBuf::from("/nonexistent/supersonic"),
         backend: None,
+        arch: "gfx1100".into(),
         model: "qwen3.5-0.8b".into(),
         model_dir: PathBuf::from("/nonexistent"),
         quant: "bf16".into(),

--- a/crates/runner/src/qwen36_moe/engine.rs
+++ b/crates/runner/src/qwen36_moe/engine.rs
@@ -719,7 +719,15 @@ fn decode_text(
     }
 
     print_last_logits_if_requested(dump_last_logits, &loop_state.last_logits_bytes);
-    print_generation_summary(&loop_state.generated_ids, prompt_ids.len(), eos_id);
+    let generation_wall_ms = generation_wall_start
+        .as_ref()
+        .map(|start| start.elapsed().as_secs_f64() * 1000.0);
+    print_generation_summary(
+        &loop_state.generated_ids,
+        prompt_ids.len(),
+        eos_id,
+        generation_wall_ms,
+    );
     if let Some(manager) = _moe_expert_residency.as_ref() {
         print_and_write_moe_residency_summary(
             manager,
@@ -733,10 +741,6 @@ fn decode_text(
     if emit_stage_timings {
         let to_ms = |d: std::time::Duration| d.as_secs_f64() * 1000.0;
         let prefill_total_ms = to_ms(prefill_embed_elapsed + prefill_chain_elapsed);
-        let generation_wall_ms = generation_wall_start
-            .as_ref()
-            .map(|start| to_ms(start.elapsed()))
-            .unwrap_or(0.0);
         eprintln!(
             "[qwen36-moe lifecycle-timings] prompt_setup_ms={:.3} \
              bake_open_ms={:.3} layer_load_ms={:.3} session_ms={:.3} \
@@ -750,7 +754,7 @@ fn decode_text(
             to_ms(prefill_embed_elapsed),
             to_ms(prefill_chain_elapsed),
             prefill_total_ms,
-            generation_wall_ms,
+            generation_wall_ms.unwrap_or(0.0),
             to_ms(decode_wall_start.elapsed()),
         );
     }

--- a/crates/runner/src/qwen36_moe/output.rs
+++ b/crates/runner/src/qwen36_moe/output.rs
@@ -96,6 +96,7 @@ pub(crate) fn print_generation_summary(
     generated_ids: &[u32],
     prompt_len: usize,
     eos_id: Option<u32>,
+    decode_ms: Option<f64>,
 ) {
     println!();
     println!();
@@ -117,9 +118,24 @@ pub(crate) fn print_generation_summary(
     if !generated_ids.is_empty() {
         println!("  Generated ids: {generated_ids:?}");
     }
-    println!(
-        "[result] prompt_tokens={} generated_tokens={}",
-        prompt_len,
-        generated_ids.len()
-    );
+    if let Some(decode_ms) = decode_ms {
+        let ms_per_step = if generated_ids.is_empty() {
+            0.0
+        } else {
+            decode_ms / generated_ids.len() as f64
+        };
+        println!(
+            "[result] prompt_tokens={} generated_tokens={} decode_ms={:.0} ms_per_step={:.1}",
+            prompt_len,
+            generated_ids.len(),
+            decode_ms,
+            ms_per_step,
+        );
+    } else {
+        println!(
+            "[result] prompt_tokens={} generated_tokens={}",
+            prompt_len,
+            generated_ids.len()
+        );
+    }
 }

--- a/crates/runner/tests/bench_combo_parity.rs
+++ b/crates/runner/tests/bench_combo_parity.rs
@@ -51,6 +51,7 @@ fn bench_combo_table_mentions_every_runner_supported_pair() {
         ("phi4-mini", "kv-fp8", "Gfx1100"),
         ("qwen3.6-35b-a3b", "int4", "Gfx1100"),
         ("qwen3.6-35b-a3b", "kv-fp8", "Gfx1100"),
+        ("qwen3.6-35b-a3b", "int4", "AppleM5Max"),
         ("qwen3.6-35b-a3b", "int4", "Sm86"),
         ("qwen3.6-35b-a3b", "int4-spec025", "Sm86"),
         ("qwen3.6-35b-a3b", "int4-spec050", "Sm86"),

--- a/docs/build-and-run.md
+++ b/docs/build-and-run.md
@@ -346,20 +346,33 @@ The large Apple M5 Max Metal smoke suite uses one canonical model root:
 
 ```bash
 export SUPERSONIC_TEST_MODEL_ROOT="$HOME/.cache/supersonic-metal-models"
+export HF_HOME="$HOME/.cache/huggingface"
+export HUGGINGFACE_HUB_CACHE="$HF_HOME/hub"
 mkdir -p "$SUPERSONIC_TEST_MODEL_ROOT"
 
 hf download Qwen/Qwen3-30B-A3B --local-dir "$SUPERSONIC_TEST_MODEL_ROOT/qwen3-30b-a3b"
 hf download google/gemma-4-E2B --local-dir "$SUPERSONIC_TEST_MODEL_ROOT/gemma4-e2b"
 hf download google/gemma-4-E4B --local-dir "$SUPERSONIC_TEST_MODEL_ROOT/gemma4-e4b"
 hf download microsoft/Phi-4-mini-instruct --local-dir "$SUPERSONIC_TEST_MODEL_ROOT/phi4-mini"
+
+# Qwen3.6 is large enough that this machine keeps the HF snapshot as the
+# source of truth and exposes a stable SuperSonic alias. Replace `<snapshot>`
+# with the hash under `$HUGGINGFACE_HUB_CACHE/models--Qwen--Qwen3.6-35B-A3B-FP8/snapshots/`.
+hf download Qwen/Qwen3.6-35B-A3B-FP8
+ln -sfn "$HUGGINGFACE_HUB_CACHE/models--Qwen--Qwen3.6-35B-A3B-FP8/snapshots/<snapshot>" \
+  "$SUPERSONIC_TEST_MODEL_ROOT/qwen3.6-35b-a3b"
 ```
 
 Quantized lanes use release-hosted bakes and install them under each model's
 `.supersonic/` directory on first run:
 
+- `v2-int4-gptq` for `qwen3.6-35b-a3b`
 - `v2-int4-gptq` for `qwen3-30b-a3b`, `gemma4-e2b`, `gemma4-e4b`, and
   `phi4-mini --int4`
 - `v2-fp8` for `phi4-mini --fp8-runtime`
+
+On this development machine, the same convention is sourced from
+`~/.config/supersonic/env.zsh` by `~/.zshenv`.
 
 The ignored large-model gate is:
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -817,6 +817,42 @@ What still dominates:
   wait, which implies the next real win should come from deeper decode fusion
   or fewer queued decode sub-operations rather than more host-side cleanup
 
+## Metal — `apple-m5-max` (Apple M5 Max)
+
+Apple M5 Max Metal is the main Apple-silicon target for Qwen3.6 bring-up. The
+current benchmark lane is deliberately narrow: `qwen3.6-35b-a3b` with INT4
+weights on the chained Metal decode path. This section is a performance harness
+checkpoint, not a claim that the HIP feature set has been ported to Metal.
+
+Reproduce the run with:
+
+```bash
+SUPERSONIC_TEST_MODEL_ROOT="$HOME/.cache/supersonic-metal-models" cargo run --release -p supersonic-bench --bin bench-perf -- --arch apple-m5-max --models qwen3.6-35b-a3b --quants int4
+```
+
+The harness records a warmup plus median-of-3 headline run at
+`--max-new-tokens 16`, then performs one additional `--emit-stage-timings`
+attribution run. For this Metal lane it also forces the dense prefill token loop
+(`SUPERSONIC_QWEN36_MOE_BATCHED_PREFILL=0` and
+`SUPERSONIC_QWEN36_DENSE_PREFILL_TOKEN_LOOP=1`) because the default Qwen3.6
+batched prefill router-permute path is HIP/CUDA-only. The attribution maps are
+stored in the same perf JSON as `stage_timings`, `chain_breakdown`, and
+`lifecycle_timings` without feeding back into the headline median.
+
+<!-- AUTOGEN BELOW: apple-m5-max-metal -->
+| Model           |  INT4 |
+| --------------- | ----: |
+| qwen3.6-35b-a3b | 2354.1 |
+
+<!-- AUTOGEN END: apple-m5-max-metal -->
+
+Unsupported Metal constraints remain explicit for this target: persistent
+decode, KV-FP8, speculative decode, batching, and Metal VMM are not benchmarked
+or claimed here yet. The first baseline from this section should drive the next
+runtime optimization target; the expected first candidate is Qwen3.6 INT4
+persistent Metal decode because the current path is still chained per-token
+dispatch.
+
 ## How to reproduce
 
 ```bash

--- a/oracle/bench/render/render_main.py
+++ b/oracle/bench/render/render_main.py
@@ -1,5 +1,6 @@
 """CLI: python -m oracle.bench.render.render_main"""
 import argparse
+import json
 from pathlib import Path
 
 from .markdown import render_perf_table, render_quality_table, render_external_comparison_table, replace_autogen_zone
@@ -24,9 +25,15 @@ def main():
     args = ap.parse_args()
     if args.cmd == "markdown":
         perf_md = render_perf_table(args.run / "perf")
+        perf_zone_key = args.perf_zone_key
+        meta_path = args.run / "meta.json"
+        if perf_zone_key == "bench-perf-matrix" and meta_path.exists():
+            arch = json.loads(meta_path.read_text()).get("arch")
+            if arch == "apple-m5-max":
+                perf_zone_key = "apple-m5-max-metal"
         perf_doc = (args.out / "docs" / "performance.md")
         if perf_doc.exists():
-            updated = replace_autogen_zone(perf_doc.read_text(), args.perf_zone_key, perf_md)
+            updated = replace_autogen_zone(perf_doc.read_text(), perf_zone_key, perf_md)
             perf_doc.write_text(updated)
             print(f"updated {perf_doc}")
 

--- a/oracle/bench/render/schema.py
+++ b/oracle/bench/render/schema.py
@@ -11,7 +11,7 @@ META_SCHEMA = {
         "arch", "rocminfo", "rocm_smi_u", "runner_version",
     ],
     "properties": {
-        "schema_version": {"type": "integer", "const": 1},
+        "schema_version": {"type": "integer", "enum": [1, 2]},
         "run_id": {"type": "string"},
         "timestamp_utc": {"type": "string"},
         "git_sha": {"type": "string"},
@@ -26,19 +26,42 @@ META_SCHEMA = {
 }
 
 _PERF_BASE = {
-    "schema_version": {"type": "integer", "const": 1},
+    "schema_version": {"type": "integer", "enum": [1, 2]},
     "model": {"type": "string"},
     "quant": {"type": "string"},
+    "arch": {"type": "string"},
+    "backend": {"type": "string"},
     "prompt": {"type": "string"},
     "max_new_tokens": {"type": "integer", "minimum": 1},
+    "stage_timings": {
+        "type": "object",
+        "additionalProperties": {"type": "number"},
+    },
+    "chain_breakdown": {
+        "type": "object",
+        "additionalProperties": {"type": "number"},
+    },
+    "lifecycle_timings": {
+        "type": "object",
+        "additionalProperties": {"type": "number"},
+    },
     "gpu_temp_c_end": {"type": ["number", "null"]},
 }
+_PERF_REQUIRED = [
+    "schema_version", "model", "quant", "prompt", "max_new_tokens", "gpu_temp_c_end",
+]
 
 PERF_CELL_SCHEMA = {
     "type": "object",
+    "allOf": [
+        {
+            "if": {"properties": {"schema_version": {"const": 2}}},
+            "then": {"required": ["arch", "backend"]},
+        }
+    ],
     "oneOf": [
         {
-            "required": list(_PERF_BASE) + ["status", "ms_per_step", "ms_per_tok", "samples"],
+            "required": _PERF_REQUIRED + ["status", "ms_per_step", "ms_per_tok", "samples"],
             "properties": {**_PERF_BASE,
                            "status": {"const": "ok"},
                            "ms_per_step": {"type": "number"},
@@ -46,13 +69,13 @@ PERF_CELL_SCHEMA = {
                            "samples": {"type": "array", "items": {"type": "number"}}},
         },
         {
-            "required": list(_PERF_BASE) + ["status", "reason"],
+            "required": _PERF_REQUIRED + ["status", "reason"],
             "properties": {**_PERF_BASE,
                            "status": {"const": "skipped"},
                            "reason": {"type": "string"}},
         },
         {
-            "required": list(_PERF_BASE) + ["status", "stderr_tail"],
+            "required": _PERF_REQUIRED + ["status", "stderr_tail"],
             "properties": {**_PERF_BASE,
                            "status": {"const": "error"},
                            "stderr_tail": {"type": "string"}},

--- a/oracle/bench/tests/test_schema.py
+++ b/oracle/bench/tests/test_schema.py
@@ -49,6 +49,27 @@ def test_perf_cell_error_status():
     validate_perf_cell(cell)
 
 
+def test_perf_cell_v2_attribution_status():
+    cell = {
+        "schema_version": 2,
+        "model": "qwen3.6-35b-a3b",
+        "quant": "int4",
+        "arch": "apple-m5-max",
+        "backend": "metal",
+        "prompt": "x",
+        "max_new_tokens": 16,
+        "status": "ok",
+        "ms_per_step": 27.5,
+        "ms_per_tok": 27.5,
+        "samples": [27.4, 27.5, 27.6],
+        "stage_timings": {"chain_ms_avg": 25.0},
+        "chain_breakdown": {"ffn_ms_avg": 12.0},
+        "lifecycle_timings": {"prefill_total_ms": 1000.0},
+        "gpu_temp_c_end": None,
+    }
+    validate_perf_cell(cell)
+
+
 def test_perf_cell_invalid_status_rejected():
     cell = {
         "schema_version": 1,


### PR DESCRIPTION
## Summary

Adds a repeatable Apple M5 Max Metal performance harness lane for `qwen3.6-35b-a3b` INT4 and records the first baseline in `docs/performance.md`.

## What changed

- Adds `apple-m5-max` to the bench matrix and forces the Metal backend for that arch.
- Adds schema v2 perf cells with `arch`, `backend`, `stage_timings`, `chain_breakdown`, and `lifecycle_timings` while keeping renderer compatibility with v1 fixtures.
- Runs Qwen3.6 headline timing as warmup plus median-of-3, then performs a separate `--emit-stage-timings` attribution run.
- Forces the Qwen3.6 Metal dense prefill token loop in the bench harness because the default batched prefill router-permute path is HIP/CUDA-only.
- Emits `decode_ms` and `ms_per_step` from Qwen3.6 generation summaries so successful runs are machine-readable.
- Documents the local HF/SuperSonic model-root convention and the Apple M5 Max baseline.

## Baseline

Exact documented command now resolves through `SUPERSONIC_TEST_MODEL_ROOT` on the M5 machine:

```bash
SUPERSONIC_TEST_MODEL_ROOT="$HOME/.cache/supersonic-metal-models" cargo run --release -p supersonic-bench --bin bench-perf -- --arch apple-m5-max --models qwen3.6-35b-a3b --quants int4
```

Latest run: `target/bench-runs/2026-05-15-a951700-4`

- Status: `ok`
- Median: `2354.1 ms/step`
- Samples: `2341.8`, `2372.1`, `2354.1`
- Attribution maps present: `stage_timings`, `chain_breakdown`, `lifecycle_timings`

## Validation

- `cargo test -p supersonic-bench`
- `cargo test -p runner --test bench_combo_parity`
- `python3 -m pytest oracle/bench/tests`
- `git diff --check`
