### PR TITLE
[codex] reduce Qwen3.6 Metal prefill wall time

### DIFF
--- a/crates/kernel-ffi/src/metal_native.mm
+++ b/crates/kernel-ffi/src/metal_native.mm
@@ -5109,6 +5109,156 @@ kernel void supersonic_full_attention_prefill_tmajor_bf16_f32(
     return pipeline;
 }
 
+id<MTLComputePipelineState> full_attention_tmajor_vec_pipeline_bf16_f32(NSError** error_out) {
+    static std::mutex mutex;
+    static bool attempted = false;
+    static __strong id<MTLComputePipelineState> pipeline = nil;
+    static __strong NSError* build_error = nil;
+
+    std::lock_guard<std::mutex> lock(mutex);
+    if (!attempted) {
+        attempted = true;
+        @autoreleasepool {
+            id<MTLDevice> device = metal_device();
+            if (device == nil) {
+                build_error = [NSError errorWithDomain:@"SuperSonicMetal"
+                                                   code:221
+                                               userInfo:@{NSLocalizedDescriptionKey : @"No Metal device"}];
+            } else {
+                static const char* kSource = R"FATTNTMAJORVEC(
+#include <metal_stdlib>
+using namespace metal;
+
+struct FullAttentionParams {
+    uint q_heads;
+    uint kv_heads;
+    uint q_len;
+    uint kv_len;
+    uint kv_stride;
+    uint head_dim;
+    uint seqlen_offset;
+    float scale;
+};
+
+kernel void supersonic_full_attention_prefill_tmajor_vec_bf16_f32(
+    device const bfloat* query [[buffer(0)]],
+    device const bfloat* key [[buffer(1)]],
+    device const bfloat* value [[buffer(2)]],
+    device float* out [[buffer(3)]],
+    constant FullAttentionParams& params [[buffer(4)]],
+    uint2 tg [[threadgroup_position_in_grid]],
+    uint lane [[thread_index_in_threadgroup]]
+) {
+    uint q_head = tg.x;
+    uint q_pos = tg.y;
+    if (q_head >= params.q_heads || q_pos >= params.q_len || lane >= 256) {
+        return;
+    }
+
+    threadgroup float scratch[256];
+    uint num_kv_groups = params.q_heads / params.kv_heads;
+    uint kv_head = q_head / num_kv_groups;
+    uint max_attend = min(params.seqlen_offset + q_pos + 1, params.kv_len);
+    uint query_base = (q_pos * params.q_heads + q_head) * params.head_dim;
+
+    float max_score = -INFINITY;
+    for (uint kv_pos = 0; kv_pos < max_attend; ++kv_pos) {
+        uint key_base = (kv_pos * params.kv_heads + kv_head) * params.head_dim;
+        float partial = 0.0f;
+        if (lane < params.head_dim) {
+            partial = float(query[query_base + lane]) * float(key[key_base + lane]);
+        }
+        scratch[lane] = partial;
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        for (uint stride = 128; stride > 0; stride >>= 1) {
+            if (lane < stride) {
+                scratch[lane] += scratch[lane + stride];
+            }
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+        }
+        float score = scratch[0] * params.scale;
+        max_score = max(max_score, score);
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    float denom = 0.0f;
+    float numer = 0.0f;
+    for (uint kv_pos = 0; kv_pos < max_attend; ++kv_pos) {
+        uint key_base = (kv_pos * params.kv_heads + kv_head) * params.head_dim;
+        float partial = 0.0f;
+        if (lane < params.head_dim) {
+            partial = float(query[query_base + lane]) * float(key[key_base + lane]);
+        }
+        scratch[lane] = partial;
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        for (uint stride = 128; stride > 0; stride >>= 1) {
+            if (lane < stride) {
+                scratch[lane] += scratch[lane + stride];
+            }
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+        }
+        float weight = exp((scratch[0] * params.scale) - max_score);
+        denom += weight;
+        if (lane < params.head_dim) {
+            uint value_base = (kv_pos * params.kv_heads + kv_head) * params.head_dim;
+            numer += weight * float(value[value_base + lane]);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    if (lane < params.head_dim) {
+        out[(q_pos * params.q_heads + q_head) * params.head_dim + lane] = numer / denom;
+    }
+}
+)FATTNTMAJORVEC";
+                NSString* source = [NSString stringWithUTF8String:kSource];
+                MTLCompileOptions* options = [[MTLCompileOptions alloc] init];
+                configure_precise_math(options);
+                NSError* library_error = nil;
+                id<MTLLibrary> library = [device newLibraryWithSource:source
+                                                              options:options
+                                                                error:&library_error];
+                if (library == nil || library_error != nil) {
+                    build_error = library_error ?: [NSError errorWithDomain:@"SuperSonicMetal"
+                                                                       code:222
+                                                                   userInfo:@{
+                                                                       NSLocalizedDescriptionKey :
+                                                                           @"Failed to compile vectorized time-major full-attention library"
+                                                                   }];
+                } else {
+                    id<MTLFunction> function =
+                        [library newFunctionWithName:@"supersonic_full_attention_prefill_tmajor_vec_bf16_f32"];
+                    if (function == nil) {
+                        build_error = [NSError errorWithDomain:@"SuperSonicMetal"
+                                                           code:223
+                                                       userInfo:@{
+                                                           NSLocalizedDescriptionKey :
+                                                               @"Failed to load vectorized time-major full-attention function"
+                                                       }];
+                    } else {
+                        NSError* pipeline_error = nil;
+                        pipeline = [device newComputePipelineStateWithFunction:function
+                                                                         error:&pipeline_error];
+                        if (pipeline == nil || pipeline_error != nil) {
+                            build_error = pipeline_error ?: [NSError errorWithDomain:@"SuperSonicMetal"
+                                                                                 code:224
+                                                                             userInfo:@{
+                                                                                 NSLocalizedDescriptionKey :
+                                                                                     @"Failed to create vectorized time-major full-attention pipeline"
+                                                                             }];
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (pipeline == nil && error_out != nullptr) {
+        *error_out = build_error;
+    }
+    return pipeline;
+}
+
 id<MTLComputePipelineState> full_attention_decode_pipeline_bf16_f32(NSError** error_out) {
     static std::mutex mutex;
     static bool attempted = false;
@@ -15849,6 +15999,81 @@ extern "C" int supersonic_metal_full_attention_prefill_tmajor_bf16_f32(
             MTLSize threads_per_grid = MTLSizeMake(head_dim, q_heads, q_len);
             [encoder dispatchThreads:threads_per_grid threadsPerThreadgroup:threads_per_group];
         }, 217, 218, 219, 220);
+    }
+}
+
+extern "C" int supersonic_metal_full_attention_prefill_tmajor_vec_bf16_f32(
+    size_t q_heads,
+    size_t kv_heads,
+    size_t q_len,
+    size_t kv_len,
+    size_t head_dim,
+    float scale,
+    size_t seqlen_offset,
+    const void* query_ptr,
+    const void* key_ptr,
+    const void* value_ptr,
+    void* out_ptr
+) {
+    @autoreleasepool {
+        if (q_heads == 0 || kv_heads == 0 || q_len == 0 || kv_len == 0 ||
+            head_dim == 0 || head_dim > 256 || query_ptr == nullptr ||
+            key_ptr == nullptr || value_ptr == nullptr || out_ptr == nullptr ||
+            (q_heads % kv_heads) != 0) {
+            return 231;
+        }
+
+        NSError* pipeline_error = nil;
+        id<MTLComputePipelineState> pipeline =
+            full_attention_tmajor_vec_pipeline_bf16_f32(&pipeline_error);
+        if (pipeline == nil) {
+            return 232;
+        }
+
+        id<MTLBuffer> query = nil;
+        id<MTLBuffer> key = nil;
+        id<MTLBuffer> value = nil;
+        id<MTLBuffer> out = nil;
+        size_t query_offset = 0;
+        size_t key_offset = 0;
+        size_t value_offset = 0;
+        size_t out_offset = 0;
+        if (lookup_buffer(query_ptr, &query, &query_offset) != 0) {
+            return 233;
+        }
+        if (lookup_buffer(key_ptr, &key, &key_offset) != 0) {
+            return 234;
+        }
+        if (lookup_buffer(value_ptr, &value, &value_offset) != 0) {
+            return 235;
+        }
+        if (lookup_buffer(out_ptr, &out, &out_offset) != 0) {
+            return 236;
+        }
+
+        FullAttentionParams params = {
+            static_cast<uint32_t>(q_heads),
+            static_cast<uint32_t>(kv_heads),
+            static_cast<uint32_t>(q_len),
+            static_cast<uint32_t>(kv_len),
+            static_cast<uint32_t>(kv_len),
+            static_cast<uint32_t>(head_dim),
+            static_cast<uint32_t>(seqlen_offset),
+            scale,
+        };
+
+        return encode_or_submit_labeled([&](id<MTLComputeCommandEncoder> encoder) {
+            [encoder setComputePipelineState:pipeline];
+            [encoder setBuffer:query offset:query_offset atIndex:0];
+            [encoder setBuffer:key offset:key_offset atIndex:1];
+            [encoder setBuffer:value offset:value_offset atIndex:2];
+            [encoder setBuffer:out offset:out_offset atIndex:3];
+            [encoder setBytes:&params length:sizeof(params) atIndex:4];
+
+            MTLSize groups = MTLSizeMake(q_heads, q_len, 1);
+            MTLSize threads = MTLSizeMake(256, 1, 1);
+            [encoder dispatchThreadgroups:groups threadsPerThreadgroup:threads];
+        }, "full_attention_prefill_tmajor_vec", 237, 238, 239, 240);
     }
 }
 

--- a/crates/kernel-ffi/src/metal_native.rs
+++ b/crates/kernel-ffi/src/metal_native.rs
@@ -529,6 +529,19 @@ unsafe extern "C" {
         value_ptr: *const c_void,
         out_ptr: *mut c_void,
     ) -> c_int;
+    fn supersonic_metal_full_attention_prefill_tmajor_vec_bf16_f32(
+        q_heads: usize,
+        kv_heads: usize,
+        q_len: usize,
+        kv_len: usize,
+        head_dim: usize,
+        scale: f32,
+        seqlen_offset: usize,
+        query_ptr: *const c_void,
+        key_ptr: *const c_void,
+        value_ptr: *const c_void,
+        out_ptr: *mut c_void,
+    ) -> c_int;
     fn supersonic_metal_full_attention_decode_bf16_f32(
         q_heads: usize,
         kv_heads: usize,
@@ -3181,6 +3194,73 @@ pub(crate) unsafe fn full_attention_prefill_tmajor_bf16_f32(
             Backend::Metal,
             format!(
                 "metal native full_attention_prefill_tmajor_bf16_f32 failed with status {status}"
+            ),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(all(target_os = "macos", supersonic_backend_metal))]
+#[allow(clippy::too_many_arguments)]
+pub(crate) unsafe fn full_attention_prefill_tmajor_vec_bf16_f32(
+    q_heads: usize,
+    kv_heads: usize,
+    q_len: usize,
+    kv_len: usize,
+    head_dim: usize,
+    scale: f32,
+    seqlen_offset: usize,
+    query: &GpuBuffer,
+    key_ptr: *const c_void,
+    value_ptr: *const c_void,
+    out: &mut GpuBuffer,
+) -> Result<(), GpuError> {
+    if query.dtype() != ScalarType::BF16 {
+        return Err(GpuError::InvalidArg(format!(
+            "metal native full_attention_prefill_tmajor_vec expects BF16 query, got {:?}",
+            query.dtype()
+        )));
+    }
+    if out.dtype() != ScalarType::F32 {
+        return Err(GpuError::InvalidArg(format!(
+            "metal native full_attention_prefill_tmajor_vec expects F32 output, got {:?}",
+            out.dtype()
+        )));
+    }
+    if q_heads == 0
+        || kv_heads == 0
+        || q_heads % kv_heads != 0
+        || q_len == 0
+        || kv_len == 0
+        || head_dim == 0
+        || head_dim > 256
+        || key_ptr.is_null()
+        || value_ptr.is_null()
+    {
+        return Err(GpuError::InvalidArg(format!(
+            "metal native full_attention_prefill_tmajor_vec invalid shape: q_heads={q_heads} kv_heads={kv_heads} q_len={q_len} kv_len={kv_len} head_dim={head_dim}"
+        )));
+    }
+    let status = unsafe {
+        supersonic_metal_full_attention_prefill_tmajor_vec_bf16_f32(
+            q_heads,
+            kv_heads,
+            q_len,
+            kv_len,
+            head_dim,
+            scale,
+            seqlen_offset,
+            query.as_ptr(),
+            key_ptr,
+            value_ptr,
+            out.as_mut_ptr(),
+        )
+    };
+    if status != 0 {
+        return Err(GpuError::backend(
+            Backend::Metal,
+            format!(
+                "metal native full_attention_prefill_tmajor_vec_bf16_f32 failed with status {status}"
             ),
         ));
     }
@@ -5913,6 +5993,27 @@ pub(crate) unsafe fn full_attention_prefill_tmajor_bf16_f32(
     Err(GpuError::backend(
         Backend::Metal,
         "metal native full_attention_prefill_tmajor_bf16_f32 is not compiled".into(),
+    ))
+}
+
+#[cfg(not(all(target_os = "macos", supersonic_backend_metal)))]
+#[allow(clippy::too_many_arguments)]
+pub(crate) unsafe fn full_attention_prefill_tmajor_vec_bf16_f32(
+    _q_heads: usize,
+    _kv_heads: usize,
+    _q_len: usize,
+    _kv_len: usize,
+    _head_dim: usize,
+    _scale: f32,
+    _seqlen_offset: usize,
+    _query: &GpuBuffer,
+    _key_ptr: *const c_void,
+    _value_ptr: *const c_void,
+    _out: &mut GpuBuffer,
+) -> Result<(), GpuError> {
+    Err(GpuError::backend(
+        Backend::Metal,
+        "metal native full_attention_prefill_tmajor_vec_bf16_f32 is not compiled".into(),
     ))
 }
 

--- a/crates/kernel-ffi/src/prefill_ffi.rs
+++ b/crates/kernel-ffi/src/prefill_ffi.rs
@@ -3,7 +3,7 @@
 //! orchestrates them layer by layer.
 
 use std::collections::BTreeMap;
-use std::ffi::{c_char, c_int, c_void, CStr};
+use std::ffi::{c_char, c_int, c_void, CStr, CString};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Mutex, OnceLock};
 use std::time::Instant;
@@ -305,6 +305,15 @@ pub fn metal_batch_is_active() -> bool {
 
 pub fn set_metal_batch_label(label: &str) -> Result<(), GpuError> {
     metal_native::set_batch_label(label)
+}
+
+pub fn record_metal_profile_sample(op: &str, path: &str, elapsed_ms: f64) -> Result<(), GpuError> {
+    let op = CString::new(op)
+        .map_err(|_| GpuError::InvalidArg("metal profile op contains NUL byte".to_string()))?;
+    let path = CString::new(path)
+        .map_err(|_| GpuError::InvalidArg("metal profile path contains NUL byte".to_string()))?;
+    supersonic_metal_profile_record(op.as_ptr(), path.as_ptr(), elapsed_ms);
+    Ok(())
 }
 
 pub fn commit_metal_batch_current(label: &str) -> Result<(), GpuError> {
@@ -1534,6 +1543,43 @@ pub unsafe fn metal_full_attention_prefill_tmajor_bf16_f32(
     }
     metal_profile_time("full_attention_prefill_tmajor", "native", || unsafe {
         metal_native::full_attention_prefill_tmajor_bf16_f32(
+            q_heads,
+            kv_heads,
+            q_len,
+            kv_len,
+            head_dim,
+            scale,
+            seqlen_offset,
+            query,
+            key_ptr,
+            value_ptr,
+            out,
+        )
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+pub unsafe fn metal_full_attention_prefill_tmajor_vec_bf16_f32(
+    q_heads: usize,
+    kv_heads: usize,
+    q_len: usize,
+    kv_len: usize,
+    head_dim: usize,
+    scale: f32,
+    seqlen_offset: usize,
+    query: &GpuBuffer,
+    key_ptr: *const c_void,
+    value_ptr: *const c_void,
+    out: &mut GpuBuffer,
+) -> Result<(), GpuError> {
+    if out.backend() != Backend::Metal {
+        return Err(GpuError::InvalidArg(
+            "metal_full_attention_prefill_tmajor_vec_bf16_f32 requires a Metal output buffer"
+                .into(),
+        ));
+    }
+    metal_profile_time("full_attention_prefill_tmajor_vec", "native", || unsafe {
+        metal_native::full_attention_prefill_tmajor_vec_bf16_f32(
             q_heads,
             kv_heads,
             q_len,

--- a/crates/runner/src/qwen36_moe/batched_prefill.rs
+++ b/crates/runner/src/qwen36_moe/batched_prefill.rs
@@ -7,10 +7,11 @@
 //! attention layers and the MoE FFN keep the per-token chained launchers
 //! (their batched paths land in M9-M11 / a follow-up).
 //!
-//! When `SUPERSONIC_QWEN36_MOE_BATCHED_PREFILL=1` is set the engine
-//! routes prefill through `run_batched_prefill_stub` instead of running
-//! the prefill iterations of its main per-step loop. This module owns
-//! the *prefill range only* — the FIRST generation step (where
+//! The engine routes prefill through `run_batched_prefill_stub` by default
+//! instead of running the prefill iterations of its main per-step loop.
+//! Set `SUPERSONIC_QWEN36_MOE_BATCHED_PREFILL=0` to bisect back to the
+//! legacy token loop. This module owns the *prefill range only* — the
+//! FIRST generation step (where
 //! `step + 1 == effective_prompt_len` and logits are computed) is left
 //! to the engine's main loop.
 //!
@@ -111,6 +112,88 @@ pub(crate) struct BatchedPrefillTimings {
     pub chain_total: Duration,
     pub chunks: usize,
     pub tokens: usize,
+}
+
+fn metal_profile_enabled() -> bool {
+    std::env::var_os("SUPERSONIC_METAL_PROFILE").is_some()
+}
+
+fn batched_prefill_variant_label(backend: Backend) -> String {
+    let force_host_native = std::env::var_os("SUPERSONIC_METAL_FORCE_HOST_NATIVE").is_some();
+    let mut parts = if backend == Backend::Metal {
+        if std::env::var_os("SUPERSONIC_QWEN36_MOE_METAL_BATCHED_PREFILL_PROTOTYPE").is_some() {
+            vec!["metal-prototype"]
+        } else {
+            vec!["metal-default"]
+        }
+    } else {
+        vec!["batched"]
+    };
+    if force_host_native {
+        parts.push("force-host-native");
+    }
+
+    let metal_native_enabled = backend == Backend::Metal && !force_host_native;
+    let full_attn_tmajor_enabled = metal_native_enabled
+        && std::env::var("SUPERSONIC_QWEN36_MOE_METAL_FULL_ATTN_TMAJOR")
+            .map(|v| v != "0")
+            .unwrap_or(false);
+    let full_attn_vec_enabled = metal_native_enabled
+        && !full_attn_tmajor_enabled
+        && std::env::var("SUPERSONIC_QWEN36_MOE_METAL_FULL_ATTN_VEC")
+            .map(|v| v != "0")
+            .unwrap_or(true);
+    let shared_expert_batch_enabled = metal_native_enabled
+        && std::env::var("SUPERSONIC_QWEN36_MOE_METAL_SHARED_EXPERT_BATCH")
+            .map(|v| v != "0")
+            .unwrap_or(true);
+
+    if full_attn_tmajor_enabled {
+        parts.push("full-attn-tmajor");
+    }
+    if full_attn_vec_enabled {
+        parts.push("full-attn-vec");
+    }
+    if metal_native_enabled
+        && std::env::var("SUPERSONIC_QWEN36_MOE_METAL_ROUTER_TOPK")
+            .map(|v| v != "0")
+            .unwrap_or(false)
+    {
+        parts.push("router-topk");
+    }
+    if shared_expert_batch_enabled {
+        parts.push("shared-expert-batch");
+    }
+    if shared_expert_batch_enabled
+        && std::env::var("SUPERSONIC_QWEN36_MOE_METAL_FUSED_FFN_RESIDUAL")
+            .map(|v| v != "0")
+            .unwrap_or(true)
+    {
+        parts.push("fused-residual");
+    }
+    parts.join("+")
+}
+
+fn emit_prefill_progress(
+    mode: &str,
+    variant: &str,
+    timings: &BatchedPrefillTimings,
+    prefill_tokens: usize,
+    last_context: usize,
+    elapsed: Duration,
+) {
+    eprintln!(
+        "[qwen36-moe prefill-progress] mode={mode} variant={variant} \
+         chunks={} tokens={} prefill_tokens={} last_context={} embed_ms={:.3} \
+         chain_ms={:.3} elapsed_ms={:.3}",
+        timings.chunks,
+        timings.tokens,
+        prefill_tokens,
+        last_context,
+        timings.embed_total.as_secs_f64() * 1000.0,
+        timings.chain_total.as_secs_f64() * 1000.0,
+        elapsed.as_secs_f64() * 1000.0,
+    );
 }
 
 /// CPU-built RoPE cos/sin tables uploaded once per orchestrator invocation.
@@ -352,6 +435,8 @@ pub(crate) fn run_batched_prefill_stub(
     // FFN/linear-attn fallbacks; pull them through the orchestrator.
     let mut persistent_scratch = persistent_scratch;
     let mut moe_expert_residency = moe_expert_residency;
+    let variant = batched_prefill_variant_label(gpu_hal::current_backend());
+    let prefill_start = Instant::now();
 
     let mut step = 0usize;
     while step < prefill_count {
@@ -390,6 +475,14 @@ pub(crate) fn run_batched_prefill_stub(
         let _ = t_chunk;
 
         step += n;
+        emit_prefill_progress(
+            "batched",
+            &variant,
+            &timings,
+            prefill_count,
+            step,
+            prefill_start.elapsed(),
+        );
     }
 
     Ok(timings)
@@ -416,11 +509,6 @@ fn supports_batched_path(
     moe_expert_residency_active: bool,
 ) -> bool {
     let _ = keep_mask;
-    if gpu_hal::current_backend() == Backend::Metal
-        && std::env::var_os("SUPERSONIC_QWEN36_MOE_METAL_BATCHED_PREFILL_PROTOTYPE").is_none()
-    {
-        return false;
-    }
     if moe_expert_residency_active {
         return false;
     }
@@ -1124,10 +1212,17 @@ fn process_full_attn_layer_batched(
     }
 
     let kv_len = past_len + n;
-    let use_metal_tmajor_full_attn = chunk_hidden.backend() == Backend::Metal
+    let metal_native_enabled = chunk_hidden.backend() == Backend::Metal
+        && std::env::var_os("SUPERSONIC_METAL_FORCE_HOST_NATIVE").is_none();
+    let use_metal_tmajor_full_attn = metal_native_enabled
         && std::env::var("SUPERSONIC_QWEN36_MOE_METAL_FULL_ATTN_TMAJOR")
             .map(|v| v != "0")
             .unwrap_or(false);
+    let use_metal_vec_full_attn = metal_native_enabled
+        && !use_metal_tmajor_full_attn
+        && std::env::var("SUPERSONIC_QWEN36_MOE_METAL_FULL_ATTN_VEC")
+            .map(|v| v != "0")
+            .unwrap_or(true);
 
     if use_metal_tmajor_full_attn {
         // 7. Metal-only fast layout path. The native kernel reads the
@@ -1150,6 +1245,23 @@ fn process_full_attn_layer_batched(
             )
         }
         .map_err(|e| anyhow!("metal full_attention_prefill_tmajor: {e}"))?;
+    } else if use_metal_vec_full_attn {
+        unsafe {
+            prefill_ffi::metal_full_attention_prefill_tmajor_vec_bf16_f32(
+                h,
+                hkv,
+                n,
+                kv_len,
+                hd,
+                scale,
+                past_len,
+                &scratch.q_after,
+                cache_k_ptr as *const c_void,
+                cache_v_ptr as *const c_void,
+                &mut scratch.attn_out_nhd_f32,
+            )
+        }
+        .map_err(|e| anyhow!("metal full_attention_prefill_tmajor_vec: {e}"))?;
     } else {
         // 7. Legacy layout path: transpose q [n, h, hd] -> [h, n, hd] and
         // materialize a compact head-major KV prefix for M3 input.
@@ -2159,8 +2271,26 @@ fn process_ffn_batched_grouped(
             .map_err(|e| anyhow!("finish Metal router/expert FFN batch: {e}"))?;
     }
 
-    // 7. Shared expert (batched primitives).
-    //
+    // 7. Shared expert (batched primitives). On Metal, encode the shared
+    // expert tail in one command buffer by default. Profile runs split at
+    // phase labels so the report can still attribute the work.
+    let use_metal_shared_expert_batch = scratch.h_norm.backend() == Backend::Metal
+        && std::env::var_os("SUPERSONIC_METAL_FORCE_HOST_NATIVE").is_none()
+        && std::env::var("SUPERSONIC_QWEN36_MOE_METAL_SHARED_EXPERT_BATCH")
+            .map(|v| v != "0")
+            .unwrap_or(true);
+    let metal_shared_profile = use_metal_shared_expert_batch && metal_profile_enabled();
+    let metal_shared_start = metal_shared_profile.then(Instant::now);
+    let metal_shared_batch = if use_metal_shared_expert_batch {
+        let guard = prefill_ffi::MetalBatchGuard::begin()
+            .map_err(|e| anyhow!("begin Metal shared FFN batch: {e}"))?;
+        prefill_ffi::set_metal_batch_label("qwen36_batched_prefill_shared_expert_int4")
+            .map_err(|e| anyhow!("label Metal shared FFN batch: {e}"))?;
+        Some(guard)
+    } else {
+        None
+    };
+
     //    7a. shared_gate = INT4_matmul(h_norm, shared_gate_proj_w)
     //         shape [shared_intermediate, hidden] INT4 → out [N, shared_intermediate]
     prefill_ffi::matmul_rhs_transposed_int4(
@@ -2206,6 +2336,12 @@ fn process_ffn_batched_grouped(
         &mut scratch.shared_silu_mul,
     )
     .map_err(|e| anyhow!("swiglu_mul shared: {e}"))?;
+    if metal_shared_profile {
+        prefill_ffi::commit_metal_batch_current("qwen36_batched_prefill_shared_gate_up")
+            .map_err(|e| anyhow!("profile commit Metal shared gate/up: {e}"))?;
+        prefill_ffi::set_metal_batch_label("qwen36_batched_prefill_shared_down_scalar")
+            .map_err(|e| anyhow!("label Metal shared down/scalar: {e}"))?;
+    }
     //    7d. shared_down = INT4_matmul(shared_silu_mul, shared_down_proj_w)
     //         shape [hidden, shared_intermediate] INT4 → out [N, hidden]
     prefill_ffi::matmul_rhs_transposed_int4(
@@ -2277,6 +2413,12 @@ fn process_ffn_batched_grouped(
         )
         .context("d2d shared_out_final -> shared_out")?;
     }
+    if metal_shared_profile {
+        prefill_ffi::commit_metal_batch_current("qwen36_batched_prefill_shared_down_scalar")
+            .map_err(|e| anyhow!("profile commit Metal shared down/scalar: {e}"))?;
+        prefill_ffi::set_metal_batch_label("qwen36_batched_prefill_ffn_finalize")
+            .map_err(|e| anyhow!("label Metal FFN finalize: {e}"))?;
+    }
 
     // 8. Residual add: chunk_hidden += combined; chunk_hidden += shared_out.
     // Opt-in diagnostic only: the fused Metal residual-add path preserves the
@@ -2284,9 +2426,10 @@ fn process_ffn_batched_grouped(
     // the existing two-add sequence.
     let use_metal_fused_residual = chunk_hidden.backend() == Backend::Metal
         && std::env::var_os("SUPERSONIC_METAL_FORCE_HOST_NATIVE").is_none()
+        && use_metal_shared_expert_batch
         && std::env::var("SUPERSONIC_QWEN36_MOE_METAL_FUSED_FFN_RESIDUAL")
             .map(|v| v != "0")
-            .unwrap_or(false);
+            .unwrap_or(true);
     if use_metal_fused_residual {
         prefill_ffi::qwen36_ffn_residual_add_bf16(
             n * hidden,
@@ -2312,6 +2455,19 @@ fn process_ffn_batched_grouped(
             &scratch.shared_out,
         )
         .map_err(|e| anyhow!("residual add (shared_out): {e}"))?;
+    }
+    if let Some(batch) = metal_shared_batch {
+        batch
+            .finish()
+            .map_err(|e| anyhow!("finish Metal shared FFN batch: {e}"))?;
+    }
+    if let Some(start) = metal_shared_start {
+        prefill_ffi::record_metal_profile_sample(
+            "qwen36_batched_prefill_shared_expert_int4",
+            "native",
+            start.elapsed().as_secs_f64() * 1000.0,
+        )
+        .map_err(|e| anyhow!("record Metal shared FFN profile: {e}"))?;
     }
 
     // Touch unused fields to keep the compiler happy on cfg(feature) gates.

--- a/crates/runner/src/qwen36_moe/engine.rs
+++ b/crates/runner/src/qwen36_moe/engine.rs
@@ -678,6 +678,17 @@ fn decode_text(
             prefill_chain_elapsed += t_prefill;
             loop_state.position += dense_prefill_count as i32;
             loop_state.current_token = prompt_ids[dense_prefill_count];
+            eprintln!(
+                "[qwen36-moe prefill-progress] mode=dense-token-loop variant=legacy \
+                 chunks=1 tokens={} prefill_tokens={} last_context={} embed_ms={:.3} \
+                 chain_ms={:.3} elapsed_ms={:.3}",
+                dense_prefill_count,
+                dense_prefill_count,
+                dense_prefill_count,
+                0.0,
+                t_prefill.as_secs_f64() * 1000.0,
+                t_prefill.as_secs_f64() * 1000.0,
+            );
         }
     }
 

--- a/docs/build-and-run.md
+++ b/docs/build-and-run.md
@@ -545,16 +545,18 @@ On the first 512-token smoke, the 512/1024-token plans tied because the prompt
 had 417 profiled prefill tokens: 82.7% WMMA16 assignment coverage, 23,048
 scalar-tail assignments, and 54.6% WMMA16 padding overhead. Smaller chunks
 increased scalar tails sharply.
-With `--batched-prefill-prototype`, the harness flips the explicit
-`SUPERSONIC_QWEN36_MOE_METAL_BATCHED_PREFILL_PROTOTYPE=1` opt-in and runs the
-experimental Metal batched-prefill route. This path uses Metal batched
-full-attention and a direct routed-expert INT4 kernel pair for grouped MoE
-prefill while keeping router/top-k and shared-expert work on the existing host
-or primitive path. It is not the supported default lane yet.
+The Metal long-context harness now runs the Metal batched-prefill route by
+default. This path uses Metal batched full-attention and a direct routed-expert
+INT4 kernel pair for grouped MoE prefill while keeping router/top-k on the
+existing host path; set `--legacy-prefill-baseline` to force the older
+per-token Metal prefill baseline for A/B reports. `--batched-prefill-prototype`
+is retained as a compatibility/provenance tag for reports that still separate
+prototype-default from baseline modes.
 `--batched-prefill-variant` makes the env-gated prototype probes reproducible
-from the harness: `linear-direct-off`, `full-attn-tmajor`, `split-qgate`,
-`router-topk`, and `fused-residual`. The JSON rows record both the variant name
-and the exact env overrides used for the run.
+from the harness: `linear-direct-off`, `full-attn-vec-off`, `full-attn-tmajor`,
+`split-qgate`, `router-topk`, `fused-residual-off`, and
+`shared-expert-batch-off`. The JSON rows record both the variant name and the
+exact env overrides used for the run.
 `tests/metal/sweep_qwen36_batched_prefill_variants.py` runs the supported
 `baseline`, `prototype-default`, and selected named variants against the same
 deterministic NIAH prompt per context. It writes

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -880,7 +880,7 @@ The local-main-target workflow for this machine is:
 3. long-context smoke: `SUPERSONIC_TEST_MODEL_ROOT="$HOME/.cache/supersonic-metal-models" python3 tests/metal/bench_qwen36_longctx.py --preset smoke`
 4. profile smoke: `SUPERSONIC_TEST_MODEL_ROOT="$HOME/.cache/supersonic-metal-models" python3 tests/metal/bench_qwen36_longctx.py --preset smoke --metal-profile`
 5. batched-prefill MoE feasibility: `SUPERSONIC_TEST_MODEL_ROOT="$HOME/.cache/supersonic-metal-models" python3 tests/metal/bench_qwen36_longctx.py --preset smoke --batched-prefill-feasibility`
-6. batched-prefill Metal prototype: `SUPERSONIC_TEST_MODEL_ROOT="$HOME/.cache/supersonic-metal-models" python3 tests/metal/bench_qwen36_longctx.py --preset smoke --batched-prefill-prototype`
+6. batched-prefill Metal default: `SUPERSONIC_TEST_MODEL_ROOT="$HOME/.cache/supersonic-metal-models" python3 tests/metal/bench_qwen36_longctx.py --preset smoke`
 7. batched-prefill variant sweep: `SUPERSONIC_TEST_MODEL_ROOT="$HOME/.cache/supersonic-metal-models" python3 tests/metal/sweep_qwen36_batched_prefill_variants.py --metal-profile`
 8. MTP tensor audit: `SUPERSONIC_TEST_MODEL_ROOT="$HOME/.cache/supersonic-metal-models" python3 tests/metal/audit_qwen36_mtp.py --require-complete-bake`
 9. MTP acceptance/policy probe: `SUPERSONIC_TEST_MODEL_ROOT="$HOME/.cache/supersonic-metal-models" python3 tests/metal/probe_qwen36_mtp_acceptance.py`
@@ -914,21 +914,34 @@ metadata a future Metal prefill kernel would consume: profiled tokens, chunks,
 expert segments, average rows per touched expert, and WMMA16 assignment
 coverage. It also emits `[qwen36-batched-prefill-plan]` rows for candidate
 64/128/256/512/1024-token chunks, recording scalar tail assignments, WMMA16
-padded assignments, and padding overhead. With `--batched-prefill-prototype`,
-the harness sets
-`SUPERSONIC_QWEN36_MOE_METAL_BATCHED_PREFILL_PROTOTYPE=1` and runs the
-experimental Metal batched-prefill path: Metal batched full-attention plus a
-direct routed-expert INT4 gate/up and down/combine kernel pair, with
-router/top-k and shared-expert work still on the existing host/primitive path.
+padded assignments, and padding overhead. The harness now runs the Metal
+batched-prefill path by default: Metal batched full-attention plus a direct
+routed-expert INT4 gate/up and down/combine kernel pair, with router/top-k
+still on the existing host path. Set `--legacy-prefill-baseline` when a report
+needs the older per-token Metal prefill baseline; `--batched-prefill-prototype`
+is retained as a compatibility/provenance tag for older A/B report modes. The
+shared-expert tail now opens one Metal batch per layer/chunk by default and
+uses the fused residual add to avoid the old batch-flushing two-add sequence;
+set
+`SUPERSONIC_QWEN36_MOE_METAL_SHARED_EXPERT_BATCH=0` to bisect back to the
+primitive sequence. Full-attention prefill now uses a prefill-specific
+time-major vector kernel by default. One threadgroup owns each `(query, head)`
+row, reduces the Q·K dot across `head_dim` once per KV token, and has lanes
+accumulate V dimensions; set `SUPERSONIC_QWEN36_MOE_METAL_FULL_ATTN_VEC=0` to
+fall back to the older scalar-per-output-dimension attention path.
 `--batched-prefill-variant` names the measured env-gated prototype probes
 without requiring hand-built environment overrides: `linear-direct-off`,
-`full-attn-tmajor`, `split-qgate`, `router-topk`, and `fused-residual`.
+`full-attn-vec-off`, `full-attn-tmajor`, `split-qgate`, `router-topk`,
+`fused-residual-off`, and `shared-expert-batch-off`.
 The harness records the selected variant and its env overrides per row so A/B
 comparison outputs are self-describing. The long-context JSON schema is now
-`qwen36-moe-metal-longctx-bench-v5` and
+`qwen36-moe-metal-longctx-bench-v6` and
 records `batched_prefill_prototype` at top level plus
 `metal_batched_prefill_prototype` and `batched_prefill_variant` per row;
-feasibility rows remain under `batched_prefill_plans`; set
+feasibility rows remain under `batched_prefill_plans`, and each row can carry
+`prefill_progress` entries from `[qwen36-moe prefill-progress]` so an 8192-token
+crash still preserves chunks/tokens completed, active variant, and elapsed
+prefill time; set
 `SUPERSONIC_QWEN36_MOE_BATCHED_PREFILL_PLAN_CHUNKS=...` to override the planner
 chunk list without adding a SuperSonic CLI flag.
 `tests/metal/sweep_qwen36_batched_prefill_variants.py` wraps those variant
@@ -984,7 +997,47 @@ materializing the baked model buffers. That makes the next measured target
 prefill orchestration, linear-attention command-buffer volume, full-attention
 prefill, and routed-expert direct work, not per-token MPS slab materialization.
 
-The next orchestration slice targets `qwen36_linear_int4_stage5`, which had
+The current prefill-reduction pass adds crash-resilient progress telemetry,
+promotes the Metal shared-expert tail from separate primitive submissions into
+a batched command-buffer section, and adds the prefill-specific vector
+full-attention kernel. Profile runs split the shared section into stable labels
+(`qwen36_batched_prefill_shared_gate_up`,
+`qwen36_batched_prefill_shared_down_scalar`,
+`qwen36_batched_prefill_ffn_finalize`) while also recording aggregate
+`qwen36_batched_prefill_shared_expert_int4` wall time. The vector attention
+kernel is labelled `full_attention_prefill_tmajor_vec`.
+
+The first validation run for that pass used one-token NIAH smokes on 2026-05-25
+with no warmup. Baseline rows are the pre-change legacy Metal prefill path;
+prototype/vector rows use the promoted Metal batched-prefill path with the
+shared-expert batch enabled:
+
+| Context | Legacy prefill | Shared-batch prototype | Promoted vector prefill | Improvement vs legacy | Vector ms/tok | Progress row |
+|---:|---:|---:|---:|---:|---:|:---|
+| 512 | 25.33 s | 9.71 s | 7.01 s | 72.3% | 100.38 | 417 tokens, 1 chunk |
+| 2048 | 165.24 s | 75.31 s | 28.24 s | 82.9% | 199.31 | 1762 tokens, 4 chunks |
+| 8192 | - | 1018.00 s | 147.94 s | - | 613.29 | 7142 tokens, 14 chunks |
+
+The 8192 prototype row completed cleanly with generated ID `[271]`; the prior
+`-11` long-prefill failure did not reproduce on either prototype path. NIAH
+still reports NO for these rows because the run intentionally generates only
+one token. A no-`--batched-prefill-prototype` default rerun confirms the
+promoted runtime path: progress rows report
+`metal-default+full-attn-vec+shared-expert-batch` for 512, 2048, and 8192. The
+post-vector 512 profile names `command_buffer_wait` (8.57 s),
+`qwen36_linear_int4_stage5` (4.48 s), and
+`qwen36_batched_prefill_grouped_expert_direct` (3.47 s) as the largest native
+rows. The post-vector 2048 profile reports 37.63 s prefill under
+profiling, with `command_buffer_wait` (34.98 s), `qwen36_linear_int4_stage5`
+(18.78 s native), `qwen36_batched_prefill_grouped_expert_direct` (12.20 s
+native), HAL `copy_h2d` (10.78 s), and `full_attention_prefill_tmajor_vec`
+(2.01 s native) as the largest rows. The next measured bottleneck is therefore
+linear-attention command-buffer volume plus routed expert work at short
+contexts, and full-attention/KV bandwidth becomes visible again as context
+length grows.
+
+The earlier linear-attention orchestration slice targeted
+`qwen36_linear_int4_stage5`, which had
 12,540 waited calls in the profiled 512-token run. The normal Metal prototype
 now keeps the native stage-5 temporary output separate from the final residual
 destination, opens one Metal batch per linear-attention layer, and writes final
@@ -1008,7 +1061,8 @@ prefill, and native Q/gate splitting via
 `SUPERSONIC_QWEN36_MOE_METAL_SPLIT_QGATE=1` measured 11.00s prefill. With both
 probes disabled, the default path measured 10.73s prefill and generated the
 same `[271]` sanity row. The measured next bottleneck remains routed expert
-compute/residency, not these full-attention layout probes.
+compute/residency at the 512-token smoke size, while the 2048/8192 rows above
+shift the next long-context target to full-attention/KV bandwidth.
 
 Two routed-FFN micro-orchestration probes are also measured negative and remain
 opt-in only. `SUPERSONIC_QWEN36_MOE_METAL_FUSED_FFN_RESIDUAL=1` fuses

--- a/docs/research/2026-05-23-qwen36-moe-sota.md
+++ b/docs/research/2026-05-23-qwen36-moe-sota.md
@@ -407,7 +407,7 @@ under the same smoke:
    the measured faster host-top-k and two-add residual path.
    The long-context harness now has a `--batched-prefill-variant` selector for
    these measured env-gated probes (`linear-direct-off`, `full-attn-tmajor`,
-   `split-qgate`, `router-topk`, and `fused-residual`) and records the selected
+   `split-qgate`, `router-topk`, and `fused-residual-off`) and records the selected
    variant plus env overrides in JSON rows. This keeps the negative/prototype
    gates reproducible without promoting them into the SuperSonic CLI.
 

--- a/tests/metal/bench_qwen36_longctx.py
+++ b/tests/metal/bench_qwen36_longctx.py
@@ -23,7 +23,7 @@ from typing import Any
 
 
 MODEL = "qwen3.6-35b-a3b"
-SCHEMA = "qwen36-moe-metal-longctx-bench-v5"
+SCHEMA = "qwen36-moe-metal-longctx-bench-v6"
 
 PRESETS: dict[str, dict[str, Any]] = {
     "smoke": {
@@ -48,11 +48,18 @@ PRESETS: dict[str, dict[str, Any]] = {
 
 BATCHED_PREFILL_VARIANTS: dict[str, dict[str, str]] = {
     "default": {},
+    "full-attn-vec-off": {"SUPERSONIC_QWEN36_MOE_METAL_FULL_ATTN_VEC": "0"},
     "linear-direct-off": {"SUPERSONIC_QWEN36_MOE_METAL_LINEAR_PREFILL_DIRECT": "0"},
-    "full-attn-tmajor": {"SUPERSONIC_QWEN36_MOE_METAL_FULL_ATTN_TMAJOR": "1"},
+    "full-attn-tmajor": {
+        "SUPERSONIC_QWEN36_MOE_METAL_FULL_ATTN_TMAJOR": "1",
+        "SUPERSONIC_QWEN36_MOE_METAL_FULL_ATTN_VEC": "0",
+    },
     "split-qgate": {"SUPERSONIC_QWEN36_MOE_METAL_SPLIT_QGATE": "1"},
     "router-topk": {"SUPERSONIC_QWEN36_MOE_METAL_ROUTER_TOPK": "1"},
-    "fused-residual": {"SUPERSONIC_QWEN36_MOE_METAL_FUSED_FFN_RESIDUAL": "1"},
+    "fused-residual-off": {"SUPERSONIC_QWEN36_MOE_METAL_FUSED_FFN_RESIDUAL": "0"},
+    "shared-expert-batch-off": {
+        "SUPERSONIC_QWEN36_MOE_METAL_SHARED_EXPERT_BATCH": "0"
+    },
 }
 
 
@@ -90,7 +97,7 @@ def resolve_model_dir(raw_model_dir: Path | None, env: dict[str, str]) -> Path:
     return Path.home() / ".cache" / "supersonic-metal-models" / MODEL
 
 
-def build_metal_env(base_env: dict[str, str]) -> dict[str, str]:
+def build_metal_env(base_env: dict[str, str], *, legacy_prefill: bool = False) -> dict[str, str]:
     env = base_env.copy()
     env["SUPERSONIC_BACKENDS"] = "metal"
 
@@ -104,10 +111,24 @@ def build_metal_env(base_env: dict[str, str]) -> dict[str, str]:
     ):
         env.pop(key, None)
 
-    env["SUPERSONIC_QWEN36_MOE_BATCHED_PREFILL"] = "0"
-    env["SUPERSONIC_QWEN36_MOE_BATCHED_ATTN"] = "0"
-    env["SUPERSONIC_QWEN36_MOE_GROUPED_FFN"] = "0"
-    env["SUPERSONIC_QWEN36_DENSE_PREFILL_TOKEN_LOOP"] = "1"
+    for key in (
+        "SUPERSONIC_QWEN36_MOE_BATCHED_PREFILL",
+        "SUPERSONIC_QWEN36_MOE_BATCHED_ATTN",
+        "SUPERSONIC_QWEN36_MOE_GROUPED_FFN",
+        "SUPERSONIC_QWEN36_DENSE_PREFILL_TOKEN_LOOP",
+        "SUPERSONIC_QWEN36_MOE_METAL_BATCHED_PREFILL_PROTOTYPE",
+    ):
+        env.pop(key, None)
+
+    if legacy_prefill:
+        env["SUPERSONIC_QWEN36_MOE_BATCHED_PREFILL"] = "0"
+        env["SUPERSONIC_QWEN36_MOE_BATCHED_ATTN"] = "0"
+        env["SUPERSONIC_QWEN36_MOE_GROUPED_FFN"] = "0"
+        env["SUPERSONIC_QWEN36_DENSE_PREFILL_TOKEN_LOOP"] = "1"
+    else:
+        env["SUPERSONIC_QWEN36_MOE_BATCHED_PREFILL"] = "1"
+        env["SUPERSONIC_QWEN36_MOE_BATCHED_ATTN"] = "1"
+        env["SUPERSONIC_QWEN36_MOE_GROUPED_FFN"] = "1"
     return env
 
 
@@ -133,6 +154,10 @@ def parse_key_values(line: str) -> dict[str, str]:
         key, raw = part.split("=", 1)
         values[key] = raw.rstrip(",)")
     return values
+
+
+def render_float(value: Any) -> str:
+    return f"{value:.3f}" if isinstance(value, (int, float)) else ""
 
 
 def parse_profile(output: str, summary_prefix: str, op_prefix: str) -> dict[str, Any] | None:
@@ -200,6 +225,27 @@ def parse_batched_prefill_plans(output: str) -> list[dict[str, Any]]:
                 parsed[key] = value
         plans.append(parsed)
     return plans
+
+
+def parse_prefill_progress(output: str) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for line in output.splitlines():
+        if not line.startswith("[qwen36-moe prefill-progress]"):
+            continue
+        parsed: dict[str, Any] = {}
+        for key, value in parse_key_values(line).items():
+            if key in {"mode", "variant"}:
+                parsed[key] = value
+                continue
+            try:
+                if any(ch in value for ch in ".eE"):
+                    parsed[key] = float(value)
+                else:
+                    parsed[key] = int(value)
+            except ValueError:
+                parsed[key] = value
+        rows.append(parsed)
+    return rows
 
 
 def append_batched_prefill_feasibility_markdown(md: str, rows: list[dict[str, Any]]) -> str:
@@ -271,6 +317,37 @@ def append_batched_prefill_plan_markdown(md: str, rows: list[dict[str, Any]]) ->
     return md.rstrip() + "\n" + "\n".join(lines) + "\n"
 
 
+def append_prefill_progress_markdown(md: str, rows: list[dict[str, Any]]) -> str:
+    profiled = [row for row in rows if row.get("prefill_progress")]
+    if not profiled:
+        return md
+    lines = [
+        "",
+        "### Prefill Progress",
+        "",
+        "| Context | Return | Mode | Variant | Tokens | Chunks | Last context | Embed ms | Chain ms | Elapsed ms |",
+        "|---:|---:|---|---|---:|---:|---:|---:|---:|---:|",
+    ]
+    for row in profiled:
+        progress = row.get("prefill_progress") or []
+        last = progress[-1] if progress else {}
+        lines.append(
+            "| {ctx} | {ret} | {mode} | {variant} | {tokens} | {chunks} | {last_ctx} | {embed} | {chain} | {elapsed} |".format(
+                ctx=row.get("context_tokens_requested", ""),
+                ret=row.get("returncode", ""),
+                mode=last.get("mode", ""),
+                variant=last.get("variant", ""),
+                tokens=last.get("tokens", ""),
+                chunks=last.get("chunks", ""),
+                last_ctx=last.get("last_context", ""),
+                embed=render_float(last.get("embed_ms")),
+                chain=render_float(last.get("chain_ms")),
+                elapsed=render_float(last.get("elapsed_ms")),
+            )
+        )
+    return md.rstrip() + "\n" + "\n".join(lines) + "\n"
+
+
 def append_profile_markdown(md: str, rows: list[dict[str, Any]]) -> str:
     profiled = [row for row in rows if row.get("metal_profile") or row.get("hal_profile")]
     if not profiled:
@@ -310,10 +387,14 @@ def run_one(
     expected_answer: str,
     warmup: bool,
 ) -> dict[str, Any]:
-    env = build_metal_env(os.environ)
+    env = build_metal_env(
+        os.environ,
+        legacy_prefill=args.legacy_prefill_baseline or args.batched_prefill_feasibility,
+    )
     variant_env_overrides: dict[str, str] = {}
     if args.batched_prefill_prototype:
         enable_metal_batched_prefill_prototype(env)
+    if args.batched_prefill_variant != "default":
         variant_env_overrides = apply_batched_prefill_variant(env, args.batched_prefill_variant)
     if args.batched_prefill_feasibility and not warmup:
         env["SUPERSONIC_QWEN36_MOE_BATCHED_PREFILL_FEASIBILITY"] = "1"
@@ -388,6 +469,7 @@ def run_one(
             "stage": BASE.parse_stage_timings(output),
             "chain_breakdown": BASE.parse_chain_breakdown(output),
             "lifecycle": BASE.parse_lifecycle_timings(output),
+            "prefill_progress": parse_prefill_progress(output),
             "batched_prefill_feasibility": parse_batched_prefill_feasibility(output),
             "batched_prefill_plans": parse_batched_prefill_plans(output),
             "metal_profile": parse_profile(output, "[metal-profile]", "[metal-profile-op]"),
@@ -421,6 +503,7 @@ def run_one(
         "stage": BASE.parse_stage_timings(output),
         "chain_breakdown": BASE.parse_chain_breakdown(output),
         "lifecycle": BASE.parse_lifecycle_timings(output),
+        "prefill_progress": parse_prefill_progress(output),
         "batched_prefill_feasibility": parse_batched_prefill_feasibility(output),
         "batched_prefill_plans": parse_batched_prefill_plans(output),
         "metal_profile": parse_profile(output, "[metal-profile]", "[metal-profile-op]"),
@@ -483,23 +566,26 @@ def main() -> int:
         ),
     )
     parser.add_argument(
+        "--legacy-prefill-baseline",
+        action="store_true",
+        help="force the legacy per-token Metal prefill path for baseline comparisons",
+    )
+    parser.add_argument(
         "--batched-prefill-prototype",
         action="store_true",
         help=(
-            "run the experimental Metal batched-prefill path with direct "
-            "batched routed-expert compute"
+            "tag the run with the legacy Metal batched-prefill prototype env for "
+            "backward-compatible A/B reports"
         ),
     )
     parser.add_argument(
         "--batched-prefill-variant",
         choices=sorted(BATCHED_PREFILL_VARIANTS),
         default="default",
-        help="named env-gated variant for --batched-prefill-prototype A/B runs",
+        help="named env-gated variant for Metal batched-prefill A/B runs",
     )
     args = apply_preset_defaults(parser.parse_args())
     args.model_dir = resolve_model_dir(args.model_dir, os.environ)
-    if args.batched_prefill_variant != "default" and not args.batched_prefill_prototype:
-        parser.error("--batched-prefill-variant requires --batched-prefill-prototype")
 
     try:
         contexts = BASE.parse_int_list(args.contexts)
@@ -545,6 +631,7 @@ def main() -> int:
     summary = BASE.summarize(rows)
     md = append_batched_prefill_feasibility_markdown(BASE.markdown(rows, summary), rows)
     md = append_batched_prefill_plan_markdown(md, rows)
+    md = append_prefill_progress_markdown(md, rows)
     md = append_profile_markdown(md, rows)
     payload = {
         "schema": SCHEMA,
@@ -556,6 +643,7 @@ def main() -> int:
         "modes": ["int4"],
         "max_new_tokens": args.max_new_tokens,
         "metal_profile": args.metal_profile,
+        "legacy_prefill_baseline": args.legacy_prefill_baseline,
         "batched_prefill_feasibility": args.batched_prefill_feasibility,
         "batched_prefill_prototype": args.batched_prefill_prototype,
         "batched_prefill_variant": args.batched_prefill_variant,

--- a/tests/metal/sweep_qwen36_batched_prefill_variants.py
+++ b/tests/metal/sweep_qwen36_batched_prefill_variants.py
@@ -34,7 +34,7 @@ MODE_ALIASES: dict[str, str] = {
 }
 DEFAULT_MODES = (
     "baseline,prototype-default,linear-direct-off,full-attn-tmajor,"
-    "split-qgate,router-topk,fused-residual"
+    "split-qgate,router-topk,fused-residual-off"
 )
 
 
@@ -70,6 +70,7 @@ def prototype_enabled(mode: str) -> bool:
 
 def args_for_mode(args: argparse.Namespace, mode: str) -> argparse.Namespace:
     run_args = copy.copy(args)
+    run_args.legacy_prefill_baseline = mode == "baseline"
     run_args.batched_prefill_prototype = prototype_enabled(mode)
     run_args.batched_prefill_variant = variant_for_mode(mode)
     return run_args
@@ -510,7 +511,7 @@ def render_markdown(report: dict[str, Any]) -> str:
     lines.extend(
         [
             "",
-            "Rows use the same deterministic NIAH prompt per context. `baseline` is the supported Metal per-token prefill path; all other modes enable the experimental batched-prefill prototype and one named env-gated variant.",
+            "Rows use the same deterministic NIAH prompt per context. `baseline` forces the legacy Metal per-token prefill path; all other modes run the default Metal batched-prefill path and, where applicable, one named env-gated variant.",
         ]
     )
     candidates = promotion_gate.get("candidates") or []

--- a/tests/test_qwen36_metal_longctx_bench.py
+++ b/tests/test_qwen36_metal_longctx_bench.py
@@ -70,14 +70,25 @@ class Qwen36MetalLongContextBenchTests(unittest.TestCase):
             }
         )
         self.assertEqual(env["SUPERSONIC_BACKENDS"], "metal")
-        self.assertEqual(env["SUPERSONIC_QWEN36_MOE_BATCHED_PREFILL"], "0")
-        self.assertEqual(env["SUPERSONIC_QWEN36_MOE_BATCHED_ATTN"], "0")
-        self.assertEqual(env["SUPERSONIC_QWEN36_MOE_GROUPED_FFN"], "0")
-        self.assertEqual(env["SUPERSONIC_QWEN36_DENSE_PREFILL_TOKEN_LOOP"], "1")
+        self.assertEqual(env["SUPERSONIC_QWEN36_MOE_BATCHED_PREFILL"], "1")
+        self.assertEqual(env["SUPERSONIC_QWEN36_MOE_BATCHED_ATTN"], "1")
+        self.assertEqual(env["SUPERSONIC_QWEN36_MOE_GROUPED_FFN"], "1")
+        self.assertNotIn("SUPERSONIC_QWEN36_DENSE_PREFILL_TOKEN_LOOP", env)
         self.assertNotIn("SUPERSONIC_VMM_KV", env)
         self.assertNotIn("SUPERSONIC_VMM_MOE_ISLANDS", env)
         self.assertNotIn("SUPERSONIC_MOE_ISLAND_CAP_EXPERTS", env)
         self.assertNotIn("SUPERSONIC_MOE_ISLAND_TELEMETRY_JSON", env)
+
+    def test_build_metal_env_can_force_legacy_prefill_baseline(self):
+        env = bench_qwen36_metal_longctx.build_metal_env(
+            {"PATH": os.environ.get("PATH", "")},
+            legacy_prefill=True,
+        )
+        self.assertEqual(env["SUPERSONIC_BACKENDS"], "metal")
+        self.assertEqual(env["SUPERSONIC_QWEN36_MOE_BATCHED_PREFILL"], "0")
+        self.assertEqual(env["SUPERSONIC_QWEN36_MOE_BATCHED_ATTN"], "0")
+        self.assertEqual(env["SUPERSONIC_QWEN36_MOE_GROUPED_FFN"], "0")
+        self.assertEqual(env["SUPERSONIC_QWEN36_DENSE_PREFILL_TOKEN_LOOP"], "1")
 
     def test_enable_metal_batched_prefill_prototype_flips_opt_in_knobs(self):
         env = bench_qwen36_metal_longctx.build_metal_env(
@@ -102,11 +113,27 @@ class Qwen36MetalLongContextBenchTests(unittest.TestCase):
             env, "router-topk"
         )
 
+        self.assertEqual(overrides, {"SUPERSONIC_QWEN36_MOE_METAL_ROUTER_TOPK": "1"})
+        self.assertEqual(env["SUPERSONIC_QWEN36_MOE_METAL_ROUTER_TOPK"], "1")
+
+    def test_full_attn_tmajor_variant_disables_vector_kernel(self):
+        env = bench_qwen36_metal_longctx.build_metal_env(
+            {"PATH": os.environ.get("PATH", "")}
+        )
+
+        overrides = bench_qwen36_metal_longctx.apply_batched_prefill_variant(
+            env, "full-attn-tmajor"
+        )
+
         self.assertEqual(
             overrides,
-            {"SUPERSONIC_QWEN36_MOE_METAL_ROUTER_TOPK": "1"},
+            {
+                "SUPERSONIC_QWEN36_MOE_METAL_FULL_ATTN_TMAJOR": "1",
+                "SUPERSONIC_QWEN36_MOE_METAL_FULL_ATTN_VEC": "0",
+            },
         )
-        self.assertEqual(env["SUPERSONIC_QWEN36_MOE_METAL_ROUTER_TOPK"], "1")
+        self.assertEqual(env["SUPERSONIC_QWEN36_MOE_METAL_FULL_ATTN_TMAJOR"], "1")
+        self.assertEqual(env["SUPERSONIC_QWEN36_MOE_METAL_FULL_ATTN_VEC"], "0")
 
     def test_batched_prefill_variant_catalog_covers_measured_probes(self):
         self.assertIn(
@@ -115,10 +142,17 @@ class Qwen36MetalLongContextBenchTests(unittest.TestCase):
         self.assertIn(
             "full-attn-tmajor", bench_qwen36_metal_longctx.BATCHED_PREFILL_VARIANTS
         )
+        self.assertIn(
+            "full-attn-vec-off", bench_qwen36_metal_longctx.BATCHED_PREFILL_VARIANTS
+        )
         self.assertIn("split-qgate", bench_qwen36_metal_longctx.BATCHED_PREFILL_VARIANTS)
         self.assertIn("router-topk", bench_qwen36_metal_longctx.BATCHED_PREFILL_VARIANTS)
         self.assertIn(
-            "fused-residual", bench_qwen36_metal_longctx.BATCHED_PREFILL_VARIANTS
+            "fused-residual-off", bench_qwen36_metal_longctx.BATCHED_PREFILL_VARIANTS
+        )
+        self.assertIn(
+            "shared-expert-batch-off",
+            bench_qwen36_metal_longctx.BATCHED_PREFILL_VARIANTS,
         )
 
     def test_parse_profile_extracts_summary_and_entries(self):
@@ -157,6 +191,17 @@ class Qwen36MetalLongContextBenchTests(unittest.TestCase):
         self.assertEqual(plans[0]["chunk_size"], 128)
         self.assertEqual(plans[1]["chunks"], 1)
         self.assertAlmostEqual(plans[1]["wmma16_assignment_coverage"], 0.966243)
+
+    def test_parse_prefill_progress_keeps_last_partial_row(self):
+        output = """
+[qwen36-moe prefill-progress] mode=batched variant=metal-prototype+shared-expert-batch chunks=1 tokens=512 prefill_tokens=8191 last_context=512 embed_ms=0.123 chain_ms=1000.500 elapsed_ms=1001.000
+[qwen36-moe prefill-progress] mode=batched variant=metal-prototype+shared-expert-batch chunks=2 tokens=1024 prefill_tokens=8191 last_context=1024 embed_ms=0.250 chain_ms=2100.500 elapsed_ms=2101.000
+"""
+        rows = bench_qwen36_metal_longctx.parse_prefill_progress(output)
+        self.assertEqual(len(rows), 2)
+        self.assertEqual(rows[-1]["tokens"], 1024)
+        self.assertEqual(rows[-1]["last_context"], 1024)
+        self.assertEqual(rows[-1]["variant"], "metal-prototype+shared-expert-batch")
 
     def test_append_batched_prefill_feasibility_markdown_adds_table(self):
         md = bench_qwen36_metal_longctx.append_batched_prefill_feasibility_markdown(
@@ -199,6 +244,33 @@ class Qwen36MetalLongContextBenchTests(unittest.TestCase):
         )
         self.assertIn("Batched-Prefill MoE Chunk Plan", md)
         self.assertIn("16.1%", md)
+
+    def test_append_prefill_progress_markdown_adds_table(self):
+        md = bench_qwen36_metal_longctx.append_prefill_progress_markdown(
+            "# report\n",
+            [
+                {
+                    "context_tokens_requested": 8192,
+                    "returncode": -11,
+                    "prefill_progress": [
+                        {
+                            "mode": "batched",
+                            "variant": "metal-prototype+shared-expert-batch",
+                            "tokens": 4096,
+                            "chunks": 8,
+                            "last_context": 4096,
+                            "embed_ms": 10.0,
+                            "chain_ms": 20000.0,
+                            "elapsed_ms": 20010.0,
+                        }
+                    ],
+                }
+            ],
+        )
+        self.assertIn("Prefill Progress", md)
+        self.assertIn("8192", md)
+        self.assertIn("-11", md)
+        self.assertIn("metal-prototype+shared-expert-batch", md)
 
     def test_append_profile_markdown_adds_profile_table(self):
         md = bench_qwen36_metal_longctx.append_profile_markdown(


### PR DESCRIPTION
## Summary

- promote the Qwen3.6 Metal batched-prefill path to the default lane while keeping legacy/A-B escape hatches
- add crash-resilient prefill progress telemetry for long-context runs
- add a Metal time-major vector full-attention prefill kernel and batch the shared-expert tail with stable profiling labels
- update the Metal long-context harness, variant sweep, tests, and docs with refreshed 512/2048/8192 measurements

## Measurements

Default Metal prefill now measures:

- 512 tokens: 25.33s -> 7.01s, generated `[271]`
- 2048 tokens: 165.24s -> 28.24s, generated `[271]`
- 8192 tokens: completes at 147.94s, generated `[271]`, no `-11`

Profiling points to linear-attention command-buffer volume plus routed expert work at shorter contexts, with full-attention/KV bandwidth becoming visible again at longer contexts.

## Validation

- `python3 -m unittest tests.test_qwen36_metal_longctx_bench tests.test_qwen36_batched_prefill_variant_sweep`
- `cargo test -p kernel-ffi qwen36_moe --lib`
- `cargo test -p supersonic-bench`
- `cargo build --release -p runner --bin supersonic`
- `rustfmt --check crates/kernel-ffi/src/prefill_ffi.rs crates/kernel-ffi/src/metal_native.rs crates/runner/src/qwen36_moe/batched_prefill.rs crates/runner/src/qwen36_moe/engine.rs`
- `git diff --check`
- Metal harness outside sandbox:
  - `bench_qwen36_longctx.py --contexts 512 --max-new-tokens 1 --no-warmup --metal-profile`
  - `bench_qwen36_longctx.py --contexts 512 --max-new-tokens 1 --no-warmup`
  - `bench_qwen36_longctx.py --contexts 2048 --max-new-tokens 1 --no-warmup`
  - `bench_qwen36_longctx.py --contexts 8192 --max-new-tokens 1 --no-warmup`
