### PR TITLE
[codex] Add FFN split-profile baseline row

### DIFF
--- a/crates/kernel-ffi/src/metal_native.mm
+++ b/crates/kernel-ffi/src/metal_native.mm
@@ -1134,6 +1134,10 @@ bool qwen36_ffn_phase_profile_enabled() {
     return NSProcessInfo.processInfo.environment[@"SUPERSONIC_METAL_PROFILE_QWEN36_FFN_PHASES"] != nil;
 }
 
+bool qwen36_ffn_phase_profile_baseline_enabled() {
+    return NSProcessInfo.processInfo.environment[@"SUPERSONIC_METAL_PROFILE_QWEN36_FFN_PHASES_BASELINE"] != nil;
+}
+
 bool qwen36_ffn_router_phase_profile_enabled() {
     return NSProcessInfo.processInfo.environment[@"SUPERSONIC_METAL_PROFILE_QWEN36_ROUTER_PHASES"] != nil;
 }
@@ -16655,6 +16659,22 @@ extern "C" int supersonic_metal_qwen36_ffn_int4_stage5(
                                 : (raw_ggml_experts ? ((hidden + 7) / 8) : hidden))), 1, 1)
                     threadsPerThreadgroup:MTLSizeMake(expert_down_rowpair_topk_parallel ? 512 : ((raw_ggml_experts || expert_down_topk_parallel || expert_down_multirow_topk_parallel) ? 256 : 32), 1, 1)];
         };
+        auto encode_stage = [&](id<MTLComputeCommandEncoder> encoder) {
+            encode_shared_gate_up(encoder);
+            [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+            if (!shared_gate_up_scalar_fused) {
+                encode_shared_scalar(encoder);
+                [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+            }
+            encode_shared_down(encoder);
+            [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+            encode_expert_gate_up(encoder);
+            [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+            encode_expert_down_finalize(encoder);
+            if (expert_down_rowpair_topk_parallel) {
+                [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+            }
+        };
 
         bool split_profile = qwen36_ffn_phase_profile_enabled();
         if (split_profile) {
@@ -16674,6 +16694,15 @@ extern "C" int supersonic_metal_qwen36_ffn_int4_stage5(
                 }
                 return flush_metal_batch_after_qwen36_ffn_profile_phase();
             };
+            if (qwen36_ffn_phase_profile_baseline_enabled()) {
+                if ((status = submit_profile_phase(
+                         encode_stage,
+                         "qwen36_ffn_int4_stage5_profile_baseline",
+                         1003,
+                         1004,
+                         1005,
+                         1006)) != 0) return status;
+            }
             const std::string shared_gate_label = shared_gate_up_exp2
                 ? "qwen36_ffn_int4_shared_gate_up_exp2"
                 : (shared_gate_up_exact_simd
@@ -16718,23 +16747,6 @@ extern "C" int supersonic_metal_qwen36_ffn_int4_stage5(
                 1002
             );
         }
-
-        auto encode_stage = [&](id<MTLComputeCommandEncoder> encoder) {
-            encode_shared_gate_up(encoder);
-            [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
-            if (!shared_gate_up_scalar_fused) {
-                encode_shared_scalar(encoder);
-                [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
-            }
-            encode_shared_down(encoder);
-            [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
-            encode_expert_gate_up(encoder);
-            [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
-            encode_expert_down_finalize(encoder);
-            if (expert_down_rowpair_topk_parallel) {
-                [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
-            }
-        };
         if (wait_for_completion != 0) {
             return encode_or_submit_labeled(
                 encode_stage,
@@ -17263,6 +17275,24 @@ extern "C" int supersonic_metal_qwen36_ffn_int4_stage5_with_router(
             [encoder dispatchThreadgroups:MTLSizeMake((hidden + 1) / 2, 1, 1)
                     threadsPerThreadgroup:MTLSizeMake(512, 1, 1)];
         };
+        auto encode_stage = [&](id<MTLComputeCommandEncoder> encoder) {
+            encode_router(encoder);
+            [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+            encode_shared_gate_up(encoder);
+            [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+            if (!shared_gate_up_scalar_fused) {
+                encode_shared_scalar(encoder);
+                [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+            }
+            encode_shared_down(encoder);
+            [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+            encode_expert_gate_up(encoder);
+            [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+            encode_expert_down_finalize(encoder);
+            if (expert_down_rowpair_topk_parallel) {
+                [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
+            }
+        };
 
         bool split_profile = qwen36_ffn_phase_profile_enabled();
         if (split_profile) {
@@ -17295,6 +17325,15 @@ extern "C" int supersonic_metal_qwen36_ffn_int4_stage5_with_router(
                 }
                 return flush_metal_batch_after_qwen36_ffn_profile_phase();
             };
+            if (qwen36_ffn_phase_profile_baseline_enabled()) {
+                if ((status = submit_profile_phase(
+                         encode_stage,
+                         "qwen36_ffn_int4_stage5_with_router_profile_baseline",
+                         1456,
+                         1457,
+                         1458,
+                         1459)) != 0) return status;
+            }
             if (router_split && qwen36_ffn_router_phase_profile_enabled()) {
                 const std::string router_norm_label = router_norm_exact_simd
                     ? "qwen36_ffn_int4_router_norm_stage5_exact_simd"
@@ -17375,25 +17414,6 @@ extern "C" int supersonic_metal_qwen36_ffn_int4_stage5_with_router(
                 1439
             );
         }
-
-        auto encode_stage = [&](id<MTLComputeCommandEncoder> encoder) {
-            encode_router(encoder);
-            [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
-            encode_shared_gate_up(encoder);
-            [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
-            if (!shared_gate_up_scalar_fused) {
-                encode_shared_scalar(encoder);
-                [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
-            }
-            encode_shared_down(encoder);
-            [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
-            encode_expert_gate_up(encoder);
-            [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
-            encode_expert_down_finalize(encoder);
-            if (expert_down_rowpair_topk_parallel) {
-                [encoder memoryBarrierWithScope:MTLBarrierScopeBuffers];
-            }
-        };
         if (wait_for_completion != 0) {
             return encode_or_submit_labeled(
                 encode_stage,

--- a/docs/build-and-run.md
+++ b/docs/build-and-run.md
@@ -371,6 +371,10 @@ Metal currently rejects or defers:
   `SUPERSONIC_METAL_PROFILE_QWEN36_FFN_PHASES=1` with
   `SUPERSONIC_METAL_PROFILE=1` only when you need per-phase FFN command-buffer
   attribution and accept the extra waited submits. Add
+  `SUPERSONIC_METAL_PROFILE_QWEN36_FFN_PHASES_BASELINE=1` to prepend one normal
+  whole-stage FFN command buffer in the same split-profile run; this is
+  diagnostic-only and intentionally doubles FFN stage work so the aggregate
+  baseline can be compared against the split-phase total. Add
   `SUPERSONIC_METAL_PROFILE_QWEN36_ROUTER_PHASES=1` to split the router block
   into norm/logits/top-k labels. Decode-batch router parity can be tapped
   without forcing the older chained router path by setting

--- a/docs/detailed_performance.md
+++ b/docs/detailed_performance.md
@@ -1139,6 +1139,18 @@ Q4_K_M smoke on Apple M5 Max exited cleanly and emitted one aggregate row per
 `qwen36_ffn_int4_router_topk_stage5_exact_simd` the largest split phase in that
 cold capture (`82.790 ms` total across 160 invocations). Use both env flags for
 future 128-token gates when Metal trace tooling is too heavyweight.
+`SUPERSONIC_METAL_PROFILE_QWEN36_FFN_PHASES_BASELINE=1` now adds a whole-stage
+FFN baseline row to the same split-profile run before the per-phase submits.
+That baseline intentionally runs the FFN stage twice, so it is not a throughput
+mode; it exists to compare the normal single-command-buffer stage GPU time with
+the sum of split command buffers and quantify launch/wait attribution.
+A 1-token raw Q4_K_M smoke emitted the expected
+`qwen36_ffn_int4_stage5_with_router_profile_baseline` row and preserved
+`Generated ids: [49602]`. The baseline was `69.374 ms` total across 40 FFN
+calls, while the split subphase summary summed to roughly the same total
+(`/tmp/supersonic-qwen35-raw-q4km-ffn-baseline-profile-1tok.log`), which
+points the next FFN speed work back at in-kernel work and inter-stage scheduling
+rather than hidden split-profile GPU timing inflation.
 
 A current-tree 2026-06-02 rerun after the online-attention rebuild kept the raw
 default 32-token stream unchanged:


### PR DESCRIPTION
## Summary

Adds an opt-in FFN profiling baseline row for Qwen3.5/Qwen3.6 Metal stage-5 runs:

- new `SUPERSONIC_METAL_PROFILE_QWEN36_FFN_PHASES_BASELINE=1` switch
- when combined with `SUPERSONIC_METAL_PROFILE_QWEN36_FFN_PHASES=1`, runs one normal whole-stage FFN command buffer before the split per-phase submits
- records `qwen36_ffn_int4_stage5_profile_baseline` or `qwen36_ffn_int4_stage5_with_router_profile_baseline`
- updates build/performance docs with the diagnostic meaning and the first smoke result

## Why

The split FFN profiler intentionally submits and waits each FFN subphase separately, which makes it good for attribution but risky to read as throughput. This baseline row lets the same run compare the normal single-command-buffer FFN stage against the sum of split command buffers.

## Result

A 1-token raw Q4_K_M smoke preserved `Generated ids: [49602]` and emitted the expected `qwen36_ffn_int4_stage5_with_router_profile_baseline` row. The baseline was `69.374 ms` total across 40 FFN calls, roughly matching the split subphase total, which points the next speed work at in-kernel FFN/router work and inter-stage scheduling rather than hidden split-profile GPU timing inflation.

## Validation

- `git diff --check`
- `cargo build --release -p runner --bin supersonic`
- `cargo test -p runner --no-run`
- Metal 1-token profile smoke with `SUPERSONIC_METAL_PROFILE_QWEN36_FFN_PHASES_BASELINE=1`