### PR TITLE
[codex] bench m5 metal tensor profiling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,6 +1246,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "blake3",
+ "cc",
  "chrono",
  "clap",
  "gpu-hal",

--- a/crates/bench/src/matrix.rs
+++ b/crates/bench/src/matrix.rs
@@ -382,6 +382,7 @@ pub fn run_matrix(cfg: &MatrixConfig, rd: &RunDir) -> Result<()> {
                     stage_timings: None,
                     chain_breakdown: None,
                     lifecycle_timings: None,
+                    mpp_pilot: None,
                     gpu_temp_c_end: None,
                 };
                 rd.write_perf(&cell)?;

--- a/crates/bench/src/perf.rs
+++ b/crates/bench/src/perf.rs
@@ -17,6 +17,7 @@ pub struct AttributionTimings {
     pub stage_timings: Option<BTreeMap<String, f64>>,
     pub chain_breakdown: Option<BTreeMap<String, f64>>,
     pub lifecycle_timings: Option<BTreeMap<String, f64>>,
+    pub mpp_pilot: Option<BTreeMap<String, f64>>,
 }
 
 #[derive(Debug, Clone)]
@@ -96,6 +97,11 @@ pub fn extract_attribution_timings(output: &str) -> AttributionTimings {
             .lines()
             .rev()
             .find(|l| l.starts_with("[qwen36-moe lifecycle-timings]"))
+            .map(parse_numeric_fields),
+        mpp_pilot: output
+            .lines()
+            .rev()
+            .find(|l| l.starts_with("[qwen36-moe mpp-pilot]"))
             .map(parse_numeric_fields),
     }
 }
@@ -199,6 +205,7 @@ pub fn run_one_combo(invocation: &ComboInvocation, policy: &RunPolicy) -> Result
         stage_timings: attribution.stage_timings,
         chain_breakdown: attribution.chain_breakdown,
         lifecycle_timings: attribution.lifecycle_timings,
+        mpp_pilot: attribution.mpp_pilot,
         gpu_temp_c_end: None,
     })
 }
@@ -215,6 +222,9 @@ fn invoke_supersonic(
     if invocation.arch == "apple-m5-max" && invocation.model == "qwen3.6-35b-a3b" {
         cmd.env("SUPERSONIC_QWEN36_MOE_BATCHED_PREFILL", "0")
             .env("SUPERSONIC_QWEN36_DENSE_PREFILL_TOKEN_LOOP", "1");
+        if emit_stage_timings {
+            cmd.env("SUPERSONIC_METAL_QWEN36_MPP_PILOT", "1");
+        }
     }
     cmd.arg("--model")
         .arg(&invocation.model)

--- a/crates/bench/src/runs.rs
+++ b/crates/bench/src/runs.rs
@@ -53,6 +53,8 @@ pub struct PerfCellJson {
     pub chain_breakdown: Option<BTreeMap<String, f64>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lifecycle_timings: Option<BTreeMap<String, f64>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mpp_pilot: Option<BTreeMap<String, f64>>,
     pub gpu_temp_c_end: Option<f64>,
 }
 

--- a/crates/bench/tests/extract_metrics.rs
+++ b/crates/bench/tests/extract_metrics.rs
@@ -72,6 +72,7 @@ fn extracts_qwen36_attribution_timing_maps() {
 [qwen36-moe stage-timings] gen_steps=16 embed_ms_avg=0.123 chain_ms_avg=25.456 lm_head_ms_avg=2.000 sample_ms_avg=0.010 detok_ms_avg=0.001 total_ms_avg=27.590 (chain_total_ms=407.3 lm_head_total_ms=32.0)
 [qwen36-moe chain-breakdown] gen_steps=16 full_attn_ms_avg=8.000 linear_attn_ms_avg=4.000 ffn_ms_avg=13.456 (full_attn_total_ms=128.0 linear_attn_total_ms=64.0 ffn_total_ms=215.3)
 [qwen36-moe lifecycle-timings] prompt_setup_ms=1.000 bake_open_ms=2.000 layer_load_ms=3.000 session_ms=4.000 prefill_steps=1 prefill_embed_ms=5.000 prefill_chain_ms=6.000 prefill_total_ms=11.000 generation_wall_ms=441.0 total_wall_ms=452.0
+[qwen36-moe mpp-pilot] status=ok size=2048 iterations=5 tile_m=64 tile_n=32 tile_k=64 tflops=13.250
 ";
     let timings = extract_attribution_timings(s);
     assert_eq!(
@@ -86,4 +87,5 @@ fn extracts_qwen36_attribution_timing_maps() {
         timings.lifecycle_timings.unwrap().get("prefill_total_ms"),
         Some(&11.0)
     );
+    assert_eq!(timings.mpp_pilot.unwrap().get("tflops"), Some(&13.25));
 }

--- a/crates/bench/tests/run_dir_layout.rs
+++ b/crates/bench/tests/run_dir_layout.rs
@@ -41,6 +41,7 @@ fn perf_cell_json_status_variants() {
         stage_timings: None,
         chain_breakdown: None,
         lifecycle_timings: None,
+        mpp_pilot: None,
         gpu_temp_c_end: Some(60.0),
     };
     let s = serde_json::to_string(&ok).unwrap();

--- a/crates/kernel-ffi/build.rs
+++ b/crates/kernel-ffi/build.rs
@@ -386,15 +386,48 @@ fn compile_metal_stubs(manifest_dir: &Path) {
         .file(manifest_dir.join("src/metal_link_stubs.cc"))
         .flag_if_supported("-std=c++17")
         .compile("kernel_ffi_metal_stubs");
-    cc::Build::new()
+    let have_mtl4_mpp = have_mtl4_mpp_sdk();
+    let mut metal = cc::Build::new();
+    metal
         .cpp(true)
         .file(manifest_dir.join("src/metal_native.mm"))
         .flag_if_supported("-std=c++17")
-        .flag("-fobjc-arc")
-        .compile("kernel_ffi_metal_native");
+        .flag("-fobjc-arc");
+    if have_mtl4_mpp {
+        metal.define("SUPERSONIC_HAVE_MTL4_MPP", "1");
+    } else {
+        println!(
+            "cargo:warning=Metal 4 MPP tensor headers not found; M5 MPP attribution pilot disabled"
+        );
+    }
+    metal.compile("kernel_ffi_metal_native");
     println!("cargo:rustc-link-lib=framework=Foundation");
     println!("cargo:rustc-link-lib=framework=Metal");
+    if have_mtl4_mpp {
+        println!("cargo:rustc-link-lib=framework=MetalPerformancePrimitives");
+    }
     println!("cargo:rustc-cfg=supersonic_backend_metal");
+}
+
+fn have_mtl4_mpp_sdk() -> bool {
+    let Ok(output) = Command::new("xcrun")
+        .args(["--sdk", "macosx", "--show-sdk-path"])
+        .output()
+    else {
+        return false;
+    };
+    if !output.status.success() {
+        return false;
+    }
+    let sdk = PathBuf::from(String::from_utf8_lossy(&output.stdout).trim().to_string());
+    sdk.join("System/Library/Frameworks/Metal.framework/Headers/MTL4CommandQueue.h")
+        .is_file()
+        && sdk
+            .join("System/Library/Frameworks/Metal.framework/Headers/MTLTensor.h")
+            .is_file()
+        && sdk
+            .join("System/Library/Frameworks/MetalPerformancePrimitives.framework/Headers/MetalPerformancePrimitives.h")
+            .is_file()
 }
 
 fn main() {

--- a/crates/kernel-ffi/src/metal_native.mm
+++ b/crates/kernel-ffi/src/metal_native.mm
@@ -1,5 +1,8 @@
 #import <Foundation/Foundation.h>
 #import <Metal/Metal.h>
+#if SUPERSONIC_HAVE_MTL4_MPP
+#import <MetalPerformancePrimitives/MetalPerformancePrimitives.h>
+#endif
 
 #include <algorithm>
 #include <chrono>
@@ -548,6 +551,161 @@ void configure_precise_math(MTLCompileOptions* options) {
 #pragma clang diagnostic pop
     }
 }
+
+#if SUPERSONIC_HAVE_MTL4_MPP
+id<MTLComputePipelineState> mpp_mtl4_pipeline_from_source(
+    NSString* source,
+    NSString* name,
+    NSUInteger threads_per_threadgroup
+) {
+    NSError* error = nil;
+    MTLCompileOptions* options = [[MTLCompileOptions alloc] init];
+    options.languageVersion = MTLLanguageVersion4_0;
+    id<MTLLibrary> library = [metal_device() newLibraryWithSource:source options:options error:&error];
+    if (library == nil || error != nil) {
+        if (NSProcessInfo.processInfo.environment[@"SUPERSONIC_METAL_PROFILE_DEBUG"] != nil) {
+            NSLog(@"SuperSonic MPP pilot Metal4 compile failed for %@: %@", name, error);
+        }
+        return nil;
+    }
+
+    MTL4LibraryFunctionDescriptor* function_desc = [[MTL4LibraryFunctionDescriptor alloc] init];
+    function_desc.name = name;
+    function_desc.library = library;
+
+    MTL4ComputePipelineDescriptor* pipeline_desc = [[MTL4ComputePipelineDescriptor alloc] init];
+    pipeline_desc.computeFunctionDescriptor = function_desc;
+    pipeline_desc.maxTotalThreadsPerThreadgroup = threads_per_threadgroup;
+    pipeline_desc.requiredThreadsPerThreadgroup = MTLSizeMake(threads_per_threadgroup, 1, 1);
+
+    MTL4CompilerDescriptor* compiler_desc = [[MTL4CompilerDescriptor alloc] init];
+    id<MTL4Compiler> compiler = [metal_device() newCompilerWithDescriptor:compiler_desc error:&error];
+    if (compiler == nil || error != nil) {
+        if (NSProcessInfo.processInfo.environment[@"SUPERSONIC_METAL_PROFILE_DEBUG"] != nil) {
+            NSLog(@"SuperSonic MPP pilot Metal4 compiler failed for %@: %@", name, error);
+        }
+        return nil;
+    }
+
+    id<MTLComputePipelineState> pipeline =
+        [compiler newComputePipelineStateWithDescriptor:pipeline_desc compilerTaskOptions:nil error:&error];
+    if (pipeline == nil && NSProcessInfo.processInfo.environment[@"SUPERSONIC_METAL_PROFILE_DEBUG"] != nil) {
+        NSLog(@"SuperSonic MPP pilot Metal4 pipeline failed for %@: %@", name, error);
+    }
+    return pipeline;
+}
+
+MTLTensorDescriptor* mpp_tensor_descriptor(NSUInteger dim0, NSUInteger dim1, MTLTensorDataType data_type) {
+    NSInteger dims[2] = {
+        static_cast<NSInteger>(dim0),
+        static_cast<NSInteger>(dim1),
+    };
+    NSInteger strides[2] = {
+        1,
+        static_cast<NSInteger>(dim0),
+    };
+    MTLTensorDescriptor* desc = [[MTLTensorDescriptor alloc] init];
+    desc.dimensions = [[MTLTensorExtents alloc] initWithRank:2 values:dims];
+    desc.strides = [[MTLTensorExtents alloc] initWithRank:2 values:strides];
+    desc.dataType = data_type;
+    desc.usage = MTLTensorUsageCompute | MTLTensorUsageMachineLearning;
+    desc.storageMode = MTLStorageModeShared;
+    return desc;
+}
+
+MTLTensorDescriptor* mpp_device_tensor_descriptor(NSUInteger dim0, NSUInteger dim1, MTLTensorDataType data_type) {
+    MTLTensorDescriptor* desc = mpp_tensor_descriptor(dim0, dim1, data_type);
+    desc.strides = nil;
+    return desc;
+}
+
+id<MTLTensor> mpp_tensor_from_device(id<MTLDevice> device, MTLTensorDescriptor* desc) {
+    NSError* error = nil;
+    id<MTLTensor> tensor = [device newTensorWithDescriptor:desc error:&error];
+    if (tensor == nil && NSProcessInfo.processInfo.environment[@"SUPERSONIC_METAL_PROFILE_DEBUG"] != nil) {
+        NSLog(@"SuperSonic MPP pilot tensor creation failed: %@", error);
+    }
+    return tensor;
+}
+
+void mpp_tensor_replace_all_f16(id<MTLTensor> tensor, const uint16_t* values, NSUInteger dim0, NSUInteger dim1) {
+    NSInteger origin_values[2] = {0, 0};
+    NSInteger dim_values[2] = {
+        static_cast<NSInteger>(dim0),
+        static_cast<NSInteger>(dim1),
+    };
+    NSInteger stride_values[2] = {
+        1,
+        static_cast<NSInteger>(dim0),
+    };
+    MTLTensorExtents* origin = [[MTLTensorExtents alloc] initWithRank:2 values:origin_values];
+    MTLTensorExtents* dims = [[MTLTensorExtents alloc] initWithRank:2 values:dim_values];
+    MTLTensorExtents* strides = [[MTLTensorExtents alloc] initWithRank:2 values:stride_values];
+    [tensor replaceSliceOrigin:origin sliceDimensions:dims withBytes:values strides:strides];
+}
+
+float mpp_tensor_first_f32(id<MTLTensor> tensor) {
+    NSInteger origin_values[2] = {0, 0};
+    NSInteger dim_values[2] = {1, 1};
+    NSInteger stride_values[2] = {1, 1};
+    MTLTensorExtents* origin = [[MTLTensorExtents alloc] initWithRank:2 values:origin_values];
+    MTLTensorExtents* dims = [[MTLTensorExtents alloc] initWithRank:2 values:dim_values];
+    MTLTensorExtents* strides = [[MTLTensorExtents alloc] initWithRank:2 values:stride_values];
+    float value = 0.0f;
+    [tensor getBytes:&value strides:strides fromSliceOrigin:origin sliceDimensions:dims];
+    return value;
+}
+
+id<MTL4ArgumentTable> mpp_mtl4_argument_table(id<MTLDevice> device, NSUInteger buffer_bind_count) {
+    MTL4ArgumentTableDescriptor* desc = [[MTL4ArgumentTableDescriptor alloc] init];
+    desc.maxBufferBindCount = buffer_bind_count;
+    desc.initializeBindings = YES;
+    NSError* error = nil;
+    id<MTL4ArgumentTable> table = [device newArgumentTableWithDescriptor:desc error:&error];
+    if (table == nil && NSProcessInfo.processInfo.environment[@"SUPERSONIC_METAL_PROFILE_DEBUG"] != nil) {
+        NSLog(@"SuperSonic MPP pilot argument table failed: %@", error);
+    }
+    return table;
+}
+
+bool mpp_wait_for_mtl4_queue(id<MTL4CommandQueue> queue, id<MTLSharedEvent> event, uint64_t value) {
+    [queue signalEvent:event value:value];
+    return [event waitUntilSignaledValue:value timeoutMS:30000];
+}
+
+bool mpp_encode_gemm_mtl4(
+    id<MTLDevice> device,
+    id<MTL4CommandQueue> queue,
+    id<MTLComputePipelineState> pipeline,
+    id<MTL4ArgumentTable> args,
+    uint32_t tg_x,
+    uint32_t tg_y,
+    NSUInteger threads_per_threadgroup,
+    id<MTLSharedEvent> event,
+    uint64_t signal_value
+) {
+    id<MTL4CommandAllocator> allocator = [device newCommandAllocator];
+    id<MTL4CommandBuffer> command_buffer = [device newCommandBuffer];
+    if (allocator == nil || command_buffer == nil) {
+        return false;
+    }
+    [command_buffer beginCommandBufferWithAllocator:allocator];
+    id<MTL4ComputeCommandEncoder> encoder = [command_buffer computeCommandEncoder];
+    if (encoder == nil) {
+        [command_buffer endCommandBuffer];
+        return false;
+    }
+    [encoder setComputePipelineState:pipeline];
+    [encoder setArgumentTable:args];
+    [encoder dispatchThreadgroups:MTLSizeMake(tg_x, tg_y, 1)
+            threadsPerThreadgroup:MTLSizeMake(threads_per_threadgroup, 1, 1)];
+    [encoder endEncoding];
+    [command_buffer endCommandBuffer];
+    id<MTL4CommandBuffer> buffers[1] = { command_buffer };
+    [queue commit:buffers count:1];
+    return mpp_wait_for_mtl4_queue(queue, event, signal_value);
+}
+#endif  // SUPERSONIC_HAVE_MTL4_MPP
 
 id<MTLComputePipelineState> matmul_pipeline_bf16(NSError** error_out) {
     static std::mutex mutex;
@@ -9714,6 +9872,133 @@ extern "C" int supersonic_metal_matmul_rhs_transposed_f32(
             [encoder dispatchThreads:threads_per_grid threadsPerThreadgroup:threads_per_group];
         }, 315, 316, 317, 318);
     }
+}
+
+extern "C" double supersonic_metal_mpp_tile_gemm_f16_tflops(uint32_t size, uint32_t iterations) {
+#if SUPERSONIC_HAVE_MTL4_MPP
+    @autoreleasepool {
+        id<MTLDevice> device = metal_device();
+        if (device == nil || size == 0 || iterations == 0 || (size % 64u) != 0u) {
+            return 0.0;
+        }
+        id<MTL4CommandQueue> queue = [device newMTL4CommandQueue];
+        if (queue == nil) {
+            return 0.0;
+        }
+
+        NSString* source =
+             @"#include <metal_stdlib>\n"
+             "#include <MetalPerformancePrimitives/MetalPerformancePrimitives.h>\n"
+             "using namespace metal;\n"
+             "using namespace mpp::tensor_ops;\n"
+             "kernel void supersonic_mpp_gemm_tile(tensor<device half, dextents<int32_t, 2>> A [[buffer(0)]],\n"
+             "                                      tensor<device half, dextents<int32_t, 2>> B [[buffer(1)]],\n"
+             "                                      tensor<device float, dextents<int32_t, 2>> C [[buffer(2)]]) {\n"
+             "  constexpr auto desc = matmul2d_descriptor(64, 32, 64, false, false, false);\n"
+             "  matmul2d<desc, execution_simdgroups<4>> op;\n"
+             "  auto tA = A.slice(0, 0);\n"
+             "  auto tB = B.slice(0, 0);\n"
+             "  auto tC = C.slice(0, 0);\n"
+             "  op.run(tA, tB, tC);\n"
+             "}\n";
+        id<MTLComputePipelineState> pipeline =
+            mpp_mtl4_pipeline_from_source(source, @"supersonic_mpp_gemm_tile", 128);
+        if (pipeline == nil) {
+            return 0.0;
+        }
+
+        const NSUInteger a_count = 64u * 64u;
+        const NSUInteger b_count = 32u * 64u;
+        id<MTLBuffer> a_buf = [device newBufferWithLength:a_count * sizeof(uint16_t)
+                                                   options:MTLResourceStorageModeShared];
+        id<MTLBuffer> b_buf = [device newBufferWithLength:b_count * sizeof(uint16_t)
+                                                   options:MTLResourceStorageModeShared];
+        if (a_buf == nil || b_buf == nil) {
+            return 0.0;
+        }
+        auto* a = static_cast<uint16_t*>(a_buf.contents);
+        auto* b = static_cast<uint16_t*>(b_buf.contents);
+        for (NSUInteger i = 0; i < a_count; ++i) {
+            a[i] = static_cast<uint16_t>(0x3c00u + (i & 1u));
+        }
+        for (NSUInteger i = 0; i < b_count; ++i) {
+            b[i] = static_cast<uint16_t>(0x3800u + (i & 1u));
+        }
+
+        id<MTLTensor> a_tensor = mpp_tensor_from_device(
+            device,
+            mpp_device_tensor_descriptor(64, 64, MTLTensorDataTypeFloat16)
+        );
+        id<MTLTensor> b_tensor = mpp_tensor_from_device(
+            device,
+            mpp_device_tensor_descriptor(32, 64, MTLTensorDataTypeFloat16)
+        );
+        id<MTLTensor> c_tensor = mpp_tensor_from_device(
+            device,
+            mpp_device_tensor_descriptor(32, 64, MTLTensorDataTypeFloat32)
+        );
+        if (a_tensor == nil || b_tensor == nil || c_tensor == nil) {
+            return 0.0;
+        }
+        mpp_tensor_replace_all_f16(a_tensor, a, 64, 64);
+        mpp_tensor_replace_all_f16(b_tensor, b, 32, 64);
+
+        id<MTL4ArgumentTable> args = mpp_mtl4_argument_table(device, 3);
+        id<MTLSharedEvent> event = [device newSharedEvent];
+        if (args == nil || event == nil) {
+            return 0.0;
+        }
+        [args setResource:a_tensor.gpuResourceID atBufferIndex:0];
+        [args setResource:b_tensor.gpuResourceID atBufferIndex:1];
+        [args setResource:c_tensor.gpuResourceID atBufferIndex:2];
+
+        const uint32_t tile_m = size / 64u;
+        const uint32_t tile_n = size / 32u;
+        const uint32_t tile_k = size / 64u;
+        const uint32_t tg_x = tile_n;
+        const uint32_t tg_y = tile_m * tile_k;
+        const NSUInteger threads_per_threadgroup = pipeline.threadExecutionWidth * 4u;
+
+        if (!mpp_encode_gemm_mtl4(
+                device, queue, pipeline, args, tg_x, tg_y, threads_per_threadgroup, event, 1)) {
+            return 0.0;
+        }
+
+        auto start = std::chrono::steady_clock::now();
+        for (uint32_t i = 0; i < iterations; ++i) {
+            const uint64_t signal_value = static_cast<uint64_t>(i) + 2u;
+            if (!mpp_encode_gemm_mtl4(
+                    device, queue, pipeline, args, tg_x, tg_y, threads_per_threadgroup, event, signal_value)) {
+                return 0.0;
+            }
+        }
+
+        const double seconds =
+            std::chrono::duration<double>(std::chrono::steady_clock::now() - start).count();
+        if (seconds <= 0.0 || !std::isfinite(seconds)) {
+            return 0.0;
+        }
+        volatile float guard = mpp_tensor_first_f32(c_tensor);
+        if (guard == 0.0f || !std::isfinite(static_cast<double>(guard))) {
+            return 0.0;
+        }
+        (void)guard;
+
+        const double flops = static_cast<double>(iterations)
+            * 2.0
+            * static_cast<double>(tile_m)
+            * static_cast<double>(tile_n)
+            * static_cast<double>(tile_k)
+            * 64.0
+            * 32.0
+            * 64.0;
+        return flops / seconds / 1.0e12;
+    }
+#else
+    (void)size;
+    (void)iterations;
+    return 0.0;
+#endif
 }
 
 extern "C" int supersonic_metal_qwen_linear_projections_bf16(

--- a/crates/kernel-ffi/src/metal_native.rs
+++ b/crates/kernel-ffi/src/metal_native.rs
@@ -102,6 +102,7 @@ unsafe extern "C" {
         rhs_ptr: *const c_void,
         out_ptr: *mut c_void,
     ) -> c_int;
+    fn supersonic_metal_mpp_tile_gemm_f16_tflops(size: u32, iterations: u32) -> f64;
     fn supersonic_metal_qwen_linear_projections_bf16(
         hidden_dim: usize,
         qkv_dim: usize,
@@ -1253,6 +1254,23 @@ pub(crate) fn matmul_rhs_transposed_f32(
         ));
     }
     Ok(())
+}
+
+#[cfg(all(target_os = "macos", supersonic_backend_metal))]
+pub(crate) fn mpp_tile_gemm_f16_tflops(size: u32, iterations: u32) -> Result<f64, GpuError> {
+    if size == 0 || iterations == 0 || size % 64 != 0 {
+        return Err(GpuError::InvalidArg(format!(
+            "metal native MPP tile GEMM requires non-zero size divisible by 64 and iterations > 0, got size={size} iterations={iterations}"
+        )));
+    }
+    let tflops = unsafe { supersonic_metal_mpp_tile_gemm_f16_tflops(size, iterations) };
+    if tflops.is_finite() && tflops > 0.0 {
+        Ok(tflops)
+    } else {
+        Err(GpuError::InvalidArg(
+            "metal native MPP tile GEMM pilot returned no measurement".into(),
+        ))
+    }
 }
 
 #[cfg(all(target_os = "macos", supersonic_backend_metal))]
@@ -3785,6 +3803,14 @@ pub(crate) fn matmul_rhs_transposed_f32(
 }
 
 #[cfg(not(all(target_os = "macos", supersonic_backend_metal)))]
+pub(crate) fn mpp_tile_gemm_f16_tflops(_size: u32, _iterations: u32) -> Result<f64, GpuError> {
+    Err(GpuError::backend(
+        Backend::Metal,
+        "metal native MPP tile GEMM pilot is not compiled".into(),
+    ))
+}
+
+#[cfg(not(all(target_os = "macos", supersonic_backend_metal)))]
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn qwen_linear_projections_bf16(
     _hidden_dim: usize,
@@ -4397,6 +4423,17 @@ mod tests {
             .chunks_exact(4)
             .map(|chunk| u32::from_le_bytes(chunk.try_into().unwrap()))
             .collect()
+    }
+
+    #[test]
+    #[ignore = "MPP/Metal Tensor availability depends on Xcode 26.1+ and M5 hardware"]
+    fn metal_mpp_tile_gemm_f16_pilot_smoke() {
+        set_backend(Backend::Metal);
+        let tflops = mpp_tile_gemm_f16_tflops(2048, 2).expect("run MPP tile GEMM pilot");
+        assert!(
+            tflops.is_finite() && tflops > 0.0,
+            "invalid MPP pilot TFLOPS: {tflops}"
+        );
     }
 
     #[test]

--- a/crates/kernel-ffi/src/qwen36_moe.rs
+++ b/crates/kernel-ffi/src/qwen36_moe.rs
@@ -248,6 +248,15 @@ impl Default for Qwen36MoeBatchSeqDesc {
     }
 }
 
+/// Attribution-only MPP pilot used by the Apple M5 Metal bench harness.
+///
+/// This measures repeated exact `64x32x64` MPP tensor tiles as an equivalent
+/// square GEMM throughput number. It does not consume Qwen3.6 model weights
+/// and must not be interpreted as a decode-path replacement.
+pub fn metal_mpp_tile_gemm_f16_tflops(size: u32, iterations: u32) -> Result<f64, GpuError> {
+    crate::metal_native::mpp_tile_gemm_f16_tflops(size, iterations)
+}
+
 #[cfg(any(supersonic_backend_hip, supersonic_backend_cuda))]
 extern "C" {
     /// Stub launch entry. Walks the descriptor array, validates field

--- a/crates/machine-profile/Cargo.toml
+++ b/crates/machine-profile/Cargo.toml
@@ -22,5 +22,8 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
 
+[build-dependencies]
+cc = "1"
+
 [dev-dependencies]
 tempfile = "3"

--- a/crates/machine-profile/build.rs
+++ b/crates/machine-profile/build.rs
@@ -4,10 +4,18 @@ use std::process::Command;
 
 fn detect_hip_archs() -> Vec<String> {
     if let Ok(arch) = env::var("HIP_ARCH") {
-        return arch.split(',').map(|s| s.trim().to_string()).filter(|s| !s.is_empty()).collect();
+        return arch
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
     }
-    let Ok(output) = Command::new("rocminfo").output() else { return Vec::new() };
-    if !output.status.success() { return Vec::new(); }
+    let Ok(output) = Command::new("rocminfo").output() else {
+        return Vec::new();
+    };
+    if !output.status.success() {
+        return Vec::new();
+    }
     let stdout = String::from_utf8_lossy(&output.stdout);
     stdout
         .split_whitespace()
@@ -17,20 +25,30 @@ fn detect_hip_archs() -> Vec<String> {
 }
 
 fn have_hipcc() -> bool {
-    Command::new("sh").arg("-lc").arg("command -v hipcc >/dev/null 2>&1")
-        .status().map(|s| s.success()).unwrap_or(false)
+    Command::new("sh")
+        .arg("-lc")
+        .arg("command -v hipcc >/dev/null 2>&1")
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
 }
 
 fn have_nvcc() -> bool {
-    Command::new("sh").arg("-lc").arg("command -v nvcc >/dev/null 2>&1")
-        .status().map(|s| s.success()).unwrap_or(false)
+    Command::new("sh")
+        .arg("-lc")
+        .arg("command -v nvcc >/dev/null 2>&1")
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
 }
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=src/gpu/metal_bridge.mm");
     println!("cargo:rerun-if-env-changed=HIP_ARCH");
     println!("cargo:rerun-if-env-changed=SUPERSONIC_BACKENDS");
     println!("cargo:rustc-check-cfg=cfg(supersonic_backend_hip)");
+    println!("cargo:rustc-check-cfg=cfg(supersonic_backend_metal)");
 
     // Mirror kernel-ffi's SUPERSONIC_BACKENDS gating exactly:
     // - explicit non-HIP selection (e.g. `cuda` or `metal`) must skip the
@@ -42,12 +60,42 @@ fn main() {
     let requested = env::var("SUPERSONIC_BACKENDS").unwrap_or_else(|_| "auto".to_string());
     let normalized = requested.trim().to_ascii_lowercase();
     let explicit_hip = normalized.split(',').any(|p| p.trim() == "hip");
+    let explicit_metal = normalized.split(',').any(|p| p.trim() == "metal");
     let auto = normalized == "auto";
+    let is_macos = env::var("CARGO_CFG_TARGET_OS")
+        .map(|os| os == "macos")
+        .unwrap_or(false);
+    let want_metal = (explicit_metal || auto) && is_macos && !explicit_hip;
+    if want_metal {
+        let have_mtl4_mpp = have_mtl4_mpp_sdk();
+        let mut metal = cc::Build::new();
+        metal
+            .cpp(true)
+            .file("src/gpu/metal_bridge.mm")
+            .flag_if_supported("-std=c++17")
+            .flag("-fobjc-arc");
+        if have_mtl4_mpp {
+            metal.define("SUPERSONIC_HAVE_MTL4_MPP", "1");
+        } else {
+            println!(
+                "cargo:warning=Metal 4 MPP tensor headers not found; MPP profile rows disabled"
+            );
+        }
+        metal.compile("machine_profile_metal");
+        println!("cargo:rustc-link-lib=framework=Foundation");
+        println!("cargo:rustc-link-lib=framework=Metal");
+        println!("cargo:rustc-link-lib=framework=MetalPerformanceShaders");
+        if have_mtl4_mpp {
+            println!("cargo:rustc-link-lib=framework=MetalPerformancePrimitives");
+        }
+        println!("cargo:rustc-cfg=supersonic_backend_metal");
+    }
+
     let want_hip = if explicit_hip {
         true
     } else if auto {
         // Auto mode: defer to CUDA when both toolchains are present.
-        !have_nvcc()
+        !want_metal && !have_nvcc()
     } else {
         false
     };
@@ -77,9 +125,13 @@ fn main() {
         let mut cmd = Command::new("hipcc");
         cmd.args(["-std=c++17", "-O3", "-fPIC", "-x", "hip", "-c"])
             .arg(kernels.join(src))
-            .args(["-I"]).arg(&kernels)
-            .arg("-o").arg(&obj_path);
-        for a in &archs { cmd.arg(format!("--offload-arch={a}")); }
+            .args(["-I"])
+            .arg(&kernels)
+            .arg("-o")
+            .arg(&obj_path);
+        for a in &archs {
+            cmd.arg(format!("--offload-arch={a}"));
+        }
         let status = cmd.status().expect("hipcc failed to start");
         assert!(status.success(), "hipcc failed for {src}");
         objects.push(obj_path);
@@ -87,7 +139,9 @@ fn main() {
     let lib = out_dir.join("libmp_profile_hip.a");
     let mut ar = Command::new("ar");
     ar.arg("crus").arg(&lib);
-    for o in &objects { ar.arg(o); }
+    for o in &objects {
+        ar.arg(o);
+    }
     ar.status().expect("ar failed");
 
     println!("cargo:rustc-link-search=native={}", out_dir.display());
@@ -95,4 +149,25 @@ fn main() {
     println!("cargo:rustc-link-lib=dylib=amdhip64");
     println!("cargo:rustc-link-lib=dylib=stdc++");
     println!("cargo:rustc-cfg=supersonic_backend_hip");
+}
+
+fn have_mtl4_mpp_sdk() -> bool {
+    let Ok(output) = Command::new("xcrun")
+        .args(["--sdk", "macosx", "--show-sdk-path"])
+        .output()
+    else {
+        return false;
+    };
+    if !output.status.success() {
+        return false;
+    }
+    let sdk = PathBuf::from(String::from_utf8_lossy(&output.stdout).trim().to_string());
+    sdk.join("System/Library/Frameworks/Metal.framework/Headers/MTL4CommandQueue.h")
+        .is_file()
+        && sdk
+            .join("System/Library/Frameworks/Metal.framework/Headers/MTLTensor.h")
+            .is_file()
+        && sdk
+            .join("System/Library/Frameworks/MetalPerformancePrimitives.framework/Headers/MetalPerformancePrimitives.h")
+            .is_file()
 }

--- a/crates/machine-profile/src/bin/machine_profile.rs
+++ b/crates/machine-profile/src/bin/machine_profile.rs
@@ -60,7 +60,9 @@ fn main() -> anyhow::Result<()> {
         }
         Cmd::ClearCache => {
             let dir = store::cache_dir();
-            if dir.exists() { std::fs::remove_dir_all(&dir)?; }
+            if dir.exists() {
+                std::fs::remove_dir_all(&dir)?;
+            }
             println!("cleared {}", dir.display());
         }
         Cmd::Catalog => {
@@ -74,19 +76,54 @@ fn pretty_print(p: &machine_profile::Profile) {
     println!("fingerprint: {}", p.fingerprint);
     println!("captured_at: {}", p.captured_at);
     if let Some(cpu) = &p.cpu {
-        println!("cpu:        {} {} ({} cores)", cpu.vendor, cpu.model, cpu.topology.cores_total);
+        println!(
+            "cpu:        {} {} ({} cores)",
+            cpu.vendor, cpu.model, cpu.topology.cores_total
+        );
         if let Some(fp32) = &cpu.vector_peak.fp32 {
-            println!("  fp32:     {:.1} GFLOPS aggregate", fp32.measured_aggregate);
+            println!(
+                "  fp32:     {:.1} GFLOPS aggregate",
+                fp32.measured_aggregate
+            );
         }
     }
     for g in &p.gpus {
-        println!("gpu[{}]:    {} {} ({} CUs, wave {})",
-            g.device_index, g.backend, g.arch_name, g.cu_count, g.wave_size);
+        println!(
+            "gpu[{}]:    {} {} ({} CUs, wave {})",
+            g.device_index, g.backend, g.arch_name, g.cu_count, g.wave_size
+        );
         if let Some(r) = g.vram_bw.read_gb_s {
             println!("  hbm read: {:.1} GB/s", r);
         }
         if let Some(m) = &g.mma_peak.bf16 {
             println!("  bf16 mma: {:.1} TFLOPS", m.measured_tflops);
+        }
+        if let Some(metal) = &g.metal {
+            if let Some(family) = &metal.metal_family {
+                println!("  metal:    {family}");
+            }
+            if let Some(supported) = metal.simdgroup_matrix_supported {
+                println!("  simd mat: {supported}");
+            }
+            if let Some(supported) = metal.mpp_tensor_matmul_supported {
+                println!("  mpp mat:  {supported}");
+            }
+            if let Some(status) = &metal.mpp_tensor_matmul_probe_status {
+                println!("  mpp probe: {status}");
+            }
+            if let Some(value) = metal.mpp_tensor_write_probe_value {
+                println!("  mpp tensor write: {value:.1}");
+            }
+            if let Some(value) = metal.mpp_tensor_matmul_probe_value {
+                println!("  mpp matmul value: {value:.1}");
+            }
+        }
+        for mk in &g.microkernels {
+            match (mk.measured_gb_s, mk.measured_tflops) {
+                (Some(gb_s), _) => println!("  {:<28} {:>8.1} GB/s", mk.name, gb_s),
+                (_, Some(tflops)) => println!("  {:<28} {:>8.1} TFLOPS", mk.name, tflops),
+                _ => {}
+            }
         }
     }
     for w in &p.warnings {

--- a/crates/machine-profile/src/cpu/identify.rs
+++ b/crates/machine-profile/src/cpu/identify.rs
@@ -14,8 +14,54 @@ pub fn detect_cpu_id() -> CpuId {
     if let Ok(text) = fs::read_to_string("/proc/cpuinfo") {
         parse_proc_cpuinfo(&text, &mut id);
     }
+    #[cfg(target_os = "macos")]
+    fill_macos_cpu_id(&mut id);
     fill_isa_from_runtime(&mut id);
     id
+}
+
+#[cfg(target_os = "macos")]
+fn fill_macos_cpu_id(id: &mut CpuId) {
+    if id.model.is_empty() {
+        id.model = sysctl_string("machdep.cpu.brand_string")
+            .or_else(|| sysctl_string("machdep.cpu.brand"))
+            .or_else(|| system_profiler_field("chip_type"))
+            .unwrap_or_else(|| "Apple Silicon".into());
+    }
+    if id.vendor.is_empty() {
+        id.vendor = "Apple".into();
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn sysctl_string(name: &str) -> Option<String> {
+    let output = std::process::Command::new("/usr/sbin/sysctl")
+        .args(["-n", name])
+        .output()
+        .ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+#[cfg(target_os = "macos")]
+fn system_profiler_field(field: &str) -> Option<String> {
+    let output = std::process::Command::new("/usr/sbin/system_profiler")
+        .args(["SPHardwareDataType", "-json"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let root: serde_json::Value = serde_json::from_slice(&output.stdout).ok()?;
+    root.get("SPHardwareDataType")?
+        .as_array()?
+        .first()?
+        .get(field)?
+        .as_str()
+        .map(str::to_string)
 }
 
 fn parse_proc_cpuinfo(text: &str, id: &mut CpuId) {
@@ -50,19 +96,35 @@ fn fill_isa_from_runtime(id: &mut CpuId) {
             id.isa.push(s.to_string());
         }
     };
-    if std::is_x86_feature_detected!("avx2") { add("AVX2"); }
-    if std::is_x86_feature_detected!("avx512f") { add("AVX-512F"); }
-    if std::is_x86_feature_detected!("avx512bf16") { add("AVX-512BF16"); }
-    if std::is_x86_feature_detected!("avxvnni") { add("AVX-VNNI"); }
+    if std::is_x86_feature_detected!("avx2") {
+        add("AVX2");
+    }
+    if std::is_x86_feature_detected!("avx512f") {
+        add("AVX-512F");
+    }
+    if std::is_x86_feature_detected!("avx512bf16") {
+        add("AVX-512BF16");
+    }
+    if std::is_x86_feature_detected!("avxvnni") {
+        add("AVX-VNNI");
+    }
     #[cfg(feature = "x86_amx_intrinsics")]
-    if std::is_x86_feature_detected!("amx-bf16") { add("AMX-BF16"); }
-    if std::is_x86_feature_detected!("fma") { add("FMA"); }
+    if std::is_x86_feature_detected!("amx-bf16") {
+        add("AMX-BF16");
+    }
+    if std::is_x86_feature_detected!("fma") {
+        add("FMA");
+    }
 }
 
 #[cfg(target_arch = "aarch64")]
 fn fill_isa_from_runtime(id: &mut CpuId) {
-    if std::arch::is_aarch64_feature_detected!("neon") { id.isa.push("NEON".into()); }
-    if std::arch::is_aarch64_feature_detected!("sve") { id.isa.push("SVE".into()); }
+    if std::arch::is_aarch64_feature_detected!("neon") {
+        id.isa.push("NEON".into());
+    }
+    if std::arch::is_aarch64_feature_detected!("sve") {
+        id.isa.push("SVE".into());
+    }
 }
 
 #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]

--- a/crates/machine-profile/src/cpu/topology.rs
+++ b/crates/machine-profile/src/cpu/topology.rs
@@ -3,7 +3,82 @@ use std::fs;
 use std::path::Path;
 
 pub fn detect() -> CpuTopology {
+    #[cfg(target_os = "macos")]
+    if let Some(t) = detect_macos() {
+        return t;
+    }
     detect_from(Path::new("/sys/devices/system"))
+}
+
+#[cfg(target_os = "macos")]
+fn detect_macos() -> Option<CpuTopology> {
+    let cores_total = sysctl_u32("hw.physicalcpu").or_else(|| sysctl_u32("hw.ncpu"))?;
+    let (p, e) = macos_core_split().unwrap_or((cores_total, 0));
+    Some(CpuTopology {
+        sockets: 1,
+        cores_total,
+        cores_p: p,
+        cores_e: e,
+        threads_per_core: 1,
+        numa_nodes: vec![NumaNode {
+            id: 0,
+            cpus: (0..cores_total).collect(),
+            ram_bytes: sysctl_u64("hw.memsize").unwrap_or(0),
+        }],
+    })
+}
+
+#[cfg(target_os = "macos")]
+fn sysctl_u32(name: &str) -> Option<u32> {
+    sysctl_string(name)?.parse().ok()
+}
+
+#[cfg(target_os = "macos")]
+fn sysctl_u64(name: &str) -> Option<u64> {
+    sysctl_string(name)?.parse().ok()
+}
+
+#[cfg(target_os = "macos")]
+fn sysctl_string(name: &str) -> Option<String> {
+    let output = std::process::Command::new("/usr/sbin/sysctl")
+        .args(["-n", name])
+        .output()
+        .ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+#[cfg(target_os = "macos")]
+fn macos_core_split() -> Option<(u32, u32)> {
+    let output = std::process::Command::new("/usr/sbin/system_profiler")
+        .args(["SPHardwareDataType", "-json"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let root: serde_json::Value = serde_json::from_slice(&output.stdout).ok()?;
+    let number = root
+        .get("SPHardwareDataType")?
+        .as_array()?
+        .first()?
+        .get("number_processors")?
+        .as_str()?;
+    // Example: "proc 18:6:0:12" => total 18, performance 6, efficiency 12.
+    let fields: Vec<u32> = number
+        .split_whitespace()
+        .last()?
+        .split(':')
+        .filter_map(|s| s.parse().ok())
+        .collect();
+    if fields.len() >= 4 {
+        Some((fields[1], fields[3]))
+    } else {
+        None
+    }
 }
 
 pub fn detect_from(sys_root: &Path) -> CpuTopology {
@@ -16,18 +91,15 @@ pub fn detect_from(sys_root: &Path) -> CpuTopology {
     let mut threads_per_core_count = std::collections::HashMap::<(u32, u32), u32>::new();
 
     for &cpu in &online_cpus {
-        let socket = read_u32(&cpu_root.join(format!("cpu{cpu}/topology/physical_package_id"))).unwrap_or(0);
+        let socket =
+            read_u32(&cpu_root.join(format!("cpu{cpu}/topology/physical_package_id"))).unwrap_or(0);
         let core_id = read_u32(&cpu_root.join(format!("cpu{cpu}/topology/core_id"))).unwrap_or(cpu);
         socket_set.insert(socket);
         core_set.insert((socket, core_id));
         *threads_per_core_count.entry((socket, core_id)).or_insert(0) += 1;
     }
 
-    let threads_per_core = threads_per_core_count
-        .values()
-        .max()
-        .copied()
-        .unwrap_or(1);
+    let threads_per_core = threads_per_core_count.values().max().copied().unwrap_or(1);
 
     let numa_nodes = detect_numa(&sys_root.join("node"));
 
@@ -43,15 +115,25 @@ pub fn detect_from(sys_root: &Path) -> CpuTopology {
 
 fn detect_numa(node_root: &Path) -> Vec<NumaNode> {
     let mut nodes = Vec::new();
-    let Ok(entries) = fs::read_dir(node_root) else { return nodes };
+    let Ok(entries) = fs::read_dir(node_root) else {
+        return nodes;
+    };
     for entry in entries.flatten() {
         let name = entry.file_name();
         let s = name.to_string_lossy();
-        if !s.starts_with("node") { continue; }
-        let Ok(id) = s.trim_start_matches("node").parse::<u32>() else { continue };
+        if !s.starts_with("node") {
+            continue;
+        }
+        let Ok(id) = s.trim_start_matches("node").parse::<u32>() else {
+            continue;
+        };
         let cpus = read_cpu_list(&entry.path().join("cpulist")).unwrap_or_default();
         let ram_bytes = read_meminfo_total(&entry.path().join("meminfo")).unwrap_or(0);
-        nodes.push(NumaNode { id, cpus, ram_bytes });
+        nodes.push(NumaNode {
+            id,
+            cpus,
+            ram_bytes,
+        });
     }
     nodes.sort_by_key(|n| n.id);
     nodes
@@ -61,11 +143,15 @@ fn read_cpu_list(path: &Path) -> Option<Vec<u32>> {
     let s = fs::read_to_string(path).ok()?;
     let mut out = Vec::new();
     for chunk in s.trim().split(',') {
-        if chunk.is_empty() { continue; }
+        if chunk.is_empty() {
+            continue;
+        }
         if let Some((a, b)) = chunk.split_once('-') {
             let a: u32 = a.parse().ok()?;
             let b: u32 = b.parse().ok()?;
-            for i in a..=b { out.push(i); }
+            for i in a..=b {
+                out.push(i);
+            }
         } else if let Ok(v) = chunk.parse::<u32>() {
             out.push(v);
         }

--- a/crates/machine-profile/src/gpu/hip.rs
+++ b/crates/machine-profile/src/gpu/hip.rs
@@ -15,10 +15,9 @@ impl GpuProfiler for HipProfiler {
         // gpu-hal currently exposes a single device. If multi-device support
         // lands, iterate here.
         for device_index in 0..1u32 {
-            set_device(device_index as usize)
-                .map_err(|e| GpuProfileError::Hip(e.to_string()))?;
-            let info = query_device_info_hip(device_index as i32)
-                .map_err(|e| GpuProfileError::Hip(e))?;
+            set_device(device_index as usize).map_err(|e| GpuProfileError::Hip(e.to_string()))?;
+            let info =
+                query_device_info_hip(device_index as i32).map_err(|e| GpuProfileError::Hip(e))?;
             out.push(profile_one(device_index, &info));
         }
         Ok(out)
@@ -62,7 +61,10 @@ pub(crate) fn query_device_info_hip(device: i32) -> Result<HipDeviceInfo, String
     if status != 0 {
         return Err(format!("mp_query_device_info returned {status}"));
     }
-    let nul = arch_buf.iter().position(|&b| b == 0).unwrap_or(arch_buf.len());
+    let nul = arch_buf
+        .iter()
+        .position(|&b| b == 0)
+        .unwrap_or(arch_buf.len());
     let arch_name = String::from_utf8_lossy(&arch_buf[..nul]).to_string();
     Ok(HipDeviceInfo {
         arch_name,
@@ -96,8 +98,7 @@ pub(crate) fn enumerate_for_fingerprint() -> Result<Vec<HipDeviceInfo>, super::G
 
 fn profile_one(device_index: u32, info: &HipDeviceInfo) -> GpuProfile {
     let cu_count = info.cu_count.max(1);
-    let lds_aggregate =
-        unsafe { mp_lds_bandwidth_run(device_index as i32, cu_count, 1_000_000) };
+    let lds_aggregate = unsafe { mp_lds_bandwidth_run(device_index as i32, cu_count, 1_000_000) };
     let read = unsafe { mp_hbm_bandwidth_read(device_index as i32, 1u64 << 28) };
     let write = unsafe { mp_hbm_bandwidth_write(device_index as i32, 1u64 << 28) };
     let copy = unsafe { mp_hbm_bandwidth_copy(device_index as i32, 1u64 << 28) };
@@ -108,8 +109,7 @@ fn profile_one(device_index: u32, info: &HipDeviceInfo) -> GpuProfile {
     // On unsupported (or unprobeable) archs we leave MMA fields as None
     // rather than reporting fake numbers from launch-overhead-only runs.
     let mut wmma_flags = [0i32; 3];
-    let probe_status =
-        unsafe { mp_wmma_probe(device_index as i32, wmma_flags.as_mut_ptr()) };
+    let probe_status = unsafe { mp_wmma_probe(device_index as i32, wmma_flags.as_mut_ptr()) };
     let probe_ok = probe_status == 0;
     let f16 = if probe_ok && wmma_flags[0] == 1 {
         Some(unsafe { mp_wmma_peak_f16(device_index as i32, cu_count, 100_000) })
@@ -127,14 +127,24 @@ fn profile_one(device_index: u32, info: &HipDeviceInfo) -> GpuProfile {
         None
     };
 
-    let mut h2d = vec![MpTransferSample { bytes: 0, gb_s: 0.0 }; 16];
-    let n_h2d =
-        unsafe { mp_pcie_h2d(device_index as i32, h2d.as_mut_ptr(), h2d.len() as i32) };
+    let mut h2d = vec![
+        MpTransferSample {
+            bytes: 0,
+            gb_s: 0.0
+        };
+        16
+    ];
+    let n_h2d = unsafe { mp_pcie_h2d(device_index as i32, h2d.as_mut_ptr(), h2d.len() as i32) };
     h2d.truncate(n_h2d.max(0) as usize);
 
-    let mut d2h = vec![MpTransferSample { bytes: 0, gb_s: 0.0 }; 16];
-    let n_d2h =
-        unsafe { mp_pcie_d2h(device_index as i32, d2h.as_mut_ptr(), d2h.len() as i32) };
+    let mut d2h = vec![
+        MpTransferSample {
+            bytes: 0,
+            gb_s: 0.0
+        };
+        16
+    ];
+    let n_d2h = unsafe { mp_pcie_d2h(device_index as i32, d2h.as_mut_ptr(), d2h.len() as i32) };
     d2h.truncate(n_d2h.max(0) as usize);
 
     let duplex = unsafe { mp_pcie_duplex(device_index as i32, 1u64 << 27) };
@@ -145,7 +155,12 @@ fn profile_one(device_index: u32, info: &HipDeviceInfo) -> GpuProfile {
         arch_name: info.arch_name.clone(),
         pci_id: Some(format!("0x{:04x}", info.pci_device_id)),
         uuid: None,
-        memory_arch: if info.integrated { "Unified" } else { "Discrete" }.into(),
+        memory_arch: if info.integrated {
+            "Unified"
+        } else {
+            "Discrete"
+        }
+        .into(),
         total_vram_bytes: info.total_vram_bytes,
         cu_count,
         wave_size: info.warp_size,
@@ -196,6 +211,7 @@ fn profile_one(device_index: u32, info: &HipDeviceInfo) -> GpuProfile {
             duplex_gb_s: Some(duplex),
         },
         clock_rate_khz_measured: Some(info.clock_rate_khz),
+        metal: None,
+        microkernels: Vec::new(),
     }
 }
-

--- a/crates/machine-profile/src/gpu/metal.rs
+++ b/crates/machine-profile/src/gpu/metal.rs
@@ -1,9 +1,497 @@
 use crate::gpu::GpuProfileError;
-use crate::schema::GpuProfile;
+use crate::schema::*;
 
 pub struct MetalProfiler;
 impl crate::gpu::GpuProfiler for MetalProfiler {
     fn profile(&self) -> Result<Vec<GpuProfile>, GpuProfileError> {
-        Err(GpuProfileError::NotImplemented("Metal"))
+        profile()
     }
+}
+
+#[cfg(supersonic_backend_metal)]
+mod ffi {
+    use std::ffi::{c_char, c_int};
+
+    #[repr(C)]
+    #[derive(Debug, Clone, Copy)]
+    pub struct MpMetalDeviceInfo {
+        pub total_vram_bytes: u64,
+        pub recommended_working_set_bytes: u64,
+        pub core_count: u32,
+        pub wave_size: u32,
+        pub max_threadgroup_memory_bytes: u64,
+        pub max_threads_per_threadgroup: u64,
+    }
+
+    #[repr(C)]
+    #[derive(Debug, Clone, Copy)]
+    pub struct MpMetalMppProbeInfo {
+        pub status: i32,
+        pub tensor_write_value: f32,
+        pub matmul_value: f32,
+    }
+
+    unsafe extern "C" {
+        pub fn mp_metal_query_device_info(
+            arch_name_out: *mut c_char,
+            arch_name_len: usize,
+            device_name_out: *mut c_char,
+            device_name_len: usize,
+            family_out: *mut c_char,
+            family_len: usize,
+            info_out: *mut MpMetalDeviceInfo,
+        ) -> c_int;
+        pub fn mp_metal_unified_read_gb_s(bytes: u64) -> f64;
+        pub fn mp_metal_unified_write_gb_s(bytes: u64) -> f64;
+        pub fn mp_metal_unified_copy_gb_s(bytes: u64) -> f64;
+        pub fn mp_metal_threadgroup_gb_s(core_count: u32, iterations: u32) -> f64;
+        pub fn mp_metal_simdgroup_matrix_probe() -> c_int;
+        pub fn mp_metal_mpp_tensor_matmul_probe_detail(
+            info_out: *mut MpMetalMppProbeInfo,
+            status_out: *mut c_char,
+            status_len: usize,
+        ) -> c_int;
+        pub fn mp_metal_simdgroup_mma_f16_tflops(
+            core_count: u32,
+            threadgroups_per_core: u32,
+            iterations: u32,
+        ) -> f64;
+        pub fn mp_metal_simdgroup_mma_f16_accum_f16_tflops(
+            core_count: u32,
+            threadgroups_per_core: u32,
+            iterations: u32,
+        ) -> f64;
+        pub fn mp_metal_simdgroup_mma_f16_sweep_tflops(
+            core_count: u32,
+            threadgroups_per_core: u32,
+            simdgroups_per_threadgroup: u32,
+            accumulators: u32,
+            iterations: u32,
+            f16_accum: u32,
+        ) -> f64;
+        pub fn mp_metal_simdgroup_gemm_f16_tflops(
+            size: u32,
+            iterations: u32,
+            simdgroups_per_threadgroup: u32,
+        ) -> f64;
+        pub fn mp_metal_mpp_tensor_gemm_f16_tflops(size: u32, iterations: u32) -> f64;
+        pub fn mp_metal_mps_gemm_f16_tflops(size: u32, iterations: u32) -> f64;
+        pub fn mp_metal_int4_gemv_gb_s(
+            in_dim: u32,
+            out_dim: u32,
+            group_size: u32,
+            iterations: u32,
+        ) -> f64;
+    }
+}
+
+#[cfg(supersonic_backend_metal)]
+#[derive(Debug, Clone)]
+pub(crate) struct MetalDeviceInfo {
+    pub arch_name: String,
+    pub device_name: String,
+    pub metal_family: String,
+    pub total_vram_bytes: u64,
+    pub recommended_working_set_bytes: u64,
+    pub core_count: u32,
+    pub wave_size: u32,
+    pub max_threadgroup_memory_bytes: u64,
+    pub max_threads_per_threadgroup: u64,
+}
+
+#[cfg(supersonic_backend_metal)]
+pub(crate) fn enumerate_for_fingerprint() -> Result<Vec<MetalDeviceInfo>, GpuProfileError> {
+    query_device_info().map(|info| vec![info])
+}
+
+#[cfg(supersonic_backend_metal)]
+fn query_device_info() -> Result<MetalDeviceInfo, GpuProfileError> {
+    let mut arch = [0i8; 128];
+    let mut device = [0i8; 128];
+    let mut family = [0i8; 128];
+    let mut info = ffi::MpMetalDeviceInfo {
+        total_vram_bytes: 0,
+        recommended_working_set_bytes: 0,
+        core_count: 0,
+        wave_size: 0,
+        max_threadgroup_memory_bytes: 0,
+        max_threads_per_threadgroup: 0,
+    };
+    let status = unsafe {
+        ffi::mp_metal_query_device_info(
+            arch.as_mut_ptr(),
+            arch.len(),
+            device.as_mut_ptr(),
+            device.len(),
+            family.as_mut_ptr(),
+            family.len(),
+            &mut info,
+        )
+    };
+    if status != 0 {
+        return Err(GpuProfileError::Metal(format!(
+            "mp_metal_query_device_info returned {status}"
+        )));
+    }
+
+    Ok(MetalDeviceInfo {
+        arch_name: c_buf_to_string(&arch),
+        device_name: c_buf_to_string(&device),
+        metal_family: c_buf_to_string(&family),
+        total_vram_bytes: info.total_vram_bytes,
+        recommended_working_set_bytes: info.recommended_working_set_bytes,
+        core_count: info.core_count,
+        wave_size: info.wave_size,
+        max_threadgroup_memory_bytes: info.max_threadgroup_memory_bytes,
+        max_threads_per_threadgroup: info.max_threads_per_threadgroup,
+    })
+}
+
+#[cfg(supersonic_backend_metal)]
+fn c_buf_to_string(buf: &[i8]) -> String {
+    let nul = buf.iter().position(|&c| c == 0).unwrap_or(buf.len());
+    String::from_utf8_lossy(&buf[..nul].iter().map(|&c| c as u8).collect::<Vec<_>>()).to_string()
+}
+
+#[cfg(supersonic_backend_metal)]
+fn profile() -> Result<Vec<GpuProfile>, GpuProfileError> {
+    let info = query_device_info()?;
+    let core_count = info.core_count.max(1);
+    let bytes = 64u64 << 20;
+    let read = positive(unsafe { ffi::mp_metal_unified_read_gb_s(bytes) });
+    let write = positive(unsafe { ffi::mp_metal_unified_write_gb_s(bytes) });
+    let copy = positive(unsafe { ffi::mp_metal_unified_copy_gb_s(bytes) });
+    let threadgroup = positive(unsafe { ffi::mp_metal_threadgroup_gb_s(core_count, 4096) });
+    let simd_probe = unsafe { ffi::mp_metal_simdgroup_matrix_probe() } == 0;
+    let mut mpp_probe_info = ffi::MpMetalMppProbeInfo {
+        status: 0,
+        tensor_write_value: 0.0,
+        matmul_value: 0.0,
+    };
+    let mut mpp_probe_status = [0i8; 128];
+    let mpp_probe_code = unsafe {
+        ffi::mp_metal_mpp_tensor_matmul_probe_detail(
+            &mut mpp_probe_info,
+            mpp_probe_status.as_mut_ptr(),
+            mpp_probe_status.len(),
+        )
+    };
+    let mpp_probe = mpp_probe_code == 0;
+    let mma_threadgroups_per_core = 256;
+    let mma_iterations = 4096;
+    let f16_mma = simd_probe
+        .then(|| {
+            positive(unsafe {
+                ffi::mp_metal_simdgroup_mma_f16_tflops(
+                    core_count,
+                    mma_threadgroups_per_core,
+                    mma_iterations,
+                )
+            })
+        })
+        .flatten();
+    let f16_accum_f16_mma = simd_probe
+        .then(|| {
+            positive(unsafe {
+                ffi::mp_metal_simdgroup_mma_f16_accum_f16_tflops(
+                    core_count,
+                    mma_threadgroups_per_core,
+                    mma_iterations,
+                )
+            })
+        })
+        .flatten();
+    let sweep_iterations = 4096;
+    let sweep_configs = [
+        ("f32acc.tgpc128.sg8.acc16", 128, 8, 16, false),
+        ("f32acc.tgpc256.sg8.acc16", 256, 8, 16, false),
+        ("f32acc.tgpc256.sg16.acc16", 256, 16, 16, false),
+        ("f32acc.tgpc256.sg32.acc16", 256, 32, 16, false),
+        ("f32acc.tgpc512.sg16.acc16", 512, 16, 16, false),
+        ("f32acc.tgpc512.sg32.acc16", 512, 32, 16, false),
+        ("f32acc.tgpc256.sg16.acc8", 256, 16, 8, false),
+        ("f32acc.tgpc256.sg16.acc24", 256, 16, 24, false),
+        ("f32acc.tgpc256.sg16.acc32", 256, 16, 32, false),
+        ("f16acc.tgpc256.sg16.acc16", 256, 16, 16, true),
+        ("f16acc.tgpc256.sg32.acc16", 256, 32, 16, true),
+    ];
+    let simd_sweep = if simd_probe {
+        sweep_configs
+            .into_iter()
+            .map(|(label, tgpc, sgtg, acc, f16_accum)| {
+                let tflops = positive(unsafe {
+                    ffi::mp_metal_simdgroup_mma_f16_sweep_tflops(
+                        core_count,
+                        tgpc,
+                        sgtg,
+                        acc,
+                        sweep_iterations,
+                        u32::from(f16_accum),
+                    )
+                });
+                (label, tgpc, sgtg, acc, f16_accum, tflops)
+            })
+            .collect::<Vec<_>>()
+    } else {
+        Vec::new()
+    };
+    let mps_gemm_size = 4096;
+    let mps_gemm_iterations = 3;
+    let simd_gemm_size = 2048;
+    let simd_gemm_iterations = 2;
+    let simd_gemm_configs = [8u32, 16, 32];
+    let simd_gemm = if simd_probe {
+        simd_gemm_configs
+            .into_iter()
+            .map(|simdgroups_per_threadgroup| {
+                let tflops = positive(unsafe {
+                    ffi::mp_metal_simdgroup_gemm_f16_tflops(
+                        simd_gemm_size,
+                        simd_gemm_iterations,
+                        simdgroups_per_threadgroup,
+                    )
+                });
+                (simdgroups_per_threadgroup, tflops)
+            })
+            .collect::<Vec<_>>()
+    } else {
+        Vec::new()
+    };
+    let mps_gemm_2048_f16 = positive(unsafe {
+        ffi::mp_metal_mps_gemm_f16_tflops(simd_gemm_size, simd_gemm_iterations)
+    });
+    let mpp_tensor_gemm_2048_f16 = if mpp_probe {
+        positive(unsafe {
+            ffi::mp_metal_mpp_tensor_gemm_f16_tflops(simd_gemm_size, simd_gemm_iterations)
+        })
+    } else {
+        None
+    };
+    let mpp_tensor_gemm_4096_f16 = if mpp_probe {
+        positive(unsafe { ffi::mp_metal_mpp_tensor_gemm_f16_tflops(mps_gemm_size, 1) })
+    } else {
+        None
+    };
+    let mps_gemm_f16 =
+        positive(unsafe { ffi::mp_metal_mps_gemm_f16_tflops(mps_gemm_size, mps_gemm_iterations) });
+    let best_sweep_f16 = simd_sweep
+        .iter()
+        .filter_map(|(_, _, _, _, _, tflops)| *tflops)
+        .reduce(f64::max);
+    let best_simd_gemm_f16 = simd_gemm
+        .iter()
+        .filter_map(|(_, tflops)| *tflops)
+        .reduce(f64::max);
+    let best_f16_mma = [
+        f16_mma,
+        f16_accum_f16_mma,
+        best_sweep_f16,
+        best_simd_gemm_f16,
+        mpp_tensor_gemm_2048_f16,
+        mpp_tensor_gemm_4096_f16,
+        mps_gemm_2048_f16,
+        mps_gemm_f16,
+    ]
+    .into_iter()
+    .flatten()
+    .reduce(f64::max);
+
+    let mut microkernels = Vec::new();
+    microkernels.push(MicroKernelMeasurement {
+        name: "metal.unified_read".into(),
+        dtype: None,
+        shape: Some(format!("{bytes} bytes")),
+        measured_gb_s: read,
+        measured_tflops: None,
+        iterations: 1,
+    });
+    microkernels.push(MicroKernelMeasurement {
+        name: "metal.unified_write".into(),
+        dtype: None,
+        shape: Some(format!("{bytes} bytes")),
+        measured_gb_s: write,
+        measured_tflops: None,
+        iterations: 1,
+    });
+    microkernels.push(MicroKernelMeasurement {
+        name: "metal.unified_copy".into(),
+        dtype: None,
+        shape: Some(format!("{bytes} bytes")),
+        measured_gb_s: copy,
+        measured_tflops: None,
+        iterations: 1,
+    });
+    microkernels.push(MicroKernelMeasurement {
+        name: "metal.threadgroup_rw".into(),
+        dtype: None,
+        shape: Some(format!("{core_count} gpu cores")),
+        measured_gb_s: threadgroup,
+        measured_tflops: None,
+        iterations: 4096,
+    });
+    microkernels.push(MicroKernelMeasurement {
+        name: "metal.simdgroup_mma_f16_f32acc".into(),
+        dtype: Some("f16*f16->f32".into()),
+        shape: Some(format!(
+            "8x8x8, {} threadgroups/core",
+            mma_threadgroups_per_core
+        )),
+        measured_gb_s: None,
+        measured_tflops: f16_mma,
+        iterations: mma_iterations as u64,
+    });
+    microkernels.push(MicroKernelMeasurement {
+        name: "metal.simdgroup_mma_f16_f16acc".into(),
+        dtype: Some("f16*f16->f16".into()),
+        shape: Some(format!(
+            "8x8x8, {} threadgroups/core",
+            mma_threadgroups_per_core
+        )),
+        measured_gb_s: None,
+        measured_tflops: f16_accum_f16_mma,
+        iterations: mma_iterations as u64,
+    });
+    for (label, tgpc, sgtg, acc, f16_accum, tflops) in simd_sweep {
+        microkernels.push(MicroKernelMeasurement {
+            name: format!("metal.simdgroup_mma_f16_sweep.{label}"),
+            dtype: Some(if f16_accum {
+                "f16*f16->f16".into()
+            } else {
+                "f16*f16->f32".into()
+            }),
+            shape: Some(format!(
+                "8x8x8, threadgroups/core={tgpc}, simdgroups/threadgroup={sgtg}, accumulators={acc}"
+            )),
+            measured_gb_s: None,
+            measured_tflops: tflops,
+            iterations: sweep_iterations as u64,
+        });
+    }
+    for (simdgroups_per_threadgroup, tflops) in simd_gemm {
+        microkernels.push(MicroKernelMeasurement {
+            name: format!("metal.simdgroup_gemm_f16_f32acc.sg{simdgroups_per_threadgroup}"),
+            dtype: Some("f16*f16->f32".into()),
+            shape: Some(format!(
+                "{simd_gemm_size}x{simd_gemm_size}x{simd_gemm_size}, 8x8 output tile, simdgroups/threadgroup={simdgroups_per_threadgroup}"
+            )),
+            measured_gb_s: None,
+            measured_tflops: tflops,
+            iterations: simd_gemm_iterations as u64,
+        });
+    }
+    microkernels.push(MicroKernelMeasurement {
+        name: "metal.mps_gemm_f16_2048".into(),
+        dtype: Some("f16".into()),
+        shape: Some(format!(
+            "{simd_gemm_size}x{simd_gemm_size}x{simd_gemm_size}"
+        )),
+        measured_gb_s: None,
+        measured_tflops: mps_gemm_2048_f16,
+        iterations: simd_gemm_iterations as u64,
+    });
+    microkernels.push(MicroKernelMeasurement {
+        name: "metal.mpp_tensor_gemm_f16_2048".into(),
+        dtype: Some("f16*f16->f32".into()),
+        shape: Some(format!(
+            "{simd_gemm_size}x{simd_gemm_size}x{simd_gemm_size} equivalent, repeated 64x32x64 MPP tiles"
+        )),
+        measured_gb_s: None,
+        measured_tflops: mpp_tensor_gemm_2048_f16,
+        iterations: simd_gemm_iterations as u64,
+    });
+    microkernels.push(MicroKernelMeasurement {
+        name: "metal.mpp_tensor_gemm_f16_4096".into(),
+        dtype: Some("f16*f16->f32".into()),
+        shape: Some(format!(
+            "{mps_gemm_size}x{mps_gemm_size}x{mps_gemm_size} equivalent, repeated 64x32x64 MPP tiles"
+        )),
+        measured_gb_s: None,
+        measured_tflops: mpp_tensor_gemm_4096_f16,
+        iterations: 1,
+    });
+    microkernels.push(MicroKernelMeasurement {
+        name: "metal.mps_gemm_f16".into(),
+        dtype: Some("f16".into()),
+        shape: Some(format!("{mps_gemm_size}x{mps_gemm_size}x{mps_gemm_size}")),
+        measured_gb_s: None,
+        measured_tflops: mps_gemm_f16,
+        iterations: mps_gemm_iterations as u64,
+    });
+    for (name, in_dim, out_dim, iters) in [
+        ("qwen36.int4_gemv.hidden_to_experts", 2048, 256 * 1024, 1),
+        ("qwen36.int4_gemv.expert_down_topk8", 512, 2048 * 8, 16),
+        ("qwen36.int4_gemv.lm_head", 2048, 248_320, 1),
+    ] {
+        let gb_s = positive(unsafe { ffi::mp_metal_int4_gemv_gb_s(in_dim, out_dim, 128, iters) });
+        microkernels.push(MicroKernelMeasurement {
+            name: name.into(),
+            dtype: Some("int4->bf16".into()),
+            shape: Some(format!("in={in_dim}, out={out_dim}, group=128")),
+            measured_gb_s: gb_s,
+            measured_tflops: None,
+            iterations: iters as u64,
+        });
+    }
+
+    Ok(vec![GpuProfile {
+        backend: "Metal".into(),
+        device_index: 0,
+        arch_name: info.arch_name.clone(),
+        pci_id: None,
+        uuid: None,
+        memory_arch: "Unified".into(),
+        total_vram_bytes: info.total_vram_bytes,
+        cu_count: core_count,
+        wave_size: info.wave_size.max(32),
+        lds_per_cu_bytes: info.max_threadgroup_memory_bytes,
+        lds_bw_per_cu_gb_s: threadgroup.map(|x| x / core_count as f64),
+        lds_bw_aggregate_gb_s: threadgroup,
+        vram_bw: VramBandwidth {
+            read_gb_s: read,
+            write_gb_s: write,
+            copy_gb_s: copy,
+            theoretical_peak_gb_s: None,
+            ratio_read: None,
+        },
+        mma_peak: MmaPeak {
+            f16: best_f16_mma.map(|measured_tflops| MmaMeasurement {
+                measured_tflops,
+                theoretical_tflops: None,
+                ratio: None,
+            }),
+            ..MmaPeak::default()
+        },
+        pcie: PcieProfile::default(),
+        clock_rate_khz_measured: None,
+        metal: Some(MetalProfile {
+            device_name: Some(info.device_name),
+            metal_family: Some(info.metal_family),
+            gpu_core_count_source: Some("system_profiler SPDisplaysDataType".into()),
+            max_threadgroup_memory_bytes: Some(info.max_threadgroup_memory_bytes),
+            max_threads_per_threadgroup: Some(info.max_threads_per_threadgroup),
+            recommended_working_set_bytes: Some(info.recommended_working_set_bytes),
+            simdgroup_matrix_supported: Some(simd_probe),
+            mpp_tensor_matmul_supported: Some(mpp_probe),
+            mpp_tensor_matmul_probe_status: Some(c_buf_to_string(&mpp_probe_status)),
+            mpp_tensor_matmul_probe_code: Some(mpp_probe_info.status),
+            mpp_tensor_write_probe_value: finite_f32(mpp_probe_info.tensor_write_value),
+            mpp_tensor_matmul_probe_value: finite_f32(mpp_probe_info.matmul_value),
+        }),
+        microkernels,
+    }])
+}
+
+#[cfg(not(supersonic_backend_metal))]
+fn profile() -> Result<Vec<GpuProfile>, GpuProfileError> {
+    Err(GpuProfileError::NotImplemented("Metal"))
+}
+
+#[cfg(supersonic_backend_metal)]
+fn positive(v: f64) -> Option<f64> {
+    (v.is_finite() && v > 0.0).then_some(v)
+}
+
+#[cfg(supersonic_backend_metal)]
+fn finite_f32(v: f32) -> Option<f32> {
+    v.is_finite().then_some(v)
 }

--- a/crates/machine-profile/src/gpu/metal_bridge.mm
+++ b/crates/machine-profile/src/gpu/metal_bridge.mm
@@ -1,0 +1,1243 @@
+#import <Foundation/Foundation.h>
+#import <Metal/Metal.h>
+#import <MetalPerformanceShaders/MetalPerformanceShaders.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstring>
+#include <stdint.h>
+#include <string>
+
+namespace {
+
+struct MpMetalDeviceInfo {
+    uint64_t total_vram_bytes;
+    uint64_t recommended_working_set_bytes;
+    uint32_t core_count;
+    uint32_t wave_size;
+    uint64_t max_threadgroup_memory_bytes;
+    uint64_t max_threads_per_threadgroup;
+};
+
+struct MpMetalMppProbeInfo {
+    int32_t status;
+    float tensor_write_value;
+    float matmul_value;
+};
+
+id<MTLDevice> metal_device() {
+    static id<MTLDevice> device = MTLCreateSystemDefaultDevice();
+    return device;
+}
+
+id<MTLCommandQueue> metal_queue() {
+    static id<MTLCommandQueue> queue = [metal_device() newCommandQueue];
+    return queue;
+}
+
+std::string normalized_arch_name(id<MTLDevice> device) {
+    NSString* name = device ? device.name : nil;
+    if (name == nil) {
+        return "apple-gpu";
+    }
+    NSString* lowered = [[name lowercaseString] stringByReplacingOccurrencesOfString:@" " withString:@"-"];
+    return std::string([lowered UTF8String]);
+}
+
+void copy_cstr(const std::string& src, char* out, size_t out_len) {
+    if (out == nullptr || out_len == 0) {
+        return;
+    }
+    const size_t n = std::min(out_len - 1, src.size());
+    memcpy(out, src.data(), n);
+    out[n] = '\0';
+}
+
+NSDictionary* system_profiler_gpu_entry() {
+    @autoreleasepool {
+        NSTask* task = [[NSTask alloc] init];
+        task.executableURL = [NSURL fileURLWithPath:@"/usr/sbin/system_profiler"];
+        task.arguments = @[ @"SPDisplaysDataType", @"-json" ];
+        NSPipe* pipe = [NSPipe pipe];
+        task.standardOutput = pipe;
+        task.standardError = [NSPipe pipe];
+        NSError* launch_error = nil;
+        if (![task launchAndReturnError:&launch_error]) {
+            return nil;
+        }
+        [task waitUntilExit];
+        if (task.terminationStatus != 0) {
+            return nil;
+        }
+        NSData* data = [[pipe fileHandleForReading] readDataToEndOfFile];
+        if (data.length == 0) {
+            return nil;
+        }
+        NSError* json_error = nil;
+        NSDictionary* root = [NSJSONSerialization JSONObjectWithData:data options:0 error:&json_error];
+        if (![root isKindOfClass:[NSDictionary class]]) {
+            return nil;
+        }
+        NSArray* displays = root[@"SPDisplaysDataType"];
+        if (![displays isKindOfClass:[NSArray class]]) {
+            return nil;
+        }
+        for (NSDictionary* entry in displays) {
+            NSString* type = entry[@"sppci_device_type"];
+            if ([type isKindOfClass:[NSString class]] && [type containsString:@"gpu"]) {
+                return entry;
+            }
+        }
+        return nil;
+    }
+}
+
+uint32_t system_profiler_gpu_cores(NSDictionary* entry) {
+    NSString* cores = entry[@"sppci_cores"];
+    if ([cores isKindOfClass:[NSString class]]) {
+        return static_cast<uint32_t>(cores.intValue);
+    }
+    NSNumber* n = entry[@"sppci_cores"];
+    if ([n isKindOfClass:[NSNumber class]]) {
+        return static_cast<uint32_t>(n.unsignedIntValue);
+    }
+    return 0;
+}
+
+std::string system_profiler_metal_support(NSDictionary* entry) {
+    NSString* support = entry[@"spdisplays_mtlgpufamilysupport"];
+    if (![support isKindOfClass:[NSString class]]) {
+        return "Apple GPU Family";
+    }
+    if ([support isEqualToString:@"spdisplays_metal4"]) {
+        return "Metal 4";
+    }
+    return std::string([support UTF8String]);
+}
+
+id<MTLComputePipelineState> pipeline_from_source(NSString* source, NSString* name) {
+    NSError* error = nil;
+    MTLCompileOptions* options = [[MTLCompileOptions alloc] init];
+#if SUPERSONIC_HAVE_MTL4_MPP
+    options.languageVersion = MTLLanguageVersion4_0;
+#endif
+    id<MTLLibrary> library = [metal_device() newLibraryWithSource:source options:options error:&error];
+    if (library == nil || error != nil) {
+        if (NSProcessInfo.processInfo.environment[@"SUPERSONIC_METAL_PROFILE_DEBUG"] != nil) {
+            NSLog(@"machine-profile Metal compile failed for %@: %@", name, error);
+        }
+        return nil;
+    }
+    id<MTLFunction> function = [library newFunctionWithName:name];
+    if (function == nil) {
+        if (NSProcessInfo.processInfo.environment[@"SUPERSONIC_METAL_PROFILE_DEBUG"] != nil) {
+            NSLog(@"machine-profile Metal function %@ not found", name);
+        }
+        return nil;
+    }
+    id<MTLComputePipelineState> pipeline = [metal_device() newComputePipelineStateWithFunction:function error:&error];
+    if (pipeline == nil && NSProcessInfo.processInfo.environment[@"SUPERSONIC_METAL_PROFILE_DEBUG"] != nil) {
+        NSLog(@"machine-profile Metal pipeline failed for %@: %@", name, error);
+    }
+    return pipeline;
+}
+
+#if SUPERSONIC_HAVE_MTL4_MPP
+id<MTLComputePipelineState> mtl4_pipeline_from_source(
+    NSString* source,
+    NSString* name,
+    NSUInteger threads_per_threadgroup
+) {
+    NSError* error = nil;
+    MTLCompileOptions* options = [[MTLCompileOptions alloc] init];
+    options.languageVersion = MTLLanguageVersion4_0;
+    id<MTLLibrary> library = [metal_device() newLibraryWithSource:source options:options error:&error];
+    if (library == nil || error != nil) {
+        if (NSProcessInfo.processInfo.environment[@"SUPERSONIC_METAL_PROFILE_DEBUG"] != nil) {
+            NSLog(@"machine-profile Metal4 compile failed for %@: %@", name, error);
+        }
+        return nil;
+    }
+    MTL4LibraryFunctionDescriptor* function_desc = [[MTL4LibraryFunctionDescriptor alloc] init];
+    function_desc.name = name;
+    function_desc.library = library;
+
+    MTL4ComputePipelineDescriptor* pipeline_desc = [[MTL4ComputePipelineDescriptor alloc] init];
+    pipeline_desc.computeFunctionDescriptor = function_desc;
+    pipeline_desc.maxTotalThreadsPerThreadgroup = threads_per_threadgroup;
+    pipeline_desc.requiredThreadsPerThreadgroup = MTLSizeMake(threads_per_threadgroup, 1, 1);
+
+    MTL4CompilerDescriptor* compiler_desc = [[MTL4CompilerDescriptor alloc] init];
+    id<MTL4Compiler> compiler = [metal_device() newCompilerWithDescriptor:compiler_desc error:&error];
+    if (compiler == nil || error != nil) {
+        if (NSProcessInfo.processInfo.environment[@"SUPERSONIC_METAL_PROFILE_DEBUG"] != nil) {
+            NSLog(@"machine-profile Metal4 compiler failed for %@: %@", name, error);
+        }
+        return nil;
+    }
+    id<MTLComputePipelineState> pipeline =
+        [compiler newComputePipelineStateWithDescriptor:pipeline_desc compilerTaskOptions:nil error:&error];
+    if (pipeline == nil && NSProcessInfo.processInfo.environment[@"SUPERSONIC_METAL_PROFILE_DEBUG"] != nil) {
+        NSLog(@"machine-profile Metal4 pipeline failed for %@: %@", name, error);
+    }
+    return pipeline;
+}
+#endif  // SUPERSONIC_HAVE_MTL4_MPP
+
+void copy_probe_status(const char* src, char* out, size_t out_len) {
+    if (out == nullptr || out_len == 0) {
+        return;
+    }
+    const size_t n = std::min(out_len - 1, strlen(src));
+    memcpy(out, src, n);
+    out[n] = '\0';
+}
+
+double command_elapsed_seconds(id<MTLCommandBuffer> command_buffer, std::chrono::steady_clock::time_point start) {
+    [command_buffer waitUntilCompleted];
+    if (command_buffer.status != MTLCommandBufferStatusCompleted) {
+        return 0.0;
+    }
+    const CFTimeInterval gpu_start = command_buffer.GPUStartTime;
+    const CFTimeInterval gpu_end = command_buffer.GPUEndTime;
+    if (gpu_end > gpu_start && gpu_start > 0.0) {
+        return static_cast<double>(gpu_end - gpu_start);
+    }
+    return std::chrono::duration<double>(std::chrono::steady_clock::now() - start).count();
+}
+
+double run_unary_bandwidth_kernel(NSString* function_name, NSString* source, uint64_t bytes, bool read_kernel) {
+    @autoreleasepool {
+        id<MTLDevice> device = metal_device();
+        id<MTLCommandQueue> queue = metal_queue();
+        if (device == nil || queue == nil || bytes < 4096) {
+            return 0.0;
+        }
+        id<MTLComputePipelineState> pipeline = pipeline_from_source(source, function_name);
+        if (pipeline == nil) {
+            return 0.0;
+        }
+        id<MTLBuffer> buf = [device newBufferWithLength:bytes options:MTLResourceStorageModeShared];
+        id<MTLBuffer> sink = [device newBufferWithLength:sizeof(uint32_t) options:MTLResourceStorageModeShared];
+        if (buf == nil || sink == nil) {
+            return 0.0;
+        }
+        memset(buf.contents, 1, bytes);
+        memset(sink.contents, 0, sizeof(uint32_t));
+        const uint32_t n_words = static_cast<uint32_t>(bytes / sizeof(uint32_t));
+        id<MTLBuffer> params = [device newBufferWithBytes:&n_words length:sizeof(n_words) options:MTLResourceStorageModeShared];
+        const NSUInteger threads = 65536;
+        id<MTLCommandBuffer> command_buffer = [queue commandBuffer];
+        id<MTLComputeCommandEncoder> encoder = [command_buffer computeCommandEncoder];
+        [encoder setComputePipelineState:pipeline];
+        [encoder setBuffer:buf offset:0 atIndex:0];
+        [encoder setBuffer:sink offset:0 atIndex:1];
+        [encoder setBuffer:params offset:0 atIndex:2];
+        [encoder dispatchThreads:MTLSizeMake(threads, 1, 1) threadsPerThreadgroup:MTLSizeMake(256, 1, 1)];
+        [encoder endEncoding];
+        auto start = std::chrono::steady_clock::now();
+        [command_buffer commit];
+        const double seconds = command_elapsed_seconds(command_buffer, start);
+        if (seconds <= 0.0 || !std::isfinite(seconds)) {
+            return 0.0;
+        }
+        const double traffic = read_kernel ? static_cast<double>(bytes) : static_cast<double>(bytes);
+        return traffic / seconds / 1.0e9;
+    }
+}
+
+#if SUPERSONIC_HAVE_MTL4_MPP
+MTLTensorDescriptor* tensor_descriptor(NSUInteger dim0, NSUInteger dim1, MTLTensorDataType data_type) {
+    NSInteger dims[2] = {
+        static_cast<NSInteger>(dim0),
+        static_cast<NSInteger>(dim1),
+    };
+    NSInteger strides[2] = {
+        1,
+        static_cast<NSInteger>(dim0),
+    };
+    MTLTensorDescriptor* desc = [[MTLTensorDescriptor alloc] init];
+    desc.dimensions = [[MTLTensorExtents alloc] initWithRank:2 values:dims];
+    desc.strides = [[MTLTensorExtents alloc] initWithRank:2 values:strides];
+    desc.dataType = data_type;
+    desc.usage = MTLTensorUsageCompute | MTLTensorUsageMachineLearning;
+    desc.storageMode = MTLStorageModeShared;
+    return desc;
+}
+
+MTLTensorDescriptor* device_tensor_descriptor(NSUInteger dim0, NSUInteger dim1, MTLTensorDataType data_type) {
+    MTLTensorDescriptor* desc = tensor_descriptor(dim0, dim1, data_type);
+    desc.strides = nil;
+    return desc;
+}
+
+id<MTLTensor> tensor_from_device(id<MTLDevice> device, MTLTensorDescriptor* desc) {
+    NSError* error = nil;
+    id<MTLTensor> tensor = [device newTensorWithDescriptor:desc error:&error];
+    if (tensor == nil && NSProcessInfo.processInfo.environment[@"SUPERSONIC_METAL_PROFILE_DEBUG"] != nil) {
+        NSLog(@"machine-profile Metal device tensor creation failed: %@", error);
+    }
+    return tensor;
+}
+
+void tensor_replace_all_f16(id<MTLTensor> tensor, const uint16_t* values, NSUInteger dim0, NSUInteger dim1) {
+    NSInteger origin_values[2] = {0, 0};
+    NSInteger dim_values[2] = {
+        static_cast<NSInteger>(dim0),
+        static_cast<NSInteger>(dim1),
+    };
+    NSInteger stride_values[2] = {
+        1,
+        static_cast<NSInteger>(dim0),
+    };
+    MTLTensorExtents* origin = [[MTLTensorExtents alloc] initWithRank:2 values:origin_values];
+    MTLTensorExtents* dims = [[MTLTensorExtents alloc] initWithRank:2 values:dim_values];
+    MTLTensorExtents* strides = [[MTLTensorExtents alloc] initWithRank:2 values:stride_values];
+    [tensor replaceSliceOrigin:origin sliceDimensions:dims withBytes:values strides:strides];
+}
+
+float tensor_first_f32(id<MTLTensor> tensor) {
+    NSInteger origin_values[2] = {0, 0};
+    NSInteger dim_values[2] = {1, 1};
+    NSInteger stride_values[2] = {1, 1};
+    MTLTensorExtents* origin = [[MTLTensorExtents alloc] initWithRank:2 values:origin_values];
+    MTLTensorExtents* dims = [[MTLTensorExtents alloc] initWithRank:2 values:dim_values];
+    MTLTensorExtents* strides = [[MTLTensorExtents alloc] initWithRank:2 values:stride_values];
+    float value = 0.0f;
+    [tensor getBytes:&value strides:strides fromSliceOrigin:origin sliceDimensions:dims];
+    return value;
+}
+
+id<MTL4ArgumentTable> mtl4_argument_table(id<MTLDevice> device, NSUInteger buffer_bind_count) {
+    MTL4ArgumentTableDescriptor* desc = [[MTL4ArgumentTableDescriptor alloc] init];
+    desc.maxBufferBindCount = buffer_bind_count;
+    desc.initializeBindings = YES;
+    NSError* error = nil;
+    id<MTL4ArgumentTable> table = [device newArgumentTableWithDescriptor:desc error:&error];
+    if (table == nil && NSProcessInfo.processInfo.environment[@"SUPERSONIC_METAL_PROFILE_DEBUG"] != nil) {
+        NSLog(@"machine-profile Metal4 argument table failed: %@", error);
+    }
+    return table;
+}
+
+bool wait_for_mtl4_queue(id<MTL4CommandQueue> queue, id<MTLSharedEvent> event, uint64_t value) {
+    [queue signalEvent:event value:value];
+    return [event waitUntilSignaledValue:value timeoutMS:30000];
+}
+
+bool encode_mpp_gemm_mtl4(
+    id<MTLDevice> device,
+    id<MTL4CommandQueue> queue,
+    id<MTLComputePipelineState> pipeline,
+    id<MTL4ArgumentTable> args,
+    uint32_t tg_x,
+    uint32_t tg_y,
+    NSUInteger threads_per_threadgroup,
+    id<MTLSharedEvent> event,
+    uint64_t signal_value
+) {
+    id<MTL4CommandAllocator> allocator = [device newCommandAllocator];
+    id<MTL4CommandBuffer> command_buffer = [device newCommandBuffer];
+    if (allocator == nil || command_buffer == nil) {
+        return false;
+    }
+    [command_buffer beginCommandBufferWithAllocator:allocator];
+    id<MTL4ComputeCommandEncoder> encoder = [command_buffer computeCommandEncoder];
+    if (encoder == nil) {
+        [command_buffer endCommandBuffer];
+        return false;
+    }
+    [encoder setComputePipelineState:pipeline];
+    [encoder setArgumentTable:args];
+    [encoder dispatchThreadgroups:MTLSizeMake(tg_x, tg_y, 1)
+            threadsPerThreadgroup:MTLSizeMake(threads_per_threadgroup, 1, 1)];
+    [encoder endEncoding];
+    [command_buffer endCommandBuffer];
+    id<MTL4CommandBuffer> buffers[1] = { command_buffer };
+    [queue commit:buffers count:1];
+    return wait_for_mtl4_queue(queue, event, signal_value);
+}
+#endif  // SUPERSONIC_HAVE_MTL4_MPP
+
+}  // namespace
+
+extern "C" int mp_metal_query_device_info(
+    char* arch_name_out,
+    size_t arch_name_len,
+    char* device_name_out,
+    size_t device_name_len,
+    char* family_out,
+    size_t family_len,
+    MpMetalDeviceInfo* info_out
+) {
+    @autoreleasepool {
+        if (arch_name_out == nullptr || arch_name_len == 0 || device_name_out == nullptr ||
+            device_name_len == 0 || family_out == nullptr || family_len == 0 || info_out == nullptr) {
+            return 1;
+        }
+        id<MTLDevice> device = metal_device();
+        if (device == nil) {
+            return 2;
+        }
+
+        const std::string arch = normalized_arch_name(device);
+        NSString* name = device.name ?: @"Apple GPU";
+        copy_cstr(arch, arch_name_out, arch_name_len);
+        copy_cstr(std::string([name UTF8String]), device_name_out, device_name_len);
+        NSDictionary* profiler_entry = system_profiler_gpu_entry();
+        copy_cstr(system_profiler_metal_support(profiler_entry), family_out, family_len);
+
+        uint64_t working_set = 0;
+        if ([device respondsToSelector:@selector(recommendedMaxWorkingSetSize)]) {
+            working_set = static_cast<uint64_t>(device.recommendedMaxWorkingSetSize);
+        }
+        if (working_set == 0) {
+            working_set = static_cast<uint64_t>(NSProcessInfo.processInfo.physicalMemory);
+        }
+
+        MTLSize max_threads = device.maxThreadsPerThreadgroup;
+        info_out->total_vram_bytes = working_set;
+        info_out->recommended_working_set_bytes = working_set;
+        info_out->core_count = system_profiler_gpu_cores(profiler_entry);
+        info_out->wave_size = 32;
+        info_out->max_threadgroup_memory_bytes = static_cast<uint64_t>(device.maxThreadgroupMemoryLength);
+        info_out->max_threads_per_threadgroup = static_cast<uint64_t>(max_threads.width);
+        return 0;
+    }
+}
+
+extern "C" double mp_metal_unified_read_gb_s(uint64_t bytes) {
+    NSString* source =
+        @"#include <metal_stdlib>\n"
+         "using namespace metal;\n"
+         "kernel void mp_read(device const uint* buf [[buffer(0)]],\n"
+         "                    device atomic_uint* sink [[buffer(1)]],\n"
+         "                    constant uint& n [[buffer(2)]],\n"
+         "                    uint tid [[thread_position_in_grid]],\n"
+         "                    uint grid [[threads_per_grid]]) {\n"
+         "  uint acc = 0;\n"
+         "  for (uint i = tid; i < n; i += grid) acc += buf[i];\n"
+         "  atomic_fetch_add_explicit(sink, acc, memory_order_relaxed);\n"
+         "}\n";
+    return run_unary_bandwidth_kernel(@"mp_read", source, bytes, true);
+}
+
+extern "C" double mp_metal_unified_write_gb_s(uint64_t bytes) {
+    NSString* source =
+        @"#include <metal_stdlib>\n"
+         "using namespace metal;\n"
+         "kernel void mp_write(device uint* buf [[buffer(0)]],\n"
+         "                     device atomic_uint* sink [[buffer(1)]],\n"
+         "                     constant uint& n [[buffer(2)]],\n"
+         "                     uint tid [[thread_position_in_grid]],\n"
+         "                     uint grid [[threads_per_grid]]) {\n"
+         "  for (uint i = tid; i < n; i += grid) buf[i] = i;\n"
+         "  if (tid == 0) atomic_store_explicit(sink, 1, memory_order_relaxed);\n"
+         "}\n";
+    return run_unary_bandwidth_kernel(@"mp_write", source, bytes, false);
+}
+
+extern "C" double mp_metal_unified_copy_gb_s(uint64_t bytes) {
+    @autoreleasepool {
+        id<MTLDevice> device = metal_device();
+        id<MTLCommandQueue> queue = metal_queue();
+        if (device == nil || queue == nil || bytes < 4096) {
+            return 0.0;
+        }
+        id<MTLBuffer> src = [device newBufferWithLength:bytes options:MTLResourceStorageModeShared];
+        id<MTLBuffer> dst = [device newBufferWithLength:bytes options:MTLResourceStorageModeShared];
+        if (src == nil || dst == nil) {
+            return 0.0;
+        }
+        memset(src.contents, 3, bytes);
+        id<MTLCommandBuffer> command_buffer = [queue commandBuffer];
+        id<MTLBlitCommandEncoder> encoder = [command_buffer blitCommandEncoder];
+        [encoder copyFromBuffer:src sourceOffset:0 toBuffer:dst destinationOffset:0 size:bytes];
+        [encoder endEncoding];
+        auto start = std::chrono::steady_clock::now();
+        [command_buffer commit];
+        const double seconds = command_elapsed_seconds(command_buffer, start);
+        if (seconds <= 0.0 || !std::isfinite(seconds)) {
+            return 0.0;
+        }
+        return static_cast<double>(bytes) / seconds / 1.0e9;
+    }
+}
+
+extern "C" double mp_metal_threadgroup_gb_s(uint32_t core_count, uint32_t iterations) {
+    @autoreleasepool {
+        id<MTLDevice> device = metal_device();
+        id<MTLCommandQueue> queue = metal_queue();
+        if (device == nil || queue == nil || core_count == 0 || iterations == 0) {
+            return 0.0;
+        }
+        NSString* source =
+            @"#include <metal_stdlib>\n"
+             "using namespace metal;\n"
+             "kernel void mp_tg(device uint* out [[buffer(0)]],\n"
+             "                  constant uint& iters [[buffer(1)]],\n"
+             "                  uint tid [[thread_position_in_threadgroup]],\n"
+             "                  uint gid [[threadgroup_position_in_grid]]) {\n"
+             "  threadgroup uint scratch[256];\n"
+             "  uint v = tid + gid;\n"
+             "  for (uint i = 0; i < iters; ++i) {\n"
+             "    scratch[tid] = v + i;\n"
+             "    threadgroup_barrier(mem_flags::mem_threadgroup);\n"
+             "    v += scratch[(tid + 17) & 255];\n"
+             "    threadgroup_barrier(mem_flags::mem_threadgroup);\n"
+             "  }\n"
+             "  if (tid == 0) out[gid] = v;\n"
+             "}\n";
+        id<MTLComputePipelineState> pipeline = pipeline_from_source(source, @"mp_tg");
+        if (pipeline == nil) {
+            return 0.0;
+        }
+        id<MTLBuffer> out = [device newBufferWithLength:core_count * sizeof(uint32_t) options:MTLResourceStorageModeShared];
+        id<MTLBuffer> params = [device newBufferWithBytes:&iterations length:sizeof(iterations) options:MTLResourceStorageModeShared];
+        id<MTLCommandBuffer> command_buffer = [queue commandBuffer];
+        id<MTLComputeCommandEncoder> encoder = [command_buffer computeCommandEncoder];
+        [encoder setComputePipelineState:pipeline];
+        [encoder setBuffer:out offset:0 atIndex:0];
+        [encoder setBuffer:params offset:0 atIndex:1];
+        [encoder dispatchThreadgroups:MTLSizeMake(core_count, 1, 1) threadsPerThreadgroup:MTLSizeMake(256, 1, 1)];
+        [encoder endEncoding];
+        auto start = std::chrono::steady_clock::now();
+        [command_buffer commit];
+        const double seconds = command_elapsed_seconds(command_buffer, start);
+        if (seconds <= 0.0 || !std::isfinite(seconds)) {
+            return 0.0;
+        }
+        const double bytes = static_cast<double>(core_count) * 256.0 * static_cast<double>(iterations) * 2.0 * sizeof(uint32_t);
+        return bytes / seconds / 1.0e9;
+    }
+}
+
+extern "C" int mp_metal_simdgroup_matrix_probe() {
+    @autoreleasepool {
+        NSString* source =
+             @"#include <metal_stdlib>\n"
+             "#include <metal_simdgroup_matrix>\n"
+             "using namespace metal;\n"
+             "kernel void mp_probe(device half* out [[buffer(0)]], uint tid [[thread_position_in_grid]]) {\n"
+             "  simdgroup_half8x8 a;\n"
+             "  simdgroup_half8x8 b;\n"
+             "  simdgroup_float8x8 c;\n"
+             "  simdgroup_multiply_accumulate(c, a, b, c);\n"
+             "  out[tid] = half(1.0);\n"
+             "}\n";
+        id<MTLComputePipelineState> pipeline = pipeline_from_source(source, @"mp_probe");
+        return pipeline == nil ? 1 : 0;
+    }
+}
+
+extern "C" int mp_metal_mpp_tensor_matmul_probe_detail(
+    MpMetalMppProbeInfo* info_out,
+    char* status_out,
+    size_t status_len
+) {
+#if SUPERSONIC_HAVE_MTL4_MPP
+    @autoreleasepool {
+        if (info_out == nullptr) {
+            copy_probe_status("invalid-output", status_out, status_len);
+            return 99;
+        }
+        info_out->status = 0;
+        info_out->tensor_write_value = 0.0f;
+        info_out->matmul_value = 0.0f;
+
+        id<MTLDevice> device = metal_device();
+        if (device == nil) {
+            info_out->status = 2;
+            copy_probe_status("no-device", status_out, status_len);
+            return info_out->status;
+        }
+
+        NSString* tensor_write_source =
+             @"#include <metal_stdlib>\n"
+             "using namespace metal;\n"
+             "kernel void mp_tensor_write(tensor<device float, dextents<int32_t, 2>> C [[buffer(0)]]) {\n"
+             "  C[0, 0] = 123.0f;\n"
+             "}\n";
+        id<MTLComputePipelineState> tensor_write_pipeline =
+            mtl4_pipeline_from_source(tensor_write_source, @"mp_tensor_write", 32);
+        if (tensor_write_pipeline == nil) {
+            info_out->status = 10;
+            copy_probe_status("tensor-write-pipeline", status_out, status_len);
+            return info_out->status;
+        }
+        id<MTL4CommandQueue> tensor_write_queue = [device newMTL4CommandQueue];
+        id<MTLSharedEvent> tensor_write_event = [device newSharedEvent];
+        id<MTL4ArgumentTable> tensor_write_args = mtl4_argument_table(device, 1);
+        id<MTLTensor> tensor_write_tensor =
+            tensor_from_device(device, device_tensor_descriptor(1, 1, MTLTensorDataTypeFloat32));
+        if (tensor_write_queue == nil || tensor_write_event == nil ||
+            tensor_write_args == nil || tensor_write_tensor == nil) {
+            info_out->status = 11;
+            copy_probe_status("tensor-write-setup", status_out, status_len);
+            return info_out->status;
+        }
+        [tensor_write_args setResource:tensor_write_tensor.gpuResourceID atBufferIndex:0];
+        if (!encode_mpp_gemm_mtl4(
+                device, tensor_write_queue, tensor_write_pipeline, tensor_write_args,
+                1, 1, 32, tensor_write_event, 1)) {
+            info_out->status = 12;
+            copy_probe_status("tensor-write-dispatch", status_out, status_len);
+            return info_out->status;
+        }
+        info_out->tensor_write_value = tensor_first_f32(tensor_write_tensor);
+        if (info_out->tensor_write_value != 123.0f) {
+            info_out->status = 13;
+            copy_probe_status("tensor-write-readback", status_out, status_len);
+            return info_out->status;
+        }
+
+        NSString* source =
+             @"#include <metal_stdlib>\n"
+             "#include <MetalPerformancePrimitives/MetalPerformancePrimitives.h>\n"
+             "using namespace metal;\n"
+             "using namespace mpp::tensor_ops;\n"
+             "kernel void mp_mpp_probe(tensor<device half, dextents<int32_t, 2>> A [[buffer(0)]],\n"
+             "                         tensor<device half, dextents<int32_t, 2>> B [[buffer(1)]],\n"
+             "                         tensor<device float, dextents<int32_t, 2>> C [[buffer(2)]],\n"
+             "                         uint2 tgid [[threadgroup_position_in_grid]]) {\n"
+             "  constexpr auto desc = matmul2d_descriptor(64, 32, static_cast<int>(dynamic_extent), false, false, false);\n"
+             "  matmul2d<desc, execution_simdgroups<4>> op;\n"
+             "  auto tA = A.slice(0, tgid.y * 64);\n"
+             "  auto tB = B.slice(tgid.x * 32, 0);\n"
+             "  auto tC = C.slice(tgid.x * 32, tgid.y * 64);\n"
+             "  op.run(tA, tB, tC);\n"
+             "}\n";
+        id<MTLComputePipelineState> pipeline = mtl4_pipeline_from_source(source, @"mp_mpp_probe", 128);
+        if (pipeline == nil) {
+            info_out->status = 20;
+            copy_probe_status("mpp-pipeline", status_out, status_len);
+            return info_out->status;
+        }
+        id<MTL4CommandQueue> queue = [device newMTL4CommandQueue];
+        id<MTLSharedEvent> event = [device newSharedEvent];
+        id<MTL4ArgumentTable> args = mtl4_argument_table(device, 3);
+        if (queue == nil || event == nil || args == nil) {
+            info_out->status = 21;
+            copy_probe_status("mpp-command-setup", status_out, status_len);
+            return info_out->status;
+        }
+        const NSUInteger a_bytes = 64u * 64u * sizeof(uint16_t);
+        const NSUInteger b_bytes = 32u * 64u * sizeof(uint16_t);
+        id<MTLBuffer> a_buf = [device newBufferWithLength:a_bytes options:MTLResourceStorageModeShared];
+        id<MTLBuffer> b_buf = [device newBufferWithLength:b_bytes options:MTLResourceStorageModeShared];
+        if (a_buf == nil || b_buf == nil) {
+            info_out->status = 22;
+            copy_probe_status("mpp-input-buffer", status_out, status_len);
+            return info_out->status;
+        }
+        auto* a = static_cast<uint16_t*>(a_buf.contents);
+        auto* b = static_cast<uint16_t*>(b_buf.contents);
+        for (NSUInteger i = 0; i < 64u * 64u; ++i) {
+            a[i] = 0x3c00u;
+        }
+        for (NSUInteger i = 0; i < 32u * 64u; ++i) {
+            b[i] = 0x3800u;
+        }
+        id<MTLTensor> a_tensor = tensor_from_device(device, device_tensor_descriptor(64, 64, MTLTensorDataTypeFloat16));
+        id<MTLTensor> b_tensor = tensor_from_device(device, device_tensor_descriptor(32, 64, MTLTensorDataTypeFloat16));
+        id<MTLTensor> c_tensor = tensor_from_device(device, device_tensor_descriptor(32, 64, MTLTensorDataTypeFloat32));
+        if (a_tensor == nil || b_tensor == nil || c_tensor == nil) {
+            info_out->status = 23;
+            copy_probe_status("mpp-tensor-create", status_out, status_len);
+            return info_out->status;
+        }
+        tensor_replace_all_f16(a_tensor, a, 64, 64);
+        tensor_replace_all_f16(b_tensor, b, 32, 64);
+        [args setResource:a_tensor.gpuResourceID atBufferIndex:0];
+        [args setResource:b_tensor.gpuResourceID atBufferIndex:1];
+        [args setResource:c_tensor.gpuResourceID atBufferIndex:2];
+        const NSUInteger threads_per_threadgroup = pipeline.threadExecutionWidth * 4u;
+        const bool ok = encode_mpp_gemm_mtl4(
+            device, queue, pipeline, args, 1, 1, threads_per_threadgroup, event, 1
+        );
+        if (!ok) {
+            info_out->status = 24;
+            copy_probe_status("mpp-dispatch", status_out, status_len);
+            return info_out->status;
+        }
+        info_out->matmul_value = tensor_first_f32(c_tensor);
+        if (info_out->matmul_value == 0.0f || !std::isfinite(static_cast<double>(info_out->matmul_value))) {
+            info_out->status = 25;
+            copy_probe_status("mpp-readback", status_out, status_len);
+            return info_out->status;
+        }
+        copy_probe_status("ok", status_out, status_len);
+        return 0;
+    }
+#else
+    if (info_out != nullptr) {
+        info_out->status = 1;
+        info_out->tensor_write_value = 0.0f;
+        info_out->matmul_value = 0.0f;
+    }
+    copy_probe_status("sdk-unavailable", status_out, status_len);
+    return 1;
+#endif
+}
+
+extern "C" int mp_metal_mpp_tensor_matmul_probe() {
+    MpMetalMppProbeInfo info;
+    char status[64];
+    return mp_metal_mpp_tensor_matmul_probe_detail(&info, status, sizeof(status));
+}
+
+extern "C" double mp_metal_mpp_tensor_gemm_f16_tflops(uint32_t size, uint32_t iterations) {
+#if SUPERSONIC_HAVE_MTL4_MPP
+    @autoreleasepool {
+        id<MTLDevice> device = metal_device();
+        id<MTL4CommandQueue> queue = [device newMTL4CommandQueue];
+        if (device == nil || queue == nil || size == 0 || iterations == 0 || (size % 64u) != 0u) {
+            if (NSProcessInfo.processInfo.environment[@"SUPERSONIC_METAL_PROFILE_DEBUG"] != nil) {
+                NSLog(@"machine-profile MPP GEMM setup rejected: size=%u iterations=%u", size, iterations);
+            }
+            return 0.0;
+        }
+        NSString* source =
+             @"#include <metal_stdlib>\n"
+             "#include <MetalPerformancePrimitives/MetalPerformancePrimitives.h>\n"
+             "using namespace metal;\n"
+             "using namespace mpp::tensor_ops;\n"
+             "kernel void mp_mpp_gemm_tile(tensor<device half, dextents<int32_t, 2>> A [[buffer(0)]],\n"
+             "                             tensor<device half, dextents<int32_t, 2>> B [[buffer(1)]],\n"
+             "                             tensor<device float, dextents<int32_t, 2>> C [[buffer(2)]]) {\n"
+             "  constexpr auto desc = matmul2d_descriptor(64, 32, 64, false, false, false);\n"
+             "  matmul2d<desc, execution_simdgroups<4>> op;\n"
+             "  auto tA = A.slice(0, 0);\n"
+             "  auto tB = B.slice(0, 0);\n"
+             "  auto tC = C.slice(0, 0);\n"
+             "  op.run(tA, tB, tC);\n"
+             "}\n";
+        id<MTLComputePipelineState> pipeline = mtl4_pipeline_from_source(source, @"mp_mpp_gemm_tile", 128);
+        if (pipeline == nil) {
+            if (NSProcessInfo.processInfo.environment[@"SUPERSONIC_METAL_PROFILE_DEBUG"] != nil) {
+                NSLog(@"machine-profile MPP GEMM pipeline failed");
+            }
+            return 0.0;
+        }
+
+        const NSUInteger a_count = 64u * 64u;
+        const NSUInteger b_count = 32u * 64u;
+        id<MTLBuffer> a_buf = [device newBufferWithLength:a_count * sizeof(uint16_t) options:MTLResourceStorageModeShared];
+        id<MTLBuffer> b_buf = [device newBufferWithLength:b_count * sizeof(uint16_t) options:MTLResourceStorageModeShared];
+        if (a_buf == nil || b_buf == nil) {
+            if (NSProcessInfo.processInfo.environment[@"SUPERSONIC_METAL_PROFILE_DEBUG"] != nil) {
+                NSLog(@"machine-profile MPP GEMM input buffers failed");
+            }
+            return 0.0;
+        }
+        auto* a = static_cast<uint16_t*>(a_buf.contents);
+        auto* b = static_cast<uint16_t*>(b_buf.contents);
+        for (NSUInteger i = 0; i < a_count; ++i) {
+            a[i] = static_cast<uint16_t>(0x3c00u + (i & 1u));
+        }
+        for (NSUInteger i = 0; i < b_count; ++i) {
+            b[i] = static_cast<uint16_t>(0x3800u + (i & 1u));
+        }
+        id<MTLTensor> a_tensor = tensor_from_device(device, device_tensor_descriptor(64, 64, MTLTensorDataTypeFloat16));
+        id<MTLTensor> b_tensor = tensor_from_device(device, device_tensor_descriptor(32, 64, MTLTensorDataTypeFloat16));
+        id<MTLTensor> c_tensor = tensor_from_device(device, device_tensor_descriptor(32, 64, MTLTensorDataTypeFloat32));
+        if (a_tensor == nil || b_tensor == nil || c_tensor == nil) {
+            if (NSProcessInfo.processInfo.environment[@"SUPERSONIC_METAL_PROFILE_DEBUG"] != nil) {
+                NSLog(@"machine-profile MPP GEMM tensor creation failed");
+            }
+            return 0.0;
+        }
+        tensor_replace_all_f16(a_tensor, a, 64, 64);
+        tensor_replace_all_f16(b_tensor, b, 32, 64);
+
+        id<MTL4ArgumentTable> args = mtl4_argument_table(device, 3);
+        id<MTLSharedEvent> event = [device newSharedEvent];
+        if (args == nil || event == nil) {
+            if (NSProcessInfo.processInfo.environment[@"SUPERSONIC_METAL_PROFILE_DEBUG"] != nil) {
+                NSLog(@"machine-profile MPP GEMM argument table/event failed");
+            }
+            return 0.0;
+        }
+        [args setResource:a_tensor.gpuResourceID atBufferIndex:0];
+        [args setResource:b_tensor.gpuResourceID atBufferIndex:1];
+        [args setResource:c_tensor.gpuResourceID atBufferIndex:2];
+        const uint32_t tile_m = size / 64u;
+        const uint32_t tile_n = size / 32u;
+        const uint32_t tile_k = size / 64u;
+        const uint32_t tg_x = tile_n;
+        const uint32_t tg_y = tile_m * tile_k;
+        const NSUInteger threads_per_threadgroup = pipeline.threadExecutionWidth * 4u;
+
+        if (!encode_mpp_gemm_mtl4(
+                device, queue, pipeline, args, tg_x, tg_y, threads_per_threadgroup, event, 1)) {
+            if (NSProcessInfo.processInfo.environment[@"SUPERSONIC_METAL_PROFILE_DEBUG"] != nil) {
+                NSLog(@"machine-profile MPP GEMM warmup dispatch failed");
+            }
+            return 0.0;
+        }
+
+        auto start = std::chrono::steady_clock::now();
+        for (uint32_t i = 0; i < iterations; ++i) {
+            const uint64_t signal_value = static_cast<uint64_t>(i) + 2u;
+            if (!encode_mpp_gemm_mtl4(
+                    device, queue, pipeline, args, tg_x, tg_y, threads_per_threadgroup, event, signal_value)) {
+                if (NSProcessInfo.processInfo.environment[@"SUPERSONIC_METAL_PROFILE_DEBUG"] != nil) {
+                    NSLog(@"machine-profile MPP GEMM timed dispatch failed at iteration %u", i);
+                }
+                return 0.0;
+            }
+        }
+        const double seconds =
+            std::chrono::duration<double>(std::chrono::steady_clock::now() - start).count();
+        if (seconds <= 0.0 || !std::isfinite(seconds)) {
+            return 0.0;
+        }
+        volatile float guard = tensor_first_f32(c_tensor);
+        if (guard == 0.0f || !std::isfinite(static_cast<double>(guard))) {
+            if (NSProcessInfo.processInfo.environment[@"SUPERSONIC_METAL_PROFILE_DEBUG"] != nil) {
+                NSLog(@"machine-profile MPP GEMM guard failed: %f", static_cast<double>(guard));
+            }
+            return 0.0;
+        }
+        (void)guard;
+        const double flops = static_cast<double>(iterations)
+            * 2.0
+            * static_cast<double>(tile_m)
+            * static_cast<double>(tile_n)
+            * static_cast<double>(tile_k)
+            * 64.0
+            * 32.0
+            * 64.0;
+        return flops / seconds / 1.0e12;
+    }
+#else
+    (void)size;
+    (void)iterations;
+    return 0.0;
+#endif
+}
+
+static double run_simdgroup_mma_f16(
+    uint32_t core_count,
+    uint32_t threadgroups_per_core,
+    uint32_t simdgroups_per_threadgroup,
+    uint32_t accumulators,
+    uint32_t iterations,
+    bool f16_accum
+) {
+    @autoreleasepool {
+        id<MTLDevice> device = metal_device();
+        id<MTLCommandQueue> queue = metal_queue();
+        if (device == nil || queue == nil || core_count == 0 || threadgroups_per_core == 0 ||
+            simdgroups_per_threadgroup == 0 || accumulators == 0 || iterations == 0) {
+            return 0.0;
+        }
+        const uint32_t threads_per_threadgroup = simdgroups_per_threadgroup * 32u;
+        if (threads_per_threadgroup > device.maxThreadsPerThreadgroup.width) {
+            return 0.0;
+        }
+        accumulators = std::min<uint32_t>(accumulators, 32u);
+
+        NSString* acc_type = f16_accum ? @"half" : @"float";
+        NSString* matrix_type = f16_accum ? @"simdgroup_half8x8" : @"simdgroup_float8x8";
+        NSString* out_type = f16_accum ? @"half" : @"float";
+        NSString* zero = f16_accum ? @"0.0h" : @"0.0f";
+        NSMutableString* source = [NSMutableString string];
+        [source appendString:
+            @"#include <metal_stdlib>\n"
+             "#include <metal_simdgroup_matrix>\n"
+             "using namespace metal;\n"
+             "struct Params { uint iterations; uint tile_count; };\n"];
+        [source appendFormat:
+            @"kernel void mp_mma_sweep(device const half* a_buf [[buffer(0)]],\n"
+             "                         device const half* b_buf [[buffer(1)]],\n"
+             "                         device %@* out [[buffer(2)]],\n"
+             "                         constant Params& p [[buffer(3)]],\n"
+             "                         uint tg [[threadgroup_position_in_grid]],\n"
+             "                         uint sg [[simdgroup_index_in_threadgroup]],\n"
+             "                         uint simdgroups_per_tg [[simdgroups_per_threadgroup]]) {\n"
+             "  const uint logical = tg * simdgroups_per_tg + sg;\n"
+             "  const uint tile = logical %% p.tile_count;\n"
+             "  simdgroup_half8x8 a;\n"
+             "  simdgroup_half8x8 b;\n", out_type];
+        for (uint32_t i = 0; i < accumulators; ++i) {
+            [source appendFormat:@"  %@ c%u = make_filled_simdgroup_matrix<%@, 8>(%@);\n",
+                                 matrix_type, i, acc_type, zero];
+        }
+        [source appendString:
+             @"  simdgroup_load(a, a_buf + tile * 64, 8);\n"
+             "  simdgroup_load(b, b_buf + tile * 64, 8);\n"
+             "  for (uint i = 0; i < p.iterations; ++i) {\n"];
+        for (uint32_t i = 0; i < accumulators; ++i) {
+            [source appendFormat:@"    simdgroup_multiply_accumulate(c%u, a, b, c%u);\n", i, i];
+        }
+        [source appendString:@"  }\n"];
+        [source appendFormat:@"  const uint base = logical * %u;\n", accumulators * 64u];
+        for (uint32_t i = 0; i < accumulators; ++i) {
+            [source appendFormat:@"  simdgroup_store(c%u, out + base + %u, 8);\n", i, i * 64u];
+        }
+        [source appendString:@"}\n"];
+
+        id<MTLComputePipelineState> pipeline = pipeline_from_source(source, @"mp_mma_sweep");
+        if (pipeline == nil) {
+            return 0.0;
+        }
+        const uint32_t threadgroups = core_count * threadgroups_per_core;
+        const uint32_t logical_simdgroups = threadgroups * simdgroups_per_threadgroup;
+        const uint32_t tile_count = 1024;
+        const uint64_t tile_elems = static_cast<uint64_t>(tile_count) * 64u;
+        const uint64_t out_elems = static_cast<uint64_t>(logical_simdgroups) * static_cast<uint64_t>(accumulators) * 64u;
+        const size_t out_elem_size = f16_accum ? sizeof(uint16_t) : sizeof(float);
+        id<MTLBuffer> a = [device newBufferWithLength:tile_elems * sizeof(uint16_t) options:MTLResourceStorageModeShared];
+        id<MTLBuffer> b = [device newBufferWithLength:tile_elems * sizeof(uint16_t) options:MTLResourceStorageModeShared];
+        id<MTLBuffer> out = [device newBufferWithLength:out_elems * out_elem_size options:MTLResourceStorageModeShared];
+        if (a == nil || b == nil || out == nil) {
+            return 0.0;
+        }
+        auto* a_words = static_cast<uint16_t*>(a.contents);
+        auto* b_words = static_cast<uint16_t*>(b.contents);
+        for (uint64_t i = 0; i < tile_elems; ++i) {
+            a_words[i] = static_cast<uint16_t>(0x3c00u + (i & 3u));
+            b_words[i] = static_cast<uint16_t>(0x3800u + (i & 1u));
+        }
+        memset(out.contents, 0, out_elems * out_elem_size);
+        struct Params {
+            uint32_t iterations;
+            uint32_t tile_count;
+        } params = { iterations, tile_count };
+        id<MTLBuffer> params_buf = [device newBufferWithBytes:&params length:sizeof(params) options:MTLResourceStorageModeShared];
+        id<MTLCommandBuffer> command_buffer = [queue commandBuffer];
+        id<MTLComputeCommandEncoder> encoder = [command_buffer computeCommandEncoder];
+        [encoder setComputePipelineState:pipeline];
+        [encoder setBuffer:a offset:0 atIndex:0];
+        [encoder setBuffer:b offset:0 atIndex:1];
+        [encoder setBuffer:out offset:0 atIndex:2];
+        [encoder setBuffer:params_buf offset:0 atIndex:3];
+        [encoder dispatchThreadgroups:MTLSizeMake(threadgroups, 1, 1)
+                 threadsPerThreadgroup:MTLSizeMake(threads_per_threadgroup, 1, 1)];
+        [encoder endEncoding];
+        auto start = std::chrono::steady_clock::now();
+        [command_buffer commit];
+        const double seconds = command_elapsed_seconds(command_buffer, start);
+        if (seconds <= 0.0 || !std::isfinite(seconds)) {
+            return 0.0;
+        }
+        volatile uint16_t guard = static_cast<uint16_t*>(out.contents)[0];
+        (void)guard;
+        const double flops = static_cast<double>(logical_simdgroups)
+            * static_cast<double>(iterations)
+            * static_cast<double>(accumulators)
+            * 2.0
+            * 8.0
+            * 8.0
+            * 8.0;
+        return flops / seconds / 1.0e12;
+    }
+}
+
+extern "C" double mp_metal_simdgroup_mma_f16_sweep_tflops(
+    uint32_t core_count,
+    uint32_t threadgroups_per_core,
+    uint32_t simdgroups_per_threadgroup,
+    uint32_t accumulators,
+    uint32_t iterations,
+    uint32_t f16_accum
+) {
+    return run_simdgroup_mma_f16(
+        core_count,
+        threadgroups_per_core,
+        simdgroups_per_threadgroup,
+        accumulators,
+        iterations,
+        f16_accum != 0
+    );
+}
+
+extern "C" double mp_metal_simdgroup_mma_f16_tflops(
+    uint32_t core_count,
+    uint32_t threadgroups_per_core,
+    uint32_t iterations
+) {
+    return run_simdgroup_mma_f16(core_count, threadgroups_per_core, 32, 16, iterations, false);
+}
+
+extern "C" double mp_metal_simdgroup_mma_f16_accum_f16_tflops(
+    uint32_t core_count,
+    uint32_t threadgroups_per_core,
+    uint32_t iterations
+) {
+    return run_simdgroup_mma_f16(core_count, threadgroups_per_core, 32, 8, iterations, true);
+}
+
+extern "C" double mp_metal_simdgroup_gemm_f16_tflops(
+    uint32_t size,
+    uint32_t iterations,
+    uint32_t simdgroups_per_threadgroup
+) {
+    @autoreleasepool {
+        id<MTLDevice> device = metal_device();
+        id<MTLCommandQueue> queue = metal_queue();
+        if (device == nil || queue == nil || size == 0 || iterations == 0 || simdgroups_per_threadgroup == 0) {
+            return 0.0;
+        }
+        if ((size % 8u) != 0u) {
+            return 0.0;
+        }
+        const uint32_t threads_per_threadgroup = simdgroups_per_threadgroup * 32u;
+        if (threads_per_threadgroup > device.maxThreadsPerThreadgroup.width) {
+            return 0.0;
+        }
+        NSString* source =
+            @"#include <metal_stdlib>\n"
+             "#include <metal_simdgroup_matrix>\n"
+             "using namespace metal;\n"
+             "struct Params { uint n; uint tiles_n; uint tiles_total; };\n"
+             "kernel void mp_sg_gemm(device const half* a_buf [[buffer(0)]],\n"
+             "                       device const half* b_buf [[buffer(1)]],\n"
+             "                       device float* c_buf [[buffer(2)]],\n"
+             "                       constant Params& p [[buffer(3)]],\n"
+             "                       uint tg [[threadgroup_position_in_grid]],\n"
+             "                       uint sg [[simdgroup_index_in_threadgroup]],\n"
+             "                       uint simdgroups_per_tg [[simdgroups_per_threadgroup]]) {\n"
+             "  const uint logical = tg * simdgroups_per_tg + sg;\n"
+             "  if (logical >= p.tiles_total) return;\n"
+             "  const uint tile_m = logical / p.tiles_n;\n"
+             "  const uint tile_n = logical - tile_m * p.tiles_n;\n"
+             "  simdgroup_float8x8 c = make_filled_simdgroup_matrix<float, 8>(0.0f);\n"
+             "  for (uint tile_k = 0; tile_k < p.tiles_n; ++tile_k) {\n"
+             "    simdgroup_half8x8 a;\n"
+             "    simdgroup_half8x8 b;\n"
+             "    simdgroup_load(a, a_buf + (tile_m * 8) * p.n + tile_k * 8, p.n);\n"
+             "    simdgroup_load(b, b_buf + (tile_k * 8) * p.n + tile_n * 8, p.n);\n"
+             "    simdgroup_multiply_accumulate(c, a, b, c);\n"
+             "  }\n"
+             "  simdgroup_store(c, c_buf + (tile_m * 8) * p.n + tile_n * 8, p.n);\n"
+             "}\n";
+        id<MTLComputePipelineState> pipeline = pipeline_from_source(source, @"mp_sg_gemm");
+        if (pipeline == nil) {
+            return 0.0;
+        }
+        const NSUInteger n = static_cast<NSUInteger>(size);
+        const NSUInteger half_bytes = n * n * sizeof(uint16_t);
+        const NSUInteger out_bytes = n * n * sizeof(float);
+        id<MTLBuffer> a_buf = [device newBufferWithLength:half_bytes options:MTLResourceStorageModeShared];
+        id<MTLBuffer> b_buf = [device newBufferWithLength:half_bytes options:MTLResourceStorageModeShared];
+        id<MTLBuffer> c_buf = [device newBufferWithLength:out_bytes options:MTLResourceStorageModeShared];
+        if (a_buf == nil || b_buf == nil || c_buf == nil) {
+            return 0.0;
+        }
+        auto* a = static_cast<uint16_t*>(a_buf.contents);
+        auto* b = static_cast<uint16_t*>(b_buf.contents);
+        for (NSUInteger i = 0; i < n * n; ++i) {
+            a[i] = static_cast<uint16_t>(0x3c00u + (i & 1u));
+            b[i] = static_cast<uint16_t>(0x3800u + (i & 1u));
+        }
+        memset(c_buf.contents, 0, out_bytes);
+        struct Params {
+            uint32_t n;
+            uint32_t tiles_n;
+            uint32_t tiles_total;
+        } params = { size, size / 8u, (size / 8u) * (size / 8u) };
+        id<MTLBuffer> params_buf = [device newBufferWithBytes:&params length:sizeof(params) options:MTLResourceStorageModeShared];
+        const uint32_t threadgroups = (params.tiles_total + simdgroups_per_threadgroup - 1u) / simdgroups_per_threadgroup;
+
+        {
+            id<MTLCommandBuffer> warm = [queue commandBuffer];
+            id<MTLComputeCommandEncoder> warm_encoder = [warm computeCommandEncoder];
+            [warm_encoder setComputePipelineState:pipeline];
+            [warm_encoder setBuffer:a_buf offset:0 atIndex:0];
+            [warm_encoder setBuffer:b_buf offset:0 atIndex:1];
+            [warm_encoder setBuffer:c_buf offset:0 atIndex:2];
+            [warm_encoder setBuffer:params_buf offset:0 atIndex:3];
+            [warm_encoder dispatchThreadgroups:MTLSizeMake(threadgroups, 1, 1)
+                         threadsPerThreadgroup:MTLSizeMake(threads_per_threadgroup, 1, 1)];
+            [warm_encoder endEncoding];
+            [warm commit];
+            [warm waitUntilCompleted];
+            if (warm.status != MTLCommandBufferStatusCompleted) {
+                return 0.0;
+            }
+        }
+
+        id<MTLCommandBuffer> command_buffer = [queue commandBuffer];
+        for (uint32_t i = 0; i < iterations; ++i) {
+            id<MTLComputeCommandEncoder> encoder = [command_buffer computeCommandEncoder];
+            [encoder setComputePipelineState:pipeline];
+            [encoder setBuffer:a_buf offset:0 atIndex:0];
+            [encoder setBuffer:b_buf offset:0 atIndex:1];
+            [encoder setBuffer:c_buf offset:0 atIndex:2];
+            [encoder setBuffer:params_buf offset:0 atIndex:3];
+            [encoder dispatchThreadgroups:MTLSizeMake(threadgroups, 1, 1)
+                     threadsPerThreadgroup:MTLSizeMake(threads_per_threadgroup, 1, 1)];
+            [encoder endEncoding];
+        }
+        auto start = std::chrono::steady_clock::now();
+        [command_buffer commit];
+        const double seconds = command_elapsed_seconds(command_buffer, start);
+        if (seconds <= 0.0 || !std::isfinite(seconds)) {
+            return 0.0;
+        }
+        volatile float guard = static_cast<float*>(c_buf.contents)[0];
+        (void)guard;
+        const double flops = static_cast<double>(iterations)
+            * 2.0
+            * static_cast<double>(size)
+            * static_cast<double>(size)
+            * static_cast<double>(size);
+        return flops / seconds / 1.0e12;
+    }
+}
+
+extern "C" double mp_metal_mps_gemm_f16_tflops(uint32_t size, uint32_t iterations) {
+    @autoreleasepool {
+        id<MTLDevice> device = metal_device();
+        id<MTLCommandQueue> queue = metal_queue();
+        if (device == nil || queue == nil || size == 0 || iterations == 0) {
+            return 0.0;
+        }
+        const NSUInteger n = static_cast<NSUInteger>(size);
+        const NSUInteger row_bytes = n * sizeof(uint16_t);
+        const NSUInteger bytes = row_bytes * n;
+        id<MTLBuffer> a_buf = [device newBufferWithLength:bytes options:MTLResourceStorageModeShared];
+        id<MTLBuffer> b_buf = [device newBufferWithLength:bytes options:MTLResourceStorageModeShared];
+        id<MTLBuffer> c_buf = [device newBufferWithLength:bytes options:MTLResourceStorageModeShared];
+        if (a_buf == nil || b_buf == nil || c_buf == nil) {
+            return 0.0;
+        }
+        auto* a = static_cast<uint16_t*>(a_buf.contents);
+        auto* b = static_cast<uint16_t*>(b_buf.contents);
+        for (NSUInteger i = 0; i < static_cast<NSUInteger>(size) * static_cast<NSUInteger>(size); ++i) {
+            a[i] = static_cast<uint16_t>(0x3c00u + (i & 1u));
+            b[i] = static_cast<uint16_t>(0x3800u + (i & 1u));
+        }
+        memset(c_buf.contents, 0, bytes);
+
+        MPSMatrixDescriptor* desc = [MPSMatrixDescriptor matrixDescriptorWithRows:n
+                                                                           columns:n
+                                                                          rowBytes:row_bytes
+                                                                          dataType:MPSDataTypeFloat16];
+        MPSMatrix* a_mat = [[MPSMatrix alloc] initWithBuffer:a_buf descriptor:desc];
+        MPSMatrix* b_mat = [[MPSMatrix alloc] initWithBuffer:b_buf descriptor:desc];
+        MPSMatrix* c_mat = [[MPSMatrix alloc] initWithBuffer:c_buf descriptor:desc];
+        MPSMatrixMultiplication* gemm = [[MPSMatrixMultiplication alloc] initWithDevice:device
+                                                                          transposeLeft:false
+                                                                         transposeRight:false
+                                                                            resultRows:n
+                                                                         resultColumns:n
+                                                                       interiorColumns:n
+                                                                                alpha:1.0
+                                                                                 beta:0.0];
+        if (a_mat == nil || b_mat == nil || c_mat == nil || gemm == nil) {
+            return 0.0;
+        }
+
+        // Warm the MPS pipeline and allocation path before the measured pass.
+        {
+            id<MTLCommandBuffer> warm = [queue commandBuffer];
+            [gemm encodeToCommandBuffer:warm leftMatrix:a_mat rightMatrix:b_mat resultMatrix:c_mat];
+            [warm commit];
+            [warm waitUntilCompleted];
+            if (warm.status != MTLCommandBufferStatusCompleted) {
+                return 0.0;
+            }
+        }
+
+        id<MTLCommandBuffer> command_buffer = [queue commandBuffer];
+        for (uint32_t i = 0; i < iterations; ++i) {
+            [gemm encodeToCommandBuffer:command_buffer leftMatrix:a_mat rightMatrix:b_mat resultMatrix:c_mat];
+        }
+        auto start = std::chrono::steady_clock::now();
+        [command_buffer commit];
+        const double seconds = command_elapsed_seconds(command_buffer, start);
+        if (seconds <= 0.0 || !std::isfinite(seconds)) {
+            return 0.0;
+        }
+        volatile uint16_t guard = static_cast<uint16_t*>(c_buf.contents)[0];
+        (void)guard;
+        const double flops = static_cast<double>(iterations)
+            * 2.0
+            * static_cast<double>(size)
+            * static_cast<double>(size)
+            * static_cast<double>(size);
+        return flops / seconds / 1.0e12;
+    }
+}
+
+extern "C" double mp_metal_int4_gemv_gb_s(uint32_t in_dim, uint32_t out_dim, uint32_t group_size, uint32_t iterations) {
+    @autoreleasepool {
+        id<MTLDevice> device = metal_device();
+        id<MTLCommandQueue> queue = metal_queue();
+        if (device == nil || queue == nil || in_dim == 0 || out_dim == 0 || group_size == 0 || iterations == 0) {
+            return 0.0;
+        }
+        NSString* source =
+            @"#include <metal_stdlib>\n"
+             "using namespace metal;\n"
+             "struct Params { uint in_dim; uint out_dim; uint group_size; uint iterations; };\n"
+             "kernel void mp_int4(device const half* lhs [[buffer(0)]],\n"
+             "                    device const uchar* rhs [[buffer(1)]],\n"
+             "                    device const half* scales [[buffer(2)]],\n"
+             "                    device const half* zeros [[buffer(3)]],\n"
+             "                    device half* out [[buffer(4)]],\n"
+             "                    constant Params& p [[buffer(5)]],\n"
+             "                    uint row [[thread_position_in_grid]]) {\n"
+             "  if (row >= p.out_dim) return;\n"
+             "  const uint groups = (p.in_dim + p.group_size - 1) / p.group_size;\n"
+             "  float acc = 0.0f;\n"
+             "  for (uint rep = 0; rep < p.iterations; ++rep) {\n"
+             "    for (uint k = 0; k < p.in_dim; ++k) {\n"
+             "      uint packed = rhs[row * ((p.in_dim + 1) / 2) + (k >> 1)];\n"
+             "      uint nib = (k & 1) ? (packed >> 4) : (packed & 15);\n"
+             "      uint g = k / p.group_size;\n"
+             "      float w = (float(nib) - float(zeros[row * groups + g])) * float(scales[row * groups + g]);\n"
+             "      acc += float(lhs[k]) * w;\n"
+             "    }\n"
+             "  }\n"
+             "  out[row] = half(acc);\n"
+             "}\n";
+        id<MTLComputePipelineState> pipeline = pipeline_from_source(source, @"mp_int4");
+        if (pipeline == nil) {
+            return 0.0;
+        }
+        const uint64_t rhs_bytes = static_cast<uint64_t>(out_dim) * ((in_dim + 1) / 2);
+        const uint64_t groups = (in_dim + group_size - 1) / group_size;
+        id<MTLBuffer> lhs = [device newBufferWithLength:in_dim * sizeof(uint16_t) options:MTLResourceStorageModeShared];
+        id<MTLBuffer> rhs = [device newBufferWithLength:rhs_bytes options:MTLResourceStorageModeShared];
+        id<MTLBuffer> scales = [device newBufferWithLength:out_dim * groups * sizeof(uint16_t) options:MTLResourceStorageModeShared];
+        id<MTLBuffer> zeros = [device newBufferWithLength:out_dim * groups * sizeof(uint16_t) options:MTLResourceStorageModeShared];
+        id<MTLBuffer> out = [device newBufferWithLength:out_dim * sizeof(uint16_t) options:MTLResourceStorageModeShared];
+        if (lhs == nil || rhs == nil || scales == nil || zeros == nil || out == nil) {
+            return 0.0;
+        }
+        memset(lhs.contents, 0x3c, in_dim * sizeof(uint16_t));
+        memset(rhs.contents, 0x11, rhs_bytes);
+        memset(scales.contents, 0x3c, out_dim * groups * sizeof(uint16_t));
+        memset(zeros.contents, 0, out_dim * groups * sizeof(uint16_t));
+        struct Params { uint32_t in_dim; uint32_t out_dim; uint32_t group_size; uint32_t iterations; } params = {
+            in_dim, out_dim, group_size, iterations
+        };
+        id<MTLBuffer> params_buf = [device newBufferWithBytes:&params length:sizeof(params) options:MTLResourceStorageModeShared];
+        id<MTLCommandBuffer> command_buffer = [queue commandBuffer];
+        id<MTLComputeCommandEncoder> encoder = [command_buffer computeCommandEncoder];
+        [encoder setComputePipelineState:pipeline];
+        [encoder setBuffer:lhs offset:0 atIndex:0];
+        [encoder setBuffer:rhs offset:0 atIndex:1];
+        [encoder setBuffer:scales offset:0 atIndex:2];
+        [encoder setBuffer:zeros offset:0 atIndex:3];
+        [encoder setBuffer:out offset:0 atIndex:4];
+        [encoder setBuffer:params_buf offset:0 atIndex:5];
+        [encoder dispatchThreads:MTLSizeMake(out_dim, 1, 1) threadsPerThreadgroup:MTLSizeMake(256, 1, 1)];
+        [encoder endEncoding];
+        auto start = std::chrono::steady_clock::now();
+        [command_buffer commit];
+        const double seconds = command_elapsed_seconds(command_buffer, start);
+        if (seconds <= 0.0 || !std::isfinite(seconds)) {
+            return 0.0;
+        }
+        const double bytes = static_cast<double>(iterations) *
+            (static_cast<double>(rhs_bytes) + static_cast<double>(out_dim * groups * sizeof(uint16_t) * 2) +
+             static_cast<double>(out_dim) * static_cast<double>(in_dim) * sizeof(uint16_t));
+        return bytes / seconds / 1.0e9;
+    }
+}

--- a/crates/machine-profile/src/gpu/mod.rs
+++ b/crates/machine-profile/src/gpu/mod.rs
@@ -14,6 +14,8 @@ pub enum GpuProfileError {
     NotImplemented(&'static str),
     #[error("hip error: {0}")]
     Hip(String),
+    #[error("metal error: {0}")]
+    Metal(String),
 }
 
 pub trait GpuProfiler {
@@ -27,6 +29,13 @@ pub fn run_all() -> Vec<GpuProfile> {
         match hip::HipProfiler.profile() {
             Ok(p) => out.extend(p),
             Err(e) => eprintln!("HIP profiler failed: {e}"),
+        }
+    }
+    #[cfg(supersonic_backend_metal)]
+    {
+        match metal::MetalProfiler.profile() {
+            Ok(p) => out.extend(p),
+            Err(e) => eprintln!("Metal profiler failed: {e}"),
         }
     }
     out

--- a/crates/machine-profile/src/lib.rs
+++ b/crates/machine-profile/src/lib.rs
@@ -30,7 +30,7 @@ pub fn measure() -> Profile {
     let cpu_id = cpu::detect_cpu_id();
     let topology = cpu::topology::detect();
     let cache = cpu::cache::detect();
-    let vector_peak = cpu::vector_kernels::measure(topology.cores_p);
+    let vector_peak = cpu::vector_kernels::measure(topology.cores_p.max(1));
 
     // Skip DRAM in startup-mode measurement (allocates ~768 MiB); the CLI
     // can opt in via a future flag. For now we record `null` and warn.
@@ -64,22 +64,21 @@ pub fn measure() -> Profile {
 
     let driver = detect_driver();
     let fp_components = FingerprintComponents {
-        cpu: format!("{} stepping={} microcode={}",
+        cpu: format!(
+            "{} stepping={} microcode={}",
             cpu_profile.model,
             cpu_profile.stepping,
-            cpu_profile.microcode.as_deref().unwrap_or("?")),
-        gpus: gpus.iter()
-            .map(|g| format!("{}:{}:{}", g.backend, g.arch_name,
-                             g.pci_id.as_deref().unwrap_or("?")))
-            .collect(),
+            cpu_profile.microcode.as_deref().unwrap_or("?")
+        ),
+        gpus: gpus.iter().map(gpu_fingerprint_descriptor).collect(),
         driver: driver.clone(),
         isa: cpu_profile.isa.clone(),
     };
     let fp = fingerprint::compute(&fp_components);
 
     Profile {
-        schema_version: 1,
-        profile_version: "machine-profile/0.1.0".into(),
+        schema_version: 2,
+        profile_version: "machine-profile/0.2.0".into(),
         fingerprint: fp,
         fingerprint_components: fp_components,
         captured_at: Utc::now().to_rfc3339(),
@@ -92,6 +91,18 @@ pub fn measure() -> Profile {
             kernel_driver: Some(driver),
         },
     }
+}
+
+fn gpu_fingerprint_descriptor(g: &schema::GpuProfile) -> String {
+    if g.backend == "Metal" {
+        return format!("Metal:{}:{}", g.arch_name, g.cu_count);
+    }
+    format!(
+        "{}:{}:{}",
+        g.backend,
+        g.arch_name,
+        g.pci_id.as_deref().unwrap_or("?")
+    )
 }
 
 /// Compute the fingerprint without running any microkernels.
@@ -112,9 +123,16 @@ pub fn fingerprint_only() -> (String, schema::FingerprintComponents) {
             for info in infos {
                 gpu_descriptors.push(format!(
                     "HIP:{}:0x{:04x}",
-                    info.arch_name,
-                    info.pci_device_id
+                    info.arch_name, info.pci_device_id
                 ));
+            }
+        }
+    }
+    #[cfg(supersonic_backend_metal)]
+    {
+        if let Ok(infos) = gpu::metal::enumerate_for_fingerprint() {
+            for info in infos {
+                gpu_descriptors.push(format!("Metal:{}:{}", info.arch_name, info.core_count));
             }
         }
     }
@@ -156,6 +174,12 @@ fn apply_catalog(gpus: &mut [schema::GpuProfile], cpu: &schema::CpuProfile) {
 }
 
 fn read_total_ram() -> Option<u64> {
+    #[cfg(target_os = "macos")]
+    {
+        if let Some(v) = sysctl_string("hw.memsize").and_then(|s| s.parse().ok()) {
+            return Some(v);
+        }
+    }
     let s = std::fs::read_to_string("/proc/meminfo").ok()?;
     for line in s.lines() {
         if let Some(rest) = line.strip_prefix("MemTotal:") {
@@ -167,9 +191,31 @@ fn read_total_ram() -> Option<u64> {
 }
 
 fn read_uname_release() -> String {
-    std::fs::read_to_string("/proc/sys/kernel/osrelease")
-        .map(|s| format!("linux {}", s.trim()))
-        .unwrap_or_else(|_| "unknown".into())
+    #[cfg(target_os = "macos")]
+    {
+        let product = sysctl_string("kern.osproductversion")
+            .or_else(|| sysctl_string("kern.osrelease"))
+            .unwrap_or_else(|| "unknown".into());
+        format!("macos {product}")
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        std::fs::read_to_string("/proc/sys/kernel/osrelease")
+            .map(|s| format!("linux {}", s.trim()))
+            .unwrap_or_else(|_| "unknown".into())
+    }
+}
+
+fn sysctl_string(name: &str) -> Option<String> {
+    let output = std::process::Command::new("/usr/sbin/sysctl")
+        .args(["-n", name])
+        .output()
+        .ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
+        .filter(|s| !s.is_empty())
 }
 
 /// Detect a stable driver-version string for fingerprinting.

--- a/crates/machine-profile/src/schema.rs
+++ b/crates/machine-profile/src/schema.rs
@@ -126,6 +126,10 @@ pub struct GpuProfile {
     pub mma_peak: MmaPeak,
     pub pcie: PcieProfile,
     pub clock_rate_khz_measured: Option<u32>,
+    #[serde(default)]
+    pub metal: Option<MetalProfile>,
+    #[serde(default)]
+    pub microkernels: Vec<MicroKernelMeasurement>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
@@ -166,14 +170,40 @@ pub struct TransferSample {
     pub gb_s: f64,
 }
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct MetalProfile {
+    pub device_name: Option<String>,
+    pub metal_family: Option<String>,
+    pub gpu_core_count_source: Option<String>,
+    pub max_threadgroup_memory_bytes: Option<u64>,
+    pub max_threads_per_threadgroup: Option<u64>,
+    pub recommended_working_set_bytes: Option<u64>,
+    pub simdgroup_matrix_supported: Option<bool>,
+    pub mpp_tensor_matmul_supported: Option<bool>,
+    pub mpp_tensor_matmul_probe_status: Option<String>,
+    pub mpp_tensor_matmul_probe_code: Option<i32>,
+    pub mpp_tensor_write_probe_value: Option<f32>,
+    pub mpp_tensor_matmul_probe_value: Option<f32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MicroKernelMeasurement {
+    pub name: String,
+    pub dtype: Option<String>,
+    pub shape: Option<String>,
+    pub measured_gb_s: Option<f64>,
+    pub measured_tflops: Option<f64>,
+    pub iterations: u64,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     fn sample_profile() -> Profile {
         Profile {
-            schema_version: 1,
-            profile_version: "machine-profile/0.1.0".into(),
+            schema_version: 2,
+            profile_version: "machine-profile/0.2.0".into(),
             fingerprint: "blake3:test".into(),
             fingerprint_components: FingerprintComponents {
                 cpu: "AMD Ryzen 9 7950X".into(),
@@ -196,6 +226,95 @@ mod tests {
     #[test]
     fn profile_round_trips_through_json() {
         let p = sample_profile();
+        let s = serde_json::to_string(&p).unwrap();
+        let back: Profile = serde_json::from_str(&s).unwrap();
+        assert_eq!(p, back);
+    }
+
+    #[test]
+    fn v1_gpu_profile_defaults_new_v2_fields() {
+        let json = r#"{
+          "schema_version": 1,
+          "profile_version": "machine-profile/0.1.0",
+          "fingerprint": "blake3:test",
+          "fingerprint_components": {
+            "cpu": "AMD Ryzen",
+            "gpus": ["HIP:gfx1100:0x744c"],
+            "driver": "amdgpu",
+            "isa": ["AVX2"]
+          },
+          "captured_at": "2026-05-06T12:34:56Z",
+          "warnings": [],
+          "cpu": null,
+          "gpus": [{
+            "backend": "HIP",
+            "device_index": 0,
+            "arch_name": "gfx1100",
+            "pci_id": "0x744c",
+            "uuid": null,
+            "memory_arch": "Discrete",
+            "total_vram_bytes": 25769803776,
+            "cu_count": 48,
+            "wave_size": 32,
+            "lds_per_cu_bytes": 65536,
+            "lds_bw_per_cu_gb_s": 100.0,
+            "lds_bw_aggregate_gb_s": 4800.0,
+            "vram_bw": {"read_gb_s": 700.0, "write_gb_s": 600.0, "copy_gb_s": 650.0, "theoretical_peak_gb_s": null, "ratio_read": null},
+            "mma_peak": {"f16": null, "bf16": null, "fp8_e4m3": null, "i8": null},
+            "pcie": {"generation": null, "h2d_gb_s_by_size": [], "d2h_gb_s_by_size": [], "duplex_gb_s": null},
+            "clock_rate_khz_measured": null
+          }],
+          "system": {"ram_bytes": 64000000000, "os": "linux", "kernel_driver": "amdgpu"}
+        }"#;
+        let p: Profile = serde_json::from_str(json).unwrap();
+        assert_eq!(p.schema_version, 1);
+        assert!(p.gpus[0].metal.is_none());
+        assert!(p.gpus[0].microkernels.is_empty());
+    }
+
+    #[test]
+    fn v2_metal_profile_round_trips() {
+        let mut p = sample_profile();
+        p.gpus.push(GpuProfile {
+            backend: "Metal".into(),
+            device_index: 0,
+            arch_name: "apple-m5-max".into(),
+            pci_id: None,
+            uuid: None,
+            memory_arch: "Unified".into(),
+            total_vram_bytes: 48_000_000_000,
+            cu_count: 40,
+            wave_size: 32,
+            lds_per_cu_bytes: 32_768,
+            lds_bw_per_cu_gb_s: Some(100.0),
+            lds_bw_aggregate_gb_s: Some(4000.0),
+            vram_bw: VramBandwidth::default(),
+            mma_peak: MmaPeak::default(),
+            pcie: PcieProfile::default(),
+            clock_rate_khz_measured: None,
+            metal: Some(MetalProfile {
+                device_name: Some("Apple M5 Max".into()),
+                metal_family: Some("Apple GPU Family".into()),
+                gpu_core_count_source: Some("system_profiler".into()),
+                max_threadgroup_memory_bytes: Some(32_768),
+                max_threads_per_threadgroup: Some(1024),
+                recommended_working_set_bytes: Some(48_000_000_000),
+                simdgroup_matrix_supported: Some(true),
+                mpp_tensor_matmul_supported: Some(true),
+                mpp_tensor_matmul_probe_status: Some("ok".into()),
+                mpp_tensor_matmul_probe_code: Some(0),
+                mpp_tensor_write_probe_value: Some(123.0),
+                mpp_tensor_matmul_probe_value: Some(32.0),
+            }),
+            microkernels: vec![MicroKernelMeasurement {
+                name: "qwen36.int4_gemv.lm_head".into(),
+                dtype: Some("int4->bf16".into()),
+                shape: Some("in=2048, out=248320, group=128".into()),
+                measured_gb_s: Some(1000.0),
+                measured_tflops: None,
+                iterations: 1,
+            }],
+        });
         let s = serde_json::to_string(&p).unwrap();
         let back: Profile = serde_json::from_str(&s).unwrap();
         assert_eq!(p, back);

--- a/crates/machine-profile/tests/gpu_smoke.rs
+++ b/crates/machine-profile/tests/gpu_smoke.rs
@@ -3,7 +3,10 @@
 #[ignore = "requires GPU; run with --ignored"]
 fn hip_profile_passes_sanity_floors() {
     let profile = machine_profile::measure();
-    let gpu = profile.gpus.first().expect("HIP profiler should report >=1 GPU");
+    let gpu = profile
+        .gpus
+        .first()
+        .expect("HIP profiler should report >=1 GPU");
     assert!(
         gpu.vram_bw.read_gb_s.unwrap() > 50.0,
         "VRAM read {:.1} GB/s below floor of 50 GB/s",
@@ -18,5 +21,57 @@ fn hip_profile_passes_sanity_floors() {
         gpu.lds_bw_aggregate_gb_s.unwrap() > 1000.0,
         "LDS aggregate {:.1} GB/s below floor of 1000 GB/s",
         gpu.lds_bw_aggregate_gb_s.unwrap()
+    );
+}
+
+#[cfg(supersonic_backend_metal)]
+#[test]
+#[ignore = "requires Apple Metal GPU; run with --ignored"]
+fn metal_profile_passes_sanity_floors() {
+    let profile = machine_profile::measure();
+    let gpu = profile
+        .gpus
+        .iter()
+        .find(|g| g.backend == "Metal")
+        .expect("Metal profiler should report a GPU");
+    assert_eq!(gpu.memory_arch, "Unified");
+    assert!(
+        gpu.total_vram_bytes > 0,
+        "Metal working set should be nonzero"
+    );
+    assert!(gpu.cu_count > 0, "Metal GPU core count should be nonzero");
+    assert!(
+        gpu.vram_bw.read_gb_s.unwrap_or(0.0) > 1.0,
+        "Metal read bandwidth missing or too low"
+    );
+    assert!(
+        gpu.microkernels
+            .iter()
+            .any(|m| m.name == "qwen36.int4_gemv.lm_head" && m.measured_gb_s.unwrap_or(0.0) > 1.0),
+        "Qwen3.6-shaped INT4 GEMV microkernel missing or too low"
+    );
+    assert!(
+        gpu.metal
+            .as_ref()
+            .and_then(|m| m.simdgroup_matrix_supported)
+            .unwrap_or(false),
+        "Metal simdgroup matrix support should compile on this target"
+    );
+    assert!(
+        gpu.mma_peak
+            .f16
+            .as_ref()
+            .map(|m| m.measured_tflops)
+            .unwrap_or(0.0)
+            > 1.0,
+        "Metal F16 simdgroup MMA profile missing or too low"
+    );
+    assert!(
+        gpu.metal
+            .as_ref()
+            .and_then(|m| m.recommended_working_set_bytes)
+            .unwrap_or(0)
+            > 0,
+        "Metal recommended working set should be captured"
     );
 }

--- a/crates/runner/src/qwen36_moe/engine.rs
+++ b/crates/runner/src/qwen36_moe/engine.rs
@@ -758,6 +758,31 @@ fn decode_text(
             to_ms(decode_wall_start.elapsed()),
         );
     }
+    emit_mpp_pilot_if_requested(emit_stage_timings);
 
     Ok(())
+}
+
+fn emit_mpp_pilot_if_requested(emit_stage_timings: bool) {
+    if !emit_stage_timings || std::env::var_os("SUPERSONIC_METAL_QWEN36_MPP_PILOT").is_none() {
+        return;
+    }
+    let size = std::env::var("SUPERSONIC_METAL_QWEN36_MPP_PILOT_SIZE")
+        .ok()
+        .and_then(|v| v.parse::<u32>().ok())
+        .unwrap_or(2048);
+    let iterations = std::env::var("SUPERSONIC_METAL_QWEN36_MPP_PILOT_ITERS")
+        .ok()
+        .and_then(|v| v.parse::<u32>().ok())
+        .unwrap_or(5);
+    match kernel_ffi::qwen36_moe::metal_mpp_tile_gemm_f16_tflops(size, iterations) {
+        Ok(tflops) => eprintln!(
+            "[qwen36-moe mpp-pilot] status=ok size={} iterations={} tile_m=64 tile_n=32 tile_k=64 tflops={:.3}",
+            size, iterations, tflops
+        ),
+        Err(err) => eprintln!(
+            "[qwen36-moe mpp-pilot] status=error size={} iterations={} tflops=0.000 error={}",
+            size, iterations, err
+        ),
+    }
 }

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -830,28 +830,67 @@ Reproduce the run with:
 SUPERSONIC_TEST_MODEL_ROOT="$HOME/.cache/supersonic-metal-models" cargo run --release -p supersonic-bench --bin bench-perf -- --arch apple-m5-max --models qwen3.6-35b-a3b --quants int4
 ```
 
+Capture the native Metal hardware profile before starting runtime optimization:
+
+```bash
+SUPERSONIC_BACKENDS=metal cargo run -p machine-profile --bin machine-profile -- show --raw
+```
+
+The Metal profile records the Apple GPU device name, Metal capability metadata,
+unified-memory bandwidth, threadgroup-memory bandwidth, F16
+`simdgroup_multiply_accumulate` throughput rows split by accumulator dtype, a
+small sweep over simdgroups-per-threadgroup/threadgroups-per-core/accumulator
+count, an MPS FP16 GEMM roofline row, and Qwen3.6-shaped INT4 GEMV
+microkernels. On the current M5 Max machine the profiler identifies the GPU as
+`apple-m5-max` with 40 GPU cores from `system_profiler`; published profiles must
+remain sanitized and must not include serial numbers, hardware UUIDs, display
+serials, or provisioning identifiers. Treat the MPS row as the vendor-library
+hardware ceiling and the explicit simdgroup rows as SuperSonic kernel-design
+probes. The profile also includes a public-MSL tiled simdgroup GEMM row at
+`2048^3`, a same-size MPS row, and guarded MPP + Metal Tensor matmul rows. The
+MPP rows are the only rows intended to represent the supported M5 Neural
+Accelerator path; they remain `null` unless the runtime can compile the MPP
+shader, bind `MTLTensor` arguments through Metal 4 argument tables, complete the
+dispatch, and read back a nonzero tensor result. The support probe is a single
+full `64x64 * 64x32 -> 64x32` MPP tile; the large MPP rows are equivalent-GEMM
+throughput measurements built from repeated exact `64x32x64` MPP tiles and are
+independently guarded by their own output readback. They are not yet a claim
+that one whole square `MTLTensor` matmul invocation is working. The raw profile
+also records `mpp_tensor_matmul_probe_status`, `mpp_tensor_write_probe_value`,
+and `mpp_tensor_matmul_probe_value` so a failed MPP row distinguishes tensor
+binding from the MPP operation itself. If the isolated MMA sweep stays flat and
+the public tiled GEMM remains far below same-size MPS, the next
+optimization step is MPP/Metal-Tensor or MLX interop for large dense phases, not
+another single occupancy tweak.
+
 The harness records a warmup plus median-of-3 headline run at
 `--max-new-tokens 16`, then performs one additional `--emit-stage-timings`
 attribution run. For this Metal lane it also forces the dense prefill token loop
 (`SUPERSONIC_QWEN36_MOE_BATCHED_PREFILL=0` and
 `SUPERSONIC_QWEN36_DENSE_PREFILL_TOKEN_LOOP=1`) because the default Qwen3.6
-batched prefill router-permute path is HIP/CUDA-only. The attribution maps are
-stored in the same perf JSON as `stage_timings`, `chain_breakdown`, and
-`lifecycle_timings` without feeding back into the headline median.
+batched prefill router-permute path is HIP/CUDA-only. The attribution run also
+enables `SUPERSONIC_METAL_QWEN36_MPP_PILOT=1`, which emits a separate
+`[qwen36-moe mpp-pilot]` row for repeated exact `64x32x64` MPP tiles. This is a
+runtime-adjacent MPP pilot measurement, not a model matmul replacement. The
+attribution maps are stored in the same perf JSON as `stage_timings`,
+`chain_breakdown`, `lifecycle_timings`, and `mpp_pilot` without feeding back
+into the headline median.
 
 <!-- AUTOGEN BELOW: apple-m5-max-metal -->
 | Model           |  INT4 |
 | --------------- | ----: |
-| qwen3.6-35b-a3b | 2354.1 |
+| qwen3.6-35b-a3b | 2374.6 |
 
 <!-- AUTOGEN END: apple-m5-max-metal -->
 
 Unsupported Metal constraints remain explicit for this target: persistent
 decode, KV-FP8, speculative decode, batching, and Metal VMM are not benchmarked
-or claimed here yet. The first baseline from this section should drive the next
-runtime optimization target; the expected first candidate is Qwen3.6 INT4
-persistent Metal decode because the current path is still chained per-token
-dispatch.
+or claimed here yet. The benchmark baseline plus the native Metal profile should
+drive the next runtime optimization target. Because the Qwen3.6 hero lane uses
+GPTQ-packed INT4 weights and the public MPP tile currently consumes FP16
+`MTLTensor` inputs, the next runtime PR should either prove an INT4-compatible
+MPP packing/dequant bridge or keep MPP as an attribution-only pilot while the
+native Metal path targets fused FFN/MoE dispatch overhead.
 
 ## How to reproduce
 


### PR DESCRIPTION
## Summary

Adds the Apple M5 Max Metal profiling and benchmark attribution path needed before the next runtime optimization PR.

- extends the Qwen3.6 Apple M5 bench JSON with `mpp_pilot` attribution data
- adds an MPP + Metal Tensor FP16 tiled GEMM pilot behind `SUPERSONIC_METAL_QWEN36_MPP_PILOT`
- expands `machine-profile` with Metal device metadata, simdgroup, MPS, MPP, and Qwen3.6-shaped INT4 microkernel rows
- updates `docs/performance.md` with the latest Apple M5 Max Metal baseline and the current MPP/INT4 caveat

## Validation

- `cargo test -p supersonic-bench`
- `cargo test -p runner bench_combo_table_mentions_every_runner_supported_pair`
- `python3 -m pytest oracle/bench/tests/test_renderer.py oracle/bench/tests/test_schema.py -q`
- `SUPERSONIC_BACKENDS=metal cargo test -p kernel-ffi metal_mpp_tile_gemm_f16_pilot_smoke -- --ignored --nocapture`
- `git diff --check`

Manual M5 bench baseline:

- `target/bench-runs/2026-05-16-c2f06d7`
- Qwen3.6 35B-A3B INT4 Metal median: `2374.6 ms/step`
- MPP pilot attribution: `10.018 TFLOPS`

## Notes

This PR proves the supported public M5 tensor-unit access path through MPP + `MTLTensor` + Metal 4 argument tables, but it does not replace Qwen3.6 decode matmuls. The current hero lane remains GPTQ-packed INT4 on native Metal; the MPP pilot currently consumes FP16 tensors and is attribution-only.