### PR TITLE
[codex] Add Qwen3.6 27B Lucebox comparison path

### DIFF
--- a/crates/core/src/registry.rs
+++ b/crates/core/src/registry.rs
@@ -417,6 +417,25 @@ static REGISTRY: &[RegistryEntry] = &[
         }),
     },
     RegistryEntry {
+        model: ModelVariant::Qwen3_6_27B,
+        backend: Backend::Hip,
+        arch: GpuArch::Gfx1100,
+        vram: VramBudget {
+            fixed_bytes: 22 * GIB,
+            overhead_factor: 1.05,
+        },
+        params: FamilyParams::Qwen35(Qwen35KernelParams {
+            // Qwen3.6-27B: qkv 8192 + z 6144 + b/a 48 each.
+            proj_buf_floats: 16480,
+            // Floor for 3*nh*hd + nh*aligned_kv_t at short contexts.
+            // The runner still expands this from --context-size.
+            attn_scratch_floats: 24576,
+            weight_prefix: "model.language_model",
+            kv_chunk_size: 256,
+            use_4b_kernel: true,
+        }),
+    },
+    RegistryEntry {
         model: ModelVariant::Qwen3_5_0_8B,
         backend: Backend::Hip,
         arch: GpuArch::Gfx1150,
@@ -1220,6 +1239,7 @@ mod tests {
             ModelVariant::Qwen3_5_2B,
             ModelVariant::Qwen3_5_4B,
             ModelVariant::Qwen3_5_9B,
+            ModelVariant::Qwen3_6_27B,
             ModelVariant::Qwen3_30B_A3B,
             ModelVariant::Gemma4_E2B,
             ModelVariant::Gemma4_E4B,
@@ -1260,6 +1280,21 @@ mod tests {
     fn cuda_sm86_qwen36_27b_registry_params_match_geometry() {
         let entry = lookup(&ModelVariant::Qwen3_6_27B, &Backend::Cuda, &GpuArch::Sm86)
             .expect("qwen3.6-27b CUDA sm86 registry entry");
+        match entry.params {
+            FamilyParams::Qwen35(params) => {
+                assert_eq!(params.weight_prefix, "model.language_model");
+                assert!(params.use_4b_kernel);
+                assert_eq!(params.proj_buf_floats, 16_480);
+                assert_eq!(params.attn_scratch_floats, 24_576);
+            }
+            _ => panic!("qwen3.6-27b must use the Qwen hybrid-attention engine"),
+        }
+    }
+
+    #[test]
+    fn hip_gfx1100_qwen36_27b_registry_params_match_geometry() {
+        let entry = lookup(&ModelVariant::Qwen3_6_27B, &Backend::Hip, &GpuArch::Gfx1100)
+            .expect("qwen3.6-27b HIP gfx1100 registry entry");
         match entry.params {
             FamilyParams::Qwen35(params) => {
                 assert_eq!(params.weight_prefix, "model.language_model");

--- a/crates/runner/src/cli.rs
+++ b/crates/runner/src/cli.rs
@@ -27,6 +27,10 @@ pub(crate) struct Cli {
     #[arg(long, default_value = "8")]
     pub(crate) max_new_tokens: usize,
 
+    /// Continue until --max-new-tokens even if the model emits EOS.
+    #[arg(long)]
+    pub(crate) ignore_eos: bool,
+
     /// Sampling temperature. 0 = greedy argmax (default; reproducible).
     /// Typical sampled values: 0.7–1.0.
     #[arg(long, default_value = "0.0")]

--- a/crates/runner/src/policy.rs
+++ b/crates/runner/src/policy.rs
@@ -36,14 +36,11 @@ pub(crate) fn validate_global_flags(
     if cli.q4km
         && !(backend == Backend::Cuda
             || (backend == Backend::Hip
-                && matches!(
-                    model_variant.family(),
-                    ModelFamily::Qwen35 | ModelFamily::Qwen36Moe
-                ))
+                && model_variant.family() == ModelFamily::Qwen36Moe)
             || (backend == Backend::Metal && model_variant.family() == ModelFamily::Qwen36Moe))
     {
         anyhow::bail!(
-            "--q4km raw GGML blocks are currently supported only on CUDA Qwen paths, HIP Qwen3.5/3.6 paths, and Metal Qwen3.5/3.6 MoE"
+            "--q4km raw GGML blocks are currently supported only on CUDA Qwen paths, HIP Qwen3.6 MoE, and Metal Qwen3.5/3.6 MoE"
         );
     }
     if cli.q4km_gptq
@@ -204,9 +201,9 @@ mod tests {
     }
 
     #[test]
-    fn allows_raw_q4km_for_qwen36_dense_on_hip() {
+    fn rejects_raw_q4km_for_qwen36_dense_on_hip() {
         validate_global_flags(&cli(&["--q4km"]), &ModelVariant::Qwen3_6_27B, Backend::Hip)
-            .expect("Qwen3.6-27B HIP can load raw GGML q4km through the Qwen3.5 dense path");
+            .expect_err("Qwen3.6-27B HIP dense kernels require native INT4 sidecars");
     }
 
     #[test]

--- a/crates/runner/src/policy.rs
+++ b/crates/runner/src/policy.rs
@@ -35,18 +35,28 @@ pub(crate) fn validate_global_flags(
     }
     if cli.q4km
         && !(backend == Backend::Cuda
+            || (backend == Backend::Hip
+                && matches!(
+                    model_variant.family(),
+                    ModelFamily::Qwen35 | ModelFamily::Qwen36Moe
+                ))
             || (backend == Backend::Metal && model_variant.family() == ModelFamily::Qwen36Moe))
     {
         anyhow::bail!(
-            "--q4km raw GGML blocks are currently supported only on CUDA Qwen paths and Metal Qwen3.5/3.6 MoE"
+            "--q4km raw GGML blocks are currently supported only on CUDA Qwen paths, HIP Qwen3.5/3.6 paths, and Metal Qwen3.5/3.6 MoE"
         );
     }
     if cli.q4km_gptq
         && !(backend == Backend::Cuda
+            || (backend == Backend::Hip
+                && matches!(
+                    model_variant.family(),
+                    ModelFamily::Qwen35 | ModelFamily::Qwen36Moe
+                ))
             || (backend == Backend::Metal && model_variant.family() == ModelFamily::Qwen36Moe))
     {
         anyhow::bail!(
-            "--q4km-gptq is currently supported on CUDA Qwen paths and Metal Qwen3.5/3.6 MoE"
+            "--q4km-gptq is currently supported on CUDA Qwen paths, HIP Qwen3.5/3.6 paths, and Metal Qwen3.5/3.6 MoE"
         );
     }
     if matches!(model_variant.family(), ModelFamily::Qwen3Moe) {
@@ -191,6 +201,22 @@ mod tests {
             Backend::Metal,
         )
         .expect("Qwen3.5/3.6 MoE Metal can load raw GGML q4km through the staged path");
+    }
+
+    #[test]
+    fn allows_raw_q4km_for_qwen36_dense_on_hip() {
+        validate_global_flags(&cli(&["--q4km"]), &ModelVariant::Qwen3_6_27B, Backend::Hip)
+            .expect("Qwen3.6-27B HIP can load raw GGML q4km through the Qwen3.5 dense path");
+    }
+
+    #[test]
+    fn allows_q4km_gptq_for_qwen36_dense_on_hip() {
+        validate_global_flags(
+            &cli(&["--q4km-gptq"]),
+            &ModelVariant::Qwen3_6_27B,
+            Backend::Hip,
+        )
+        .expect("Qwen3.6-27B HIP can load Q4KM-sourced native INT4 through the Qwen3.5 dense path");
     }
 }
 

--- a/crates/runner/src/qwen35_decode_loop.rs
+++ b/crates/runner/src/qwen35_decode_loop.rs
@@ -54,7 +54,7 @@ pub(crate) fn run_qwen35_decode_loop(
 
     let decode_start = Instant::now();
     for step in 0..decode.cli.max_new_tokens {
-        if decode.eos_ids.contains(&next_token) {
+        if !decode.cli.ignore_eos && decode.eos_ids.contains(&next_token) {
             break;
         }
 

--- a/crates/runner/src/qwen36_moe/engine.rs
+++ b/crates/runner/src/qwen36_moe/engine.rs
@@ -361,6 +361,7 @@ fn run_inner(
         cli.profile_prefill,
         cli.profile_prefill_json.as_deref(),
         &cli.model,
+        cli.ignore_eos,
         keep_mask,
     )?;
     Ok(())
@@ -402,6 +403,7 @@ fn decode_text(
     profile_prefill: bool,
     profile_prefill_json: Option<&Path>,
     model_name: &str,
+    ignore_eos: bool,
     keep_mask: Option<Vec<bool>>,
 ) -> Result<()> {
     validate_speculative_sampling(speculative_decode, sampling)?;
@@ -422,7 +424,11 @@ fn decode_text(
     let prompt_setup_elapsed = prompt_setup_start.elapsed();
     let tokenizer = prompt_setup.tokenizer;
     let prompt_ids = prompt_setup.prompt_ids;
-    let eos_id = prompt_setup.eos_id;
+    let eos_id = if ignore_eos {
+        None
+    } else {
+        prompt_setup.eos_id
+    };
     print_prompt_summary(prompt, &prompt_ids);
 
     let bake_open_start = std::time::Instant::now();

--- a/kernels/full_attention_4b.hip
+++ b/kernels/full_attention_4b.hip
@@ -4980,9 +4980,13 @@ __global__ void supersonic_qwen35_persistent_decode_kernel(
 
     // FP8 E4M3 → F32 lookup table in LDS (256 entries = 1KB).
     // Placed after the input cache area. Populated once, used for all FP8 dequant.
-    // LDS is sized by the bridge as: block_size + max(B*hidden_dim, intermediate_size).
+    // LDS is sized by the bridge as: block_size + max(B*hidden_dim, 2*hidden_dim).
+    // MLP down-proj reads the SwiGLU intermediate from global scratch so large
+    // models do not require `intermediate_size` floats of LDS.
     // The LUT sits after the input cache region.
-    const int lds_input_size = (B * hidden_dim > intermediate_size) ? B * hidden_dim : intermediate_size;
+    const int hidden_cache = B * hidden_dim;
+    const int attention_cache = hidden_dim * 2;
+    const int lds_input_size = hidden_cache > attention_cache ? hidden_cache : attention_cache;
     float* fp8_lut = lds + bs + lds_input_size;
 
     // Populate FP8 LUT: thread i fills entry i (256 threads → 256 entries, one pass).
@@ -6583,9 +6587,7 @@ __global__ void supersonic_qwen35_persistent_decode_kernel(
         // Process one batch item at a time: cache SwiGLU output in LDS, work-steal
         const unsigned long long mlp_down_clock = clock64();
         for (int b = 0; b < B; b++) {
-            for (int c = tid; c < L.intermediate_size; c += bs)
-                lds_input[c] = gate_up[b * intermediate_size * 2 + c];
-            __syncthreads();
+            const float* swiglu_b = gate_up + b * intermediate_size * 2;
 
             if (blockIdx.x == 0 && tid == 0) { counters[0] = 0; __threadfence(); }
             grid_barrier(barrier_counter, barrier_flag, nb);
@@ -6616,12 +6618,12 @@ __global__ void supersonic_qwen35_persistent_decode_kernel(
                             float w[8];
                             int4_dequant_8(pk, d_sc, d_zr, sr_g, c, sc_cols, gsz, w);
                             apply_awq_inv_scale_8(w, d_awq_inv, c);
-                            p += w[0]*lds_input[c] + w[1]*lds_input[c+1] + w[2]*lds_input[c+2] + w[3]*lds_input[c+3]
-                               + w[4]*lds_input[c+4] + w[5]*lds_input[c+5] + w[6]*lds_input[c+6] + w[7]*lds_input[c+7];
+                            p += w[0]*swiglu_b[c] + w[1]*swiglu_b[c+1] + w[2]*swiglu_b[c+2] + w[3]*swiglu_b[c+3]
+                               + w[4]*swiglu_b[c+4] + w[5]*swiglu_b[c+5] + w[6]*swiglu_b[c+6] + w[7]*swiglu_b[c+7];
                         }
                         for (int c = is8 + tid; c < L.intermediate_size; c += bs)
                             p += int4_dequant_scalar(L.down_proj_w, int4_scales[layer].down_proj_scale, int4_scales[layer].down_proj_zero, my_row, c, L.intermediate_size, gsz) *
-                                 awq_inv_scale_at(d_awq_inv, c) * lds_input[c];
+                                 awq_inv_scale_at(d_awq_inv, c) * swiglu_b[c];
 
                         lds[tid] = p;
                         __syncthreads();
@@ -6661,12 +6663,12 @@ __global__ void supersonic_qwen35_persistent_decode_kernel(
                                 float w[8];
                                 int4_dequant_8(pk, d_sc, d_zr, sr_g, c, sc_cols, gsz, w);
                                 apply_awq_inv_scale_8(w, d_awq_inv, c);
-                                p += w[0]*lds_input[c] + w[1]*lds_input[c+1] + w[2]*lds_input[c+2] + w[3]*lds_input[c+3]
-                                   + w[4]*lds_input[c+4] + w[5]*lds_input[c+5] + w[6]*lds_input[c+6] + w[7]*lds_input[c+7];
+                                p += w[0]*swiglu_b[c] + w[1]*swiglu_b[c+1] + w[2]*swiglu_b[c+2] + w[3]*swiglu_b[c+3]
+                                   + w[4]*swiglu_b[c+4] + w[5]*swiglu_b[c+5] + w[6]*swiglu_b[c+6] + w[7]*swiglu_b[c+7];
                             }
                             for (int c = is8 + lane_d; c < L.intermediate_size; c += warpSize)
                                 p += int4_dequant_scalar(L.down_proj_w, int4_scales[layer].down_proj_scale, int4_scales[layer].down_proj_zero, my_row, c, L.intermediate_size, gsz) *
-                                     awq_inv_scale_at(d_awq_inv, c) * lds_input[c];
+                                     awq_inv_scale_at(d_awq_inv, c) * swiglu_b[c];
                         } else if (down_fp8) {
                             const uint8_t* d_fp8 = static_cast<const uint8_t*>(L.down_proj_w) + static_cast<size_t>(my_row) * L.intermediate_size;
                             const hip_bfloat16* d_scales = static_cast<const hip_bfloat16*>(fp8_scales[layer].down_proj_scale);
@@ -6681,10 +6683,10 @@ __global__ void supersonic_qwen35_persistent_decode_kernel(
                                 float w1 = bf16_round_rne_f32_finite((fp8_lut[(pk>>8) & 0xFF] * static_cast<float>(d_scales[sb + (c+1) / bsz])));
                                 float w2 = bf16_round_rne_f32_finite((fp8_lut[(pk>>16) & 0xFF] * static_cast<float>(d_scales[sb + (c+2) / bsz])));
                                 float w3 = bf16_round_rne_f32_finite((fp8_lut[(pk>>24)] * static_cast<float>(d_scales[sb + (c+3) / bsz])));
-                                p += w0*lds_input[c] + w1*lds_input[c+1] + w2*lds_input[c+2] + w3*lds_input[c+3];
+                                p += w0*swiglu_b[c] + w1*swiglu_b[c+1] + w2*swiglu_b[c+2] + w3*swiglu_b[c+3];
                             }
                             for (int c = is4 + lane_d; c < L.intermediate_size; c += warpSize)
-                                p += fp8_dequant_weight_lut(L.down_proj_w, fp8_scales[layer].down_proj_scale, my_row, c, L.intermediate_size, bsz, fp8_lut) * lds_input[c];
+                                p += fp8_dequant_weight_lut(L.down_proj_w, fp8_scales[layer].down_proj_scale, my_row, c, L.intermediate_size, bsz, fp8_lut) * swiglu_b[c];
                         } else {
                             const T* wr = static_cast<const T*>(L.down_proj_w) + static_cast<size_t>(my_row) * L.intermediate_size;
                             const int is4 = L.intermediate_size & ~3;
@@ -6693,11 +6695,11 @@ __global__ void supersonic_qwen35_persistent_decode_kernel(
                                 float w1 = supersonic_qwen35_to_float(wr[c+1]);
                                 float w2 = supersonic_qwen35_to_float(wr[c+2]);
                                 float w3 = supersonic_qwen35_to_float(wr[c+3]);
-                                p += w0*lds_input[c]   + w1*lds_input[c+1]
-                                   + w2*lds_input[c+2] + w3*lds_input[c+3];
+                                p += w0*swiglu_b[c]   + w1*swiglu_b[c+1]
+                                   + w2*swiglu_b[c+2] + w3*swiglu_b[c+3];
                             }
                             for (int c = is4 + lane_d; c < L.intermediate_size; c += warpSize)
-                                p += supersonic_qwen35_to_float(wr[c]) * lds_input[c];
+                                p += supersonic_qwen35_to_float(wr[c]) * swiglu_b[c];
                         }
                         float result = wave_reduce_sum_f32(p);
                         if (lane_d == 0) {

--- a/kernels/full_attention_bridge_4b.cpp
+++ b/kernels/full_attention_bridge_4b.cpp
@@ -4954,11 +4954,13 @@ int persistent_decode_device(
     const bool coop_requested =
         std::getenv("SUPERSONIC_QWEN4B_COOP") != nullptr || preset_coop_hint;
     constexpr int block_size = 256;
-    // LDS: reduction scratch [block_size] + input cache [max(batch_size * hidden_dim, intermediate_size)]
-    //      + FP8 LUT [256] (only when fp8_scales != nullptr, but always allocated for simplicity)
-    const size_t input_cache = static_cast<size_t>(hidden_dim) * batch_size > static_cast<size_t>(intermediate_size)
-        ? static_cast<size_t>(hidden_dim) * batch_size
-        : static_cast<size_t>(intermediate_size);
+    // LDS: reduction scratch [block_size] + input cache + FP8 LUT [256].
+    // The persistent kernel no longer caches the full MLP intermediate in LDS;
+    // down-proj streams it from global scratch. Keep enough cache for hidden
+    // vectors and attention/output-projection inputs on Qwen3.5/3.6.
+    const size_t hidden_cache = static_cast<size_t>(hidden_dim) * batch_size;
+    const size_t attention_cache = static_cast<size_t>(hidden_dim) * 2;
+    const size_t input_cache = hidden_cache > attention_cache ? hidden_cache : attention_cache;
     const size_t fp8_lut_size = 256;  // FP8 E4M3 → F32 lookup table
     const size_t shared_bytes = (block_size + input_cache + fp8_lut_size) * sizeof(float);
 

--- a/oracle/bake_q4km.py
+++ b/oracle/bake_q4km.py
@@ -1188,6 +1188,7 @@ def bake_from_gguf(args, weight_prefix: str, layer_types: list[str], family: str
             raw_layout = ggml_k_layout(info.ggml_type)
             if (
                 raw_layout is not None
+                and not args.gguf_native_int4
                 # The runtime lm-head path expects BF16 or native INT4 sidecars,
                 # not raw GGML K-block bytes.
                 and mapped != "lm_head.weight"
@@ -1234,8 +1235,16 @@ def bake_from_gguf(args, weight_prefix: str, layer_types: list[str], family: str
             raise SystemExit("GGUF import produced no SuperSonic tensors; unsupported tensor naming?")
         tensors_out.sort(key=lambda x: x[0])
         log(f"[q4km] quantized {quantized} tensors, skipped {skipped} unmapped GGUF tensors")
-        source_quant = "ggml-q4-k-family+gptq-hessian" if quantizer == QUANT_GPTQ else "ggml-q4-k-family"
-        quant_profile = "q4km-ggml-v1"
+        if args.gguf_native_int4:
+            source_quant = (
+                "ggml-q4-k-family+native-gptq-hessian"
+                if quantizer == QUANT_GPTQ
+                else "ggml-q4-k-family+native-minmax"
+            )
+            quant_profile = "q4km-gptq-v1"
+        else:
+            source_quant = "ggml-q4-k-family+gptq-hessian" if quantizer == QUANT_GPTQ else "ggml-q4-k-family"
+            quant_profile = "q4km-ggml-v1"
         write_bake(out_dir, tensors_out, family, "gguf", source_quant, quant_profile)
     finally:
         gguf.close()
@@ -1246,6 +1255,17 @@ def main() -> None:
     ap.add_argument("--model-dir", required=True, type=Path)
     ap.add_argument("--model", default=None)
     ap.add_argument("--gguf-file", type=Path, default=None)
+    ap.add_argument(
+        "--gguf-native-int4",
+        action="store_true",
+        help=(
+            "When importing GGUF, dequantize GGML K-block projection tensors "
+            "and emit SuperSonic's native INT4 sidecar layout instead of raw "
+            "GGML blocks. This produces a q4km-gptq runtime package; with the "
+            "default --quantizer minmax it is calibration-free but not "
+            "Hessian-GPTQ quality."
+        ),
+    )
     ap.add_argument("--group-size", type=int, default=128)
     ap.add_argument("--out-dir", type=Path, default=None)
     ap.add_argument("--quantizer", choices=[QUANT_MINMAX, QUANT_GPTQ], default=QUANT_MINMAX)

--- a/oracle/bake_q4km.py
+++ b/oracle/bake_q4km.py
@@ -1285,7 +1285,15 @@ def main() -> None:
         weight_prefix = infer_weight_prefix(sorted(tensor_index(files)))
     model_name = (args.model or "").lower()
     family = "qwen36-moe" if "35b-a3b" in model_name else "qwen35"
-    out_dir = args.out_dir or (args.model_dir / ".supersonic" / f"v{FORMAT_VERSION}-q4km")
+    if args.out_dir is not None:
+        out_dir = args.out_dir
+    else:
+        bake_suffix = (
+            "q4km-gptq"
+            if args.gguf_file is not None and args.gguf_native_int4
+            else "q4km"
+        )
+        out_dir = args.model_dir / ".supersonic" / f"v{FORMAT_VERSION}-{bake_suffix}"
 
     if args.gguf_file is not None:
         bake_from_gguf(args, weight_prefix, layer_types, family, out_dir)

--- a/tests/gfx1100/bench_qwen36_he_supersonic.py
+++ b/tests/gfx1100/bench_qwen36_he_supersonic.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Run SuperSonic Qwen3.6 over the Lucebox HumanEval DFlash prompts.
+
+This is a comparison harness, not a correctness gate: Lucebox benchmarks a
+Qwen3.6-27B GGUF target plus DFlash draft. SuperSonic can run the same
+tokenizer/config/source GGUF through a Q4KM-sourced native INT4 package on HIP.
+The prompt set and generation length are kept identical.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+DEFAULT_LUCEBOX_BENCH = Path("/home/deano/projects/lucebox-hub/server/scripts/bench_he.py")
+RESULT_RE = re.compile(
+    r"\[result\]\s+prompt_tokens=(?P<prompt>\d+)\s+"
+    r"generated_tokens=(?P<generated>\d+)\s+"
+    r"decode_ms=(?P<decode_ms>[0-9.]+)\s+"
+    r"ms_per_(?:step|tok)=(?P<ms_per_step>[0-9.]+)"
+)
+
+
+def load_lucebox_prompts(path: Path) -> list[tuple[str, str]]:
+    script_dir = str(path.parent)
+    if script_dir not in sys.path:
+        sys.path.insert(0, script_dir)
+    spec = importlib.util.spec_from_file_location("lucebox_bench_he", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"unable to import Lucebox bench script: {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    prompts = getattr(module, "PROMPTS", None)
+    if not prompts:
+        raise RuntimeError(f"no PROMPTS found in {path}")
+    return [(str(name), str(prompt)) for name, prompt in prompts]
+
+
+def run_one(args: argparse.Namespace, name: str, prompt: str, warmup: bool = False) -> dict:
+    cmd = [
+        str(args.binary),
+        "--backend",
+        args.backend,
+        "--model",
+        args.model,
+        "--model-dir",
+        str(args.model_dir),
+        "--prompt",
+        prompt,
+        "--prompt-no-special-tokens",
+        "--context-size",
+        str(args.context_size),
+        "--max-new-tokens",
+        str(args.warmup_new_tokens if warmup else args.n_gen),
+        "--temperature",
+        "0",
+        "--top-k",
+        "1",
+        "--sampling-seed",
+        str(args.seed),
+        "--no-download",
+    ]
+    if args.quant != "none":
+        cmd.append(f"--{args.quant}")
+    if args.ignore_eos:
+        cmd.append("--ignore-eos")
+    if args.emit_stage_timings:
+        cmd.append("--emit-stage-timings")
+    if args.kv_fp8:
+        cmd.append("--kv-fp8")
+
+    env = os.environ.copy()
+    env["SUPERSONIC_BACKENDS"] = args.backend
+
+    start = time.monotonic()
+    proc = subprocess.run(
+        cmd,
+        text=True,
+        capture_output=True,
+        timeout=args.timeout,
+        env=env,
+    )
+    elapsed = time.monotonic() - start
+    combined = proc.stdout + "\n" + proc.stderr
+    match = RESULT_RE.search(combined)
+    row = {
+        "name": name,
+        "returncode": proc.returncode,
+        "wall_s": elapsed,
+        "stdout_tail": proc.stdout[-4000:],
+        "stderr_tail": proc.stderr[-4000:],
+    }
+    if match:
+        row.update(
+            {
+                "prompt_tokens": int(match.group("prompt")),
+                "generated_tokens": int(match.group("generated")),
+                "decode_ms": float(match.group("decode_ms")),
+                "ms_per_step": float(match.group("ms_per_step")),
+                "tok_s": 1000.0 / float(match.group("ms_per_step")),
+            }
+        )
+    return row
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--binary", type=Path, default=Path("target/release/supersonic"))
+    parser.add_argument("--model", default="qwen3.6-27b")
+    parser.add_argument(
+        "--model-dir",
+        type=Path,
+        default=Path("/mnt/data/tmp/supersonic-qwen36-27b-lucebox"),
+    )
+    parser.add_argument(
+        "--quant",
+        choices=["q4km-gptq", "q4km", "int4", "none"],
+        default="q4km-gptq",
+    )
+    parser.add_argument("--lucebox-bench", type=Path, default=DEFAULT_LUCEBOX_BENCH)
+    parser.add_argument("--backend", default="hip")
+    parser.add_argument("--context-size", type=int, default=512)
+    parser.add_argument("--n-gen", type=int, default=256)
+    parser.add_argument("--warmup-new-tokens", type=int, default=2)
+    parser.add_argument("--seed", type=int, default=20260504)
+    parser.add_argument("--timeout", type=int, default=900)
+    parser.add_argument("--limit", type=int, default=0)
+    parser.add_argument("--warmup", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--ignore-eos", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--emit-stage-timings", action="store_true")
+    parser.add_argument("--kv-fp8", action="store_true")
+    parser.add_argument("--out-json", type=Path, default=Path("target/qwen36_he_supersonic.json"))
+    args = parser.parse_args()
+
+    if not args.binary.exists():
+        raise FileNotFoundError(args.binary)
+    prompts = load_lucebox_prompts(args.lucebox_bench)
+    if args.limit > 0:
+        prompts = prompts[: args.limit]
+
+    rows = []
+    if args.warmup and prompts:
+        print(f"[warmup] {prompts[0][0]} {args.warmup_new_tokens} tokens", flush=True)
+        warmup = run_one(args, prompts[0][0], prompts[0][1], warmup=True)
+        if warmup["returncode"] != 0:
+            print(warmup["stderr_tail"] or warmup["stdout_tail"], file=sys.stderr)
+
+    print(f"{'prompt':28s} {'ptok':>5s} {'gen':>5s} {'ms/tok':>8s} {'tok/s':>8s} {'wall_s':>8s}")
+    print("-" * 70)
+    for name, prompt in prompts:
+        row = run_one(args, name, prompt)
+        rows.append(row)
+        if row["returncode"] != 0 or "tok_s" not in row:
+            print(f"{name:28s} FAILED rc={row['returncode']}")
+            print(row["stderr_tail"] or row["stdout_tail"], file=sys.stderr)
+            continue
+        print(
+            f"{name:28s} {row['prompt_tokens']:5d} {row['generated_tokens']:5d} "
+            f"{row['ms_per_step']:8.2f} {row['tok_s']:8.2f} {row['wall_s']:8.1f}",
+            flush=True,
+        )
+
+    ok = [r for r in rows if r.get("returncode") == 0 and "tok_s" in r]
+    if not ok:
+        return 1
+    summary = {
+        "count": len(ok),
+        "mean_tok_s": sum(r["tok_s"] for r in ok) / len(ok),
+        "mean_ms_per_step": sum(r["ms_per_step"] for r in ok) / len(ok),
+        "min_tok_s": min(r["tok_s"] for r in ok),
+        "max_tok_s": max(r["tok_s"] for r in ok),
+    }
+    payload = {
+        "schema": "supersonic-qwen36-he-comparison-v1",
+        "model": args.model,
+        "model_dir": str(args.model_dir),
+        "quant": args.quant,
+        "backend": args.backend,
+        "context_size": args.context_size,
+        "n_gen": args.n_gen,
+        "lucebox_bench": str(args.lucebox_bench),
+        "summary": summary,
+        "rows": rows,
+    }
+    args.out_json.parent.mkdir(parents=True, exist_ok=True)
+    args.out_json.write_text(json.dumps(payload, indent=2))
+    print("-" * 70)
+    print(f"{'MEAN':28s} {'':5s} {'':5s} {summary['mean_ms_per_step']:8.2f} {summary['mean_tok_s']:8.2f}")
+    print(f"[wrote] {args.out_json}")
+    return 0 if len(ok) == len(rows) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds the minimum SuperSonic support needed to run the Qwen3.6-27B Lucebox comparison on HIP/gfx1100:

- registers Qwen3.6-27B for the HIP Qwen3.5-style dense path
- permits Q4KM/Q4KM-derived native INT4 flags for HIP Qwen3.5/3.6 paths
- adds `--ignore-eos` so fixed-token throughput benches do not stop early
- fixes the 4-bit persistent decode LDS allocation for large Qwen3.6 MLP intermediates by streaming the SwiGLU intermediate from global scratch
- adds `oracle/bake_q4km.py --gguf-native-int4` to import GGUF Q4_K-family tensors into the native INT4 sidecar layout currently supported by the HIP kernels
- adds a HumanEval benchmark harness that reuses the Lucebox prompt set

## Result

Full local run on RX 7900 XTX:

- SuperSonic Qwen3.6-27B q4km-gptq-derived native INT4: **7.35 tok/s mean**
- Lucebox Qwen3.6-27B Q4_K_M + DFlash: **49.80 tok/s mean**

The SuperSonic run produced all 256 measured tokens for each prompt.

## Caveat

This is the closest runnable comparison today, but not an exact apples-to-apples result yet. SuperSonic uses a GGUF-derived native INT4 repack because the HIP runtime does not yet implement raw GGML Q4_K_M dense decode. It also runs target-only decode here, while the Lucebox number uses DFlash speculative decoding.

## Validation

- `SUPERSONIC_BACKENDS=hip HIP_ARCH=gfx1100 cargo build --release --bin supersonic`
- `python3 tests/gfx1100/bench_qwen36_he_supersonic.py --limit 2 --n-gen 16 --warmup-new-tokens 1 --out-json target/qwen36_he_supersonic_27b_q4km_gptq_ignoreeos_smoke.json`
- `python3 tests/gfx1100/bench_qwen36_he_supersonic.py --n-gen 256 --out-json target/qwen36_he_supersonic_27b_q4km_gptq_256_ignoreeos.json`
- `cargo test -p runner allows_raw_q4km_for_qwen36_dense_on_hip`
- `cargo test -p runner allows_q4km_gptq_for_qwen36_dense_on_hip`
- `cargo test -p supersonic-core hip_gfx1100_qwen36_27b_registry_params_match_geometry`

Cargo currently emits pre-existing warning noise in this checkout.