### PR TITLE
[codex] Fix router top-k 512-token divergence

### DIFF
--- a/crates/kernel-ffi/src/metal_native.mm
+++ b/crates/kernel-ffi/src/metal_native.mm
@@ -5019,7 +5019,6 @@ kernel void supersonic_qwen36_ffn_router_topk_stage5_from_logits_parallel_select
     device uint* output_idx [[buffer(1)]],
     constant Qwen36FfnInt4Params& params [[buffer(2)]],
     threadgroup float* scratch [[threadgroup(0)]],
-    threadgroup uint* scratch_idx [[threadgroup(1)]],
     uint tid [[thread_index_in_threadgroup]]
 ) {
     if (params.num_experts > 256u || params.top_k > 16u) {
@@ -5055,28 +5054,39 @@ kernel void supersonic_qwen36_ffn_router_topk_stage5_from_logits_parallel_select
 
     float sum_k = 0.0f;
     for (uint k = 0u; k < params.top_k; ++k) {
-        scratch[256u + tid] = scratch[tid];
-        scratch_idx[tid] = (tid < params.num_experts) ? tid : 0xffffffffu;
-        threadgroup_barrier(mem_flags::mem_threadgroup);
-
-        for (uint stride = 128u; stride > 0u; stride >>= 1u) {
-            if (tid < stride) {
-                float a_val = scratch[256u + tid];
-                float b_val = scratch[256u + tid + stride];
-                uint a_idx = scratch_idx[tid];
-                uint b_idx = scratch_idx[tid + stride];
-                if (b_val > a_val || (b_val == a_val && b_idx < a_idx)) {
-                    scratch[256u + tid] = b_val;
-                    scratch_idx[tid] = b_idx;
+        // Fixed block scans preserve the serial lower-index tie-break without the
+        // reduction-tree cadence that diverged in no-tap 512-token runs.
+        if (tid < 8u) {
+            uint base = tid * 32u;
+            float best_val = -INFINITY;
+            uint best_idx = params.num_experts;
+            for (uint i = 0u; i < 32u; ++i) {
+                uint expert = base + i;
+                if (expert < params.num_experts) {
+                    float prob = scratch[expert];
+                    if (prob > best_val || (prob == best_val && expert < best_idx)) {
+                        best_val = prob;
+                        best_idx = expert;
+                    }
                 }
             }
-            threadgroup_barrier(mem_flags::mem_threadgroup);
+            scratch[256u + tid] = best_val;
+            scratch[264u + tid] = float(best_idx);
         }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
 
         if (tid == 0u) {
-            float best_val = scratch[256u];
-            uint best_idx = scratch_idx[0];
-            scratch[512u + k] = best_val;
+            float best_val = -INFINITY;
+            uint best_idx = params.num_experts;
+            for (uint block = 0u; block < 8u; ++block) {
+                float block_val = scratch[256u + block];
+                uint block_idx = uint(scratch[264u + block]);
+                if (block_val > best_val || (block_val == best_val && block_idx < best_idx)) {
+                    best_val = block_val;
+                    best_idx = block_idx;
+                }
+            }
+            scratch[272u + k] = best_val;
             output_idx[k] = best_idx;
             sum_k += best_val;
             workspace[params.off_topk_idx + k] = as_type<float>(best_idx);
@@ -5091,7 +5101,7 @@ kernel void supersonic_qwen36_ffn_router_topk_stage5_from_logits_parallel_select
         float inv_k = 1.0f / sum_k;
         for (uint k = 0u; k < params.top_k; ++k) {
             workspace[params.off_topk_val + k] =
-                bf16_round_rne_finite(scratch[512u + k] * inv_k);
+                bf16_round_rne_finite(scratch[272u + k] * inv_k);
         }
     }
 }
@@ -17188,12 +17198,13 @@ extern "C" int supersonic_metal_qwen36_ffn_int4_stage5_with_router(
             [encoder setBuffer:workspace offset:workspace_offset atIndex:0];
             [encoder setBuffer:output_idx offset:output_idx_offset atIndex:1];
             [encoder setBytes:&params length:sizeof(params) atIndex:2];
-            [encoder setThreadgroupMemoryLength:(router_topk_parallel_select ? (512 + 16) : (256 + 16)) * sizeof(float) atIndex:0];
-            if (router_topk_parallel_select) {
-                [encoder setThreadgroupMemoryLength:256 * sizeof(uint32_t) atIndex:1];
-            }
+            [encoder setThreadgroupMemoryLength:(router_topk_parallel_select ? (272 + 16) : (256 + 16)) * sizeof(float) atIndex:0];
             [encoder dispatchThreadgroups:MTLSizeMake(1, 1, 1)
                     threadsPerThreadgroup:MTLSizeMake(256, 1, 1)];
+            if (router_topk_parallel_select) {
+                id<MTLResource> topk_outputs[] = { workspace, output_idx };
+                [encoder memoryBarrierWithResources:topk_outputs count:2];
+            }
         };
         auto encode_router = [&](id<MTLComputeCommandEncoder> encoder) {
             if (router_split) {

--- a/docs/build-and-run.md
+++ b/docs/build-and-run.md
@@ -379,10 +379,12 @@ Metal currently rejects or defers:
   into norm/logits/top-k labels. A parity-oriented top-k selector probe,
   `SUPERSONIC_METAL_ENABLE_QWEN36_FFN_ROUTER_TOPK_PARALLEL_SELECT=1`, keeps the
   same BF16-rounded probability scratch as the default top-k kernel but selects
-  each routed expert with a threadgroup reduction instead of a serial scan on
-  thread 0. It remains diagnostic-only after repeated 512-token gates showed
-  long-run divergence. Decode-batch router parity can be tapped
-  without forcing the older chained router path by setting
+  each routed expert with an 8-way deterministic block scan instead of a full
+  serial scan on thread 0. This path now emits a resource-specific Metal barrier
+  for the top-k workspace/output-index buffers; earlier reduction-only variants
+  were parity-clean under taps but diverged in repeated 512-token no-tap gates.
+  It remains opt-in while longer benchmark coverage accumulates. Decode-batch
+  router parity can be tapped without forcing the older chained router path by setting
   `SUPERSONIC_METAL_QWEN36_DECODE_BATCH_ROUTER_STAGE5_PARITY_TAP=1`; narrow it
   with the matching `_MAX_CALLS`, `_POSITION`, and `_LAYER` suffixes. The legacy
   non-batch router tap also supports

--- a/docs/build-and-run.md
+++ b/docs/build-and-run.md
@@ -380,7 +380,8 @@ Metal currently rejects or defers:
   `SUPERSONIC_METAL_ENABLE_QWEN36_FFN_ROUTER_TOPK_PARALLEL_SELECT=1`, keeps the
   same BF16-rounded probability scratch as the default top-k kernel but selects
   each routed expert with a threadgroup reduction instead of a serial scan on
-  thread 0. Decode-batch router parity can be tapped
+  thread 0. It remains diagnostic-only after repeated 512-token gates showed
+  long-run divergence. Decode-batch router parity can be tapped
   without forcing the older chained router path by setting
   `SUPERSONIC_METAL_QWEN36_DECODE_BATCH_ROUTER_STAGE5_PARITY_TAP=1`; narrow it
   with the matching `_MAX_CALLS`, `_POSITION`, and `_LAYER` suffixes. The legacy

--- a/docs/detailed_performance.md
+++ b/docs/detailed_performance.md
@@ -1175,6 +1175,27 @@ opt-in), but the stream instability keeps the parallel selector diagnostic-only
 (`/tmp/supersonic-qwen35-raw-q4km-router-topk-{default,parallel}-512-serial.log`,
 `/tmp/supersonic-qwen35-raw-q4km-router-topk-parallel-512-repeat.log`).
 
+The 2026-06-03 bug hunt isolated that instability to the no-tap Metal command
+cadence around the top-k selector outputs. Targeted decode-batch router parity
+taps at the observed divergent positions (`44`, then `227`, then `39`) matched
+all 40 layers and also made the generated prefix match, so the tap's extra
+snapshot/copy ordering was masking the issue rather than exposing a local
+router math error. A single-float-scratch reduction and then an 8-way block
+selector both still produced at least one divergent 512-token repeat without
+an explicit output barrier. The accepted fix keeps the 8-way deterministic
+block selector and adds a Metal `memoryBarrierWithResources` for the top-k
+workspace and output-index buffers immediately after the top-k dispatch.
+After rebuilding, the opt-in path matched the stable default stream for the
+128-token gate (`/tmp/supersonic-qwen35-raw-q4km-router-topk-blockselect-128.log`)
+and for two 512-token gates:
+`/tmp/supersonic-qwen35-raw-q4km-router-topk-resourcebarrier-512.log` and
+`/tmp/supersonic-qwen35-raw-q4km-router-topk-resourcebarrier-512-repeat.log`.
+The matched 512-token samples measured `88.4` and `86.0 ms/token`, versus the
+same-session stable default at `92.2 ms/token`
+(`/tmp/supersonic-qwen35-raw-q4km-router-topk-default-512-fixed.log`).
+Keep the flag opt-in until it has broader prompt/model coverage, but the prior
+512-token divergence is fixed for the target raw Q4_K_M gate.
+
 A current-tree 2026-06-02 rerun after the online-attention rebuild kept the raw
 default 32-token stream unchanged:
 `[49602, 165189, 184475, 145239, 31375, 47477, 11625, 58985, 757, 155221,

--- a/docs/detailed_performance.md
+++ b/docs/detailed_performance.md
@@ -1164,7 +1164,16 @@ same value/index tie-break. A 1-token raw Q4_K_M router-split profile preserved
 A 32-token A/B matched generated IDs exactly and measured `81.4 ms/token`
 default vs `69.7 ms/token` with the opt-in
 (`/tmp/supersonic-qwen35-raw-q4km-router-topk-{default,parallel}-32.log`).
-Keep it opt-in until a 128/512-token serial gate confirms the shorter result.
+A 128-token serial gate also matched exactly, measuring `65.5 ms/token`
+default vs `61.6 ms/token` opt-in
+(`/tmp/supersonic-qwen35-raw-q4km-router-topk-{default,parallel}-128-serial.log`).
+The 512-token promotion gate failed, though: the first opt-in run diverged from
+default at generated-token index 44, and a repeat opt-in run diverged at index
+264 while also differing from the first opt-in run at index 44. Timings were
+still slightly faster (`63.2 ms/token` default vs `62.5` and `60.6 ms/token`
+opt-in), but the stream instability keeps the parallel selector diagnostic-only
+(`/tmp/supersonic-qwen35-raw-q4km-router-topk-{default,parallel}-512-serial.log`,
+`/tmp/supersonic-qwen35-raw-q4km-router-topk-parallel-512-repeat.log`).
 
 A current-tree 2026-06-02 rerun after the online-attention rebuild kept the raw
 default 32-token stream unchanged:


### PR DESCRIPTION
## Summary

Fixes the 512-token divergence in the opt-in Metal router top-k selector:

- replaces the reduction-tree selected-expert scan with a deterministic 8-way block scan
- adds a resource-specific Metal barrier for the top-k workspace/output-index buffers after the top-k dispatch
- updates the docs with the bug-hunt evidence and current performance/coverage

## Root Cause

The selector was parity-clean when observed through decode-batch router taps, but repeated no-tap 512-token runs diverged. Targeted taps at the observed divergent positions (`44`, `227`, and `39`) matched all router rows and made the generated prefix match, so the tap's snapshot/copy ordering was masking a Metal command-cadence/output-visibility issue rather than exposing local router math drift.

A single-float-scratch selector and an 8-way block selector both still produced at least one divergent no-tap 512-token repeat without an explicit output barrier. Adding `memoryBarrierWithResources` for the top-k outputs fixed the target gate.

## Result

The opt-in path remains behind `SUPERSONIC_METAL_ENABLE_QWEN36_FFN_ROUTER_TOPK_PARALLEL_SELECT=1` while broader prompt/model coverage accumulates, but the prior 512-token raw Q4_K_M gate now passes.

- 128-token opt-in matched default
- 512-token opt-in matched default
- 512-token opt-in repeat matched default
- matched 512-token samples: `88.4` and `86.0 ms/token`
- same-session stable default: `92.2 ms/token`

## Validation

- `cargo build --release -p runner --bin supersonic`
- default 512-token repeat matched default
- opt-in 128-token generated IDs matched default
- opt-in 512-token generated IDs matched default
- opt-in 512-token repeat generated IDs matched default

Key local logs recorded in `docs/detailed_performance.md`:

- `/tmp/supersonic-qwen35-raw-q4km-router-topk-blockselect-128.log`
- `/tmp/supersonic-qwen35-raw-q4km-router-topk-resourcebarrier-512.log`
- `/tmp/supersonic-qwen35-raw-q4km-router-topk-resourcebarrier-512-repeat.log`
- `/tmp/supersonic-qwen35-raw-q4km-router-topk-default-512-fixed.log`