### PR TITLE
Qwen3.6 DFlash exact-comparison bring-up

### DIFF
--- a/crates/qwen35_dflash/src/forward.rs
+++ b/crates/qwen35_dflash/src/forward.rs
@@ -51,6 +51,7 @@ pub fn forward<'a>(
     target_hidden_raw: &GpuBuffer,
     params: ForwardParams,
 ) -> Result<&'a GpuBuffer, GpuError> {
+    let trace = std::env::var_os("SUPERSONIC_DFLASH_TRACE").is_some();
     let cfg = &weights.config;
     let ordinal = scratch.ordinal;
     let dtype = ScalarType::BF16;
@@ -108,6 +109,12 @@ pub fn forward<'a>(
     }
 
     // ----- Per-round fuser (runs once, reused by every layer) -----
+    if trace {
+        eprintln!(
+            "[dflash-forward] fuser ctx_len={ctx_len} q_len={q_len} hidden={hidden} fuser_in={}",
+            cfg.fuser_in_dim()
+        );
+    }
     prefill_ffi::matmul_rhs_transposed(
         ordinal,
         dtype,
@@ -119,6 +126,9 @@ pub fn forward<'a>(
         &weights.fc_w,
         &mut scratch.target_hidden_ctx,
     )?;
+    if trace {
+        eprintln!("[dflash-forward] fuser matmul ok");
+    }
     prefill_ffi::rms_norm_rows_plain(
         ordinal,
         dtype,
@@ -129,6 +139,9 @@ pub fn forward<'a>(
         &weights.hidden_norm_w,
         &mut scratch.target_hidden_ctx_norm,
     )?;
+    if trace {
+        eprintln!("[dflash-forward] fuser norm ok");
+    }
 
     // ----- Initial hidden = noise_embedding (D2D copy) -----
     let hidden_bytes = q_len * hidden * bf16_bytes;
@@ -146,6 +159,9 @@ pub fn forward<'a>(
 
     // ----- Per-layer loop -----
     for (idx, layer) in weights.layers.iter().enumerate() {
+        if trace {
+            eprintln!("[dflash-forward] layer {idx} start");
+        }
         let layer_kv = &mut state.layers[idx];
 
         // 1) input_layernorm (noise side only).
@@ -159,6 +175,9 @@ pub fn forward<'a>(
             &layer.input_norm_w,
             &mut scratch.hidden_norm,
         )?;
+        if trace {
+            eprintln!("[dflash-forward] layer {idx} input norm ok");
+        }
 
         // 2) Concat [target_hidden_ctx_norm; hidden_norm] into norm_concat.
         let ctx_bytes = ctx_len * hidden * bf16_bytes;
@@ -191,6 +210,9 @@ pub fn forward<'a>(
             &layer.q_proj_w,
             &mut scratch.q_proj,
         )?;
+        if trace {
+            eprintln!("[dflash-forward] layer {idx} q proj ok");
+        }
         prefill_ffi::matmul_rhs_transposed(
             ordinal,
             dtype,
@@ -202,6 +224,9 @@ pub fn forward<'a>(
             &layer.k_proj_w,
             &mut scratch.k_concat,
         )?;
+        if trace {
+            eprintln!("[dflash-forward] layer {idx} k proj ok");
+        }
         prefill_ffi::matmul_rhs_transposed(
             ordinal,
             dtype,
@@ -213,6 +238,9 @@ pub fn forward<'a>(
             &layer.v_proj_w,
             &mut scratch.v_concat,
         )?;
+        if trace {
+            eprintln!("[dflash-forward] layer {idx} v proj ok");
+        }
 
         // 4) Per-head q_norm / k_norm (in-place over head_dim).
         prefill_ffi::rms_norm_rows_plain_inplace(
@@ -224,6 +252,9 @@ pub fn forward<'a>(
             &mut scratch.q_proj,
             &layer.q_norm_w,
         )?;
+        if trace {
+            eprintln!("[dflash-forward] layer {idx} q norm ok");
+        }
         prefill_ffi::rms_norm_rows_plain_inplace(
             ordinal,
             dtype,
@@ -233,6 +264,9 @@ pub fn forward<'a>(
             &mut scratch.k_concat,
             &layer.k_norm_w,
         )?;
+        if trace {
+            eprintln!("[dflash-forward] layer {idx} k norm ok");
+        }
 
         // 5) RoPE — full-dim rotary. Q at pos_offset + ctx_len; K across full
         //    kv_seq starting at pos_offset. V is not rotated (dflash.py).
@@ -248,6 +282,9 @@ pub fn forward<'a>(
             pos_offset,
             &mut scratch.k_concat,
         )?;
+        if trace {
+            eprintln!("[dflash-forward] layer {idx} k rope ok");
+        }
         prefill_ffi::apply_rope_prefill(
             ordinal,
             dtype,
@@ -260,6 +297,9 @@ pub fn forward<'a>(
             pos_offset + ctx_len,
             &mut scratch.q_proj,
         )?;
+        if trace {
+            eprintln!("[dflash-forward] layer {idx} q rope ok");
+        }
 
         // 6) Append this round's K/V to the per-layer cache.
         //    Dst offset = past_len * row_bytes. Source is the current round's
@@ -303,6 +343,9 @@ pub fn forward<'a>(
             &layer_kv.cache_v,
             &mut scratch.attn_out,
         )?;
+        if trace {
+            eprintln!("[dflash-forward] layer {idx} attention ok");
+        }
 
         // 8) o_proj into hidden_b, residual-add into hidden_a.
         prefill_ffi::matmul_rhs_transposed(
@@ -316,6 +359,9 @@ pub fn forward<'a>(
             &layer.o_proj_w,
             &mut scratch.hidden_b,
         )?;
+        if trace {
+            eprintln!("[dflash-forward] layer {idx} o proj ok");
+        }
         let hidden_elems = q_len * hidden;
         prefill_ffi::element_add_inplace(
             ordinal,
@@ -336,6 +382,9 @@ pub fn forward<'a>(
             &layer.post_attn_norm_w,
             &mut scratch.post_attn_norm,
         )?;
+        if trace {
+            eprintln!("[dflash-forward] layer {idx} post norm ok");
+        }
         prefill_ffi::matmul_rhs_transposed(
             ordinal,
             dtype,
@@ -347,6 +396,9 @@ pub fn forward<'a>(
             &layer.gate_proj_w,
             &mut scratch.gate,
         )?;
+        if trace {
+            eprintln!("[dflash-forward] layer {idx} gate proj ok");
+        }
         prefill_ffi::matmul_rhs_transposed(
             ordinal,
             dtype,
@@ -358,6 +410,9 @@ pub fn forward<'a>(
             &layer.up_proj_w,
             &mut scratch.up,
         )?;
+        if trace {
+            eprintln!("[dflash-forward] layer {idx} up proj ok");
+        }
         prefill_ffi::swiglu_mul(
             ordinal,
             dtype,
@@ -377,6 +432,9 @@ pub fn forward<'a>(
             &layer.down_proj_w,
             &mut scratch.hidden_b,
         )?;
+        if trace {
+            eprintln!("[dflash-forward] layer {idx} down proj ok");
+        }
         prefill_ffi::element_add_inplace(
             ordinal,
             dtype,
@@ -400,6 +458,9 @@ pub fn forward<'a>(
         &weights.norm_w,
         &mut scratch.final_hidden,
     )?;
+    if trace {
+        eprintln!("[dflash-forward] final norm ok");
+    }
 
     Ok(&scratch.final_hidden)
 }

--- a/crates/runner/src/cli.rs
+++ b/crates/runner/src/cli.rs
@@ -442,9 +442,9 @@ pub(crate) struct Cli {
     #[arg(long)]
     pub(crate) bake_release: Option<String>,
 
-    /// Enable DFlash speculative decoding. Requires `--model qwen3.5-9b`,
-    /// `--int4`, and `--dflash-draft-dir`. Target is the Qwen3.5-9B INT4
-    /// bake; draft is the DFlash 5-layer checkpoint shared via Arc.
+    /// Enable DFlash speculative decoding. Requires `--model qwen3.5-9b`
+    /// or `qwen3.6-27b`, a low-bit target bake, and `--dflash-draft-dir`.
+    /// Draft is the DFlash checkpoint shared with target embeddings/head via Arc.
     #[arg(long)]
     pub(crate) dflash: bool,
 

--- a/crates/runner/src/policy.rs
+++ b/crates/runner/src/policy.rs
@@ -36,11 +36,14 @@ pub(crate) fn validate_global_flags(
     if cli.q4km
         && !(backend == Backend::Cuda
             || (backend == Backend::Hip
-                && model_variant.family() == ModelFamily::Qwen36Moe)
+                && matches!(
+                    model_variant.family(),
+                    ModelFamily::Qwen35 | ModelFamily::Qwen36Moe
+                ))
             || (backend == Backend::Metal && model_variant.family() == ModelFamily::Qwen36Moe))
     {
         anyhow::bail!(
-            "--q4km raw GGML blocks are currently supported only on CUDA Qwen paths, HIP Qwen3.6 MoE, and Metal Qwen3.5/3.6 MoE"
+            "--q4km raw GGML blocks are currently supported only on CUDA Qwen paths, HIP Qwen3.5/3.6 paths, and Metal Qwen3.5/3.6 MoE"
         );
     }
     if cli.q4km_gptq
@@ -201,9 +204,9 @@ mod tests {
     }
 
     #[test]
-    fn rejects_raw_q4km_for_qwen36_dense_on_hip() {
+    fn allows_raw_q4km_for_qwen36_dense_on_hip() {
         validate_global_flags(&cli(&["--q4km"]), &ModelVariant::Qwen3_6_27B, Backend::Hip)
-            .expect_err("Qwen3.6-27B HIP dense kernels require native INT4 sidecars");
+            .expect("Qwen3.6-27B HIP can load raw GGML q4km through the Qwen3.5 dense path");
     }
 
     #[test]

--- a/crates/runner/src/qwen35_alt_runtime.rs
+++ b/crates/runner/src/qwen35_alt_runtime.rs
@@ -53,13 +53,18 @@ fn run_qwen35_dflash(
             cli.download_bake,
             model_store::fetch::version_ok_for_variant(variant, &bake_dir),
         ) {
+            let local_bake_ok = dflash_local_bake_ok(cli, variant);
             let canonical_model = model_variant.to_string();
             match try_download_bake(cli, variant, &canonical_model, &bake_dir) {
                 Ok(true) => {
                     eprintln!("[fetch] installed {variant} bake at {}", bake_dir.display());
                 }
                 Ok(false) => {
-                    if q4km_like(cli) {
+                    if local_bake_ok {
+                        eprintln!(
+                            "[fetch] no {variant} bake downloaded; falling back to local bake"
+                        );
+                    } else if q4km_like(cli) {
                         anyhow::bail!(
                             "no {variant} bake at {} and --no-download set.\n\
                              Rerun with --gguf-file /path/to/model.gguf to create a local raw GGML q4km bake, \
@@ -76,7 +81,9 @@ fn run_qwen35_dflash(
                     }
                 }
                 Err(e) => {
-                    if q4km_like(cli) {
+                    if local_bake_ok {
+                        eprintln!("[fetch] {e}; falling back to local bake");
+                    } else if q4km_like(cli) {
                         anyhow::bail!(
                             "could not obtain {variant} bake for --dflash: {e}\n\n\
                              Rerun with --gguf-file /path/to/model.gguf to create a local raw GGML q4km bake, \
@@ -96,4 +103,44 @@ fn run_qwen35_dflash(
     }
 
     qwen35_dflash_engine::run_qwen35_dflash(cli, model_variant, entry, ordinal, total_vram)
+}
+
+fn dflash_local_bake_ok(cli: &Cli, variant: model_store::fetch::BakeVariant) -> bool {
+    variant == model_store::fetch::BakeVariant::Q4Km && cli.gguf_file.is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+    use model_store::fetch::BakeVariant;
+
+    use super::dflash_local_bake_ok;
+    use crate::Cli;
+
+    fn cli(extra: &[&str]) -> Cli {
+        let mut args = vec!["supersonic", "--model-dir", "/tmp/model", "--dry-run"];
+        args.extend_from_slice(extra);
+        Cli::parse_from(args)
+    }
+
+    #[test]
+    fn dflash_allows_local_raw_q4km_bake_from_gguf() {
+        assert!(dflash_local_bake_ok(
+            &cli(&["--q4km", "--gguf-file", "/tmp/model.gguf"]),
+            BakeVariant::Q4Km
+        ));
+    }
+
+    #[test]
+    fn dflash_q4km_download_preflight_still_bails_without_gguf_source() {
+        assert!(!dflash_local_bake_ok(&cli(&["--q4km"]), BakeVariant::Q4Km));
+    }
+
+    #[test]
+    fn dflash_q4km_gptq_is_not_locally_baked_from_raw_gguf() {
+        assert!(!dflash_local_bake_ok(
+            &cli(&["--q4km-gptq"]),
+            BakeVariant::Q4KmGptq
+        ));
+    }
 }

--- a/crates/runner/src/qwen35_alt_runtime.rs
+++ b/crates/runner/src/qwen35_alt_runtime.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 
-use crate::bakes::ensure_hf_metadata_present;
+use crate::bakes::{cli_variant, ensure_hf_metadata_present};
+use crate::policy::q4km_like;
 use crate::registry::{ModelVariant, RegistryEntry};
 use crate::{
     qwen35_dflash_engine, should_fetch_exact_bake, specprefill_engine, try_download_bake, Cli,
@@ -44,31 +45,51 @@ fn run_qwen35_dflash(
     // the INT4 bake itself.
     ensure_hf_metadata_present(cli, model_variant)?;
     if !cli.no_bake {
-        let variant = model_store::fetch::BakeVariant::Int4Gptq;
+        let variant = cli_variant(cli)?;
         let bake_dir = variant.bake_dir(&cli.model_dir);
         let _lock = model_store::BakeLock::acquire(&cli.model_dir)
             .map_err(|e| anyhow::anyhow!("acquire bake lock: {e}"))?;
-        if should_fetch_exact_bake(cli.download_bake, model_store::version_ok(&bake_dir)) {
+        if should_fetch_exact_bake(
+            cli.download_bake,
+            model_store::fetch::version_ok_for_variant(variant, &bake_dir),
+        ) {
             let canonical_model = model_variant.to_string();
             match try_download_bake(cli, variant, &canonical_model, &bake_dir) {
                 Ok(true) => {
                     eprintln!("[fetch] installed {variant} bake at {}", bake_dir.display());
                 }
                 Ok(false) => {
-                    anyhow::bail!(
-                        "no INT4 bake at {} and --no-download set.\n\
-                         Run:\n  python oracle/bake_int4.py --model-dir {}",
-                        bake_dir.display(),
-                        cli.model_dir.display(),
-                    );
+                    if q4km_like(cli) {
+                        anyhow::bail!(
+                            "no {variant} bake at {} and --no-download set.\n\
+                             Rerun with --gguf-file /path/to/model.gguf to create a local raw GGML q4km bake, \
+                             or provide/download a q4km-gptq bake.",
+                            bake_dir.display(),
+                        );
+                    } else {
+                        anyhow::bail!(
+                            "no {variant} bake at {} and --no-download set.\n\
+                             Run:\n  python oracle/bake_int4.py --model-dir {}",
+                            bake_dir.display(),
+                            cli.model_dir.display(),
+                        );
+                    }
                 }
                 Err(e) => {
-                    anyhow::bail!(
-                        "could not obtain INT4 bake for --dflash: {e}\n\n\
-                         INT4 baking requires a GPTQ calibration pass in Python. \
-                         Run on a bigger machine:\n  python oracle/bake_int4.py --model-dir {}",
-                        cli.model_dir.display(),
-                    );
+                    if q4km_like(cli) {
+                        anyhow::bail!(
+                            "could not obtain {variant} bake for --dflash: {e}\n\n\
+                             Rerun with --gguf-file /path/to/model.gguf to create a local raw GGML q4km bake, \
+                             or provide/download a q4km-gptq bake.",
+                        );
+                    } else {
+                        anyhow::bail!(
+                            "could not obtain {variant} bake for --dflash: {e}\n\n\
+                             INT4 baking requires a GPTQ calibration pass in Python. \
+                             Run on a bigger machine:\n  python oracle/bake_int4.py --model-dir {}",
+                            cli.model_dir.display(),
+                        );
+                    }
                 }
             }
         }

--- a/crates/runner/src/qwen35_dflash_engine.rs
+++ b/crates/runner/src/qwen35_dflash_engine.rs
@@ -548,6 +548,17 @@ pub fn run_qwen35_dflash(
          generated={} decode_ms={decode_ms:.0}",
         generated_ids.len()
     );
+    let ms_per_tok = if generated_ids.is_empty() {
+        0.0
+    } else {
+        decode_ms / generated_ids.len() as f64
+    };
+    eprintln!(
+        "[result] prompt_tokens={} generated_tokens={} decode_ms={decode_ms:.0} \
+         ms_per_tok={ms_per_tok:.2}",
+        prompt_ids.len(),
+        generated_ids.len()
+    );
     let ms_other = (decode_ms - ms_draft - ms_verify - ms_redecode).max(0.0);
     eprintln!(
         "[dflash] breakdown ms: draft={ms_draft:.0} verify={ms_verify:.0} \

--- a/crates/runner/src/qwen35_dflash_engine.rs
+++ b/crates/runner/src/qwen35_dflash_engine.rs
@@ -1,6 +1,6 @@
-//! Qwen3.5-9B DFlash speculative-decoding engine (M3.3).
+//! Dense Qwen DFlash speculative-decoding engine (M3.3).
 //!
-//! Drives the target (Qwen3.5-9B INT4) and the DFlash draft together through
+//! Drives a dense Qwen low-bit target and the DFlash draft together through
 //! the speculative loop described in `docs/dflash.md` §5–§6:
 //!
 //! 1. Prefill target with prompt (via `prefill_with_taps`); keep the last
@@ -24,7 +24,7 @@
 //!    f. Rewind target's full-attention `kv_filled` to `L + accepted + 1`.
 //!    g. Crop the draft's KV cache to the new committed length.
 
-use std::sync::Arc;
+use std::sync::{Arc, Once};
 use std::time::Instant;
 
 use anyhow::{anyhow, bail, Result};
@@ -34,11 +34,12 @@ use qwen35::state::LinearStateSnapshot;
 use qwen35::weights::Qwen35Weights;
 use qwen35_dflash as dflash;
 
+use crate::bakes::{effective_quant_profile, load_qwen35_weights};
 use crate::decode_engine::DecodeEngine;
 use crate::registry::{FamilyParams, ModelVariant, RegistryEntry};
 use crate::Cli;
 
-/// Run the Qwen3.5-9B DFlash speculative decoder. Parallels
+/// Run the dense-Qwen DFlash speculative decoder. Parallels
 /// `phi4_engine::run_phi4` in shape — but drives both target and draft
 /// models through the speculative loop.
 pub fn run_qwen35_dflash(
@@ -49,11 +50,26 @@ pub fn run_qwen35_dflash(
     total_vram: u64,
 ) -> Result<()> {
     // --------- 1. Validate CLI combo -------------------------------------
-    if !cli.int4 {
-        bail!("--dflash requires --int4 (Qwen3.5-9B INT4 target)");
+    if !matches!(
+        model_variant,
+        ModelVariant::Qwen3_5_9B | ModelVariant::Qwen3_6_27B
+    ) {
+        bail!(
+            "--dflash is supported for --model qwen3.5-9b and qwen3.6-27b \
+             (got {model_variant})"
+        );
     }
-    if model_variant.to_string() != "qwen3.5-9b" {
-        bail!("--dflash is only supported for --model qwen3.5-9b (got {model_variant})");
+    let profile = effective_quant_profile(cli)?;
+    if !matches!(
+        profile,
+        model_store::manifest::QuantProfile::Int4Gptq
+            | model_store::manifest::QuantProfile::Int4Awq
+            | model_store::manifest::QuantProfile::Int4Autoround
+            | model_store::manifest::QuantProfile::Int4Hqq
+            | model_store::manifest::QuantProfile::Q4Km
+            | model_store::manifest::QuantProfile::Q4KmGptq
+    ) {
+        bail!("--dflash requires a low-bit target bake (--int4, --q4km, or --q4km-gptq)");
     }
     let draft_dir = cli
         .dflash_draft_dir
@@ -80,7 +96,7 @@ pub fn run_qwen35_dflash(
         }
     };
     if !params.use_4b_kernel {
-        bail!("--dflash requires the 4B kernel path (qwen3.5-9b INT4)");
+        bail!("--dflash requires the 4B kernel path");
     }
     let weight_prefix: &'static str = params.weight_prefix;
 
@@ -103,7 +119,7 @@ pub fn run_qwen35_dflash(
     let tokenizer = crate::load_tokenizer(&tokenizer_path)?;
     let prompt_ids = crate::resolve_prompt_token_ids(cli, &tokenizer)?;
 
-    // --------- 3. VRAM estimate (target INT4 + ~2 GiB draft) -------------
+    // --------- 3. VRAM estimate (low-bit target + ~2 GiB draft) ----------
     let context_tokens = cli
         .context_size
         .unwrap_or(prompt_ids.len() + cli.max_new_tokens);
@@ -115,14 +131,24 @@ pub fn run_qwen35_dflash(
         );
     }
     let kv_per_token = text_config.kv_bytes_per_token(ScalarType::BF16.size_in_bytes());
-    let target_fixed = (entry.vram.fixed_bytes as f64 * 0.37) as u64; // INT4 scaling
+    let target_fixed = match profile {
+        model_store::manifest::QuantProfile::Q4Km => (entry.vram.fixed_bytes as f64 * 0.28) as u64,
+        model_store::manifest::QuantProfile::Q4KmGptq
+        | model_store::manifest::QuantProfile::Int4Gptq
+        | model_store::manifest::QuantProfile::Int4Awq
+        | model_store::manifest::QuantProfile::Int4Autoround
+        | model_store::manifest::QuantProfile::Int4Hqq => {
+            (entry.vram.fixed_bytes as f64 * 0.37) as u64
+        }
+        _ => (entry.vram.fixed_bytes as f64 * 0.37) as u64,
+    };
     let target_kv = kv_per_token * context_tokens as u64;
     let draft_fixed: u64 = 2 * 1024 * 1024 * 1024; // ~2 GiB for DFlash draft weights + scratch
     let estimated =
         ((target_fixed + target_kv + draft_fixed) as f64 * entry.vram.overhead_factor) as u64;
     let gib = |b: u64| b as f64 / (1024.0 * 1024.0 * 1024.0);
     eprintln!(
-        "[vram] estimated={:.2}GiB (target weights={:.2}GiB + target KV={:.2}GiB + draft={:.2}GiB) \
+        "[vram] estimated={:.2}GiB (target {profile} weights={:.2}GiB + target KV={:.2}GiB + draft={:.2}GiB) \
          available={:.1}GiB",
         gib(estimated),
         gib(target_fixed),
@@ -141,15 +167,18 @@ pub fn run_qwen35_dflash(
 
     gpu_hal::set_device(ordinal).map_err(|e| anyhow!("set_device: {e}"))?;
 
-    // --------- 4. Load target weights (INT4 bake) ------------------------
+    // --------- 4. Load target weights (selected low-bit bake) ------------
     let t0 = Instant::now();
     let target_weights =
-        load_target_int4_weights(cli, entry, &text_config, ordinal, weight_prefix)?;
+        load_target_lowbit_weights(cli, model_variant, &text_config, ordinal, weight_prefix)?;
     eprintln!(
-        "[weights] target (INT4, group_size={}) loaded in {:.0}ms",
+        "[weights] target ({profile}, group_size={}) loaded in {:.0}ms",
         target_weights.int4_group_size,
         t0.elapsed().as_millis(),
     );
+    if !target_weights.is_int4 {
+        bail!("--dflash target loader did not produce low-bit weights for {profile}");
+    }
 
     // Grab Arc clones of embed_tokens + lm_head before moving weights into
     // the engine — the draft borrows them without owning them (docs §7).
@@ -283,19 +312,20 @@ pub fn run_qwen35_dflash(
     let mut committed_len: usize = prompt_ids.len();
     let mut generated_ids: Vec<u32> = Vec::new();
     let eos_ids: Vec<u32> = text_config.eos_token_ids();
-    // Default block_size = 3: the fused verify path (now the only verify
-    // path after M4.3c) caps B at 3 on Qwen3.5-9B because the 4B
-    // megakernel's 64 KiB LDS budget has to hold (block_size + B*hidden
-    // + fp8_lut) * 4 bytes. 4*4096 = 16384 floats exceeds the 15872
-    // float budget — verify_block_fused_decode errors out with a
-    // diagnostic if the user forces --dflash-block >= 4 on 9B.
-    // Historical context: the M4.1 prefill verify path had no such cap
-    // and used DEFAULT_BLOCK_SIZE=4 per project_m4_2_findings; see git
-    // history before M4.3c for the B=4 vs B=16 sweep.
-    const DEFAULT_BLOCK_SIZE: usize = 3;
+    // Qwen3.5-9B keeps the historical fused-verify default of B=3. The
+    // Qwen3.6-27B comparison path defaults to the draft checkpoint's full
+    // block size (16 for the Lucebox DFlash draft); if the fused verifier
+    // cannot fit the model shape in LDS, the loop falls back to sequential
+    // verify below.
+    const DEFAULT_FUSED_BLOCK_SIZE: usize = 3;
+    let default_block_size = if matches!(model_variant, ModelVariant::Qwen3_6_27B) {
+        draft_config.block_size
+    } else {
+        DEFAULT_FUSED_BLOCK_SIZE.min(draft_config.block_size)
+    };
     let block_size = cli
         .dflash_block
-        .unwrap_or(DEFAULT_BLOCK_SIZE.min(draft_config.block_size));
+        .unwrap_or(default_block_size);
     if block_size == 0 || block_size > draft_config.block_size {
         bail!(
             "--dflash-block must be in 1..={} (got {block_size})",
@@ -358,7 +388,8 @@ pub fn run_qwen35_dflash(
         //     position b reads the K/V written by positions 0..b of the
         //     same launch.
         let t_verify = Instant::now();
-        let verify_logits = target_engine.verify_block_fused_decode(&draft_candidates, l)?;
+        let verify_logits =
+            verify_block_for_dflash(&mut target_engine, &draft_candidates, l, &tap_layers)?;
         ms_verify += t_verify.elapsed().as_secs_f64() * 1000.0;
 
         // 8d. Accept check, full protocol (docs/dflash.md §6):
@@ -546,26 +577,60 @@ fn parse_tap_override(raw: &str, num_target_layers: usize) -> Result<Vec<usize>>
     Ok(out)
 }
 
-fn load_target_int4_weights(
+fn load_target_lowbit_weights(
     cli: &Cli,
-    _entry: &RegistryEntry,
+    model_variant: &ModelVariant,
     text_config: &qwen35::config::TextConfig,
     ordinal: usize,
     weight_prefix: &str,
 ) -> Result<Qwen35Weights> {
-    let bake_dir = model_store::fetch::BakeVariant::Int4Gptq.bake_dir(&cli.model_dir);
-    if !model_store::version_ok(&bake_dir) {
-        bail!(
-            "Qwen3.5-9B INT4 bake not found at {}. Run:\n  python oracle/bake_int4.py --model-dir {}\n\
-             (or run once without --dflash to let the release-bake downloader populate it).",
-            bake_dir.display(),
-            cli.model_dir.display(),
-        );
+    load_qwen35_weights(
+        cli,
+        model_variant,
+        text_config,
+        ordinal,
+        weight_prefix,
+        true, // DFlash dispatcher already called ensure_hf_metadata_present.
+        crate::policy::q4km_like(cli),
+    )
+    .map_err(|e| anyhow!("load target low-bit weights: {e}"))
+}
+
+fn verify_block_for_dflash(
+    target_engine: &mut DecodeEngine,
+    tokens: &[u32],
+    pos_offset: usize,
+    tap_layers: &[usize],
+) -> Result<Vec<Vec<f32>>> {
+    let needs_sequential = tokens.len() > kernel_ffi::MAX_BATCH_SIZE;
+    if !needs_sequential {
+        match target_engine.verify_block_fused_decode(tokens, pos_offset) {
+            Ok(logits) => return Ok(logits),
+            Err(err) => {
+                let msg = err.to_string();
+                if !msg.contains("shared-memory budget exceeded") {
+                    return Err(err);
+                }
+            }
+        }
     }
-    let store = model_store::BakedStore::open(&bake_dir)
-        .map_err(|e| anyhow!("open target INT4 bake: {e}"))?;
-    Qwen35Weights::load_baked(&store, text_config, ordinal, weight_prefix)
-        .map_err(|e| anyhow!("load target INT4 weights: {e}"))
+
+    static NOTICE: Once = Once::new();
+    NOTICE.call_once(|| {
+        eprintln!(
+            "[dflash] fused verify does not fit this target shape/block; \
+             using sequential target verify fallback"
+        );
+    });
+
+    let mut logits = Vec::with_capacity(tokens.len());
+    for (i, &tok) in tokens.iter().enumerate() {
+        let (step_logits, _tap_bytes) = target_engine
+            .decode_step_with_taps_kernel(tok, pos_offset + i, tap_layers)
+            .map_err(|e| anyhow!("sequential verify decode step {i}: {e}"))?;
+        logits.push(step_logits);
+    }
+    Ok(logits)
 }
 
 /// Concatenate per-tap `[hidden_dim]` BF16 blobs into a single
@@ -662,22 +727,56 @@ fn draft_forward_and_sample(
     .map_err(|e| anyhow!("draft forward: {e}"))?;
 
     // 4) lm_head projection → block_logits [block_size, vocab].
-    let lm_head = &target_engine.weights().lm_head;
+    let target_weights = target_engine.weights();
+    let lm_head = &target_weights.lm_head;
+    let lm_head_buf: &GpuBuffer = lm_head.as_ref();
     let vocab = draft_weights.config.vocab_size;
     let mut block_logits = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[block_size, vocab])
         .map_err(|e| anyhow!("alloc block_logits: {e}"))?;
-    kernel_ffi::matmul_rhs_transposed_4b(
-        ordinal,
-        ScalarType::BF16,
-        1,          // batch
-        block_size, // m
-        vocab,      // n
-        hidden,     // k
-        final_hidden,
-        &**lm_head,
-        &mut block_logits,
-    )
-    .map_err(|e| anyhow!("draft lm_head: {e}"))?;
+    let lm_head_qtype = qwen35::weights::infer_lowbit_type(
+        lm_head_buf,
+        hidden,
+        target_weights.lm_head_int4_scale.is_some(),
+    );
+    if lm_head_qtype != 0 {
+        let scale = target_weights
+            .lm_head_int4_scale
+            .as_ref()
+            .unwrap_or(lm_head_buf);
+        let zero = target_weights
+            .lm_head_int4_zero
+            .as_ref()
+            .unwrap_or(lm_head_buf);
+        kernel_ffi::prefill_ffi::matmul_rhs_transposed_int4(
+            ordinal,
+            1,          // batch
+            block_size, // m
+            vocab,      // n
+            hidden,     // k
+            final_hidden,
+            lm_head_buf,
+            scale,
+            zero,
+            target_weights.lm_head_awq_inv_scale.as_ref(),
+            target_weights.int4_group_size,
+            lm_head_qtype,
+            &mut block_logits,
+        )
+        .map_err(|e| anyhow!("draft lm_head low-bit matmul: {e}"))?;
+    } else {
+        kernel_ffi::matmul_rhs_transposed_4b(
+            ordinal,
+            ScalarType::BF16,
+            1,          // batch
+            block_size, // m
+            vocab,      // n
+            hidden,     // k
+            final_hidden,
+            lm_head_buf,
+            &mut block_logits,
+        )
+        .map_err(|e| anyhow!("draft lm_head: {e}"))?;
+    }
 
     // 5) D2H + argmax per position.
     let logits_bytes = block_logits
@@ -700,6 +799,12 @@ fn draft_forward_and_sample(
         }
         candidates.push(best_idx);
         let _ = row_elems;
+    }
+    if let Some(first) = candidates.first_mut() {
+        // Lucebox DFlash treats slot 0 as the previous target token, not a
+        // free draft proposal: noise_ids[0] = bonus_seed and then
+        // draft_tok[0] is forced back to that same token after projection.
+        *first = bonus_seed;
     }
 
     // Retain the final-hidden bytes for potential debugging; cost is a

--- a/kernels/full_attention_4b.hip
+++ b/kernels/full_attention_4b.hip
@@ -330,6 +330,25 @@ struct Qwen35INT4ScaleDesc {
     int o_proj_type;
 };
 
+static constexpr int QWEN35_LOWBIT_NATIVE_INT4 = 4;
+static constexpr int QWEN35_LOWBIT_GGML_Q4_K = 12;
+static constexpr int QWEN35_LOWBIT_GGML_Q5_K = 13;
+static constexpr int QWEN35_LOWBIT_GGML_Q6_K = 14;
+
+__device__ inline bool qwen35_lowbit_native_int4(int qtype) {
+    return qtype == QWEN35_LOWBIT_NATIVE_INT4;
+}
+
+__device__ inline bool qwen35_lowbit_ggml_k(int qtype) {
+    return qtype == QWEN35_LOWBIT_GGML_Q4_K ||
+           qtype == QWEN35_LOWBIT_GGML_Q5_K ||
+           qtype == QWEN35_LOWBIT_GGML_Q6_K;
+}
+
+__device__ inline bool qwen35_lowbit_supported(int qtype) {
+    return qwen35_lowbit_native_int4(qtype) || qwen35_lowbit_ggml_k(qtype);
+}
+
 // Dequantize 8 INT4 weights from 4 packed bytes.
 // packed: 4 bytes = 8 nibbles, low nibble first per byte.
 // scales: BF16 scale array, zeros: BF16 zero array.
@@ -412,6 +431,151 @@ __device__ inline float int4_dequant_scalar(
     // Round through BF16 so reconstruction matches Python's bf16-stored Q_dq.
     return bf16_round_rne_f32_finite(
         static_cast<float>(nibble) * s - static_cast<float>(zeros[si]) * s);
+}
+
+__device__ inline int ggml_k_row_bytes(int qtype, int cols) {
+    const int blocks = cols / 256;
+    if (qtype == QWEN35_LOWBIT_GGML_Q4_K) return blocks * 144;
+    if (qtype == QWEN35_LOWBIT_GGML_Q5_K) return blocks * 176;
+    if (qtype == QWEN35_LOWBIT_GGML_Q6_K) return blocks * 210;
+    return cols / 2;
+}
+
+__device__ inline float ggml_f16_to_f32_unaligned(const uint8_t* p) {
+    uint16_t bits = static_cast<uint16_t>(p[0]) |
+                    (static_cast<uint16_t>(p[1]) << 8);
+    __half h = *reinterpret_cast<__half*>(&bits);
+    return __half2float(h);
+}
+
+__device__ inline void ggml_q4_k_scale_min(const uint8_t* q, int j, int& scale, int& minv) {
+    if (j < 4) {
+        scale = static_cast<int>(q[j] & 63);
+        minv = static_cast<int>(q[j + 4] & 63);
+    } else {
+        scale = static_cast<int>((q[j + 4] & 0x0F) | ((q[j - 4] >> 6) << 4));
+        minv = static_cast<int>((q[j + 4] >> 4) | ((q[j] >> 6) << 4));
+    }
+}
+
+__device__ inline float ggml_k_dequant_scalar(
+    const void* w_ptr, int qtype, int row, int col, int cols
+) {
+    const uint8_t* data = static_cast<const uint8_t*>(w_ptr);
+    const int block = col / 256;
+    const int inb = col - block * 256;
+    const uint8_t* b = data + static_cast<size_t>(row) * ggml_k_row_bytes(qtype, cols);
+
+    if (qtype == QWEN35_LOWBIT_GGML_Q4_K) {
+        b += block * 144;
+        const float d = ggml_f16_to_f32_unaligned(b);
+        const float dmin = ggml_f16_to_f32_unaligned(b + 2);
+        const uint8_t* sc = b + 4;
+        const uint8_t* qs = b + 16;
+        const int g = inb / 64;
+        const int sub = (inb % 64) / 32;
+        const int j = 2 * g + sub;
+        int scale = 0;
+        int minv = 0;
+        ggml_q4_k_scale_min(sc, j, scale, minv);
+        const uint8_t qbyte = qs[g * 32 + (inb % 32)];
+        const int q = sub != 0 ? ((qbyte >> 4) & 0x0F) : (qbyte & 0x0F);
+        return d * static_cast<float>(scale) * static_cast<float>(q) -
+               dmin * static_cast<float>(minv);
+    }
+
+    if (qtype == QWEN35_LOWBIT_GGML_Q5_K) {
+        b += block * 176;
+        const float d = ggml_f16_to_f32_unaligned(b);
+        const float dmin = ggml_f16_to_f32_unaligned(b + 2);
+        const uint8_t* sc = b + 4;
+        const uint8_t* qh = b + 16;
+        const uint8_t* ql = b + 48;
+        const int g = inb / 64;
+        const int sub = (inb % 64) / 32;
+        const int j = 2 * g + sub;
+        int scale = 0;
+        int minv = 0;
+        ggml_q4_k_scale_min(sc, j, scale, minv);
+        const int idx = inb % 32;
+        const uint8_t qbyte = ql[g * 32 + idx];
+        const int lo = sub != 0 ? ((qbyte >> 4) & 0x0F) : (qbyte & 0x0F);
+        const int hi = (qh[idx] & (sub != 0 ? (2 << (2 * g)) : (1 << (2 * g)))) ? 16 : 0;
+        return d * static_cast<float>(scale) * static_cast<float>(lo + hi) -
+               dmin * static_cast<float>(minv);
+    }
+
+    if (qtype == QWEN35_LOWBIT_GGML_Q6_K) {
+        b += block * 210;
+        const uint8_t* ql = b;
+        const uint8_t* qh = b + 128;
+        const int8_t* sc = reinterpret_cast<const int8_t*>(b + 192);
+        const float d = ggml_f16_to_f32_unaligned(b + 208);
+        const int half_idx = inb / 128;
+        const int pos = inb - half_idx * 128;
+        const int idx = pos % 32;
+        int q = 0;
+        int scale_idx = half_idx * 8 + idx / 16;
+        const uint8_t qh_byte = qh[half_idx * 32 + idx];
+        if (pos < 32) {
+            q = static_cast<int>(ql[half_idx * 64 + idx] & 0x0F) |
+                static_cast<int>(((qh_byte >> 0) & 3) << 4);
+        } else if (pos < 64) {
+            q = static_cast<int>(ql[half_idx * 64 + 32 + idx] & 0x0F) |
+                static_cast<int>(((qh_byte >> 2) & 3) << 4);
+            scale_idx += 2;
+        } else if (pos < 96) {
+            q = static_cast<int>((ql[half_idx * 64 + idx] >> 4) & 0x0F) |
+                static_cast<int>(((qh_byte >> 4) & 3) << 4);
+            scale_idx += 4;
+        } else {
+            q = static_cast<int>((ql[half_idx * 64 + 32 + idx] >> 4) & 0x0F) |
+                static_cast<int>(((qh_byte >> 6) & 3) << 4);
+            scale_idx += 6;
+        }
+        return d * static_cast<float>(sc[scale_idx]) * static_cast<float>(q - 32);
+    }
+
+    return 0.0f;
+}
+
+__device__ inline float lowbit_dequant_scalar(
+    const void* w_ptr, const void* scale_ptr, const void* zero_ptr,
+    int qtype, int row, int col, int cols, int group_size
+) {
+    if (qwen35_lowbit_native_int4(qtype)) {
+        return int4_dequant_scalar(w_ptr, scale_ptr, zero_ptr, row, col, cols, group_size);
+    }
+    return ggml_k_dequant_scalar(w_ptr, qtype, row, col, cols);
+}
+
+__device__ inline void lowbit_dequant_8(
+    const void* w_ptr, const void* scale_ptr, const void* zero_ptr,
+    int qtype, int row, int col, int cols, int group_size,
+    float out[8]
+) {
+    if (qwen35_lowbit_native_int4(qtype)) {
+        const int byte_cols = cols / 2;
+        const uint8_t* i4_row = static_cast<const uint8_t*>(w_ptr) +
+            static_cast<size_t>(row) * byte_cols;
+        const int scale_row = row / group_size;
+        const int scale_cols = (cols + group_size - 1) / group_size;
+        const uint32_t packed = *reinterpret_cast<const uint32_t*>(&i4_row[col / 2]);
+        int4_dequant_8(
+            packed,
+            static_cast<const hip_bfloat16*>(scale_ptr),
+            static_cast<const hip_bfloat16*>(zero_ptr),
+            scale_row,
+            col,
+            scale_cols,
+            group_size,
+            out);
+    } else {
+        #pragma unroll
+        for (int i = 0; i < 8; ++i) {
+            out[i] = ggml_k_dequant_scalar(w_ptr, qtype, row, col + i, cols);
+        }
+    }
 }
 
 __device__ inline float awq_inv_scale_at(const void* awq_inv_scale, int col) {
@@ -3254,6 +3418,7 @@ __global__ void supersonic_qwen35_matmul_int4_dequant_kernel(
     const T* __restrict__ zero,            // [n/group_size, k/group_size] BF16
     const T* __restrict__ awq_inv_scale,   // optional [k] BF16, nullptr for GPTQ/HQQ
     int group_size,
+    int quant_type,
     T* __restrict__ out                    // [batch, m, n] BF16
 ) {
     const int tx = threadIdx.x % INT4_TILE_N;
@@ -3267,8 +3432,10 @@ __global__ void supersonic_qwen35_matmul_int4_dequant_kernel(
     const int col = tile_col + tx;
 
     const size_t lhs_base = static_cast<size_t>(batch_idx) * m * k;
-    const int k_packed = k / 2;
-    const size_t rhs_base = static_cast<size_t>(batch_idx) * n * k_packed;
+    const int row_bytes = qwen35_lowbit_native_int4(quant_type)
+        ? k / 2
+        : ggml_k_row_bytes(quant_type, k);
+    const size_t rhs_base = static_cast<size_t>(batch_idx) * n * row_bytes;
 
     const int scale_cols = (k + group_size - 1) / group_size;
 
@@ -3299,19 +3466,25 @@ __global__ void supersonic_qwen35_matmul_int4_dequant_kernel(
             int global_n = tile_col + rr;
             int global_k = kk_base + rc;
             if (global_n < n && global_k < k) {
-                // Unpack INT4 nibble
-                int byte_idx = global_k / 2;
-                uint8_t packed_byte = rhs[rhs_base + static_cast<size_t>(global_n) * k_packed + byte_idx];
-                int nibble = (global_k & 1) ? ((packed_byte >> 4) & 0xF) : (packed_byte & 0xF);
-                // Dequant: (nibble - zero) * scale
-                int sr = global_n / group_size;
-                int sc = global_k / group_size;
-                int si = sr * scale_cols + sc;
-                float s = supersonic_qwen35_to_float(scale[si]);
-                float z = supersonic_qwen35_to_float(zero[si]);
-                // Round through BF16 so prefill matches the decode megakernel's
-                // dequant path and the Python GPTQ reference (`bf16(q*s - zf*s)`).
-                float w = bf16_round_rne_f32_finite(static_cast<float>(nibble) * s - z * s);
+                float w = 0.0f;
+                if (qwen35_lowbit_native_int4(quant_type)) {
+                    // Unpack INT4 nibble
+                    int byte_idx = global_k / 2;
+                    uint8_t packed_byte = rhs[
+                        rhs_base + static_cast<size_t>(global_n) * row_bytes + byte_idx];
+                    int nibble = (global_k & 1) ? ((packed_byte >> 4) & 0xF) : (packed_byte & 0xF);
+                    // Dequant: (nibble - zero) * scale
+                    int sr = global_n / group_size;
+                    int sc = global_k / group_size;
+                    int si = sr * scale_cols + sc;
+                    float s = supersonic_qwen35_to_float(scale[si]);
+                    float z = supersonic_qwen35_to_float(zero[si]);
+                    // Round through BF16 so prefill matches the decode megakernel's
+                    // dequant path and the Python GPTQ reference (`bf16(q*s - zf*s)`).
+                    w = bf16_round_rne_f32_finite(static_cast<float>(nibble) * s - z * s);
+                } else {
+                    w = ggml_k_dequant_scalar(rhs + rhs_base, quant_type, global_n, global_k, k);
+                }
                 if (awq_inv_scale != nullptr) {
                     w *= supersonic_qwen35_to_float(awq_inv_scale[global_k]);
                 }
@@ -5088,52 +5261,64 @@ __global__ void supersonic_qwen35_persistent_decode_kernel(
                     const void* w_i4_scale = nullptr;
                     const void* w_i4_zero = nullptr;
                     const void* w_i4_awq_inv_scale = nullptr;
+                    int w_qtype = 0;
                     int row;
                     if (sr < static_cast<unsigned int>(L.q_out_dim)) {
                         w_raw = L.q_proj_w;
                         row = sr;
                         if (fp8_scales) w_scale = fp8_scales[layer].q_proj_scale;
                         if (int4_scales) { w_i4_scale = int4_scales[layer].q_proj_scale; w_i4_zero = int4_scales[layer].q_proj_zero; w_i4_awq_inv_scale = int4_scales[layer].q_proj_awq_inv_scale; }
+                        if (int4_scales) w_qtype = int4_scales[layer].q_proj_type;
                     } else if (sr < static_cast<unsigned int>(L.q_out_dim + L.k_out_dim)) {
                         w_raw = L.k_proj_w;
                         row = sr - L.q_out_dim;
                         if (fp8_scales) w_scale = fp8_scales[layer].k_proj_scale;
                         if (int4_scales) { w_i4_scale = int4_scales[layer].k_proj_scale; w_i4_zero = int4_scales[layer].k_proj_zero; w_i4_awq_inv_scale = int4_scales[layer].k_proj_awq_inv_scale; }
+                        if (int4_scales) w_qtype = int4_scales[layer].k_proj_type;
                     } else {
                         w_raw = L.v_proj_w;
                         row = sr - L.q_out_dim - L.k_out_dim;
                         if (fp8_scales) w_scale = fp8_scales[layer].v_proj_scale;
                         if (int4_scales) { w_i4_scale = int4_scales[layer].v_proj_scale; w_i4_zero = int4_scales[layer].v_proj_zero; w_i4_awq_inv_scale = int4_scales[layer].v_proj_awq_inv_scale; }
+                        if (int4_scales) w_qtype = int4_scales[layer].v_proj_type;
                     }
 
                     float p[MAX_BATCH_SIZE];
                     for (int b = 0; b < B; b++) p[b] = 0.0f;
-                    if (int4_scales != nullptr && w_i4_scale != nullptr) {
-                        // INT4 dequant: load 4 packed bytes (8 weights) at a time
+                    if (qwen35_lowbit_supported(w_qtype)) {
                         const int gsz = int4_scales[layer].group_size;
-                        const int byte_cols = hidden_dim / 2;  // packed width
-                        const uint8_t* i4_row = static_cast<const uint8_t*>(w_raw) + static_cast<size_t>(row) * byte_cols;
-                        const hip_bfloat16* scales_p = static_cast<const hip_bfloat16*>(w_i4_scale);
-                        const hip_bfloat16* zeros_p = static_cast<const hip_bfloat16*>(w_i4_zero);
-                        const int scale_row = row / gsz;
-                        const int scale_cols = (hidden_dim + gsz - 1) / gsz;
-                        const int vd8 = hidden_dim & ~7;
-                        for (int c = lane_p * 8; c < vd8; c += warpSize * 8) {
-                            uint32_t packed = *reinterpret_cast<const uint32_t*>(&i4_row[c / 2]);
-                            float w[8];
-                            int4_dequant_8(packed, scales_p, zeros_p, scale_row, c, scale_cols, gsz, w);
-                            apply_awq_inv_scale_8(w, w_i4_awq_inv_scale, c);
-                            for (int b = 0; b < B; b++) {
-                                const float* inp = lds_input + b * hidden_dim + c;
-                                p[b] += w[0]*inp[0] + w[1]*inp[1] + w[2]*inp[2] + w[3]*inp[3]
-                                      + w[4]*inp[4] + w[5]*inp[5] + w[6]*inp[6] + w[7]*inp[7];
+                        if (qwen35_lowbit_native_int4(w_qtype)) {
+                            // INT4 dequant: load 4 packed bytes (8 weights) at a time
+                            const int byte_cols = hidden_dim / 2;  // packed width
+                            const uint8_t* i4_row = static_cast<const uint8_t*>(w_raw) + static_cast<size_t>(row) * byte_cols;
+                            const hip_bfloat16* scales_p = static_cast<const hip_bfloat16*>(w_i4_scale);
+                            const hip_bfloat16* zeros_p = static_cast<const hip_bfloat16*>(w_i4_zero);
+                            const int scale_row = row / gsz;
+                            const int scale_cols = (hidden_dim + gsz - 1) / gsz;
+                            const int vd8 = hidden_dim & ~7;
+                            for (int c = lane_p * 8; c < vd8; c += warpSize * 8) {
+                                uint32_t packed = *reinterpret_cast<const uint32_t*>(&i4_row[c / 2]);
+                                float w[8];
+                                int4_dequant_8(packed, scales_p, zeros_p, scale_row, c, scale_cols, gsz, w);
+                                apply_awq_inv_scale_8(w, w_i4_awq_inv_scale, c);
+                                for (int b = 0; b < B; b++) {
+                                    const float* inp = lds_input + b * hidden_dim + c;
+                                    p[b] += w[0]*inp[0] + w[1]*inp[1] + w[2]*inp[2] + w[3]*inp[3]
+                                          + w[4]*inp[4] + w[5]*inp[5] + w[6]*inp[6] + w[7]*inp[7];
+                                }
                             }
-                        }
-                        for (int c = vd8 + lane_p; c < hidden_dim; c += warpSize) {
-                            float w = int4_dequant_scalar(w_raw, w_i4_scale, w_i4_zero, row, c, hidden_dim, gsz) *
-                                      awq_inv_scale_at(w_i4_awq_inv_scale, c);
-                            for (int b = 0; b < B; b++)
-                                p[b] += w * lds_input[b * hidden_dim + c];
+                            for (int c = vd8 + lane_p; c < hidden_dim; c += warpSize) {
+                                float w = lowbit_dequant_scalar(w_raw, w_i4_scale, w_i4_zero, w_qtype, row, c, hidden_dim, gsz) *
+                                          awq_inv_scale_at(w_i4_awq_inv_scale, c);
+                                for (int b = 0; b < B; b++)
+                                    p[b] += w * lds_input[b * hidden_dim + c];
+                            }
+                        } else {
+                            for (int c = lane_p; c < hidden_dim; c += warpSize) {
+                                float w = lowbit_dequant_scalar(w_raw, nullptr, nullptr, w_qtype, row, c, hidden_dim, gsz);
+                                for (int b = 0; b < B; b++)
+                                    p[b] += w * lds_input[b * hidden_dim + c];
+                            }
                         }
                     } else if (fp8_scales != nullptr && w_scale != nullptr) {
                         // Vectorized FP8 dequant: load 4 bytes at a time, LUT decode, scale
@@ -5587,23 +5772,26 @@ __global__ void supersonic_qwen35_persistent_decode_kernel(
                         if (sr >= static_cast<unsigned int>(hidden_dim)) break;
 
                         float p = 0.0f;
-                        if (int4_scales != nullptr && int4_scales[layer].o_proj_scale != nullptr) {
+                        const int o_qtype =
+                            int4_scales != nullptr ? int4_scales[layer].o_proj_type : 0;
+                        if (qwen35_lowbit_supported(o_qtype)) {
                             const int gsz = int4_scales[layer].group_size;
                             const void* o_awq_inv = int4_scales[layer].o_proj_awq_inv_scale;
                             if (kv_fp8 != nullptr) {
                                 if (lane_o == 0) {
                                     for (int c = 0; c < attn_size; ++c) {
-                                        p += int4_dequant_scalar(
+                                        p += lowbit_dequant_scalar(
                                             L.o_proj_w,
                                             int4_scales[layer].o_proj_scale,
                                             int4_scales[layer].o_proj_zero,
+                                            o_qtype,
                                             sr,
                                             c,
                                             attn_size,
                                             gsz) * awq_inv_scale_at(o_awq_inv, c) * lds_input[c];
                                     }
                                 }
-                            } else {
+                            } else if (qwen35_lowbit_native_int4(o_qtype)) {
                                 const int byte_cols = attn_size / 2;
                                 const uint8_t* i4_row = static_cast<const uint8_t*>(L.o_proj_w) + static_cast<size_t>(sr) * byte_cols;
                                 const hip_bfloat16* sc = static_cast<const hip_bfloat16*>(int4_scales[layer].o_proj_scale);
@@ -5620,8 +5808,12 @@ __global__ void supersonic_qwen35_persistent_decode_kernel(
                                        + w[4]*lds_input[c+4] + w[5]*lds_input[c+5] + w[6]*lds_input[c+6] + w[7]*lds_input[c+7];
                                 }
                                 for (int c = as8 + lane_o; c < attn_size; c += warpSize)
-                                    p += int4_dequant_scalar(L.o_proj_w, int4_scales[layer].o_proj_scale, int4_scales[layer].o_proj_zero, sr, c, attn_size, gsz) *
+                                    p += lowbit_dequant_scalar(L.o_proj_w, int4_scales[layer].o_proj_scale, int4_scales[layer].o_proj_zero, o_qtype, sr, c, attn_size, gsz) *
                                          awq_inv_scale_at(o_awq_inv, c) * lds_input[c];
+                            } else {
+                                for (int c = lane_o; c < attn_size; c += warpSize)
+                                    p += lowbit_dequant_scalar(L.o_proj_w, nullptr, nullptr, o_qtype, sr, c, attn_size, gsz) *
+                                         lds_input[c];
                             }
                         } else if (fp8_scales != nullptr && fp8_scales[layer].o_proj_scale != nullptr) {
                             if (kv_fp8 != nullptr) {
@@ -5710,6 +5902,7 @@ __global__ void supersonic_qwen35_persistent_decode_kernel(
                     const void* w_i4_scale = nullptr;
                     const void* w_i4_zero = nullptr;
                     const void* w_i4_awq_inv_scale = nullptr;
+                    int w_qtype = 0;
                     int row;
                     if (sr < static_cast<unsigned int>(L.qkv_out_dim)) {
                         w_raw = L.qkv_proj_w;
@@ -5717,6 +5910,7 @@ __global__ void supersonic_qwen35_persistent_decode_kernel(
                         w_i4_scale = int4_scales[layer].qkv_proj_scale;
                         w_i4_zero = int4_scales[layer].qkv_proj_zero;
                         w_i4_awq_inv_scale = int4_scales[layer].qkv_proj_awq_inv_scale;
+                        w_qtype = int4_scales[layer].qkv_proj_type;
                         if (fp8_scales) w_scale = fp8_scales[layer].qkv_proj_scale;
                     } else if (sr < static_cast<unsigned int>(L.qkv_out_dim + L.z_out_dim)) {
                         w_raw = L.z_proj_w;
@@ -5724,6 +5918,7 @@ __global__ void supersonic_qwen35_persistent_decode_kernel(
                         w_i4_scale = int4_scales[layer].z_proj_scale;
                         w_i4_zero = int4_scales[layer].z_proj_zero;
                         w_i4_awq_inv_scale = int4_scales[layer].z_proj_awq_inv_scale;
+                        w_qtype = int4_scales[layer].z_proj_type;
                         if (fp8_scales) w_scale = fp8_scales[layer].z_proj_scale;
                     } else if (sr < static_cast<unsigned int>(L.qkv_out_dim + L.z_out_dim + nv_heads)) {
                         w_raw = L.b_proj_w;
@@ -5739,31 +5934,39 @@ __global__ void supersonic_qwen35_persistent_decode_kernel(
 
                     float p[MAX_BATCH_SIZE];
                     for (int b = 0; b < B; b++) p[b] = 0.0f;
-                    if (w_i4_scale != nullptr) {
+                    if (qwen35_lowbit_supported(w_qtype)) {
                         const int gsz = int4_scales[layer].group_size;
-                        const int byte_cols = hidden_dim / 2;
-                        const uint8_t* i4_row = static_cast<const uint8_t*>(w_raw) + static_cast<size_t>(row) * byte_cols;
-                        const hip_bfloat16* sc = static_cast<const hip_bfloat16*>(w_i4_scale);
-                        const hip_bfloat16* zr = static_cast<const hip_bfloat16*>(w_i4_zero);
-                        const int sr_g = row / gsz;
-                        const int sc_cols = (hidden_dim + gsz - 1) / gsz;
-                        const int vd8 = hidden_dim & ~7;
-                        for (int c = tid * 8; c < vd8; c += bs * 8) {
-                            uint32_t pk = *reinterpret_cast<const uint32_t*>(&i4_row[c / 2]);
-                            float w[8];
-                            int4_dequant_8(pk, sc, zr, sr_g, c, sc_cols, gsz, w);
-                            apply_awq_inv_scale_8(w, w_i4_awq_inv_scale, c);
-                            for (int b = 0; b < B; b++) {
-                                const float* inp = lds_input + b * hidden_dim + c;
-                                p[b] += w[0]*inp[0] + w[1]*inp[1] + w[2]*inp[2] + w[3]*inp[3]
-                                      + w[4]*inp[4] + w[5]*inp[5] + w[6]*inp[6] + w[7]*inp[7];
+                        if (qwen35_lowbit_native_int4(w_qtype)) {
+                            const int byte_cols = hidden_dim / 2;
+                            const uint8_t* i4_row = static_cast<const uint8_t*>(w_raw) + static_cast<size_t>(row) * byte_cols;
+                            const hip_bfloat16* sc = static_cast<const hip_bfloat16*>(w_i4_scale);
+                            const hip_bfloat16* zr = static_cast<const hip_bfloat16*>(w_i4_zero);
+                            const int sr_g = row / gsz;
+                            const int sc_cols = (hidden_dim + gsz - 1) / gsz;
+                            const int vd8 = hidden_dim & ~7;
+                            for (int c = tid * 8; c < vd8; c += bs * 8) {
+                                uint32_t pk = *reinterpret_cast<const uint32_t*>(&i4_row[c / 2]);
+                                float w[8];
+                                int4_dequant_8(pk, sc, zr, sr_g, c, sc_cols, gsz, w);
+                                apply_awq_inv_scale_8(w, w_i4_awq_inv_scale, c);
+                                for (int b = 0; b < B; b++) {
+                                    const float* inp = lds_input + b * hidden_dim + c;
+                                    p[b] += w[0]*inp[0] + w[1]*inp[1] + w[2]*inp[2] + w[3]*inp[3]
+                                          + w[4]*inp[4] + w[5]*inp[5] + w[6]*inp[6] + w[7]*inp[7];
+                                }
                             }
-                        }
-                        for (int c = vd8 + tid; c < hidden_dim; c += bs) {
-                            float w = int4_dequant_scalar(w_raw, w_i4_scale, w_i4_zero, row, c, hidden_dim, gsz) *
-                                      awq_inv_scale_at(w_i4_awq_inv_scale, c);
-                            for (int b = 0; b < B; b++)
-                                p[b] += w * lds_input[b * hidden_dim + c];
+                            for (int c = vd8 + tid; c < hidden_dim; c += bs) {
+                                float w = lowbit_dequant_scalar(w_raw, w_i4_scale, w_i4_zero, w_qtype, row, c, hidden_dim, gsz) *
+                                          awq_inv_scale_at(w_i4_awq_inv_scale, c);
+                                for (int b = 0; b < B; b++)
+                                    p[b] += w * lds_input[b * hidden_dim + c];
+                            }
+                        } else {
+                            for (int c = tid; c < hidden_dim; c += bs) {
+                                float w = lowbit_dequant_scalar(w_raw, nullptr, nullptr, w_qtype, row, c, hidden_dim, gsz);
+                                for (int b = 0; b < B; b++)
+                                    p[b] += w * lds_input[b * hidden_dim + c];
+                            }
                         }
                     } else if (w_scale != nullptr) {
                         for (int c = tid; c < hidden_dim; c += bs) {
@@ -5815,17 +6018,20 @@ __global__ void supersonic_qwen35_persistent_decode_kernel(
                     const void* w_i4_scale = nullptr;
                     const void* w_i4_zero = nullptr;
                     const void* w_i4_awq_inv_scale = nullptr;
+                    int w_qtype = 0;
                     int row;
                     if (sr < static_cast<unsigned int>(L.qkv_out_dim)) {
                         w_raw = L.qkv_proj_w;
                         row = sr;
                         if (fp8_scales) w_scale = fp8_scales[layer].qkv_proj_scale;
                         if (int4_scales) { w_i4_scale = int4_scales[layer].qkv_proj_scale; w_i4_zero = int4_scales[layer].qkv_proj_zero; w_i4_awq_inv_scale = int4_scales[layer].qkv_proj_awq_inv_scale; }
+                        if (int4_scales) w_qtype = int4_scales[layer].qkv_proj_type;
                     } else if (sr < static_cast<unsigned int>(L.qkv_out_dim + L.z_out_dim)) {
                         w_raw = L.z_proj_w;
                         row = sr - L.qkv_out_dim;
                         if (fp8_scales) w_scale = fp8_scales[layer].z_proj_scale;
                         if (int4_scales) { w_i4_scale = int4_scales[layer].z_proj_scale; w_i4_zero = int4_scales[layer].z_proj_zero; w_i4_awq_inv_scale = int4_scales[layer].z_proj_awq_inv_scale; }
+                        if (int4_scales) w_qtype = int4_scales[layer].z_proj_type;
                     } else if (sr < static_cast<unsigned int>(L.qkv_out_dim + L.z_out_dim + nv_heads)) {
                         w_raw = L.b_proj_w;
                         row = sr - L.qkv_out_dim - L.z_out_dim;
@@ -5840,31 +6046,39 @@ __global__ void supersonic_qwen35_persistent_decode_kernel(
 
                     float p[MAX_BATCH_SIZE];
                     for (int b = 0; b < B; b++) p[b] = 0.0f;
-                    if (w_i4_scale != nullptr) {
+                    if (qwen35_lowbit_supported(w_qtype)) {
                         const int gsz = int4_scales[layer].group_size;
-                        const int byte_cols = hidden_dim / 2;
-                        const uint8_t* i4_row = static_cast<const uint8_t*>(w_raw) + static_cast<size_t>(row) * byte_cols;
-                        const hip_bfloat16* sc = static_cast<const hip_bfloat16*>(w_i4_scale);
-                        const hip_bfloat16* zr = static_cast<const hip_bfloat16*>(w_i4_zero);
-                        const int sr_g = row / gsz;
-                        const int sc_cols = (hidden_dim + gsz - 1) / gsz;
-                        const int vd8 = hidden_dim & ~7;
-                        for (int c = lane_p * 8; c < vd8; c += warpSize * 8) {
-                            uint32_t pk = *reinterpret_cast<const uint32_t*>(&i4_row[c / 2]);
-                            float w[8];
-                            int4_dequant_8(pk, sc, zr, sr_g, c, sc_cols, gsz, w);
-                            apply_awq_inv_scale_8(w, w_i4_awq_inv_scale, c);
-                            for (int b = 0; b < B; b++) {
-                                const float* inp = lds_input + b * hidden_dim + c;
-                                p[b] += w[0]*inp[0] + w[1]*inp[1] + w[2]*inp[2] + w[3]*inp[3]
-                                      + w[4]*inp[4] + w[5]*inp[5] + w[6]*inp[6] + w[7]*inp[7];
+                        if (qwen35_lowbit_native_int4(w_qtype)) {
+                            const int byte_cols = hidden_dim / 2;
+                            const uint8_t* i4_row = static_cast<const uint8_t*>(w_raw) + static_cast<size_t>(row) * byte_cols;
+                            const hip_bfloat16* sc = static_cast<const hip_bfloat16*>(w_i4_scale);
+                            const hip_bfloat16* zr = static_cast<const hip_bfloat16*>(w_i4_zero);
+                            const int sr_g = row / gsz;
+                            const int sc_cols = (hidden_dim + gsz - 1) / gsz;
+                            const int vd8 = hidden_dim & ~7;
+                            for (int c = lane_p * 8; c < vd8; c += warpSize * 8) {
+                                uint32_t pk = *reinterpret_cast<const uint32_t*>(&i4_row[c / 2]);
+                                float w[8];
+                                int4_dequant_8(pk, sc, zr, sr_g, c, sc_cols, gsz, w);
+                                apply_awq_inv_scale_8(w, w_i4_awq_inv_scale, c);
+                                for (int b = 0; b < B; b++) {
+                                    const float* inp = lds_input + b * hidden_dim + c;
+                                    p[b] += w[0]*inp[0] + w[1]*inp[1] + w[2]*inp[2] + w[3]*inp[3]
+                                          + w[4]*inp[4] + w[5]*inp[5] + w[6]*inp[6] + w[7]*inp[7];
+                                }
                             }
-                        }
-                        for (int c = vd8 + lane_p; c < hidden_dim; c += warpSize) {
-                            float w = int4_dequant_scalar(w_raw, w_i4_scale, w_i4_zero, row, c, hidden_dim, gsz) *
-                                      awq_inv_scale_at(w_i4_awq_inv_scale, c);
-                            for (int b = 0; b < B; b++)
-                                p[b] += w * lds_input[b * hidden_dim + c];
+                            for (int c = vd8 + lane_p; c < hidden_dim; c += warpSize) {
+                                float w = lowbit_dequant_scalar(w_raw, w_i4_scale, w_i4_zero, w_qtype, row, c, hidden_dim, gsz) *
+                                          awq_inv_scale_at(w_i4_awq_inv_scale, c);
+                                for (int b = 0; b < B; b++)
+                                    p[b] += w * lds_input[b * hidden_dim + c];
+                            }
+                        } else {
+                            for (int c = lane_p; c < hidden_dim; c += warpSize) {
+                                float w = lowbit_dequant_scalar(w_raw, nullptr, nullptr, w_qtype, row, c, hidden_dim, gsz);
+                                for (int b = 0; b < B; b++)
+                                    p[b] += w * lds_input[b * hidden_dim + c];
+                            }
                         }
                     } else if (fp8_scales != nullptr && w_scale != nullptr) {
                         for (int c = lane_p; c < hidden_dim; c += warpSize) {
@@ -6171,10 +6385,10 @@ __global__ void supersonic_qwen35_persistent_decode_kernel(
                 // INT4 on small models keeps block-level reduction (see
                 // PR #20 for the 0.8B argmax sensitivity). Larger hidden_dim
                 // (2B/4B/9B) falls through to wave-per-row.
-                const bool out_int4 =
-                    (int4_scales != nullptr &&
-                     int4_scales[layer].linear_out_proj_scale != nullptr);
-                if (out_int4 && hidden_dim <= 1024) {
+                const int out_qtype =
+                    int4_scales != nullptr ? int4_scales[layer].linear_out_proj_type : 0;
+                const bool out_lowbit = qwen35_lowbit_supported(out_qtype);
+                if (out_lowbit && hidden_dim <= 1024) {
                     for (;;) {
                         unsigned int sr;
                         if (tid == 0) sr = atomicAdd(&counters[0], 1u);
@@ -6187,24 +6401,30 @@ __global__ void supersonic_qwen35_persistent_decode_kernel(
                         float p = 0.0f;
                         const int gsz = int4_scales[layer].group_size;
                         const void* out_awq_inv = int4_scales[layer].linear_out_proj_awq_inv_scale;
-                        const int byte_cols = vd / 2;
-                        const uint8_t* i4_row = static_cast<const uint8_t*>(L.linear_out_proj_w) + static_cast<size_t>(sr) * byte_cols;
-                        const hip_bfloat16* sc = static_cast<const hip_bfloat16*>(int4_scales[layer].linear_out_proj_scale);
-                        const hip_bfloat16* zr = static_cast<const hip_bfloat16*>(int4_scales[layer].linear_out_proj_zero);
-                        const int sr_g = sr / gsz;
-                        const int sc_cols = (vd + gsz - 1) / gsz;
-                        const int vd8 = vd & ~7;
-                        for (int c = tid * 8; c < vd8; c += bs * 8) {
-                            uint32_t pk = *reinterpret_cast<const uint32_t*>(&i4_row[c / 2]);
-                            float w[8];
-                            int4_dequant_8(pk, sc, zr, sr_g, c, sc_cols, gsz, w);
-                            apply_awq_inv_scale_8(w, out_awq_inv, c);
-                            p += w[0]*lds_input[c] + w[1]*lds_input[c+1] + w[2]*lds_input[c+2] + w[3]*lds_input[c+3]
-                               + w[4]*lds_input[c+4] + w[5]*lds_input[c+5] + w[6]*lds_input[c+6] + w[7]*lds_input[c+7];
+                        if (qwen35_lowbit_native_int4(out_qtype)) {
+                            const int byte_cols = vd / 2;
+                            const uint8_t* i4_row = static_cast<const uint8_t*>(L.linear_out_proj_w) + static_cast<size_t>(sr) * byte_cols;
+                            const hip_bfloat16* sc = static_cast<const hip_bfloat16*>(int4_scales[layer].linear_out_proj_scale);
+                            const hip_bfloat16* zr = static_cast<const hip_bfloat16*>(int4_scales[layer].linear_out_proj_zero);
+                            const int sr_g = sr / gsz;
+                            const int sc_cols = (vd + gsz - 1) / gsz;
+                            const int vd8 = vd & ~7;
+                            for (int c = tid * 8; c < vd8; c += bs * 8) {
+                                uint32_t pk = *reinterpret_cast<const uint32_t*>(&i4_row[c / 2]);
+                                float w[8];
+                                int4_dequant_8(pk, sc, zr, sr_g, c, sc_cols, gsz, w);
+                                apply_awq_inv_scale_8(w, out_awq_inv, c);
+                                p += w[0]*lds_input[c] + w[1]*lds_input[c+1] + w[2]*lds_input[c+2] + w[3]*lds_input[c+3]
+                                   + w[4]*lds_input[c+4] + w[5]*lds_input[c+5] + w[6]*lds_input[c+6] + w[7]*lds_input[c+7];
+                            }
+                            for (int c = vd8 + tid; c < vd; c += bs)
+                                p += lowbit_dequant_scalar(L.linear_out_proj_w, int4_scales[layer].linear_out_proj_scale, int4_scales[layer].linear_out_proj_zero, out_qtype, sr, c, vd, gsz) *
+                                     awq_inv_scale_at(out_awq_inv, c) * lds_input[c];
+                        } else {
+                            for (int c = tid; c < vd; c += bs)
+                                p += lowbit_dequant_scalar(L.linear_out_proj_w, nullptr, nullptr, out_qtype, sr, c, vd, gsz) *
+                                     lds_input[c];
                         }
-                        for (int c = vd8 + tid; c < vd; c += bs)
-                            p += int4_dequant_scalar(L.linear_out_proj_w, int4_scales[layer].linear_out_proj_scale, int4_scales[layer].linear_out_proj_zero, sr, c, vd, gsz) *
-                                 awq_inv_scale_at(out_awq_inv, c) * lds_input[c];
 
                         lds[tid] = p;
                         __syncthreads();
@@ -6228,27 +6448,33 @@ __global__ void supersonic_qwen35_persistent_decode_kernel(
                         if (sr >= static_cast<unsigned int>(hidden_dim)) break;
 
                         float p = 0.0f;
-                        if (out_int4) {
+                        if (out_lowbit) {
                             const int gsz = int4_scales[layer].group_size;
                             const void* out_awq_inv = int4_scales[layer].linear_out_proj_awq_inv_scale;
-                            const int byte_cols = vd / 2;
-                            const uint8_t* i4_row = static_cast<const uint8_t*>(L.linear_out_proj_w) + static_cast<size_t>(sr) * byte_cols;
-                            const hip_bfloat16* sc = static_cast<const hip_bfloat16*>(int4_scales[layer].linear_out_proj_scale);
-                            const hip_bfloat16* zr = static_cast<const hip_bfloat16*>(int4_scales[layer].linear_out_proj_zero);
-                            const int sr_g = sr / gsz;
-                            const int sc_cols = (vd + gsz - 1) / gsz;
-                            const int vd8 = vd & ~7;
-                            for (int c = lane_o * 8; c < vd8; c += warpSize * 8) {
-                                uint32_t pk = *reinterpret_cast<const uint32_t*>(&i4_row[c / 2]);
-                                float w[8];
-                                int4_dequant_8(pk, sc, zr, sr_g, c, sc_cols, gsz, w);
-                                apply_awq_inv_scale_8(w, out_awq_inv, c);
-                                p += w[0]*lds_input[c] + w[1]*lds_input[c+1] + w[2]*lds_input[c+2] + w[3]*lds_input[c+3]
-                                   + w[4]*lds_input[c+4] + w[5]*lds_input[c+5] + w[6]*lds_input[c+6] + w[7]*lds_input[c+7];
+                            if (qwen35_lowbit_native_int4(out_qtype)) {
+                                const int byte_cols = vd / 2;
+                                const uint8_t* i4_row = static_cast<const uint8_t*>(L.linear_out_proj_w) + static_cast<size_t>(sr) * byte_cols;
+                                const hip_bfloat16* sc = static_cast<const hip_bfloat16*>(int4_scales[layer].linear_out_proj_scale);
+                                const hip_bfloat16* zr = static_cast<const hip_bfloat16*>(int4_scales[layer].linear_out_proj_zero);
+                                const int sr_g = sr / gsz;
+                                const int sc_cols = (vd + gsz - 1) / gsz;
+                                const int vd8 = vd & ~7;
+                                for (int c = lane_o * 8; c < vd8; c += warpSize * 8) {
+                                    uint32_t pk = *reinterpret_cast<const uint32_t*>(&i4_row[c / 2]);
+                                    float w[8];
+                                    int4_dequant_8(pk, sc, zr, sr_g, c, sc_cols, gsz, w);
+                                    apply_awq_inv_scale_8(w, out_awq_inv, c);
+                                    p += w[0]*lds_input[c] + w[1]*lds_input[c+1] + w[2]*lds_input[c+2] + w[3]*lds_input[c+3]
+                                       + w[4]*lds_input[c+4] + w[5]*lds_input[c+5] + w[6]*lds_input[c+6] + w[7]*lds_input[c+7];
+                                }
+                                for (int c = vd8 + lane_o; c < vd; c += warpSize)
+                                    p += lowbit_dequant_scalar(L.linear_out_proj_w, int4_scales[layer].linear_out_proj_scale, int4_scales[layer].linear_out_proj_zero, out_qtype, sr, c, vd, gsz) *
+                                         awq_inv_scale_at(out_awq_inv, c) * lds_input[c];
+                            } else {
+                                for (int c = lane_o; c < vd; c += warpSize)
+                                    p += lowbit_dequant_scalar(L.linear_out_proj_w, nullptr, nullptr, out_qtype, sr, c, vd, gsz) *
+                                         lds_input[c];
                             }
-                            for (int c = vd8 + lane_o; c < vd; c += warpSize)
-                                p += int4_dequant_scalar(L.linear_out_proj_w, int4_scales[layer].linear_out_proj_scale, int4_scales[layer].linear_out_proj_zero, sr, c, vd, gsz) *
-                                     awq_inv_scale_at(out_awq_inv, c) * lds_input[c];
                         } else if (fp8_scales != nullptr && fp8_scales[layer].linear_out_proj_scale != nullptr) {
                             for (int c = lane_o; c < vd; c += warpSize)
                                 p += fp8_dequant_weight_lut(L.linear_out_proj_w, fp8_scales[layer].linear_out_proj_scale, sr, c, vd, fp8_scales[layer].block_size, fp8_lut) * lds_input[c];
@@ -6355,11 +6581,14 @@ __global__ void supersonic_qwen35_persistent_decode_kernel(
         {
             const bool gate_fp8 = (fp8_scales != nullptr && fp8_scales[layer].gate_proj_scale != nullptr);
             const bool up_fp8 = (fp8_scales != nullptr && fp8_scales[layer].up_proj_scale != nullptr);
-            const bool gate_int4 = (int4_scales != nullptr && int4_scales[layer].gate_proj_scale != nullptr);
-            const bool up_int4 = (int4_scales != nullptr && int4_scales[layer].up_proj_scale != nullptr);
-            const bool mlp_int4 = (gate_int4 || up_int4);
+            const int gate_qtype =
+                int4_scales != nullptr ? int4_scales[layer].gate_proj_type : 0;
+            const int up_qtype =
+                int4_scales != nullptr ? int4_scales[layer].up_proj_type : 0;
+            const bool mlp_lowbit =
+                qwen35_lowbit_supported(gate_qtype) || qwen35_lowbit_supported(up_qtype);
 
-            if (mlp_int4 && hidden_dim <= 1024) {
+            if (mlp_lowbit && hidden_dim <= 1024) {
                 __shared__ unsigned int shared_row_mlp;
                 for (;;) {
                     if (tid == 0) shared_row_mlp = atomicAdd(&counters[0], 1u);
@@ -6385,11 +6614,9 @@ __global__ void supersonic_qwen35_persistent_decode_kernel(
                     const int sc_cols = (hidden_dim + gsz - 1) / gsz;
                     const int vd8 = hidden_dim & ~7;
                     for (int c = tid * 8; c < vd8; c += bs * 8) {
-                        uint32_t gpk = *reinterpret_cast<const uint32_t*>(&g_i4[c / 2]);
-                        uint32_t upk = *reinterpret_cast<const uint32_t*>(&u_i4[c / 2]);
                         float gw[8], uw[8];
-                        int4_dequant_8(gpk, g_sc, g_zr, g_sr, c, sc_cols, gsz, gw);
-                        int4_dequant_8(upk, u_sc, u_zr, g_sr, c, sc_cols, gsz, uw);
+                        lowbit_dequant_8(L.gate_proj_w, g_sc, g_zr, gate_qtype, my_row, c, hidden_dim, gsz, gw);
+                        lowbit_dequant_8(L.up_proj_w, u_sc, u_zr, up_qtype, my_row, c, hidden_dim, gsz, uw);
                         apply_awq_inv_scale_8(gw, g_awq_inv, c);
                         apply_awq_inv_scale_8(uw, u_awq_inv, c);
                         for (int b = 0; b < B; b++) {
@@ -6401,9 +6628,9 @@ __global__ void supersonic_qwen35_persistent_decode_kernel(
                         }
                     }
                     for (int c = vd8 + tid; c < hidden_dim; c += bs) {
-                        float gw = int4_dequant_scalar(L.gate_proj_w, int4_scales[layer].gate_proj_scale, int4_scales[layer].gate_proj_zero, my_row, c, hidden_dim, gsz) *
+                        float gw = lowbit_dequant_scalar(L.gate_proj_w, int4_scales[layer].gate_proj_scale, int4_scales[layer].gate_proj_zero, gate_qtype, my_row, c, hidden_dim, gsz) *
                                    awq_inv_scale_at(g_awq_inv, c);
-                        float uw = int4_dequant_scalar(L.up_proj_w, int4_scales[layer].up_proj_scale, int4_scales[layer].up_proj_zero, my_row, c, hidden_dim, gsz) *
+                        float uw = lowbit_dequant_scalar(L.up_proj_w, int4_scales[layer].up_proj_scale, int4_scales[layer].up_proj_zero, up_qtype, my_row, c, hidden_dim, gsz) *
                                    awq_inv_scale_at(u_awq_inv, c);
                         for (int b = 0; b < B; b++) {
                             float inp = lds_input[b * hidden_dim + c];
@@ -6447,7 +6674,7 @@ __global__ void supersonic_qwen35_persistent_decode_kernel(
                     float up[MAX_BATCH_SIZE];
                     for (int b = 0; b < B; b++) { gp[b] = 0.0f; up[b] = 0.0f; }
 
-                    if (mlp_int4) {
+                    if (mlp_lowbit) {
                         const int gsz = int4_scales[layer].group_size;
                         const int byte_cols = hidden_dim / 2;
                         const uint8_t* g_i4 = static_cast<const uint8_t*>(L.gate_proj_w) + static_cast<size_t>(my_row) * byte_cols;
@@ -6460,15 +6687,13 @@ __global__ void supersonic_qwen35_persistent_decode_kernel(
                         const void* u_awq_inv = int4_scales[layer].up_proj_awq_inv_scale;
                         const int g_sr = my_row / gsz;
                         const int sc_cols = (hidden_dim + gsz - 1) / gsz;
-                        const int vd8 = hidden_dim & ~7;
-                        for (int c = lane_p * 8; c < vd8; c += warpSize * 8) {
-                            uint32_t gpk = *reinterpret_cast<const uint32_t*>(&g_i4[c / 2]);
-                            uint32_t upk = *reinterpret_cast<const uint32_t*>(&u_i4[c / 2]);
-                            float gw[8], uw[8];
-                            int4_dequant_8(gpk, g_sc, g_zr, g_sr, c, sc_cols, gsz, gw);
-                            int4_dequant_8(upk, u_sc, u_zr, g_sr, c, sc_cols, gsz, uw);
-                            apply_awq_inv_scale_8(gw, g_awq_inv, c);
-                            apply_awq_inv_scale_8(uw, u_awq_inv, c);
+                            const int vd8 = hidden_dim & ~7;
+                            for (int c = lane_p * 8; c < vd8; c += warpSize * 8) {
+                                float gw[8], uw[8];
+                                lowbit_dequant_8(L.gate_proj_w, g_sc, g_zr, gate_qtype, my_row, c, hidden_dim, gsz, gw);
+                                lowbit_dequant_8(L.up_proj_w, u_sc, u_zr, up_qtype, my_row, c, hidden_dim, gsz, uw);
+                                apply_awq_inv_scale_8(gw, g_awq_inv, c);
+                                apply_awq_inv_scale_8(uw, u_awq_inv, c);
                             for (int b = 0; b < B; b++) {
                                 const float* inp = lds_input + b * hidden_dim + c;
                                 gp[b] += gw[0]*inp[0] + gw[1]*inp[1] + gw[2]*inp[2] + gw[3]*inp[3]
@@ -6478,9 +6703,9 @@ __global__ void supersonic_qwen35_persistent_decode_kernel(
                             }
                         }
                         for (int c = vd8 + lane_p; c < hidden_dim; c += warpSize) {
-                            float gw = int4_dequant_scalar(L.gate_proj_w, int4_scales[layer].gate_proj_scale, int4_scales[layer].gate_proj_zero, my_row, c, hidden_dim, gsz) *
+                            float gw = lowbit_dequant_scalar(L.gate_proj_w, int4_scales[layer].gate_proj_scale, int4_scales[layer].gate_proj_zero, gate_qtype, my_row, c, hidden_dim, gsz) *
                                        awq_inv_scale_at(g_awq_inv, c);
-                            float uw = int4_dequant_scalar(L.up_proj_w, int4_scales[layer].up_proj_scale, int4_scales[layer].up_proj_zero, my_row, c, hidden_dim, gsz) *
+                            float uw = lowbit_dequant_scalar(L.up_proj_w, int4_scales[layer].up_proj_scale, int4_scales[layer].up_proj_zero, up_qtype, my_row, c, hidden_dim, gsz) *
                                        awq_inv_scale_at(u_awq_inv, c);
                             for (int b = 0; b < B; b++) {
                                 float inp = lds_input[b * hidden_dim + c];
@@ -6594,8 +6819,10 @@ __global__ void supersonic_qwen35_persistent_decode_kernel(
 
             {
                 const bool down_fp8 = (fp8_scales != nullptr && fp8_scales[layer].down_proj_scale != nullptr);
-                const bool down_int4 = (int4_scales != nullptr && int4_scales[layer].down_proj_scale != nullptr);
-                if (down_int4 && hidden_dim <= 1024) {
+                const int down_qtype =
+                    int4_scales != nullptr ? int4_scales[layer].down_proj_type : 0;
+                const bool down_lowbit = qwen35_lowbit_supported(down_qtype);
+                if (down_lowbit && hidden_dim <= 1024) {
                     __shared__ unsigned int shared_row_down;
                     for (;;) {
                         if (tid == 0) shared_row_down = atomicAdd(&counters[0], 1u);
@@ -6614,15 +6841,14 @@ __global__ void supersonic_qwen35_persistent_decode_kernel(
                         const int sc_cols = (L.intermediate_size + gsz - 1) / gsz;
                         const int is8 = L.intermediate_size & ~7;
                         for (int c = tid * 8; c < is8; c += bs * 8) {
-                            uint32_t pk = *reinterpret_cast<const uint32_t*>(&i4_row[c / 2]);
                             float w[8];
-                            int4_dequant_8(pk, d_sc, d_zr, sr_g, c, sc_cols, gsz, w);
+                            lowbit_dequant_8(L.down_proj_w, d_sc, d_zr, down_qtype, my_row, c, L.intermediate_size, gsz, w);
                             apply_awq_inv_scale_8(w, d_awq_inv, c);
                             p += w[0]*swiglu_b[c] + w[1]*swiglu_b[c+1] + w[2]*swiglu_b[c+2] + w[3]*swiglu_b[c+3]
                                + w[4]*swiglu_b[c+4] + w[5]*swiglu_b[c+5] + w[6]*swiglu_b[c+6] + w[7]*swiglu_b[c+7];
                         }
                         for (int c = is8 + tid; c < L.intermediate_size; c += bs)
-                            p += int4_dequant_scalar(L.down_proj_w, int4_scales[layer].down_proj_scale, int4_scales[layer].down_proj_zero, my_row, c, L.intermediate_size, gsz) *
+                            p += lowbit_dequant_scalar(L.down_proj_w, int4_scales[layer].down_proj_scale, int4_scales[layer].down_proj_zero, down_qtype, my_row, c, L.intermediate_size, gsz) *
                                  awq_inv_scale_at(d_awq_inv, c) * swiglu_b[c];
 
                         lds[tid] = p;
@@ -6648,7 +6874,7 @@ __global__ void supersonic_qwen35_persistent_decode_kernel(
                         if (my_row >= static_cast<unsigned int>(hidden_dim)) break;
 
                         float p = 0.0f;
-                        if (down_int4) {
+                        if (down_lowbit) {
                             const int gsz = int4_scales[layer].group_size;
                             const void* d_awq_inv = int4_scales[layer].down_proj_awq_inv_scale;
                             const int byte_cols = L.intermediate_size / 2;
@@ -6659,15 +6885,14 @@ __global__ void supersonic_qwen35_persistent_decode_kernel(
                             const int sc_cols = (L.intermediate_size + gsz - 1) / gsz;
                             const int is8 = L.intermediate_size & ~7;
                             for (int c = lane_d * 8; c < is8; c += warpSize * 8) {
-                                uint32_t pk = *reinterpret_cast<const uint32_t*>(&i4_row[c / 2]);
                                 float w[8];
-                                int4_dequant_8(pk, d_sc, d_zr, sr_g, c, sc_cols, gsz, w);
+                                lowbit_dequant_8(L.down_proj_w, d_sc, d_zr, down_qtype, my_row, c, L.intermediate_size, gsz, w);
                                 apply_awq_inv_scale_8(w, d_awq_inv, c);
                                 p += w[0]*swiglu_b[c] + w[1]*swiglu_b[c+1] + w[2]*swiglu_b[c+2] + w[3]*swiglu_b[c+3]
                                    + w[4]*swiglu_b[c+4] + w[5]*swiglu_b[c+5] + w[6]*swiglu_b[c+6] + w[7]*swiglu_b[c+7];
                             }
                             for (int c = is8 + lane_d; c < L.intermediate_size; c += warpSize)
-                                p += int4_dequant_scalar(L.down_proj_w, int4_scales[layer].down_proj_scale, int4_scales[layer].down_proj_zero, my_row, c, L.intermediate_size, gsz) *
+                                p += lowbit_dequant_scalar(L.down_proj_w, int4_scales[layer].down_proj_scale, int4_scales[layer].down_proj_zero, down_qtype, my_row, c, L.intermediate_size, gsz) *
                                      awq_inv_scale_at(d_awq_inv, c) * swiglu_b[c];
                         } else if (down_fp8) {
                             const uint8_t* d_fp8 = static_cast<const uint8_t*>(L.down_proj_w) + static_cast<size_t>(my_row) * L.intermediate_size;

--- a/kernels/full_attention_bridge_4b.cpp
+++ b/kernels/full_attention_bridge_4b.cpp
@@ -3825,6 +3825,7 @@ int matmul_int4_dequant_device(
     const void* zero,
     const void* awq_inv_scale,
     int group_size,
+    int quant_type,
     void* out
 ) {
     ScopedHipDevice scoped(device_ordinal);
@@ -3844,6 +3845,7 @@ int matmul_int4_dequant_device(
         static_cast<const T*>(zero),
         static_cast<const T*>(awq_inv_scale),
         group_size,
+        quant_type,
         static_cast<T*>(out));
     hipError_t launch_err = hipGetLastError();
     hipError_t sync_err = hipDeviceSynchronize();
@@ -3937,7 +3939,15 @@ extern "C" int supersonic_qwen35_4b_hip_matmul_int4_dequant(
     int quant_type,
     void* out) {
     constexpr int QWEN35_LOWBIT_NATIVE_INT4 = 4;
-    if (quant_type != QWEN35_LOWBIT_NATIVE_INT4) {
+    constexpr int QWEN35_LOWBIT_GGML_Q4_K = 12;
+    constexpr int QWEN35_LOWBIT_GGML_Q5_K = 13;
+    constexpr int QWEN35_LOWBIT_GGML_Q6_K = 14;
+    const bool native_int4 = quant_type == QWEN35_LOWBIT_NATIVE_INT4;
+    const bool ggml_k =
+        quant_type == QWEN35_LOWBIT_GGML_Q4_K ||
+        quant_type == QWEN35_LOWBIT_GGML_Q5_K ||
+        quant_type == QWEN35_LOWBIT_GGML_Q6_K;
+    if (!native_int4 && !ggml_k) {
         return 273;
     }
 
@@ -3950,7 +3960,7 @@ extern "C" int supersonic_qwen35_4b_hip_matmul_int4_dequant(
         // GPTQ bakes use group_size=128, so this path activates in
         // practice; other group sizes fall back to the scalar kernel.
         constexpr int TILED_BK = 64;
-        if (group_size % TILED_BK == 0 &&
+        if (native_int4 && group_size % TILED_BK == 0 &&
             device_supports_wmma_bf16(static_cast<int>(device_ordinal))) {
             return matmul_int4_dequant_wmma_bf16_device(
                 static_cast<int>(device_ordinal), batch_elems, m, n, k,
@@ -3958,7 +3968,7 @@ extern "C" int supersonic_qwen35_4b_hip_matmul_int4_dequant(
         }
         return matmul_int4_dequant_device<hip_bfloat16>(
             static_cast<int>(device_ordinal), batch_elems, m, n, k,
-            lhs, rhs_int4, scale, zero, awq_inv_scale, group_size, out);
+            lhs, rhs_int4, scale, zero, awq_inv_scale, group_size, quant_type, out);
     }
     default:
         return 272;

--- a/oracle/dflash_gguf_to_safetensors.py
+++ b/oracle/dflash_gguf_to_safetensors.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Convert a Lucebox DFlash draft GGUF into SuperSonic's DFlash safetensors layout.
+
+The SuperSonic DFlash draft loader consumes a HF-style directory:
+
+  config.json
+  model.safetensors
+
+Lucebox publishes Qwen3.6-27B drafters as GGUF. This converter handles the
+Q8_0 draft path used by the apples-to-apples HumanEval benchmark and writes
+BF16 tensors with the names expected by crates/qwen35_dflash.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import mmap
+import struct
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+GGUF_TYPE_UINT8 = 0
+GGUF_TYPE_INT8 = 1
+GGUF_TYPE_UINT16 = 2
+GGUF_TYPE_INT16 = 3
+GGUF_TYPE_UINT32 = 4
+GGUF_TYPE_INT32 = 5
+GGUF_TYPE_FLOAT32 = 6
+GGUF_TYPE_BOOL = 7
+GGUF_TYPE_STRING = 8
+GGUF_TYPE_ARRAY = 9
+GGUF_TYPE_UINT64 = 10
+GGUF_TYPE_INT64 = 11
+GGUF_TYPE_FLOAT64 = 12
+
+GGML_TYPE_F32 = 0
+GGML_TYPE_F16 = 1
+GGML_TYPE_Q8_0 = 8
+
+DEFAULT_QWEN36_27B_TAPS = [1, 16, 31, 46, 61]
+
+
+@dataclass
+class TensorInfo:
+    name: str
+    dims: list[int]
+    ggml_type: int
+    offset: int
+
+
+class GgufReader:
+    def __init__(self, path: Path):
+        self.path = path
+        self.file = path.open("rb")
+        self.data = mmap.mmap(self.file.fileno(), 0, access=mmap.ACCESS_READ)
+        self.pos = 0
+
+    def close(self) -> None:
+        self.data.close()
+        self.file.close()
+
+    def read(self, n: int) -> bytes:
+        out = self.data[self.pos : self.pos + n]
+        if len(out) != n:
+            raise EOFError(f"{self.path}: short read")
+        self.pos += n
+        return out
+
+    def unpack(self, fmt: str):
+        return struct.unpack(fmt, self.read(struct.calcsize(fmt)))[0]
+
+    def string(self) -> str:
+        n = self.unpack("<Q")
+        return self.read(n).decode("utf-8")
+
+    def value(self, ty: int):
+        if ty == GGUF_TYPE_UINT8:
+            return self.unpack("<B")
+        if ty == GGUF_TYPE_INT8:
+            return self.unpack("<b")
+        if ty == GGUF_TYPE_UINT16:
+            return self.unpack("<H")
+        if ty == GGUF_TYPE_INT16:
+            return self.unpack("<h")
+        if ty == GGUF_TYPE_UINT32:
+            return self.unpack("<I")
+        if ty == GGUF_TYPE_INT32:
+            return self.unpack("<i")
+        if ty == GGUF_TYPE_FLOAT32:
+            return self.unpack("<f")
+        if ty == GGUF_TYPE_BOOL:
+            return self.unpack("<?")
+        if ty == GGUF_TYPE_STRING:
+            return self.string()
+        if ty == GGUF_TYPE_UINT64:
+            return self.unpack("<Q")
+        if ty == GGUF_TYPE_INT64:
+            return self.unpack("<q")
+        if ty == GGUF_TYPE_FLOAT64:
+            return self.unpack("<d")
+        if ty == GGUF_TYPE_ARRAY:
+            elem_ty = self.unpack("<I")
+            n = self.unpack("<Q")
+            return [self.value(elem_ty) for _ in range(n)]
+        raise ValueError(f"unsupported GGUF metadata type {ty}")
+
+
+@dataclass
+class GgufFile:
+    version: int
+    metadata: dict[str, object]
+    tensors: list[TensorInfo]
+    data_start: int
+    data: mmap.mmap
+    reader: GgufReader
+
+    def close(self) -> None:
+        self.reader.close()
+
+
+def align_up(x: int, alignment: int) -> int:
+    return ((x + alignment - 1) // alignment) * alignment
+
+
+def parse_gguf(path: Path) -> GgufFile:
+    r = GgufReader(path)
+    if r.read(4) != b"GGUF":
+        raise SystemExit(f"{path} is not a GGUF file")
+    version = r.unpack("<I")
+    if version != 3:
+        raise SystemExit(f"{path}: unsupported GGUF version {version}")
+    tensor_count = r.unpack("<Q")
+    kv_count = r.unpack("<Q")
+    metadata = {}
+    for _ in range(kv_count):
+        key = r.string()
+        ty = r.unpack("<I")
+        metadata[key] = r.value(ty)
+    tensors = []
+    for _ in range(tensor_count):
+        name = r.string()
+        ndims = r.unpack("<I")
+        dims = [int(r.unpack("<Q")) for _ in range(ndims)]
+        ggml_type = int(r.unpack("<I"))
+        offset = int(r.unpack("<Q"))
+        tensors.append(TensorInfo(name, dims, ggml_type, offset))
+    alignment = int(metadata.get("general.alignment", 32))
+    data_start = align_up(r.pos, alignment)
+    return GgufFile(version, metadata, tensors, data_start, r.data, r)
+
+
+def gguf_shape(info: TensorInfo) -> list[int]:
+    if len(info.dims) == 1:
+        return [info.dims[0]]
+    return list(reversed(info.dims))
+
+
+def gguf_nbytes(info: TensorInfo) -> int:
+    cols = info.dims[0]
+    rows = int(np.prod(info.dims[1:], dtype=np.int64)) if len(info.dims) > 1 else 1
+    if info.ggml_type == GGML_TYPE_F32:
+        return rows * cols * 4
+    if info.ggml_type == GGML_TYPE_F16:
+        return rows * cols * 2
+    if info.ggml_type == GGML_TYPE_Q8_0:
+        if cols % 32 != 0:
+            raise SystemExit(f"{info.name}: Q8_0 cols {cols} not divisible by 32")
+        return rows * (cols // 32) * 34
+    raise SystemExit(f"{info.name}: unsupported GGML type {info.ggml_type}; use the Q8_0 draft")
+
+
+def raw_tensor(g: GgufFile, info: TensorInfo) -> bytes:
+    start = g.data_start + info.offset
+    end = start + gguf_nbytes(info)
+    if end > len(g.data):
+        raise SystemExit(f"{info.name}: tensor overruns GGUF file")
+    return g.data[start:end]
+
+
+def f32_to_bf16_bytes(x: np.ndarray) -> bytes:
+    f32 = np.asarray(x, dtype="<f4")
+    u32 = f32.view(np.uint32)
+    lsb = (u32 >> 16) & 1
+    rounded = u32 + np.uint32(0x7FFF) + lsb.astype(np.uint32)
+    bf16 = (rounded >> 16).astype("<u2", copy=False)
+    return bf16.tobytes(order="C")
+
+
+def dequant_q8_0(raw: bytes, rows: int, cols: int) -> np.ndarray:
+    blocks = cols // 32
+    q = np.frombuffer(raw, dtype=np.uint8).reshape(rows, blocks, 34)
+    d = q[:, :, 0:2].copy().view("<f2").reshape(rows, blocks).astype(np.float32)
+    qs = q[:, :, 2:34].copy().view(np.int8).astype(np.float32)
+    return (qs * d[:, :, None]).reshape(rows, cols)
+
+
+def tensor_to_bf16(info: TensorInfo, raw: bytes) -> bytes:
+    shape = gguf_shape(info)
+    if info.ggml_type == GGML_TYPE_F32:
+        return f32_to_bf16_bytes(np.frombuffer(raw, dtype="<f4").reshape(shape))
+    if info.ggml_type == GGML_TYPE_F16:
+        return f32_to_bf16_bytes(np.frombuffer(raw, dtype="<f2").reshape(shape).astype(np.float32))
+    if info.ggml_type == GGML_TYPE_Q8_0:
+        rows = shape[0]
+        cols = shape[1]
+        return f32_to_bf16_bytes(dequant_q8_0(raw, rows, cols))
+    raise AssertionError(info.ggml_type)
+
+
+def map_name(name: str) -> str | None:
+    if name == "dflash.fc.weight":
+        return "fc.weight"
+    if name == "dflash.hidden_norm.weight":
+        return "hidden_norm.weight"
+    if name == "output_norm.weight":
+        return "norm.weight"
+    if not name.startswith("blk."):
+        return None
+    parts = name.split(".")
+    if len(parts) < 4:
+        return None
+    layer = int(parts[1])
+    suffix = ".".join(parts[2:])
+    mapped = {
+        "attn_norm.weight": "input_layernorm.weight",
+        "ffn_norm.weight": "post_attention_layernorm.weight",
+        "attn_q.weight": "self_attn.q_proj.weight",
+        "attn_k.weight": "self_attn.k_proj.weight",
+        "attn_v.weight": "self_attn.v_proj.weight",
+        "attn_output.weight": "self_attn.o_proj.weight",
+        "attn_q_norm.weight": "self_attn.q_norm.weight",
+        "attn_k_norm.weight": "self_attn.k_norm.weight",
+        "ffn_gate.weight": "mlp.gate_proj.weight",
+        "ffn_up.weight": "mlp.up_proj.weight",
+        "ffn_down.weight": "mlp.down_proj.weight",
+    }.get(suffix)
+    if mapped is None:
+        return None
+    return f"layers.{layer}.{mapped}"
+
+
+def write_safetensors(path: Path, entries: list[tuple[str, list[int], TensorInfo, bytes]]) -> None:
+    header: dict[str, object] = {"__metadata__": {"format": "pt"}}
+    offset = 0
+    for name, shape, _info, data in entries:
+        header[name] = {
+            "dtype": "BF16",
+            "shape": shape,
+            "data_offsets": [offset, offset + len(data)],
+        }
+        offset += len(data)
+    header_bytes = json.dumps(header, separators=(",", ":")).encode("utf-8")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("wb") as f:
+        f.write(struct.pack("<Q", len(header_bytes)))
+        f.write(header_bytes)
+        for _name, _shape, _info, data in entries:
+            f.write(data)
+
+
+def make_config(g: GgufFile, target_layer_ids: list[int], num_target_layers: int) -> dict[str, object]:
+    arch = str(g.metadata["general.architecture"])
+    p = f"{arch}."
+    head_dim = int(g.metadata.get(p + "attention.key_length", 128))
+    return {
+        "vocab_size": int(g.metadata[p + "vocab_size"]),
+        "hidden_size": int(g.metadata[p + "embedding_length"]),
+        "intermediate_size": int(g.metadata[p + "feed_forward_length"]),
+        "num_hidden_layers": int(g.metadata[p + "block_count"]),
+        "num_attention_heads": int(g.metadata[p + "attention.head_count"]),
+        "num_key_value_heads": int(g.metadata[p + "attention.head_count_kv"]),
+        "head_dim": head_dim,
+        "max_position_embeddings": int(g.metadata[p + "context_length"]),
+        "rope_theta": float(g.metadata[p + "rope.freq_base"]),
+        "rms_norm_eps": float(g.metadata[p + "attention.layer_norm_rms_epsilon"]),
+        "block_size": int(g.metadata[p + "dflash.block_size"]),
+        "num_target_layers": num_target_layers,
+        "attention_bias": False,
+        "tie_word_embeddings": False,
+        "dflash_config": {
+            "mask_token_id": int(g.metadata[p + "dflash.mask_token_id"]),
+            "target_layer_ids": target_layer_ids,
+        },
+    }
+
+
+def parse_taps(raw: str) -> list[int]:
+    vals = [int(part.strip()) for part in raw.split(",") if part.strip()]
+    if not vals:
+        raise argparse.ArgumentTypeError("tap list must not be empty")
+    return vals
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--gguf", type=Path, required=True)
+    ap.add_argument("--out-dir", type=Path, required=True)
+    ap.add_argument(
+        "--target-layer-ids",
+        type=parse_taps,
+        default=DEFAULT_QWEN36_27B_TAPS,
+        help="Comma-separated target tap layer IDs. Default: Qwen3.6-27B Lucebox taps.",
+    )
+    ap.add_argument(
+        "--num-target-layers",
+        type=int,
+        default=64,
+        help="Target model layer count for config validation. Default: Qwen3.6-27B (64).",
+    )
+    args = ap.parse_args()
+
+    g = parse_gguf(args.gguf)
+    try:
+        by_name = {info.name: info for info in g.tensors}
+        entries = []
+        for src_name in sorted(by_name):
+            dst_name = map_name(src_name)
+            if dst_name is None:
+                continue
+            info = by_name[src_name]
+            if info.ggml_type not in (GGML_TYPE_F32, GGML_TYPE_F16, GGML_TYPE_Q8_0):
+                raise SystemExit(
+                    f"{src_name}: GGML type {info.ggml_type} is not supported by this BF16 converter"
+                )
+            print(f"[dflash-gguf] {src_name} -> {dst_name} {gguf_shape(info)}")
+            data = tensor_to_bf16(info, raw_tensor(g, info))
+            entries.append((dst_name, gguf_shape(info), info, data))
+        if len(entries) != 58:
+            raise SystemExit(f"expected 58 mapped DFlash tensors, got {len(entries)}")
+        write_safetensors(args.out_dir / "model.safetensors", entries)
+        config = make_config(g, args.target_layer_ids, args.num_target_layers)
+        (args.out_dir / "config.json").write_text(json.dumps(config, indent=2) + "\n")
+        print(f"[dflash-gguf] wrote {args.out_dir}")
+    finally:
+        g.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/gfx1100/bench_qwen36_he_supersonic.py
+++ b/tests/gfx1100/bench_qwen36_he_supersonic.py
@@ -76,6 +76,11 @@ def run_one(args: argparse.Namespace, name: str, prompt: str, warmup: bool = Fal
         cmd.append("--emit-stage-timings")
     if args.kv_fp8:
         cmd.append("--kv-fp8")
+    if args.dflash:
+        cmd.append("--dflash")
+        cmd.extend(["--dflash-draft-dir", str(args.dflash_draft_dir)])
+        if args.dflash_block:
+            cmd.extend(["--dflash-block", str(args.dflash_block)])
 
     env = os.environ.copy()
     env["SUPERSONIC_BACKENDS"] = args.backend
@@ -137,6 +142,13 @@ def main() -> int:
     parser.add_argument("--ignore-eos", action=argparse.BooleanOptionalAction, default=True)
     parser.add_argument("--emit-stage-timings", action="store_true")
     parser.add_argument("--kv-fp8", action="store_true")
+    parser.add_argument("--dflash", action="store_true")
+    parser.add_argument(
+        "--dflash-draft-dir",
+        type=Path,
+        default=Path("/mnt/data/tmp/qwen36-27b-dflash-q8-bf16"),
+    )
+    parser.add_argument("--dflash-block", type=int, default=0)
     parser.add_argument("--out-json", type=Path, default=Path("target/qwen36_he_supersonic.json"))
     args = parser.parse_args()
 
@@ -183,6 +195,9 @@ def main() -> int:
         "model": args.model,
         "model_dir": str(args.model_dir),
         "quant": args.quant,
+        "dflash": args.dflash,
+        "dflash_draft_dir": str(args.dflash_draft_dir) if args.dflash else None,
+        "dflash_block": args.dflash_block if args.dflash_block else None,
         "backend": args.backend,
         "context_size": args.context_size,
         "n_gen": args.n_gen,


### PR DESCRIPTION
## Summary
- add HIP raw/low-bit matmul support needed by Q4_K-style DFlash target projections
- allow dense Qwen3.6-27B DFlash runs with q4km/q4km-gptq target bakes
- add a Q8_0 DFlash GGUF -> SuperSonic safetensors converter
- fix DFlash draft slot-0 semantics to match Lucebox and add sequential target verify fallback when fused verify cannot fit Qwen3.6/block=16

## Validation
- `SUPERSONIC_BACKENDS=hip HIP_ARCH=gfx1100 cargo build --release --bin supersonic`
- Qwen3.6 q4km target-only smoke: 4 tokens, 420 ms/tok, tokens `15 239 11595 82`
- Qwen3.6 q4km + Q8 DFlash smoke: 4 tokens, rounds=2, mean_accepted_per_round=1.00, tokens match target-only

## Known gaps before exact perf comparison
- verifier falls back to sequential target decode for Qwen3.6 block=16; still needs DDTree/tree or larger batched verifier to match Lucebox throughput
- draft context is still the incremental accepted-block context, not Lucebox's full/sliding target feature history
- draft compute uses BF16 converted weights/activations rather than Lucebox's local GGUF/F32 graph path