### PR TITLE
[codex] Promote Metal router top-k selector

### DIFF
--- a/crates/kernel-ffi/src/metal_native.mm
+++ b/crates/kernel-ffi/src/metal_native.mm
@@ -1167,7 +1167,7 @@ bool qwen36_ffn_router_stage5_fused_exact_enabled() {
 }
 
 bool qwen36_ffn_router_topk_parallel_select_enabled() {
-    return NSProcessInfo.processInfo.environment[@"SUPERSONIC_METAL_ENABLE_QWEN36_FFN_ROUTER_TOPK_PARALLEL_SELECT"] != nil;
+    return NSProcessInfo.processInfo.environment[@"SUPERSONIC_METAL_DISABLE_QWEN36_FFN_ROUTER_TOPK_PARALLEL_SELECT"] == nil;
 }
 
 bool qwen36_ffn_router_stage5_exact_multirow_enabled() {

--- a/docs/build-and-run.md
+++ b/docs/build-and-run.md
@@ -376,15 +376,13 @@ Metal currently rejects or defers:
   diagnostic-only and intentionally doubles FFN stage work so the aggregate
   baseline can be compared against the split-phase total. Add
   `SUPERSONIC_METAL_PROFILE_QWEN36_ROUTER_PHASES=1` to split the router block
-  into norm/logits/top-k labels. A parity-oriented top-k selector probe,
-  `SUPERSONIC_METAL_ENABLE_QWEN36_FFN_ROUTER_TOPK_PARALLEL_SELECT=1`, keeps the
-  same BF16-rounded probability scratch as the default top-k kernel but selects
-  each routed expert with an 8-way deterministic block scan instead of a full
-  serial scan on thread 0. This path now emits a resource-specific Metal barrier
-  for the top-k workspace/output-index buffers; earlier reduction-only variants
-  were parity-clean under taps but diverged in repeated 512-token no-tap gates.
-  It remains opt-in while longer benchmark coverage accumulates. Decode-batch
-  router parity can be tapped without forcing the older chained router path by setting
+  into norm/logits/top-k labels. The default router top-k selector keeps the
+  same BF16-rounded probability scratch as the serial kernel but selects each
+  routed expert with an 8-way deterministic block scan and emits a
+  resource-specific Metal barrier for the top-k workspace/output-index buffers.
+  Set `SUPERSONIC_METAL_DISABLE_QWEN36_FFN_ROUTER_TOPK_PARALLEL_SELECT=1` to
+  force the older serial scan for comparison. Decode-batch router parity can be
+  tapped without forcing the older chained router path by setting
   `SUPERSONIC_METAL_QWEN36_DECODE_BATCH_ROUTER_STAGE5_PARITY_TAP=1`; narrow it
   with the matching `_MAX_CALLS`, `_POSITION`, and `_LAYER` suffixes. The legacy
   non-batch router tap also supports

--- a/docs/detailed_performance.md
+++ b/docs/detailed_performance.md
@@ -1193,8 +1193,29 @@ and for two 512-token gates:
 The matched 512-token samples measured `88.4` and `86.0 ms/token`, versus the
 same-session stable default at `92.2 ms/token`
 (`/tmp/supersonic-qwen35-raw-q4km-router-topk-default-512-fixed.log`).
-Keep the flag opt-in until it has broader prompt/model coverage, but the prior
-512-token divergence is fixed for the target raw Q4_K_M gate.
+The flag remained opt-in at that point until broader prompt/model coverage
+could confirm the fix beyond the original target prompt.
+
+A broader 2026-06-03 validation sweep then covered three 512-token prompts with
+one default control and two opt-in repeats each:
+`hello` (`1` prompt token), `code` (`25` prompt tokens), and `long_prefill`
+(`49` prompt tokens). All generated ID streams matched exactly: opt-in A,
+opt-in B, and opt-in A vs. B had no first mismatch for all three prompts.
+The sweep summary is
+`/tmp/supersonic-router-topk-sweep-20260603/summary.json`; per-run logs live
+under `/tmp/supersonic-router-topk-sweep-20260603/`. The matched timings were
+`94.2` default vs `90.1`/`92.9 ms/token` for `hello`, `88.6` default vs
+`88.6`/`88.6` for `code`, and `91.1` default vs `89.2`/`89.7` for
+`long_prefill`. With that coverage in place, the block-scan top-k selector is
+promoted to default and the serial scan remains available with
+`SUPERSONIC_METAL_DISABLE_QWEN36_FFN_ROUTER_TOPK_PARALLEL_SELECT=1`.
+The post-promotion 512-token `hello` gate matched the disable-flag serial scan
+exactly. The first promoted-default timing sample was noisy at `96.3 ms/token`
+(`/tmp/supersonic-router-topk-promoted-default-512.log`), but the immediate
+repeat landed at `90.1 ms/token`
+(`/tmp/supersonic-router-topk-promoted-default-512-repeat.log`) against the
+serial-disable comparison at `90.5 ms/token`
+(`/tmp/supersonic-router-topk-promoted-disable-512.log`).
 
 A current-tree 2026-06-02 rerun after the online-attention rebuild kept the raw
 default 32-token stream unchanged:


### PR DESCRIPTION
## Summary

Promotes the validated Metal Qwen3.5/Qwen3.6 FFN router top-k selector to default:

- makes the 8-way deterministic block-scan selector default-on
- adds `SUPERSONIC_METAL_DISABLE_QWEN36_FFN_ROUTER_TOPK_PARALLEL_SELECT=1` to force the older serial scan
- updates docs with the broader 512-token validation sweep and post-promotion gate

## Validation Sweep

Ran a broader raw Q4_K_M 512-token sweep on Apple M5 Max with one default control and two opt-in repeats per prompt before promotion:

| Prompt | Prompt tokens | Default | Opt-in A | Opt-in B | Stream result |
| --- | ---: | ---: | ---: | ---: | --- |
| `hello` | 1 | 94.2 ms/token | 90.1 ms/token | 92.9 ms/token | all equal |
| `code` | 25 | 88.6 ms/token | 88.6 ms/token | 88.6 ms/token | all equal |
| `long_prefill` | 49 | 91.1 ms/token | 89.2 ms/token | 89.7 ms/token | all equal |

Sweep summary: `/tmp/supersonic-router-topk-sweep-20260603/summary.json`.

## Post-Promotion Validation

- `cargo build --release -p runner --bin supersonic`
- `git diff --check`
- promoted default 512-token `hello` stream matched serial-disable stream exactly
- promoted default repeat matched serial-disable stream exactly

Post-promotion timing notes:

- promoted default: `96.3 ms/token` first sample, noisy
- promoted default repeat: `90.1 ms/token`
- serial-disable comparison: `90.5 ms/token`

Logs recorded in `docs/detailed_performance.md`:

- `/tmp/supersonic-router-topk-promoted-default-512.log`
- `/tmp/supersonic-router-topk-promoted-default-512-repeat.log`
- `/tmp/supersonic-router-topk-promoted-disable-512.log`