### PR TITLE
[codex] Add Qwen3.6 perf and lower-precision scaffolds

### DIFF
--- a/crates/bench/src/matrix.rs
+++ b/crates/bench/src/matrix.rs
@@ -6,7 +6,7 @@
 //! the runner registry, you MUST update this table or the test fails.
 
 use crate::perf::{run_one_combo, ComboInvocation, RunPolicy};
-use crate::runs::{MetaJson, PerfCellJson, PerfStatus, RunDir, SCHEMA_VERSION};
+use crate::runs::{MetaJson, PerfCellJson, PerfStatus, QuantArtifactJson, RunDir, SCHEMA_VERSION};
 use anyhow::Result;
 use chrono::Utc;
 use std::path::PathBuf;
@@ -57,6 +57,33 @@ pub struct ComboDescriptor {
     pub quant: &'static str, // "bf16" | "int4" | "fp8r" | "kv-fp8" | "int8"
     pub arch: BenchArch,
     pub min_vram_gib: f64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct LowerPrecisionCandidate {
+    pub model: &'static str,
+    pub quant: &'static str,
+    pub arch: BenchArch,
+    pub profile: &'static str,
+    pub source_format: &'static str,
+    pub source_quant: &'static str,
+    pub producer: &'static str,
+    pub average_bits_per_weight: Option<f64>,
+    pub notes: &'static [&'static str],
+}
+
+impl LowerPrecisionCandidate {
+    pub fn quant_artifact(&self) -> QuantArtifactJson {
+        QuantArtifactJson {
+            profile: self.profile.to_string(),
+            source_format: self.source_format.to_string(),
+            source_quant: self.source_quant.to_string(),
+            producer: self.producer.to_string(),
+            runtime_supported: false,
+            average_bits_per_weight: self.average_bits_per_weight,
+            notes: self.notes.iter().map(|note| (*note).to_string()).collect(),
+        }
+    }
 }
 
 /// Mirrors docs/feature-compatibility.md + docs/performance.md as of 2026-05-05.
@@ -304,8 +331,86 @@ pub static SUPPORTED_COMBOS: &[ComboDescriptor] = &[
     },
 ];
 
+/// Explicit lower-precision probe lanes. These are intentionally not part of
+/// `SUPPORTED_COMBOS`: asking for one writes a skipped perf cell with artifact
+/// metadata until loader/runtime support exists. Keeping the lanes source-owned
+/// lets docs and future AutoRound/SignRoundV2 artifacts use stable names.
+pub static LOWER_PRECISION_CANDIDATES: &[LowerPrecisionCandidate] = &[
+    LowerPrecisionCandidate {
+        model: "qwen3.5-0.8b",
+        quant: "int3",
+        arch: BenchArch::AppleM5Max,
+        profile: "autoround-int3",
+        source_format: "gguf-or-supersonic-bake",
+        source_quant: "SignRoundV2 INT3 weight-only",
+        producer: "intel/auto-round --enable_alg_ext",
+        average_bits_per_weight: Some(3.0),
+        notes: &[
+            "small-model artifact probe before Qwen3.5/Qwen3.6 35B kernels",
+            "quality gate must pass before runtime support is added",
+        ],
+    },
+    LowerPrecisionCandidate {
+        model: "qwen3.5-0.8b",
+        quant: "int2-4-mixed",
+        arch: BenchArch::AppleM5Max,
+        profile: "autoround-int2-4-mixed",
+        source_format: "gguf-or-supersonic-bake",
+        source_quant: "SignRoundV2 adaptive INT2/INT4 mixed-bit weight-only",
+        producer: "intel/auto-round --enable_alg_ext AutoScheme",
+        average_bits_per_weight: Some(3.0),
+        notes: &[
+            "candidate inspired by SignRoundV2 adaptive bit allocation",
+            "records mixed-bit metadata before kernels consume it",
+        ],
+    },
+    LowerPrecisionCandidate {
+        model: "qwen3.5-0.8b",
+        quant: "mxfp4",
+        arch: BenchArch::AppleM5Max,
+        profile: "autoround-mxfp4",
+        source_format: "supersonic-bake",
+        source_quant: "SignRoundV2 MXFP4 weight-only",
+        producer: "intel/auto-round --enable_alg_ext",
+        average_bits_per_weight: Some(4.0),
+        notes: &[
+            "format probe only; Metal unpack/dequant cost decides whether it becomes a perf lane",
+        ],
+    },
+    LowerPrecisionCandidate {
+        model: "qwen3.5-35b-a3b",
+        quant: "int2-4-mixed",
+        arch: BenchArch::AppleM5Max,
+        profile: "autoround-int2-4-mixed",
+        source_format: "gguf-or-supersonic-bake",
+        source_quant: "SignRoundV2 adaptive INT2/INT4 mixed-bit weight-only",
+        producer: "intel/auto-round --enable_alg_ext AutoScheme",
+        average_bits_per_weight: Some(3.0),
+        notes: &["target-model placeholder; run only after the qwen3.5-0.8b artifact probe passes"],
+    },
+];
+
 pub fn combos_for_arch(arch: BenchArch) -> Vec<&'static ComboDescriptor> {
     SUPPORTED_COMBOS.iter().filter(|c| c.arch == arch).collect()
+}
+
+pub fn lower_precision_candidates_for_arch(
+    arch: BenchArch,
+) -> Vec<&'static LowerPrecisionCandidate> {
+    LOWER_PRECISION_CANDIDATES
+        .iter()
+        .filter(|c| c.arch == arch)
+        .collect()
+}
+
+pub fn lower_precision_candidate(
+    model: &str,
+    quant: &str,
+    arch: &BenchArch,
+) -> Option<&'static LowerPrecisionCandidate> {
+    LOWER_PRECISION_CANDIDATES
+        .iter()
+        .find(|c| c.model == model && c.quant == quant && c.arch == *arch)
 }
 
 /// True iff `(model, quant, arch)` can be run by `bench-perf`. Most entries
@@ -389,22 +494,33 @@ pub fn run_matrix(cfg: &MatrixConfig, rd: &RunDir) -> Result<()> {
             // qwen3.6-35b-a3b + bf16). Record a Skipped cell rather than
             // letting the runner produce a useless Error cell.
             if !is_supported_combo(model, quant, &cfg.arch) {
+                let lower_precision_candidate = lower_precision_candidate(model, quant, &cfg.arch);
+                let reason = if let Some(candidate) = lower_precision_candidate {
+                    format!(
+                        "experimental lower-precision candidate for {}: ({}, {}) uses {} but runtime support is not implemented yet",
+                        cfg.arch.as_str(),
+                        candidate.model,
+                        candidate.quant,
+                        candidate.profile
+                    )
+                } else {
+                    format!(
+                        "unsupported combo for {}: ({}, {}) not in SUPPORTED_COMBOS",
+                        cfg.arch.as_str(),
+                        model,
+                        quant
+                    )
+                };
                 let cell = PerfCellJson {
                     schema_version: SCHEMA_VERSION,
                     model: model.clone(),
                     quant: quant.clone(),
                     arch: cfg.arch.as_str().to_string(),
                     backend: cfg.arch.backend().unwrap_or("auto").to_string(),
+                    quant_artifact: lower_precision_candidate.map(|c| c.quant_artifact()),
                     prompt: cfg.prompt.clone(),
                     max_new_tokens: cfg.max_new_tokens,
-                    status: PerfStatus::Skipped {
-                        reason: format!(
-                            "unsupported combo for {}: ({}, {}) not in SUPPORTED_COMBOS",
-                            cfg.arch.as_str(),
-                            model,
-                            quant
-                        ),
-                    },
+                    status: PerfStatus::Skipped { reason },
                     stage_timings: None,
                     chain_breakdown: None,
                     lifecycle_timings: None,

--- a/crates/bench/src/perf.rs
+++ b/crates/bench/src/perf.rs
@@ -358,6 +358,7 @@ pub fn run_one_combo(invocation: &ComboInvocation, policy: &RunPolicy) -> Result
             .backend
             .clone()
             .unwrap_or_else(|| "auto".to_string()),
+        quant_artifact: None,
         prompt: invocation.prompt.clone(),
         max_new_tokens: invocation.max_new_tokens,
         status,

--- a/crates/bench/src/runs.rs
+++ b/crates/bench/src/runs.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use std::io;
 use std::path::{Path, PathBuf};
 
-pub const SCHEMA_VERSION: u32 = 9;
+pub const SCHEMA_VERSION: u32 = 10;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MetaJson {
@@ -49,6 +49,8 @@ pub struct PerfCellJson {
     pub quant: String,
     pub arch: String,
     pub backend: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub quant_artifact: Option<QuantArtifactJson>,
     pub prompt: String,
     pub max_new_tokens: u32,
     #[serde(flatten)]
@@ -82,6 +84,19 @@ pub struct PerfCellJson {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hal_profile: Option<ProfileJson>,
     pub gpu_temp_c_end: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct QuantArtifactJson {
+    pub profile: String,
+    pub source_format: String,
+    pub source_quant: String,
+    pub producer: String,
+    pub runtime_supported: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub average_bits_per_weight: Option<f64>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub notes: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/crates/bench/tests/extract_metrics.rs
+++ b/crates/bench/tests/extract_metrics.rs
@@ -199,7 +199,7 @@ fi
     };
 
     let cell = run_one_combo(&invocation, &policy).unwrap();
-    assert_eq!(cell.schema_version, 9);
+    assert_eq!(cell.schema_version, 10);
     assert_eq!(
         cell.stage_timings
             .as_ref()

--- a/crates/bench/tests/matrix_writes_run_dir.rs
+++ b/crates/bench/tests/matrix_writes_run_dir.rs
@@ -118,3 +118,47 @@ fn matrix_runs_ad_hoc_sm86_specprefill_lane() {
         "ad hoc sm86 spec lane should not be filtered out: {cell_text}"
     );
 }
+
+#[test]
+fn matrix_writes_skipped_lower_precision_candidate_with_artifact_metadata() {
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg = MatrixConfig {
+        arch: BenchArch::AppleM5Max,
+        models: vec!["qwen3.5-0.8b".into()],
+        quants: vec!["int2-4-mixed".into()],
+        binary: PathBuf::from("/bin/false"),
+        model_dir_resolver: Box::new(|_| Ok(PathBuf::from("/nonexistent"))),
+        specprefill_draft_dir_resolver: Box::new(|_| None),
+        prompt: "x".into(),
+        max_new_tokens: 1,
+        context_size: None,
+        warmup_tokens: 1,
+        measurement_runs: 1,
+        cooldown_seconds: 0,
+        collect_attribution: true,
+        git_sha: "test".into(),
+        git_dirty: false,
+        git_dirty_paths: vec![],
+        git_diff_hash: Some("clean".into()),
+        runner_version: "test 0.0.0".into(),
+    };
+    let rd = RunDir::new(tmp.path().join("run-lower-precision-skip"));
+    run_matrix(&cfg, &rd).unwrap();
+    let cell_text = std::fs::read_to_string(rd.perf_path("qwen3.5-0.8b", "int2-4-mixed")).unwrap();
+    assert!(
+        cell_text.contains("\"status\": \"skipped\""),
+        "expected skipped status, got: {cell_text}"
+    );
+    assert!(
+        cell_text.contains("experimental lower-precision candidate"),
+        "expected lower-precision reason, got: {cell_text}"
+    );
+    assert!(
+        cell_text.contains("\"quant_artifact\""),
+        "expected quant artifact metadata, got: {cell_text}"
+    );
+    assert!(
+        cell_text.contains("\"profile\": \"autoround-int2-4-mixed\""),
+        "expected AutoRound profile metadata, got: {cell_text}"
+    );
+}

--- a/crates/bench/tests/registry_filter.rs
+++ b/crates/bench/tests/registry_filter.rs
@@ -1,4 +1,7 @@
-use supersonic_bench::matrix::{combos_for_arch, is_supported_combo, BenchArch};
+use supersonic_bench::matrix::{
+    combos_for_arch, is_supported_combo, lower_precision_candidate,
+    lower_precision_candidates_for_arch, BenchArch,
+};
 
 #[test]
 fn gfx1100_includes_shipping_models() {
@@ -35,6 +38,29 @@ fn apple_m5_max_includes_qwen_moe_metal_lanes() {
     assert!(model_quants.contains(&("qwen3.5-35b-a3b", "q4km-gptq")));
     assert!(model_quants.contains(&("qwen3.5-35b-a3b", "q4km")));
     assert!(!model_quants.contains(&("qwen3.6-35b-a3b", "kv-fp8")));
+}
+
+#[test]
+fn apple_m5_max_tracks_lower_precision_candidates_separately() {
+    let candidates = lower_precision_candidates_for_arch(BenchArch::AppleM5Max);
+    let model_quants: Vec<(&str, &str)> = candidates.iter().map(|c| (c.model, c.quant)).collect();
+
+    assert!(model_quants.contains(&("qwen3.5-0.8b", "int3")));
+    assert!(model_quants.contains(&("qwen3.5-0.8b", "int2-4-mixed")));
+    assert!(model_quants.contains(&("qwen3.5-0.8b", "mxfp4")));
+    assert!(model_quants.contains(&("qwen3.5-35b-a3b", "int2-4-mixed")));
+    assert!(
+        !is_supported_combo("qwen3.5-0.8b", "int2-4-mixed", &BenchArch::AppleM5Max),
+        "lower-precision probes must stay out of SUPPORTED_COMBOS until runtime support exists"
+    );
+
+    let artifact =
+        lower_precision_candidate("qwen3.5-0.8b", "int2-4-mixed", &BenchArch::AppleM5Max)
+            .expect("candidate should be registered")
+            .quant_artifact();
+    assert_eq!(artifact.profile, "autoround-int2-4-mixed");
+    assert_eq!(artifact.average_bits_per_weight, Some(3.0));
+    assert!(!artifact.runtime_supported);
 }
 
 #[test]

--- a/crates/bench/tests/run_dir_layout.rs
+++ b/crates/bench/tests/run_dir_layout.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 use supersonic_bench::runs::{
-    MetaJson, PerfCellJson, PerfStatus, Qwen36ExpertResidencyPolicyJson, RunDir,
+    MetaJson, PerfCellJson, PerfStatus, QuantArtifactJson, Qwen36ExpertResidencyPolicyJson, RunDir,
 };
 
 #[test]
@@ -43,6 +43,7 @@ fn perf_cell_json_status_variants() {
         quant: "bf16".into(),
         arch: "gfx1100".into(),
         backend: "hip".into(),
+        quant_artifact: None,
         prompt: "The quick brown fox jumps over".into(),
         max_new_tokens: 16,
         status: PerfStatus::Ok {
@@ -97,11 +98,12 @@ fn perf_cell_preserves_qwen36_expert_residency_policy_labels() {
     metrics.insert("copied_bytes".to_string(), 2014248960.0);
 
     let cell = PerfCellJson {
-        schema_version: 9,
+        schema_version: 10,
         model: "qwen3.6-35b-a3b".into(),
         quant: "int4".into(),
         arch: "apple-m5-max".into(),
         backend: "metal".into(),
+        quant_artifact: None,
         prompt: "The quick brown fox jumps over".into(),
         max_new_tokens: 16,
         status: PerfStatus::Ok {
@@ -143,6 +145,57 @@ fn perf_cell_preserves_qwen36_expert_residency_policy_labels() {
     assert_eq!(rows[0].miss_policy, "exact_route");
     assert_eq!(rows[0].capacity, 8.0);
     assert_eq!(rows[0].metrics.get("copied_bytes"), Some(&2014248960.0));
+}
+
+#[test]
+fn perf_cell_preserves_lower_precision_quant_artifact_metadata() {
+    let cell = PerfCellJson {
+        schema_version: 10,
+        model: "qwen3.5-0.8b".into(),
+        quant: "int2-4-mixed".into(),
+        arch: "apple-m5-max".into(),
+        backend: "metal".into(),
+        quant_artifact: Some(QuantArtifactJson {
+            profile: "autoround-int2-4-mixed".into(),
+            source_format: "gguf-or-supersonic-bake".into(),
+            source_quant: "SignRoundV2 adaptive INT2/INT4 mixed-bit weight-only".into(),
+            producer: "intel/auto-round --enable_alg_ext AutoScheme".into(),
+            runtime_supported: false,
+            average_bits_per_weight: Some(3.0),
+            notes: vec!["quality gate before runtime support".into()],
+        }),
+        prompt: "The quick brown fox jumps over".into(),
+        max_new_tokens: 16,
+        status: PerfStatus::Skipped {
+            reason: "experimental lower-precision candidate".into(),
+        },
+        stage_timings: None,
+        chain_breakdown: None,
+        lifecycle_timings: None,
+        profile_stage_timings: None,
+        profile_chain_breakdown: None,
+        profile_lifecycle_timings: None,
+        mpp_pilot: None,
+        mps_expert_pilot: None,
+        qwen36_pack_cache: None,
+        qwen36_expert_residency: None,
+        qwen36_expert_residency_policies: None,
+        qwen36_expert_residency_policy_rows: None,
+        metal_profile: None,
+        hal_profile: None,
+        gpu_temp_c_end: None,
+    };
+
+    let s = serde_json::to_string(&cell).unwrap();
+    assert!(s.contains("\"quant_artifact\""));
+    assert!(s.contains("\"average_bits_per_weight\":3.0"));
+    let parsed: PerfCellJson = serde_json::from_str(&s).unwrap();
+    let artifact = parsed
+        .quant_artifact
+        .expect("quant_artifact should round-trip");
+    assert_eq!(artifact.profile, "autoround-int2-4-mixed");
+    assert_eq!(artifact.average_bits_per_weight, Some(3.0));
+    assert!(!artifact.runtime_supported);
 }
 
 #[test]

--- a/crates/model-store/src/manifest.rs
+++ b/crates/model-store/src/manifest.rs
@@ -130,6 +130,12 @@ pub struct QuantMethodMeta {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parameters: Option<serde_json::Value>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub average_bits_per_weight: Option<f32>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub candidate_weight_bits: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mixed_precision_assignment: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub calibration_corpus: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub calibration_samples: Option<u32>,
@@ -200,5 +206,34 @@ mod tests {
         assert!(QuantProfile::Int4Hqq.is_native_int4_runtime());
         assert!(QuantProfile::Higgs4.is_runtime_backed_lowbit());
         assert!(!QuantProfile::Bf16.is_native_int4_runtime());
+    }
+
+    #[test]
+    fn quant_method_meta_round_trips_lower_precision_artifact_fields() {
+        let meta = QuantMethodMeta {
+            profile: "autoround-int2-4-mixed".to_string(),
+            parameters: Some(serde_json::json!({"enable_alg_ext": true})),
+            average_bits_per_weight: Some(3.0),
+            candidate_weight_bits: vec!["int2".to_string(), "int4".to_string()],
+            mixed_precision_assignment: Some(serde_json::json!({
+                "layers.0.mlp.down_proj": "int4",
+                "layers.1.mlp.down_proj": "int2"
+            })),
+            calibration_corpus: Some("wikitext2".to_string()),
+            calibration_samples: Some(128),
+            calibration_seqlen: Some(2048),
+            calibration_seed: Some(20260504),
+            source_dtype: Some("bf16".to_string()),
+            producer_version: Some("auto-round enable_alg_ext".to_string()),
+        };
+
+        let s = serde_json::to_string(&meta).unwrap();
+        assert!(s.contains("\"average_bits_per_weight\":3.0"));
+        assert!(s.contains("\"candidate_weight_bits\":[\"int2\",\"int4\"]"));
+        let parsed: QuantMethodMeta = serde_json::from_str(&s).unwrap();
+        assert_eq!(parsed.profile, "autoround-int2-4-mixed");
+        assert_eq!(parsed.average_bits_per_weight, Some(3.0));
+        assert_eq!(parsed.candidate_weight_bits, vec!["int2", "int4"]);
+        assert!(parsed.mixed_precision_assignment.is_some());
     }
 }

--- a/docs/lower-precision.md
+++ b/docs/lower-precision.md
@@ -1,0 +1,49 @@
+# Lower-Precision Quantization Track
+
+This track is for quality-aware lower-precision experiments before any Metal
+kernel promotion. The benchmark matrix owns stable lane names early so generated
+artifacts, docs, and future kernels do not drift.
+
+## Candidate Lanes
+
+| Lane | First model | Target | Artifact source | Runtime status |
+|:---|:---|:---|:---|:---|
+| `int3` | `qwen3.5-0.8b` | weight-only INT3 probe | AutoRound / SignRoundV2 with `enable_alg_ext` | skipped |
+| `int2-4-mixed` | `qwen3.5-0.8b` | adaptive INT2/INT4 mixed-bit probe | AutoRound AutoScheme / SignRoundV2 | skipped |
+| `mxfp4` | `qwen3.5-0.8b` | MXFP4 format probe | AutoRound / SignRoundV2 | skipped |
+| `int2-4-mixed` | `qwen3.5-35b-a3b` | target-model placeholder | AutoRound AutoScheme / SignRoundV2 | skipped |
+
+These rows are intentionally separate from `SUPPORTED_COMBOS`. A requested
+candidate writes a skipped `bench-perf` cell with `quant_artifact` metadata
+instead of silently falling through to BF16 or a generic unsupported row.
+
+## Artifact Metadata
+
+Lower-precision artifacts must record:
+
+- `quant_method.profile`
+- producer and producer version
+- source format and source quant
+- average bits per weight
+- candidate bit set, such as `["int2", "int4"]`
+- mixed-precision assignment payload when the artifact uses per-layer or
+  per-projection bit allocation
+- calibration corpus, sample count, sequence length, and seed
+
+The benchmark-side `quant_artifact` field mirrors the high-level artifact
+identity in skipped/perf cells. The bake manifest remains the source of truth
+once an artifact exists.
+
+## Acceptance Gates
+
+Before adding runtime kernels for a candidate:
+
+1. Generate the small-model artifact first.
+2. Run single-projection dequant/matvec checks against a BF16 or GGUF oracle.
+3. Pass 1-token smoke and 8-token deterministic decode.
+4. Pass 128-token drift classification and 512-token divergence checks.
+5. Compare memory footprint and tok/s against `q4km` and `q4km-gptq` controls.
+
+If quality passes but tok/s does not improve after unpack/dequant overhead, keep
+the lane as a memory-capacity experiment rather than a promoted performance
+lane.

--- a/tests/metal/summarize_qwen36_sota_gates.py
+++ b/tests/metal/summarize_qwen36_sota_gates.py
@@ -61,7 +61,7 @@ GATE_SPECS = (
         kind="runtime_promotion",
         refresh_command=(
             f"{MODEL_ROOT_ENV} python3 tests/metal/sweep_qwen36_fused_routed_int4.py "
-            "--prompt-set smoke --modes default,direct-gather,direct-defer-wait,direct-gather-batch,direct-defer-wait-batch,gpu-pack,full-stage5,full-stage5-router,router-defer-wait --metal-profile"
+            "--prompt-set smoke --modes default,direct-gather,direct-defer-wait,gpu-pack,full-stage5,full-stage5-router,router-defer-wait --metal-profile"
         ),
     ),
     GateSpec(

--- a/tests/metal/summarize_qwen36_sota_gates.py
+++ b/tests/metal/summarize_qwen36_sota_gates.py
@@ -56,12 +56,12 @@ GATE_SPECS = (
         gate_id="fused_routed_int4",
         label="Fused routed INT4",
         default_path=Path("target/qwen36_fused_routed_int4_sweep.json"),
-        expected_schema="qwen36-fused-routed-int4-sweep-v43",
+        expected_schema="qwen36-fused-routed-int4-sweep-v44",
         gate_keys=("promotion_gate",),
         kind="runtime_promotion",
         refresh_command=(
             f"{MODEL_ROOT_ENV} python3 tests/metal/sweep_qwen36_fused_routed_int4.py "
-            "--prompt-set smoke --modes default,direct-gather,direct-defer-wait,gpu-pack,full-stage5,full-stage5-router,router-defer-wait --metal-profile"
+            "--prompt-set smoke --modes default,direct-gather,direct-defer-wait,direct-gather-batch,direct-defer-wait-batch,gpu-pack,full-stage5,full-stage5-router,router-defer-wait --metal-profile"
         ),
     ),
     GateSpec(

--- a/tests/metal/sweep_qwen36_fused_routed_int4.py
+++ b/tests/metal/sweep_qwen36_fused_routed_int4.py
@@ -27,8 +27,6 @@ BF16_BOUNDARY_SOURCES = {
     "final_residual_rounding_boundary",
     ROUTED_SILU_ULP_BOUNDARY_SOURCE,
 }
-DIRECT_GATHER_BATCH_MODE = "direct-gather-batch"
-DIRECT_DEFER_WAIT_BATCH_MODE = "direct-defer-wait-batch"
 COARSE_BATCH_SERIAL_MODE = "full-stage5-router-batch"
 COARSE_BATCH_SIMD_MODE = "full-stage5-router-simd-batch"
 ROUTER_FUSED_EXACT_BATCH_MODE = "full-stage5-router-fused-exact-batch"
@@ -96,8 +94,6 @@ SHARED_COMPONENT_MODES = {
     SHARED_DOWN_TILED_BATCH_SIMD_MODE,
 }
 BATCH_FAST_PROFILE_MODES = {
-    DIRECT_GATHER_BATCH_MODE,
-    DIRECT_DEFER_WAIT_BATCH_MODE,
     "full-stage5-router-batch",
     "full-stage5-router-simd-batch",
     ROUTER_FUSED_EXACT_BATCH_MODE,
@@ -171,14 +167,6 @@ MODE_ALIASES: dict[str, str] = {
     "direct-defer": "direct-defer-wait",
     "direct-defer-wait": "direct-defer-wait",
     "defer-direct-wait": "direct-defer-wait",
-    "direct-batch": DIRECT_GATHER_BATCH_MODE,
-    "batch-direct": DIRECT_GATHER_BATCH_MODE,
-    "direct-gather-batch": DIRECT_GATHER_BATCH_MODE,
-    "direct-batch-defer": DIRECT_DEFER_WAIT_BATCH_MODE,
-    "direct-batch-defer-wait": DIRECT_DEFER_WAIT_BATCH_MODE,
-    "batch-direct-defer": DIRECT_DEFER_WAIT_BATCH_MODE,
-    "batch-direct-defer-wait": DIRECT_DEFER_WAIT_BATCH_MODE,
-    "direct-defer-wait-batch": DIRECT_DEFER_WAIT_BATCH_MODE,
     "gpu-pack": "gpu-pack",
     "gpack": "gpu-pack",
     "full": "full-stage5",
@@ -331,14 +319,12 @@ MODE_ALIASES: dict[str, str] = {
     "router-defer-wait": "router-defer-wait",
     "defer-router-wait": "router-defer-wait",
 }
-DEFAULT_MODES = "default,direct-gather,direct-defer-wait,direct-gather-batch,direct-defer-wait-batch,gpu-pack,full-stage5,full-stage5-router,router-defer-wait"
+DEFAULT_MODES = "default,direct-gather,direct-defer-wait,gpu-pack,full-stage5,full-stage5-router,router-defer-wait"
 
 FUSED_OP_NEEDLES = {
     "packed": "qwen36_ffn_int4_expert_packed_stage5",
     "direct-gather": "qwen36_ffn_int4_expert_direct_gather_stage5",
     "direct-defer-wait": "qwen36_ffn_int4_expert_direct_gather_stage5",
-    DIRECT_GATHER_BATCH_MODE: "qwen36_ffn_int4_stage5_with_router",
-    DIRECT_DEFER_WAIT_BATCH_MODE: "qwen36_ffn_int4_stage5_with_router",
     "gpu-pack": "qwen36_ffn_int4_expert_gpu_pack_stage5",
     "full-stage5": "qwen36_ffn_int4_stage5",
     "full-stage5-router": "qwen36_ffn_int4_stage5_with_router",
@@ -380,28 +366,6 @@ FUSED_GPU_OP_PREFIXES = {
     "packed": ("command_buffer_gpu:qwen36_ffn_int4_expert_packed_stage5",),
     "direct-gather": ("command_buffer_gpu:qwen36_ffn_int4_expert_direct_gather_stage5",),
     "direct-defer-wait": ("command_buffer_gpu:qwen36_ffn_int4_expert_direct_gather_stage5",),
-    DIRECT_GATHER_BATCH_MODE: (
-        "command_buffer_gpu:qwen36_decode_batch",
-        "command_buffer_gpu:qwen36_ffn_int4_stage5_with_router",
-        "command_buffer_gpu:qwen36_ffn_int4_router_topk_stage5",
-        "command_buffer_gpu:qwen36_ffn_int4_shared_gate_up",
-        "command_buffer_gpu:qwen36_ffn_int4_shared_gate_scalar",
-        "command_buffer_gpu:qwen36_ffn_int4_shared_down",
-        "command_buffer_gpu:qwen36_ffn_int4_expert_gate_up_tiled_stage5",
-        "command_buffer_gpu:qwen36_ffn_int4_expert_gate_up_multirow_stage5",
-        "command_buffer_gpu:qwen36_ffn_int4_expert_down_finalize",
-    ),
-    DIRECT_DEFER_WAIT_BATCH_MODE: (
-        "command_buffer_gpu:qwen36_decode_batch",
-        "command_buffer_gpu:qwen36_ffn_int4_stage5_with_router",
-        "command_buffer_gpu:qwen36_ffn_int4_router_topk_stage5",
-        "command_buffer_gpu:qwen36_ffn_int4_shared_gate_up",
-        "command_buffer_gpu:qwen36_ffn_int4_shared_gate_scalar",
-        "command_buffer_gpu:qwen36_ffn_int4_shared_down",
-        "command_buffer_gpu:qwen36_ffn_int4_expert_gate_up_tiled_stage5",
-        "command_buffer_gpu:qwen36_ffn_int4_expert_gate_up_multirow_stage5",
-        "command_buffer_gpu:qwen36_ffn_int4_expert_down_finalize",
-    ),
     "gpu-pack": ("command_buffer_gpu:qwen36_ffn_int4_expert_gpu_pack",),
     "full-stage5": (
         "command_buffer_gpu:qwen36_ffn_int4_stage5",
@@ -3320,16 +3284,6 @@ def build_env_overrides(args: argparse.Namespace, mode: str) -> dict[str, str]:
     elif mode == "direct-defer-wait":
         overrides["SUPERSONIC_METAL_ENABLE_QWEN36_FFN_EXPERT_DIRECT_GATHER_STAGE5"] = "1"
         overrides["SUPERSONIC_METAL_QWEN36_DEFER_FFN_DIRECT_GATHER_STAGE5_WAIT"] = "1"
-    elif mode == DIRECT_GATHER_BATCH_MODE:
-        overrides["SUPERSONIC_METAL_ENABLE_QWEN36_FFN_EXPERT_DIRECT_GATHER_STAGE5"] = "1"
-        overrides["SUPERSONIC_METAL_ENABLE_QWEN36_FFN_INT4_STAGE5_ROUTER"] = "1"
-        overrides["SUPERSONIC_METAL_QWEN36_DECODE_BATCH"] = "1"
-    elif mode == DIRECT_DEFER_WAIT_BATCH_MODE:
-        overrides["SUPERSONIC_METAL_ENABLE_QWEN36_FFN_EXPERT_DIRECT_GATHER_STAGE5"] = "1"
-        overrides["SUPERSONIC_METAL_ENABLE_QWEN36_FFN_INT4_STAGE5_ROUTER"] = "1"
-        overrides["SUPERSONIC_METAL_QWEN36_DEFER_FFN_DIRECT_GATHER_STAGE5_WAIT"] = "1"
-        overrides["SUPERSONIC_METAL_QWEN36_DEFER_FFN_ROUTER_STAGE5_WAIT"] = "1"
-        overrides["SUPERSONIC_METAL_QWEN36_DECODE_BATCH"] = "1"
     elif mode == "gpu-pack":
         overrides["SUPERSONIC_METAL_ENABLE_QWEN36_FFN_EXPERT_PACKED_STAGE5"] = "1"
         overrides["SUPERSONIC_METAL_ENABLE_QWEN36_FFN_EXPERT_GPU_PACK_STAGE5"] = "1"

--- a/tests/metal/sweep_qwen36_fused_routed_int4.py
+++ b/tests/metal/sweep_qwen36_fused_routed_int4.py
@@ -16,7 +16,7 @@ from typing import Any
 
 
 MODEL = "qwen3.6-35b-a3b"
-SCHEMA = "qwen36-fused-routed-int4-sweep-v43"
+SCHEMA = "qwen36-fused-routed-int4-sweep-v44"
 DEFAULT_MAX_FUSED_WALL_GPU_RATIO = 4.0
 DEFAULT_MAX_WAIT_GPU_RATIO = 4.0
 ROUTED_SILU_ULP_BOUNDARY_SOURCE = "routed_expert_silu_ulp_boundary"
@@ -27,6 +27,8 @@ BF16_BOUNDARY_SOURCES = {
     "final_residual_rounding_boundary",
     ROUTED_SILU_ULP_BOUNDARY_SOURCE,
 }
+DIRECT_GATHER_BATCH_MODE = "direct-gather-batch"
+DIRECT_DEFER_WAIT_BATCH_MODE = "direct-defer-wait-batch"
 COARSE_BATCH_SERIAL_MODE = "full-stage5-router-batch"
 COARSE_BATCH_SIMD_MODE = "full-stage5-router-simd-batch"
 ROUTER_FUSED_EXACT_BATCH_MODE = "full-stage5-router-fused-exact-batch"
@@ -94,6 +96,8 @@ SHARED_COMPONENT_MODES = {
     SHARED_DOWN_TILED_BATCH_SIMD_MODE,
 }
 BATCH_FAST_PROFILE_MODES = {
+    DIRECT_GATHER_BATCH_MODE,
+    DIRECT_DEFER_WAIT_BATCH_MODE,
     "full-stage5-router-batch",
     "full-stage5-router-simd-batch",
     ROUTER_FUSED_EXACT_BATCH_MODE,
@@ -167,6 +171,14 @@ MODE_ALIASES: dict[str, str] = {
     "direct-defer": "direct-defer-wait",
     "direct-defer-wait": "direct-defer-wait",
     "defer-direct-wait": "direct-defer-wait",
+    "direct-batch": DIRECT_GATHER_BATCH_MODE,
+    "batch-direct": DIRECT_GATHER_BATCH_MODE,
+    "direct-gather-batch": DIRECT_GATHER_BATCH_MODE,
+    "direct-batch-defer": DIRECT_DEFER_WAIT_BATCH_MODE,
+    "direct-batch-defer-wait": DIRECT_DEFER_WAIT_BATCH_MODE,
+    "batch-direct-defer": DIRECT_DEFER_WAIT_BATCH_MODE,
+    "batch-direct-defer-wait": DIRECT_DEFER_WAIT_BATCH_MODE,
+    "direct-defer-wait-batch": DIRECT_DEFER_WAIT_BATCH_MODE,
     "gpu-pack": "gpu-pack",
     "gpack": "gpu-pack",
     "full": "full-stage5",
@@ -319,12 +331,14 @@ MODE_ALIASES: dict[str, str] = {
     "router-defer-wait": "router-defer-wait",
     "defer-router-wait": "router-defer-wait",
 }
-DEFAULT_MODES = "default,direct-gather,direct-defer-wait,gpu-pack,full-stage5,full-stage5-router,router-defer-wait"
+DEFAULT_MODES = "default,direct-gather,direct-defer-wait,direct-gather-batch,direct-defer-wait-batch,gpu-pack,full-stage5,full-stage5-router,router-defer-wait"
 
 FUSED_OP_NEEDLES = {
     "packed": "qwen36_ffn_int4_expert_packed_stage5",
     "direct-gather": "qwen36_ffn_int4_expert_direct_gather_stage5",
     "direct-defer-wait": "qwen36_ffn_int4_expert_direct_gather_stage5",
+    DIRECT_GATHER_BATCH_MODE: "qwen36_ffn_int4_stage5_with_router",
+    DIRECT_DEFER_WAIT_BATCH_MODE: "qwen36_ffn_int4_stage5_with_router",
     "gpu-pack": "qwen36_ffn_int4_expert_gpu_pack_stage5",
     "full-stage5": "qwen36_ffn_int4_stage5",
     "full-stage5-router": "qwen36_ffn_int4_stage5_with_router",
@@ -366,6 +380,28 @@ FUSED_GPU_OP_PREFIXES = {
     "packed": ("command_buffer_gpu:qwen36_ffn_int4_expert_packed_stage5",),
     "direct-gather": ("command_buffer_gpu:qwen36_ffn_int4_expert_direct_gather_stage5",),
     "direct-defer-wait": ("command_buffer_gpu:qwen36_ffn_int4_expert_direct_gather_stage5",),
+    DIRECT_GATHER_BATCH_MODE: (
+        "command_buffer_gpu:qwen36_decode_batch",
+        "command_buffer_gpu:qwen36_ffn_int4_stage5_with_router",
+        "command_buffer_gpu:qwen36_ffn_int4_router_topk_stage5",
+        "command_buffer_gpu:qwen36_ffn_int4_shared_gate_up",
+        "command_buffer_gpu:qwen36_ffn_int4_shared_gate_scalar",
+        "command_buffer_gpu:qwen36_ffn_int4_shared_down",
+        "command_buffer_gpu:qwen36_ffn_int4_expert_gate_up_tiled_stage5",
+        "command_buffer_gpu:qwen36_ffn_int4_expert_gate_up_multirow_stage5",
+        "command_buffer_gpu:qwen36_ffn_int4_expert_down_finalize",
+    ),
+    DIRECT_DEFER_WAIT_BATCH_MODE: (
+        "command_buffer_gpu:qwen36_decode_batch",
+        "command_buffer_gpu:qwen36_ffn_int4_stage5_with_router",
+        "command_buffer_gpu:qwen36_ffn_int4_router_topk_stage5",
+        "command_buffer_gpu:qwen36_ffn_int4_shared_gate_up",
+        "command_buffer_gpu:qwen36_ffn_int4_shared_gate_scalar",
+        "command_buffer_gpu:qwen36_ffn_int4_shared_down",
+        "command_buffer_gpu:qwen36_ffn_int4_expert_gate_up_tiled_stage5",
+        "command_buffer_gpu:qwen36_ffn_int4_expert_gate_up_multirow_stage5",
+        "command_buffer_gpu:qwen36_ffn_int4_expert_down_finalize",
+    ),
     "gpu-pack": ("command_buffer_gpu:qwen36_ffn_int4_expert_gpu_pack",),
     "full-stage5": (
         "command_buffer_gpu:qwen36_ffn_int4_stage5",
@@ -3284,6 +3320,16 @@ def build_env_overrides(args: argparse.Namespace, mode: str) -> dict[str, str]:
     elif mode == "direct-defer-wait":
         overrides["SUPERSONIC_METAL_ENABLE_QWEN36_FFN_EXPERT_DIRECT_GATHER_STAGE5"] = "1"
         overrides["SUPERSONIC_METAL_QWEN36_DEFER_FFN_DIRECT_GATHER_STAGE5_WAIT"] = "1"
+    elif mode == DIRECT_GATHER_BATCH_MODE:
+        overrides["SUPERSONIC_METAL_ENABLE_QWEN36_FFN_EXPERT_DIRECT_GATHER_STAGE5"] = "1"
+        overrides["SUPERSONIC_METAL_ENABLE_QWEN36_FFN_INT4_STAGE5_ROUTER"] = "1"
+        overrides["SUPERSONIC_METAL_QWEN36_DECODE_BATCH"] = "1"
+    elif mode == DIRECT_DEFER_WAIT_BATCH_MODE:
+        overrides["SUPERSONIC_METAL_ENABLE_QWEN36_FFN_EXPERT_DIRECT_GATHER_STAGE5"] = "1"
+        overrides["SUPERSONIC_METAL_ENABLE_QWEN36_FFN_INT4_STAGE5_ROUTER"] = "1"
+        overrides["SUPERSONIC_METAL_QWEN36_DEFER_FFN_DIRECT_GATHER_STAGE5_WAIT"] = "1"
+        overrides["SUPERSONIC_METAL_QWEN36_DEFER_FFN_ROUTER_STAGE5_WAIT"] = "1"
+        overrides["SUPERSONIC_METAL_QWEN36_DECODE_BATCH"] = "1"
     elif mode == "gpu-pack":
         overrides["SUPERSONIC_METAL_ENABLE_QWEN36_FFN_EXPERT_PACKED_STAGE5"] = "1"
         overrides["SUPERSONIC_METAL_ENABLE_QWEN36_FFN_EXPERT_GPU_PACK_STAGE5"] = "1"

--- a/tests/test_qwen36_next_bottleneck.py
+++ b/tests/test_qwen36_next_bottleneck.py
@@ -141,7 +141,7 @@ def prefill_report() -> dict:
 
 def bench_perf_report() -> dict:
     return {
-        "schema_version": 9,
+        "schema_version": 10,
         "model": selector.MODEL,
         "quant": "int4",
         "arch": "apple-m5-max",
@@ -248,7 +248,7 @@ class Qwen36NextBottleneckTests(unittest.TestCase):
         self.assertEqual(report["prefill"]["best_mode"], "prototype-default")
         self.assertIn("prototype_linear_attention_orchestration", md)
 
-    def test_includes_schema_v9_bench_perf_as_runtime_evidence(self):
+    def test_includes_schema_v10_bench_perf_as_runtime_evidence(self):
         with tempfile.TemporaryDirectory() as tmp:
             paths = self.write_default_inputs(Path(tmp))
             bench_path = Path(tmp) / "bench.json"
@@ -258,8 +258,8 @@ class Qwen36NextBottleneckTests(unittest.TestCase):
             md = selector.render_markdown(report)
 
         self.assertEqual(report["schema"], selector.SCHEMA)
-        self.assertEqual(report["input_reports"]["bench_perf"]["schema"], 9)
-        self.assertEqual(report["bench_perf"]["schema_version"], 9)
+        self.assertEqual(report["input_reports"]["bench_perf"]["schema"], 10)
+        self.assertEqual(report["bench_perf"]["schema_version"], 10)
         self.assertEqual(report["bench_perf"]["linear_attn_ms_avg"], 31.335)
         self.assertEqual(report["bench_perf"]["profile_linear_attn_ms_avg"], 53.165)
         buckets = {row["bucket"]: row for row in report["decode_bucket_ranking"]}
@@ -346,7 +346,7 @@ class Qwen36NextBottleneckTests(unittest.TestCase):
             write_json(
                 matching.parent.parent / "meta.json",
                 {
-                    "schema_version": 9,
+                    "schema_version": 10,
                     "git_sha": "abc1234",
                     "git_dirty": True,
                     "git_dirty_paths": ["crates/kernel-ffi/src/metal_native.mm"],
@@ -356,7 +356,7 @@ class Qwen36NextBottleneckTests(unittest.TestCase):
             write_json(
                 stale.parent.parent / "meta.json",
                 {
-                    "schema_version": 9,
+                    "schema_version": 10,
                     "git_sha": "abc1234",
                     "git_dirty": True,
                     "git_dirty_paths": ["crates/kernel-ffi/src/metal_native.mm"],
@@ -385,7 +385,7 @@ class Qwen36NextBottleneckTests(unittest.TestCase):
             write_json(
                 stale.parent.parent / "meta.json",
                 {
-                    "schema_version": 9,
+                    "schema_version": 10,
                     "git_sha": "abc1234",
                     "git_dirty": True,
                     "git_dirty_paths": ["crates/kernel-ffi/src/metal_native.mm"],

--- a/tests/test_qwen36_sota_contracts.py
+++ b/tests/test_qwen36_sota_contracts.py
@@ -116,8 +116,8 @@ class Qwen36SotaContractTests(unittest.TestCase):
         self.assertIn("full-stage5", specs["fused_routed_int4"].refresh_command)
         self.assertIn("full-stage5-router", specs["fused_routed_int4"].refresh_command)
         self.assertIn("direct-defer-wait", specs["fused_routed_int4"].refresh_command)
-        self.assertIn("direct-gather-batch", specs["fused_routed_int4"].refresh_command)
-        self.assertIn("direct-defer-wait-batch", specs["fused_routed_int4"].refresh_command)
+        self.assertNotIn("direct-gather-batch", specs["fused_routed_int4"].refresh_command)
+        self.assertNotIn("direct-defer-wait-batch", specs["fused_routed_int4"].refresh_command)
         self.assertIn("router-defer-wait", specs["fused_routed_int4"].refresh_command)
         self.assertEqual(
             specs["mps_resident_table"].expected_schema,
@@ -163,70 +163,23 @@ class Qwen36SotaContractTests(unittest.TestCase):
         self.assertEqual(specs["mps_resident_table"].gate_keys, ("viability_gate",))
         self.assertEqual(specs["route_residency"].gate_keys, ("decision_gate",))
 
-    def test_fused_direct_batch_modes_set_residency_env(self):
-        modes = fused_sweep.parse_modes(
-            "direct-batch,direct-batch-defer-wait,direct-gather-batch,direct-defer-wait-batch"
-        )
-        self.assertEqual(
-            modes,
-            [
-                fused_sweep.DIRECT_GATHER_BATCH_MODE,
-                fused_sweep.DIRECT_DEFER_WAIT_BATCH_MODE,
-            ],
-        )
-        self.assertIn(
-            fused_sweep.DIRECT_GATHER_BATCH_MODE,
-            fused_sweep.BATCH_FAST_PROFILE_MODES,
-        )
-        self.assertIn(
-            fused_sweep.DIRECT_DEFER_WAIT_BATCH_MODE,
-            fused_sweep.BATCH_FAST_PROFILE_MODES,
-        )
+    def test_fused_direct_batch_modes_are_not_exposed_until_native_shared_split(self):
+        for alias in (
+            "direct-batch",
+            "batch-direct",
+            "direct-gather-batch",
+            "direct-batch-defer",
+            "direct-batch-defer-wait",
+            "batch-direct-defer",
+            "batch-direct-defer-wait",
+            "direct-defer-wait-batch",
+        ):
+            self.assertNotIn(alias, fused_sweep.MODE_ALIASES)
 
-        args = SimpleNamespace(metal_profile=True)
-        direct_batch_env = fused_sweep.build_env_overrides(
-            args,
-            fused_sweep.DIRECT_GATHER_BATCH_MODE,
-        )
-        self.assertEqual(
-            direct_batch_env["SUPERSONIC_METAL_ENABLE_QWEN36_FFN_EXPERT_DIRECT_GATHER_STAGE5"],
-            "1",
-        )
-        self.assertEqual(
-            direct_batch_env["SUPERSONIC_METAL_ENABLE_QWEN36_FFN_INT4_STAGE5_ROUTER"],
-            "1",
-        )
-        self.assertEqual(direct_batch_env["SUPERSONIC_METAL_QWEN36_DECODE_BATCH"], "1")
-        self.assertNotIn(
-            "SUPERSONIC_METAL_QWEN36_DEFER_FFN_DIRECT_GATHER_STAGE5_WAIT",
-            direct_batch_env,
-        )
-        self.assertNotIn(
-            "SUPERSONIC_METAL_QWEN36_DEFER_FFN_ROUTER_STAGE5_WAIT",
-            direct_batch_env,
-        )
-
-        defer_batch_env = fused_sweep.build_env_overrides(
-            args,
-            fused_sweep.DIRECT_DEFER_WAIT_BATCH_MODE,
-        )
-        self.assertEqual(
-            defer_batch_env["SUPERSONIC_METAL_ENABLE_QWEN36_FFN_EXPERT_DIRECT_GATHER_STAGE5"],
-            "1",
-        )
-        self.assertEqual(
-            defer_batch_env["SUPERSONIC_METAL_ENABLE_QWEN36_FFN_INT4_STAGE5_ROUTER"],
-            "1",
-        )
-        self.assertEqual(defer_batch_env["SUPERSONIC_METAL_QWEN36_DECODE_BATCH"], "1")
-        self.assertEqual(
-            defer_batch_env["SUPERSONIC_METAL_QWEN36_DEFER_FFN_DIRECT_GATHER_STAGE5_WAIT"],
-            "1",
-        )
-        self.assertEqual(
-            defer_batch_env["SUPERSONIC_METAL_QWEN36_DEFER_FFN_ROUTER_STAGE5_WAIT"],
-            "1",
-        )
+        self.assertNotIn("direct-gather-batch", fused_sweep.DEFAULT_MODES)
+        self.assertNotIn("direct-defer-wait-batch", fused_sweep.DEFAULT_MODES)
+        self.assertNotIn("direct-gather-batch", fused_sweep.BATCH_FAST_PROFILE_MODES)
+        self.assertNotIn("direct-defer-wait-batch", fused_sweep.BATCH_FAST_PROFILE_MODES)
 
     def test_batched_prefill_variants_cover_documented_negative_gates(self):
         expected = {

--- a/tests/test_qwen36_sota_contracts.py
+++ b/tests/test_qwen36_sota_contracts.py
@@ -81,7 +81,7 @@ class Qwen36SotaContractTests(unittest.TestCase):
             "qwen36-metal-batched-prefill-variant-sweep-v2",
         )
         self.assertEqual(static_sweep.SCHEMA, "qwen36-static-topn-runtime-sweep-v6")
-        self.assertEqual(fused_sweep.SCHEMA, "qwen36-fused-routed-int4-sweep-v43")
+        self.assertEqual(fused_sweep.SCHEMA, "qwen36-fused-routed-int4-sweep-v44")
         self.assertEqual(mps_probe.SCHEMA, "qwen36-mps-resident-table-probe-v2")
         self.assertEqual(route_sweep.SCHEMA, "qwen36-route-residency-sweep-v1")
         self.assertEqual(mtp_sweep.SCHEMA, "qwen36-moe-mtp-acceptance-sweep-v2")
@@ -116,6 +116,8 @@ class Qwen36SotaContractTests(unittest.TestCase):
         self.assertIn("full-stage5", specs["fused_routed_int4"].refresh_command)
         self.assertIn("full-stage5-router", specs["fused_routed_int4"].refresh_command)
         self.assertIn("direct-defer-wait", specs["fused_routed_int4"].refresh_command)
+        self.assertIn("direct-gather-batch", specs["fused_routed_int4"].refresh_command)
+        self.assertIn("direct-defer-wait-batch", specs["fused_routed_int4"].refresh_command)
         self.assertIn("router-defer-wait", specs["fused_routed_int4"].refresh_command)
         self.assertEqual(
             specs["mps_resident_table"].expected_schema,
@@ -160,6 +162,71 @@ class Qwen36SotaContractTests(unittest.TestCase):
         )
         self.assertEqual(specs["mps_resident_table"].gate_keys, ("viability_gate",))
         self.assertEqual(specs["route_residency"].gate_keys, ("decision_gate",))
+
+    def test_fused_direct_batch_modes_set_residency_env(self):
+        modes = fused_sweep.parse_modes(
+            "direct-batch,direct-batch-defer-wait,direct-gather-batch,direct-defer-wait-batch"
+        )
+        self.assertEqual(
+            modes,
+            [
+                fused_sweep.DIRECT_GATHER_BATCH_MODE,
+                fused_sweep.DIRECT_DEFER_WAIT_BATCH_MODE,
+            ],
+        )
+        self.assertIn(
+            fused_sweep.DIRECT_GATHER_BATCH_MODE,
+            fused_sweep.BATCH_FAST_PROFILE_MODES,
+        )
+        self.assertIn(
+            fused_sweep.DIRECT_DEFER_WAIT_BATCH_MODE,
+            fused_sweep.BATCH_FAST_PROFILE_MODES,
+        )
+
+        args = SimpleNamespace(metal_profile=True)
+        direct_batch_env = fused_sweep.build_env_overrides(
+            args,
+            fused_sweep.DIRECT_GATHER_BATCH_MODE,
+        )
+        self.assertEqual(
+            direct_batch_env["SUPERSONIC_METAL_ENABLE_QWEN36_FFN_EXPERT_DIRECT_GATHER_STAGE5"],
+            "1",
+        )
+        self.assertEqual(
+            direct_batch_env["SUPERSONIC_METAL_ENABLE_QWEN36_FFN_INT4_STAGE5_ROUTER"],
+            "1",
+        )
+        self.assertEqual(direct_batch_env["SUPERSONIC_METAL_QWEN36_DECODE_BATCH"], "1")
+        self.assertNotIn(
+            "SUPERSONIC_METAL_QWEN36_DEFER_FFN_DIRECT_GATHER_STAGE5_WAIT",
+            direct_batch_env,
+        )
+        self.assertNotIn(
+            "SUPERSONIC_METAL_QWEN36_DEFER_FFN_ROUTER_STAGE5_WAIT",
+            direct_batch_env,
+        )
+
+        defer_batch_env = fused_sweep.build_env_overrides(
+            args,
+            fused_sweep.DIRECT_DEFER_WAIT_BATCH_MODE,
+        )
+        self.assertEqual(
+            defer_batch_env["SUPERSONIC_METAL_ENABLE_QWEN36_FFN_EXPERT_DIRECT_GATHER_STAGE5"],
+            "1",
+        )
+        self.assertEqual(
+            defer_batch_env["SUPERSONIC_METAL_ENABLE_QWEN36_FFN_INT4_STAGE5_ROUTER"],
+            "1",
+        )
+        self.assertEqual(defer_batch_env["SUPERSONIC_METAL_QWEN36_DECODE_BATCH"], "1")
+        self.assertEqual(
+            defer_batch_env["SUPERSONIC_METAL_QWEN36_DEFER_FFN_DIRECT_GATHER_STAGE5_WAIT"],
+            "1",
+        )
+        self.assertEqual(
+            defer_batch_env["SUPERSONIC_METAL_QWEN36_DEFER_FFN_ROUTER_STAGE5_WAIT"],
+            "1",
+        )
 
     def test_batched_prefill_variants_cover_documented_negative_gates(self):
         expected = {


### PR DESCRIPTION
## Summary

- remove the misleading direct-gather-batch and direct-defer-wait-batch Qwen3.6 fused routed INT4 sweep modes
- keep the existing single-FFN direct-gather controls and router-native batch modes as separate, honest lanes
- add lower-precision benchmark scaffolding for `int3`, `int2-4-mixed`, and `mxfp4` candidate lanes
- add optional `quant_artifact` metadata to bench perf cells and lower-precision metadata fields to bake manifests
- document the lower-precision quality/perf acceptance path in `docs/lower-precision.md`

## Why

The review caught that a batch mode cannot currently be both true direct-gather and router-native: enabling the combined router-native FFN path masks the direct-gather expert kernel, while leaving it off preserves the host-router boundary. Until SuperSonic has a native split that covers router plus shared FFN before the direct-gather expert phase, the sweep should not advertise that lane.

The next quantization direction still needs a quality-aware runway before kernels: the lower-precision lanes are stable names for AutoRound/SignRoundV2 artifacts, but remain skipped until loader/runtime support exists. This keeps lower-bit experiments visible in the matrix without pretending they are supported.

## Validation

Latest review-fix validation:

- `PYTHONPYCACHEPREFIX=/tmp/supersonic-pycache python3 -m py_compile tests/metal/sweep_qwen36_fused_routed_int4.py tests/metal/summarize_qwen36_sota_gates.py tests/test_qwen36_sota_contracts.py`
- `PYTHONPYCACHEPREFIX=/tmp/supersonic-pycache python3 -m unittest tests.test_qwen36_sota_contracts`

Earlier validation on this PR:

- `PYTHONPYCACHEPREFIX=/tmp/supersonic-pycache python3 tests/metal/select_qwen36_next_bottleneck.py --require-selected`
- `cargo test -p supersonic-bench`
- `cargo test -p model-store`
- `PYTHONPYCACHEPREFIX=/tmp/supersonic-pycache python3 -m unittest tests.test_qwen36_next_bottleneck`
- `cargo test -p runner --test bench_combo_parity`

## Note

A tiny Metal smoke sweep was attempted locally, but this sandbox cannot query the Metal device (`metalQueryDeviceInfo failed with status 2`), so no live timing data is included in this PR.