### PR TITLE
[codex] Add safe multirow top-k expert down probe

### DIFF
--- a/crates/kernel-ffi/src/metal_native.mm
+++ b/crates/kernel-ffi/src/metal_native.mm
@@ -161,6 +161,11 @@ inline bool qwen36_ffn_expert_down_topk_parallel_disabled() {
     return std::getenv("SUPERSONIC_METAL_DISABLE_QWEN36_FFN_EXPERT_DOWN_TOPK_PARALLEL") != nullptr;
 }
 
+inline bool qwen36_ffn_expert_down_multirow_topk_parallel_enabled() {
+    return std::getenv("SUPERSONIC_METAL_ENABLE_QWEN36_FFN_EXPERT_DOWN_MULTIROW_TOPK_PARALLEL") != nullptr &&
+           std::getenv("SUPERSONIC_METAL_FORCE_HOST_NATIVE") == nullptr;
+}
+
 inline bool qwen36_ffn_expert_down_rowpair_topk_parallel_enabled() {
     return std::getenv("SUPERSONIC_METAL_DIAG_QWEN36_FFN_EXPERT_DOWN_ROWPAIR_TOPK_PARALLEL") != nullptr &&
            std::getenv("SUPERSONIC_METAL_FORCE_HOST_NATIVE") == nullptr;
@@ -4121,6 +4126,7 @@ struct Qwen36FfnInt4Pipelines {
     __strong id<MTLComputePipelineState> expert_down_rowpair_compare_multirow = nil;
     __strong id<MTLComputePipelineState> expert_down_rowpair_compare_rowpair = nil;
     __strong id<MTLComputePipelineState> expert_down_finalize_topk_parallel = nil;
+    __strong id<MTLComputePipelineState> expert_down_finalize_multirow_topk_parallel = nil;
     __strong id<MTLComputePipelineState> expert_down_gathered_matmul = nil;
     __strong id<MTLComputePipelineState> expert_down_gathered_combine = nil;
     __strong id<MTLComputePipelineState> batched_expert_gate_up_tiled = nil;
@@ -5994,6 +6000,74 @@ kernel void supersonic_qwen36_ffn_expert_down_finalize_topk_parallel(
     }
 }
 
+kernel void supersonic_qwen36_ffn_expert_down_finalize_multirow_topk_parallel(
+    device float* workspace [[buffer(0)]],
+    device const bfloat* input_hidden [[buffer(1)]],
+    device const uchar* down_proj [[buffer(2)]],
+    device const bfloat* down_scale [[buffer(3)]],
+    device const bfloat* down_zero [[buffer(4)]],
+    device bfloat* output [[buffer(5)]],
+    constant Qwen36FfnInt4Params& params [[buffer(6)]],
+    threadgroup float* downs [[threadgroup(0)]],
+    uint row_pair [[threadgroup_position_in_grid]],
+    uint lane [[thread_index_in_simdgroup]],
+    uint simd_id [[simdgroup_index_in_threadgroup]]
+) {
+    uint group = simd_id;
+    if (group < params.top_k) {
+        uint expert = as_type<uint>(workspace[params.off_topk_idx + group]);
+        device const float* expert_mid =
+            workspace + params.off_expert_mid + group * params.moe_intermediate;
+        for (uint row_local = 0u; row_local < 2u; ++row_local) {
+            uint row = row_pair * 2u + row_local;
+            if (row < params.hidden) {
+                float partial = 0.0f;
+                if ((params.q4_k_pair_flags & 2u) != 0u &&
+                    params.down_proj_type == QWEN36_LOWBIT_GGML_Q4_K &&
+                    (params.moe_intermediate % 256u) == 0u) {
+                    uint flat_row = expert * params.hidden + row;
+                    partial = ggml_q4_k_dot_lane_pair(
+                        down_proj, flat_row, params.moe_intermediate, lane, expert_mid
+                    );
+                } else {
+                    for (uint col = lane; col < params.moe_intermediate; col += 32u) {
+                        float w = lowbit_weight_expert(
+                            down_proj, down_scale, down_zero,
+                            params.down_proj_type,
+                            expert, row, params.hidden, col, params.moe_intermediate, params.group_size
+                        );
+                        partial += w * expert_mid[col];
+                    }
+                }
+                float down = simd_sum(partial);
+                if (lane == 0u) {
+                    downs[row_local * params.top_k + group] = down;
+                }
+            }
+        }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    if (simd_id == 0u && lane == 0u) {
+        for (uint row_local = 0u; row_local < 2u; ++row_local) {
+            uint row = row_pair * 2u + row_local;
+            if (row < params.hidden) {
+                float moe_acc = 0.0f;
+                for (uint group_idx = 0u; group_idx < params.top_k; ++group_idx) {
+                    moe_acc += workspace[params.off_topk_val + group_idx] *
+                        downs[row_local * params.top_k + group_idx];
+                }
+                float moe = bf16_round_rne_finite(moe_acc);
+                workspace[params.off_moe_out + row] = moe;
+                float final = bf16_round_rne_finite(
+                    float(input_hidden[row]) + moe + workspace[params.off_shared_out + row]
+                );
+                output[row] = bfloat(final);
+            }
+        }
+    }
+}
+
 kernel void supersonic_qwen36_ffn_expert_down_gathered_matmul(
     device float* workspace [[buffer(0)]],
     device const uchar* down_proj [[buffer(1)]],
@@ -6456,6 +6530,7 @@ kernel void supersonic_qwen36_ffn_mps_transcode_down_lut(
                         @"supersonic_qwen36_ffn_expert_down_rowpair_compare_multirow",
                         @"supersonic_qwen36_ffn_expert_down_rowpair_compare_rowpair",
                         @"supersonic_qwen36_ffn_expert_down_finalize_topk_parallel",
+                        @"supersonic_qwen36_ffn_expert_down_finalize_multirow_topk_parallel",
                         @"supersonic_qwen36_ffn_expert_down_gathered_matmul",
                         @"supersonic_qwen36_ffn_expert_down_gathered_combine",
                         @"supersonic_qwen36_batched_ffn_expert_gate_up_tiled",
@@ -6557,6 +6632,8 @@ kernel void supersonic_qwen36_ffn_mps_transcode_down_lut(
                             pipelines.expert_down_rowpair_compare_rowpair = pipeline;
                         } else if ([name isEqualToString:@"supersonic_qwen36_ffn_expert_down_finalize_topk_parallel"]) {
                             pipelines.expert_down_finalize_topk_parallel = pipeline;
+                        } else if ([name isEqualToString:@"supersonic_qwen36_ffn_expert_down_finalize_multirow_topk_parallel"]) {
+                            pipelines.expert_down_finalize_multirow_topk_parallel = pipeline;
                         } else if ([name isEqualToString:@"supersonic_qwen36_ffn_expert_down_gathered_matmul"]) {
                             pipelines.expert_down_gathered_matmul = pipeline;
                         } else if ([name isEqualToString:@"supersonic_qwen36_ffn_expert_down_gathered_combine"]) {
@@ -6612,6 +6689,7 @@ kernel void supersonic_qwen36_ffn_mps_transcode_down_lut(
         pipelines.expert_down_rowpair_compare_multirow != nil &&
         pipelines.expert_down_rowpair_compare_rowpair != nil &&
         pipelines.expert_down_finalize_topk_parallel != nil &&
+        pipelines.expert_down_finalize_multirow_topk_parallel != nil &&
         pipelines.expert_down_gathered_matmul != nil &&
         pipelines.expert_down_gathered_combine != nil &&
         pipelines.batched_expert_gate_up_tiled != nil &&
@@ -16284,17 +16362,23 @@ extern "C" int supersonic_metal_qwen36_ffn_int4_stage5(
         bool shared_down_exact_simd = qwen36_ffn_shared_down_exact_simd_enabled();
         bool expert_gate_up_host_order = qwen36_ffn_expert_gate_up_host_order_enabled();
         bool expert_down_topk_parallel = qwen36_ffn_expert_down_topk_parallel_enabled();
+        bool expert_down_multirow_topk_parallel =
+            qwen36_ffn_expert_down_multirow_topk_parallel_enabled();
         bool expert_down_rowpair_topk_parallel = qwen36_ffn_expert_down_rowpair_topk_parallel_enabled();
         bool expert_down_gathered =
-            !expert_down_topk_parallel && !expert_down_rowpair_topk_parallel &&
+            !expert_down_topk_parallel && !expert_down_multirow_topk_parallel &&
+            !expert_down_rowpair_topk_parallel &&
             qwen36_ffn_expert_down_gathered_enabled();
         bool raw_ggml_experts =
             static_cast<uint32_t>(gate_up_proj_type) != QWEN36_LOWBIT_NATIVE_INT4 ||
             static_cast<uint32_t>(down_proj_type) != QWEN36_LOWBIT_NATIVE_INT4;
         expert_down_rowpair_topk_parallel =
             expert_down_rowpair_topk_parallel && raw_ggml_experts && top_k <= 8;
+        expert_down_multirow_topk_parallel =
+            !expert_down_rowpair_topk_parallel && expert_down_multirow_topk_parallel &&
+            raw_ggml_experts && top_k <= 8;
         expert_down_topk_parallel =
-            !expert_down_rowpair_topk_parallel &&
+            !expert_down_rowpair_topk_parallel && !expert_down_multirow_topk_parallel &&
             (expert_down_topk_parallel ||
              (!qwen36_ffn_expert_down_topk_parallel_disabled() && raw_ggml_experts)) &&
             raw_ggml_experts && top_k <= 8;
@@ -16304,6 +16388,8 @@ extern "C" int supersonic_metal_qwen36_ffn_int4_stage5(
             (raw_ggml_experts && (pipelines.expert_gate_up_multirow == nil ||
                                   pipelines.expert_down_finalize_multirow == nil)) ||
             (expert_down_topk_parallel && pipelines.expert_down_finalize_topk_parallel == nil) ||
+            (expert_down_multirow_topk_parallel &&
+             pipelines.expert_down_finalize_multirow_topk_parallel == nil) ||
             (expert_down_rowpair_topk_parallel &&
              pipelines.expert_down_finalize_rowpair_topk_parallel == nil) ||
             (expert_down_gathered && (pipelines.expert_down_gathered_matmul == nil ||
@@ -16537,13 +16623,15 @@ extern "C" int supersonic_metal_qwen36_ffn_int4_stage5(
                         threadsPerThreadgroup:MTLSizeMake(256, 1, 1)];
                 return;
             }
-            [encoder setComputePipelineState:expert_down_topk_parallel
-                ? pipelines.expert_down_finalize_topk_parallel
-                : (expert_down_rowpair_topk_parallel
-                    ? pipelines.expert_down_finalize_rowpair_topk_parallel
-                    : (raw_ggml_experts
-                        ? pipelines.expert_down_finalize_multirow
-                        : pipelines.expert_down_finalize))];
+            [encoder setComputePipelineState:expert_down_multirow_topk_parallel
+                ? pipelines.expert_down_finalize_multirow_topk_parallel
+                : (expert_down_topk_parallel
+                    ? pipelines.expert_down_finalize_topk_parallel
+                    : (expert_down_rowpair_topk_parallel
+                        ? pipelines.expert_down_finalize_rowpair_topk_parallel
+                        : (raw_ggml_experts
+                            ? pipelines.expert_down_finalize_multirow
+                            : pipelines.expert_down_finalize)))];
             [encoder setBuffer:workspace offset:workspace_offset atIndex:0];
             [encoder setBuffer:input_hidden offset:input_hidden_offset atIndex:1];
             [encoder setBuffer:down_proj offset:down_proj_offset atIndex:2];
@@ -16551,17 +16639,21 @@ extern "C" int supersonic_metal_qwen36_ffn_int4_stage5(
             [encoder setBuffer:down_zero offset:down_zero_offset atIndex:4];
             [encoder setBuffer:output offset:output_offset atIndex:5];
             [encoder setBytes:&params length:sizeof(params) atIndex:6];
-            if (expert_down_topk_parallel) {
+            if (expert_down_multirow_topk_parallel) {
+                [encoder setThreadgroupMemoryLength:2 * top_k * sizeof(float) atIndex:0];
+            } else if (expert_down_topk_parallel) {
                 [encoder setThreadgroupMemoryLength:top_k * sizeof(float) atIndex:0];
             } else if (expert_down_rowpair_topk_parallel) {
                 [encoder setThreadgroupMemoryLength:2 * top_k * sizeof(float) atIndex:0];
             }
-            [encoder dispatchThreadgroups:MTLSizeMake(expert_down_topk_parallel
-                        ? hidden
-                        : (expert_down_rowpair_topk_parallel
-                            ? ((hidden + 1) / 2)
-                            : (raw_ggml_experts ? ((hidden + 7) / 8) : hidden)), 1, 1)
-                    threadsPerThreadgroup:MTLSizeMake(expert_down_rowpair_topk_parallel ? 512 : ((raw_ggml_experts || expert_down_topk_parallel) ? 256 : 32), 1, 1)];
+            [encoder dispatchThreadgroups:MTLSizeMake(expert_down_multirow_topk_parallel
+                        ? ((hidden + 1) / 2)
+                        : (expert_down_topk_parallel
+                            ? hidden
+                            : (expert_down_rowpair_topk_parallel
+                                ? ((hidden + 1) / 2)
+                                : (raw_ggml_experts ? ((hidden + 7) / 8) : hidden))), 1, 1)
+                    threadsPerThreadgroup:MTLSizeMake(expert_down_rowpair_topk_parallel ? 512 : ((raw_ggml_experts || expert_down_topk_parallel || expert_down_multirow_topk_parallel) ? 256 : 32), 1, 1)];
         };
 
         bool split_profile = qwen36_ffn_phase_profile_enabled();
@@ -16606,15 +16698,17 @@ extern "C" int supersonic_metal_qwen36_ffn_int4_stage5(
                     ? "qwen36_ffn_int4_expert_gate_up_multirow_stage5"
                     : "qwen36_ffn_int4_expert_gate_up_tiled_stage5");
             if ((status = submit_profile_phase(encode_expert_gate_up, expert_gate_label, 995, 996, 997, 998)) != 0) return status;
-            const std::string expert_down_label = expert_down_topk_parallel
-                ? "qwen36_ffn_int4_expert_down_finalize_topk_parallel"
-                : (expert_down_rowpair_topk_parallel
-                    ? "qwen36_ffn_int4_expert_down_finalize_rowpair_topk_parallel"
-                    : (expert_down_gathered
-                        ? "qwen36_ffn_int4_expert_down_gathered"
-                        : (raw_ggml_experts
-                            ? "qwen36_ffn_int4_expert_down_finalize_multirow"
-                            : "qwen36_ffn_int4_expert_down_finalize")));
+            const std::string expert_down_label = expert_down_multirow_topk_parallel
+                ? "qwen36_ffn_int4_expert_down_finalize_multirow_topk_parallel"
+                : (expert_down_topk_parallel
+                    ? "qwen36_ffn_int4_expert_down_finalize_topk_parallel"
+                    : (expert_down_rowpair_topk_parallel
+                        ? "qwen36_ffn_int4_expert_down_finalize_rowpair_topk_parallel"
+                        : (expert_down_gathered
+                            ? "qwen36_ffn_int4_expert_down_gathered"
+                            : (raw_ggml_experts
+                                ? "qwen36_ffn_int4_expert_down_finalize_multirow"
+                                : "qwen36_ffn_int4_expert_down_finalize"))));
             return submit_profile_phase(
                 encode_expert_down_finalize,
                 expert_down_label,
@@ -16751,17 +16845,23 @@ extern "C" int supersonic_metal_qwen36_ffn_int4_stage5_with_router(
         bool shared_down_exact_simd = qwen36_ffn_shared_down_exact_simd_enabled();
         bool expert_gate_up_host_order = qwen36_ffn_expert_gate_up_host_order_enabled();
         bool expert_down_topk_parallel = qwen36_ffn_expert_down_topk_parallel_enabled();
+        bool expert_down_multirow_topk_parallel =
+            qwen36_ffn_expert_down_multirow_topk_parallel_enabled();
         bool expert_down_rowpair_topk_parallel = qwen36_ffn_expert_down_rowpair_topk_parallel_enabled();
         bool expert_down_gathered =
-            !expert_down_topk_parallel && !expert_down_rowpair_topk_parallel &&
+            !expert_down_topk_parallel && !expert_down_multirow_topk_parallel &&
+            !expert_down_rowpair_topk_parallel &&
             qwen36_ffn_expert_down_gathered_enabled();
         bool raw_ggml_experts =
             static_cast<uint32_t>(gate_up_proj_type) != QWEN36_LOWBIT_NATIVE_INT4 ||
             static_cast<uint32_t>(down_proj_type) != QWEN36_LOWBIT_NATIVE_INT4;
         expert_down_rowpair_topk_parallel =
             expert_down_rowpair_topk_parallel && raw_ggml_experts && top_k <= 8;
+        expert_down_multirow_topk_parallel =
+            !expert_down_rowpair_topk_parallel && expert_down_multirow_topk_parallel &&
+            raw_ggml_experts && top_k <= 8;
         expert_down_topk_parallel =
-            !expert_down_rowpair_topk_parallel &&
+            !expert_down_rowpair_topk_parallel && !expert_down_multirow_topk_parallel &&
             (expert_down_topk_parallel ||
              (!qwen36_ffn_expert_down_topk_parallel_disabled() && raw_ggml_experts)) &&
             raw_ggml_experts && top_k <= 8;
@@ -16798,6 +16898,8 @@ extern "C" int supersonic_metal_qwen36_ffn_int4_stage5_with_router(
             (raw_ggml_experts && (pipelines.expert_gate_up_multirow == nil ||
                                   pipelines.expert_down_finalize_multirow == nil)) ||
             (expert_down_topk_parallel && pipelines.expert_down_finalize_topk_parallel == nil) ||
+            (expert_down_multirow_topk_parallel &&
+             pipelines.expert_down_finalize_multirow_topk_parallel == nil) ||
             (expert_down_rowpair_topk_parallel &&
              pipelines.expert_down_finalize_rowpair_topk_parallel == nil) ||
             (expert_down_rowpair_compare &&
@@ -17108,13 +17210,15 @@ extern "C" int supersonic_metal_qwen36_ffn_int4_stage5_with_router(
                         threadsPerThreadgroup:MTLSizeMake(256, 1, 1)];
                 return;
             }
-            [encoder setComputePipelineState:expert_down_topk_parallel
-                ? pipelines.expert_down_finalize_topk_parallel
-                : (expert_down_rowpair_topk_parallel
-                    ? pipelines.expert_down_finalize_rowpair_topk_parallel
-                    : (raw_ggml_experts
-                        ? pipelines.expert_down_finalize_multirow
-                        : pipelines.expert_down_finalize))];
+            [encoder setComputePipelineState:expert_down_multirow_topk_parallel
+                ? pipelines.expert_down_finalize_multirow_topk_parallel
+                : (expert_down_topk_parallel
+                    ? pipelines.expert_down_finalize_topk_parallel
+                    : (expert_down_rowpair_topk_parallel
+                        ? pipelines.expert_down_finalize_rowpair_topk_parallel
+                        : (raw_ggml_experts
+                            ? pipelines.expert_down_finalize_multirow
+                            : pipelines.expert_down_finalize)))];
             [encoder setBuffer:workspace offset:workspace_offset atIndex:0];
             [encoder setBuffer:input_hidden offset:input_hidden_offset atIndex:1];
             [encoder setBuffer:down_proj offset:down_proj_offset atIndex:2];
@@ -17122,17 +17226,21 @@ extern "C" int supersonic_metal_qwen36_ffn_int4_stage5_with_router(
             [encoder setBuffer:down_zero offset:down_zero_offset atIndex:4];
             [encoder setBuffer:output offset:output_offset atIndex:5];
             [encoder setBytes:&params length:sizeof(params) atIndex:6];
-            if (expert_down_topk_parallel) {
+            if (expert_down_multirow_topk_parallel) {
+                [encoder setThreadgroupMemoryLength:2 * top_k * sizeof(float) atIndex:0];
+            } else if (expert_down_topk_parallel) {
                 [encoder setThreadgroupMemoryLength:top_k * sizeof(float) atIndex:0];
             } else if (expert_down_rowpair_topk_parallel) {
                 [encoder setThreadgroupMemoryLength:2 * top_k * sizeof(float) atIndex:0];
             }
-            [encoder dispatchThreadgroups:MTLSizeMake(expert_down_topk_parallel
-                        ? hidden
-                        : (expert_down_rowpair_topk_parallel
-                            ? ((hidden + 1) / 2)
-                            : (raw_ggml_experts ? ((hidden + 7) / 8) : hidden)), 1, 1)
-                    threadsPerThreadgroup:MTLSizeMake(expert_down_rowpair_topk_parallel ? 512 : ((raw_ggml_experts || expert_down_topk_parallel) ? 256 : 32), 1, 1)];
+            [encoder dispatchThreadgroups:MTLSizeMake(expert_down_multirow_topk_parallel
+                        ? ((hidden + 1) / 2)
+                        : (expert_down_topk_parallel
+                            ? hidden
+                            : (expert_down_rowpair_topk_parallel
+                                ? ((hidden + 1) / 2)
+                                : (raw_ggml_experts ? ((hidden + 7) / 8) : hidden))), 1, 1)
+                    threadsPerThreadgroup:MTLSizeMake(expert_down_rowpair_topk_parallel ? 512 : ((raw_ggml_experts || expert_down_topk_parallel || expert_down_multirow_topk_parallel) ? 256 : 32), 1, 1)];
         };
         auto encode_expert_down_rowpair_compare = [&](id<MTLComputeCommandEncoder> encoder) {
             [encoder setComputePipelineState:pipelines.expert_down_rowpair_compare_multirow];
@@ -17247,15 +17355,17 @@ extern "C" int supersonic_metal_qwen36_ffn_int4_stage5_with_router(
                     expert_down_rowpair_compare_call_index
                 );
             }
-            const std::string expert_down_label = expert_down_topk_parallel
-                ? "qwen36_ffn_int4_expert_down_finalize_topk_parallel"
-                : (expert_down_rowpair_topk_parallel
-                    ? "qwen36_ffn_int4_expert_down_finalize_rowpair_topk_parallel"
-                    : (expert_down_gathered
-                        ? "qwen36_ffn_int4_expert_down_gathered"
-                        : (raw_ggml_experts
-                            ? "qwen36_ffn_int4_expert_down_finalize_multirow"
-                            : "qwen36_ffn_int4_expert_down_finalize")));
+            const std::string expert_down_label = expert_down_multirow_topk_parallel
+                ? "qwen36_ffn_int4_expert_down_finalize_multirow_topk_parallel"
+                : (expert_down_topk_parallel
+                    ? "qwen36_ffn_int4_expert_down_finalize_topk_parallel"
+                    : (expert_down_rowpair_topk_parallel
+                        ? "qwen36_ffn_int4_expert_down_finalize_rowpair_topk_parallel"
+                        : (expert_down_gathered
+                            ? "qwen36_ffn_int4_expert_down_gathered"
+                            : (raw_ggml_experts
+                                ? "qwen36_ffn_int4_expert_down_finalize_multirow"
+                                : "qwen36_ffn_int4_expert_down_finalize"))));
             return submit_profile_phase(
                 encode_expert_down_finalize,
                 expert_down_label,

--- a/docs/build-and-run.md
+++ b/docs/build-and-run.md
@@ -330,6 +330,10 @@ Metal currently rejects or defers:
   the older multirow finalizer for A/B checks. The explicit
   `SUPERSONIC_METAL_ENABLE_QWEN36_FFN_EXPERT_DOWN_TOPK_PARALLEL=1` switch is
   still accepted for older scripts, but is no longer required for raw `--q4km`.
+  `SUPERSONIC_METAL_ENABLE_QWEN36_FFN_EXPERT_DOWN_MULTIROW_TOPK_PARALLEL=1`
+  tests a two-row-per-threadgroup top-k variant that keeps one-row top-k
+  semantics with isolated per-row scratch; it is diagnostic-only until it shows
+  a real speedup over the one-row default.
   `SUPERSONIC_METAL_DIAG_QWEN36_FFN_EXPERT_DOWN_ROWPAIR_TOPK_PARALLEL=1`
   tests a two-row, top-k-parallel raw Q4_K_M expert-down/finalize variant. It
   is diagnostic-only/quarantined: a 128-token A/B preserved the stream and

--- a/docs/detailed_performance.md
+++ b/docs/detailed_performance.md
@@ -1447,6 +1447,20 @@ identified the next safe work area:
   (`/tmp/supersonic-qwen35-raw-q4km-topk-auto-profile-1tok.log`). Keep
   rowpair quarantined behind
   `SUPERSONIC_METAL_DIAG_QWEN36_FFN_EXPERT_DOWN_ROWPAIR_TOPK_PARALLEL=1`.
+  A safer two-row follow-up is available behind
+  `SUPERSONIC_METAL_ENABLE_QWEN36_FFN_EXPERT_DOWN_MULTIROW_TOPK_PARALLEL=1`.
+  It keeps one simdgroup per selected expert, computes two rows serially inside
+  each expert simdgroup, stores isolated `[2][top_k]` scratch, and combines both
+  rows from one owner simdgroup. It is deterministic but not faster: the
+  1-token profile smoke emitted
+  `qwen36_ffn_int4_expert_down_finalize_multirow_topk_parallel`
+  (`/tmp/supersonic-qwen35-raw-q4km-multirow-topk-profile-1tok.log`), the
+  8-token smoke matched the known prefix
+  (`/tmp/supersonic-qwen35-raw-q4km-multirow-topk-smoke-8.log`), and two
+  512-token gates matched the default stream exactly at `66.6` and
+  `66.7 ms/token`
+  (`/tmp/supersonic-qwen35-raw-q4km-multirow-topk-gate-512-{a,b}.log`).
+  Keep the one-row top-k path as the default.
 - The opt-in native full-attention path is also a real speed lever but not
   promotable yet. `SUPERSONIC_METAL_ENABLE_QWEN36_FULL_ATTN_NATIVE=1` measured
   58.4 ms/token on a 128-token run but diverged at token 0. Adding


### PR DESCRIPTION
## Summary

Adds an opt-in Metal probe for Qwen3.5/Qwen3.6 raw Q4_K_M FFN expert-down finalization:

- new `SUPERSONIC_METAL_ENABLE_QWEN36_FFN_EXPERT_DOWN_MULTIROW_TOPK_PARALLEL=1` diagnostic switch
- new two-row-per-threadgroup top-k expert-down/finalize kernel
- dispatch/profile wiring in both stage-5 flows
- docs recording that the path is deterministic but slower than the one-row top-k default

## Why

The previous rowpair top-k experiment exposed correctness/divergence risk. This probe keeps one simdgroup per selected expert and isolated per-row scratch while processing two rows per threadgroup, giving us a safer measurement of whether the two-row shape itself can help.

## Result

The path is correctness-clean but not a promotion candidate yet. Two 512-token gates matched the default stream exactly, but measured about `66.6`/`66.7 ms/token` versus the default around `64.8 ms/token`, so the one-row top-k path remains the default.

## Validation

- `git diff --check`
- `cargo build --release -p runner --bin supersonic`
- `cargo test -p runner --no-run`
- 1-token profile smoke emitted `qwen36_ffn_int4_expert_down_finalize_multirow_topk_parallel`
- 8-token smoke matched the known prefix
- two 512-token gates matched the default stream exactly