### PR TITLE
[codex] Speed up Qwen DFlash tree verify

### DIFF
--- a/crates/kernel-ffi/src/prefill_ffi.rs
+++ b/crates/kernel-ffi/src/prefill_ffi.rs
@@ -1518,6 +1518,42 @@ unsafe extern "C" {
         state_trace: *mut c_void,
     ) -> c_int;
 
+    fn supersonic_qwen35_hip_delta_recurrent_tree_prefill_capture_bf16_trace(
+        dtype: c_int,
+        device_ordinal: usize,
+        batch_heads: usize,
+        seq_len: usize,
+        k_head_dim: usize,
+        v_head_dim: usize,
+        initial_state: *const c_void,
+        query: *const c_void,
+        key: *const c_void,
+        value: *const c_void,
+        beta: *const c_void,
+        g: *const c_void,
+        parent_ids: *const c_void,
+        out: *mut c_void,
+        state_trace: *mut c_void,
+    ) -> c_int;
+
+    fn supersonic_qwen35_hip_delta_recurrent_tree_prefill_capture_q8_trace(
+        dtype: c_int,
+        device_ordinal: usize,
+        batch_heads: usize,
+        seq_len: usize,
+        k_head_dim: usize,
+        v_head_dim: usize,
+        initial_state: *const c_void,
+        query: *const c_void,
+        key: *const c_void,
+        value: *const c_void,
+        beta: *const c_void,
+        g: *const c_void,
+        parent_ids: *const c_void,
+        out: *mut c_void,
+        state_trace: *mut c_void,
+    ) -> c_int;
+
     fn supersonic_qwen35_hip_dflash_apply_rollback(
         dtype: c_int,
         device_ordinal: usize,
@@ -1570,6 +1606,42 @@ unsafe extern "C" {
     ) -> c_int;
 
     fn supersonic_qwen35_hip_dflash_apply_tree_rollback(
+        dtype: c_int,
+        device_ordinal: usize,
+        qkv_dim: usize,
+        conv_state_len: usize,
+        conv_input_len: usize,
+        tree_len: usize,
+        commit_len: usize,
+        num_v_heads: usize,
+        head_k_dim: usize,
+        head_v_dim: usize,
+        conv_input: *const c_void,
+        accepted_indices: *const c_void,
+        conv_state: *mut c_void,
+        recurrent_trace: *const c_void,
+        recurrent_state: *mut c_void,
+    ) -> c_int;
+
+    fn supersonic_qwen35_hip_dflash_apply_tree_rollback_bf16_trace(
+        dtype: c_int,
+        device_ordinal: usize,
+        qkv_dim: usize,
+        conv_state_len: usize,
+        conv_input_len: usize,
+        tree_len: usize,
+        commit_len: usize,
+        num_v_heads: usize,
+        head_k_dim: usize,
+        head_v_dim: usize,
+        conv_input: *const c_void,
+        accepted_indices: *const c_void,
+        conv_state: *mut c_void,
+        recurrent_trace: *const c_void,
+        recurrent_state: *mut c_void,
+    ) -> c_int;
+
+    fn supersonic_qwen35_hip_dflash_apply_tree_rollback_q8_trace(
         dtype: c_int,
         device_ordinal: usize,
         qkv_dim: usize,
@@ -2867,6 +2939,138 @@ pub fn delta_recurrent_tree_prefill_capture(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
+pub fn delta_recurrent_tree_prefill_capture_bf16_trace(
+    ordinal: usize,
+    dtype: ScalarType,
+    batch_heads: usize,
+    seq_len: usize,
+    k_head_dim: usize,
+    v_head_dim: usize,
+    initial_state: &GpuBuffer,
+    query: &GpuBuffer,
+    key: &GpuBuffer,
+    value: &GpuBuffer,
+    beta: &GpuBuffer,
+    g: &GpuBuffer,
+    parent_ids: &GpuBuffer,
+    out: &mut GpuBuffer,
+    state_trace: &mut GpuBuffer,
+) -> Result<(), GpuError> {
+    if out.backend() == Backend::Metal {
+        return Err(ffi_error(
+            "delta_recurrent_tree_prefill_capture_bf16_trace is not implemented for Metal".into(),
+        ));
+    }
+    if dtype != ScalarType::F32
+        || state_trace.dtype() != ScalarType::BF16
+        || k_head_dim != 128
+        || v_head_dim != 128
+    {
+        return Err(ffi_error(
+            "delta_recurrent_tree_prefill_capture_bf16_trace requires F32 state, BF16 trace, k/v head dim 128"
+                .into(),
+        ));
+    }
+    ffi_profile_time_result(
+        "qwen.delta_recurrent_tree_prefill_capture_bf16_trace",
+        ordinal,
+        || {
+            let status = unsafe {
+                supersonic_qwen35_hip_delta_recurrent_tree_prefill_capture_bf16_trace(
+                    dtype.kernel_dtype_code(),
+                    ordinal,
+                    batch_heads,
+                    seq_len,
+                    k_head_dim,
+                    v_head_dim,
+                    initial_state.as_ptr(),
+                    query.as_ptr(),
+                    key.as_ptr(),
+                    value.as_ptr(),
+                    beta.as_ptr(),
+                    g.as_ptr(),
+                    parent_ids.as_ptr(),
+                    out.as_mut_ptr(),
+                    state_trace.as_mut_ptr(),
+                )
+            };
+            if status != 0 {
+                return Err(ffi_error(format!(
+                    "delta_recurrent_tree_prefill_capture_bf16_trace failed: {status}"
+                )));
+            }
+            Ok(())
+        },
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn delta_recurrent_tree_prefill_capture_q8_trace(
+    ordinal: usize,
+    dtype: ScalarType,
+    batch_heads: usize,
+    seq_len: usize,
+    k_head_dim: usize,
+    v_head_dim: usize,
+    initial_state: &GpuBuffer,
+    query: &GpuBuffer,
+    key: &GpuBuffer,
+    value: &GpuBuffer,
+    beta: &GpuBuffer,
+    g: &GpuBuffer,
+    parent_ids: &GpuBuffer,
+    out: &mut GpuBuffer,
+    state_trace: &mut GpuBuffer,
+) -> Result<(), GpuError> {
+    if out.backend() == Backend::Metal {
+        return Err(ffi_error(
+            "delta_recurrent_tree_prefill_capture_q8_trace is not implemented for Metal".into(),
+        ));
+    }
+    if dtype != ScalarType::F32
+        || state_trace.dtype() != ScalarType::U8
+        || k_head_dim != 128
+        || v_head_dim != 128
+    {
+        return Err(ffi_error(
+            "delta_recurrent_tree_prefill_capture_q8_trace requires F32 state, U8 trace, k/v head dim 128"
+                .into(),
+        ));
+    }
+    ffi_profile_time_result(
+        "qwen.delta_recurrent_tree_prefill_capture_q8_trace",
+        ordinal,
+        || {
+            let status = unsafe {
+                supersonic_qwen35_hip_delta_recurrent_tree_prefill_capture_q8_trace(
+                    dtype.kernel_dtype_code(),
+                    ordinal,
+                    batch_heads,
+                    seq_len,
+                    k_head_dim,
+                    v_head_dim,
+                    initial_state.as_ptr(),
+                    query.as_ptr(),
+                    key.as_ptr(),
+                    value.as_ptr(),
+                    beta.as_ptr(),
+                    g.as_ptr(),
+                    parent_ids.as_ptr(),
+                    out.as_mut_ptr(),
+                    state_trace.as_mut_ptr(),
+                )
+            };
+            if status != 0 {
+                return Err(ffi_error(format!(
+                    "delta_recurrent_tree_prefill_capture_q8_trace failed: {status}"
+                )));
+            }
+            Ok(())
+        },
+    )
+}
+
 pub fn dflash_apply_rollback(
     ordinal: usize,
     conv_dtype: ScalarType,
@@ -3077,6 +3281,138 @@ pub fn dflash_apply_tree_rollback(
         if status != 0 {
             return Err(ffi_error(format!(
                 "dflash_apply_tree_rollback failed: {status}"
+            )));
+        }
+        Ok(())
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn dflash_apply_tree_rollback_bf16_trace(
+    ordinal: usize,
+    conv_dtype: ScalarType,
+    qkv_dim: usize,
+    conv_state_len: usize,
+    conv_input_len: usize,
+    tree_len: usize,
+    commit_len: usize,
+    num_v_heads: usize,
+    head_k_dim: usize,
+    head_v_dim: usize,
+    conv_input: &GpuBuffer,
+    accepted_indices: &GpuBuffer,
+    conv_state: &mut GpuBuffer,
+    recurrent_trace: &GpuBuffer,
+    recurrent_state: &mut GpuBuffer,
+) -> Result<(), GpuError> {
+    if conv_input.backend() == Backend::Metal {
+        return Err(ffi_error(
+            "dflash_apply_tree_rollback_bf16_trace is not implemented for Metal".into(),
+        ));
+    }
+    if recurrent_trace.dtype() != ScalarType::BF16 {
+        return Err(ffi_error(
+            "dflash_apply_tree_rollback_bf16_trace requires BF16 recurrent_trace".into(),
+        ));
+    }
+    if accepted_indices.dtype() != ScalarType::U32 || accepted_indices.elem_count() < commit_len {
+        return Err(GpuError::InvalidArg(format!(
+            "dflash_apply_tree_rollback_bf16_trace accepted_indices must be U32[{commit_len}], got {:?}[{}]",
+            accepted_indices.dtype(),
+            accepted_indices.elem_count()
+        )));
+    }
+    ffi_profile_time_result(
+        "qwen.dflash_apply_tree_rollback_bf16_trace",
+        ordinal,
+        || {
+            let status = unsafe {
+                supersonic_qwen35_hip_dflash_apply_tree_rollback_bf16_trace(
+                    conv_dtype.kernel_dtype_code(),
+                    ordinal,
+                    qkv_dim,
+                    conv_state_len,
+                    conv_input_len,
+                    tree_len,
+                    commit_len,
+                    num_v_heads,
+                    head_k_dim,
+                    head_v_dim,
+                    conv_input.as_ptr(),
+                    accepted_indices.as_ptr(),
+                    conv_state.as_mut_ptr(),
+                    recurrent_trace.as_ptr(),
+                    recurrent_state.as_mut_ptr(),
+                )
+            };
+            if status != 0 {
+                return Err(ffi_error(format!(
+                    "dflash_apply_tree_rollback_bf16_trace failed: {status}"
+                )));
+            }
+            Ok(())
+        },
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn dflash_apply_tree_rollback_q8_trace(
+    ordinal: usize,
+    conv_dtype: ScalarType,
+    qkv_dim: usize,
+    conv_state_len: usize,
+    conv_input_len: usize,
+    tree_len: usize,
+    commit_len: usize,
+    num_v_heads: usize,
+    head_k_dim: usize,
+    head_v_dim: usize,
+    conv_input: &GpuBuffer,
+    accepted_indices: &GpuBuffer,
+    conv_state: &mut GpuBuffer,
+    recurrent_trace: &GpuBuffer,
+    recurrent_state: &mut GpuBuffer,
+) -> Result<(), GpuError> {
+    if conv_input.backend() == Backend::Metal {
+        return Err(ffi_error(
+            "dflash_apply_tree_rollback_q8_trace is not implemented for Metal".into(),
+        ));
+    }
+    if recurrent_trace.dtype() != ScalarType::U8 {
+        return Err(ffi_error(
+            "dflash_apply_tree_rollback_q8_trace requires U8 recurrent_trace".into(),
+        ));
+    }
+    if accepted_indices.dtype() != ScalarType::U32 || accepted_indices.elem_count() < commit_len {
+        return Err(GpuError::InvalidArg(format!(
+            "dflash_apply_tree_rollback_q8_trace accepted_indices must be U32[{commit_len}], got {:?}[{}]",
+            accepted_indices.dtype(),
+            accepted_indices.elem_count()
+        )));
+    }
+    ffi_profile_time_result("qwen.dflash_apply_tree_rollback_q8_trace", ordinal, || {
+        let status = unsafe {
+            supersonic_qwen35_hip_dflash_apply_tree_rollback_q8_trace(
+                conv_dtype.kernel_dtype_code(),
+                ordinal,
+                qkv_dim,
+                conv_state_len,
+                conv_input_len,
+                tree_len,
+                commit_len,
+                num_v_heads,
+                head_k_dim,
+                head_v_dim,
+                conv_input.as_ptr(),
+                accepted_indices.as_ptr(),
+                conv_state.as_mut_ptr(),
+                recurrent_trace.as_ptr(),
+                recurrent_state.as_mut_ptr(),
+            )
+        };
+        if status != 0 {
+            return Err(ffi_error(format!(
+                "dflash_apply_tree_rollback_q8_trace failed: {status}"
             )));
         }
         Ok(())

--- a/crates/qwen35_dflash/src/forward.rs
+++ b/crates/qwen35_dflash/src/forward.rs
@@ -305,8 +305,9 @@ pub fn forward<'a>(
             eprintln!("[dflash-forward] layer {idx} q proj ok");
         }
         let use_fused_kv = std::env::var_os("SUPERSONIC_DFLASH_DISABLE_DRAFT_FUSED_KV").is_none();
-        if use_fused_kv {
+        if use_fused_kv && layer.kv_proj_w.is_some() {
             let t_kv_proj = std::time::Instant::now();
+            let kv_proj_w = layer.kv_proj_w.as_ref().expect("checked is_some");
             draft_matmul_rhs_transposed(
                 ordinal,
                 dtype,
@@ -315,7 +316,7 @@ pub fn forward<'a>(
                 2 * kv_out,
                 hidden,
                 &scratch.norm_concat,
-                &layer.kv_proj_w,
+                kv_proj_w,
                 &weights.dummy_lowbit_scale,
                 &mut scratch.kv_concat,
             )?;

--- a/crates/qwen35_dflash/src/loader.rs
+++ b/crates/qwen35_dflash/src/loader.rs
@@ -12,7 +12,9 @@ use std::path::Path;
 use gpu_hal::{GpuBuffer, GpuError, ScalarType};
 use half::{bf16, f16};
 use memmap2::Mmap;
-use qwen35::weights::{ggml_k_row_bytes, LOWBIT_GGML_Q8_0};
+use qwen35::weights::{
+    ggml_k_row_bytes, LOWBIT_GGML_Q4_K, LOWBIT_GGML_Q5_K, LOWBIT_GGML_Q6_K, LOWBIT_GGML_Q8_0,
+};
 use safetensors::SafeTensors;
 
 #[derive(Debug)]
@@ -192,6 +194,9 @@ impl WeightLoader {
 const GGML_TYPE_F32: u32 = 0;
 const GGML_TYPE_F16: u32 = 1;
 const GGML_TYPE_Q8_0: u32 = 8;
+const GGML_TYPE_Q4_K: u32 = 12;
+const GGML_TYPE_Q5_K: u32 = 13;
+const GGML_TYPE_Q6_K: u32 = 14;
 const GGML_TYPE_BF16: u32 = 30;
 
 #[derive(Debug, Clone)]
@@ -403,16 +408,22 @@ impl GgufWeightLoader {
         let logical_cols = tensor.dims[0];
         let logical_rows = tensor.dims[1];
         match tensor.tensor_type {
-            GGML_TYPE_Q8_0 => {
-                let row_bytes =
-                    ggml_k_row_bytes(LOWBIT_GGML_Q8_0, logical_cols).ok_or_else(|| {
-                        LoadError::UnexpectedTensor(format!(
-                            "GGUF Q8_0 tensor {name} has invalid K={logical_cols}"
-                        ))
-                    })?;
+            GGML_TYPE_Q8_0 | GGML_TYPE_Q4_K | GGML_TYPE_Q5_K | GGML_TYPE_Q6_K => {
+                let quant_type = gguf_linear_quant_type(tensor.tensor_type).ok_or_else(|| {
+                    LoadError::UnsupportedDtype(format!(
+                        "GGUF linear tensor {name} has unsupported ggml type {}",
+                        tensor.tensor_type
+                    ))
+                })?;
+                let row_bytes = ggml_k_row_bytes(quant_type, logical_cols).ok_or_else(|| {
+                    LoadError::UnexpectedTensor(format!(
+                        "GGUF quantized tensor {name} has invalid K={logical_cols} for type {}",
+                        tensor.tensor_type
+                    ))
+                })?;
                 Ok(LinearHostParts {
                     dtype: ScalarType::U8,
-                    quant_type: LOWBIT_GGML_Q8_0,
+                    quant_type,
                     logical_rows,
                     logical_cols,
                     upload_shape: vec![logical_rows, row_bytes],
@@ -581,22 +592,38 @@ fn gguf_tensor_nbytes(dims: &[usize], tensor_type: u32) -> Result<usize, LoadErr
         GGML_TYPE_F16 | GGML_TYPE_BF16 => elems
             .checked_mul(2)
             .ok_or_else(|| LoadError::InvalidGguf("16-bit tensor byte size overflows".into())),
-        GGML_TYPE_Q8_0 => {
+        GGML_TYPE_Q8_0 | GGML_TYPE_Q4_K | GGML_TYPE_Q5_K | GGML_TYPE_Q6_K => {
             if dims.len() != 2 {
                 return Err(LoadError::UnexpectedTensor(format!(
-                    "Q8_0 tensor must be rank-2, got {dims:?}"
+                    "quantized GGUF tensor must be rank-2, got {dims:?}"
                 )));
             }
-            let row_bytes = ggml_k_row_bytes(LOWBIT_GGML_Q8_0, dims[0]).ok_or_else(|| {
-                LoadError::UnexpectedTensor(format!("Q8_0 tensor has invalid K={}", dims[0]))
+            let quant_type = gguf_linear_quant_type(tensor_type).ok_or_else(|| {
+                LoadError::UnsupportedDtype(format!("unsupported GGUF tensor type {tensor_type}"))
             })?;
-            dims[1]
-                .checked_mul(row_bytes)
-                .ok_or_else(|| LoadError::InvalidGguf("Q8_0 tensor byte size overflows".into()))
+            let row_bytes = ggml_k_row_bytes(quant_type, dims[0]).ok_or_else(|| {
+                LoadError::UnexpectedTensor(format!(
+                    "quantized GGUF tensor has invalid K={} for type {tensor_type}",
+                    dims[0]
+                ))
+            })?;
+            dims[1].checked_mul(row_bytes).ok_or_else(|| {
+                LoadError::InvalidGguf("quantized GGUF tensor byte size overflows".into())
+            })
         }
         other => Err(LoadError::UnsupportedDtype(format!(
             "unsupported GGUF tensor type {other}"
         ))),
+    }
+}
+
+fn gguf_linear_quant_type(tensor_type: u32) -> Option<i32> {
+    match tensor_type {
+        GGML_TYPE_Q8_0 => Some(LOWBIT_GGML_Q8_0),
+        GGML_TYPE_Q4_K => Some(LOWBIT_GGML_Q4_K),
+        GGML_TYPE_Q5_K => Some(LOWBIT_GGML_Q5_K),
+        GGML_TYPE_Q6_K => Some(LOWBIT_GGML_Q6_K),
+        _ => None,
     }
 }
 

--- a/crates/qwen35_dflash/src/weights.rs
+++ b/crates/qwen35_dflash/src/weights.rs
@@ -79,7 +79,7 @@ pub struct DFlashLayerWeights {
     pub q_proj_w: LinearWeight,
     pub k_proj_w: LinearWeight,
     pub v_proj_w: LinearWeight,
-    pub kv_proj_w: LinearWeight,
+    pub kv_proj_w: Option<LinearWeight>,
     pub o_proj_w: LinearWeight,
 
     // Per-head RMSNorm over head_dim (NOT hidden_size). Shape [head_dim].
@@ -201,7 +201,7 @@ impl DFlashWeights {
                 q_proj_w,
                 k_proj_w,
                 v_proj_w,
-                kv_proj_w,
+                kv_proj_w: Some(kv_proj_w),
                 o_proj_w,
                 q_norm_w,
                 k_norm_w,
@@ -266,11 +266,19 @@ impl DFlashWeights {
             let v_proj_w = Self::linear_from_gguf(
                 loader.load_linear_to_gpu(&format!("blk.{idx}.attn_v.weight"), ordinal)?,
             );
-            let kv_proj_w = Self::linear_from_gguf(loader.load_concat_dim0_linear_to_gpu(
+            let kv_proj_w = match loader.load_concat_dim0_linear_to_gpu(
                 &format!("blk.{idx}.attn_k.weight"),
                 &format!("blk.{idx}.attn_v.weight"),
                 ordinal,
-            )?);
+            ) {
+                Ok(parts) => Some(Self::linear_from_gguf(parts)),
+                Err(LoadError::UnexpectedTensor(msg))
+                    if msg.contains("cannot concat GGUF linears") =>
+                {
+                    None
+                }
+                Err(err) => return Err(err),
+            };
             let o_proj_w = Self::linear_from_gguf(
                 loader.load_linear_to_gpu(&format!("blk.{idx}.attn_output.weight"), ordinal)?,
             );

--- a/crates/runner/src/cli.rs
+++ b/crates/runner/src/cli.rs
@@ -453,9 +453,10 @@ pub(crate) struct Cli {
     #[arg(long)]
     pub(crate) dflash: bool,
 
-    /// Path to the DFlash draft checkpoint directory (e.g.
-    /// `z-lab/Qwen3.5-9B-DFlash` extracted locally). Must contain
-    /// `config.json` and `model.safetensors`.
+    /// Path to the DFlash draft checkpoint config directory (e.g.
+    /// `z-lab/Qwen3.5-9B-DFlash` extracted locally). Normally contains
+    /// `config.json` and `model.safetensors`; GGUF draft weights can be
+    /// selected by setting `SUPERSONIC_DFLASH_DRAFT_GGUF`.
     #[arg(long)]
     pub(crate) dflash_draft_dir: Option<PathBuf>,
 

--- a/crates/runner/src/decode_engine.rs
+++ b/crates/runner/src/decode_engine.rs
@@ -861,6 +861,10 @@ pub struct DecodeEngine {
     /// Qwen3.6 path verifies in fixed B=8 chunks, so reusing this avoids
     /// re-allocating the prefill component scratch every segment.
     dflash_prefill_append_cache: Option<prefill_engine::PrefillAppendVerifyCache>,
+    /// Cached scratch and metadata buffers for DDTree prefill verification.
+    /// Reused across rounds with the same tree width to avoid per-round
+    /// `PrefillScratch` allocation and small metadata GPU uploads.
+    dflash_prefill_tree_cache: Option<prefill_engine::PrefillTreeVerifyCache>,
     /// Reusable fixed-size scratch for component full-attention decode.
     /// Avoids per-layer-per-step allocation churn on single-sequence
     /// component decode paths.
@@ -10188,6 +10192,7 @@ impl DecodeEngine {
             dflash_tap_cache: None,
             dflash_fused_verify_cache: None,
             dflash_prefill_append_cache: None,
+            dflash_prefill_tree_cache: None,
             component_full_attn_scratch,
             component_mlp_scratch,
             metal_v2_scratch: None,
@@ -11842,25 +11847,57 @@ impl DecodeEngine {
             anyhow::bail!("verify_tree_prefill: tokens must be non-empty");
         }
 
-        let result = prefill_engine::prefill_tree_verify(
-            &self.weights,
-            &mut self.state,
-            &self.rotary,
-            tokens,
-            positions,
-            parent_ids,
-            visibility,
-            prefix_len,
-            self.ordinal,
-            self.kv_chunk_size,
-            self.use_4b_kernel,
-            Some(tap_layers),
-            true,
-            capture_rollback,
-        )?;
-        self.scratch
-            .reset_sync()
-            .map_err(|e| anyhow::anyhow!("reset sync after tree prefill verify: {e}"))?;
+        let result = if std::env::var_os("SUPERSONIC_DFLASH_DISABLE_TREE_VERIFY_CACHE").is_some() {
+            prefill_engine::prefill_tree_verify(
+                &self.weights,
+                &mut self.state,
+                &self.rotary,
+                tokens,
+                positions,
+                parent_ids,
+                visibility,
+                prefix_len,
+                self.ordinal,
+                self.kv_chunk_size,
+                self.use_4b_kernel,
+                Some(tap_layers),
+                true,
+                capture_rollback,
+            )?
+        } else {
+            let mut cache = match self.dflash_prefill_tree_cache.take() {
+                Some(cache) => cache,
+                None => prefill_engine::PrefillTreeVerifyCache::new(
+                    &self.weights.config,
+                    tokens.len(),
+                    self.ordinal,
+                )?,
+            };
+            let result = prefill_engine::prefill_tree_verify_cached(
+                &self.weights,
+                &mut self.state,
+                &self.rotary,
+                tokens,
+                positions,
+                parent_ids,
+                visibility,
+                prefix_len,
+                self.ordinal,
+                self.kv_chunk_size,
+                self.use_4b_kernel,
+                Some(tap_layers),
+                true,
+                capture_rollback,
+                &mut cache,
+            )?;
+            self.dflash_prefill_tree_cache = Some(cache);
+            result
+        };
+        if std::env::var_os("SUPERSONIC_DFLASH_TREE_VERIFY_STRICT_SYNC").is_some() {
+            self.scratch
+                .reset_sync()
+                .map_err(|e| anyhow::anyhow!("reset sync after tree prefill verify: {e}"))?;
+        }
         Ok(result)
     }
 
@@ -12027,6 +12064,8 @@ impl DecodeEngine {
         accepted_indices: &[usize],
         commit_len: usize,
     ) -> Result<()> {
+        let profile_verify = std::env::var_os("SUPERSONIC_DFLASH_PROFILE_VERIFY").is_some();
+        let t_rollback = std::time::Instant::now();
         prefill_engine::apply_prefill_tree_rollback(
             &mut self.state,
             &self.weights.config,
@@ -12036,9 +12075,19 @@ impl DecodeEngine {
             self.ordinal,
             self.kv_chunk_size,
         )?;
-        self.scratch
-            .reset_sync()
-            .map_err(|e| anyhow::anyhow!("reset sync after prefill tree rollback: {e}"))?;
+        if profile_verify {
+            eprintln!(
+                "[dflash-profile] tree_rollback commit_len={} accepted={} apply={:.2}ms",
+                commit_len,
+                accepted_indices.len(),
+                t_rollback.elapsed().as_secs_f64() * 1000.0,
+            );
+        }
+        if std::env::var_os("SUPERSONIC_DFLASH_TREE_VERIFY_STRICT_SYNC").is_some() {
+            self.scratch
+                .reset_sync()
+                .map_err(|e| anyhow::anyhow!("reset sync after prefill tree rollback: {e}"))?;
+        }
         Ok(())
     }
 

--- a/crates/runner/src/prefill_engine.rs
+++ b/crates/runner/src/prefill_engine.rs
@@ -131,14 +131,6 @@ fn encode_u32_le(values: &[usize]) -> Vec<u8> {
     out
 }
 
-fn encode_i32_le(values: &[i32]) -> Vec<u8> {
-    let mut out = Vec::with_capacity(values.len() * 4);
-    for &v in values {
-        out.extend_from_slice(&v.to_le_bytes());
-    }
-    out
-}
-
 fn detect_outlier_cols(lhs_bf16: &[f32], rows: usize, cols: usize, threshold: f32) -> Vec<usize> {
     let mut flags = vec![false; cols];
     for r in 0..rows {
@@ -1444,6 +1436,14 @@ struct PrefillScratch {
     attn_v: GpuBuffer,
     /// [num_q_heads, seq_len, head_dim] F32 — attention output
     attn_out_f32: GpuBuffer,
+    /// [seq_len, max full-attention Q projection dim] BF16
+    full_q_buf: GpuBuffer,
+    /// [seq_len, num_q_heads * head_dim] BF16
+    full_query_buf: GpuBuffer,
+    /// [seq_len, num_q_heads * head_dim] BF16
+    full_gate_buf: GpuBuffer,
+    /// [seq_len, num_kv_heads * head_dim] BF16
+    full_v_buf: GpuBuffer,
     // Linear attention scratch:
     /// [qkv_dim, seq_len + kern - 1] BF16 — padded conv input
     conv_input: GpuBuffer,
@@ -1487,6 +1487,8 @@ struct PrefillScratch {
     linear_gated_out: GpuBuffer,
     /// [seq_len, linear_value_dim] BF16
     linear_gated_s_first: GpuBuffer,
+    /// [linear_num_value_heads, linear_key_head_dim, linear_value_head_dim] F32
+    linear_dummy_state: GpuBuffer,
 }
 
 impl PrefillScratch {
@@ -1590,6 +1592,30 @@ impl PrefillScratch {
                 &[num_q_heads, seq_len, head_dim],
             )
             .map_err(|e| anyhow::anyhow!("prefill attn_out_f32: {e}"))?,
+            full_q_buf: GpuBuffer::alloc(
+                ordinal,
+                ScalarType::BF16,
+                &[seq_len, num_q_heads * head_dim * 2],
+            )
+            .map_err(|e| anyhow::anyhow!("prefill full_q_buf: {e}"))?,
+            full_query_buf: GpuBuffer::alloc(
+                ordinal,
+                ScalarType::BF16,
+                &[seq_len, num_q_heads * head_dim],
+            )
+            .map_err(|e| anyhow::anyhow!("prefill full_query_buf: {e}"))?,
+            full_gate_buf: GpuBuffer::alloc(
+                ordinal,
+                ScalarType::BF16,
+                &[seq_len, num_q_heads * head_dim],
+            )
+            .map_err(|e| anyhow::anyhow!("prefill full_gate_buf: {e}"))?,
+            full_v_buf: GpuBuffer::alloc(
+                ordinal,
+                ScalarType::BF16,
+                &[seq_len, num_kv_heads * head_dim],
+            )
+            .map_err(|e| anyhow::anyhow!("prefill full_v_buf: {e}"))?,
             conv_input: GpuBuffer::zeros(ordinal, ScalarType::BF16, &[qkv_dim, conv_total_len])
                 .map_err(|e| anyhow::anyhow!("prefill conv_input: {e}"))?,
             linear_new_tail: GpuBuffer::alloc(ordinal, ScalarType::BF16, &[qkv_dim, pad])
@@ -1632,6 +1658,8 @@ impl PrefillScratch {
                 .map_err(|e| anyhow::anyhow!("prefill linear_gated_out: {e}"))?,
             linear_gated_s_first: GpuBuffer::alloc(ordinal, ScalarType::BF16, &[seq_len, val_dim])
                 .map_err(|e| anyhow::anyhow!("prefill linear_gated_s_first: {e}"))?,
+            linear_dummy_state: GpuBuffer::alloc(ordinal, ScalarType::F32, &[nv, khd, vhd])
+                .map_err(|e| anyhow::anyhow!("prefill linear_dummy_state: {e}"))?,
         })
     }
 }
@@ -1818,6 +1846,109 @@ pub struct PrefillAppendVerifyCache {
     chunk_conv_tail: Vec<Option<GpuBuffer>>,
     token_ids_gpu: GpuBuffer,
     rollback: Option<PrefillAppendRollback>,
+}
+
+pub struct PrefillTreeVerifyCache {
+    tree_len: usize,
+    ordinal: usize,
+    scratch: PrefillScratch,
+    token_ids_gpu: GpuBuffer,
+    positions_gpu: GpuBuffer,
+    parent_ids_gpu: GpuBuffer,
+    visibility_gpu: GpuBuffer,
+    token_id_bytes: Vec<u8>,
+    position_bytes: Vec<u8>,
+    parent_id_bytes: Vec<u8>,
+}
+
+impl PrefillTreeVerifyCache {
+    pub fn new(config: &TextConfig, tree_len: usize, ordinal: usize) -> Result<Self> {
+        let scratch = PrefillScratch::new(config, tree_len, ordinal)?;
+        let token_ids_gpu = GpuBuffer::alloc(ordinal, ScalarType::U32, &[tree_len])
+            .map_err(|e| anyhow::anyhow!("tree cache token ids alloc: {e}"))?;
+        let positions_gpu = GpuBuffer::alloc(ordinal, ScalarType::U32, &[tree_len])
+            .map_err(|e| anyhow::anyhow!("tree cache positions alloc: {e}"))?;
+        let parent_ids_gpu = GpuBuffer::alloc(ordinal, ScalarType::U32, &[tree_len])
+            .map_err(|e| anyhow::anyhow!("tree cache parent ids alloc: {e}"))?;
+        let visibility_gpu = GpuBuffer::alloc(ordinal, ScalarType::U8, &[tree_len, tree_len])
+            .map_err(|e| anyhow::anyhow!("tree cache visibility alloc: {e}"))?;
+
+        Ok(Self {
+            tree_len,
+            ordinal,
+            scratch,
+            token_ids_gpu,
+            positions_gpu,
+            parent_ids_gpu,
+            visibility_gpu,
+            token_id_bytes: Vec::with_capacity(tree_len * 4),
+            position_bytes: Vec::with_capacity(tree_len * 4),
+            parent_id_bytes: Vec::with_capacity(tree_len * 4),
+        })
+    }
+
+    fn matches(&self, tree_len: usize, ordinal: usize) -> bool {
+        self.tree_len == tree_len && self.ordinal == ordinal
+    }
+
+    fn upload_inputs(
+        &mut self,
+        token_ids: &[u32],
+        positions: &[usize],
+        parent_ids: &[i32],
+        visibility: &[u8],
+    ) -> Result<()> {
+        self.token_id_bytes.clear();
+        self.token_id_bytes.reserve(token_ids.len() * 4);
+        for &id in token_ids {
+            self.token_id_bytes.extend_from_slice(&id.to_le_bytes());
+        }
+        copy_h2d(
+            self.ordinal,
+            self.token_ids_gpu.as_mut_ptr(),
+            self.token_id_bytes.as_ptr() as *const c_void,
+            self.token_id_bytes.len(),
+        )
+        .map_err(|e| anyhow::anyhow!("tree verify upload token IDs: {e}"))?;
+
+        self.position_bytes.clear();
+        self.position_bytes.reserve(positions.len() * 4);
+        for &pos in positions {
+            self.position_bytes
+                .extend_from_slice(&(pos as u32).to_le_bytes());
+        }
+        copy_h2d(
+            self.ordinal,
+            self.positions_gpu.as_mut_ptr(),
+            self.position_bytes.as_ptr() as *const c_void,
+            self.position_bytes.len(),
+        )
+        .map_err(|e| anyhow::anyhow!("tree verify upload positions: {e}"))?;
+
+        self.parent_id_bytes.clear();
+        self.parent_id_bytes.reserve(parent_ids.len() * 4);
+        for &parent in parent_ids {
+            self.parent_id_bytes
+                .extend_from_slice(&parent.to_le_bytes());
+        }
+        copy_h2d(
+            self.ordinal,
+            self.parent_ids_gpu.as_mut_ptr(),
+            self.parent_id_bytes.as_ptr() as *const c_void,
+            self.parent_id_bytes.len(),
+        )
+        .map_err(|e| anyhow::anyhow!("tree verify upload parent IDs: {e}"))?;
+
+        copy_h2d(
+            self.ordinal,
+            self.visibility_gpu.as_mut_ptr(),
+            visibility.as_ptr() as *const c_void,
+            visibility.len(),
+        )
+        .map_err(|e| anyhow::anyhow!("tree verify upload visibility: {e}"))?;
+
+        Ok(())
+    }
 }
 
 impl PrefillAppendVerifyCache {
@@ -3633,6 +3764,80 @@ pub fn prefill_tree_verify(
     greedy_only: bool,
     capture_rollback: bool,
 ) -> Result<PrefillTreeVerifyResult> {
+    prefill_tree_verify_impl(
+        weights,
+        state,
+        rotary,
+        token_ids,
+        positions,
+        parent_ids,
+        visibility,
+        prefix_len,
+        ordinal,
+        kv_chunk_size,
+        use_4b_kernel,
+        tap_layers,
+        greedy_only,
+        capture_rollback,
+        None,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn prefill_tree_verify_cached(
+    weights: &Qwen35Weights,
+    state: &mut ModelState,
+    rotary: &RotaryTables,
+    token_ids: &[u32],
+    positions: &[usize],
+    parent_ids: &[i32],
+    visibility: &[u8],
+    prefix_len: usize,
+    ordinal: usize,
+    kv_chunk_size: usize,
+    use_4b_kernel: bool,
+    tap_layers: Option<&[usize]>,
+    greedy_only: bool,
+    capture_rollback: bool,
+    cache: &mut PrefillTreeVerifyCache,
+) -> Result<PrefillTreeVerifyResult> {
+    prefill_tree_verify_impl(
+        weights,
+        state,
+        rotary,
+        token_ids,
+        positions,
+        parent_ids,
+        visibility,
+        prefix_len,
+        ordinal,
+        kv_chunk_size,
+        use_4b_kernel,
+        tap_layers,
+        greedy_only,
+        capture_rollback,
+        Some(cache),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn prefill_tree_verify_impl(
+    weights: &Qwen35Weights,
+    state: &mut ModelState,
+    rotary: &RotaryTables,
+    token_ids: &[u32],
+    positions: &[usize],
+    parent_ids: &[i32],
+    visibility: &[u8],
+    prefix_len: usize,
+    ordinal: usize,
+    kv_chunk_size: usize,
+    use_4b_kernel: bool,
+    tap_layers: Option<&[usize]>,
+    greedy_only: bool,
+    capture_rollback: bool,
+    cache: Option<&mut PrefillTreeVerifyCache>,
+) -> Result<PrefillTreeVerifyResult> {
     if token_ids.is_empty() {
         return Err(anyhow::anyhow!("prefill_tree_verify: token_ids is empty"));
     }
@@ -3659,7 +3864,35 @@ pub fn prefill_tree_verify(
 
     let config = &weights.config;
     let hidden_dim = config.hidden_size;
-    let mut scratch = PrefillScratch::new(config, tree_len, ordinal)?;
+    let profile = std::env::var_os("SUPERSONIC_DFLASH_PROFILE_VERIFY").is_some();
+    let mut ms_setup = 0.0_f64;
+    let mut ms_embed = 0.0_f64;
+    let mut ms_input_norm = 0.0_f64;
+    let mut ms_full_attn = 0.0_f64;
+    let mut ms_linear_attn = 0.0_f64;
+    let mut ms_post_norm = 0.0_f64;
+    let mut ms_mlp = 0.0_f64;
+    let mut ms_taps = 0.0_f64;
+    let mut ms_logits = 0.0_f64;
+
+    let t_setup = std::time::Instant::now();
+    let mut local_cache;
+    let cache = match cache {
+        Some(cache) => cache,
+        None => {
+            local_cache = PrefillTreeVerifyCache::new(config, tree_len, ordinal)?;
+            &mut local_cache
+        }
+    };
+    if !cache.matches(tree_len, ordinal) {
+        *cache = PrefillTreeVerifyCache::new(config, tree_len, ordinal)?;
+    }
+    cache.upload_inputs(token_ids, positions, parent_ids, visibility)?;
+    if profile {
+        ms_setup += t_setup.elapsed().as_secs_f64() * 1000.0;
+    }
+
+    let scratch = &mut cache.scratch;
     let mut tap_hiddens_all: Option<Vec<Vec<u8>>> =
         tap_layers.map(|tap| vec![Vec::with_capacity(tree_len * hidden_dim * 2); tap.len()]);
     let mut rollback = capture_rollback.then(|| PrefillTreeRollback {
@@ -3668,28 +3901,7 @@ pub fn prefill_tree_verify(
         per_layer: (0..config.num_hidden_layers).map(|_| None).collect(),
     });
 
-    let id_bytes: Vec<u8> = token_ids.iter().flat_map(|id| id.to_le_bytes()).collect();
-    let token_ids_gpu =
-        GpuBuffer::from_host_bytes(ordinal, ScalarType::U32, &[tree_len], &id_bytes)
-            .map_err(|e| anyhow::anyhow!("tree verify upload token IDs: {e}"))?;
-    let positions_gpu = GpuBuffer::from_host_bytes(
-        ordinal,
-        ScalarType::U32,
-        &[tree_len],
-        &encode_u32_le(positions),
-    )
-    .map_err(|e| anyhow::anyhow!("tree verify upload positions: {e}"))?;
-    let parent_ids_gpu = GpuBuffer::from_host_bytes(
-        ordinal,
-        ScalarType::U32,
-        &[tree_len],
-        &encode_i32_le(parent_ids),
-    )
-    .map_err(|e| anyhow::anyhow!("tree verify upload parent IDs: {e}"))?;
-    let visibility_gpu =
-        GpuBuffer::from_host_bytes(ordinal, ScalarType::U8, &[tree_len, tree_len], visibility)
-            .map_err(|e| anyhow::anyhow!("tree verify upload visibility: {e}"))?;
-
+    let t_embed = std::time::Instant::now();
     prefill_ffi::embedding_lookup(
         ordinal,
         ScalarType::BF16,
@@ -3697,12 +3909,16 @@ pub fn prefill_tree_verify(
         config.vocab_size,
         hidden_dim,
         &weights.embed_tokens,
-        &token_ids_gpu,
+        &cache.token_ids_gpu,
         &mut scratch.hidden,
     )
     .map_err(|e| anyhow::anyhow!("tree verify embedding lookup: {e}"))?;
+    if profile {
+        ms_embed += t_embed.elapsed().as_secs_f64() * 1000.0;
+    }
 
     for idx in 0..config.num_hidden_layers {
+        let t_input_norm = std::time::Instant::now();
         rms_norm_rows_model(
             config,
             ordinal,
@@ -3713,40 +3929,52 @@ pub fn prefill_tree_verify(
             &mut scratch.normed,
             &format!("tree layer {idx} input norm"),
         )?;
+        if profile {
+            ms_input_norm += t_input_norm.elapsed().as_secs_f64() * 1000.0;
+        }
 
         if config.is_full_attention(idx) {
             let capture_slot = rollback.as_mut().map(|r| &mut r.per_layer[idx]);
+            let t_attn = std::time::Instant::now();
             prefill_tree_full_attention_layer(
                 weights,
                 state,
                 rotary,
-                &mut scratch,
+                &mut *scratch,
                 config,
                 idx,
                 tree_len,
                 prefix_len,
                 ordinal,
                 kv_chunk_size,
-                &positions_gpu,
-                &visibility_gpu,
+                &cache.positions_gpu,
+                &cache.visibility_gpu,
                 capture_slot,
             )?;
+            if profile {
+                ms_full_attn += t_attn.elapsed().as_secs_f64() * 1000.0;
+            }
         } else {
             let capture_slot = rollback.as_mut().map(|r| &mut r.per_layer[idx]);
+            let t_attn = std::time::Instant::now();
             prefill_tree_linear_attention_layer(
                 weights,
                 state,
-                &mut scratch,
+                &mut *scratch,
                 config,
                 idx,
                 tree_len,
                 prefix_len,
                 ordinal,
-                &parent_ids_gpu,
+                &cache.parent_ids_gpu,
                 capture_slot,
             )?;
+            if profile {
+                ms_linear_attn += t_attn.elapsed().as_secs_f64() * 1000.0;
+            }
         }
 
+        let t_post_norm = std::time::Instant::now();
         rms_norm_rows_model(
             config,
             ordinal,
@@ -3757,9 +3985,17 @@ pub fn prefill_tree_verify(
             &mut scratch.normed,
             &format!("tree layer {idx} post-attn norm"),
         )?;
+        if profile {
+            ms_post_norm += t_post_norm.elapsed().as_secs_f64() * 1000.0;
+        }
 
-        prefill_mlp_layer(weights, &mut scratch, config, idx, tree_len, ordinal)?;
+        let t_mlp = std::time::Instant::now();
+        prefill_mlp_layer(weights, &mut *scratch, config, idx, tree_len, ordinal)?;
+        if profile {
+            ms_mlp += t_mlp.elapsed().as_secs_f64() * 1000.0;
+        }
         if let (Some(tap), Some(out_all)) = (tap_layers, tap_hiddens_all.as_mut()) {
+            let t_taps = std::time::Instant::now();
             for (slot, &target_layer) in tap.iter().enumerate() {
                 if target_layer == idx {
                     let hidden_bytes = hidden_dim * ScalarType::BF16.size_in_bytes();
@@ -3770,9 +4006,13 @@ pub fn prefill_tree_verify(
                     out_all[slot].extend_from_slice(&host[..tree_bytes]);
                 }
             }
+            if profile {
+                ms_taps += t_taps.elapsed().as_secs_f64() * 1000.0;
+            }
         }
     }
 
+    let t_logits = std::time::Instant::now();
     let (target_next, _normed) = if greedy_only {
         compute_greedy_for_range(
             &scratch.hidden,
@@ -3809,6 +4049,23 @@ pub fn prefill_tree_verify(
             .collect();
         (ids, normed)
     };
+    if profile {
+        ms_logits += t_logits.elapsed().as_secs_f64() * 1000.0;
+        eprintln!(
+            "[dflash-profile] tree_verify len={} prefix={} setup/upload={:.2}ms embed={:.2}ms input_norm={:.2}ms full_attn={:.2}ms linear_attn={:.2}ms post_norm={:.2}ms mlp={:.2}ms taps={:.2}ms logits/greedy={:.2}ms",
+            tree_len,
+            prefix_len,
+            ms_setup,
+            ms_embed,
+            ms_input_norm,
+            ms_full_attn,
+            ms_linear_attn,
+            ms_post_norm,
+            ms_mlp,
+            ms_taps,
+            ms_logits,
+        );
+    }
 
     Ok(PrefillTreeVerifyResult {
         target_next,
@@ -3984,6 +4241,17 @@ pub fn apply_prefill_tree_rollback(
     let nv = config.linear_num_value_heads;
     let khd = config.linear_key_head_dim;
     let vhd = config.linear_value_head_dim;
+    let needs_q8_trace_sync = rollback.per_layer.iter().any(|layer| {
+        layer.as_ref().is_some_and(|layer_rb| match layer_rb {
+            PrefillTreeLayerRollback::Linear {
+                recurrent_trace, ..
+            } => recurrent_trace.dtype() == ScalarType::U8,
+            PrefillTreeLayerRollback::Full { .. } => false,
+        })
+    });
+    if needs_q8_trace_sync {
+        gpu_hal::sync(ordinal).map_err(|e| anyhow::anyhow!("dflash tree Q8 trace sync: {e}"))?;
+    }
     let elem_bytes = ScalarType::BF16.size_in_bytes();
 
     for idx in 0..state.layers.len() {
@@ -4066,24 +4334,66 @@ pub fn apply_prefill_tree_rollback(
             anyhow::anyhow!("prefill tree rollback layer {idx} missing recurrent_state")
         })?;
 
-        prefill_ffi::dflash_apply_tree_rollback(
-            ordinal,
-            ScalarType::BF16,
-            qkv_dim,
-            pad,
-            pad + rollback.tree_len,
-            rollback.tree_len,
-            commit_len,
-            nv,
-            khd,
-            vhd,
-            conv_input,
-            &accepted_gpu,
-            conv_dst,
-            recurrent_trace,
-            rec_dst,
-        )
-        .map_err(|e| anyhow::anyhow!("layer {idx} dflash tree rollback apply: {e}"))?;
+        if recurrent_trace.dtype() == ScalarType::U8 {
+            prefill_ffi::dflash_apply_tree_rollback_q8_trace(
+                ordinal,
+                ScalarType::BF16,
+                qkv_dim,
+                pad,
+                pad + rollback.tree_len,
+                rollback.tree_len,
+                commit_len,
+                nv,
+                khd,
+                vhd,
+                conv_input,
+                &accepted_gpu,
+                conv_dst,
+                recurrent_trace,
+                rec_dst,
+            )
+            .map_err(|e| anyhow::anyhow!("layer {idx} dflash tree Q8-trace rollback apply: {e}"))?;
+        } else if recurrent_trace.dtype() == ScalarType::BF16 {
+            prefill_ffi::dflash_apply_tree_rollback_bf16_trace(
+                ordinal,
+                ScalarType::BF16,
+                qkv_dim,
+                pad,
+                pad + rollback.tree_len,
+                rollback.tree_len,
+                commit_len,
+                nv,
+                khd,
+                vhd,
+                conv_input,
+                &accepted_gpu,
+                conv_dst,
+                recurrent_trace,
+                rec_dst,
+            )
+            .map_err(|e| {
+                anyhow::anyhow!("layer {idx} dflash tree BF16-trace rollback apply: {e}")
+            })?;
+        } else {
+            prefill_ffi::dflash_apply_tree_rollback(
+                ordinal,
+                ScalarType::BF16,
+                qkv_dim,
+                pad,
+                pad + rollback.tree_len,
+                rollback.tree_len,
+                commit_len,
+                nv,
+                khd,
+                vhd,
+                conv_input,
+                &accepted_gpu,
+                conv_dst,
+                recurrent_trace,
+                rec_dst,
+            )
+            .map_err(|e| anyhow::anyhow!("layer {idx} dflash tree rollback apply: {e}"))?;
+        }
     }
 
     Ok(())
@@ -5086,8 +5396,6 @@ fn prefill_tree_full_attention_layer(
     let rotary_dim = config.rotary_dim();
     let elem_bytes = ScalarType::BF16.size_in_bytes();
 
-    let mut q_full = GpuBuffer::alloc(ordinal, ScalarType::BF16, &[tree_len, q_proj_dim])
-        .map_err(|e| anyhow::anyhow!("tree q_full alloc: {e}"))?;
     matmul_proj(
         ordinal,
         1,
@@ -5099,17 +5407,13 @@ fn prefill_tree_full_attention_layer(
         fw.q_proj_scale.as_ref(),
         fw.q_proj_int8_scale.as_ref(),
         weights.fp8_block_size,
-        &mut q_full,
+        &mut scratch.full_q_buf,
         fw.q_proj_int4_scale.as_ref(),
         fw.q_proj_int4_zero.as_ref(),
         fw.q_proj_awq_inv_scale.as_ref(),
         weights.int4_group_size,
     )?;
 
-    let mut query_buf = GpuBuffer::alloc(ordinal, ScalarType::BF16, &[tree_len, q_dim])
-        .map_err(|e| anyhow::anyhow!("tree query_buf alloc: {e}"))?;
-    let mut gate_buf = GpuBuffer::alloc(ordinal, ScalarType::BF16, &[tree_len, q_dim])
-        .map_err(|e| anyhow::anyhow!("tree gate_buf alloc: {e}"))?;
     let q_norm_done = if has_attn_gate {
         if maybe_split_qgate_norm_bf16(
             config,
@@ -5117,10 +5421,10 @@ fn prefill_tree_full_attention_layer(
             tree_len,
             num_q_heads,
             head_dim,
-            &q_full,
+            &scratch.full_q_buf,
             fw.q_norm_w.as_ref(),
-            &mut query_buf,
-            &mut gate_buf,
+            &mut scratch.full_query_buf,
+            &mut scratch.full_gate_buf,
             &format!("tree layer {idx} fused Q split+norm"),
         )? {
             true
@@ -5131,9 +5435,9 @@ fn prefill_tree_full_attention_layer(
                 tree_len,
                 num_q_heads,
                 head_dim,
-                &q_full,
-                &mut query_buf,
-                &mut gate_buf,
+                &scratch.full_q_buf,
+                &mut scratch.full_query_buf,
+                &mut scratch.full_gate_buf,
             )
             .map_err(|e| anyhow::anyhow!("tree layer {idx} Q split: {e}"))?;
             false
@@ -5141,8 +5445,8 @@ fn prefill_tree_full_attention_layer(
     } else {
         copy_d2d_batched(
             ordinal,
-            query_buf.as_ptr() as *mut c_void,
-            q_full.as_ptr(),
+            scratch.full_query_buf.as_ptr() as *mut c_void,
+            scratch.full_q_buf.as_ptr(),
             tree_len * q_dim * elem_bytes,
         )
         .map_err(|e| anyhow::anyhow!("tree layer {idx} Q copy: {e}"))?;
@@ -5173,7 +5477,7 @@ fn prefill_tree_full_attention_layer(
             ordinal,
             tree_len * num_q_heads,
             head_dim,
-            &mut query_buf,
+            &mut scratch.full_query_buf,
             fw.q_norm_w.as_ref(),
             &format!("tree layer {idx} Q norm inplace"),
         )?
@@ -5189,14 +5493,14 @@ fn prefill_tree_full_attention_layer(
             ordinal,
             tree_len * num_q_heads,
             head_dim,
-            &query_buf,
+            &scratch.full_query_buf,
             fw.q_norm_w.as_ref(),
             &mut q_normed,
             &format!("tree layer {idx} Q norm"),
         )?;
         copy_d2d_batched(
             ordinal,
-            query_buf.as_ptr() as *mut c_void,
+            scratch.full_query_buf.as_ptr() as *mut c_void,
             q_normed.as_ptr(),
             tree_len * q_dim * elem_bytes,
         )
@@ -5247,7 +5551,7 @@ fn prefill_tree_full_attention_layer(
         &rotary.cos,
         &rotary.sin,
         positions_gpu,
-        &mut query_buf,
+        &mut scratch.full_query_buf,
     )
     .map_err(|e| anyhow::anyhow!("tree layer {idx} Q RoPE: {e}"))?;
     prefill_ffi::apply_rope_prefill_indirect(
@@ -5264,8 +5568,6 @@ fn prefill_tree_full_attention_layer(
     )
     .map_err(|e| anyhow::anyhow!("tree layer {idx} K RoPE: {e}"))?;
 
-    let mut v_buf = GpuBuffer::alloc(ordinal, ScalarType::BF16, &[tree_len, kv_dim])
-        .map_err(|e| anyhow::anyhow!("tree v_buf alloc: {e}"))?;
     matmul_proj(
         ordinal,
         1,
@@ -5277,7 +5579,7 @@ fn prefill_tree_full_attention_layer(
         fw.v_proj_scale.as_ref(),
         fw.v_proj_int8_scale.as_ref(),
         weights.fp8_block_size,
-        &mut v_buf,
+        &mut scratch.full_v_buf,
         fw.v_proj_int4_scale.as_ref(),
         fw.v_proj_int4_zero.as_ref(),
         fw.v_proj_awq_inv_scale.as_ref(),
@@ -5300,7 +5602,7 @@ fn prefill_tree_full_attention_layer(
         tree_len,
         num_kv_heads,
         head_dim,
-        &v_buf,
+        &scratch.full_v_buf,
         &mut scratch.attn_v,
     )
     .map_err(|e| anyhow::anyhow!("tree layer {idx} V transpose: {e}"))?;
@@ -5330,7 +5632,7 @@ fn prefill_tree_full_attention_layer(
         tree_len,
         num_q_heads,
         head_dim,
-        &query_buf,
+        &scratch.full_query_buf,
         &mut scratch.attn_q,
     )
     .map_err(|e| anyhow::anyhow!("tree layer {idx} Q transpose: {e}"))?;
@@ -5439,7 +5741,7 @@ fn prefill_tree_full_attention_layer(
             num_q_heads,
             head_dim,
             &scratch.attn_out_f32,
-            &gate_buf,
+            &scratch.full_gate_buf,
             &mut scratch.proj_buf,
         )
         .map_err(|e| anyhow::anyhow!("tree layer {idx} fused attn gate prep: {e}"))?;
@@ -5473,7 +5775,7 @@ fn prefill_tree_full_attention_layer(
                     ScalarType::BF16,
                     tree_len * q_dim,
                     &mut scratch.proj_buf,
-                    &gate_buf,
+                    &scratch.full_gate_buf,
                 )
                 .map_err(|e| anyhow::anyhow!("tree layer {idx} gate inplace: {e}"))?;
             } else {
@@ -5484,7 +5786,7 @@ fn prefill_tree_full_attention_layer(
                     ScalarType::BF16,
                     tree_len * q_dim,
                     &scratch.proj_buf,
-                    &gate_buf,
+                    &scratch.full_gate_buf,
                     &mut gated,
                 )
                 .map_err(|e| anyhow::anyhow!("tree layer {idx} gate: {e}"))?;
@@ -6702,12 +7004,7 @@ fn prefill_tree_linear_attention_layer(
 
     let use_fused_ba =
         lw.ba_proj_w.is_some() && scratch.normed.backend() != gpu_hal::Backend::Metal;
-    let mut ba_buf: Option<GpuBuffer> = None;
-    let mut b_buf: Option<GpuBuffer> = None;
-    let mut a_buf: Option<GpuBuffer> = None;
     if use_fused_ba {
-        let mut buf = GpuBuffer::alloc(ordinal, ScalarType::BF16, &[tree_len, 2 * nv])
-            .map_err(|e| anyhow::anyhow!("tree ba_buf alloc: {e}"))?;
         matmul_proj(
             ordinal,
             1,
@@ -6719,16 +7016,13 @@ fn prefill_tree_linear_attention_layer(
             None,
             None,
             weights.fp8_block_size,
-            &mut buf,
+            &mut scratch.linear_ba_buf,
             None,
             None,
             None,
             0,
         )?;
-        ba_buf = Some(buf);
     } else {
-        let mut b = GpuBuffer::alloc(ordinal, ScalarType::BF16, &[tree_len, nv])
-            .map_err(|e| anyhow::anyhow!("tree b_buf alloc: {e}"))?;
         matmul_proj(
             ordinal,
             1,
@@ -6740,15 +7034,13 @@ fn prefill_tree_linear_attention_layer(
             lw.b_proj_scale.as_ref(),
             lw.b_proj_int8_scale.as_ref(),
             weights.fp8_block_size,
-            &mut b,
+            &mut scratch.linear_b_buf,
             None,
             None,
             None,
             0,
         )?;
 
-        let mut a = GpuBuffer::alloc(ordinal, ScalarType::BF16, &[tree_len, nv])
-            .map_err(|e| anyhow::anyhow!("tree a_buf alloc: {e}"))?;
         matmul_proj(
             ordinal,
             1,
@@ -6760,14 +7052,12 @@ fn prefill_tree_linear_attention_layer(
             lw.a_proj_scale.as_ref(),
             lw.a_proj_int8_scale.as_ref(),
             weights.fp8_block_size,
-            &mut a,
+            &mut scratch.linear_a_buf,
             None,
             None,
             None,
             0,
         )?;
-        b_buf = Some(b);
-        a_buf = Some(a);
     }
 
     let pad = kern - 1;
@@ -6827,12 +7117,6 @@ fn prefill_tree_linear_attention_layer(
     )
     .map_err(|e| anyhow::anyhow!("tree layer {idx} conv: {e}"))?;
 
-    let mut q_linear_f32 = GpuBuffer::alloc(ordinal, ScalarType::F32, &[tree_len, key_dim])
-        .map_err(|e| anyhow::anyhow!("tree q_linear_f32 alloc: {e}"))?;
-    let mut k_linear_f32 = GpuBuffer::alloc(ordinal, ScalarType::F32, &[tree_len, key_dim])
-        .map_err(|e| anyhow::anyhow!("tree k_linear_f32 alloc: {e}"))?;
-    let mut v_linear_f32 = GpuBuffer::alloc(ordinal, ScalarType::F32, &[tree_len, val_dim])
-        .map_err(|e| anyhow::anyhow!("tree v_linear_f32 alloc: {e}"))?;
     if gpu_hal::current_backend() == Backend::Hip {
         prefill_ffi::split_qkv_bf16_to_f32(
             ordinal,
@@ -6840,9 +7124,9 @@ fn prefill_tree_linear_attention_layer(
             key_dim,
             val_dim,
             &scratch.proj_buf,
-            &mut q_linear_f32,
-            &mut k_linear_f32,
-            &mut v_linear_f32,
+            &mut scratch.linear_q_f32,
+            &mut scratch.linear_k_f32,
+            &mut scratch.linear_v_f32,
         )
         .map_err(|e| anyhow::anyhow!("tree layer {idx} QKV split+cast: {e}"))?;
     } else {
@@ -6870,7 +7154,7 @@ fn prefill_tree_linear_attention_layer(
             ScalarType::F32,
             tree_len * key_dim,
             &q_linear,
-            &mut q_linear_f32,
+            &mut scratch.linear_q_f32,
         )
         .map_err(|e| anyhow::anyhow!("tree layer {idx} Q cast: {e}"))?;
         prefill_ffi::cast(
@@ -6879,7 +7163,7 @@ fn prefill_tree_linear_attention_layer(
             ScalarType::F32,
             tree_len * key_dim,
             &k_linear,
-            &mut k_linear_f32,
+            &mut scratch.linear_k_f32,
         )
         .map_err(|e| anyhow::anyhow!("tree layer {idx} K cast: {e}"))?;
         prefill_ffi::cast(
@@ -6888,68 +7172,56 @@ fn prefill_tree_linear_attention_layer(
             ScalarType::F32,
             tree_len * val_dim,
             &v_linear,
-            &mut v_linear_f32,
+            &mut scratch.linear_v_f32,
         )
         .map_err(|e| anyhow::anyhow!("tree layer {idx} V cast: {e}"))?;
     }
 
-    let mut q_normed = GpuBuffer::alloc(ordinal, ScalarType::F32, &[tree_len * nk, khd])
-        .map_err(|e| anyhow::anyhow!("tree q_normed alloc: {e}"))?;
     prefill_ffi::l2norm(
         ordinal,
         ScalarType::F32,
         tree_len * nk,
         khd,
         1e-6,
-        &q_linear_f32,
-        &mut q_normed,
+        &scratch.linear_q_f32,
+        &mut scratch.linear_q_normed,
     )
     .map_err(|e| anyhow::anyhow!("tree layer {idx} Q l2norm: {e}"))?;
     let q_scale = 1.0 / (khd as f32).sqrt();
-    let mut q_scaled = GpuBuffer::alloc(ordinal, ScalarType::F32, &[tree_len, key_dim])
-        .map_err(|e| anyhow::anyhow!("tree q_scaled alloc: {e}"))?;
     prefill_ffi::mul_scalar(
         ordinal,
         ScalarType::F32,
         tree_len * key_dim,
         q_scale,
-        &q_normed,
-        &mut q_scaled,
+        &scratch.linear_q_normed,
+        &mut scratch.linear_q_scaled,
     )
     .map_err(|e| anyhow::anyhow!("tree layer {idx} Q scale: {e}"))?;
 
-    let mut k_normed = GpuBuffer::alloc(ordinal, ScalarType::F32, &[tree_len * nk, khd])
-        .map_err(|e| anyhow::anyhow!("tree k_normed alloc: {e}"))?;
     prefill_ffi::l2norm(
         ordinal,
         ScalarType::F32,
         tree_len * nk,
         khd,
         1e-6,
-        &k_linear_f32,
-        &mut k_normed,
+        &scratch.linear_k_f32,
+        &mut scratch.linear_k_normed,
     )
     .map_err(|e| anyhow::anyhow!("tree layer {idx} K l2norm: {e}"))?;
 
-    let mut beta_gpu = GpuBuffer::alloc(ordinal, ScalarType::F32, &[nv, tree_len])
-        .map_err(|e| anyhow::anyhow!("tree beta alloc: {e}"))?;
-    let mut g_gpu = GpuBuffer::alloc(ordinal, ScalarType::F32, &[nv, tree_len])
-        .map_err(|e| anyhow::anyhow!("tree g alloc: {e}"))?;
-    if let Some(ba) = ba_buf.as_ref() {
+    if use_fused_ba {
         prefill_ffi::compute_beta_g_ba_bf16(
             ordinal,
             tree_len,
             nv,
-            ba,
+            &scratch.linear_ba_buf,
             &lw.dt_bias,
             &lw.a_log_exp,
-            &mut beta_gpu,
-            &mut g_gpu,
+            &mut scratch.linear_beta,
+            &mut scratch.linear_g,
         )
         .map_err(|e| anyhow::anyhow!("tree layer {idx} fused beta/g: {e}"))?;
     } else {
-        let a_buf = a_buf.as_ref().expect("separate A buffer initialized");
-        let b_buf = b_buf.as_ref().expect("separate B buffer initialized");
         let mut a_buf_f32 = GpuBuffer::alloc(ordinal, ScalarType::F32, &[tree_len, nv])
             .map_err(|e| anyhow::anyhow!("tree a_buf_f32 alloc: {e}"))?;
         let mut b_buf_f32 = GpuBuffer::alloc(ordinal, ScalarType::F32, &[tree_len, nv])
@@ -6963,7 +7235,7 @@ fn prefill_tree_linear_attention_layer(
             ScalarType::BF16,
             ScalarType::F32,
             tree_len * nv,
-            a_buf,
+            &scratch.linear_a_buf,
             &mut a_buf_f32,
         )
         .map_err(|e| anyhow::anyhow!("tree layer {idx} A cast: {e}"))?;
@@ -6972,7 +7244,7 @@ fn prefill_tree_linear_attention_layer(
             ScalarType::BF16,
             ScalarType::F32,
             tree_len * nv,
-            b_buf,
+            &scratch.linear_b_buf,
             &mut b_buf_f32,
         )
         .map_err(|e| anyhow::anyhow!("tree layer {idx} B cast: {e}"))?;
@@ -7003,30 +7275,25 @@ fn prefill_tree_linear_attention_layer(
             &a_buf_f32,
             &dt_bias_f32,
             &a_log_exp_f32,
-            &mut beta_gpu,
-            &mut g_gpu,
+            &mut scratch.linear_beta,
+            &mut scratch.linear_g,
         )
         .map_err(|e| anyhow::anyhow!("tree layer {idx} beta/g: {e}"))?;
     }
 
     let head_repeat = nv / nk;
-    let q_trans = if head_repeat == 1 {
-        let mut buf = GpuBuffer::alloc(ordinal, ScalarType::F32, &[nk, tree_len, khd])
-            .map_err(|e| anyhow::anyhow!("tree q_trans alloc: {e}"))?;
+    if head_repeat == 1 {
         prefill_ffi::transpose_shd_hsd(
             ordinal,
             ScalarType::F32,
             tree_len,
             nk,
             khd,
-            &q_scaled,
-            &mut buf,
+            &scratch.linear_q_scaled,
+            &mut scratch.linear_q_trans,
         )
         .map_err(|e| anyhow::anyhow!("tree layer {idx} Q linear transpose: {e}"))?;
-        buf
     } else {
-        let mut expanded = GpuBuffer::alloc(ordinal, ScalarType::F32, &[nv, tree_len, khd])
-            .map_err(|e| anyhow::anyhow!("tree q_expanded alloc: {e}"))?;
         prefill_ffi::repeat_interleave_transpose_hsd(
             ordinal,
             ScalarType::F32,
@@ -7034,29 +7301,23 @@ fn prefill_tree_linear_attention_layer(
             nk,
             khd,
             head_repeat,
-            &q_scaled,
-            &mut expanded,
+            &scratch.linear_q_scaled,
+            &mut scratch.linear_q_trans,
         )
         .map_err(|e| anyhow::anyhow!("tree layer {idx} Q repeat+transpose: {e}"))?;
-        expanded
     };
-    let k_trans = if head_repeat == 1 {
-        let mut buf = GpuBuffer::alloc(ordinal, ScalarType::F32, &[nk, tree_len, khd])
-            .map_err(|e| anyhow::anyhow!("tree k_trans alloc: {e}"))?;
+    if head_repeat == 1 {
         prefill_ffi::transpose_shd_hsd(
             ordinal,
             ScalarType::F32,
             tree_len,
             nk,
             khd,
-            &k_normed,
-            &mut buf,
+            &scratch.linear_k_normed,
+            &mut scratch.linear_k_trans,
         )
         .map_err(|e| anyhow::anyhow!("tree layer {idx} K linear transpose: {e}"))?;
-        buf
     } else {
-        let mut expanded = GpuBuffer::alloc(ordinal, ScalarType::F32, &[nv, tree_len, khd])
-            .map_err(|e| anyhow::anyhow!("tree k_expanded alloc: {e}"))?;
         prefill_ffi::repeat_interleave_transpose_hsd(
             ordinal,
             ScalarType::F32,
@@ -7064,30 +7325,33 @@ fn prefill_tree_linear_attention_layer(
             nk,
             khd,
             head_repeat,
-            &k_normed,
-            &mut expanded,
+            &scratch.linear_k_normed,
+            &mut scratch.linear_k_trans,
         )
         .map_err(|e| anyhow::anyhow!("tree layer {idx} K repeat+transpose: {e}"))?;
-        expanded
     };
-    let mut v_trans = GpuBuffer::alloc(ordinal, ScalarType::F32, &[nv, tree_len, vhd])
-        .map_err(|e| anyhow::anyhow!("tree v_trans alloc: {e}"))?;
     prefill_ffi::transpose_shd_hsd(
         ordinal,
         ScalarType::F32,
         tree_len,
         nv,
         vhd,
-        &v_linear_f32,
-        &mut v_trans,
+        &scratch.linear_v_f32,
+        &mut scratch.linear_v_trans,
     )
     .map_err(|e| anyhow::anyhow!("tree layer {idx} V linear transpose: {e}"))?;
 
-    let out_rows = tree_len + khd;
-    let mut delta_out = GpuBuffer::alloc(ordinal, ScalarType::F32, &[nv, out_rows, vhd])
-        .map_err(|e| anyhow::anyhow!("tree delta_out alloc: {e}"))?;
-    let mut recurrent_trace = GpuBuffer::alloc(ordinal, ScalarType::F32, &[nv, tree_len, khd, vhd])
-        .map_err(|e| anyhow::anyhow!("tree recurrent trace alloc: {e}"))?;
+    let recurrent_trace_dtype = dflash_rollback_trace_dtype();
+    let mut recurrent_trace = if recurrent_trace_dtype == ScalarType::U8 {
+        GpuBuffer::alloc(
+            ordinal,
+            recurrent_trace_dtype,
+            &[dflash_q8_trace_bytes(nv, tree_len, khd, vhd)],
+        )
+    } else {
+        GpuBuffer::alloc(ordinal, recurrent_trace_dtype, &[nv, tree_len, khd, vhd])
+    }
+    .map_err(|e| anyhow::anyhow!("tree recurrent trace alloc: {e}"))?;
     let zero_recurrent;
     let recurrent_initial = if let Some(rec_state) = state.layers[idx].recurrent_state.as_ref() {
         rec_state
@@ -7096,24 +7360,64 @@ fn prefill_tree_linear_attention_layer(
             .map_err(|e| anyhow::anyhow!("tree zero recurrent alloc: {e}"))?;
         &zero_recurrent
     };
-    prefill_ffi::delta_recurrent_tree_prefill_capture(
-        ordinal,
-        ScalarType::F32,
-        nv,
-        tree_len,
-        khd,
-        vhd,
-        recurrent_initial,
-        &q_trans,
-        &k_trans,
-        &v_trans,
-        &beta_gpu,
-        &g_gpu,
-        parent_ids_gpu,
-        &mut delta_out,
-        &mut recurrent_trace,
-    )
-    .map_err(|e| anyhow::anyhow!("tree layer {idx} delta recurrent capture: {e}"))?;
+    if recurrent_trace.dtype() == ScalarType::U8 {
+        prefill_ffi::delta_recurrent_tree_prefill_capture_q8_trace(
+            ordinal,
+            ScalarType::F32,
+            nv,
+            tree_len,
+            khd,
+            vhd,
+            recurrent_initial,
+            &scratch.linear_q_trans,
+            &scratch.linear_k_trans,
+            &scratch.linear_v_trans,
+            &scratch.linear_beta,
+            &scratch.linear_g,
+            parent_ids_gpu,
+            &mut scratch.linear_delta_out,
+            &mut recurrent_trace,
+        )
+        .map_err(|e| anyhow::anyhow!("tree layer {idx} delta recurrent Q8 trace capture: {e}"))?;
+    } else if recurrent_trace.dtype() == ScalarType::BF16 {
+        prefill_ffi::delta_recurrent_tree_prefill_capture_bf16_trace(
+            ordinal,
+            ScalarType::F32,
+            nv,
+            tree_len,
+            khd,
+            vhd,
+            recurrent_initial,
+            &scratch.linear_q_trans,
+            &scratch.linear_k_trans,
+            &scratch.linear_v_trans,
+            &scratch.linear_beta,
+            &scratch.linear_g,
+            parent_ids_gpu,
+            &mut scratch.linear_delta_out,
+            &mut recurrent_trace,
+        )
+        .map_err(|e| anyhow::anyhow!("tree layer {idx} delta recurrent BF16 trace capture: {e}"))?;
+    } else {
+        prefill_ffi::delta_recurrent_tree_prefill_capture(
+            ordinal,
+            ScalarType::F32,
+            nv,
+            tree_len,
+            khd,
+            vhd,
+            recurrent_initial,
+            &scratch.linear_q_trans,
+            &scratch.linear_k_trans,
+            &scratch.linear_v_trans,
+            &scratch.linear_beta,
+            &scratch.linear_g,
+            parent_ids_gpu,
+            &mut scratch.linear_delta_out,
+            &mut recurrent_trace,
+        )
+        .map_err(|e| anyhow::anyhow!("tree layer {idx} delta recurrent capture: {e}"))?;
+    }
     if let (Some(slot), Some(conv_input)) = (capture_slot.as_deref_mut(), conv_input_capture) {
         *slot = Some(PrefillTreeLayerRollback::Linear {
             conv_input,
@@ -7121,24 +7425,18 @@ fn prefill_tree_linear_attention_layer(
         });
     }
 
-    let mut dummy_state = GpuBuffer::alloc(ordinal, ScalarType::F32, &[nv, khd, vhd])
-        .map_err(|e| anyhow::anyhow!("tree dummy recurrent state alloc: {e}"))?;
-    let mut attn_output = GpuBuffer::alloc(ordinal, ScalarType::BF16, &[nv, tree_len, vhd])
-        .map_err(|e| anyhow::anyhow!("tree attn_output alloc: {e}"))?;
     prefill_ffi::dflash_extract_recurrent_attn(
         ordinal,
         nv,
         tree_len,
         khd,
         vhd,
-        &delta_out,
-        &mut dummy_state,
-        &mut attn_output,
+        &scratch.linear_delta_out,
+        &mut scratch.linear_dummy_state,
+        &mut scratch.linear_attn_output,
     )
     .map_err(|e| anyhow::anyhow!("tree layer {idx} recurrent/attn extract: {e}"))?;
 
-    let mut z_trans = GpuBuffer::alloc(ordinal, ScalarType::BF16, &[nv, tree_len, vhd])
-        .map_err(|e| anyhow::anyhow!("tree z_trans alloc: {e}"))?;
     prefill_ffi::transpose_shd_hsd(
         ordinal,
         ScalarType::BF16,
@@ -7146,35 +7444,31 @@ fn prefill_tree_linear_attention_layer(
         nv,
         vhd,
         &scratch.proj_buf2,
-        &mut z_trans,
+        &mut scratch.linear_z_trans,
     )
     .map_err(|e| anyhow::anyhow!("tree layer {idx} Z transpose: {e}"))?;
 
-    let mut gated_out = GpuBuffer::alloc(ordinal, ScalarType::BF16, &[nv * tree_len, vhd])
-        .map_err(|e| anyhow::anyhow!("tree gated_out alloc: {e}"))?;
     prefill_ffi::rms_norm_gated(
         ordinal,
         ScalarType::BF16,
         nv * tree_len,
         vhd,
         config.rms_norm_eps as f32,
-        &attn_output,
-        &z_trans,
+        &scratch.linear_attn_output,
+        &scratch.linear_z_trans,
         &lw.norm_w_bf16,
-        &mut gated_out,
+        &mut scratch.linear_gated_out,
     )
     .map_err(|e| anyhow::anyhow!("tree layer {idx} gated norm: {e}"))?;
 
-    let mut gated_s_first = GpuBuffer::alloc(ordinal, ScalarType::BF16, &[tree_len, val_dim])
-        .map_err(|e| anyhow::anyhow!("tree gated_s_first alloc: {e}"))?;
     prefill_ffi::transpose_shd_hsd(
         ordinal,
         ScalarType::BF16,
         nv,
         tree_len,
         vhd,
-        &gated_out,
-        &mut gated_s_first,
+        &scratch.linear_gated_out,
+        &mut scratch.linear_gated_s_first,
     )
     .map_err(|e| anyhow::anyhow!("tree layer {idx} gated transpose: {e}"))?;
 
@@ -7184,7 +7478,7 @@ fn prefill_tree_linear_attention_layer(
         tree_len,
         hidden_dim,
         val_dim,
-        &gated_s_first,
+        &scratch.linear_gated_s_first,
         &lw.out_proj_w,
         lw.out_proj_scale.as_ref(),
         lw.out_proj_int8_scale.as_ref(),

--- a/crates/runner/src/qwen35_dflash_engine.rs
+++ b/crates/runner/src/qwen35_dflash_engine.rs
@@ -45,8 +45,8 @@ use crate::prefill_engine::{PrefillAppendVerifyResult, PrefillTreeVerifyResult};
 use crate::registry::{FamilyParams, ModelVariant, RegistryEntry};
 use crate::Cli;
 
-const DDTREE_DEFAULT_BUDGET: usize = 22;
-const DDTREE_DEFAULT_TOP_K: usize = 8;
+const DDTREE_DEFAULT_BUDGET: usize = 14;
+const DDTREE_DEFAULT_TOP_K: usize = 4;
 
 #[derive(Debug, Clone)]
 struct DFlashDDTreeProbeConfig {
@@ -560,7 +560,7 @@ pub fn run_qwen35_dflash(
         // 8d. Accept check. Chain mode compares adjacent draft positions;
         // DDTree mode follows the target posterior through matching child
         // edges and commits that accepted branch path.
-        let (accept_n, carried_seed, mut committed_block, mut accepted_tree_indices) =
+        let (accept_n, mut carried_seed, mut committed_block, mut accepted_tree_indices) =
             match &verify_output {
                 DFlashVerifyOutput::Tree(tree_output) => {
                     let (indices, carried, _terminal_index) =
@@ -600,12 +600,12 @@ pub fn run_qwen35_dflash(
                 }
             };
 
-        let accepted_len = accept_n.min(remaining_budget);
+        let mut accepted_len = accept_n.min(remaining_budget);
         committed_block.truncate(accepted_len);
         if let Some(indices) = accepted_tree_indices.as_mut() {
             indices.truncate(accepted_len);
         }
-        let finish_after_commit = accepted_len >= remaining_budget
+        let mut finish_after_commit = accepted_len >= remaining_budget
             || (!cli.ignore_eos && committed_block.iter().any(|t| eos_ids.contains(t)));
         if trace_accept {
             eprintln!(
@@ -756,47 +756,78 @@ pub fn run_qwen35_dflash(
                             indices,
                         )?
                     } else {
-                        let append_result = target_engine.verify_block_prefill_append_captured(
-                            &committed_block,
-                            l,
-                            &tap_layers,
-                        )?;
+                        let append_result = if dflash_gpu_tap_history_enabled() {
+                            target_engine
+                                .verify_block_prefill_append_captured_lazy_acceptance_gpu_taps(
+                                    &committed_block,
+                                    l,
+                                    &tap_layers,
+                                    &mut tap_history_gpu,
+                                    tap_history_len,
+                                    per_tap_row_bytes,
+                                )?
+                        } else {
+                            target_engine.verify_block_prefill_append_captured_lazy_acceptance(
+                                &committed_block,
+                                l,
+                                &tap_layers,
+                            )?
+                        };
                         let append_next = append_result.target_next.as_ref().ok_or_else(|| {
                             anyhow!("append reverify did not return greedy target IDs")
                         })?;
-                        let append_seed = append_next
-                            .get(accepted_len - 1)
-                            .copied()
-                            .ok_or_else(|| anyhow!("append reverify returned no carried seed"))?;
-                        if append_seed != carried_seed {
-                            bail!(
-                                "DDTree carried seed mismatch after append reverify: tree={} append={}",
-                                carried_seed,
-                                append_seed
-                            );
+                        let (append_accept_len, append_seed) =
+                            append_reverify_accept_len(append_next, &committed_block)?;
+                        if append_accept_len != accepted_len || append_seed != carried_seed {
+                            if append_accept_len != accepted_len {
+                                eprintln!(
+                                    "[dflash-ddtree-verify] append reverify trimmed accept from {} \
+                                     to {} (tree_seed={} append_seed={})",
+                                    accepted_len, append_accept_len, carried_seed, append_seed
+                                );
+                            } else {
+                                eprintln!(
+                                    "[dflash-ddtree-verify] append reverify corrected carried seed \
+                                     at accept_len={} (tree_seed={} append_seed={})",
+                                    accepted_len, carried_seed, append_seed
+                                );
+                            }
+                            accepted_len = append_accept_len;
+                            committed_block.truncate(accepted_len);
+                            if let Some(indices) = accepted_tree_indices.as_mut() {
+                                indices.truncate(accepted_len);
+                            }
+                            carried_seed = append_seed;
+                            finish_after_commit = accepted_len >= remaining_budget
+                                || (!cli.ignore_eos
+                                    && committed_block.iter().any(|t| eos_ids.contains(t)));
                         }
                         target_engine.commit_prefill_append_verify(&append_result, accepted_len)?;
-                        let per_tap = append_result
-                            .tap_hiddens_all
-                            .as_ref()
-                            .ok_or_else(|| anyhow!("append reverify did not return tap history"))?;
-                        flatten_tap_history(per_tap, accepted_len, text_config.hidden_size)?
+                        if let Some(per_tap) = append_result.tap_hiddens_all.as_ref() {
+                            flatten_tap_history(per_tap, accepted_len, text_config.hidden_size)?
+                        } else if dflash_gpu_tap_history_enabled() {
+                            Vec::new()
+                        } else {
+                            bail!("append reverify did not return tap history");
+                        }
                     };
                     let expected_tap_bytes = accepted_len * per_tap_row_bytes;
-                    if taps_bytes.len() != expected_tap_bytes {
+                    if !taps_bytes.is_empty() && taps_bytes.len() != expected_tap_bytes {
                         bail!(
                             "tree verifier accepted tap gather returned {} tap bytes, expected {}",
                             taps_bytes.len(),
                             expected_tap_bytes,
                         );
                     }
-                    upload_taps_to_gpu_history(
-                        &mut tap_history_gpu,
-                        tap_history_len,
-                        per_tap_row_bytes,
-                        &taps_bytes,
-                    )?;
-                    tap_history.extend_from_slice(&taps_bytes);
+                    if !taps_bytes.is_empty() {
+                        upload_taps_to_gpu_history(
+                            &mut tap_history_gpu,
+                            tap_history_len,
+                            per_tap_row_bytes,
+                            &taps_bytes,
+                        )?;
+                        tap_history.extend_from_slice(&taps_bytes);
+                    }
                     tap_history_len += accepted_len;
                     next_bonus_seed = Some(carried_seed);
                     ms_rollback += t_rollback.elapsed().as_secs_f64() * 1000.0;
@@ -846,7 +877,7 @@ pub fn run_qwen35_dflash(
         // it samples. Without this, generation would keep rolling past
         // an EOS that appeared inside a speculative commit block.
         committed_len = l + accepted_len;
-        accepted_total += accept_n;
+        accepted_total += accepted_len;
         let mut hit_eos = false;
         for &t in committed_block.iter() {
             generated_ids.push(t);
@@ -1166,6 +1197,34 @@ fn chain_accept_needs_more(target_next: &[u32], tokens: &[u32], verify_len: usiz
         }
     }
     accept_n > target_next.len()
+}
+
+fn append_reverify_accept_len(
+    append_next: &[u32],
+    committed_block: &[u32],
+) -> Result<(usize, u32)> {
+    if committed_block.is_empty() {
+        bail!("append reverify committed block is empty");
+    }
+    let mut accept_n = 1usize;
+    while accept_n < committed_block.len() {
+        let pred = append_next.get(accept_n - 1).copied().ok_or_else(|| {
+            anyhow!(
+                "append reverify returned {} greedy IDs, insufficient for accept_n={accept_n} committed_len={}",
+                append_next.len(),
+                committed_block.len()
+            )
+        })?;
+        if pred != committed_block[accept_n] {
+            break;
+        }
+        accept_n += 1;
+    }
+    let carried_seed = append_next
+        .get(accept_n - 1)
+        .copied()
+        .ok_or_else(|| anyhow!("append reverify returned no carried seed"))?;
+    Ok((accept_n, carried_seed))
 }
 
 fn verify_block_prefill_append_windowed(
@@ -1841,7 +1900,10 @@ fn probe_ddtree_round(
 
 #[cfg(test)]
 mod tests {
-    use super::{chain_accept_needs_more, dflash_verify_len_for_round, dflash_window_step};
+    use super::{
+        append_reverify_accept_len, chain_accept_needs_more, dflash_verify_len_for_round,
+        dflash_window_step,
+    };
     use std::sync::{Mutex, OnceLock};
 
     fn env_lock() -> &'static Mutex<()> {
@@ -1930,5 +1992,35 @@ mod tests {
             &tokens,
             tokens.len()
         ));
+    }
+
+    #[test]
+    fn append_reverify_accept_len_keeps_full_match_seed() {
+        let committed = [10, 20, 30];
+        let append_next = [20, 30, 99];
+
+        assert_eq!(
+            append_reverify_accept_len(&append_next, &committed).unwrap(),
+            (3, 99)
+        );
+    }
+
+    #[test]
+    fn append_reverify_accept_len_trims_on_first_mismatch() {
+        let committed = [10, 20, 30, 40];
+        let append_next = [20, 31, 99, 100];
+
+        assert_eq!(
+            append_reverify_accept_len(&append_next, &committed).unwrap(),
+            (2, 31)
+        );
+    }
+
+    #[test]
+    fn append_reverify_accept_len_errors_when_seed_missing() {
+        let committed = [10, 20, 30];
+        let append_next = [20];
+
+        assert!(append_reverify_accept_len(&append_next, &committed).is_err());
     }
 }

--- a/docs/qwen36-lucebox-20pct-performance-guide.md
+++ b/docs/qwen36-lucebox-20pct-performance-guide.md
@@ -1,0 +1,416 @@
+# Qwen3.6 Lucebox +20% Performance Guide
+
+This guide defines the measurement and implementation path for getting
+SuperSonic's Qwen3.6-27B DFlash path to 20% above the current `main`
+baseline on the local RX 7900 XTX (`gfx1100`) machine.
+
+Current `main` already includes the merged PR #261 work. The important
+boundary is that baseline and profile data must be regenerated from current
+`main`, not read from stale local artifacts:
+
+```bash
+git log --oneline --decorate -8
+```
+
+The local `main` history currently includes:
+
+```text
+954e2dc Merge pull request #261 from DeanoC/codex/qwen36-dflash-verify-batch
+3e3a7ba Gate Q6_K MMQ lm_head by WMMA support
+cf165a8 Align Qwen3.6 DFlash with Lucebox
+```
+
+Older `target/qwen36_he_supersonic_*.json` files from before PR #261 must be
+treated as stale. In particular, runs that report `fused verify does not fit`
+and fall back to sequential target verify are useful historical breadcrumbs,
+not valid current baselines.
+
+## Target
+
+The optimization target is based on fresh current-`main` SuperSonic numbers:
+
+```text
+target_tok_s = current_main_mean_tok_s * 1.20
+```
+
+Use the full Lucebox HumanEval 10-prompt Qwen3.6-27B DFlash suite with
+`n_gen=256`. Report Lucebox separately as the reference comparison. Lucebox's
+top-level README advertises RX 7900 XTX HIP around `50 tok/s`, while
+`server/README.md` notes that `gfx1100` prefers DDTree `budget=8`. The local
+`server/docs/HIP_PERF_PLAN.md` says that budget shift lifted Lucebox's canonical
+gfx1100 run from `49.81 tok/s` to `76.02 tok/s`, so use the local Lucebox run
+as the source of truth before treating any static number as a hard target.
+
+Track these values in every report:
+
+- SuperSonic mean tok/s, min tok/s, max tok/s, and per-prompt rows.
+- Lucebox mean tok/s under the same machine state.
+- Acceptance length or accepted tokens per round.
+- `1.2x` target tok/s derived from the fresh SuperSonic baseline.
+- Whether prefill is excluded from decode tok/s.
+
+Do not accept a mean-only win if one or two prompts collapse. The follow-up PR
+needs prompt-level evidence.
+
+## Current Snapshot
+
+As of the first implementation pass after PR #261, direct DDTree rollback is no
+longer blocked by the old F32 recurrent-trace allocation failure. The tree path
+now uses the same compressed rollback trace policy as append rollback:
+
+- Default HIP trace dtype: Q8, unless `SUPERSONIC_DFLASH_DISABLE_Q8_ROLLBACK_TRACE`
+  is set.
+- Fallback HIP trace dtype: BF16, unless
+  `SUPERSONIC_DFLASH_DISABLE_BF16_ROLLBACK_TRACE` is set.
+- Debug fallback: F32 when both compressed trace modes are disabled.
+
+Fresh local result with direct DDTree rollback:
+
+```text
+file: target/qwen36_lucebox20/direct_q8_tree_10x256.json
+config: budget=8, top_k=8, direct_rollback=1, n_gen=256, 10 prompts
+mean: 32.18 tok/s
+min:  24.46 tok/s
+max:  43.07 tok/s
+target_1p2x: 38.62 tok/s
+```
+
+Current implementation result after the tree-verify speedup work:
+
+```text
+file: target/qwen36_lucebox20/tree_tiled_scratch_budget14_top4_chain_10x256.json
+config: budget=14, top_k=4, direct_rollback=1, chain_seed=on, n_gen=256, 10 prompts
+mean: 38.69 tok/s
+min:  27.64 tok/s
+max:  67.02 tok/s
+target_1p2x: 38.62 tok/s
+```
+
+Per-prompt result:
+
+| Prompt | tok/s |
+|---|---:|
+| has_close_elements | 35.83 |
+| separate_paren_groups | 24.46 |
+| truncate_number | 26.43 |
+| below_zero | 36.67 |
+| mean_absolute_deviation | 32.53 |
+| intersperse | 36.34 |
+| parse_nested_parens | 32.62 |
+| filter_by_substring | 29.13 |
+| sum_product | 43.07 |
+| rolling_max | 24.76 |
+
+The previous append-reverify fallback run at budget 8 completed only 8 of 10
+prompts and averaged about `5.26 tok/s`; it is no longer a useful performance
+baseline, though it remains a safety fallback. Direct rollback is now the
+required baseline mode for this guide.
+
+The internal profile for the direct run shows verify as the dominant component.
+Example rows:
+
+```text
+has_close_elements: rounds=42 mean_accepted_per_round=6.10
+  draft=855ms verify=6083ms rollback=140ms decode=7146ms
+rolling_max: rounds=61 mean_accepted_per_round=4.20
+  draft=1236ms verify=8830ms rollback=173ms decode=10338ms
+```
+
+The first implementation phase is therefore Track B: reduce tree verify cost
+and improve acceptance on low rows. The current `1.2x` target from this baseline
+is `38.62 tok/s`, before comparing against a fresh Lucebox run on the same
+machine state.
+
+## Baseline Measurement
+
+Start from a clean tree and rebuild the release binary:
+
+```bash
+cd /home/deano/projects/SuperSonicBase
+git status --short --branch
+HIP_ARCH=gfx1100 cargo build --release
+```
+
+Capture the machine state before performance runs:
+
+```bash
+cat profiles/gfx1100-baseline.json
+rocm-smi
+rocm-smi --showclocks --showpower --showtemp --showfan
+```
+
+Run the current-`main` SuperSonic baseline:
+
+```bash
+SUPERSONIC_DFLASH_DDTREE_VERIFY=1 \
+SUPERSONIC_DFLASH_DDTREE_BUDGET=14 \
+SUPERSONIC_DFLASH_DDTREE_TOP_K=4 \
+SUPERSONIC_DFLASH_DDTREE_DIRECT_ROLLBACK=1 \
+python3 tests/gfx1100/bench_qwen36_he_supersonic.py \
+  --binary target/release/supersonic \
+  --model qwen3.6-27b \
+  --model-dir /mnt/data/tmp/supersonic-qwen36-27b-lucebox \
+  --quant q4km \
+  --backend hip \
+  --context-size 512 \
+  --n-gen 256 \
+  --dflash \
+  --dflash-draft-dir /mnt/data/tmp/qwen36-27b-dflash-q8-bf16 \
+  --ignore-eos \
+  --out-json target/qwen36_lucebox20/current_main_supersonic_budget14_top4.json
+```
+
+If direct rollback fails, first check whether compressed rollback traces were
+disabled in the environment. A failure in direct mode is a correctness or memory
+regression; do not replace the baseline with append-reverify numbers without
+calling that out explicitly.
+
+Then run the Lucebox reference from the checked-out repo. Keep its model and
+draft paths matched to the SuperSonic run:
+
+```bash
+cd /home/deano/projects/lucebox-hub/server
+python3 scripts/bench_he.py \
+  --ddtree-budget 8 \
+  --n-gen 256
+```
+
+If Lucebox requires different local model arguments, record the exact command
+and explain the difference in the comparison notes. The comparison is only
+valid when prompt set, generation length, model quant, draft quant, backend, and
+thermal state are materially equivalent.
+
+## Sweep And Profile
+
+Run a narrow DDTree sweep first. Lucebox says `gfx1100` prefers budget 8, but
+SuperSonic's implementation should prove that locally:
+
+```bash
+mkdir -p target/qwen36_lucebox20
+for budget in 4 8 12 16 22 28 36; do
+  SUPERSONIC_DFLASH_DDTREE_VERIFY=1 \
+  SUPERSONIC_DFLASH_DDTREE_BUDGET="$budget" \
+  SUPERSONIC_DFLASH_DDTREE_TOP_K=8 \
+  SUPERSONIC_DFLASH_DDTREE_DIRECT_ROLLBACK=1 \
+  python3 tests/gfx1100/bench_qwen36_he_supersonic.py \
+    --binary target/release/supersonic \
+    --model qwen3.6-27b \
+    --model-dir /mnt/data/tmp/supersonic-qwen36-27b-lucebox \
+    --quant q4km \
+    --backend hip \
+    --context-size 512 \
+    --n-gen 256 \
+    --dflash \
+    --dflash-draft-dir /mnt/data/tmp/qwen36-27b-dflash-q8-bf16 \
+    --ignore-eos \
+    --out-json "target/qwen36_lucebox20/supersonic_budget${budget}.json"
+done
+```
+
+Repeat the best budget with `SUPERSONIC_DFLASH_DDTREE_TOP_K=4` and with
+`SUPERSONIC_DFLASH_DDTREE_DIRECT_ROLLBACK` unset. Keep whichever combination
+improves mean tok/s without hurting prompt-level acceptance.
+
+For the best candidate, collect SuperSonic's internal attribution:
+
+```bash
+SUPERSONIC_DFLASH_DDTREE_VERIFY=1 \
+SUPERSONIC_DFLASH_DDTREE_BUDGET=14 \
+SUPERSONIC_DFLASH_DDTREE_TOP_K=4 \
+SUPERSONIC_DFLASH_DDTREE_DIRECT_ROLLBACK=1 \
+SUPERSONIC_DFLASH_PROFILE_DRAFT=1 \
+SUPERSONIC_DFLASH_PROFILE_APPEND=1 \
+SUPERSONIC_DFLASH_PROFILE_VERIFY=1 \
+SUPERSONIC_DFLASH_PROFILE_FFI=1 \
+SUPERSONIC_DFLASH_TRACE_ACCEPT=1 \
+python3 tests/gfx1100/bench_qwen36_he_supersonic.py \
+  --binary target/release/supersonic \
+  --model qwen3.6-27b \
+  --model-dir /mnt/data/tmp/supersonic-qwen36-27b-lucebox \
+  --quant q4km \
+  --backend hip \
+  --context-size 512 \
+  --n-gen 256 \
+  --dflash \
+  --dflash-draft-dir /mnt/data/tmp/qwen36-27b-dflash-q8-bf16 \
+  --ignore-eos \
+  --tail-chars 12000 \
+  --out-json target/qwen36_lucebox20/supersonic_profile_best.json
+```
+
+Use `rocprofv3` for external attribution. Start with timeline-level evidence:
+
+```bash
+mkdir -p target/qwen36_lucebox20/rocprof
+export PATH="$PATH:/opt/rocm/bin"
+SUPERSONIC_DFLASH_DDTREE_VERIFY=1 \
+SUPERSONIC_DFLASH_DDTREE_BUDGET=14 \
+SUPERSONIC_DFLASH_DDTREE_TOP_K=4 \
+SUPERSONIC_DFLASH_DDTREE_DIRECT_ROLLBACK=1 \
+rocprofv3 \
+  --kernel-trace \
+  --memory-copy-trace \
+  --memory-allocation-trace \
+  --stats \
+  --summary \
+  --output-directory target/qwen36_lucebox20/rocprof \
+  --output-file supersonic_best \
+  --output-format csv json \
+  -- \
+  python3 tests/gfx1100/bench_qwen36_he_supersonic.py \
+    --binary target/release/supersonic \
+    --model qwen3.6-27b \
+    --model-dir /mnt/data/tmp/supersonic-qwen36-27b-lucebox \
+    --quant q4km \
+    --backend hip \
+    --context-size 512 \
+    --n-gen 256 \
+    --dflash \
+    --dflash-draft-dir /mnt/data/tmp/qwen36-27b-dflash-q8-bf16 \
+    --ignore-eos \
+    --limit 1 \
+    --out-json target/qwen36_lucebox20/supersonic_rocprof_one_prompt.json
+```
+
+After identifying the hottest kernels, run targeted counter passes with
+`rocprofv3 --pmc`. Keep counter sets small; ROCprofiler can fail if all
+counters cannot be collected in one pass. Use `rocprofv3 --list-avail` to see
+available counters on the installed ROCm stack.
+
+On this machine `rocprofv3` was not on `PATH` during the first implementation
+pass. Install or expose the ROCm profiler before treating the guide's profiling
+gate as complete.
+
+## Bottleneck Decisions
+
+Use the measurements to pick exactly one first implementation track.
+
+| Finding | First track |
+|---|---|
+| Acceptance length trails Lucebox at similar per-round cost | Tune DDTree budget, top-k, temperature, chain seed, and direct rollback. Compare per-prompt AL before touching kernels. |
+| Verify dominates decode time | Optimize `prefill_tree_verify`, tree rollback, visibility handling, and lm-head. Avoid reintroducing sequential verify. |
+| Draft dominates decode time | Profile draft attention, MLP, fuser, lm-head, and tap copies. Reduce kernel launches and memory traffic before changing algorithm shape. |
+| FFI, sync, allocation, or D2H time dominates | Remove per-round allocations, unnecessary `reset_sync` boundaries, and host transfers from the decode loop. |
+| One kernel dominates and counters show memory stalls | Improve coalescing, LDS use, and data layout; reduce redundant global reads. |
+| One kernel dominates and counters show low occupancy | Reduce register pressure, tune `__launch_bounds__`, reduce per-block shared memory, and check `hipcc --resource-usage`. |
+
+AMD's HIP performance guidance is the frame for kernel work:
+
+- Use roofline thinking to distinguish compute-bound, memory-bound, and
+  overhead-bound paths.
+- Hide latency with enough eligible waves and independent work.
+- Watch register pressure because excessive registers reduce occupancy.
+- Use `__launch_bounds__` and `hipcc --resource-usage` to control and inspect
+  register allocation.
+- Prefer block sizes that avoid partial waves on Radeon `gfx1100` wave32 paths.
+
+## Implementation Tracks
+
+### Track A: DDTree acceptance tuning
+
+Use this track when SuperSonic's per-prompt acceptance length is below Lucebox.
+
+Expected changes:
+
+- Keep the existing env-var surface stable:
+  `SUPERSONIC_DFLASH_DDTREE_VERIFY`,
+  `SUPERSONIC_DFLASH_DDTREE_BUDGET`,
+  `SUPERSONIC_DFLASH_DDTREE_TOP_K`,
+  `SUPERSONIC_DFLASH_DDTREE_TEMP`, and
+  `SUPERSONIC_DFLASH_DDTREE_DIRECT_ROLLBACK`.
+- Add new controls only if a measured experiment needs them and their default
+  behavior is off.
+- Promote the winning `gfx1100` default only after the 10-prompt suite shows
+  better mean tok/s and no prompt-level collapse.
+
+Acceptance:
+
+- Mean tok/s moves toward the `1.2x` target.
+- Per-prompt AL explains the improvement.
+- SuperSonic remains comparable to Lucebox on prompt set and generation length.
+
+### Track B: Tree verify and rollback cost
+
+Use this track when verify or rollback dominates the internal profile.
+
+Expected changes:
+
+- Keep tree verification batched. Do not fall back to sequential target verify.
+- Attribute `prefill_tree_verify` into full attention, linear attention, MLP,
+  lm-head, tap capture, rollback capture, and rollback apply.
+- Eliminate redundant visibility/parent processing if it is repeated per layer.
+- Reuse buffers across rounds; avoid per-round allocation and D2H transfers.
+- Compare append-reverify against direct tree rollback on the same prompt set.
+
+Acceptance:
+
+- Verify milliseconds per accepted token falls materially.
+- `SUPERSONIC_DFLASH_TRACE_ACCEPT=1` shows stable or improved acceptance.
+- Prompt-level outputs remain deterministic under greedy decode.
+
+### Track C: Draft forward cost
+
+Use this track when draft time is the largest remaining component.
+
+Expected changes:
+
+- Profile the draft fuser, attention, MLP, lm-head, argmax, tap copy, and tree
+  probe sections.
+- Reduce host-visible intermediate copies first.
+- Fuse or batch small draft-side kernels only after profiles show launch
+  overhead or memory traffic is material.
+
+Acceptance:
+
+- Draft milliseconds per round drops without reducing acceptance length.
+- No extra target-side work is added to hide a draft regression.
+
+### Track D: HIP kernel occupancy and memory path
+
+Use this track when `rocprofv3` counters point at one or two hot kernels.
+
+Expected changes:
+
+- Compile candidate kernels with resource reporting and record register/LDS
+  changes.
+- Tune launch bounds and block sizes for `gfx1100` wave32 behavior.
+- Move temporary per-thread arrays to shared memory only when it improves
+  occupancy and does not create a worse LDS bottleneck.
+- Improve coalescing and reduce redundant global memory reads before adding
+  more arithmetic.
+
+Acceptance:
+
+- The hot kernel improves in isolation and in the full 10-prompt suite.
+- No regression appears in existing HIP parity tests.
+
+## PR Gate
+
+A performance PR pursuing this guide is ready when it includes:
+
+- Fresh current-`main` baseline JSON.
+- Fresh Lucebox reference command and result.
+- DDTree sweep table.
+- Internal profile for the selected configuration.
+- `rocprofv3` trace or counter evidence for any kernel-level claim.
+- New result with mean tok/s at least `1.2x` the fresh SuperSonic baseline.
+- Per-prompt table showing no hidden collapse.
+- Correctness/parity tests for any changed verifier, rollback, or kernel code.
+
+If the PR does not hit `1.2x`, it can still land as an enabling optimization
+only if the report explains the new bottleneck and updates the next track.
+
+## References
+
+- SuperSonic DFlash reference: [dflash.md](dflash.md)
+- SuperSonic performance headline table: [performance.md](performance.md)
+- Lucebox local repo: `/home/deano/projects/lucebox-hub/README.md`
+- Lucebox AMD notes: `/home/deano/projects/lucebox-hub/server/README.md`
+- Lucebox gfx1100 HIP perf plan:
+  `/home/deano/projects/lucebox-hub/server/docs/HIP_PERF_PLAN.md`
+- AMD rocprofv3 usage:
+  <https://rocm.docs.amd.com/projects/rocprofiler-sdk/en/latest/how-to/using-rocprofv3.html>
+- AMD HIP performance optimization:
+  <https://rocm.docs.amd.com/projects/HIP/en/latest/understand/performance_optimization.html>
+- AMD HIP performance guidelines:
+  <https://rocm.docs.amd.com/projects/HIP/en/latest/how-to/performance_guidelines.html>

--- a/kernels/full_attention.hip
+++ b/kernels/full_attention.hip
@@ -502,6 +502,132 @@ __global__ void supersonic_qwen35_full_attention_tree_prefill_kernel(
     }
 }
 
+template <typename T, int BM, int BK>
+__global__ void supersonic_qwen35_full_attention_tree_prefill_tiled_kernel(
+    int batch_size,
+    int q_heads,
+    int kv_heads,
+    int tree_len,
+    int prefix_len,
+    int head_dim,
+    int num_kv_groups,
+    float scale,
+    const T* query,
+    const T* prefix_key,
+    const T* prefix_value,
+    const T* tree_key,
+    const T* tree_value,
+    const uint8_t* visibility,
+    float* out
+) {
+    constexpr int ACC_MAX = 8;
+
+    const int qr_base = blockIdx.x * BM;
+    const int qh = blockIdx.y;
+    const int batch = blockIdx.z;
+    const int kv_h = qh / num_kv_groups;
+    const int warp_y = threadIdx.y;
+    const int lane = threadIdx.x;
+    const int qr = qr_base + warp_y;
+    if (lane >= warpSize) return;
+    if (batch >= batch_size || qh >= q_heads) return;
+
+    extern __shared__ unsigned char smem_raw[];
+    T* k_tile = reinterpret_cast<T*>(smem_raw);
+    T* v_tile = k_tile + BK * head_dim;
+
+    const bool active = (qr < tree_len);
+    const T* q_row = active ? (query + (((batch * q_heads + qh) * tree_len + qr) * head_dim)) : nullptr;
+    const T* prefix_k_head = prefix_key + ((batch * kv_heads + kv_h) * prefix_len * head_dim);
+    const T* prefix_v_head = prefix_value + ((batch * kv_heads + kv_h) * prefix_len * head_dim);
+    const T* tree_k_head = tree_key + ((batch * kv_heads + kv_h) * tree_len * head_dim);
+    const T* tree_v_head = tree_value + ((batch * kv_heads + kv_h) * tree_len * head_dim);
+    float* out_row = active ? (out + (((batch * q_heads + qh) * tree_len + qr) * head_dim)) : nullptr;
+
+    float acc[ACC_MAX];
+    int acc_dim[ACC_MAX];
+    int acc_count = 0;
+    #pragma unroll
+    for (int i = 0; i < ACC_MAX; ++i) acc[i] = 0.0f;
+    for (int d = lane; d < head_dim && acc_count < ACC_MAX; d += warpSize) {
+        acc_dim[acc_count++] = d;
+    }
+
+    float m_i = -INFINITY;
+    float l_i = 0.0f;
+
+    for (int tile_base = 0; tile_base < prefix_len; tile_base += BK) {
+        const int tile_len = min(BK, prefix_len - tile_base);
+        const int load_total = tile_len * head_dim;
+        const int total_threads = BM * warpSize;
+        const int linear_tid = warp_y * warpSize + lane;
+        for (int i = linear_tid; i < load_total; i += total_threads) {
+            const int row = i / head_dim;
+            const int col = i - row * head_dim;
+            const int k_pos = tile_base + row;
+            const size_t off = static_cast<size_t>(k_pos) * head_dim + static_cast<size_t>(col);
+            k_tile[i] = prefix_k_head[off];
+            v_tile[i] = prefix_v_head[off];
+        }
+        __syncthreads();
+
+        if (active) {
+            for (int j = 0; j < tile_len; ++j) {
+                const T* k_row = k_tile + j * head_dim;
+                const T* v_row = v_tile + j * head_dim;
+
+                float partial = 0.0f;
+                for (int d = lane; d < head_dim; d += warpSize) {
+                    partial += supersonic_qwen35_to_float(q_row[d]) * supersonic_qwen35_to_float(k_row[d]);
+                }
+                const float score = __shfl(supersonic_qwen35_wave_sum(partial), 0) * scale;
+                const float m_old = m_i;
+                const float m_new = score > m_old ? score : m_old;
+                const float alpha = (m_old == -INFINITY) ? 0.0f : expf(m_old - m_new);
+                const float weight = expf(score - m_new);
+                l_i = l_i * alpha + weight;
+                m_i = m_new;
+
+                for (int i = 0; i < acc_count; ++i) {
+                    acc[i] = acc[i] * alpha + weight * supersonic_qwen35_to_float(v_row[acc_dim[i]]);
+                }
+            }
+        }
+        __syncthreads();
+    }
+
+    if (active) {
+        for (int k_pos = 0; k_pos < tree_len; ++k_pos) {
+            if (visibility[qr * tree_len + k_pos] == 0) {
+                continue;
+            }
+            const T* k_row = tree_k_head + k_pos * head_dim;
+            const T* v_row = tree_v_head + k_pos * head_dim;
+
+            float partial = 0.0f;
+            for (int d = lane; d < head_dim; d += warpSize) {
+                partial += supersonic_qwen35_to_float(q_row[d]) * supersonic_qwen35_to_float(k_row[d]);
+            }
+            const float score = __shfl(supersonic_qwen35_wave_sum(partial), 0) * scale;
+            const float m_old = m_i;
+            const float m_new = score > m_old ? score : m_old;
+            const float alpha = (m_old == -INFINITY) ? 0.0f : expf(m_old - m_new);
+            const float weight = expf(score - m_new);
+            l_i = l_i * alpha + weight;
+            m_i = m_new;
+
+            for (int i = 0; i < acc_count; ++i) {
+                acc[i] = acc[i] * alpha + weight * supersonic_qwen35_to_float(v_row[acc_dim[i]]);
+            }
+        }
+
+        const float inv = (l_i > 0.0f) ? (1.0f / l_i) : 0.0f;
+        for (int i = 0; i < acc_count; ++i) {
+            out_row[acc_dim[i]] = acc[i] * inv;
+        }
+    }
+}
+
 // Stage 3: K-tiled FlashAttention-style prefill attention.
 //
 // Grid:  (ceil(q_len / BM), q_heads, batch)
@@ -1726,6 +1852,151 @@ void supersonic_qwen35_delta_recurrent_tree_prefill_capture_f32_k128_kernel(
     out[state_out + k_idx * V + v_idx] = last_state;
 }
 
+__global__ __launch_bounds__(128, 2)
+void supersonic_qwen35_delta_recurrent_tree_prefill_capture_bf16_trace_transposed_f32_k128_kernel(
+    int batch_heads,
+    int seq_len,
+    const float* __restrict__ initial_state,
+    const float* __restrict__ query,
+    const float* __restrict__ key,
+    const float* __restrict__ value,
+    const float* __restrict__ beta,
+    const float* __restrict__ g,
+    const int* __restrict__ parent_ids,
+    float* __restrict__ out,
+    hip_bfloat16* __restrict__ state_trace
+) {
+    constexpr int K = 128;
+    constexpr int V = 128;
+    const int k_idx = threadIdx.x;
+    const int v_idx = blockIdx.x;
+    const int bh = blockIdx.y;
+
+    __shared__ float reduce_smem[K];
+
+    const int state_stride = K * V;
+    const int token_stride_k = seq_len * K;
+    const int token_stride_v = seq_len * V;
+    const int token_stride_s = seq_len;
+    const int out_base = bh * (seq_len + K) * V;
+
+    float last_state = initial_state[bh * state_stride + k_idx * V + v_idx];
+    for (int t = 0; t < seq_len; ++t) {
+        const int parent = parent_ids[t];
+        float state = parent < 0
+            ? initial_state[bh * state_stride + k_idx * V + v_idx]
+            : static_cast<float>(state_trace[((bh * seq_len + parent) * V + v_idx) * K + k_idx]);
+
+        const int key_row = bh * token_stride_k + t * K;
+        const int value_row = bh * token_stride_v + t * V;
+        const int beta_row = bh * token_stride_s + t;
+        const float g_t = expf(g[beta_row]);
+        const float k_t = key[key_row + k_idx];
+
+        state *= g_t;
+        const float kv_mem = supersonic_qwen35_block_sum_128_wave(state * k_t, reduce_smem);
+        const float delta = (value[value_row + v_idx] - kv_mem) * beta[beta_row];
+
+        state += k_t * delta;
+        state_trace[((bh * seq_len + t) * V + v_idx) * K + k_idx] =
+            supersonic_qwen35_from_float<hip_bfloat16>(state);
+        last_state = state;
+
+        const float out_t =
+            supersonic_qwen35_block_sum_128_wave(state * query[key_row + k_idx], reduce_smem);
+        if (k_idx == 0) {
+            out[out_base + t * V + v_idx] = out_t;
+        }
+    }
+
+    const int state_out = out_base + seq_len * V;
+    out[state_out + k_idx * V + v_idx] = last_state;
+}
+
+__global__ __launch_bounds__(128, 2)
+void supersonic_qwen35_delta_recurrent_tree_prefill_capture_q8_trace_transposed_f32_k128_kernel(
+    int batch_heads,
+    int seq_len,
+    const float* __restrict__ initial_state,
+    const float* __restrict__ query,
+    const float* __restrict__ key,
+    const float* __restrict__ value,
+    const float* __restrict__ beta,
+    const float* __restrict__ g,
+    const int* __restrict__ parent_ids,
+    float* __restrict__ out,
+    uint8_t* __restrict__ state_trace
+) {
+    constexpr int K = 128;
+    constexpr int V = 128;
+    constexpr int QK8_0 = 32;
+    constexpr int Q8_0_BLOCK_BYTES = 34;
+    const int k_idx = threadIdx.x;
+    const int v_idx = blockIdx.x;
+    const int bh = blockIdx.y;
+    const int q8_block = k_idx / QK8_0;
+    const int q8_lane = k_idx - q8_block * QK8_0;
+
+    __shared__ float reduce_smem[K];
+
+    const int state_stride = K * V;
+    const int token_stride_k = seq_len * K;
+    const int token_stride_v = seq_len * V;
+    const int token_stride_s = seq_len;
+    const int out_base = bh * (seq_len + K) * V;
+
+    float last_state = initial_state[bh * state_stride + k_idx * V + v_idx];
+    for (int t = 0; t < seq_len; ++t) {
+        const int parent = parent_ids[t];
+        float state;
+        if (parent < 0) {
+            state = initial_state[bh * state_stride + k_idx * V + v_idx];
+        } else {
+            const int parent_base =
+                (((bh * seq_len + parent) * V + v_idx) * (K / QK8_0) + q8_block) * Q8_0_BLOCK_BYTES;
+            const half d_half = qwen35_load_q8_0_block_scale(state_trace + parent_base);
+            const int8_t q = static_cast<int8_t>(state_trace[parent_base + 2 + q8_lane]);
+            state = static_cast<float>(q) * __half2float(d_half);
+        }
+
+        const int key_row = bh * token_stride_k + t * K;
+        const int value_row = bh * token_stride_v + t * V;
+        const int beta_row = bh * token_stride_s + t;
+        const float g_t = expf(g[beta_row]);
+        const float k_t = key[key_row + k_idx];
+
+        state *= g_t;
+        const float kv_mem = supersonic_qwen35_block_sum_128_wave(state * k_t, reduce_smem);
+        const float delta = (value[value_row + v_idx] - kv_mem) * beta[beta_row];
+
+        state += k_t * delta;
+
+        float amax = fabsf(state);
+        for (int offset = 16; offset > 0; offset >>= 1) {
+            amax = fmaxf(amax, __shfl_xor(amax, offset));
+        }
+        const float d = amax / 127.0f;
+        const float id = d == 0.0f ? 0.0f : 1.0f / d;
+        const int q = static_cast<int>(roundf(state * id));
+        const int row_base =
+            (((bh * seq_len + t) * V + v_idx) * (K / QK8_0) + q8_block) * Q8_0_BLOCK_BYTES;
+        if (q8_lane == 0) {
+            qwen35_store_q8_0_block_scale(state_trace + row_base, __float2half(d));
+        }
+        state_trace[row_base + 2 + q8_lane] = static_cast<uint8_t>(static_cast<int8_t>(q));
+        last_state = state;
+
+        const float out_t =
+            supersonic_qwen35_block_sum_128_wave(state * query[key_row + k_idx], reduce_smem);
+        if (k_idx == 0) {
+            out[out_base + t * V + v_idx] = out_t;
+        }
+    }
+
+    const int state_out = out_base + seq_len * V;
+    out[state_out + k_idx * V + v_idx] = last_state;
+}
+
 template <typename T>
 __global__ void supersonic_qwen35_dflash_apply_rollback_kernel(
     int qkv_dim,
@@ -1920,6 +2191,110 @@ __global__ void supersonic_qwen35_dflash_apply_tree_rollback_kernel(
         if (accepted_idx < static_cast<uint32_t>(tree_len)) {
             recurrent_state[idx] =
                 recurrent_trace[(h * tree_len + static_cast<int>(accepted_idx)) * rec_head_elems + rem];
+        }
+    }
+}
+
+template <typename T>
+__global__ void supersonic_qwen35_dflash_apply_tree_rollback_bf16_trace_kernel(
+    int qkv_dim,
+    int conv_state_len,
+    int conv_input_len,
+    int tree_len,
+    int commit_len,
+    int num_v_heads,
+    int head_k_dim,
+    int head_v_dim,
+    const T* conv_input,
+    const uint32_t* accepted_indices,
+    T* conv_state,
+    const hip_bfloat16* recurrent_trace,
+    float* recurrent_state
+) {
+    const int idx = static_cast<int>(blockIdx.x * blockDim.x + threadIdx.x);
+    const int conv_total = qkv_dim * conv_state_len;
+    const int rec_head_elems = head_k_dim * head_v_dim;
+    const int rec_total = num_v_heads * rec_head_elems;
+
+    if (idx < conv_total) {
+        const int ch = idx / conv_state_len;
+        const int tap = idx - ch * conv_state_len;
+        const int logical = commit_len + tap - conv_state_len;
+        int src_col = commit_len + tap;
+        if (logical >= 0) {
+            const uint32_t node = accepted_indices[logical];
+            src_col = conv_state_len + static_cast<int>(node);
+        }
+        if (src_col >= 0 && src_col < conv_input_len) {
+            conv_state[idx] = conv_input[ch * conv_input_len + src_col];
+        }
+    }
+
+    if (idx < rec_total) {
+        const int h = idx / rec_head_elems;
+        const int rem = idx - h * rec_head_elems;
+        const int k = rem / head_v_dim;
+        const int v = rem - k * head_v_dim;
+        const uint32_t accepted_idx = accepted_indices[commit_len - 1];
+        if (accepted_idx < static_cast<uint32_t>(tree_len)) {
+            recurrent_state[idx] = static_cast<float>(
+                recurrent_trace[((h * tree_len + static_cast<int>(accepted_idx)) * head_v_dim + v) * head_k_dim + k]);
+        }
+    }
+}
+
+template <typename T>
+__global__ void supersonic_qwen35_dflash_apply_tree_rollback_q8_trace_kernel(
+    int qkv_dim,
+    int conv_state_len,
+    int conv_input_len,
+    int tree_len,
+    int commit_len,
+    int num_v_heads,
+    int head_k_dim,
+    int head_v_dim,
+    const T* conv_input,
+    const uint32_t* accepted_indices,
+    T* conv_state,
+    const uint8_t* recurrent_trace,
+    float* recurrent_state
+) {
+    constexpr int QK8_0 = 32;
+    constexpr int Q8_0_BLOCK_BYTES = 34;
+    const int idx = static_cast<int>(blockIdx.x * blockDim.x + threadIdx.x);
+    const int conv_total = qkv_dim * conv_state_len;
+    const int rec_head_elems = head_k_dim * head_v_dim;
+    const int rec_total = num_v_heads * rec_head_elems;
+
+    if (idx < conv_total) {
+        const int ch = idx / conv_state_len;
+        const int tap = idx - ch * conv_state_len;
+        const int logical = commit_len + tap - conv_state_len;
+        int src_col = commit_len + tap;
+        if (logical >= 0) {
+            const uint32_t node = accepted_indices[logical];
+            src_col = conv_state_len + static_cast<int>(node);
+        }
+        if (src_col >= 0 && src_col < conv_input_len) {
+            conv_state[idx] = conv_input[ch * conv_input_len + src_col];
+        }
+    }
+
+    if (idx < rec_total) {
+        const int h = idx / rec_head_elems;
+        const int rem = idx - h * rec_head_elems;
+        const int k = rem / head_v_dim;
+        const int v = rem - k * head_v_dim;
+        const uint32_t accepted_idx = accepted_indices[commit_len - 1];
+        if (accepted_idx < static_cast<uint32_t>(tree_len)) {
+            const int q8_block = k / QK8_0;
+            const int q8_lane = k - q8_block * QK8_0;
+            const int row_base =
+                (((h * tree_len + static_cast<int>(accepted_idx)) * head_v_dim + v) * (head_k_dim / QK8_0)
+                 + q8_block) * Q8_0_BLOCK_BYTES;
+            const half d_half = qwen35_load_q8_0_block_scale(recurrent_trace + row_base);
+            const int8_t q = static_cast<int8_t>(recurrent_trace[row_base + 2 + q8_lane]);
+            recurrent_state[idx] = static_cast<float>(q) * __half2float(d_half);
         }
     }
 }

--- a/kernels/full_attention_bridge.cpp
+++ b/kernels/full_attention_bridge.cpp
@@ -204,6 +204,88 @@ int full_attention_tree_prefill_device(
     return 0;
 }
 
+template <typename T, int BM, int BK>
+static int launch_tree_tiled(
+    int batch_size, int q_heads, int kv_heads,
+    int tree_len, int prefix_len, int head_dim, int num_kv_groups,
+    float scale,
+    const void* query,
+    const void* prefix_key,
+    const void* prefix_value,
+    const void* tree_key,
+    const void* tree_value,
+    const void* visibility,
+    void* out
+) {
+    const int grid_x = (tree_len + BM - 1) / BM;
+    dim3 grid(grid_x, q_heads, batch_size);
+    dim3 block(32, BM, 1);
+    const size_t lds_bytes = static_cast<size_t>(2) * BK * head_dim * sizeof(T);
+    if (lds_bytes > 48 * 1024) return 143;
+    hipLaunchKernelGGL(
+        HIP_KERNEL_NAME(supersonic_qwen35_full_attention_tree_prefill_tiled_kernel<T, BM, BK>),
+        grid, block, lds_bytes, 0,
+        batch_size, q_heads, kv_heads, tree_len, prefix_len, head_dim,
+        num_kv_groups, scale,
+        static_cast<const T*>(query),
+        static_cast<const T*>(prefix_key),
+        static_cast<const T*>(prefix_value),
+        static_cast<const T*>(tree_key),
+        static_cast<const T*>(tree_value),
+        static_cast<const uint8_t*>(visibility),
+        static_cast<float*>(out));
+    if (hipGetLastError() != hipSuccess) return 144;
+    if (hipDeviceSynchronize() != hipSuccess) return 145;
+    return 0;
+}
+
+template <typename T>
+int full_attention_tree_prefill_tiled_device(
+    int device_ordinal,
+    int batch_size,
+    int q_heads,
+    int kv_heads,
+    int tree_len,
+    int prefix_len,
+    int head_dim,
+    int num_kv_groups,
+    float scale,
+    const void* query,
+    const void* prefix_key,
+    const void* prefix_value,
+    const void* tree_key,
+    const void* tree_value,
+    const void* visibility,
+    void* out
+) {
+    constexpr int BM = 4;
+    if (head_dim > 8 * 32) return 142;
+    if (tree_len <= 0) return 0;
+
+    ScopedHipDevice scoped(device_ordinal);
+
+    hipDeviceProp_t props;
+    if (hipGetDeviceProperties(&props, device_ordinal) != hipSuccess) return 146;
+    if (props.warpSize != 32) return 147;
+
+    if (head_dim <= 64) {
+        return launch_tree_tiled<T, BM, 128>(
+            batch_size, q_heads, kv_heads, tree_len, prefix_len, head_dim,
+            num_kv_groups, scale, query, prefix_key, prefix_value,
+            tree_key, tree_value, visibility, out);
+    } else if (head_dim <= 128) {
+        return launch_tree_tiled<T, BM, 64>(
+            batch_size, q_heads, kv_heads, tree_len, prefix_len, head_dim,
+            num_kv_groups, scale, query, prefix_key, prefix_value,
+            tree_key, tree_value, visibility, out);
+    } else {
+        return launch_tree_tiled<T, BM, 32>(
+            batch_size, q_heads, kv_heads, tree_len, prefix_len, head_dim,
+            num_kv_groups, scale, query, prefix_key, prefix_value,
+            tree_key, tree_value, visibility, out);
+    }
+}
+
 // Dispatch the K-tiled kernel with the right BK template instantiation for
 // the given head_dim. BK is picked to keep LDS (= 2 * BK * head_dim * sizeof(T))
 // under the 48 KiB safety cap on RDNA3:
@@ -836,6 +918,84 @@ int delta_recurrent_tree_prefill_capture_f32_k128_device(
     return 0;
 }
 
+int delta_recurrent_tree_prefill_capture_bf16_trace_f32_k128_device(
+    int device_ordinal,
+    int batch_heads,
+    int seq_len,
+    const void* initial_state,
+    const void* query,
+    const void* key,
+    const void* value,
+    const void* beta,
+    const void* g,
+    const void* parent_ids,
+    void* out,
+    void* state_trace
+) {
+    ScopedHipDevice scoped(device_ordinal);
+    if (parent_ids == nullptr || state_trace == nullptr) return 69;
+    constexpr int threads = 128;
+    hipLaunchKernelGGL(
+        supersonic_qwen35_delta_recurrent_tree_prefill_capture_bf16_trace_transposed_f32_k128_kernel,
+        dim3(128, batch_heads),
+        dim3(threads),
+        0,
+        0,
+        batch_heads,
+        seq_len,
+        static_cast<const float*>(initial_state),
+        static_cast<const float*>(query),
+        static_cast<const float*>(key),
+        static_cast<const float*>(value),
+        static_cast<const float*>(beta),
+        static_cast<const float*>(g),
+        static_cast<const int*>(parent_ids),
+        static_cast<float*>(out),
+        static_cast<hip_bfloat16*>(state_trace));
+    if (hipGetLastError() != hipSuccess) return 67;
+    if (maybe_sync() != hipSuccess) return 68;
+    return 0;
+}
+
+int delta_recurrent_tree_prefill_capture_q8_trace_f32_k128_device(
+    int device_ordinal,
+    int batch_heads,
+    int seq_len,
+    const void* initial_state,
+    const void* query,
+    const void* key,
+    const void* value,
+    const void* beta,
+    const void* g,
+    const void* parent_ids,
+    void* out,
+    void* state_trace
+) {
+    ScopedHipDevice scoped(device_ordinal);
+    if (parent_ids == nullptr || state_trace == nullptr) return 69;
+    constexpr int threads = 128;
+    hipLaunchKernelGGL(
+        supersonic_qwen35_delta_recurrent_tree_prefill_capture_q8_trace_transposed_f32_k128_kernel,
+        dim3(128, batch_heads),
+        dim3(threads),
+        0,
+        0,
+        batch_heads,
+        seq_len,
+        static_cast<const float*>(initial_state),
+        static_cast<const float*>(query),
+        static_cast<const float*>(key),
+        static_cast<const float*>(value),
+        static_cast<const float*>(beta),
+        static_cast<const float*>(g),
+        static_cast<const int*>(parent_ids),
+        static_cast<float*>(out),
+        static_cast<uint8_t*>(state_trace));
+    if (hipGetLastError() != hipSuccess) return 67;
+    if (maybe_sync() != hipSuccess) return 68;
+    return 0;
+}
+
 template <typename T>
 int dflash_apply_rollback_device(
     int device_ordinal,
@@ -1041,6 +1201,105 @@ int dflash_apply_tree_rollback_device(
         static_cast<const uint32_t*>(accepted_indices),
         static_cast<T*>(conv_state),
         static_cast<const float*>(recurrent_trace),
+        static_cast<float*>(recurrent_state));
+    if (hipGetLastError() != hipSuccess) return 74;
+    if (maybe_sync() != hipSuccess) return 75;
+    return 0;
+}
+
+template <typename T>
+int dflash_apply_tree_rollback_bf16_trace_device(
+    int device_ordinal,
+    int qkv_dim,
+    int conv_state_len,
+    int conv_input_len,
+    int tree_len,
+    int commit_len,
+    int num_v_heads,
+    int head_k_dim,
+    int head_v_dim,
+    const void* conv_input,
+    const void* accepted_indices,
+    void* conv_state,
+    const void* recurrent_trace,
+    void* recurrent_state
+) {
+    ScopedHipDevice scoped(device_ordinal);
+    if (commit_len <= 0 || commit_len > tree_len) return 73;
+    if (conv_input_len < conv_state_len + tree_len) return 76;
+    const int conv_total = qkv_dim * conv_state_len;
+    const int rec_total = num_v_heads * head_k_dim * head_v_dim;
+    const int total = conv_total > rec_total ? conv_total : rec_total;
+    constexpr int block = 256;
+    const unsigned int grid = static_cast<unsigned int>((total + block - 1) / block);
+    hipLaunchKernelGGL(
+        HIP_KERNEL_NAME(supersonic_qwen35_dflash_apply_tree_rollback_bf16_trace_kernel<T>),
+        dim3(grid),
+        dim3(block),
+        0,
+        0,
+        qkv_dim,
+        conv_state_len,
+        conv_input_len,
+        tree_len,
+        commit_len,
+        num_v_heads,
+        head_k_dim,
+        head_v_dim,
+        static_cast<const T*>(conv_input),
+        static_cast<const uint32_t*>(accepted_indices),
+        static_cast<T*>(conv_state),
+        static_cast<const hip_bfloat16*>(recurrent_trace),
+        static_cast<float*>(recurrent_state));
+    if (hipGetLastError() != hipSuccess) return 74;
+    if (maybe_sync() != hipSuccess) return 75;
+    return 0;
+}
+
+template <typename T>
+int dflash_apply_tree_rollback_q8_trace_device(
+    int device_ordinal,
+    int qkv_dim,
+    int conv_state_len,
+    int conv_input_len,
+    int tree_len,
+    int commit_len,
+    int num_v_heads,
+    int head_k_dim,
+    int head_v_dim,
+    const void* conv_input,
+    const void* accepted_indices,
+    void* conv_state,
+    const void* recurrent_trace,
+    void* recurrent_state
+) {
+    ScopedHipDevice scoped(device_ordinal);
+    if (commit_len <= 0 || commit_len > tree_len) return 73;
+    if (conv_input_len < conv_state_len + tree_len) return 76;
+    if (head_k_dim % 32 != 0) return 77;
+    const int conv_total = qkv_dim * conv_state_len;
+    const int rec_total = num_v_heads * head_k_dim * head_v_dim;
+    const int total = conv_total > rec_total ? conv_total : rec_total;
+    constexpr int block = 256;
+    const unsigned int grid = static_cast<unsigned int>((total + block - 1) / block);
+    hipLaunchKernelGGL(
+        HIP_KERNEL_NAME(supersonic_qwen35_dflash_apply_tree_rollback_q8_trace_kernel<T>),
+        dim3(grid),
+        dim3(block),
+        0,
+        0,
+        qkv_dim,
+        conv_state_len,
+        conv_input_len,
+        tree_len,
+        commit_len,
+        num_v_heads,
+        head_k_dim,
+        head_v_dim,
+        static_cast<const T*>(conv_input),
+        static_cast<const uint32_t*>(accepted_indices),
+        static_cast<T*>(conv_state),
+        static_cast<const uint8_t*>(recurrent_trace),
         static_cast<float*>(recurrent_state));
     if (hipGetLastError() != hipSuccess) return 74;
     if (maybe_sync() != hipSuccess) return 75;
@@ -2697,6 +2956,37 @@ extern "C" int supersonic_qwen35_hip_full_attention_tree_prefill(
     const void* tree_value,
     const void* visibility,
     void* out) {
+
+    // Default: use the tree K-tiled FlashAttention-style kernel for BF16.
+    // It shares prefix K/V tile loads across several tree queries in a block,
+    // while preserving the legacy prefix-then-tree online softmax order.
+    // SUPERSONIC_DFLASH_TREE_ATTN_TILED=0 forces the legacy single-warp path.
+    static const bool disable_tiled = []{
+        const char* e = std::getenv("SUPERSONIC_DFLASH_TREE_ATTN_TILED");
+        return e != nullptr && e[0] == '0';
+    }();
+
+    if (!disable_tiled && dtype == 2) {
+        int rc = full_attention_tree_prefill_tiled_device<hip_bfloat16>(
+            static_cast<int>(device_ordinal),
+            static_cast<int>(batch_size),
+            static_cast<int>(q_heads),
+            static_cast<int>(kv_heads),
+            static_cast<int>(tree_len),
+            static_cast<int>(prefix_len),
+            static_cast<int>(head_dim),
+            static_cast<int>(num_kv_groups),
+            scale,
+            query,
+            prefix_key,
+            prefix_value,
+            tree_key,
+            tree_value,
+            visibility,
+            out);
+        if (rc == 0) return 0;
+    }
+
     switch (dtype) {
     case 0:
         return full_attention_tree_prefill_device<half>(
@@ -3161,6 +3451,74 @@ extern "C" int supersonic_qwen35_hip_delta_recurrent_tree_prefill_capture(
         state_trace);
 }
 
+extern "C" int supersonic_qwen35_hip_delta_recurrent_tree_prefill_capture_bf16_trace(
+    int dtype,
+    size_t device_ordinal,
+    size_t batch_heads,
+    size_t seq_len,
+    size_t k_head_dim,
+    size_t v_head_dim,
+    const void* initial_state,
+    const void* query,
+    const void* key,
+    const void* value,
+    const void* beta,
+    const void* g,
+    const void* parent_ids,
+    void* out,
+    void* state_trace) {
+    if (dtype != 1 || k_head_dim != 128 || v_head_dim != 128) {
+        return 66;
+    }
+    return delta_recurrent_tree_prefill_capture_bf16_trace_f32_k128_device(
+        static_cast<int>(device_ordinal),
+        static_cast<int>(batch_heads),
+        static_cast<int>(seq_len),
+        initial_state,
+        query,
+        key,
+        value,
+        beta,
+        g,
+        parent_ids,
+        out,
+        state_trace);
+}
+
+extern "C" int supersonic_qwen35_hip_delta_recurrent_tree_prefill_capture_q8_trace(
+    int dtype,
+    size_t device_ordinal,
+    size_t batch_heads,
+    size_t seq_len,
+    size_t k_head_dim,
+    size_t v_head_dim,
+    const void* initial_state,
+    const void* query,
+    const void* key,
+    const void* value,
+    const void* beta,
+    const void* g,
+    const void* parent_ids,
+    void* out,
+    void* state_trace) {
+    if (dtype != 1 || k_head_dim != 128 || v_head_dim != 128 || k_head_dim % 32 != 0) {
+        return 66;
+    }
+    return delta_recurrent_tree_prefill_capture_q8_trace_f32_k128_device(
+        static_cast<int>(device_ordinal),
+        static_cast<int>(batch_heads),
+        static_cast<int>(seq_len),
+        initial_state,
+        query,
+        key,
+        value,
+        beta,
+        g,
+        parent_ids,
+        out,
+        state_trace);
+}
+
 extern "C" int supersonic_qwen35_hip_dflash_apply_rollback(
     int dtype,
     size_t device_ordinal,
@@ -3410,6 +3768,146 @@ extern "C" int supersonic_qwen35_hip_dflash_apply_tree_rollback(
             recurrent_state);
     case 2:
         return dflash_apply_tree_rollback_device<hip_bfloat16>(
+            static_cast<int>(device_ordinal),
+            static_cast<int>(qkv_dim),
+            static_cast<int>(conv_state_len),
+            static_cast<int>(conv_input_len),
+            static_cast<int>(tree_len),
+            static_cast<int>(commit_len),
+            static_cast<int>(num_v_heads),
+            static_cast<int>(head_k_dim),
+            static_cast<int>(head_v_dim),
+            conv_input,
+            accepted_indices,
+            conv_state,
+            recurrent_trace,
+            recurrent_state);
+    default:
+        return 66;
+    }
+}
+
+extern "C" int supersonic_qwen35_hip_dflash_apply_tree_rollback_bf16_trace(
+    int dtype,
+    size_t device_ordinal,
+    size_t qkv_dim,
+    size_t conv_state_len,
+    size_t conv_input_len,
+    size_t tree_len,
+    size_t commit_len,
+    size_t num_v_heads,
+    size_t head_k_dim,
+    size_t head_v_dim,
+    const void* conv_input,
+    const void* accepted_indices,
+    void* conv_state,
+    const void* recurrent_trace,
+    void* recurrent_state) {
+    switch (dtype) {
+    case 0:
+        return dflash_apply_tree_rollback_bf16_trace_device<half>(
+            static_cast<int>(device_ordinal),
+            static_cast<int>(qkv_dim),
+            static_cast<int>(conv_state_len),
+            static_cast<int>(conv_input_len),
+            static_cast<int>(tree_len),
+            static_cast<int>(commit_len),
+            static_cast<int>(num_v_heads),
+            static_cast<int>(head_k_dim),
+            static_cast<int>(head_v_dim),
+            conv_input,
+            accepted_indices,
+            conv_state,
+            recurrent_trace,
+            recurrent_state);
+    case 1:
+        return dflash_apply_tree_rollback_bf16_trace_device<float>(
+            static_cast<int>(device_ordinal),
+            static_cast<int>(qkv_dim),
+            static_cast<int>(conv_state_len),
+            static_cast<int>(conv_input_len),
+            static_cast<int>(tree_len),
+            static_cast<int>(commit_len),
+            static_cast<int>(num_v_heads),
+            static_cast<int>(head_k_dim),
+            static_cast<int>(head_v_dim),
+            conv_input,
+            accepted_indices,
+            conv_state,
+            recurrent_trace,
+            recurrent_state);
+    case 2:
+        return dflash_apply_tree_rollback_bf16_trace_device<hip_bfloat16>(
+            static_cast<int>(device_ordinal),
+            static_cast<int>(qkv_dim),
+            static_cast<int>(conv_state_len),
+            static_cast<int>(conv_input_len),
+            static_cast<int>(tree_len),
+            static_cast<int>(commit_len),
+            static_cast<int>(num_v_heads),
+            static_cast<int>(head_k_dim),
+            static_cast<int>(head_v_dim),
+            conv_input,
+            accepted_indices,
+            conv_state,
+            recurrent_trace,
+            recurrent_state);
+    default:
+        return 66;
+    }
+}
+
+extern "C" int supersonic_qwen35_hip_dflash_apply_tree_rollback_q8_trace(
+    int dtype,
+    size_t device_ordinal,
+    size_t qkv_dim,
+    size_t conv_state_len,
+    size_t conv_input_len,
+    size_t tree_len,
+    size_t commit_len,
+    size_t num_v_heads,
+    size_t head_k_dim,
+    size_t head_v_dim,
+    const void* conv_input,
+    const void* accepted_indices,
+    void* conv_state,
+    const void* recurrent_trace,
+    void* recurrent_state) {
+    switch (dtype) {
+    case 0:
+        return dflash_apply_tree_rollback_q8_trace_device<half>(
+            static_cast<int>(device_ordinal),
+            static_cast<int>(qkv_dim),
+            static_cast<int>(conv_state_len),
+            static_cast<int>(conv_input_len),
+            static_cast<int>(tree_len),
+            static_cast<int>(commit_len),
+            static_cast<int>(num_v_heads),
+            static_cast<int>(head_k_dim),
+            static_cast<int>(head_v_dim),
+            conv_input,
+            accepted_indices,
+            conv_state,
+            recurrent_trace,
+            recurrent_state);
+    case 1:
+        return dflash_apply_tree_rollback_q8_trace_device<float>(
+            static_cast<int>(device_ordinal),
+            static_cast<int>(qkv_dim),
+            static_cast<int>(conv_state_len),
+            static_cast<int>(conv_input_len),
+            static_cast<int>(tree_len),
+            static_cast<int>(commit_len),
+            static_cast<int>(num_v_heads),
+            static_cast<int>(head_k_dim),
+            static_cast<int>(head_v_dim),
+            conv_input,
+            accepted_indices,
+            conv_state,
+            recurrent_trace,
+            recurrent_state);
+    case 2:
+        return dflash_apply_tree_rollback_q8_trace_device<hip_bfloat16>(
             static_cast<int>(device_ordinal),
             static_cast<int>(qkv_dim),
             static_cast<int>(conv_state_len),

--- a/tests/gfx1100/bench_qwen36_he_supersonic.py
+++ b/tests/gfx1100/bench_qwen36_he_supersonic.py
@@ -21,6 +21,30 @@ from pathlib import Path
 
 
 DEFAULT_LUCEBOX_BENCH = Path("/home/deano/projects/lucebox-hub/server/scripts/bench_he.py")
+DEFAULT_LUCEBOX_HE_JSONL = Path(
+    "/home/deano/projects/lucebox-hub/harness/benchmarks/prompts/bench_he.jsonl"
+)
+DEFAULT_SUPERSONIC_DFLASH_DRAFT_DIR = Path("/mnt/data/tmp/qwen36-27b-dflash-q8-bf16")
+DEFAULT_LUCEBOX_DRAFT_DIR = Path("/mnt/data/lucebox-hub/models/draft")
+DEFAULT_CONTEXT_SIZE = 512
+LUCEBOX_SERVING_CONTEXT_SIZE = 1024
+LUCEBOX_DRAFT_ALIASES = {
+    "supersonic-q8-bf16": {
+        "label": "supersonic-q8-bf16",
+        "config_dir": DEFAULT_SUPERSONIC_DFLASH_DRAFT_DIR,
+        "gguf": None,
+    },
+    "lucebox-q4-k-m": {
+        "label": "lucebox-q4-k-m",
+        "config_dir": DEFAULT_SUPERSONIC_DFLASH_DRAFT_DIR,
+        "gguf": DEFAULT_LUCEBOX_DRAFT_DIR / "dflash-draft-3.6-q4_k_m.gguf",
+    },
+    "lucebox-q8-0": {
+        "label": "lucebox-q8-0",
+        "config_dir": DEFAULT_SUPERSONIC_DFLASH_DRAFT_DIR,
+        "gguf": DEFAULT_LUCEBOX_DRAFT_DIR / "dflash-draft-3.6-q8_0.gguf",
+    },
+}
 RESULT_RE = re.compile(
     r"\[result\]\s+prompt_tokens=(?P<prompt>\d+)\s+"
     r"generated_tokens=(?P<generated>\d+)\s+"
@@ -29,7 +53,7 @@ RESULT_RE = re.compile(
 )
 
 
-def load_lucebox_prompts(path: Path) -> list[tuple[str, str]]:
+def load_lucebox_script_prompts(path: Path) -> list[tuple[str, str]]:
     script_dir = str(path.parent)
     if script_dir not in sys.path:
         sys.path.insert(0, script_dir)
@@ -44,7 +68,74 @@ def load_lucebox_prompts(path: Path) -> list[tuple[str, str]]:
     return [(str(name), str(prompt)) for name, prompt in prompts]
 
 
+QWEN3_NO_THINKING_PREFILL = "<think>\n\n</think>\n\n"
+
+
+def render_chatml(messages: list[dict], *, no_thinking: bool = False) -> str:
+    chunks = []
+    for message in messages:
+        role = str(message.get("role", "user"))
+        content = str(message.get("content", ""))
+        chunks.append(f"<|im_start|>{role}\n{content}<|im_end|>\n")
+    chunks.append("<|im_start|>assistant\n")
+    if no_thinking:
+        chunks.append(QWEN3_NO_THINKING_PREFILL)
+    return "".join(chunks)
+
+
+def load_lucebox_jsonl_prompts(path: Path, prompt_format: str) -> list[tuple[str, str]]:
+    prompts: list[tuple[str, str]] = []
+    with path.open(encoding="utf-8") as f:
+        for idx, line in enumerate(f, start=1):
+            line = line.strip()
+            if not line:
+                continue
+            case = json.loads(line)
+            name = str(case.get("id") or case.get("name") or f"case_{idx:03d}")
+            messages = case.get("messages")
+            if isinstance(messages, list) and prompt_format in {
+                "chatml",
+                "chatml-no-thinking",
+            }:
+                prompt = render_chatml(
+                    messages, no_thinking=prompt_format == "chatml-no-thinking"
+                )
+            elif isinstance(messages, list) and messages:
+                prompt = "\n\n".join(str(m.get("content", "")) for m in messages)
+            else:
+                prompt = str(case.get("prompt") or case.get("content") or "")
+            if not prompt:
+                raise RuntimeError(f"empty prompt in {path}:{idx}")
+            prompts.append((name, prompt))
+    if not prompts:
+        raise RuntimeError(f"no prompts found in {path}")
+    return prompts
+
+
+def load_prompts(args: argparse.Namespace) -> list[tuple[str, str]]:
+    if args.prompt_source == "script":
+        return load_lucebox_script_prompts(args.lucebox_bench)
+    if args.prompt_source == "jsonl":
+        return load_lucebox_jsonl_prompts(args.lucebox_jsonl, args.prompt_format)
+    raise ValueError(f"unknown prompt source: {args.prompt_source}")
+
+
+def resolve_dflash_draft(args: argparse.Namespace) -> tuple[Path, Path | None, str]:
+    config_dir = args.dflash_draft_dir
+    gguf = args.dflash_draft_gguf
+    label = "custom"
+    if args.dflash_draft_variant:
+        alias = LUCEBOX_DRAFT_ALIASES[args.dflash_draft_variant]
+        label = alias["label"]
+        config_dir = alias["config_dir"]
+        gguf = alias["gguf"]
+    if config_dir is None:
+        config_dir = DEFAULT_SUPERSONIC_DFLASH_DRAFT_DIR
+    return Path(config_dir), Path(gguf) if gguf else None, label
+
+
 def run_one(args: argparse.Namespace, name: str, prompt: str, warmup: bool = False) -> dict:
+    dflash_draft_dir, dflash_draft_gguf, dflash_draft_label = resolve_dflash_draft(args)
     cmd = [
         str(args.binary),
         "--backend",
@@ -55,7 +146,6 @@ def run_one(args: argparse.Namespace, name: str, prompt: str, warmup: bool = Fal
         str(args.model_dir),
         "--prompt",
         prompt,
-        "--prompt-no-special-tokens",
         "--context-size",
         str(args.context_size),
         "--max-new-tokens",
@@ -68,6 +158,8 @@ def run_one(args: argparse.Namespace, name: str, prompt: str, warmup: bool = Fal
         str(args.seed),
         "--no-download",
     ]
+    if args.prompt_no_special_tokens:
+        cmd.append("--prompt-no-special-tokens")
     if args.quant != "none":
         cmd.append(f"--{args.quant}")
     if args.ignore_eos:
@@ -78,12 +170,14 @@ def run_one(args: argparse.Namespace, name: str, prompt: str, warmup: bool = Fal
         cmd.append("--kv-fp8")
     if args.dflash:
         cmd.append("--dflash")
-        cmd.extend(["--dflash-draft-dir", str(args.dflash_draft_dir)])
+        cmd.extend(["--dflash-draft-dir", str(dflash_draft_dir)])
         if args.dflash_block:
             cmd.extend(["--dflash-block", str(args.dflash_block)])
 
     env = os.environ.copy()
     env["SUPERSONIC_BACKENDS"] = args.backend
+    if dflash_draft_gguf is not None:
+        env["SUPERSONIC_DFLASH_DRAFT_GGUF"] = str(dflash_draft_gguf)
 
     start = time.monotonic()
     proc = subprocess.run(
@@ -108,11 +202,18 @@ def run_one(args: argparse.Namespace, name: str, prompt: str, warmup: bool = Fal
             {
                 "prompt_tokens": int(match.group("prompt")),
                 "generated_tokens": int(match.group("generated")),
+                "requested_tokens": args.warmup_new_tokens if warmup else args.n_gen,
+                "stopped_early": int(match.group("generated"))
+                < (args.warmup_new_tokens if warmup else args.n_gen),
                 "decode_ms": float(match.group("decode_ms")),
                 "ms_per_step": float(match.group("ms_per_step")),
                 "tok_s": 1000.0 / float(match.group("ms_per_step")),
             }
         )
+    if args.dflash:
+        row["dflash_draft_label"] = dflash_draft_label
+        row["dflash_draft_dir"] = str(dflash_draft_dir)
+        row["dflash_draft_gguf"] = str(dflash_draft_gguf) if dflash_draft_gguf else None
     return row
 
 
@@ -131,8 +232,24 @@ def main() -> int:
         default="q4km-gptq",
     )
     parser.add_argument("--lucebox-bench", type=Path, default=DEFAULT_LUCEBOX_BENCH)
+    parser.add_argument("--lucebox-jsonl", type=Path, default=DEFAULT_LUCEBOX_HE_JSONL)
+    parser.add_argument("--prompt-source", choices=["script", "jsonl"], default="script")
+    parser.add_argument(
+        "--prompt-format",
+        choices=["raw", "chatml", "chatml-no-thinking"],
+        default="raw",
+    )
+    parser.add_argument(
+        "--lucebox-serving-mode",
+        action="store_true",
+        help=(
+            "Preset for Lucebox HTTP-style comparison: JSONL HE prompts, "
+            "Qwen3 no-thinking ChatML prompt text, stop on EOS, and "
+            "Lucebox Q4_K_M draft GGUF."
+        ),
+    )
     parser.add_argument("--backend", default="hip")
-    parser.add_argument("--context-size", type=int, default=512)
+    parser.add_argument("--context-size", type=int, default=DEFAULT_CONTEXT_SIZE)
     parser.add_argument("--n-gen", type=int, default=256)
     parser.add_argument("--warmup-new-tokens", type=int, default=2)
     parser.add_argument("--seed", type=int, default=20260504)
@@ -142,21 +259,62 @@ def main() -> int:
     parser.add_argument("--limit", type=int, default=0)
     parser.add_argument("--warmup", action=argparse.BooleanOptionalAction, default=True)
     parser.add_argument("--ignore-eos", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--stop-on-eos", action="store_true")
+    parser.add_argument(
+        "--prompt-no-special-tokens",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+    )
     parser.add_argument("--emit-stage-timings", action="store_true")
     parser.add_argument("--kv-fp8", action="store_true")
     parser.add_argument("--dflash", action="store_true")
     parser.add_argument(
+        "--dflash-draft-variant",
+        choices=sorted(LUCEBOX_DRAFT_ALIASES),
+        default=None,
+        help=(
+            "Convenience draft selection. Lucebox variants use their GGUF draft "
+            "weights with the local SuperSonic DFlash config directory."
+        ),
+    )
+    parser.add_argument(
         "--dflash-draft-dir",
         type=Path,
-        default=Path("/mnt/data/tmp/qwen36-27b-dflash-q8-bf16"),
+        default=DEFAULT_SUPERSONIC_DFLASH_DRAFT_DIR,
+    )
+    parser.add_argument(
+        "--dflash-draft-gguf",
+        type=Path,
+        default=None,
+        help=(
+            "Optional Lucebox-style GGUF draft weights. The config still comes "
+            "from --dflash-draft-dir."
+        ),
     )
     parser.add_argument("--dflash-block", type=int, default=0)
     parser.add_argument("--out-json", type=Path, default=Path("target/qwen36_he_supersonic.json"))
     args = parser.parse_args()
 
+    if args.lucebox_serving_mode:
+        args.prompt_source = "jsonl"
+        args.prompt_format = "chatml-no-thinking"
+        args.ignore_eos = False
+        args.dflash = True
+        args.dflash_draft_variant = args.dflash_draft_variant or "lucebox-q4-k-m"
+        if args.context_size == DEFAULT_CONTEXT_SIZE:
+            args.context_size = LUCEBOX_SERVING_CONTEXT_SIZE
+    if args.stop_on_eos:
+        args.ignore_eos = False
+
     if not args.binary.exists():
         raise FileNotFoundError(args.binary)
-    prompts = load_lucebox_prompts(args.lucebox_bench)
+    if args.dflash:
+        dflash_draft_dir, dflash_draft_gguf, _draft_label = resolve_dflash_draft(args)
+        if not dflash_draft_dir.exists():
+            raise FileNotFoundError(dflash_draft_dir)
+        if dflash_draft_gguf is not None and not dflash_draft_gguf.exists():
+            raise FileNotFoundError(dflash_draft_gguf)
+    prompts = load_prompts(args)
     if args.start_index < 0 or args.start_index > len(prompts):
         raise ValueError(f"--start-index must be in 0..{len(prompts)}")
     prompts = prompts[args.start_index :]
@@ -194,19 +352,29 @@ def main() -> int:
         "mean_ms_per_step": sum(r["ms_per_step"] for r in ok) / len(ok),
         "min_tok_s": min(r["tok_s"] for r in ok),
         "max_tok_s": max(r["tok_s"] for r in ok),
+        "total_generated_tokens": sum(r["generated_tokens"] for r in ok),
+        "stopped_early_count": sum(1 for r in ok if r.get("stopped_early")),
     }
+    dflash_draft_dir, dflash_draft_gguf, dflash_draft_label = resolve_dflash_draft(args)
     payload = {
-        "schema": "supersonic-qwen36-he-comparison-v1",
+        "schema": "supersonic-qwen36-he-comparison-v2",
         "model": args.model,
         "model_dir": str(args.model_dir),
         "quant": args.quant,
         "dflash": args.dflash,
-        "dflash_draft_dir": str(args.dflash_draft_dir) if args.dflash else None,
+        "dflash_draft_label": dflash_draft_label if args.dflash else None,
+        "dflash_draft_dir": str(dflash_draft_dir) if args.dflash else None,
+        "dflash_draft_gguf": str(dflash_draft_gguf) if args.dflash and dflash_draft_gguf else None,
         "dflash_block": args.dflash_block if args.dflash_block else None,
         "backend": args.backend,
         "context_size": args.context_size,
         "n_gen": args.n_gen,
+        "eos_policy": "ignore" if args.ignore_eos else "stop",
+        "prompt_source": args.prompt_source,
+        "prompt_format": args.prompt_format,
         "lucebox_bench": str(args.lucebox_bench),
+        "lucebox_jsonl": str(args.lucebox_jsonl),
+        "lucebox_serving_mode": args.lucebox_serving_mode,
         "summary": summary,
         "rows": rows,
     }

--- a/tests/test_qwen36_he_supersonic_bench.py
+++ b/tests/test_qwen36_he_supersonic_bench.py
@@ -1,0 +1,132 @@
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT = Path(__file__).parent / "gfx1100" / "bench_qwen36_he_supersonic.py"
+SPEC = importlib.util.spec_from_file_location("bench_qwen36_he_supersonic", SCRIPT)
+bench = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = bench
+SPEC.loader.exec_module(bench)
+
+
+class BenchQwen36HeSuperSonicTests(unittest.TestCase):
+    def test_render_chatml_wraps_messages_for_lucebox_jsonl(self):
+        prompt = bench.render_chatml(
+            [{"role": "user", "content": "Complete this function."}]
+        )
+
+        self.assertEqual(
+            prompt,
+            "<|im_start|>user\nComplete this function.<|im_end|>\n"
+            "<|im_start|>assistant\n",
+        )
+
+    def test_render_chatml_can_include_qwen3_no_thinking_prefill(self):
+        prompt = bench.render_chatml(
+            [{"role": "user", "content": "Complete this function."}],
+            no_thinking=True,
+        )
+
+        self.assertTrue(prompt.endswith("<think>\n\n</think>\n\n"))
+
+    def test_load_jsonl_prompts_supports_raw_and_chatml(self):
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", suffix=".jsonl") as tmp:
+            tmp.write(
+                json.dumps(
+                    {
+                        "id": "he_x",
+                        "messages": [
+                            {"role": "user", "content": "def f():\n    return"}
+                        ],
+                    }
+                )
+                + "\n"
+            )
+            tmp.flush()
+            path = Path(tmp.name)
+
+            self.assertEqual(
+                bench.load_lucebox_jsonl_prompts(path, "raw"),
+                [("he_x", "def f():\n    return")],
+            )
+            chatml = bench.load_lucebox_jsonl_prompts(path, "chatml")
+            no_thinking = bench.load_lucebox_jsonl_prompts(
+                path, "chatml-no-thinking"
+            )
+        self.assertEqual(chatml[0][0], "he_x")
+        self.assertIn("<|im_start|>user\n", chatml[0][1])
+        self.assertTrue(chatml[0][1].endswith("<|im_start|>assistant\n"))
+        self.assertTrue(no_thinking[0][1].endswith("<think>\n\n</think>\n\n"))
+
+    def test_resolve_lucebox_q4_alias_uses_config_dir_and_gguf(self):
+        args = types.SimpleNamespace(
+            dflash_draft_variant="lucebox-q4-k-m",
+            dflash_draft_dir=Path("/custom/config"),
+            dflash_draft_gguf=None,
+        )
+
+        config_dir, gguf, label = bench.resolve_dflash_draft(args)
+
+        self.assertEqual(label, "lucebox-q4-k-m")
+        self.assertEqual(config_dir, bench.DEFAULT_SUPERSONIC_DFLASH_DRAFT_DIR)
+        self.assertEqual(
+            gguf,
+            bench.DEFAULT_LUCEBOX_DRAFT_DIR / "dflash-draft-3.6-q4_k_m.gguf",
+        )
+
+    def test_run_one_sets_gguf_env_and_stop_on_eos_command(self):
+        args = types.SimpleNamespace(
+            binary=Path("target/release/supersonic"),
+            backend="hip",
+            model="qwen3.6-27b",
+            model_dir=Path("/models/target"),
+            context_size=1024,
+            warmup_new_tokens=2,
+            n_gen=256,
+            seed=1,
+            prompt_no_special_tokens=True,
+            quant="q4km",
+            ignore_eos=False,
+            emit_stage_timings=False,
+            kv_fp8=False,
+            dflash=True,
+            dflash_block=0,
+            dflash_draft_variant="lucebox-q8-0",
+            dflash_draft_dir=bench.DEFAULT_SUPERSONIC_DFLASH_DRAFT_DIR,
+            dflash_draft_gguf=None,
+            timeout=10,
+            tail_chars=200,
+        )
+
+        completed = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="",
+            stderr="[result] prompt_tokens=12 generated_tokens=97 decode_ms=970 ms_per_tok=10\n",
+        )
+        with mock.patch.object(bench.subprocess, "run", return_value=completed) as run:
+            row = bench.run_one(args, "case", "prompt")
+
+        cmd = run.call_args.args[0]
+        env = run.call_args.kwargs["env"]
+        self.assertIn("--dflash", cmd)
+        self.assertIn("--prompt-no-special-tokens", cmd)
+        self.assertNotIn("--ignore-eos", cmd)
+        self.assertEqual(
+            env["SUPERSONIC_DFLASH_DRAFT_GGUF"],
+            str(bench.DEFAULT_LUCEBOX_DRAFT_DIR / "dflash-draft-3.6-q8_0.gguf"),
+        )
+        self.assertEqual(row["generated_tokens"], 97)
+        self.assertTrue(row["stopped_early"])
+        self.assertEqual(row["dflash_draft_label"], "lucebox-q8-0")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Speeds up the Qwen3.6 DFlash DDTree verify path on RX 7900 XTX/gfx1100 and promotes the measured DDTree defaults.

Changes include:
- cached tree verify metadata/scratch buffers with an opt-out env var
- optional strict tree-verify sync behind `SUPERSONIC_DFLASH_TREE_VERIFY_STRICT_SYNC=1`
- tiled BF16 tree full-attention HIP path with legacy fallback
- reusable tree verify full-attention and linear scratch buffers to remove hot-loop allocations
- DDTree default tune from budget/top-k `22/8` to `14/4`
- guide update with the target, protocol, and achieved result

## Performance

Baseline from the implementation guide:
- `target/qwen36_lucebox20/direct_q8_tree_10x256.json`
- config: budget=8, top_k=8, direct rollback, 10 HumanEval prompts, `n_gen=256`
- mean: `32.18 tok/s`
- min: `24.46 tok/s`
- 1.2x target: `38.62 tok/s`

Default-only rebuilt release runs after this PR:
- `target/qwen36_lucebox20/tree_tiled_scratch_defaults_10x256.json`: mean `38.79 tok/s`, min `27.68 tok/s`, max `67.11 tok/s`
- `target/qwen36_lucebox20/tree_tiled_scratch_defaults_repeat_10x256.json`: mean `38.71 tok/s`, min `27.59 tok/s`, max `66.98 tok/s`

Both default-only runs clear the `38.62 tok/s` target and improve the weakest prompt above the old `24.46 tok/s` minimum.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `HIP_ARCH=gfx1100 cargo build --release -p runner`
- `HIP_ARCH=gfx1100 cargo check -p runner`
- `HIP_ARCH=gfx1100 cargo test -p runner dflash_tree -- --ignored --nocapture`
- `cargo test -p runner append_reverify_accept_len -- --nocapture`
- full 10-prompt Qwen3.6 DFlash benchmark using compiled defaults, run twice

## Notes

`gh` auth is stale on this machine, so this PR was opened via the GitHub connector after pushing over SSH.