### PR TITLE
[codex] Add Qwen36 35B Lucebox benchmark progress

### DIFF
--- a/crates/kernel-ffi/src/qwen36_moe.rs
+++ b/crates/kernel-ffi/src/qwen36_moe.rs
@@ -1455,6 +1455,7 @@ extern "C" {
         final_norm_w: *const c_void,
         lm_head_w: *const c_void,
         logits_out: *mut c_void,
+        top1_out: *mut c_uint,
         counters: *mut c_uint,
         barrier_counter: *mut c_uint,
         barrier_flag: *mut c_uint,
@@ -2038,11 +2039,15 @@ pub struct Qwen36MoePersistentLmHeadFold<'a> {
     /// `[hidden]` BF16. Same final_norm tensor the standalone
     /// `lm_head_launch` consumes.
     pub final_norm_w: &'a GpuBuffer,
-    /// `[vocab, hidden]` BF16. Pre-dequantized at engine startup from
-    /// the bake's INT4 lm_head; the kernel reads BF16 only.
+    /// `[vocab, hidden]` BF16. The bake may store INT4 on disk, but the
+    /// folded kernel reads the pre-dequantized BF16 upload.
     pub lm_head_w: &'a GpuBuffer,
-    /// `[vocab]` BF16 output buffer. Kernel writes one logit per row.
-    pub logits_out: &'a mut GpuBuffer,
+    /// Optional `[vocab]` BF16 output buffer. Kernel writes one logit per row
+    /// when full logits are needed for sampling or diagnostics.
+    pub logits_out: Option<&'a mut GpuBuffer>,
+    /// Optional `[1]` U32 output buffer for greedy decode. When present, the
+    /// persistent kernel reduces the lm_head argmax internally.
+    pub top1_out: Option<&'a mut GpuBuffer>,
     /// Vocab size. Must be `> 0` and match `lm_head_w.shape()[0]`.
     pub vocab: i32,
 }
@@ -2052,6 +2057,9 @@ pub enum Qwen36MoePersistentMode {
     Full,
     RouterOnly,
     FfnOnly,
+    AttnOnly,
+    FfnStage(i32),
+    LinearStage(i32),
 }
 
 impl Qwen36MoePersistentMode {
@@ -2061,6 +2069,9 @@ impl Qwen36MoePersistentMode {
             Self::Full => 0,
             Self::RouterOnly => 1,
             Self::FfnOnly => 2,
+            Self::AttnOnly => 3,
+            Self::FfnStage(stage) => 3 + stage,
+            Self::LinearStage(stage) => 8 + stage,
         }
     }
 }
@@ -2142,6 +2153,20 @@ pub fn persistent_decode_launch_range(
             "qwen36_moe::persistent_decode_launch: only BF16 wired, got {dtype:?}"
         )));
     }
+    if let Qwen36MoePersistentMode::FfnStage(stage) = mode {
+        if !(1..=5).contains(&stage) {
+            return Err(GpuError::InvalidArg(format!(
+                "qwen36_moe::persistent_decode_launch: FFN stage mode must be in 1..=5, got {stage}"
+            )));
+        }
+    }
+    if let Qwen36MoePersistentMode::LinearStage(stage) = mode {
+        if !(1..=5).contains(&stage) {
+            return Err(GpuError::InvalidArg(format!(
+                "qwen36_moe::persistent_decode_launch: linear stage mode must be in 1..=5, got {stage}"
+            )));
+        }
+    }
     let backend = layers_device.backend();
     let counters = sync_buf.as_mut_ptr() as *mut c_uint;
     let barrier_counter = unsafe { (counters as *mut u8).add(64) as *mut c_uint };
@@ -2159,20 +2184,53 @@ pub fn persistent_decode_launch_range(
 
     // Fold pointers default to null; the kernel skips the lm_head phase
     // when any of the three is null.
-    let (vocab, final_norm_w_ptr, lm_head_w_ptr, logits_out_ptr) = match lm_head_fold {
-        Some(mut f) => (
-            f.vocab,
-            f.final_norm_w.as_ptr(),
-            f.lm_head_w.as_ptr(),
-            f.logits_out.as_mut_ptr(),
+    let (vocab, final_norm_w_ptr, lm_head_w_ptr, logits_out_ptr, top1_out_ptr) = match lm_head_fold
+    {
+        Some(mut f) => {
+            let logits_out_ptr = f
+                .logits_out
+                .as_deref_mut()
+                .map(|buf| buf.as_mut_ptr())
+                .unwrap_or(std::ptr::null_mut());
+            let top1_out_ptr = f
+                .top1_out
+                .as_deref_mut()
+                .map(|buf| buf.as_mut_ptr() as *mut c_uint)
+                .unwrap_or(std::ptr::null_mut());
+            (
+                f.vocab,
+                f.final_norm_w.as_ptr(),
+                f.lm_head_w.as_ptr(),
+                logits_out_ptr,
+                top1_out_ptr,
+            )
+        }
+        None => (
+            0,
+            std::ptr::null(),
+            std::ptr::null(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
         ),
-        None => (0, std::ptr::null(), std::ptr::null(), std::ptr::null_mut()),
     };
 
     let op = match mode {
         Qwen36MoePersistentMode::Full => "qwen36.persistent_decode",
         Qwen36MoePersistentMode::RouterOnly => "qwen36.persistent_router_only",
         Qwen36MoePersistentMode::FfnOnly => "qwen36.persistent_ffn_only",
+        Qwen36MoePersistentMode::AttnOnly => "qwen36.persistent_attn_only",
+        Qwen36MoePersistentMode::FfnStage(1) => "qwen36.persistent_ffn_stage1",
+        Qwen36MoePersistentMode::FfnStage(2) => "qwen36.persistent_ffn_stage2",
+        Qwen36MoePersistentMode::FfnStage(3) => "qwen36.persistent_ffn_stage3",
+        Qwen36MoePersistentMode::FfnStage(4) => "qwen36.persistent_ffn_stage4",
+        Qwen36MoePersistentMode::FfnStage(5) => "qwen36.persistent_ffn_stage5",
+        Qwen36MoePersistentMode::FfnStage(_) => "qwen36.persistent_ffn_stage_invalid",
+        Qwen36MoePersistentMode::LinearStage(1) => "qwen36.persistent_linear_stage1",
+        Qwen36MoePersistentMode::LinearStage(2) => "qwen36.persistent_linear_stage2",
+        Qwen36MoePersistentMode::LinearStage(3) => "qwen36.persistent_linear_stage3",
+        Qwen36MoePersistentMode::LinearStage(4) => "qwen36.persistent_linear_stage4",
+        Qwen36MoePersistentMode::LinearStage(5) => "qwen36.persistent_linear_stage5",
+        Qwen36MoePersistentMode::LinearStage(_) => "qwen36.persistent_linear_stage_invalid",
     };
     crate::prefill_ffi::ffi_profile_time_result(op, ordinal, || {
         let status: c_int = match backend {
@@ -2219,6 +2277,7 @@ pub fn persistent_decode_launch_range(
                         final_norm_w_ptr,
                         lm_head_w_ptr,
                         logits_out_ptr,
+                        top1_out_ptr,
                         counters,
                         barrier_counter,
                         barrier_flag,

--- a/crates/runner/src/profiling.rs
+++ b/crates/runner/src/profiling.rs
@@ -534,3 +534,79 @@ fn disable_prefill_profiles() {
     kernel_ffi::prefill_ffi::ffi_profile_set_enabled(false);
     gpu_hal::hal_profile_set_enabled(false);
 }
+
+pub(crate) struct Qwen36DecodeProfileScope {
+    active: bool,
+    start: std::time::Instant,
+}
+
+impl Qwen36DecodeProfileScope {
+    pub(crate) fn new_from_env() -> Self {
+        let active = std::env::var_os("SUPERSONIC_QWEN36_PROFILE_FFI").is_some();
+        if active {
+            gpu_hal::hal_profile_set_enabled(true);
+            kernel_ffi::prefill_ffi::ffi_profile_set_enabled(true);
+            gpu_hal::hal_profile_reset();
+            kernel_ffi::prefill_ffi::ffi_profile_reset();
+        }
+        Self {
+            active,
+            start: std::time::Instant::now(),
+        }
+    }
+
+    pub(crate) fn finish(mut self) {
+        if !self.active {
+            return;
+        }
+        let wall_ms = self.start.elapsed().as_secs_f64() * 1000.0;
+        let ffi = kernel_ffi::prefill_ffi::ffi_profile_snapshot();
+        let hal = gpu_hal::hal_profile_snapshot();
+        eprintln!(
+            "[qwen36-decode-ffi-profile] wall_ms={:.3} ffi_calls={} ffi_ms={:.3} hal_calls={} hal_ms={:.3} alloc_calls={} alloc_bytes={} h2d={} d2h={} d2d={} memset={} sync_calls={}",
+            wall_ms,
+            ffi.total_calls,
+            ffi.total_ms,
+            hal.total_calls,
+            hal.total_ms,
+            hal.alloc_calls,
+            hal.alloc_bytes,
+            hal.h2d_bytes,
+            hal.d2h_bytes,
+            hal.d2d_bytes,
+            hal.memset_bytes,
+            hal.sync_calls,
+        );
+        for entry in ffi.entries.iter().take(40) {
+            eprintln!(
+                "[qwen36-decode-ffi-profile-op] op={} calls={} mean_ms={:.4} total_ms={:.3} max_ms={:.3}",
+                entry.op,
+                entry.calls,
+                entry.mean_ms(),
+                entry.total_ms,
+                entry.max_ms,
+            );
+        }
+        for entry in hal.entries.iter().take(20) {
+            eprintln!(
+                "[qwen36-decode-hal-profile-op] op={} calls={} mean_ms={:.4} total_ms={:.3} max_ms={:.3} bytes={}",
+                entry.op,
+                entry.calls,
+                entry.mean_ms(),
+                entry.total_ms,
+                entry.max_ms,
+                entry.total_bytes,
+            );
+        }
+        disable_prefill_profiles();
+        self.active = false;
+    }
+}
+
+impl Drop for Qwen36DecodeProfileScope {
+    fn drop(&mut self) {
+        if self.active {
+            disable_prefill_profiles();
+        }
+    }
+}

--- a/crates/runner/src/qwen36_moe/batched_prefill.rs
+++ b/crates/runner/src/qwen36_moe/batched_prefill.rs
@@ -59,8 +59,9 @@ use crate::qwen36_moe_cli::engine::current_position;
 use crate::qwen36_moe_cli::host::lookup_embed_row;
 use crate::qwen36_moe_cli::vmm_config::MoeRuntimeConfig;
 use crate::qwen36_moe_decode::{
-    ffn_output_elems, ffn_workspace_floats, full_attn_output_elems, full_attn_workspace_floats,
-    linear_attn_workspace_floats, reset_sync_buf,
+    ffn_output_elems, ffn_workspace_floats, full_attn_output_elems,
+    full_attn_score_workspace_floats, full_attn_workspace_floats, linear_attn_workspace_floats,
+    reset_sync_buf,
 };
 use crate::qwen36_moe_persistent_decode::PersistentScratch;
 use crate::qwen36_moe_residency::MoeExpertResidencyManager;
@@ -623,6 +624,7 @@ fn process_chunk_batched(
                 is_gen_step: false,
                 emit_stage_timings,
                 fold: None,
+                download_final_hidden: true,
             })?;
             let t_chain_step = t1.elapsed();
             loop_state.position += 1;
@@ -688,8 +690,8 @@ fn process_chunk_batched(
 
     // Per-token fallback workspaces. Always allocated — used either by
     // linear-attn (always) or by per-token FFN (when grouped FFN is off).
-    let attn_ws_floats = full_attn_workspace_floats(geom).max(linear_attn_workspace_floats(geom))
-        + geom.num_attention_heads as usize * pertoken_attn_extra_kv(layers);
+    let attn_ws_floats = (full_attn_workspace_floats(geom) + pertoken_attn_extra_kv(geom, layers))
+        .max(linear_attn_workspace_floats(geom));
     let attn_out_elems = full_attn_output_elems(geom);
     let mut attn_output = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[attn_out_elems])
         .context("alloc attn_output")?;
@@ -862,8 +864,8 @@ fn stage_chunk_tokens_on_gpu(
 /// Per-token attn workspace's `attn_extra` term: extra F32 floats the
 /// per-token full-attn kernel needs when KV cache is enabled (one row of
 /// scores per Q head per cache slot).
-fn pertoken_attn_extra_kv(layers: &[LayerBuffers]) -> usize {
-    layers
+fn pertoken_attn_extra_kv(geom: &MultiLayerGeom, layers: &[LayerBuffers]) -> usize {
+    let max_kv_t = layers
         .iter()
         .filter_map(|l| match &l.attn {
             AttnLayerBuffers::Full {
@@ -872,7 +874,8 @@ fn pertoken_attn_extra_kv(layers: &[LayerBuffers]) -> usize {
             _ => None,
         })
         .max()
-        .unwrap_or(0)
+        .unwrap_or(0);
+    full_attn_score_workspace_floats(geom, max_kv_t)
 }
 
 /// Per-token chunked fallback. Used when `supports_batched_path` returns
@@ -957,6 +960,7 @@ fn run_pertoken_chunked(
                 is_gen_step: false,
                 emit_stage_timings,
                 fold: None,
+                download_final_hidden: true,
             })?;
             let t_chain_step = t1.elapsed();
             loop_state.position += 1;

--- a/crates/runner/src/qwen36_moe/chain.rs
+++ b/crates/runner/src/qwen36_moe/chain.rs
@@ -35,11 +35,13 @@ pub(crate) struct Qwen36ChainStep<'a> {
     pub(crate) is_gen_step: bool,
     pub(crate) emit_stage_timings: bool,
     pub(crate) fold: Option<LmHeadFold<'a>>,
+    pub(crate) download_final_hidden: bool,
 }
 
 pub(crate) struct Qwen36ChainStepOutput {
     pub(crate) outputs: DecodeOutputs,
     pub(crate) lm_head_folded: bool,
+    pub(crate) lm_head_folded_top1: bool,
 }
 
 pub(crate) fn run_chain_step(mut args: Qwen36ChainStep<'_>) -> Result<Qwen36ChainStepOutput> {
@@ -56,6 +58,7 @@ pub(crate) fn run_chain_step(mut args: Qwen36ChainStep<'_>) -> Result<Qwen36Chai
     let cache = args.position.cache;
 
     let mut lm_head_folded = false;
+    let mut lm_head_folded_top1 = false;
     let outputs = if let Some(scratch) = args.persistent_scratch.as_deref_mut() {
         // Persistent kernel takes (rope, cache) directly. The
         // megakernel's full-attn phase consumes cache_pos via
@@ -104,15 +107,38 @@ pub(crate) fn run_chain_step(mut args: Qwen36ChainStep<'_>) -> Result<Qwen36Chai
                     )
                 })?
         } else {
-            lm_head_folded = args.fold.is_some();
-            scratch
-                .run(args.ordinal, args.initial_hidden, rope, cache, args.fold)
-                .with_context(|| {
-                    format!(
-                        "persistent decode (step {}, rope {}, cache {})",
-                        args.step, rope, cache
+            if std::env::var_os("SUPERSONIC_QWEN36_SEGMENTED_PROFILE").is_some() {
+                drop(args.fold);
+                scratch
+                    .run_segmented_profile(args.ordinal, args.initial_hidden, rope, cache)
+                    .with_context(|| {
+                        format!(
+                            "persistent segmented profile decode (step {}, rope {}, cache {})",
+                            args.step, rope, cache
+                        )
+                    })?
+            } else {
+                lm_head_folded = args.fold.is_some();
+                lm_head_folded_top1 = args
+                    .fold
+                    .as_ref()
+                    .is_some_and(|fold| fold.top1_out.is_some());
+                scratch
+                    .run(
+                        args.ordinal,
+                        args.initial_hidden,
+                        rope,
+                        cache,
+                        args.fold,
+                        args.download_final_hidden,
                     )
-                })?
+                    .with_context(|| {
+                        format!(
+                            "persistent decode (step {}, rope {}, cache {})",
+                            args.step, rope, cache
+                        )
+                    })?
+            }
         }
     } else {
         // Chained fallback for when the persistent megakernel isn't
@@ -236,5 +262,6 @@ pub(crate) fn run_chain_step(mut args: Qwen36ChainStep<'_>) -> Result<Qwen36Chai
     Ok(Qwen36ChainStepOutput {
         outputs,
         lm_head_folded,
+        lm_head_folded_top1,
     })
 }

--- a/crates/runner/src/qwen36_moe/decode.rs
+++ b/crates/runner/src/qwen36_moe/decode.rs
@@ -111,6 +111,31 @@ pub fn full_attn_workspace_floats(geom: &MultiLayerGeom) -> usize {
     6 * h * d + 4 * hkv * d + geom.hidden as usize
 }
 
+/// Per-Q-head score/partial stride for cached full attention.
+///
+/// The HIP full-attn decode path switches to tile-local online-softmax
+/// partials for histories longer than this tile. Each tile needs `[m, l]`
+/// plus one accumulator per head-dim lane, so the score workspace must be
+/// wider than the raw `kv_max_t` score row once tiling is possible.
+pub const FULL_ATTN_DECODE_TILE_T: usize = 8;
+
+pub fn full_attn_score_workspace_stride(geom: &MultiLayerGeom, kv_max_t: usize) -> usize {
+    if kv_max_t == 0 {
+        return 0;
+    }
+    let d = geom.head_dim as usize;
+    if kv_max_t > FULL_ATTN_DECODE_TILE_T && d <= 256 {
+        let tile_count = kv_max_t.div_ceil(FULL_ATTN_DECODE_TILE_T);
+        kv_max_t.max(tile_count * (d + 2))
+    } else {
+        kv_max_t
+    }
+}
+
+pub fn full_attn_score_workspace_floats(geom: &MultiLayerGeom, kv_max_t: usize) -> usize {
+    (geom.num_attention_heads as usize) * full_attn_score_workspace_stride(geom, kv_max_t)
+}
+
 /// BF16 elements sufficient for the full-attn parity launcher's largest
 /// stage (stage 3 publishes q_rot || k_rot, the widest output).
 pub(crate) fn full_attn_output_elems(geom: &MultiLayerGeom) -> usize {
@@ -2027,14 +2052,15 @@ fn run_chained_decode_impl_with_cache_pos(
             );
     let attn_extra_regions = full_attn_tap_regions.max(1);
     let attn_extra = if max_kv_t > 0 {
-        geom.num_attention_heads as usize * max_kv_t * attn_extra_regions
+        let profile_tap_extra = geom.num_attention_heads as usize * max_kv_t * attn_extra_regions;
+        profile_tap_extra.max(full_attn_score_workspace_floats(geom, max_kv_t))
     } else {
         0
     };
 
     // Shared attention scratch: sized for the larger of (full, linear).
     let attn_ws_floats =
-        full_attn_workspace_floats(geom).max(linear_attn_workspace_floats(geom)) + attn_extra;
+        (full_attn_workspace_floats(geom) + attn_extra).max(linear_attn_workspace_floats(geom));
     let attn_out_elems = full_attn_output_elems(geom).max(linear_attn_output_elems(geom));
     let mut attn_output = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[attn_out_elems])
         .context("alloc attn_output")?;

--- a/crates/runner/src/qwen36_moe/engine.rs
+++ b/crates/runner/src/qwen36_moe/engine.rs
@@ -16,7 +16,7 @@ use kernel_ffi::qwen36_moe::{
 use model_store::manifest::QuantProfile;
 use model_store::BakedStore;
 
-use crate::profiling::PrefillProfileScope;
+use crate::profiling::{PrefillProfileScope, Qwen36DecodeProfileScope};
 use crate::qwen36_moe_cli::bake::{ensure_qwen36_bake, select_decode_bake};
 use crate::qwen36_moe_cli::chain::{run_chain_step, Qwen36ChainStep};
 use crate::qwen36_moe_cli::decode_loop::Qwen36DecodeLoopState;
@@ -697,6 +697,7 @@ fn decode_text(
     let mut prefill_embed_elapsed = std::time::Duration::ZERO;
     let mut prefill_chain_elapsed = std::time::Duration::ZERO;
     let mut generation_wall_start = None;
+    let mut decode_profile = None;
     let mut moe_routes = MoeRouteRuntime::new(
         geom.num_layers as usize,
         geom.top_k as usize,
@@ -813,6 +814,7 @@ fn decode_text(
         let is_gen_step = step + 1 >= effective_prompt_len;
         if is_gen_step && generation_wall_start.is_none() {
             generation_wall_start = Some(std::time::Instant::now());
+            decode_profile = Some(Qwen36DecodeProfileScope::new_from_env());
         }
         // Per-step (rope, cache) pair. Dense mode: rope == cache.
         // SpecPrefill mode: rope on absolute prompt timeline, cache
@@ -924,16 +926,42 @@ fn decode_text(
         // into final_hidden_buf. The host then D2Hs `logits_buf`
         // directly. On prefill steps logits aren't needed; on the
         // chained path the explicit lm_head_launch path stays.
-        let fold = if is_gen_step {
-            Some(crate::qwen36_moe_persistent_decode::LmHeadFold {
-                final_norm_w: &final_norm_w_buf,
-                lm_head_w: &lm_head_w_buf,
-                logits_out: &mut logits_buf,
-                vocab: geom.vocab,
-            })
+        let disable_folded_lm_head =
+            std::env::var_os("SUPERSONIC_QWEN36_DISABLE_FOLDED_LM_HEAD").is_some();
+        let folded_top1_enabled = matches!(logits_buf.backend(), Backend::Metal | Backend::Hip)
+            && (sampling.temperature <= 0.0 || sampling.top_k == 1)
+            && !dump_last_logits
+            && std::env::var_os("SUPERSONIC_QWEN36_DUMP_LOGITS").is_none()
+            && std::env::var_os("SUPERSONIC_METAL_DISABLE_QWEN36_LM_HEAD_GPU_ARGMAX").is_none();
+        let fold = if is_gen_step && !disable_folded_lm_head {
+            if folded_top1_enabled {
+                Some(crate::qwen36_moe_persistent_decode::LmHeadFold {
+                    final_norm_w: &final_norm_w_buf,
+                    lm_head_w: &lm_head_w_buf,
+                    logits_out: None,
+                    top1_out: Some(&mut counter_buf),
+                    vocab: geom.vocab,
+                })
+            } else {
+                Some(crate::qwen36_moe_persistent_decode::LmHeadFold {
+                    final_norm_w: &final_norm_w_buf,
+                    lm_head_w: &lm_head_w_buf,
+                    logits_out: Some(&mut logits_buf),
+                    top1_out: None,
+                    vocab: geom.vocab,
+                })
+            }
         } else {
             None
         };
+        let final_hidden_observer_enabled = std::env::var_os("SUPERSONIC_QWEN36_DUMP_FINAL_HIDDEN")
+            .is_some()
+            || std::env::var_os("SUPERSONIC_QWEN36_FINAL_HIDDEN_TAP").is_some()
+            || std::env::var_os("SUPERSONIC_QWEN36_DOWNSTREAM_PARITY_TAP").is_some();
+        let download_final_hidden = !is_gen_step
+            || fold.is_none()
+            || final_hidden_observer_enabled
+            || mtp_buffers.is_some();
         let chain_step = run_chain_step(Qwen36ChainStep {
             ordinal,
             geom: &geom,
@@ -949,9 +977,11 @@ fn decode_text(
             is_gen_step,
             emit_stage_timings,
             fold,
+            download_final_hidden,
         })?;
         let outputs = chain_step.outputs;
         let lm_head_folded = chain_step.lm_head_folded;
+        let lm_head_folded_top1 = chain_step.lm_head_folded_top1;
         let t_chain_step = t1.elapsed();
         loop_state.position += 1;
 
@@ -977,6 +1007,7 @@ fn decode_text(
             geom: &geom,
             step,
             lm_head_folded,
+            lm_head_folded_top1,
             dump_last_logits,
             tokenizer: tokenizer.as_ref(),
             sampling,
@@ -1052,6 +1083,9 @@ fn decode_text(
 
     if let Some(profile) = prefill_profile.take() {
         profile.finish()?;
+    }
+    if let Some(profile) = decode_profile.take() {
+        profile.finish();
     }
 
     print_last_logits_if_requested(dump_last_logits, &loop_state.last_logits_bytes);

--- a/crates/runner/src/qwen36_moe/engine.rs
+++ b/crates/runner/src/qwen36_moe/engine.rs
@@ -813,6 +813,9 @@ fn decode_text(
         }
         let is_gen_step = step + 1 >= effective_prompt_len;
         if is_gen_step && generation_wall_start.is_none() {
+            if let Some(profile) = prefill_profile.take() {
+                profile.finish()?;
+            }
             generation_wall_start = Some(std::time::Instant::now());
             decode_profile = Some(Qwen36DecodeProfileScope::new_from_env());
         }
@@ -961,6 +964,7 @@ fn decode_text(
         let download_final_hidden = !is_gen_step
             || fold.is_none()
             || final_hidden_observer_enabled
+            || emit_stage_timings
             || mtp_buffers.is_some();
         let chain_step = run_chain_step(Qwen36ChainStep {
             ordinal,

--- a/crates/runner/src/qwen36_moe/generation.rs
+++ b/crates/runner/src/qwen36_moe/generation.rs
@@ -23,6 +23,7 @@ pub(crate) struct Qwen36GenerationStep<'a> {
     pub(crate) geom: &'a MultiLayerGeom,
     pub(crate) step: usize,
     pub(crate) lm_head_folded: bool,
+    pub(crate) lm_head_folded_top1: bool,
     pub(crate) dump_last_logits: bool,
     pub(crate) tokenizer: Option<&'a tokenizers::Tokenizer>,
     pub(crate) sampling: SamplingParams,
@@ -40,12 +41,12 @@ pub(crate) struct Qwen36GenerationStep<'a> {
     pub(crate) stage_timings: &'a mut Qwen36StageTimingTotals,
 }
 
-fn metal_gpu_argmax_enabled(
+fn gpu_argmax_enabled(
     sampling: SamplingParams,
     dump_last_logits: bool,
     logits_buf: &GpuBuffer,
 ) -> bool {
-    logits_buf.backend() == Backend::Metal
+    matches!(logits_buf.backend(), Backend::Metal | Backend::Hip)
         && (sampling.temperature <= 0.0 || sampling.top_k == 1)
         && !dump_last_logits
         && std::env::var_os("SUPERSONIC_QWEN36_DUMP_LOGITS").is_none()
@@ -58,6 +59,7 @@ pub(crate) fn run_generation_step(args: Qwen36GenerationStep<'_>) -> Result<u32>
         geom,
         step,
         lm_head_folded,
+        lm_head_folded_top1,
         dump_last_logits,
         tokenizer,
         sampling,
@@ -88,10 +90,16 @@ pub(crate) fn run_generation_step(args: Qwen36GenerationStep<'_>) -> Result<u32>
     );
 
     let t2 = std::time::Instant::now();
-    let gpu_argmax = metal_gpu_argmax_enabled(sampling, dump_last_logits, logits_buf);
-    let (logits, gpu_next_token) = if gpu_argmax && lm_head_folded {
-        let token = launch_top1_from_logits(geom, logits_buf, counter_buf)
-            .context("folded GPU lm_head Metal argmax")?;
+    let gpu_argmax = gpu_argmax_enabled(sampling, dump_last_logits, logits_buf);
+    let (logits, gpu_next_token) = if gpu_argmax && lm_head_folded_top1 {
+        let bytes = counter_buf
+            .to_host_bytes()
+            .context("d2h folded GPU lm_head top1 token")?;
+        let token = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+        (None, Some(token))
+    } else if gpu_argmax && lm_head_folded {
+        let token = launch_top1_from_logits(ordinal, geom, logits_buf, counter_buf)
+            .context("folded GPU lm_head argmax")?;
         (None, Some(token))
     } else if gpu_argmax {
         let token = launch_lm_head_top1_from_final_hidden_bytes(

--- a/crates/runner/src/qwen36_moe/lm_head.rs
+++ b/crates/runner/src/qwen36_moe/lm_head.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use gpu_hal::GpuBuffer;
+use gpu_hal::{Backend, GpuBuffer};
 
 use crate::qwen36_moe_types::MultiLayerGeom;
 
@@ -69,18 +69,34 @@ pub(crate) fn launch_lm_head_top1_from_final_hidden_bytes(
         buffers.counter,
     )
     .context("gpu lm_head launch")?;
-    launch_top1_from_logits(geom, buffers.logits, buffers.counter)
+    launch_top1_from_logits(ordinal, geom, buffers.logits, buffers.counter)
 }
 
 pub(crate) fn launch_top1_from_logits(
+    ordinal: usize,
     geom: &MultiLayerGeom,
     logits: &GpuBuffer,
     out_index: &mut GpuBuffer,
 ) -> Result<u32> {
-    kernel_ffi::metal_argmax_bf16_into(logits, out_index, geom.vocab as usize)
-        .context("metal argmax over lm_head logits")?;
-    if kernel_ffi::prefill_ffi::metal_batch_is_active() {
-        kernel_ffi::prefill_ffi::flush_metal_batch().context("flush metal argmax batch")?;
+    match logits.backend() {
+        Backend::Metal => {
+            kernel_ffi::metal_argmax_bf16_into(logits, out_index, geom.vocab as usize)
+                .context("metal argmax over lm_head logits")?;
+            if kernel_ffi::prefill_ffi::metal_batch_is_active() {
+                kernel_ffi::prefill_ffi::flush_metal_batch().context("flush metal argmax batch")?;
+            }
+        }
+        Backend::Hip => {
+            kernel_ffi::prefill_ffi::argmax_bf16_rows(
+                ordinal,
+                1,
+                geom.vocab as usize,
+                logits,
+                out_index,
+            )
+            .context("HIP argmax over lm_head logits")?;
+        }
+        other => anyhow::bail!("GPU argmax over lm_head logits is not available for {other:?}"),
     }
     let bytes = out_index
         .to_host_bytes()

--- a/crates/runner/src/qwen36_moe/mtp.rs
+++ b/crates/runner/src/qwen36_moe/mtp.rs
@@ -29,8 +29,8 @@ use kernel_ffi::qwen36_moe::{
 };
 
 use crate::qwen36_moe_decode::{
-    ffn_output_elems, ffn_workspace_floats, full_attn_output_elems, full_attn_workspace_floats,
-    reset_sync_buf,
+    ffn_output_elems, ffn_workspace_floats, full_attn_output_elems,
+    full_attn_score_workspace_floats, full_attn_workspace_floats, reset_sync_buf,
 };
 use crate::qwen36_moe_types::{MtpLayerBuffers, MultiLayerGeom};
 
@@ -96,11 +96,7 @@ pub fn alloc_mtp_forward_scratch(
     geom: &MultiLayerGeom,
     kv_max_t: usize,
 ) -> Result<MtpForwardScratch> {
-    let attn_extra = if kv_max_t > 0 {
-        (geom.num_attention_heads as usize) * kv_max_t
-    } else {
-        0
-    };
+    let attn_extra = full_attn_score_workspace_floats(geom, kv_max_t);
     let attn_output = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[full_attn_output_elems(geom)])
         .context("alloc mtp attn_output")?;
     let attn_workspace = GpuBuffer::zeros(

--- a/crates/runner/src/qwen36_moe/persistent_decode.rs
+++ b/crates/runner/src/qwen36_moe/persistent_decode.rs
@@ -49,12 +49,14 @@ pub const CACHE_POS_INHERIT: i32 = Qwen36MoeAttnStepParams::CACHE_POS_INHERIT;
 pub struct LmHeadFold<'a> {
     pub final_norm_w: &'a GpuBuffer,
     pub lm_head_w: &'a GpuBuffer,
-    pub logits_out: &'a mut GpuBuffer,
+    pub logits_out: Option<&'a mut GpuBuffer>,
+    pub top1_out: Option<&'a mut GpuBuffer>,
     pub vocab: i32,
 }
 
 use crate::qwen36_moe_decode::{
-    ffn_workspace_floats, full_attn_workspace_floats, linear_attn_workspace_floats,
+    ffn_workspace_floats, full_attn_score_workspace_floats, full_attn_workspace_floats,
+    linear_attn_workspace_floats, reset_sync_buf,
 };
 use crate::qwen36_moe_logits::bf16_bytes_to_f32;
 use crate::qwen36_moe_types::{
@@ -73,6 +75,7 @@ use crate::qwen36_moe_types::{
 pub struct PersistentScratch {
     pub geom: Qwen36MoePersistentGeom,
     pub num_layers: usize,
+    pub layer_is_full_attention: Vec<bool>,
     /// `[num_layers]` descriptors uploaded as opaque U8 bytes.
     pub layer_descs_dev: GpuBuffer,
     /// `[num_layers]` INT4 sidecar descriptors. `None` for BF16 bakes.
@@ -106,6 +109,7 @@ impl PersistentScratch {
     /// need `&mut layers`.
     pub fn new(ordinal: usize, geom: &MultiLayerGeom, layers: &mut [LayerBuffers]) -> Result<Self> {
         let num_layers = layers.len();
+        let layer_is_full_attention = layers.iter().map(LayerBuffers::is_full_attn).collect();
         let descs = build_layer_descs(layers);
         let layer_descs_dev =
             upload_descs(ordinal, &descs).context("upload layer descriptor array")?;
@@ -126,9 +130,10 @@ impl PersistentScratch {
         let hidden_pong = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[hidden])
             .context("alloc persistent hidden_pong")?;
 
-        // Kv-cache adds OFF_SCORES = [num_attention_heads * kv_max_t] F32
-        // when any full-attn layer carries a cache. Mirror the chained
-        // driver's `attn_extra` calc.
+        // KV-cache adds per-head score/partial workspace when any
+        // full-attn layer carries a cache. Mirror the chained driver's
+        // score-stride calc so the HIP tiled-attention path can use
+        // tile-local online-softmax partials.
         let max_kv_t = layers
             .iter()
             .filter_map(|l| match &l.attn {
@@ -139,15 +144,11 @@ impl PersistentScratch {
             })
             .max()
             .unwrap_or(0);
-        let attn_extra = if max_kv_t > 0 {
-            geom.num_attention_heads as usize * max_kv_t
-        } else {
-            0
-        };
-        let ws_floats = full_attn_workspace_floats(geom)
+        let full_attn_ws =
+            full_attn_workspace_floats(geom) + full_attn_score_workspace_floats(geom, max_kv_t);
+        let ws_floats = full_attn_ws
             .max(linear_attn_workspace_floats(geom))
-            .max(ffn_workspace_floats(geom))
-            + attn_extra;
+            .max(ffn_workspace_floats(geom));
         let workspace = GpuBuffer::zeros(ordinal, ScalarType::F32, &[ws_floats])
             .context("alloc persistent workspace")?;
         let ffn_topk_idx_scratch =
@@ -178,6 +179,7 @@ impl PersistentScratch {
         Ok(Self {
             geom: pgeom,
             num_layers,
+            layer_is_full_attention,
             layer_descs_dev,
             int4_scales_dev,
             kv_fp8_descs_dev,
@@ -190,7 +192,8 @@ impl PersistentScratch {
     }
 
     /// One decode step. H2D the freshly-embedded `initial_hidden` into
-    /// `hidden_ping`, run the megakernel, D2H the final hidden back.
+    /// `hidden_ping`, run the megakernel, and optionally D2H the final
+    /// hidden back.
     /// Mutates the linear-attn state in place (via the pointers cached
     /// in `layer_descs_dev`) — same semantics as
     /// `run_chained_decode_fast`.
@@ -210,6 +213,7 @@ impl PersistentScratch {
         // prefill and MTP draft layers use that shape.
         cache_pos: i32,
         lm_head_fold: Option<LmHeadFold<'_>>,
+        download_final_hidden: bool,
     ) -> Result<DecodeOutputs> {
         let hidden_bytes = self.geom.hidden as usize * 2;
         if initial_hidden_bytes.len() != hidden_bytes {
@@ -231,6 +235,7 @@ impl PersistentScratch {
             final_norm_w: f.final_norm_w,
             lm_head_w: f.lm_head_w,
             logits_out: f.logits_out,
+            top1_out: f.top1_out,
             vocab: f.vocab,
         });
 
@@ -256,18 +261,22 @@ impl PersistentScratch {
         .context("persistent_decode_launch")?;
         let elapsed_us = t_launch.elapsed().as_micros() as u64;
 
-        // D2H the final hidden — same as run_chained_decode_fast does at
-        // the end of its chain. The bridge syncs (hipDeviceSynchronize)
-        // before returning, so this measurement covers real GPU compute
-        // time, not host queue time.
-        let mut final_hidden_bytes = vec![0u8; hidden_bytes];
-        copy_d2h(
-            ordinal,
-            final_hidden_bytes.as_mut_ptr() as *mut _,
-            self.hidden_ping.as_ptr(),
-            hidden_bytes,
-        )
-        .context("d2h hidden_ping -> final_hidden_bytes")?;
+        // D2H the final hidden only when a downstream host consumer needs it.
+        // Folded generation can consume logits/token from the same stream and
+        // let that later transfer be the synchronization point.
+        let final_hidden_bytes = if download_final_hidden {
+            let mut bytes = vec![0u8; hidden_bytes];
+            copy_d2h(
+                ordinal,
+                bytes.as_mut_ptr() as *mut _,
+                self.hidden_ping.as_ptr(),
+                hidden_bytes,
+            )
+            .context("d2h hidden_ping -> final_hidden_bytes")?;
+            bytes
+        } else {
+            Vec::new()
+        };
 
         // Stage attribution isn't recoverable inside one launch — we
         // lump the whole wall-clock into `kernel_full_attn_us` so
@@ -545,6 +554,218 @@ impl PersistentScratch {
             sparse_route_d2h_us: route_d2h_us,
             sparse_demand_prefetch_us: demand_us,
             sparse_ffn_launch_us: ffn_launch_us,
+        })
+    }
+
+    /// Profiling-only segmented decode. Splits every layer into attention-only
+    /// and FFN-only persistent entry points, but skips VMM remap and route
+    /// downloads. This is intentionally slower than [`Self::run`]; use it only
+    /// under `SUPERSONIC_QWEN36_SEGMENTED_PROFILE=1` so rocprof can attribute
+    /// the one-launch megakernel's layer halves.
+    pub fn run_segmented_profile(
+        &mut self,
+        ordinal: usize,
+        initial_hidden_bytes: &[u8],
+        position: i32,
+        cache_pos: i32,
+    ) -> Result<DecodeOutputs> {
+        let hidden_bytes = self.geom.hidden as usize * 2;
+        if initial_hidden_bytes.len() != hidden_bytes {
+            return Err(anyhow!(
+                "initial_hidden_bytes len {} != expected {} (hidden*2 BF16 bytes)",
+                initial_hidden_bytes.len(),
+                hidden_bytes,
+            ));
+        }
+        copy_h2d(
+            ordinal,
+            self.hidden_ping.as_mut_ptr(),
+            initial_hidden_bytes.as_ptr() as *const _,
+            hidden_bytes,
+        )
+        .context("h2d initial_hidden -> hidden_ping")?;
+
+        let mut attn_us = 0u64;
+        let mut ffn_us = 0u64;
+        let ffn_stage_profile = std::env::var_os("SUPERSONIC_QWEN36_FFN_STAGE_PROFILE").is_some();
+        let linear_stage_profile =
+            std::env::var_os("SUPERSONIC_QWEN36_LINEAR_STAGE_PROFILE").is_some();
+        for layer_idx in 0..self.num_layers {
+            if linear_stage_profile && !self.layer_is_full_attention[layer_idx] {
+                for stage in 1..=5 {
+                    reset_sync_buf(ordinal, &mut self.sync_buf).with_context(|| {
+                        format!("reset sync_buf (segmented linear stage {stage} layer {layer_idx})")
+                    })?;
+                    let t_attn = std::time::Instant::now();
+                    persistent_decode_launch_range(
+                        ordinal,
+                        ScalarType::BF16,
+                        self.geom,
+                        layer_idx,
+                        layer_idx + 1,
+                        Qwen36MoePersistentMode::LinearStage(stage),
+                        position,
+                        cache_pos,
+                        &self.layer_descs_dev,
+                        self.int4_scales_dev.as_ref(),
+                        self.kv_fp8_descs_dev.as_ref(),
+                        self.num_layers,
+                        &mut self.hidden_ping,
+                        &mut self.hidden_pong,
+                        &mut self.workspace,
+                        &mut self.ffn_topk_idx_scratch,
+                        &mut self.sync_buf,
+                        None,
+                        -1,
+                        None,
+                        1,
+                        None,
+                    )
+                    .map_err(|e: GpuError| anyhow!(e))
+                    .with_context(|| {
+                        format!(
+                            "persistent segmented linear stage {stage} launch (layer {layer_idx})"
+                        )
+                    })?;
+                    attn_us = attn_us.saturating_add(t_attn.elapsed().as_micros() as u64);
+                }
+            } else {
+                reset_sync_buf(ordinal, &mut self.sync_buf).with_context(|| {
+                    format!("reset sync_buf (segmented attention layer {layer_idx})")
+                })?;
+                let t_attn = std::time::Instant::now();
+                persistent_decode_launch_range(
+                    ordinal,
+                    ScalarType::BF16,
+                    self.geom,
+                    layer_idx,
+                    layer_idx + 1,
+                    Qwen36MoePersistentMode::AttnOnly,
+                    position,
+                    cache_pos,
+                    &self.layer_descs_dev,
+                    self.int4_scales_dev.as_ref(),
+                    self.kv_fp8_descs_dev.as_ref(),
+                    self.num_layers,
+                    &mut self.hidden_ping,
+                    &mut self.hidden_pong,
+                    &mut self.workspace,
+                    &mut self.ffn_topk_idx_scratch,
+                    &mut self.sync_buf,
+                    None,
+                    -1,
+                    None,
+                    1,
+                    None,
+                )
+                .map_err(|e: GpuError| anyhow!(e))
+                .with_context(|| {
+                    format!("persistent segmented attention launch (layer {layer_idx})")
+                })?;
+                attn_us = attn_us.saturating_add(t_attn.elapsed().as_micros() as u64);
+            }
+
+            if ffn_stage_profile {
+                // Profiling-only cumulative stages. Each launch recomputes
+                // from post-attention hidden_pong; stage 5 is the final one
+                // and writes the real layer output to hidden_ping.
+                for stage in 1..=5 {
+                    reset_sync_buf(ordinal, &mut self.sync_buf).with_context(|| {
+                        format!("reset sync_buf (segmented ffn stage {stage} layer {layer_idx})")
+                    })?;
+                    let t_ffn = std::time::Instant::now();
+                    persistent_decode_launch_range(
+                        ordinal,
+                        ScalarType::BF16,
+                        self.geom,
+                        layer_idx,
+                        layer_idx + 1,
+                        Qwen36MoePersistentMode::FfnStage(stage),
+                        position,
+                        cache_pos,
+                        &self.layer_descs_dev,
+                        self.int4_scales_dev.as_ref(),
+                        self.kv_fp8_descs_dev.as_ref(),
+                        self.num_layers,
+                        &mut self.hidden_ping,
+                        &mut self.hidden_pong,
+                        &mut self.workspace,
+                        &mut self.ffn_topk_idx_scratch,
+                        &mut self.sync_buf,
+                        None,
+                        -1,
+                        None,
+                        1,
+                        None,
+                    )
+                    .map_err(|e: GpuError| anyhow!(e))
+                    .with_context(|| {
+                        format!("persistent segmented ffn stage {stage} launch (layer {layer_idx})")
+                    })?;
+                    ffn_us = ffn_us.saturating_add(t_ffn.elapsed().as_micros() as u64);
+                }
+            } else {
+                reset_sync_buf(ordinal, &mut self.sync_buf)
+                    .with_context(|| format!("reset sync_buf (segmented ffn layer {layer_idx})"))?;
+                let t_ffn = std::time::Instant::now();
+                persistent_decode_launch_range(
+                    ordinal,
+                    ScalarType::BF16,
+                    self.geom,
+                    layer_idx,
+                    layer_idx + 1,
+                    Qwen36MoePersistentMode::FfnOnly,
+                    position,
+                    cache_pos,
+                    &self.layer_descs_dev,
+                    self.int4_scales_dev.as_ref(),
+                    self.kv_fp8_descs_dev.as_ref(),
+                    self.num_layers,
+                    &mut self.hidden_ping,
+                    &mut self.hidden_pong,
+                    &mut self.workspace,
+                    &mut self.ffn_topk_idx_scratch,
+                    &mut self.sync_buf,
+                    None,
+                    -1,
+                    None,
+                    1,
+                    None,
+                )
+                .map_err(|e: GpuError| anyhow!(e))
+                .with_context(|| format!("persistent segmented ffn launch (layer {layer_idx})"))?;
+                ffn_us = ffn_us.saturating_add(t_ffn.elapsed().as_micros() as u64);
+            }
+        }
+
+        let mut final_hidden_bytes = vec![0u8; hidden_bytes];
+        copy_d2h(
+            ordinal,
+            final_hidden_bytes.as_mut_ptr() as *mut _,
+            self.hidden_ping.as_ptr(),
+            hidden_bytes,
+        )
+        .context("d2h hidden_ping -> final_hidden_bytes")?;
+
+        Ok(DecodeOutputs {
+            path_label: if ffn_stage_profile {
+                "persistent-segmented-ffn-stage-profile"
+            } else if linear_stage_profile {
+                "persistent-segmented-linear-stage-profile"
+            } else {
+                "persistent-segmented-profile"
+            },
+            final_hidden_bytes,
+            per_layer_attn_out: Vec::new(),
+            per_layer_ffn_out: Vec::new(),
+            kernel_full_attn_us: attn_us,
+            kernel_linear_attn_us: 0,
+            kernel_ffn_us: ffn_us,
+            sparse_lookahead_prefetch_us: 0,
+            sparse_router_launch_us: attn_us,
+            sparse_route_d2h_us: 0,
+            sparse_demand_prefetch_us: 0,
+            sparse_ffn_launch_us: ffn_us,
         })
     }
 

--- a/crates/runner/src/qwen36_moe/spec_verify.rs
+++ b/crates/runner/src/qwen36_moe/spec_verify.rs
@@ -61,7 +61,7 @@ pub(crate) fn run_spec_chain_step(args: Qwen36SpecChainStep<'_>) -> Result<Decod
         // as the pre-PR-#211 inherit-from-position path; in
         // SpecPrefill+MTP the verify replay writes accepted draft
         // tokens at the compact slot while RoPE rotates absolute.
-        scratch.run(args.ordinal, &initial_hidden, rope, cache, None)?
+        scratch.run(args.ordinal, &initial_hidden, rope, cache, None, true)?
     } else if !args.position.is_dense() {
         run_chained_decode_fast_with_cache_pos(
             args.ordinal,

--- a/crates/runner/tests/qwen36_moe_multilayer_parity.rs
+++ b/crates/runner/tests/qwen36_moe_multilayer_parity.rs
@@ -747,6 +747,7 @@ fn multilayer_persistent_decode_matches_chained() {
             position,
             runner::qwen36_moe_persistent_decode::CACHE_POS_INHERIT,
             None,
+            true,
         )
         .expect("PersistentScratch::run");
     let persistent_final = persistent_outputs.final_hidden_bytes;

--- a/docs/qwen36-lucebox-parity-log.md
+++ b/docs/qwen36-lucebox-parity-log.md
@@ -1,8 +1,265 @@
 # Qwen3.6 Lucebox Parity Log
 
-Last updated: 2026-06-18
+Last updated: 2026-06-19
 
-Purpose: durable working log for the Qwen3.6-27B DFlash Lucebox parity effort on RX 7900 XTX / gfx1100. Keep this file current before and after profiling or benchmark runs so context compaction does not cause stale results, repeated sweeps, or reverted experiments to be treated as new evidence.
+Purpose: durable working log for the Qwen3.6 Lucebox parity efforts on RX 7900 XTX / gfx1100, including the original 27B DFlash track and the newer 35B A3B local-benchmark track. Keep this file current before and after profiling or benchmark runs so context compaction does not cause stale results, repeated sweeps, or reverted experiments to be treated as new evidence.
+
+## 2026-06-19 Checkpoint: 35B A3B Local Lucebox Stack
+
+This is the authoritative memory for the Qwen3.6-35B-A3B local-benchmark parity slice. Read this section before starting another 35B kernel experiment.
+
+Baselines and current keeper:
+
+- Lucebox baseline was run from `/home/deano/projects/lucebox-hub/server` with `.venv/bin/python scripts/bench_he.py --target-profile qwen36-35b-a3b --n-gen 256 --skip-tokenize`: decode mean `78.18 tok/s`, prefill `970.08 tok/s`.
+- Supersonic pre-slice keeper: `target/qwen36_35b_a3b_raw_script_10x256_linear_qkvz_fused.json`, weighted `48.45181315769551 tok/s`, mean `48.406637480666404 tok/s`, total decode `52836.0 ms`.
+- Current Supersonic keeper: `target/qwen36_35b_a3b_raw_script_10x256_fullattn_q_gate_pair_wmma.json`, weighted `63.375748873595086 tok/s`, mean `63.37227197518149 tok/s`, total decode `40394.0 ms`.
+- Previous Supersonic keeper: `target/qwen36_35b_a3b_raw_script_10x256_ffn_direct_mid_pair_wmma.json`, weighted `63.09303758471965 tok/s`, mean `63.13242332829803 tok/s`, total decode `40575.0 ms`.
+- Previous Supersonic keeper: `target/qwen36_35b_a3b_raw_script_10x256_shared_pair_scalar.json`, weighted `61.46163449534236 tok/s`, mean `61.463303794592136 tok/s`, total decode `41652.0 ms`.
+- Previous Supersonic keeper: `target/qwen36_35b_a3b_raw_script_10x256_fullattn_kv_combined_wmma.json`, weighted `60.13342102790567 tok/s`, mean `60.13318379670013 tok/s`, total decode `42572.0 ms`.
+- Previous Supersonic keeper: `target/qwen36_35b_a3b_raw_script_10x256_shared_direct_mid_scalar.json`, weighted `59.078740884334906 tok/s`, mean `59.06759153365489 tok/s`, total decode `43332.0 ms`.
+- Previous Supersonic keeper: `target/qwen36_35b_a3b_raw_script_10x256_ffn_direct_mid_wmma_raw.json`, weighted `58.502250965515664 tok/s`, mean `58.548731610147115 tok/s`, total decode `43759.0 ms`.
+- Previous Supersonic keeper: `target/qwen36_35b_a3b_raw_script_10x256_linear_outproj_tile64.json`, weighted `57.75130842808157 tok/s`, mean `57.77102039113525 tok/s`, total decode `44328.0 ms`.
+- Previous Supersonic keeper: `target/qwen36_35b_a3b_raw_script_10x256_reset16_onebarrier.json`, weighted `57.26428811094956 tok/s`, mean `57.27459969437247 tok/s`, total decode `44705.0 ms`.
+- Previous Supersonic keeper: `target/qwen36_35b_a3b_raw_script_10x256_fullattn_tile8.json`, weighted `57.161996204086186 tok/s`, mean `57.208911777877304 tok/s`, total decode `44785.0 ms`.
+- Previous Supersonic keeper: `target/qwen36_35b_a3b_raw_script_10x256_fullattn_tile16.json`, weighted `57.09442883268656 tok/s`, mean `57.11223040165311 tok/s`, total decode `44838.0 ms`.
+- Previous Supersonic keeper: `target/qwen36_35b_a3b_raw_script_10x256_fullattn_tile32.json`, weighted `56.832056832056836 tok/s`, mean `56.85101621542299 tok/s`, total decode `45045.0 ms`.
+- Previous Supersonic keeper: `target/qwen36_35b_a3b_raw_script_10x256_fullattn_tile64.json`, weighted `56.390149345786156 tok/s`, mean `56.40267050151467 tok/s`, total decode `45398.0 ms`.
+- Previous Supersonic keeper: `target/qwen36_35b_a3b_raw_script_10x256_fullattn_tile128.json`, weighted `55.50015175822747 tok/s`, mean `55.52554211772089 tok/s`, total decode `46126.0 ms`.
+- Previous Supersonic keeper: `target/qwen36_35b_a3b_raw_script_10x256_fast_dequant.json`, weighted `51.41181668474113 tok/s`, mean `51.394279761205894 tok/s`, total decode `49794.0 ms`.
+- Previous Supersonic keeper: `target/qwen36_35b_a3b_raw_script_10x256_no_hnorm_store.json`, weighted `49.32942808694312 tok/s`, mean `49.33859425900592 tok/s`, total decode `51896.0 ms`.
+- Previous Supersonic keeper: `target/qwen36_35b_a3b_raw_script_10x256_ffn_jk_fused.json`, weighted `49.20049200492005 tok/s`, mean `49.19222423802477 tok/s`, total decode `52032.0 ms`.
+
+Kept changes:
+
+- Added Supersonic local benchmark harness support for `qwen36-35b-a3b`, model `qwen3.6-35b-a3b`, model dir `/mnt/data/models/Qwen3.6-35B-A3B`, quant `int4`, and summary fields including `weighted_tok_s` and `total_decode_ms`.
+- Folded persistent LM-head greedy top1 into the decode kernel for greedy decode. Artifact: `target/qwen36_35b_a3b_raw_script_10x256_folded_top1.json`, weighted `49.15703368024886 tok/s`, mean `49.14392905788375 tok/s`, total decode `52078.0 ms`.
+- Kept FFN Phase J/K tail fusion in `kernels/qwen36_moe_persistent/ffn_phase.cuh`, avoiding the `MOE_OUT` workspace store/read plus barrier on the full stage. Artifact: `target/qwen36_35b_a3b_raw_script_10x256_ffn_jk_fused.json`, weighted `49.20049200492005 tok/s`.
+- Removed the unused FFN `OFF_H_NORM` global scratch store while leaving the workspace layout unchanged. Artifact: `target/qwen36_35b_a3b_raw_script_10x256_no_hnorm_store.json`, weighted `49.32942808694312 tok/s`; 1x64 artifact `target/qwen36_35b_a3b_raw_script_1x64_no_hnorm_store.json`, weighted `51.90592051905921 tok/s`.
+- Removed per-nibble BF16 RNE from hot INT4 dequant helpers in `kernels/qwen36_moe_persistent/helpers.cuh`. Artifact: `target/qwen36_35b_a3b_raw_script_10x256_fast_dequant.json`, weighted `51.41181668474113 tok/s`; 1x64 artifact `target/qwen36_35b_a3b_raw_script_1x64_fast_dequant.json`, weighted `54.34782608695652 tok/s`.
+- Enabled cached full-attention tiled partials and swept the tile size to 8 tokens by widening the per-head score workspace stride. Current artifact: `target/qwen36_35b_a3b_raw_script_10x256_fullattn_tile8.json`, weighted `57.161996204086186 tok/s`; 1x64 artifact `target/qwen36_35b_a3b_raw_script_1x64_fullattn_tile8.json`, weighted `58.023572076155936 tok/s`. Previous tile16 artifact: `target/qwen36_35b_a3b_raw_script_10x256_fullattn_tile16.json`, weighted `57.09442883268656 tok/s`.
+- Folded persistent `reset_counters_16` from two grid barriers to one release barrier that resets all 16 counter slots before publishing the next phase. Artifact: `target/qwen36_35b_a3b_raw_script_10x256_reset16_onebarrier.json`, weighted `57.26428811094956 tok/s`; 1x64 artifact `target/qwen36_35b_a3b_raw_script_1x64_reset16_onebarrier.json`, weighted `58.12897366030881 tok/s`.
+- Changed linear-attention Phase I out-projection WMMA work distribution from 128 rows per block to 64 rows per block so 32 blocks, rather than 16, participate in the 2048-row projection on gfx1100. Artifact: `target/qwen36_35b_a3b_raw_script_10x256_linear_outproj_tile64.json`, weighted `57.75130842808157 tok/s`; 1x64 artifact `target/qwen36_35b_a3b_raw_script_1x64_linear_outproj_tile64.json`, weighted `58.661778185151235 tok/s`.
+- Added FFN Phase G direct-mid WMMA for production INT4 stages: paired gate/up WMMA rows write `EXPERT_MID` directly, skipping legacy Phase H and one grid barrier while keeping the stage-3 profiling path on the old layout. Comparable raw-script artifacts: `target/qwen36_35b_a3b_raw_script_1x64_ffn_direct_mid_wmma_raw.json`, weighted `59.424326833797586 tok/s`, output hash unchanged versus the tile64 keeper; `target/qwen36_35b_a3b_raw_script_10x256_ffn_direct_mid_wmma_raw.json`, weighted `58.502250965515664 tok/s`, mean `58.548731610147115 tok/s`, total decode `43759 ms`, generated `2560`, stopped early `0`. The combined generated-id hash matches the previous keeper (`ff860cdeccf012aa228409b82418219848ca9350b30e2eaab87d66527cf07ae9`).
+- Added shared-expert scalar direct-mid path in Phase D: shared gate/up remain scalar INT4 matvecs, but each shared row computes gate and up together, writes `OFF_SHARED_MID` directly, and skips Phase E plus one grid barrier. This is distinct from the rejected shared-expert WMMA direct-mid path. Validation passed `cargo fmt --check`, release build, and persistent-vs-chained parity before benchmarking. Artifacts: `target/qwen36_35b_a3b_raw_script_1x64_shared_direct_mid_scalar.json`, weighted `60.0375234521576 tok/s`, total decode `1066 ms`, generated-id hash `ee96d4ba3ccc01df68bed07b652eb1d37277bdafc224c5628c62c3055fe9e5ed`; `target/qwen36_35b_a3b_raw_script_10x256_shared_direct_mid_scalar.json`, weighted `59.078740884334906 tok/s`, mean `59.06759153365489 tok/s`, total decode `43332 ms`, generated `2560`, stopped early `0`. The 10x256 combined generated-id hash matches the previous direct-mid WMMA keeper under the current parser (`aba29b816293e7d63b078e7c987f290751e4d22280d1ab4cea7f756bf3647a01`).
+- Combined full-attention Phase D K/V INT4 WMMA into one work pool when both projections are INT4: K and V rows are aligned to the 128-row WMMA work tile, so the combined pool doubles available tasks for the small `Hkv*d` projections and removes the internal K->V counter-reset barrier. This is distinct from the rejected attention tile-size sweeps. Validation passed release build and persistent-vs-chained parity before benchmarking. Artifacts: `target/qwen36_35b_a3b_raw_script_1x64_fullattn_kv_combined_wmma.json`, weighted `61.12702960840497 tok/s`, total decode `1047 ms`, generated-id hash `ee96d4ba3ccc01df68bed07b652eb1d37277bdafc224c5628c62c3055fe9e5ed`; `target/qwen36_35b_a3b_raw_script_10x256_fullattn_kv_combined_wmma.json`, weighted `60.13342102790567 tok/s`, mean `60.13318379670013 tok/s`, total decode `42572 ms`, generated `2560`, stopped early `0`. The 10x256 combined generated-id hash matches the previous keeper (`aba29b816293e7d63b078e7c987f290751e4d22280d1ab4cea7f756bf3647a01`).
+- Paired the shared-expert scalar direct-mid INT4 gate/up row dot products: the kept scalar direct-mid path now computes shared gate and up partials for the same row in one column loop and reduces both in parallel, reusing the normalized hidden load and cutting one reduction/barrier chain per shared row. This is distinct from the rejected shared-expert WMMA direct-mid path; it preserves each row's accumulation order and generated-token hash. Validation passed release build and persistent-vs-chained parity before benchmarking. Artifacts: `target/qwen36_35b_a3b_raw_script_1x64_shared_pair_scalar.json`, weighted `62.56109481915934 tok/s`, total decode `1023 ms`, generated-id hash `ee96d4ba3ccc01df68bed07b652eb1d37277bdafc224c5628c62c3055fe9e5ed`; `target/qwen36_35b_a3b_raw_script_10x256_shared_pair_scalar.json`, weighted `61.46163449534236 tok/s`, mean `61.463303794592136 tok/s`, total decode `41652 ms`, generated `2560`, stopped early `0`. The 10x256 combined generated-id hash matches the previous keeper (`aba29b816293e7d63b078e7c987f290751e4d22280d1ab4cea7f756bf3647a01`).
+- Paired routed FFN direct-mid WMMA helper for production INT4 Phase G: the kept direct-mid path still computes separate gate and up WMMA accumulations with their original scale rows, but now packs the shared activation operand once per 16-wide K tile and returns both accumulators. Validation passed `cargo fmt --check`, release build, and exact multilayer persistent parity. Artifacts: `target/qwen36_35b_a3b_raw_script_1x64_ffn_direct_mid_pair_wmma.json`, weighted `64.1925777331996 tok/s`, total decode `997 ms`, generated-id hash `6d8b16636e45b2b337e69eac8a115d7bff2f8297af849557e1852811b324ad3e`; `target/qwen36_35b_a3b_raw_script_10x256_ffn_direct_mid_pair_wmma.json`, weighted `63.09303758471965 tok/s`, mean `63.13242332829803 tok/s`, total decode `40575 ms`, generated `2560`, stopped early `0`. The parsed 10x256 generated-id hash matches the previous shared-pair keeper (`aba29b816293e7d63b078e7c987f290751e4d22280d1ab4cea7f756bf3647a01`).
+- Paired full-attention Q/gate INT4 WMMA projection rows in Phase B: the full-attention q_proj INT4 path now computes the paired Q and gate rows with one activation packing pass per 16-wide K tile, preserving the original row writes into `workspace`. Validation passed `cargo fmt --check`, release build, exact multilayer persistent parity, and generated-token hash checks. Artifacts: `target/qwen36_35b_a3b_raw_script_1x64_fullattn_q_gate_pair_wmma.json`, weighted `64.45115810674723 tok/s`, total decode `993 ms`, generated-id hash `ee96d4ba3ccc01df68bed07b652eb1d37277bdafc224c5628c62c3055fe9e5ed`; `target/qwen36_35b_a3b_raw_script_10x256_fullattn_q_gate_pair_wmma.json`, weighted `63.375748873595086 tok/s`, mean `63.37227197518149 tok/s`, total decode `40394 ms`, generated `2560`, stopped early `0`. The parsed 10x256 generated-id hash matches the previous keeper (`aba29b816293e7d63b078e7c987f290751e4d22280d1ab4cea7f756bf3647a01`).
+- Added diagnostic `SUPERSONIC_QWEN36_DISABLE_PERSISTENT_WMMA=1` to force the non-WMMA persistent template. This is not a keeper path: 1x8 smoke was `62.7 ms/token` versus default `18.3 ms/token`, mostly because folded lm-head falls back to scalar.
+- Unit tests for the benchmark harness passed with `/home/deano/venvs/rocm/bin/python -m unittest -q tests.test_qwen36_he_supersonic_bench`. `pytest` is not installed in `/home/deano/venvs/rocm`.
+- Persistent-vs-chained synthetic parity is back online after updating `crates/runner/tests/qwen36_moe_multilayer_parity.rs` for the current `PersistentScratch::run(..., download_final_hidden)` signature. Command passed: `SUPERSONIC_QWEN36_MULTILAYER_ORACLE_JSON=/tmp/qwen36_ml_direct_mid_check.json HIP_ARCH=gfx1100 cargo test --release -p runner --test qwen36_moe_multilayer_parity multilayer_persistent_decode_matches_chained -- --nocapture`.
+- FFN oracle passed for the J/K fusion: `[parity ffn step5 int4 output_hidden] n=2048 exact=784 max_abs=3.12500e-2 mean_abs=5.63657e-3 cos_sim=0.9999897`.
+
+AMD profiling evidence:
+
+- ROCm profiler path: `/opt/rocm-7.1.1/bin/rocprofv3`.
+- Direct 35B A3B 1x32 profile directory: `target/rocprof_folded_top1_1x32/`.
+- Top kernel rows from `trace_kernel_stats.csv`: batched prefill grouped expert 40 calls / `801.417509 ms`; linear step prefill 3720 calls / `668.964004 ms`; persistent decode 32 calls / `612.811826 ms`, avg `19.1503695625 ms`.
+- App stage timers are skewed after folded-top1 because the skipped final-hidden D2H wait appears at the token/top1 read point. Use rocprof kernel rows for guidance.
+- Fresh direct Lucebox daemon one-prompt check: Qwen3.6-35B-A3B Q4_K_M reports all experts fit in VRAM (`10240 hot experts, 0 cold experts`, `20.10 GiB` on GPU, tok_embd CPU-only) and generated 32 tokens at `77.1 tok/s`. The gap is not caused by Lucebox hot/cold CPU overlap or speculative decode; it is an all-GPU graph/kernel gap.
+- Fresh Lucebox 10-prompt `--n-gen 32` no-draft check: decode mean `79.74 tok/s`, range `73.3-80.9`, prefill mean `967.47 tok/s`.
+- Fresh Supersonic segmented FFN stage profile: `target/qwen36_35b_profile/rocprof_current_ffn_stage_1x4/ss35b_current_ffn_stage_1x4_kernel_trace.csv`. App timer: total `38.580 ms/token` with FFN stage profiling overhead; parsed persistent launches show stage5/full FFN avg `0.15355854375 ms/layer` and attention avg `0.2283797625 ms/layer`.
+- Fresh Supersonic segmented linear stage profile: `target/qwen36_35b_profile/rocprof_current_linear_stage_1x4/ss35b_current_linear_stage_1x4_kernel_trace.csv`. Parsed persistent launches: full-attn `0.282334625 ms/layer`, linear stage5/full `0.1829586833 ms/layer`, FFN `0.18433230625 ms/layer`.
+- Tile16 unsegmented 1x64 rocprof trace:
+  `target/qwen36_35b_profile/rocprof_tile16_raw_1x64/ss35b_tile16_raw_1x64_kernel_stats.csv`.
+  Top decode row: `qwen36_moe_persistent_decode_kernel`, 64 calls,
+  total `1100.170 ms`, avg `17.1901 ms`, `42.26%` of traced runtime.
+  Prefill rows remain large in whole-program stats:
+  grouped expert `710.504 ms`, linear step `628.494 ms`.
+- Tile16 segmented FFN stage profile:
+  `target/qwen36_35b_profile/tile16_1x4_ffn_stage_profile.json` and
+  `target/qwen36_35b_profile/rocprof_tile16_ffn_stage_1x4/ss35b_tile16_ffn_stage_1x4_kernel_trace.csv`.
+  FFI rows: attn-only mean `0.2621 ms`, FFN stage4 `0.2013 ms`,
+  stage3 `0.1875 ms`, stage5/full `0.1857 ms`, stage2 `0.1107 ms`,
+  stage1 `0.0728 ms`.
+- Tile16 segmented linear stage profile:
+  `target/qwen36_35b_profile/tile16_1x4_linear_stage_profile.json` and
+  `target/qwen36_35b_profile/rocprof_tile16_linear_stage_1x4/ss35b_tile16_linear_stage_1x4_kernel_trace.csv`.
+  FFI rows: FFN-only mean `0.2168 ms`, linear stage5/full
+  `0.2121 ms`, stage4 `0.1374 ms`, stage1 `0.1356 ms`, stage3
+  `0.1124 ms`, stage2 `0.1097 ms`, full-attn-only `0.3169 ms`.
+- Fresh shared-direct-mid scalar segmented FFI profiles before the combined
+  K/V experiment:
+  `target/qwen36_35b_profile/shared_direct_mid_scalar_1x2_ffn_stage_ffi.json`
+  and
+  `target/qwen36_35b_profile/shared_direct_mid_scalar_1x2_linear_stage_ffi.json`.
+  FFN profile rows: full-attn-only mean `0.2569 ms`, FFN stage4
+  `0.1905 ms`, stage3 `0.1792 ms`, stage5/full `0.1743 ms`, stage2
+  `0.0967 ms`, stage1 `0.0672 ms`. Linear profile rows: FFN-only
+  `0.2065 ms`, linear stage5/full `0.2000 ms`, linear stage1
+  `0.1374 ms`, linear stage4 `0.1320 ms`, full-attn-only `0.3100 ms`.
+- Fresh combined-K/V keeper segmented FFI profiles:
+  `target/qwen36_35b_profile/fullattn_kv_combined_1x2_ffn_stage_ffi.json`
+  and
+  `target/qwen36_35b_profile/fullattn_kv_combined_1x2_linear_stage_ffi.json`.
+  FFN profile rows: full-attn-only mean `0.2473 ms`, FFN stage4
+  `0.1902 ms`, stage3 `0.1794 ms`, stage5/full `0.1747 ms`, stage2
+  `0.0967 ms`, stage1 `0.0669 ms`. Linear profile rows: FFN-only
+  `0.2059 ms`, linear stage5/full `0.1999 ms`, linear stage1
+  `0.1375 ms`, linear stage4 `0.1316 ms`, linear stage3 `0.1067 ms`,
+  linear stage2 `0.1019 ms`, full-attn-only `0.2799 ms`.
+- Fresh shared-pair-scalar keeper segmented FFI profiles:
+  `target/qwen36_35b_profile/shared_pair_scalar_1x2_ffn_stage_segmented_ffi.json`
+  and
+  `target/qwen36_35b_profile/shared_pair_scalar_1x2_linear_stage_segmented_ffi.json`.
+  FFN profile rows: full-attn-only mean `0.2521 ms`, FFN stage4
+  `0.1834 ms`, stage3 `0.1728 ms`, stage5/full `0.1678 ms`, stage2
+  `0.0897 ms`, stage1 `0.0678 ms`, argmax `0.3821 ms`. Linear profile
+  rows: FFN-only `0.1988 ms`, linear stage5/full `0.2002 ms`, linear
+  stage1 `0.1365 ms`, linear stage4 `0.1324 ms`, linear stage3
+  `0.1071 ms`, linear stage2 `0.1022 ms`, full-attn-only `0.2814 ms`,
+  argmax `0.2906 ms`. The failed parallel/non-segmented profile attempts
+  under `target/qwen36_35b_profile/shared_pair_scalar_1x2_*_stage_ffi.json`
+  should be ignored because they collided on VRAM or missed segmented
+  profiling.
+- Fresh current-keeper unsegmented rocprof trace after reverting the 96-row
+  FFN tile probe:
+  `target/qwen36_35b_profile/rocprof_shared_pair_current_1x32/ss35b_shared_pair_current_1x32_kernel_stats.csv`
+  and `target/qwen36_35b_profile/shared_pair_current_1x32_rocprof.json`.
+  The one-prompt 1x32 smoke stayed at `62.50 tok/s`; `rocprofv3` reports the
+  persistent decode kernel as `32` calls, total `508.952 ms`, average
+  `15.904740 ms`. Whole-program top rows are prefill-heavy for this short
+  trace: grouped expert prefill `709.825 ms`, linear step prefill
+  `598.376 ms`, then persistent decode `508.952 ms`. Use the persistent row
+  and segmented FFI profiles for decode optimization decisions; do not
+  mistake one-prompt whole-program percentages for decode-only attribution.
+- Fresh unsegmented rocprof trace after the paired routed FFN direct-mid WMMA
+  keeper:
+  `target/qwen36_35b_profile/rocprof_pair_wmma_current_1x32/ss35b_pair_wmma_current_1x32_kernel_stats.csv`
+  and `target/qwen36_35b_profile/pair_wmma_current_1x32_rocprof.json`.
+  The one-prompt 1x32 smoke held at weighted `64.0 tok/s`; `rocprofv3`
+  reports the persistent decode kernel as `32` calls, total `496.596 ms`,
+  average `15.518638 ms`, versus the previous shared-pair current trace at
+  `508.952 ms` total and `15.904740 ms` average.
+- Fresh unsegmented rocprof trace after the paired full-attention Q/gate WMMA
+  keeper:
+  `target/qwen36_35b_profile/rocprof_qgate_current_1x32/ss35b_qgate_current_1x32_kernel_stats.csv`
+  and `target/qwen36_35b_profile/qgate_current_1x32_rocprof.json`.
+  The one-prompt 1x32 smoke was weighted `64.38631790744466 tok/s`; `rocprofv3`
+  reports the persistent decode kernel as `32` calls, total `493.905 ms`,
+  average `15.434519 ms`, versus the paired-routed-FFN trace at `496.596 ms`
+  total and `15.518638 ms` average. Whole-program top rows remain prefill-heavy
+  for this short trace: grouped expert prefill `708.985 ms`, linear step
+  prefill `595.578 ms`, then persistent decode `493.905 ms`.
+- Lucebox comparison trace found at
+  `/home/deano/projects/lucebox-hub/server/target/profile_35b_1x64/lucebox35b_1x64_kernel_stats.csv`.
+  Its top rows are many ggml/llama.cpp qtype matvec kernels rather than a
+  Supersonic-style persistent megakernel, so direct row-by-row kernel timing
+  comparisons are not apples-to-apples. The useful inference is that Lucebox's
+  lead is likely matvec kernel maturity/quant layout plus graph scheduling,
+  not hot/cold expert overlap on this all-GPU 35B run.
+
+Rejected 35B A3B experiments:
+
+- Do not use the serving-mode direct-mid artifacts as keeper evidence against the raw-script Lucebox baseline: `target/qwen36_35b_a3b_raw_script_10x256_ffn_direct_mid_wmma.json` was actually ChatML/no-thinking serving mode (`prompt_source=jsonl`, `context_size=1024`, `eos_policy=stop`) and stopped early on `9/10` prompts. The comparable raw-script direct-mid artifact above is the keeper evidence.
+- FFN direct-mid WMMA 64-row work tile: correctness/parity passed, but 1x64 raw artifact `target/qwen36_35b_a3b_raw_script_1x64_ffn_direct_mid_tile64.json` regressed to weighted `55.25 tok/s` versus the 128-row direct-mid keeper `59.42 tok/s`. Reverted. Do not retry smaller direct-mid row tiles unless the block/wave mapping changes materially.
+- Linear recurrent Phase G tiled by `(V-head, 8 value columns)`: correctness passed, but 1x64 artifact `target/qwen36_35b_a3b_raw_script_1x64_linear_g_tiled.json` was `51.02 tok/s`, slower than the keeper 1x64 J/K fusion artifact at `51.77993527508091 tok/s`. Reverted.
+- Linear recurrent Phase G tiled by `(V-head, 32 value columns)`: correctness passed, but 1x64 artifact `target/qwen36_35b_a3b_raw_script_1x64_linear_g_tile32.json` was `51.28 tok/s`, slower than the same keeper. Reverted.
+- Forced non-WMMA persistent template: much slower (`62.7 ms/token` on 1x8 versus default `18.3 ms/token`). Do not disable persistent WMMA globally for 35B.
+- Do not repeat Phase G value-column work decomposition unless the design materially reduces atomics, synchronization, or control overhead. The simple work-stealing variants lost despite preserving linear oracle exactness (`exact=2040`, `max_abs=7.81250e-3`, `cos_sim=1.0000000`).
+- Full-attention direct gated-attn write: Phase G wrote `OFF_GATED`
+  directly for stage5/full decode and skipped Phase H plus one barrier.
+  Build and persistent-vs-chained parity passed, and generated-token hash
+  matched. 1x64 artifact:
+  `target/qwen36_35b_a3b_raw_script_1x64_fullattn_direct_gated.json`,
+  weighted `61.010486177311726 tok/s`, total decode `1049 ms`. This was
+  slightly slower than the current 1x64 keeper
+  `target/qwen36_35b_a3b_raw_script_1x64_fullattn_kv_combined_wmma.json`,
+  weighted `61.12702960840497 tok/s`, total decode `1047 ms`, so it was
+  rejected and reverted. Do not retry this direct-gated Phase G shape unless
+  the attention/o_proj input path changes materially.
+- Linear Phase G closed-form `rec_out = q_mem + delta * (k dot q)`:
+  build and persistent-vs-chained parity passed. 1x64 artifact
+  `target/qwen36_35b_a3b_raw_script_1x64_linear_qmem_rec_out.json` improved
+  to weighted `61.77606177606177 tok/s`, total decode `1036 ms`, with the
+  1x64 generated-token hash unchanged. Full 10x256 artifact
+  `target/qwen36_35b_a3b_raw_script_10x256_linear_qmem_rec_out.json` improved
+  to weighted `60.765743312207746 tok/s`, total decode `42129 ms`, but the
+  combined generated-token hash changed to
+  `e2554abcaea7b709239edf93f56be3d4818db088661723bfe8048cc5a48604d2`
+  versus keeper hash
+  `aba29b816293e7d63b078e7c987f290751e4d22280d1ab4cea7f756bf3647a01`.
+  Rejected and reverted because the algebraic regrouping perturbs generation
+  on several prompts despite synthetic parity.
+- Linear Phase G exact-order fused update plus `rec_out`: build and
+  persistent-vs-chained parity passed, and 1x64 generated-token hash matched,
+  but artifact
+  `target/qwen36_35b_a3b_raw_script_1x64_linear_fused_update_rec_out_exact.json`
+  regressed to weighted `59.9250936329588 tok/s`, total decode `1068 ms`
+  versus the current keeper's `61.12702960840497 tok/s`, total decode
+  `1047 ms`. Rejected and reverted. Do not retry Phase G update/rec_out
+  fusion unless the memory layout or per-column write coalescing changes
+  materially.
+- Linear Phase B paired BF16 `a`/`b` projection rows: build and
+  persistent-vs-chained parity passed, and the 1x64 generated-token hash
+  matched the current keeper. Artifact
+  `target/qwen36_35b_a3b_raw_script_1x64_linear_pair_ab.json` was effectively
+  tied but slightly slower, weighted `62.4390243902439 tok/s`, total decode
+  `1025 ms`, versus current keeper
+  `target/qwen36_35b_a3b_raw_script_1x64_shared_pair_scalar.json`, weighted
+  `62.56109481915934 tok/s`, total decode `1023 ms`. Rejected and reverted.
+  Do not retry this row-pairing shape unless the small BF16 projection path or
+  block-level reduction strategy changes materially.
+- Persistent full-attention RoPE row hoist/precomputed BF16 cos/sin row: build
+  and exact persistent-vs-chained parity passed, but the 1x64 artifact
+  `target/qwen36_35b_a3b_raw_script_1x64_persistent_rope_row.json` regressed
+  to weighted `62.01550387596899 tok/s`, total decode `1032 ms`, versus the
+  current keeper
+  `target/qwen36_35b_a3b_raw_script_1x64_shared_pair_scalar.json`, weighted
+  `62.56109481915934 tok/s`, total decode `1023 ms`. The generated-token hash
+  stayed `ee96d4ba3ccc01df68bed07b652eb1d37277bdafc224c5628c62c3055fe9e5ed`.
+  Rejected and reverted. Do not retry host-uploaded per-token RoPE rows unless
+  the row is generated on-device or avoids the extra per-token H2D overhead.
+- Persistent full-attention on-device RoPE row hoist: build and exact
+  persistent-vs-chained parity passed, but the 1x64 artifact
+  `target/qwen36_35b_a3b_raw_script_1x64_ondevice_rope_row.json` regressed to
+  weighted `61.77606177606177 tok/s`, total decode `1036 ms`, versus the
+  current keeper's weighted `62.56109481915934 tok/s`, total decode `1023 ms`.
+  The generated-token hash stayed
+  `ee96d4ba3ccc01df68bed07b652eb1d37277bdafc224c5628c62c3055fe9e5ed`.
+  Rejected and reverted. The extra full-grid barrier and global scratch traffic
+  outweighed removing repeated Phase F trig, so do not retry this per-layer
+  global-workspace RoPE-row shape.
+- Persistent decode block-count sweep: a temporary
+  `SUPERSONIC_QWEN36_PERSISTENT_BLOCKS` host override, clamped to resident CU
+  count, tested `96`, `88`, `80`, `72`, `64`, `56`, and `48` blocks on 1x64
+  raw decode with artifacts
+  `target/qwen36_35b_a3b_raw_script_1x64_blocks_${b}_live.json`. The `48` to
+  `96` block range tied within measurement resolution at `1023-1024 ms` total
+  decode, weighted `62.50-62.561 tok/s`. The 8-block sanity artifact
+  `target/qwen36_35b_a3b_raw_script_1x64_blocks_8_live.json` collapsed to
+  weighted `16.322366743178 tok/s`, total decode `3921 ms`, confirming the
+  override worked. Rejected and reverted. Do not reduce the persistent grid
+  below one block per CU for this kernel without a larger remapping of work
+  units and barriers.
+- FFN routed down-projection WMMA 96-row work tile: changed only the routed
+  Phase I down-projection tile from `128` rows/task to `96` rows/task with six
+  active waves per block. Build and exact persistent-vs-chained parity passed,
+  but the 1x64 raw artifact
+  `target/qwen36_35b_a3b_raw_script_1x64_ffn_down_tile96.json` regressed to
+  weighted `61.53846153846154 tok/s`, total decode `1040 ms`, versus the
+  current 1x64 keeper weighted `62.56109481915934 tok/s`, total decode
+  `1023 ms`. Rejected and reverted. Do not retry routed FFN down-projection
+  partial tiles between `64` and `128` rows without a larger remapping than
+  simply reducing active waves per block.
+- Full-attention Phase I `o_proj` paired adjacent-row WMMA: build and exact
+  persistent-vs-chained parity passed, and the 1x64 generated-token hash
+  stayed `ee96d4ba3ccc01df68bed07b652eb1d37277bdafc224c5628c62c3055fe9e5ed`,
+  but both tested work-queue shapes regressed. Artifact
+  `target/qwen36_35b_a3b_raw_script_1x64_fullattn_oproj_pair_wmma.json`
+  used `128` pair rows/task and regressed to weighted
+  `63.618290258449306 tok/s`, total decode `1006 ms`; artifact
+  `target/qwen36_35b_a3b_raw_script_1x64_fullattn_oproj_pair64_wmma.json`
+  used `64` pair rows/task and also landed at `1006 ms`. Current 1x64 keeper
+  `target/qwen36_35b_a3b_raw_script_1x64_fullattn_q_gate_pair_wmma.json`
+  is weighted `64.45115810674723 tok/s`, total decode `993 ms`. Rejected and
+  reverted; do not retry generic adjacent-row pairing on full-attention
+  `o_proj` unless register pressure or row scheduling changes materially.
+
+Next 35B A3B guidance:
+
+- The 35B gap to Lucebox remains large: about `63.38 tok/s` weighted Supersonic versus `78.18 tok/s` Lucebox decode mean.
+- Before another change, start from this log plus the rocprof kernel rows, then target a high-attribution kernel path. Do not spend another cycle on small launch cleanup, global WMMA disable, or Phase G tiling without new profiling evidence.
 
 ## Compaction Recovery Checkpoint
 
@@ -1469,3 +1726,1743 @@ Reject decision:
   - `cargo fmt --check`
   - `cargo check -p runner --bin supersonic`
   - `HIP_ARCH=gfx1100 cargo build --release --bin supersonic`
+
+## Rejected Slice: Qwen3.6 35B Folded lm_head Native INT4
+
+Date: 2026-06-19.
+
+Reason to try:
+
+- The folded BF16 lm_head reads about 970 MiB per generated token on
+  Qwen3.6 35B A3B.
+- The bake includes native INT4 sidecars for `lm_head.weight`, so using
+  the packed weight directly in the folded persistent tail looked like a
+  plausible bandwidth win.
+
+Implementation tried:
+
+- Added an experimental `SUPERSONIC_QWEN36_FOLDED_LM_HEAD_INT4=1` gate.
+- Uploaded `lm_head.weight`, `lm_head.weight_int4_scale`, and
+  `lm_head.weight_int4_zero` sidecars during decode session setup.
+- Added a native INT4 dequant path in the folded lm_head device phase.
+- First version selected the path at runtime; second version specialized
+  the branch at compile time to avoid a default-path codegen penalty.
+
+Validation while the experiment was present:
+
+1. Functional smoke:
+   - 16-token BF16 folded generated ids matched the gated INT4 path exactly.
+   - BF16 smoke: `decode_ms=301`, `ms_per_step=18.8`.
+   - INT4 smoke: `decode_ms=290`, `ms_per_step=18.2`.
+2. Runtime-branch A/B:
+   - INT4 1x64 artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_lmhead_int4.json`
+   - BF16 recheck artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_bf16_lmhead_recheck.json`
+   - Both measured about `51.28 tok/s`, below the previous keeper 1x64
+     run, indicating the default path regressed.
+3. Compile-time-specialized A/B:
+   - BF16 1x64 artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_bf16_lmhead_specialized.json`
+   - INT4 1x64 artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_lmhead_int4_specialized.json`
+   - INT4 1x64 improved to about `51.81 tok/s`, but did not exceed the
+     no-H-norm-store keeper 1x64 artifact.
+4. Full 10x256 validation:
+   - INT4 specialized artifact:
+     `target/qwen36_35b_a3b_raw_script_10x256_lmhead_int4_specialized.json`
+   - Result: mean `49.2659 tok/s`, weighted `49.2488 tok/s`,
+     total decode `51981 ms`.
+   - BF16 post-gate artifact:
+     `target/qwen36_35b_a3b_raw_script_10x256_bf16_lmhead_post_int4gate.json`
+   - Result: mean `48.8328 tok/s`, weighted `48.8056 tok/s`,
+     total decode `52453 ms`.
+
+Reject decision:
+
+- Reverted the native INT4 folded lm_head experiment completely.
+- Do not retry this shape without a materially different design: the
+  tiny smoke win did not survive the full harness, and the added code was
+  able to perturb the BF16 keeper path.
+
+Rollback validation:
+
+1. Removed all experiment symbols from the Rust/HIP folded lm_head path:
+   `lm_head_scale`, `lm_head_zero`, `lm_head_group`, `lm_head_int4`,
+   `SUPERSONIC_QWEN36_FOLDED_LM_HEAD_INT4`, and `LM_HEAD_INT4`.
+2. `cargo build --release -p runner --bin supersonic`: passed with
+   existing warnings.
+3. `/home/deano/venvs/rocm/bin/python -m unittest -q tests.test_qwen36_he_supersonic_bench`:
+   passed, 9 tests.
+4. 1x64 rollback artifact:
+   `target/qwen36_35b_a3b_raw_script_1x64_after_lmhead_int4_revert.json`
+   - mean `51.8135 tok/s`, weighted `51.8639 tok/s`,
+     total decode `1234 ms`.
+5. 10x256 rollback artifact:
+   `target/qwen36_35b_a3b_raw_script_10x256_after_lmhead_int4_revert.json`
+   - mean `49.3144 tok/s`, weighted `49.3066 tok/s`,
+     total decode `51920 ms`.
+   - This is effectively back to the current keeper:
+     `target/qwen36_35b_a3b_raw_script_10x256_no_hnorm_store.json`
+     at mean `49.3386 tok/s`, weighted `49.3294 tok/s`,
+     total decode `51896 ms`.
+
+Current status:
+
+- Current Supersonic 35B keeper remains the no-H-norm-store folded top1
+  path at about `49.33 tok/s` weighted on 10x256.
+- Lucebox 35B A3B no-draft reference remains about `78.18 tok/s` decode
+  mean on the comparable 10-prompt `n_gen=256` stack.
+- Supersonic has not yet matched Lucebox 35B A3B.
+
+## Diagnostic Slice: Qwen3.6 Decode FFI/HAL Profile Gate
+
+Date: 2026-06-19.
+
+Reason:
+
+- The full persistent decode megakernel hides internal layer/stage timing
+  from ordinary stage timing output.
+- `persistent_decode_launch_range` already records useful operation names
+  through `ffi_profile_time_result`, including:
+  - `qwen36.persistent_decode`
+  - `qwen36.persistent_attn_only`
+  - `qwen36.persistent_ffn_only`
+  - `qwen36.persistent_ffn_stage{1..5}`
+  - `qwen36.persistent_linear_stage{1..5}`
+- There was no Qwen3.6 generation-only switch to enable those profiles
+  without mixing in prefill.
+
+Implemented:
+
+- Added `Qwen36DecodeProfileScope`, enabled by
+  `SUPERSONIC_QWEN36_PROFILE_FFI=1`.
+- The scope starts at the first generation step and finishes after the
+  generation loop, so prefill does not pollute decode profiles.
+- It enables both:
+  - `kernel_ffi::prefill_ffi::ffi_profile_*`, for per-op launch timing
+    with sync around each profiled op,
+  - `gpu_hal::hal_profile_*`, for copy/sync/memset accounting.
+- It prints machine-readable stderr lines:
+  - `[qwen36-decode-ffi-profile]`
+  - `[qwen36-decode-ffi-profile-op]`
+  - `[qwen36-decode-hal-profile-op]`
+
+Validation:
+
+1. `cargo fmt --check`: passed.
+2. `cargo build --release -p runner --bin supersonic`: passed with
+   existing warnings.
+3. Full-path short profile:
+   - Artifact:
+     `target/qwen36_35b_a3b_raw_script_1x8_decode_ffi_profile.json`
+   - Result: mean `51.5464 tok/s`, weighted `51.6129 tok/s`,
+     total decode `155 ms`.
+   - Profile:
+     - `qwen36.persistent_decode`: 8 calls, mean `19.2902 ms`,
+       total `154.321 ms`, max `22.221 ms`.
+     - HAL had no allocations; generation H2D was `32768` bytes and D2H
+       was `32` bytes, matching folded top1 token-id D2H rather than
+       full logits D2H.
+   - Interpretation: the new profile gate does not materially perturb the
+     current short full-path keeper measurement.
+4. FFN cumulative-stage profile:
+   - Artifact:
+     `target/qwen36_35b_a3b_raw_script_1x1_ffn_stage_decode_ffi_profile.json`
+   - Result under profiling/segmentation: mean `18.6567 tok/s`,
+     weighted `18.5185 tok/s`; use only for attribution.
+   - Profile:
+     - `qwen36.persistent_attn_only`: 40 calls, mean `0.3291 ms`,
+       total `13.165 ms`.
+     - `qwen36.persistent_ffn_stage1`: 40 calls, mean `0.0712 ms`,
+       total `2.849 ms`.
+     - `qwen36.persistent_ffn_stage2`: 40 calls, mean `0.1083 ms`,
+       total `4.330 ms`.
+     - `qwen36.persistent_ffn_stage3`: 40 calls, mean `0.1947 ms`,
+       total `7.789 ms`.
+     - `qwen36.persistent_ffn_stage4`: 40 calls, mean `0.2151 ms`,
+       total `8.605 ms`.
+     - `qwen36.persistent_ffn_stage5`: 40 calls, mean `0.1926 ms`,
+       total `7.705 ms`.
+   - Interpretation: stage kernels are profiling variants, not strictly
+     monotonic cumulative timings. They are most useful for A/B within
+     the same stage label after a code edit.
+5. Linear cumulative-stage profile:
+   - Artifact:
+     `target/qwen36_35b_a3b_raw_script_1x1_linear_stage_decode_ffi_profile.json`
+   - Result under profiling/segmentation: mean `22.0751 tok/s`,
+     weighted `22.2222 tok/s`; use only for attribution.
+   - Profile:
+     - `qwen36.persistent_ffn_only`: 40 calls, mean `0.2362 ms`,
+       total `9.446 ms`.
+     - `qwen36.persistent_attn_only`: 10 calls, mean `0.4691 ms`,
+       total `4.691 ms`.
+     - `qwen36.persistent_linear_stage1`: 30 calls, mean `0.1643 ms`,
+       total `4.929 ms`.
+     - `qwen36.persistent_linear_stage2`: 30 calls, mean `0.1134 ms`,
+       total `3.403 ms`.
+     - `qwen36.persistent_linear_stage3`: 30 calls, mean `0.1161 ms`,
+       total `3.483 ms`.
+     - `qwen36.persistent_linear_stage4`: 30 calls, mean `0.1436 ms`,
+       total `4.308 ms`.
+     - `qwen36.persistent_linear_stage5`: 30 calls, mean `0.2306 ms`,
+       total `6.919 ms`.
+
+Use for next slice:
+
+- Use `SUPERSONIC_QWEN36_PROFILE_FFI=1` on 1-token segmented stage runs
+  for fast, synced A/B evidence before paying for 10x256.
+- Treat profile/segmented tok/s as attribution only; keeper decisions
+  still require the regular full 10x256 harness.
+- The next promising target should reduce the full-path
+  `qwen36.persistent_decode` mean below the current ~`19.3 ms/token`
+  short-run baseline, then confirm on 10x256.
+
+## Kept Slice: Fast INT4 Dequant Without Per-Nibble BF16 RNE
+
+Change:
+
+- In `kernels/qwen36_moe_persistent/helpers.cuh`, removed the
+  `bf16_round_rne_f32(...)` call from the hot INT4 dequant helpers:
+  - `int4_dequant_8`,
+  - the fallback dequant macro inside `int4_dequant_8`,
+  - `wmma_int4_matvec_partial_16rows`,
+  - `int4_dequant_scalar`.
+- The helpers now reconstruct `float(nibble) * scale - zero * scale`
+  directly. This changes exact dequant math, so it was treated as a
+  speed-plus-smoke-check experiment rather than a bit-exact refactor.
+
+Rationale:
+
+- The previous helper rounded each reconstructed nibble value to BF16 in
+  scalar and WMMA-adjacent hot paths.
+- Lucebox parity requires a large decode gain, and the BF16 RNE operation
+  sits directly in the persistent decode inner work.
+
+Validation:
+
+1. `cargo build --release -p runner --bin supersonic`: passed with
+   existing warnings before benchmarking this slice.
+2. `cargo fmt --check`: passed.
+3. `/home/deano/venvs/rocm/bin/python -m unittest -q
+   tests.test_qwen36_he_supersonic_bench`: 9 tests passed.
+4. Short profiled full-path run:
+   - Artifact:
+     `target/qwen36_35b_a3b_raw_script_1x8_fast_dequant_profile.json`
+   - Result: mean `54.0541 tok/s`, weighted `54.0541 tok/s`,
+     total decode `148 ms`.
+   - Profile:
+     - `qwen36.persistent_decode`: 8 calls, mean `18.4441 ms`,
+       total `147.552 ms`, max `21.630 ms`.
+   - Previous comparable profile:
+     `target/qwen36_35b_a3b_raw_script_1x8_decode_ffi_profile.json`
+     had mean `51.5464 tok/s` and persistent decode mean
+     `19.2902 ms`.
+5. Short normal run:
+   - Artifact: `target/qwen36_35b_a3b_raw_script_1x64_fast_dequant.json`
+   - Result: mean `54.3478 tok/s`, weighted `54.3478 tok/s`,
+     total decode `1177 ms`.
+   - Smoke: generated a coherent completion for `has_close_elements`.
+6. Full keeper run:
+   - Artifact:
+     `target/qwen36_35b_a3b_raw_script_10x256_fast_dequant.json`
+   - Result: mean `51.3943 tok/s`, weighted `51.4118 tok/s`,
+     total decode `49794 ms`, range `50.25 - 52.36 tok/s`.
+
+Decision:
+
+- Keep this slice.
+- It improves the current Supersonic 35B A3B full-run keeper from
+  weighted `49.3294 tok/s` and `51896 ms` total decode to weighted
+  `51.4118 tok/s` and `49794 ms` total decode.
+- It is still far short of the Lucebox 35B A3B no-draft baseline:
+  weighted/mean decode target remains about `78.18 tok/s`.
+
+Use for next slice:
+
+- Treat `target/qwen36_35b_a3b_raw_script_10x256_fast_dequant.json` as
+  the new Supersonic full-run keeper unless a later quality check rejects
+  the non-RNE dequant math.
+- The remaining gap is too large for launch overhead or tiny scalar
+  cleanup alone; the next slice should target a structural persistent
+  decode cost, likely routed expert/linear-attention memory traffic or
+  a Lucebox-vs-Supersonic algorithmic difference.
+
+## Kept Slice: Full-Attention Cached Tile128 Workspace
+
+Date: 2026-06-19.
+
+Reason:
+
+- Post fast-dequant segmented profiling showed full attention was still
+  expensive: about `0.435 ms/layer` for the 10 full-attention layers.
+- The cached full-attention tiled path in
+  `kernels/qwen36_moe_persistent/full_attn_phase.cuh` was effectively
+  unreachable for the 35B benchmark geometry. With `head_dim=256`,
+  `attn_tile_stride=d+2=258`, and `kv_max_t=512`, the old guard required
+  `tile_count * 258 <= kv_max_t`, so any real multi-tile history failed
+  and decode used the one-block-per-Q-head serial history loop.
+
+Change:
+
+- Added `FULL_ATTN_DECODE_TILE_T=128` and score-workspace sizing helpers
+  in `crates/runner/src/qwen36_moe/decode.rs`.
+- Updated persistent decode, chained decode, MTP, and per-token batched
+  fallback scratch allocation to size cached full-attention score storage
+  by the widened per-head partial stride.
+- In `kernels/qwen36_moe_persistent/full_attn_phase.cuh`, lowered
+  `attn_tile_t` from `384` to `128` and changed tile partial addressing
+  to use a derived `attn_score_stride` while leaving KV-cache indexing on
+  `kv_max_t`.
+- Updated the INT4 helper comment to reflect the kept fast-dequant math.
+
+Validation:
+
+1. `cargo fmt`: applied.
+2. `cargo build --release -p runner --bin supersonic`: passed with
+   existing warnings.
+3. `cargo fmt --check`: passed after benchmarking.
+4. `/home/deano/venvs/rocm/bin/python -m unittest -q
+   tests.test_qwen36_he_supersonic_bench`: 9 tests passed.
+5. Short profiled full-path run:
+   - Artifact:
+     `target/qwen36_35b_a3b_raw_script_1x8_fullattn_tile128_profile.json`
+   - Result: mean `54.3478 tok/s`, weighted `54.0541 tok/s`,
+     total decode `148 ms`.
+   - Profile:
+     - `qwen36.persistent_decode`: 8 calls, mean `18.3611 ms`,
+       total `146.889 ms`, max `21.372 ms`.
+   - Comparable fast-dequant profile:
+     `target/qwen36_35b_a3b_raw_script_1x8_fast_dequant_profile.json`
+     had persistent decode mean `18.4441 ms`.
+6. Short normal run:
+   - Artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_fullattn_tile128.json`
+   - Result: mean `55.5556 tok/s`, weighted `55.5556 tok/s`,
+     total decode `1152 ms`.
+   - Comparable fast-dequant artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_fast_dequant.json` at
+     mean/weighted `54.3478 tok/s`.
+7. Full keeper run:
+   - Artifact:
+     `target/qwen36_35b_a3b_raw_script_10x256_fullattn_tile128.json`
+   - Result: mean `55.5255 tok/s`, weighted `55.5002 tok/s`,
+     total decode `46126 ms`, range `54.95 - 55.87 tok/s`.
+
+Decision:
+
+- Keep this slice.
+- It improves the previous Supersonic 35B A3B full-run keeper from
+  weighted `51.4118 tok/s` and `49794 ms` total decode to weighted
+  `55.5002 tok/s` and `46126 ms` total decode.
+- It is still short of the Lucebox 35B A3B no-draft baseline:
+  decode target remains about `78.18 tok/s`.
+
+Use for next slice:
+
+- Treat `target/qwen36_35b_a3b_raw_script_10x256_fullattn_tile128.json`
+  as the new Supersonic full-run keeper.
+- The tile128 win shows the remaining gap includes under-parallelized
+  structural work, not just scalar dequant cost. Next candidates should
+  look for similar occupancy/parallelism issues in linear attention and
+  routed/shared FFN, or compare Lucebox's per-layer scheduling directly
+  against Supersonic's persistent megakernel.
+
+Post-keep attribution:
+
+1. Linear-stage profile over 64 generated tokens:
+   - Artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_fullattn_tile128_linear_stage_profile.json`
+   - Profiling-only result: mean `26.04 tok/s`.
+   - FFI rows:
+     - `qwen36.persistent_ffn_only`: 2560 calls, mean `0.2021 ms`,
+       total `517.354 ms`.
+     - `qwen36.persistent_linear_stage5`: 1920 calls, mean `0.1997 ms`,
+       total `383.343 ms`.
+     - `qwen36.persistent_attn_only`: 640 calls, mean `0.3928 ms`,
+       total `251.376 ms`.
+     - `qwen36.persistent_linear_stage4`: 1920 calls, mean `0.1264 ms`,
+       total `242.663 ms`.
+     - `qwen36.persistent_linear_stage1`: 1920 calls, mean `0.1201 ms`,
+       total `230.523 ms`.
+     - `qwen36.persistent_linear_stage3`: 1920 calls, mean `0.1016 ms`,
+       total `195.156 ms`.
+     - `qwen36.persistent_linear_stage2`: 1920 calls, mean `0.1014 ms`,
+       total `194.702 ms`.
+2. FFN-stage profile over 64 generated tokens:
+   - Artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_fullattn_tile128_ffn_stage_profile.json`
+   - Profiling-only result: mean `21.28 tok/s`.
+   - FFI rows:
+     - `qwen36.persistent_attn_only`: 2560 calls, mean `0.2671 ms`,
+       total `683.751 ms`.
+     - `qwen36.persistent_ffn_stage4`: 2560 calls, mean `0.1889 ms`,
+       total `483.593 ms`.
+     - `qwen36.persistent_ffn_stage3`: 2560 calls, mean `0.1771 ms`,
+       total `453.368 ms`.
+     - `qwen36.persistent_ffn_stage5`: 2560 calls, mean `0.1752 ms`,
+       total `448.517 ms`.
+     - `qwen36.persistent_ffn_stage2`: 2560 calls, mean `0.1021 ms`,
+       total `261.334 ms`.
+     - `qwen36.persistent_ffn_stage1`: 2560 calls, mean `0.0638 ms`,
+       total `163.454 ms`.
+
+## Kept Slice: Full-Attention Tile64 Sweep
+
+Date: 2026-06-19.
+
+Reason:
+
+- Tile128 proved the cached full-attention path was under-parallelized.
+- The 1x64 post-tile128 run was still full-attention sensitive, so a
+  smaller tile was worth a cheap sweep before moving to FFN/linear work.
+
+Change:
+
+- Changed `FULL_ATTN_DECODE_TILE_T` in
+  `crates/runner/src/qwen36_moe/decode.rs` from `128` to `64`.
+- Changed the matching HIP `attn_tile_t` literal in
+  `kernels/qwen36_moe_persistent/full_attn_phase.cuh` from `128` to
+  `64`.
+- The widened score/partial workspace formula already added by the
+  tile128 slice covers the larger tile count.
+
+Validation:
+
+1. `cargo fmt --check`: passed.
+2. `cargo build --release -p runner --bin supersonic`: passed with
+   existing warnings.
+3. `/home/deano/venvs/rocm/bin/python -m unittest -q
+   tests.test_qwen36_he_supersonic_bench`: 9 tests passed.
+4. Short normal run:
+   - Artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_fullattn_tile64.json`
+   - Result: mean `57.4713 tok/s`, weighted `57.4713 tok/s`,
+     total decode `1114 ms`.
+   - Comparable tile128 artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_fullattn_tile128.json`
+     at mean/weighted `55.5556 tok/s`.
+5. Full keeper run:
+   - Artifact:
+     `target/qwen36_35b_a3b_raw_script_10x256_fullattn_tile64.json`
+   - Result: mean `56.4027 tok/s`, weighted `56.3901 tok/s`,
+     total decode `45398 ms`, range `55.87 - 56.82 tok/s`.
+
+Decision:
+
+- Keep this slice.
+- It improves the previous tile128 full-run keeper from weighted
+  `55.5002 tok/s` and `46126 ms` total decode to weighted
+  `56.3901 tok/s` and `45398 ms` total decode.
+- Lucebox 35B A3B no-draft remains well ahead at about `78.18 tok/s`.
+
+Use for next slice:
+
+- Treat `target/qwen36_35b_a3b_raw_script_10x256_fullattn_tile64.json`
+  as the new Supersonic full-run keeper.
+- Another full-attention tile sweep below 64 may be possible, but the
+  remaining gap likely needs work in FFN stage3-5 and linear stage5 too.
+
+## Kept Slice: Full-Attention Tile32 Sweep
+
+Date: 2026-06-19.
+
+Reason:
+
+- Tile64 still improved over tile128, so one more smaller tile sweep was
+  cheap enough to test before moving away from full-attention tiling.
+
+Change:
+
+- Changed `FULL_ATTN_DECODE_TILE_T` in
+  `crates/runner/src/qwen36_moe/decode.rs` from `64` to `32`.
+- Changed the matching HIP `attn_tile_t` literal in
+  `kernels/qwen36_moe_persistent/full_attn_phase.cuh` from `64` to
+  `32`.
+
+Validation:
+
+1. `cargo fmt --check`: passed.
+2. `cargo build --release -p runner --bin supersonic`: passed with
+   existing warnings.
+3. `/home/deano/venvs/rocm/bin/python -m unittest -q
+   tests.test_qwen36_he_supersonic_bench`: 9 tests passed.
+4. Short normal run:
+   - Artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_fullattn_tile32.json`
+   - Result: mean `57.8035 tok/s`, weighted `57.8035 tok/s`,
+     total decode `1107 ms`.
+   - Comparable tile64 artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_fullattn_tile64.json`
+     at mean/weighted `57.4713 tok/s`.
+5. Full keeper run:
+   - Artifact:
+     `target/qwen36_35b_a3b_raw_script_10x256_fullattn_tile32.json`
+   - Result: mean `56.8510 tok/s`, weighted `56.8321 tok/s`,
+     total decode `45045 ms`, range `56.50 - 57.14 tok/s`.
+
+Decision:
+
+- Keep this slice.
+- It improves the previous tile64 full-run keeper from weighted
+  `56.3901 tok/s` and `45398 ms` total decode to weighted
+  `56.8321 tok/s` and `45045 ms` total decode.
+- The gain is much smaller than tile128 and tile64. Treat further
+  full-attention tile sweeps as lower priority unless a profile shows
+  full attention dominates again.
+
+Use for next slice:
+
+- Treat `target/qwen36_35b_a3b_raw_script_10x256_fullattn_tile32.json`
+  as the new Supersonic full-run keeper.
+- Move to FFN stage3-5 or linear stage5 structural work next; the
+  remaining gap to Lucebox is still about `56.83 tok/s` versus
+  `78.18 tok/s`.
+
+## Rejected Slice: FFN Phase H All-Group-Blocks
+
+Date: 2026-06-19.
+
+Reason:
+
+- FFN stage profiling showed stage3-5 remained meaningful after the
+  full-attention tile sweep.
+- Phase H (`mid = silu(gate) * up`) used only `sub_id == 0` for each
+  active expert group, leaving the other blocks assigned to that group
+  idle for the 512-element loop on 35B-A3B.
+
+Experiment:
+
+- Changed Phase H in `kernels/qwen36_moe_persistent/ffn_phase.cuh` so
+  all blocks assigned to an active expert group processed strided chunks
+  of the `I=512` mid vector.
+- The existing grid barrier before Phase I remained the publish point.
+
+Validation:
+
+1. `cargo fmt --check`: passed.
+2. `cargo build --release -p runner --bin supersonic`: passed with
+   existing warnings.
+3. Normal 1x64 run:
+   - Artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_ffn_phaseh_allblocks.json`
+   - Result: mean/weighted `57.8035 tok/s`, total decode `1107 ms`.
+   - This tied the current tile32 keeper's 1x64 artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_fullattn_tile32.json`.
+4. First attempt to run the FFN-stage profile concurrently with the 1x64
+   normal run failed during layer load with HIP OOM after VMM fallback.
+   Do not run two Qwen3.6 35B profile/bench jobs concurrently on this
+   24 GiB card.
+5. Rerun FFN-stage profile alone:
+   - Artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_ffn_phaseh_allblocks_ffn_stage_profile.json`
+   - Profiling-only result: mean `21.65 tok/s`.
+   - FFI rows:
+     - `qwen36.persistent_ffn_stage4`: mean `0.1893 ms` versus prior
+       `0.1889 ms`.
+     - `qwen36.persistent_ffn_stage3`: mean `0.1772 ms` versus prior
+       `0.1771 ms`.
+     - `qwen36.persistent_ffn_stage5`: mean `0.1744 ms` versus prior
+       `0.1752 ms`.
+
+Decision:
+
+- Rejected and reverted.
+- The end-to-end 1x64 result tied, and the FFN stage rows were
+  neutral/noisy: stage5 barely improved while stage3/4 did not.
+- Do not retry this exact Phase H striding shape unless a new profile
+  shows Phase H itself dominates rather than the surrounding matvecs.
+
+## Kept Slice: Full-Attention Decode Tile16
+
+Date: 2026-06-19.
+
+Reason:
+
+- Tile32 had become the current full-attention keeper, but the remaining
+  gap to Lucebox was still large enough to justify one smaller cached
+  attention tile.
+
+Experiment:
+
+- Changed `FULL_ATTN_DECODE_TILE_T` in
+  `crates/runner/src/qwen36_moe/decode.rs` from `32` to `16`.
+- Changed the matching HIP tile constant in
+  `kernels/qwen36_moe_persistent/full_attn_phase.cuh` from `32` to `16`.
+- Left the widened per-head score workspace path intact.
+
+Validation:
+
+1. Pre-run build status for the tile16 patch:
+   `cargo fmt --check && cargo build --release -p runner --bin supersonic`
+   passed with existing warnings.
+2. 1x64 filter:
+   - Artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_fullattn_tile16.json`
+   - Result: mean `57.80346820809248 tok/s`, weighted
+     `57.971014492753625 tok/s`, total decode `1104 ms`.
+   - Comparable tile32 artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_fullattn_tile32.json`
+     at mean `57.80346820809248 tok/s`, weighted
+     `57.70964833183048 tok/s`, total decode `1109 ms`.
+3. Full keeper run:
+   - Artifact:
+     `target/qwen36_35b_a3b_raw_script_10x256_fullattn_tile16.json`
+   - Result: mean `57.11223040165311 tok/s`, weighted
+     `57.09442883268656 tok/s`, total decode `44838 ms`, range
+     `56.18 - 57.47 tok/s`.
+   - Comparable tile32 artifact:
+     `target/qwen36_35b_a3b_raw_script_10x256_fullattn_tile32.json`
+     at mean `56.85101621542299 tok/s`, weighted
+     `56.832056832056836 tok/s`, total decode `45045 ms`.
+
+Decision:
+
+- Keep this slice.
+- It improves the previous tile32 full-run keeper from weighted
+  `56.8321 tok/s` and `45045 ms` total decode to weighted
+  `57.0944 tok/s` and `44838 ms` total decode.
+- The current gap to Lucebox 35B A3B no-draft is still large:
+  `57.09 tok/s` weighted Supersonic versus about `78.18 tok/s`
+  Lucebox decode mean.
+
+## Kept Slice: Full-Attention Decode Tile8
+
+Date: 2026-06-19.
+
+Reason:
+
+- Full-attention tile sweeps have improved monotonically so far:
+  tile128 `55.50`, tile64 `56.39`, tile32 `56.83`, tile16
+  `57.09` weighted tok/s on the 10x256 raw-script benchmark.
+- Try tile8 as one final small-tile probe before moving back to larger
+  FFN/linear structural work.
+
+Plan:
+
+- Change both host and HIP full-attention decode tile constants from
+  `16` to `8`.
+- Run a 1x64 filter first and compare against tile16. Only run 10x256 if
+  the filter beats the tile16 keeper.
+
+Validation:
+
+1. `cargo fmt --check && cargo build --release -p runner --bin supersonic`
+   passed with existing warnings.
+2. 1x64 filter:
+   - Artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_fullattn_tile8.json`
+   - Result: mean `58.139534883720934 tok/s`, weighted
+     `58.023572076155936 tok/s`, total decode `1103 ms`.
+   - Comparable tile16 artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_fullattn_tile16.json`
+     at mean `57.80346820809248 tok/s`, weighted
+     `57.971014492753625 tok/s`, total decode `1104 ms`.
+3. Full keeper run:
+   - Artifact:
+     `target/qwen36_35b_a3b_raw_script_10x256_fullattn_tile8.json`
+   - Result: mean `57.208911777877304 tok/s`, weighted
+     `57.161996204086186 tok/s`, total decode `44785 ms`, range
+     `56.82 - 57.47 tok/s`.
+   - Comparable tile16 artifact:
+     `target/qwen36_35b_a3b_raw_script_10x256_fullattn_tile16.json`
+     at mean `57.11223040165311 tok/s`, weighted
+     `57.09442883268656 tok/s`, total decode `44838 ms`.
+
+Decision:
+
+- Keep this slice.
+- It improves the previous tile16 full-run keeper by `53 ms` total decode
+  on the 10x256 benchmark.
+- The gain is small. Only continue to tile4 because the sweep remains
+  monotonic; stop the small-tile sweep if tile4 does not beat tile8 on the
+  1x64 filter.
+
+## Rejected Slice: Full-Attention Decode Tile4
+
+Date: 2026-06-19.
+
+Reason:
+
+- Tile128 -> tile64 -> tile32 -> tile16 -> tile8 improved monotonically,
+  so tile4 was tried as the final small-tile probe.
+
+Experiment:
+
+- Changed `FULL_ATTN_DECODE_TILE_T` in
+  `crates/runner/src/qwen36_moe/decode.rs` from `8` to `4`.
+- Changed the matching HIP tile constant in
+  `kernels/qwen36_moe_persistent/full_attn_phase.cuh` from `8` to `4`.
+
+Validation:
+
+1. `cargo fmt --check && cargo build --release -p runner --bin supersonic`
+   passed with existing warnings.
+2. 1x64 filter:
+   - Artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_fullattn_tile4.json`
+   - Result: mean `57.80346820809248 tok/s`, weighted
+     `57.86618444846293 tok/s`, total decode `1106 ms`.
+   - Comparable tile8 artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_fullattn_tile8.json`
+     at mean `58.139534883720934 tok/s`, weighted
+     `58.023572076155936 tok/s`, total decode `1103 ms`.
+
+Decision:
+
+- Rejected and reverted to tile8.
+- Stop the simple full-attention tile sweep here. Tile8 is the keeper;
+  tile4 lost on the cheap filter.
+
+## Kept Slice: One-Barrier Persistent Counter Reset
+
+Date: 2026-06-19.
+
+Reason:
+
+- `reset_counters_16` in
+  `kernels/qwen36_moe_persistent/persistent_decode.hip` used two full
+  grid barriers around sixteen counter stores.
+- The existing single-counter helper already used the safer/faster pattern:
+  the last arriving block resets the counter before releasing the barrier.
+- The full persistent path calls `reset_counters_16` between attention and
+  FFN, between layers, and before folded lm_head, so halving this barrier
+  sequence is small but repeated about 80 times per generated token.
+
+Experiment:
+
+- Rewrote `reset_counters_16` to use one grid-wide barrier:
+  each block arrives, the last-arriving block's thread 0 clears
+  `counters[0..15]`, then releases `barrier_flag`.
+- This preserves the ordering invariant: no block can enter the next phase
+  until every block reached the reset point and all 16 counter slots are
+  cleared.
+
+Validation:
+
+1. `cargo fmt --check && cargo build --release -p runner --bin supersonic`
+   passed with existing warnings.
+2. 1x64 filter:
+   - Artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_reset16_onebarrier.json`
+   - Result: mean `58.139534883720934 tok/s`, weighted
+     `58.12897366030881 tok/s`, total decode `1101 ms`.
+   - Comparable tile8 artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_fullattn_tile8.json`
+     at mean `58.139534883720934 tok/s`, weighted
+     `58.023572076155936 tok/s`, total decode `1103 ms`.
+3. Full keeper run:
+   - Artifact:
+     `target/qwen36_35b_a3b_raw_script_10x256_reset16_onebarrier.json`
+   - Result: mean `57.27459969437247 tok/s`, weighted
+     `57.26428811094956 tok/s`, total decode `44705 ms`, range
+     `57.14 - 57.80 tok/s`.
+   - Comparable tile8 artifact:
+     `target/qwen36_35b_a3b_raw_script_10x256_fullattn_tile8.json`
+     at mean `57.208911777877304 tok/s`, weighted
+     `57.161996204086186 tok/s`, total decode `44785 ms`.
+
+Decision:
+
+- Keep this slice.
+- It improves the previous tile8 full-run keeper by `80 ms` total decode
+  on the 10x256 benchmark.
+- The gain is small but from a correctness-preserving synchronization
+  cleanup on a repeated full-path barrier.
+
+## Rejected Slice: Post-FFN Counter0-Only Reset
+
+Date: 2026-06-19.
+
+Reason:
+
+- After FFN, the next layer's attention and the folded lm_head only consume
+  `counters[0]`, while the next all-counter reset still happens before FFN.
+- Tried replacing the post-FFN and pre-lm_head `reset_counters_16` calls
+  with `grid_barrier_reset_counter(..., &counters[0])`.
+
+Validation:
+
+1. `cargo fmt --check && cargo build --release -p runner --bin supersonic`
+   passed with existing warnings.
+2. 1x64 filter:
+   - Artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_postffn_counter0_reset.json`
+   - Result: mean `58.139534883720934 tok/s`, weighted
+     `58.12897366030881 tok/s`, total decode `1101 ms`.
+   - This exactly tied the current one-barrier keeper's 1x64 artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_reset16_onebarrier.json`.
+
+Decision:
+
+- Rejected and reverted.
+- The simplification was correct-looking but did not beat the filter, so
+  keep the clearer all-16 reset at those boundaries.
+
+## Kept Slice: Linear Out-Projection WMMA Tile64
+
+Date: 2026-06-19.
+
+Reason:
+
+- Current segmented attribution showed linear stage5/full linear attention
+  remained hot at about `0.2041 ms/layer` across 30 linear layers.
+- Linear Phase I out-projection used one block to process 128 output rows.
+  For the 35B-A3B geometry (`hidden=2048`) that creates only 16 block tasks,
+  underfilling the 96-CU RX 7900 XTX during the out-projection.
+
+Experiment:
+
+- In `kernels/qwen36_moe_persistent/linear_attn_phase.cuh`, changed the
+  Phase I INT4 WMMA out-projection work distribution from 128 rows per task
+  to 64 rows per task.
+- This lets 32 blocks participate in the 2048-row projection. Each active
+  row is still computed by the same WMMA helper and keeps the same arithmetic
+  order per row; only the block/wave assignment changes.
+
+Validation:
+
+1. `cargo fmt --check && cargo build --release -p runner --bin supersonic`
+   passed with existing warnings.
+2. 1x64 filter:
+   - Artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_linear_outproj_tile64.json`
+   - Result: mean `58.8235294117647 tok/s`, weighted
+     `58.661778185151235 tok/s`, total decode `1091 ms`.
+   - Comparable previous keeper artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_reset16_onebarrier.json`
+     at mean `58.139534883720934 tok/s`, weighted
+     `58.12897366030881 tok/s`, total decode `1101 ms`.
+3. Full keeper run:
+   - Artifact:
+     `target/qwen36_35b_a3b_raw_script_10x256_linear_outproj_tile64.json`
+   - Result: mean `57.77102039113525 tok/s`, weighted
+     `57.75130842808157 tok/s`, total decode `44328 ms`, range
+     `57.47 - 58.14 tok/s`.
+   - Comparable previous keeper artifact:
+     `target/qwen36_35b_a3b_raw_script_10x256_reset16_onebarrier.json`
+     at mean `57.27459969437247 tok/s`, weighted
+     `57.26428811094956 tok/s`, total decode `44705 ms`.
+
+Decision:
+
+- Keep this slice.
+- It improves the previous full-run keeper by `377 ms` total decode on the
+  10x256 benchmark.
+- Follow-up: test 32 rows per task as a cheap filter. If it loses, keep
+  tile64 and apply the same occupancy lens to other single-counter WMMA
+  row loops, especially full-attention output projection.
+
+## Rejected Slice: Linear Out-Projection WMMA Tile32
+
+Date: 2026-06-19.
+
+Reason:
+
+- Tile64 improved the linear out-projection by increasing the number of
+  participating blocks from 16 to 32. Tile32 was tested as the next occupancy
+  point, using 64 participating blocks but only two active waves per block.
+
+Validation:
+
+1. `cargo fmt --check && cargo build --release -p runner --bin supersonic`
+   passed with existing warnings.
+2. 1x64 filter:
+   - Artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_linear_outproj_tile32.json`
+   - Result: mean `54.6448087431694 tok/s`, weighted
+     `54.5144804088586 tok/s`, total decode `1174 ms`.
+   - Comparable tile64 artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_linear_outproj_tile64.json`
+     at mean `58.8235294117647 tok/s`, weighted
+     `58.661778185151235 tok/s`, total decode `1091 ms`.
+
+Decision:
+
+- Rejected and reverted to tile64.
+- The lower per-block wave utilization dominates; do not use 32-row tasks
+  for this projection shape.
+
+## Rejected Slice: FFN Shared-Expert Down WMMA Tile64
+
+Date: 2026-06-19.
+
+Reason:
+
+- FFN Phase F shared-expert down projection has a single-counter WMMA row loop
+  over `hidden=2048`, so it looked similar to the linear out-projection
+  underfill fixed by 64-row tasks.
+- Tested changing Phase F from 128 rows per task to 64 rows per task, with
+  four active waves per block.
+
+Validation:
+
+1. `cargo fmt --check && cargo build --release -p runner --bin supersonic`
+   passed with existing warnings.
+2. 1x64 filter:
+   - Artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_ffn_shared_down_tile64.json`
+   - Result: mean `58.47953216374268 tok/s`, weighted
+     `58.50091407678245 tok/s`, total decode `1094 ms`.
+   - Comparable current keeper artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_linear_outproj_tile64.json`
+     at mean `58.8235294117647 tok/s`, weighted
+     `58.661778185151235 tok/s`, total decode `1091 ms`.
+
+Decision:
+
+- Rejected and reverted.
+- The shared down projection did not benefit from the linear out-projection
+  row-task split; keep Phase F at 128 rows per task unless a materially new
+  tiling strategy changes the work balance.
+
+## Rejected Slice: Full-Attention Out-Projection WMMA Tile64
+
+Date: 2026-06-19.
+
+Reason:
+
+- Full-attention Phase I `o_proj` also uses a single-counter WMMA row loop
+  over `hidden=2048`.
+- Tested the same 64-row task split that improved linear-attention
+  out-projection.
+
+Validation:
+
+1. `cargo fmt --check && cargo build --release -p runner --bin supersonic`
+   passed with existing warnings.
+2. 1x64 filter:
+   - Artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_full_attn_outproj_tile64.json`
+   - Result: mean `58.47953216374268 tok/s`, weighted
+     `58.50091407678245 tok/s`, total decode `1094 ms`.
+   - Comparable current keeper artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_linear_outproj_tile64.json`
+     at mean `58.8235294117647 tok/s`, weighted
+     `58.661778185151235 tok/s`, total decode `1091 ms`.
+
+Decision:
+
+- Rejected and reverted.
+- The linear out-projection tile64 win does not transfer to full-attention
+  `o_proj`; keep this loop at 128 rows per task unless the projection kernel
+  is rebalanced more substantially.
+
+## Rejected Slice: FFN Routed Gate/Down WMMA Tile64
+
+Date: 2026-06-19.
+
+Reason:
+
+- FFN routed expert Phase G and Phase I use per-top-k-group WMMA work-stealing
+  loops. For 35B-A3B each expert group has a small number of 128-row tasks,
+  so 64-row tasks were tested to expose more work items per group while
+  preserving the same per-row WMMA arithmetic.
+
+Validation:
+
+1. `cargo fmt --check && cargo build --release -p runner --bin supersonic`
+   passed with existing warnings.
+2. 1x64 filter:
+   - Artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_ffn_routed_gi_tile64.json`
+   - Result: mean `55.24861878453038 tok/s`, weighted
+     `55.41125541125541 tok/s`, total decode `1155 ms`.
+   - Comparable current keeper artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_linear_outproj_tile64.json`
+     at mean `58.8235294117647 tok/s`, weighted
+     `58.661778185151235 tok/s`, total decode `1091 ms`.
+
+Decision:
+
+- Rejected and reverted.
+- The extra per-group tasks do not offset the lower active waves per block;
+  keep routed FFN Phase G/I at 128 rows per task.
+
+## Rejected Slice: Shared-Expert Direct-Mid WMMA
+
+Date: 2026-06-19.
+
+Reason:
+
+- Routed expert gate/up direct-mid WMMA improved 35B-A3B by writing
+  `EXPERT_MID` directly and removing the legacy activation pass/barrier.
+- Tested the same idea for the shared expert by computing shared gate/up WMMA
+  directly into `OFF_SHARED_MID` and skipping Phase E's activation barrier.
+
+Validation:
+
+1. Build and parity passed before the speed filter:
+   - `cargo fmt --check`
+   - `HIP_ARCH=gfx1100 cargo build --release -p runner --bin supersonic`
+   - `SUPERSONIC_QWEN36_MULTILAYER_ORACLE_JSON=/tmp/qwen36_ml_direct_mid_check.json HIP_ARCH=gfx1100 cargo test --release -p runner --test qwen36_moe_multilayer_parity multilayer_persistent_decode_matches_chained -- --nocapture`
+2. 1x64 filter:
+   - Artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_shared_direct_mid_wmma.json`
+   - Result: mean `56.17977528089887 tok/s`, weighted
+     `56.28847845206684 tok/s`, total decode `1137 ms`.
+   - Comparable current keeper artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_ffn_direct_mid_wmma_raw.json`
+     at mean `59.52380952380952 tok/s`, weighted
+     `59.424326833797586 tok/s`, total decode `1077 ms`.
+   - Generated-token hash matched the keeper:
+     `ee96d4ba3ccc01df68bed07b652eb1d37277bdafc224c5628c62c3055fe9e5ed`.
+
+Decision:
+
+- Rejected and reverted.
+- The shared expert's scalar Phase D/E remains faster than the paired WMMA
+  direct-mid path on this 1x64 filter. Do not retry shared direct-mid unless
+  the block/wave mapping changes materially.
+
+## Rejected Slice: FFN Router BF16 WMMA
+
+Date: 2026-06-19.
+
+Reason:
+
+- FFN stage1 profiling attributed about `0.064 ms/layer` to the early FFN
+  path, which includes post-attention RMS, router gate, softmax, and top-k.
+- Tested a BF16 WMMA matvec helper for the router gate (`256 x 2048` BF16)
+  to replace the scalar one-output-row-per-block reduction in Phase B.
+
+Validation:
+
+1. Build passed:
+   - `cargo fmt --check`
+   - `HIP_ARCH=gfx1100 cargo build --release -p runner --bin supersonic`
+2. Persistent parity passed against the existing oracle:
+   - `SUPERSONIC_QWEN36_MULTILAYER_ORACLE_JSON=/tmp/qwen36_ml_direct_mid_check.json HIP_ARCH=gfx1100 cargo test --release -p runner --test qwen36_moe_multilayer_parity multilayer_persistent_decode_matches_chained -- --nocapture`
+3. 1x64 filter:
+   - Artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_router_bf16_wmma.json`
+   - Result: mean `57.4712643678161 tok/s`, weighted
+     `57.502246181491465 tok/s`, total decode `1113 ms`.
+   - Comparable current keeper artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_ffn_direct_mid_wmma_raw.json`
+     at mean `59.52380952380952 tok/s`, weighted
+     `59.424326833797586 tok/s`, total decode `1077 ms`.
+   - Generated-token hash matched the keeper:
+     `ee96d4ba3ccc01df68bed07b652eb1d37277bdafc224c5628c62c3055fe9e5ed`.
+
+Decision:
+
+- Rejected and reverted.
+- The router has only 256 rows; the BF16 WMMA tile path underfilled the GPU
+  despite producing matching output. Keep the scalar router matvec unless a
+  materially different wave/task mapping is introduced.
+
+## Rejected Slice: Router Top-K Over Logits
+
+Date: 2026-06-19.
+
+Reason:
+
+- Tested a narrower router Phase C change: keep the full softmax denominator
+  for parity, but avoid writing all 256 BF16-rounded probabilities by doing
+  top-k over router logits and materializing only the selected probabilities.
+- This targeted the FFN/router slice without changing expert selection math.
+
+Validation:
+
+1. Build and parity passed before the speed filter:
+   - `cargo fmt --check`
+   - `HIP_ARCH=gfx1100 cargo build --release -p runner --bin supersonic`
+   - `SUPERSONIC_QWEN36_MULTILAYER_ORACLE_JSON=/tmp/qwen36_ml_direct_mid_check.json HIP_ARCH=gfx1100 cargo test --release -p runner --test qwen36_moe_multilayer_parity multilayer_persistent_decode_matches_chained -- --nocapture`
+2. 1x64 filter:
+   - Artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_router_topk_logits.json`
+   - Result: mean `62.5 tok/s`, weighted `62.37816764132553 tok/s`,
+     total decode `1026 ms`.
+   - Comparable current keeper artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_shared_pair_scalar.json`
+     at mean `62.5 tok/s`, weighted `62.56109481915934 tok/s`,
+     total decode `1023 ms`.
+   - Generated-token hash matched the keeper:
+     `a68b412c4282555f15546cf6e1fc42893b7e07f271557ceb021821098dd66c1b`.
+3. After rejection, the Phase C source was restored to the full
+   probability-materialization path and the restored build/parity check
+   passed again with exact final-hidden equality.
+
+Decision:
+
+- Rejected and reverted.
+- The router scratch write is not a current bottleneck at the 1x64 filter
+  granularity; do not retry top-k-over-logits without a larger router-stage
+  remapping.
+
+## Benchmark Stack Status: Lucebox 35B/A3B Local Artifacts
+
+Date: 2026-06-19.
+
+Status:
+
+- The local Lucebox HumanEval benchmark stack already has a
+  `qwen36-35b-a3b` target profile in
+  `/home/deano/projects/lucebox-hub/server/scripts/bench_he.py`.
+- That profile uses the no-draft `qwen35moe` daemon path and points at:
+  - target GGUF:
+    `/home/deano/projects/lucebox-hub/server/models/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf`
+  - tokenizer: `Qwen/Qwen3.6-35B-A3B`
+  - runner binary:
+    `/home/deano/projects/lucebox-hub/server/build/test_dflash`
+- The corresponding Supersonic comparison harness profile is
+  `qwen36-35b-a3b` in
+  `tests/gfx1100/bench_qwen36_he_supersonic.py`, pointing at
+  `/mnt/data/models/Qwen3.6-35B-A3B`.
+
+Added:
+
+- Extended Lucebox `scripts/bench_he.py` with `--out-json` so 35B Lucebox
+  runs can produce durable JSON artifacts with mean/weighted decode speed,
+  prefill speed, token totals, and per-prompt rows.
+- Added unit coverage in Lucebox `scripts/test_bench_he.py` for the JSON
+  payload summary path.
+
+Validation:
+
+- `/home/deano/projects/lucebox-hub/server/.venv/bin/python -m unittest scripts.test_bench_he`
+  passed: `7` tests.
+- `/home/deano/projects/lucebox-hub/server/.venv/bin/python -m py_compile scripts/bench_he.py scripts/test_bench_he.py`
+  passed.
+
+Note:
+
+- A live `--out-json` smoke was not run because the counted 35B prompt cache
+  was absent; running it would tokenize and load the full `21G` GGUF. Existing
+  model and binary files are present.
+
+## Rejected Slice: Linear Value/Z Paired WMMA
+
+Date: 2026-06-19.
+
+Reason:
+
+- Tested a linear-attention Phase B WMMA pairing that computed the qkv value
+  slice and z projection together. The two projections share the same
+  activation vector and row count, so this was the next structural pairing
+  after the accepted FFN gate/up and full-attention Q/gate pairs.
+- The candidate added a dual-scale paired WMMA helper because qkv and z use
+  separate INT4 scale/zero slabs.
+
+Validation:
+
+1. Candidate build and exact multilayer parity passed before speed filtering:
+   - `HIP_ARCH=gfx1100 cargo build --release -p runner --bin supersonic`
+   - `SUPERSONIC_QWEN36_MULTILAYER_ORACLE_JSON=/tmp/qwen36_ml_direct_mid_check.json HIP_ARCH=gfx1100 cargo test --release -p runner --test qwen36_moe_multilayer_parity multilayer_persistent_decode_matches_chained -- --nocapture`
+   - persistent and segmented persistent final hidden remained exact:
+     `exact=256 max_abs=0 mean_abs=0 cos_sim=1`.
+2. 1x64 filter:
+   - Artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_linear_value_z_pair_wmma.json`
+   - Result: mean `63.291139240506325 tok/s`, weighted
+     `63.116370808678504 tok/s`, total decode `1014 ms`, stopped early `0`.
+   - Comparable current keeper artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_fullattn_q_gate_pair_wmma.json`
+     at mean `64.51612903225806 tok/s`, weighted `64.45115810674723 tok/s`,
+     total decode `993 ms`.
+   - Generated-token hash matched the keeper:
+     `ee96d4ba3ccc01df68bed07b652eb1d37277bdafc224c5628c62c3055fe9e5ed`.
+3. After rejection, the dual-scale helper and linear value/Z fused pool were
+   reverted. Restored checks passed:
+   - `cargo fmt --check`
+   - `git diff --check`
+   - `HIP_ARCH=gfx1100 cargo build --release -p runner --bin supersonic`
+
+Decision:
+
+- Rejected and reverted.
+- Do not retry value/Z paired WMMA as a simple dual-scale fusion. It reduces
+  virtual row work, but the extra paired dequant/register pressure lost about
+  `21 ms` over the 64-token filter.
+
+## Rejected Slice: Skip Final Post-FFN Counter Reset
+
+Date: 2026-06-19.
+
+Reason:
+
+- The full persistent loop performs `reset_counters_16` after each layer's
+  FFN, and the folded lm-head path then performs another `reset_counters_16`
+  before reading the final hidden state.
+- Tested skipping the post-FFN reset only for the final layer, relying on the
+  lm-head reset to publish the final hidden state and clear counters.
+
+Validation:
+
+1. Candidate checks passed before speed filtering:
+   - `cargo fmt --check`
+   - `git diff --check`
+   - `HIP_ARCH=gfx1100 cargo build --release -p runner --bin supersonic`
+   - `SUPERSONIC_QWEN36_MULTILAYER_ORACLE_JSON=/tmp/qwen36_ml_direct_mid_check.json HIP_ARCH=gfx1100 cargo test --release -p runner --test qwen36_moe_multilayer_parity multilayer_persistent_decode_matches_chained -- --nocapture`
+   - persistent and segmented persistent final hidden remained exact:
+     `exact=256 max_abs=0 mean_abs=0 cos_sim=1`.
+2. 1x64 filter:
+   - Artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_skip_final_postffn_reset.json`
+   - Result: mean `61.349693251533736 tok/s`, weighted
+     `61.30268199233716 tok/s`, total decode `1044 ms`, stopped early `0`.
+   - Comparable current keeper artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_fullattn_q_gate_pair_wmma.json`
+     at mean `64.51612903225806 tok/s`, weighted `64.45115810674723 tok/s`,
+     total decode `993 ms`.
+   - Generated-token hash matched the keeper:
+     `ee96d4ba3ccc01df68bed07b652eb1d37277bdafc224c5628c62c3055fe9e5ed`.
+3. After rejection, the unconditional post-FFN reset was restored. Restored
+   checks passed:
+   - `cargo fmt --check`
+   - `git diff --check`
+   - `HIP_ARCH=gfx1100 cargo build --release -p runner --bin supersonic`
+
+Decision:
+
+- Rejected and reverted.
+- Even though the ordering was exact, removing this final reset hurt the
+  scheduler/timing path by `51 ms` over the 64-token filter. Keep the
+  unconditional post-FFN reset.
+
+## Rejected Slice: Linear Recurrent Update/Output Fusion
+
+Date: 2026-06-19.
+
+Reason:
+
+- Linear-attention Phase G updated the recurrent state matrix in one full pass
+  and then immediately reread the updated matrix for the q-scaled recurrent
+  output reduction.
+- Tested fusing the state update into the per-column reduction: each wave lane
+  computed the same F32 `new_state`, optionally wrote it when `mutate_state`
+  was true, and used it immediately for `recurrent_out`.
+
+Validation:
+
+1. Candidate checks passed before speed filtering:
+   - `cargo fmt --check`
+   - `git diff --check`
+   - `HIP_ARCH=gfx1100 cargo build --release -p runner --bin supersonic`
+   - `SUPERSONIC_QWEN36_MULTILAYER_ORACLE_JSON=/tmp/qwen36_ml_direct_mid_check.json HIP_ARCH=gfx1100 cargo test --release -p runner --test qwen36_moe_multilayer_parity multilayer_persistent_decode_matches_chained -- --nocapture`
+   - persistent and segmented persistent final hidden remained exact:
+     `exact=256 max_abs=0 mean_abs=0 cos_sim=1`.
+2. 1x64 filter:
+   - Artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_linear_recurrent_fused_update_out.json`
+   - Result: mean `60.24096385542168 tok/s`, weighted
+     `60.093896713615024 tok/s`, total decode `1065 ms`, stopped early `0`.
+   - Comparable current keeper artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_fullattn_q_gate_pair_wmma.json`
+     at mean `64.51612903225806 tok/s`, weighted `64.45115810674723 tok/s`,
+     total decode `993 ms`.
+   - Generated-token hash matched the keeper:
+     `ee96d4ba3ccc01df68bed07b652eb1d37277bdafc224c5628c62c3055fe9e5ed`.
+3. After rejection, the two-pass recurrent update/reduction path was restored.
+   Restored checks passed:
+   - `cargo fmt --check`
+   - `git diff --check`
+   - `HIP_ARCH=gfx1100 cargo build --release -p runner --bin supersonic`
+
+Decision:
+
+- Rejected and reverted.
+- Do not retry simple Step 4/5 fusion for linear recurrent state. Despite
+  exact output, the wave-level fused loop lost `72 ms` over the 64-token
+  filter, likely from worse store/reduction scheduling.
+
+## Rejected Slice: Full-Attention K/V Paired WMMA
+
+Date: 2026-06-19.
+
+Reason:
+
+- The current full-attention Phase D production INT4 path already combines K
+  and V into one WMMA work pool over `2 * Hkv * d` virtual rows, avoiding the
+  internal K-to-V counter reset while keeping enough 128-row work tiles live.
+- Tested pairing K and V for the same `Hkv * d` row: each wave packed the
+  normalized activation once and fed separate K/V INT4 sidecars into two WMMA
+  accumulators through a temporary dual-scale paired helper.
+
+Validation:
+
+1. Candidate checks passed before speed filtering:
+   - `cargo fmt --check`
+   - `git diff --check`
+   - `HIP_ARCH=gfx1100 cargo build --release -p runner --bin supersonic`
+   - `SUPERSONIC_QWEN36_MULTILAYER_ORACLE_JSON=/tmp/qwen36_ml_direct_mid_check.json HIP_ARCH=gfx1100 cargo test --release -p runner --test qwen36_moe_multilayer_parity multilayer_persistent_decode_matches_chained -- --nocapture`
+   - persistent and segmented persistent final hidden remained exact:
+     `exact=256 max_abs=0 mean_abs=0 cos_sim=1`.
+2. 1x64 filter:
+   - Artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_fullattn_kv_pair_wmma.json`
+   - Result: mean `60.97560975609757 tok/s`, weighted
+     `60.836501901140686 tok/s`, total decode `1052 ms`, stopped early
+     `0`.
+   - Comparable current keeper artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_fullattn_q_gate_pair_wmma.json`
+     at mean `64.51612903225806 tok/s`, weighted `64.45115810674723 tok/s`,
+     total decode `993 ms`.
+   - Generated-token hash matched the keeper:
+     `ee96d4ba3ccc01df68bed07b652eb1d37277bdafc224c5628c62c3055fe9e5ed`.
+3. After rejection, the temporary dual-scale helper and paired K/V branch were
+   reverted. Restored checks passed:
+   - `cargo fmt --check`
+   - `git diff --check`
+   - `HIP_ARCH=gfx1100 cargo build --release -p runner --bin supersonic`
+
+Decision:
+
+- Rejected and reverted.
+- Do not retry simple full-attention K/V paired WMMA. Although outputs were
+  exact, halving the virtual work rows and adding the paired dequant/register
+  pressure lost `59 ms` over the 64-token filter.
+
+## Rejected Slice: Linear-Attention Q/K Paired WMMA
+
+Date: 2026-06-19.
+
+Reason:
+
+- Linear-attention Phase B stores Q then K rows in the same `in_proj_qkv`
+  INT4 slab with the same sidecars. The full-attention Q/gate paired WMMA
+  keeper showed that pairing adjacent logical rows can save activation packing
+  work when the row layout is favorable.
+- Tested pairing the Q/K rows for the first `key_dim` rows while leaving the
+  V rows in the existing single-row WMMA path. The candidate used the existing
+  same-sidecar paired WMMA helper and had an aligned-geometry fallback for
+  non-128-row Q/K boundaries.
+
+Validation:
+
+1. Candidate checks passed before speed filtering:
+   - `cargo fmt --check`
+   - `git diff --check`
+   - `HIP_ARCH=gfx1100 cargo build --release -p runner --bin supersonic`
+   - `SUPERSONIC_QWEN36_MULTILAYER_ORACLE_JSON=/tmp/qwen36_ml_direct_mid_check.json HIP_ARCH=gfx1100 cargo test --release -p runner --test qwen36_moe_multilayer_parity multilayer_persistent_decode_matches_chained -- --nocapture`
+   - persistent and segmented persistent final hidden remained exact:
+     `exact=256 max_abs=0 mean_abs=0 cos_sim=1`.
+2. 1x64 filter:
+   - Artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_linear_qk_pair_wmma.json`
+   - Result: mean `62.11180124223602 tok/s`, weighted
+     `62.2568093385214 tok/s`, total decode `1028 ms`, stopped early
+     `0`.
+   - Comparable current keeper artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_fullattn_q_gate_pair_wmma.json`
+     at mean `64.51612903225806 tok/s`, weighted `64.45115810674723 tok/s`,
+     total decode `993 ms`.
+   - Generated-token hash matched the keeper:
+     `ee96d4ba3ccc01df68bed07b652eb1d37277bdafc224c5628c62c3055fe9e5ed`.
+3. After rejection, the paired Q/K branch was reverted. Restored checks
+   passed:
+   - `cargo fmt --check`
+   - `git diff --check`
+   - `HIP_ARCH=gfx1100 cargo build --release -p runner --bin supersonic`
+
+Decision:
+
+- Rejected and reverted.
+- Do not retry simple linear-attention Q/K paired WMMA. It preserved ordering
+  and generated-token output, but reducing the virtual QKV row work and mixing
+  paired/single WMMA paths lost `35 ms` over the 64-token filter.
+
+## Rejected Slice: Folded LM-Head WMMA Rows-Per-Task 256
+
+Date: 2026-06-19.
+
+Reason:
+
+- The folded lm-head WMMA path was still claiming 128 vocab rows per block per
+  `atomicAdd`: 8 waves each compute one 16-row WMMA tile.
+- Tested claiming 256 vocab rows per block per `atomicAdd`, with each wave
+  computing two 16-row WMMA tiles before the block synchronizes. The goal was
+  to reduce lm-head work-queue atomic/sync overhead without changing per-row
+  math or the folded top1 tie-break behavior.
+
+Validation:
+
+1. Candidate checks passed before speed filtering:
+   - `cargo fmt --check`
+   - `git diff --check`
+   - `HIP_ARCH=gfx1100 cargo build --release -p runner --bin supersonic`
+   - `SUPERSONIC_QWEN36_MULTILAYER_ORACLE_JSON=/tmp/qwen36_ml_direct_mid_check.json HIP_ARCH=gfx1100 cargo test --release -p runner --test qwen36_moe_multilayer_parity multilayer_persistent_decode_matches_chained -- --nocapture`
+   - persistent and segmented persistent final hidden remained exact:
+     `exact=256 max_abs=0 mean_abs=0 cos_sim=1`.
+2. 1x64 filter:
+   - Artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_lmhead_rows256.json`
+   - Result: script displayed `61.73 tok/s`; structured weighted throughput
+     from the JSON rows was `61.53846153846153 tok/s`, total decode `1040 ms`,
+     stopped early `0`.
+   - Comparable current keeper artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_fullattn_q_gate_pair_wmma.json`
+     at weighted `64.45115810674723 tok/s`, total decode `993 ms`.
+   - Generated-token hash matched the keeper:
+     `ee96d4ba3ccc01df68bed07b652eb1d37277bdafc224c5628c62c3055fe9e5ed`.
+3. After rejection, the rows-per-task sweep was reverted back to 128 rows.
+   Restored checks passed:
+   - `cargo fmt --check`
+   - `git diff --check`
+   - `HIP_ARCH=gfx1100 cargo build --release -p runner --bin supersonic`
+
+Decision:
+
+- Rejected and reverted.
+- Do not retry simple folded lm-head 256-row work claims. It preserved output
+  ordering, but the extra per-claim WMMA work reduced scheduling/fairness enough
+  to lose `47 ms` over the 64-token filter.
+
+## Rejected Slice: Linear QKV/Z Combined WMMA Work Queue
+
+Date: 2026-06-19.
+
+Reason:
+
+- Current-qgate segmented profiles still attributed meaningful time to linear
+  Phase B/linear stage1. The existing linear-attention WMMA path runs
+  `in_proj_qkv` and `in_proj_z` as separate INT4 WMMA work queues with a
+  grid barrier/counter reset between them.
+- Tested a combined qkv+z work queue that did not pair rows or add a second
+  accumulator. Each wave still computed one projection row with the original
+  per-row accumulation order and selected the qkv or z scale slab per row. The
+  goal was only to remove the internal qkv-to-z barrier and reset.
+
+Validation:
+
+1. Candidate checks passed before speed filtering:
+   - `cargo fmt --check`
+   - `git diff --check`
+   - `HIP_ARCH=gfx1100 cargo build --release -p runner --bin supersonic`
+   - `SUPERSONIC_QWEN36_MULTILAYER_ORACLE_JSON=/tmp/qwen36_ml_direct_mid_check.json HIP_ARCH=gfx1100 cargo test --release -p runner --test qwen36_moe_multilayer_parity multilayer_persistent_decode_matches_chained -- --nocapture`
+   - persistent and segmented persistent final hidden remained exact:
+     `exact=256 max_abs=0 mean_abs=0 cos_sim=1`.
+2. 1x64 filter:
+   - Artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_linear_qkvz_combined_wmma.json`
+   - Result: displayed mean rounded to `64.52 tok/s`, but structured weighted
+     throughput was `64.321608040201 tok/s`, total decode `995 ms`, stopped
+     early `0`.
+   - Comparable current keeper artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_fullattn_q_gate_pair_wmma.json`
+     at weighted `64.45115810674723 tok/s`, total decode `993 ms`.
+   - Generated-token hash matched the keeper:
+     `ee96d4ba3ccc01df68bed07b652eb1d37277bdafc224c5628c62c3055fe9e5ed`.
+3. After rejection, the combined qkv/z queue was reverted back to split qkv
+   and z queues. Restored checks passed:
+   - `cargo fmt --check`
+   - `git diff --check`
+   - `HIP_ARCH=gfx1100 cargo build --release -p runner --bin supersonic`
+
+Decision:
+
+- Rejected and reverted.
+- Do not retry simple qkv/z queue combination. Removing the internal barrier
+  preserved output ordering but still lost `2 ms` on the 64-token filter,
+  likely from branch/scale-selection overhead and reduced scheduling shape.
+
+## Rejected Slice: Full-Attention Tile8 Wave-Parallel Scores
+
+Date: 2026-06-19.
+
+Reason:
+
+- The kept full-attention tiled decode path uses `attn_tile_t=8`. Each tile
+  task still computes every token score with a full-block reduction over
+  `head_dim=256`, then walks the eight token scores in order for online
+  softmax/value accumulation.
+- Tested replacing the per-token full-block reductions with one wave per token:
+  eight waves compute the eight tile scores into shared storage, then the
+  existing softmax/value loop consumes those scores in token order. The goal was
+  to remove up to eight block-wide score reductions and their synchronizations
+  per tile.
+
+Validation:
+
+1. Candidate checks passed before speed filtering:
+   - `cargo fmt --check`
+   - `git diff --check`
+   - `HIP_ARCH=gfx1100 cargo build --release -p runner --bin supersonic`
+   - `SUPERSONIC_QWEN36_MULTILAYER_ORACLE_JSON=/tmp/qwen36_ml_direct_mid_check.json HIP_ARCH=gfx1100 cargo test --release -p runner --test qwen36_moe_multilayer_parity multilayer_persistent_decode_matches_chained -- --nocapture`
+   - persistent and segmented persistent final hidden remained exact:
+     `exact=256 max_abs=0 mean_abs=0 cos_sim=1`.
+2. 1x64 filter:
+   - Artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_fullattn_tile_wave_scores.json`
+   - Result: displayed `62.11 tok/s`; structured row throughput
+     `62.11180124223602 tok/s`, total decode `1028 ms`, generated `64`,
+     stopped early `0`.
+   - Comparable current keeper artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_fullattn_q_gate_pair_wmma.json`
+     at weighted `64.45115810674723 tok/s`, total decode `993 ms`.
+   - Generated-token hash matched the keeper:
+     `ee96d4ba3ccc01df68bed07b652eb1d37277bdafc224c5628c62c3055fe9e5ed`.
+3. After rejection, the wave-score hunk was reverted back to the original
+   serial per-token full-block score reductions inside the tile8 loop.
+   Restored checks passed:
+   - `cargo fmt --check`
+   - `git diff --check`
+   - `HIP_ARCH=gfx1100 cargo build --release -p runner --bin supersonic`
+
+Decision:
+
+- Rejected and reverted.
+- Do not retry simple wave-parallel score computation inside tile8. It
+  preserved generated output but lost `35 ms` on the 64-token filter, likely
+  because each wave only covers 256 score dimensions and the added shared score
+  handoff plus lower per-score parallelism outweighs the removed block
+  reductions.
+
+## Rejected Slice: Linear Phase C Conv4 Unroll
+
+Date: 2026-06-19.
+
+Reason:
+
+- Current segmented linear profiles still show nontrivial cost outside the
+  out-projection, and 35B A3B uses `conv_kernel_dim=4` for the linear-attention
+  depthwise conv over QKV channels.
+- Tested a shape-specific Phase C fast path in
+  `kernels/qwen36_moe_persistent/linear_attn_phase.cuh` that replaced the
+  runtime `conv_in[KERNEL_MAX]` load/dot/state-shift loops with explicit
+  `c0/c1/c2/new_qkv` loads, four multiply-adds in the same order, and explicit
+  three-slot state update. The generic fallback remained for other kernel
+  sizes.
+
+Validation:
+
+1. Candidate checks passed before speed filtering:
+   - `cargo fmt --check`
+   - `git diff --check`
+   - `HIP_ARCH=gfx1100 cargo build --release -p runner --bin supersonic`
+   - `SUPERSONIC_QWEN36_MULTILAYER_ORACLE_JSON=/tmp/qwen36_ml_direct_mid_check.json HIP_ARCH=gfx1100 cargo test --release -p runner --test qwen36_moe_multilayer_parity multilayer_persistent_decode_matches_chained -- --nocapture`
+   - persistent and segmented persistent final hidden remained exact:
+     `exact=256 max_abs=0 mean_abs=0 cos_sim=1`.
+2. 1x64 filter:
+   - Artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_linear_conv4_unroll.json`
+   - Result: displayed `61.35 tok/s`; structured weighted throughput
+     `61.53846153846153 tok/s`, total decode `1040 ms`, generated `64`,
+     stopped early `0`.
+   - Comparable current keeper artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_fullattn_q_gate_pair_wmma.json`
+     at weighted `64.45115810674723 tok/s`, total decode `993 ms`.
+   - Generated-token hash matched the keeper:
+     `ee96d4ba3ccc01df68bed07b652eb1d37277bdafc224c5628c62c3055fe9e5ed`.
+3. After rejection, the conv4 fast path was reverted back to the generic
+   Phase C loop. Restored checks passed:
+   - `cargo fmt --check`
+   - `git diff --check`
+   - `HIP_ARCH=gfx1100 cargo build --release -p runner --bin supersonic`
+
+Decision:
+
+- Rejected and reverted.
+- Do not retry simple `conv_kernel_dim=4` unrolling in linear Phase C. It
+  preserved output but lost `47 ms` on the 64-token filter, likely from
+  increased register/code pressure or worse compiler scheduling versus the
+  compact loop form.
+
+## Fresh Current-QGate Segmented Profiles
+
+Date: 2026-06-19.
+
+- Refreshed segmented FFI profiles after reverting the rejected conv4 unroll,
+  so these correspond to the current q-gate keeper:
+  - `target/qwen36_35b_profile/qgate_current_1x2_ffn_stage_segmented_ffi.json`
+  - `target/qwen36_35b_profile/qgate_current_1x2_linear_stage_segmented_ffi.json`
+- FFN-stage segmented rows:
+  - full-attn-only mean `0.2724 ms`
+  - FFN stage3 `0.1726 ms`
+  - FFN stage4 `0.1709 ms`
+  - FFN stage5/full `0.1500 ms`
+  - FFN stage2 `0.0895 ms`
+  - FFN stage1 `0.0677 ms`
+  - argmax `0.3800 ms`
+- Linear-stage segmented rows:
+  - FFN-only mean `0.1870 ms`
+  - linear stage5/full `0.2257 ms`
+  - linear stage1 `0.1636 ms`
+  - linear stage4 `0.1570 ms`
+  - linear stage3 `0.1306 ms`
+  - linear stage2 `0.1277 ms`
+  - full-attn-only `0.2777 ms`
+  - argmax `0.4027 ms`
+
+Interpretation:
+
+- Use these as attribution only; segmented FFI timings perturb throughput.
+- The next best isolated target is still linear attention, especially stage5
+  and projection/state work. FFN stage5 is no longer the obvious first target
+  after the direct-mid and pair-WMMA wins.
+
+## Rejected Slice: Linear Out-Projection WMMA Tile96
+
+Date: 2026-06-19.
+
+Reason:
+
+- The kept linear Phase I out-projection uses `rows_per_task=64`, with four
+  active waves per block, after the earlier `128 -> 64` win and `32` rejection.
+- Tested the missing midpoint `rows_per_task=96`, with six active waves per
+  block. This preserves per-row WMMA math and generated output; it only changes
+  work-claim granularity and active waves.
+
+Validation:
+
+1. Candidate checks passed before speed filtering:
+   - `cargo fmt --check`
+   - `git diff --check`
+   - `HIP_ARCH=gfx1100 cargo build --release -p runner --bin supersonic`
+   - `SUPERSONIC_QWEN36_MULTILAYER_ORACLE_JSON=/tmp/qwen36_ml_direct_mid_check.json HIP_ARCH=gfx1100 cargo test --release -p runner --test qwen36_moe_multilayer_parity multilayer_persistent_decode_matches_chained -- --nocapture`
+   - persistent and segmented persistent final hidden remained exact:
+     `exact=256 max_abs=0 mean_abs=0 cos_sim=1`.
+2. 1x64 filter:
+   - Artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_linear_outproj_tile96.json`
+   - Result: displayed `60.98 tok/s`; structured weighted throughput
+     `60.95238095238095 tok/s`, total decode `1050 ms`, generated `64`,
+     stopped early `0`.
+   - Comparable current keeper artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_fullattn_q_gate_pair_wmma.json`
+     at weighted `64.45115810674723 tok/s`, total decode `993 ms`.
+   - Generated-token hash matched the keeper:
+     `ee96d4ba3ccc01df68bed07b652eb1d37277bdafc224c5628c62c3055fe9e5ed`.
+3. After rejection, the work tile was reverted back to `rows_per_task=64`.
+   Restored checks passed:
+   - `cargo fmt --check`
+   - `git diff --check`
+   - `HIP_ARCH=gfx1100 cargo build --release -p runner --bin supersonic`
+
+Decision:
+
+- Rejected and reverted.
+- Do not retry intermediate linear out-projection row tiles by simple
+  `rows_per_task` adjustment. `64` remains the best tested shape; `96` lost
+  `57 ms` on the 64-token filter and `32` was already rejected.
+
+## Rejected Slice: Linear Reduction Zero-Lane Skip
+
+Date: 2026-06-19.
+
+Reason:
+
+- Linear Phase D and Phase H reduce live dimensions of `128` with a
+  `block_size=256` scratch array. The attempted optimization skipped the first
+  `s=128` reduction step, because lanes `128..255` appear to contribute zero
+  partials for these reductions.
+- This was intended to preserve summation over the nonzero lanes while saving
+  one reduction add and barrier per norm reduction.
+
+Validation:
+
+1. Candidate pre-checks passed:
+   - `cargo fmt --check`
+   - `git diff --check`
+   - `HIP_ARCH=gfx1100 cargo build --release -p runner --bin supersonic`
+2. Exact multilayer parity failed:
+   - Command:
+     `SUPERSONIC_QWEN36_MULTILAYER_ORACLE_JSON=/tmp/qwen36_ml_direct_mid_check.json HIP_ARCH=gfx1100 cargo test --release -p runner --test qwen36_moe_multilayer_parity multilayer_persistent_decode_matches_chained -- --nocapture`
+   - Result:
+     `[parity persistent vs chained final_hidden] n=256 exact=0 max_abs=3.36250e1 mean_abs=8.62972e0 cos_sim=0.0260963`
+   - Failure threshold: `max_abs 33.625 exceeds tolerance 0.001`.
+3. After rejection, the two reduction loops were restored to
+   `for (int s = block_size / 2; s > 0; s >>= 1)`.
+   Restored checks passed:
+   - `cargo fmt --check`
+   - `git diff --check`
+   - `HIP_ARCH=gfx1100 cargo build --release -p runner --bin supersonic`
+
+Decision:
+
+- Rejected and reverted before any speed benchmark.
+- Do not retry simple zero-lane skipping in these linear reductions. The
+  apparently zero upper lanes are part of the existing exact behavior, likely
+  because the full `block_size/2` tree also controls synchronization and stale
+  shared-scratch visibility in a way the chained parity test catches.
+
+## Rejected Slice: Router Top-K Shared Probability Buffer
+
+Date: 2026-06-19.
+
+Reason:
+
+- FFN Phase C computes router probabilities, then runs `top_k=8` argmax
+  reductions over `num_experts=256`, masking the winning probability in
+  `workspace[OFF_ROUTER_PROBS]` after each iteration.
+- Tested keeping the 256 BF16-rounded probabilities in `shared_scratch` for
+  the top-k loop and masking that shared buffer instead. This preserved the
+  existing value/index reduction tree and top-k tie-break rule, while avoiding
+  repeated global scratch reads/writes during top-k selection.
+
+Validation:
+
+1. Candidate checks passed before speed filtering:
+   - `cargo fmt --check`
+   - `git diff --check`
+   - `HIP_ARCH=gfx1100 cargo build --release -p runner --bin supersonic`
+   - `SUPERSONIC_QWEN36_MULTILAYER_ORACLE_JSON=/tmp/qwen36_ml_direct_mid_check.json HIP_ARCH=gfx1100 cargo test --release -p runner --test qwen36_moe_multilayer_parity multilayer_persistent_decode_matches_chained -- --nocapture`
+   - persistent and segmented persistent final hidden remained exact:
+     `exact=256 max_abs=0 mean_abs=0 cos_sim=1`.
+2. 1x64 filter:
+   - Artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_router_topk_shared.json`
+   - Result: displayed `60.98 tok/s`; structured weighted throughput
+     `61.06870229007633 tok/s`, total decode `1048 ms`, generated `64`,
+     stopped early `0`.
+   - Comparable current keeper artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_fullattn_q_gate_pair_wmma.json`
+     at weighted `64.45115810674723 tok/s`, total decode `993 ms`.
+   - Generated-token hash matched the keeper:
+     `ee96d4ba3ccc01df68bed07b652eb1d37277bdafc224c5628c62c3055fe9e5ed`.
+3. After rejection, the router top-k loop was restored to the global
+   `OFF_ROUTER_PROBS` masking shape. Restored checks passed:
+   - `cargo fmt --check`
+   - `git diff --check`
+   - `HIP_ARCH=gfx1100 cargo build --release -p runner --bin supersonic`
+
+Decision:
+
+- Rejected and reverted.
+- Do not retry this shared-probability top-k buffering shape. The saved
+  global scratch traffic is tiny relative to the added shared-memory pressure
+  and synchronization shape, and it lost `55 ms` on the 64-token filter.
+
+## Rejected Slice: Folded LM-Head WMMA Tail-Sync Removal
+
+Date: 2026-06-19.
+
+Reason:
+
+- The folded persistent lm-head WMMA work-stealing loop ended each claimed
+  128-row vocab tile with `__syncthreads()` after per-wave logit/top1 updates.
+- Tested removing that tail barrier because the next loop iteration begins with
+  a row-claim atomic and another `__syncthreads()`. The work tile, WMMA math,
+  BF16 rounding, and top1 reduction were unchanged.
+
+Validation:
+
+1. Candidate checks passed before speed filtering:
+   - `cargo fmt --check`
+   - `git diff --check`
+   - `HIP_ARCH=gfx1100 cargo build --release -p runner --bin supersonic`
+   - `SUPERSONIC_QWEN36_MULTILAYER_ORACLE_JSON=/tmp/qwen36_ml_direct_mid_check.json HIP_ARCH=gfx1100 cargo test --release -p runner --test qwen36_moe_multilayer_parity multilayer_persistent_decode_matches_chained -- --nocapture`
+   - persistent and segmented persistent final hidden remained exact:
+     `exact=256 max_abs=0 mean_abs=0 cos_sim=1`.
+2. 1x64 filter:
+   - Artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_lmhead_no_tail_sync.json`
+   - Result: displayed `61.35 tok/s`; structured weighted throughput
+     `61.185468451242826 tok/s`, total decode `1046 ms`, generated `64`,
+     stopped early `0`.
+   - Comparable current keeper artifact:
+     `target/qwen36_35b_a3b_raw_script_1x64_fullattn_q_gate_pair_wmma.json`
+     at weighted `64.45115810674723 tok/s`, total decode `993 ms`.
+   - Generated-token hash matched the keeper:
+     `ee96d4ba3ccc01df68bed07b652eb1d37277bdafc224c5628c62c3055fe9e5ed`.
+3. After rejection, the tail `__syncthreads()` was restored in the folded
+   lm-head WMMA loop.
+
+Decision:
+
+- Rejected and reverted.
+- Do not retry simple folded lm-head WMMA tail-sync removal. The barrier is
+  performance-positive for the current loop shape, likely by preserving cleaner
+  block-level scheduling/shared state before the next work claim, and removing
+  it lost `53 ms` on the 64-token filter.

--- a/kernels/qwen36_moe_bridge.cpp
+++ b/kernels/qwen36_moe_bridge.cpp
@@ -1113,6 +1113,7 @@ extern "C" int qwen36_moe_hip_persistent_decode_launch(
     const void*   final_norm_w,           // [hidden] BF16, nullable
     const void*   lm_head_w,              // [vocab, hidden] BF16, nullable
     void*         logits_out,             // [vocab] BF16, nullable
+    unsigned int* top1_out,               // [1] U32, nullable
     unsigned int* counters,
     unsigned int* barrier_counter,
     unsigned int* barrier_flag) {
@@ -1125,7 +1126,7 @@ extern "C" int qwen36_moe_hip_persistent_decode_launch(
     // caller downloads `hidden_ping` for the result.
     if (layers == nullptr) return 133;
     if (hidden <= 0 || num_experts <= 0 || top_k <= 0) return 134;
-    if (mode < 0 || mode > 2) return 140;
+    if (mode < 0 || mode > 13) return 140;
     if (start_layer < 0 || start_layer >= num_layers) return 141;
     if (mode == 0) {
         if (end_layer_exclusive <= start_layer ||
@@ -1133,9 +1134,10 @@ extern "C" int qwen36_moe_hip_persistent_decode_launch(
             return 142;
         }
     } else {
-        // Router-only and FFN-only are single-layer segmented sparse-VMM
-        // entry points. The host remaps between the two launches, so folded
-        // lm_head is intentionally available only to the full-step mode.
+        // Router-only, attention-only, FFN-only, and FFN staged-profile
+        // modes are single-layer segmented sparse-VMM/profile entry points.
+        // The host may remap between launches, so folded lm_head is
+        // intentionally available only to the full-step mode.
         end_layer_exclusive = start_layer + 1;
     }
     // FFN's concurrent-experts dispatch uses counters[group_id] for Phase G
@@ -1162,9 +1164,11 @@ extern "C" int qwen36_moe_hip_persistent_decode_launch(
     // Mixed state would silently skip lm_head while pretending to do
     // it — reject up front so the caller catches the misuse.
     const bool lm_head_on = (final_norm_w != nullptr) || (lm_head_w != nullptr) ||
-                            (logits_out != nullptr) || (vocab > 0);
+                            (logits_out != nullptr) || (top1_out != nullptr) ||
+                            (vocab > 0);
     const bool lm_head_complete = (final_norm_w != nullptr) && (lm_head_w != nullptr) &&
-                                  (logits_out != nullptr) && (vocab > 0);
+                                  ((logits_out != nullptr) || (top1_out != nullptr)) &&
+                                  (vocab > 0);
     if (lm_head_on && !lm_head_complete) return 139;
     if (lm_head_on && (mode != 0 || end_layer_exclusive != num_layers)) return 143;
     if (token_ids != nullptr && lm_head_on) return 149;
@@ -1257,7 +1261,10 @@ extern "C" int qwen36_moe_hip_persistent_decode_launch(
     // would force BF16-only models onto the scalar lm_head fallback
     // even on WMMA-capable hardware (Codex P1 review on PR #140), so
     // the gate now asks only "is the device WMMA-capable".
+    const bool disable_wmma =
+        std::getenv("SUPERSONIC_QWEN36_DISABLE_PERSISTENT_WMMA") != nullptr;
     const bool use_wmma =
+        !disable_wmma &&
         device_supports_wmma_bf16(static_cast<int>(device_ordinal));
 
     if (use_wmma) {
@@ -1280,6 +1287,7 @@ extern "C" int qwen36_moe_hip_persistent_decode_launch(
             static_cast<const hip_bfloat16*>(final_norm_w),
             static_cast<const hip_bfloat16*>(lm_head_w),
             static_cast<hip_bfloat16*>(logits_out),
+            top1_out,
             counters, barrier_counter, barrier_flag);
     } else {
         hipLaunchKernelGGL(
@@ -1301,6 +1309,7 @@ extern "C" int qwen36_moe_hip_persistent_decode_launch(
             static_cast<const hip_bfloat16*>(final_norm_w),
             static_cast<const hip_bfloat16*>(lm_head_w),
             static_cast<hip_bfloat16*>(logits_out),
+            top1_out,
             counters, barrier_counter, barrier_flag);
     }
 

--- a/kernels/qwen36_moe_persistent/ffn_phase.cuh
+++ b/kernels/qwen36_moe_persistent/ffn_phase.cuh
@@ -154,16 +154,12 @@ __device__ inline void qwen36_moe_ffn_step_device(
 
     // BF16-round each h_norm element so the matmul reads what PyTorch reads.
     // HF `Qwen3_5MoeRMSNorm` `(1.0 + weight)` unit offset for
-    // `post_attention_layernorm`. Block 0 also stages the F32 of-BF16 view
-    // into workspace[OFF_H_NORM] for any later stages that prefer global
-    // memory.
+    // `post_attention_layernorm`. The normalised vector stays in per-block
+    // LDS; later FFN phases read their local copy directly.
     for (int col = tid; col < hidden; col += block_size) {
         const float w = static_cast<float>(post_attn_norm_w[col]);
         const float v = bf16_round_rne_f32(h_norm_lds[col] * inv_rms_input * (1.0f + w));
         h_norm_lds[col] = v;
-        if (blockIdx.x == 0) {
-            workspace[OFF_H_NORM + col] = v;
-        }
     }
     __syncthreads();
 
@@ -260,7 +256,7 @@ __device__ inline void qwen36_moe_ffn_step_device(
 
         // Step 4: top-k via k iterations. Each iter does a 256-wide argmax
         // reduction on `router_probs`, then masks the winner. With K=8 this
-        // is 8 cycles → fine for a megakernel; a heap would beat it for
+        // is 8 cycles -- fine for a megakernel; a heap would beat it for
         // larger k but k=8 is fixed in the model card.
         //
         // Tie-breaking: torch.topk returns the lowest index on ties; we
@@ -343,137 +339,133 @@ __device__ inline void qwen36_moe_ffn_step_device(
 
     const int Is_ = shared_intermediate;
     const int total_rows_d = 2 * Is_ + 1;
-    for (;;) {
-        __shared__ unsigned int my_row_d_s;
-        if (tid == 0) {
-            my_row_d_s = atomicAdd(&counters[0], 1u);
-        }
-        __syncthreads();
-        const int my_row = static_cast<int>(my_row_d_s);
-        if (my_row >= total_rows_d) break;
-
-        const T* w_row = nullptr;
-        const void* i4_slab = nullptr;
-        const hip_bfloat16* i4_scale = nullptr;
-        const hip_bfloat16* i4_zero  = nullptr;
-        int      i4_row = 0;
-        int      write_offset;
-        bool     is_gate_row = false;
-        if (my_row < Is_) {
-            if (shared_gate_proj_scale != nullptr) {
-                i4_slab  = reinterpret_cast<const void*>(shared_gate_proj_w);
-                i4_scale = shared_gate_proj_scale;
-                i4_zero  = shared_gate_proj_zero;
-                i4_row   = my_row;
-            } else {
-                w_row = shared_gate_proj_w + static_cast<size_t>(my_row) * hidden;
-            }
-            write_offset = OFF_SGP + my_row;
-        } else if (my_row < 2 * Is_) {
-            const int local = my_row - Is_;
-            if (shared_up_proj_scale != nullptr) {
-                i4_slab  = reinterpret_cast<const void*>(shared_up_proj_w);
-                i4_scale = shared_up_proj_scale;
-                i4_zero  = shared_up_proj_zero;
-                i4_row   = local;
-            } else {
-                w_row = shared_up_proj_w + static_cast<size_t>(local) * hidden;
-            }
-            write_offset = OFF_SUP + local;
-        } else {
-            // Single-row "[1, hidden]" weight; dot it with h_norm and apply
-            // sigmoid() before storing into SG_SCALAR. Always BF16 — the
-            // INT4 bake excludes `shared_expert_gate`.
-            w_row        = shared_expert_gate_w;
-            write_offset = OFF_SG_SCALAR;
-            is_gate_row  = true;
-        }
-
-        float partial = 0.0f;
-        if (i4_scale != nullptr && !fp8_mode) {
-            partial = int4_dq8_matvec_partial(
-                static_cast<const uint8_t*>(i4_slab),
-                i4_scale, i4_zero, h_norm_lds,
-                i4_row, hidden, quant_group_size,
-                tid, block_size);
-        } else if (i4_scale != nullptr) {
-            partial = fp8_matvec_partial(
-                i4_slab,
-                i4_scale,
-                h_norm_lds,
-                i4_row, hidden, quant_group_size,
-                tid, block_size);
-        } else {
-            for (int col = tid; col < hidden; col += block_size) {
-                partial += static_cast<float>(w_row[col]) * h_norm_lds[col];
-            }
-        }
-        shared_scratch[tid] = partial;
-        __syncthreads();
-        for (int s = block_size / 2; s > 0; s >>= 1) {
-            if (tid < s) shared_scratch[tid] += shared_scratch[tid + s];
-            __syncthreads();
-        }
-        if (tid == 0) {
-            float val = shared_scratch[0];
-            if (is_gate_row) {
-                val = 1.0f / (1.0f + expf(-val));
-            }
-            workspace[write_offset] = val;
-        }
-        __syncthreads();
-    }
-
-    // -- Phase E: smid = silu(sgp) * sup  (block-0 only, F32 throughout) ---
-    grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
-                               &counters[0]);
-    if (blockIdx.x == 0) {
-        for (int i = tid; i < Is_; i += block_size) {
-            const float gp     = workspace[OFF_SGP + i];
-            const float up     = workspace[OFF_SUP + i];
-            const float sigmoid_gp = 1.0f / (1.0f + expf(-gp));
-            const float silu_gp    = gp * sigmoid_gp;
-            workspace[OFF_SHARED_MID + i] = silu_gp * up;
-        }
-        __syncthreads();
-    }
-
-    // -- Phase F: shared_out = sg_scalar * (smid @ down_proj.T) ------------
-    grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
-                               &counters[0]);
-    {
-        const float sg_scalar = workspace[OFF_SG_SCALAR];
+    const bool shared_direct_mid_scalar =
+        (shared_gate_proj_scale != nullptr) &&
+        (shared_up_proj_scale != nullptr) &&
+        !fp8_mode;
+    if (shared_direct_mid_scalar) {
+        const uint8_t* gate_slab =
+            reinterpret_cast<const uint8_t*>(shared_gate_proj_w);
+        const uint8_t* up_slab =
+            reinterpret_cast<const uint8_t*>(shared_up_proj_w);
+        __shared__ float shared_scratch_up[256];
         for (;;) {
-            __shared__ unsigned int my_row_f_s;
+            __shared__ unsigned int my_row_d_s;
             if (tid == 0) {
-                my_row_f_s = atomicAdd(&counters[0], 1u);
+                my_row_d_s = atomicAdd(&counters[0], 1u);
             }
             __syncthreads();
-            const int my_row = static_cast<int>(my_row_f_s);
-            if (my_row >= hidden) break;
+            const int my_row = static_cast<int>(my_row_d_s);
+            if (my_row > Is_) break;
+
+            if (my_row < Is_) {
+                qwen36_float_pair partials = int4_dq8_pair_matvec_partial_same_row(
+                    gate_slab,
+                    shared_gate_proj_scale, shared_gate_proj_zero,
+                    up_slab,
+                    shared_up_proj_scale, shared_up_proj_zero,
+                    h_norm_lds,
+                    my_row, hidden, quant_group_size,
+                    tid, block_size);
+                shared_scratch[tid] = partials.first;
+                shared_scratch_up[tid] = partials.second;
+                __syncthreads();
+                for (int s = block_size / 2; s > 0; s >>= 1) {
+                    if (tid < s) {
+                        shared_scratch[tid] += shared_scratch[tid + s];
+                        shared_scratch_up[tid] += shared_scratch_up[tid + s];
+                    }
+                    __syncthreads();
+                }
+                if (tid == 0) {
+                    const float gp = shared_scratch[0];
+                    const float up = shared_scratch_up[0];
+                    const float sigmoid_gp = 1.0f / (1.0f + expf(-gp));
+                    workspace[OFF_SHARED_MID + my_row] = (gp * sigmoid_gp) * up;
+                }
+            } else {
+                const T* w_row = shared_expert_gate_w;
+                float partial = 0.0f;
+                for (int col = tid; col < hidden; col += block_size) {
+                    partial += static_cast<float>(w_row[col]) * h_norm_lds[col];
+                }
+                shared_scratch[tid] = partial;
+                __syncthreads();
+                for (int s = block_size / 2; s > 0; s >>= 1) {
+                    if (tid < s) shared_scratch[tid] += shared_scratch[tid + s];
+                    __syncthreads();
+                }
+                if (tid == 0) {
+                    const float val = shared_scratch[0];
+                    workspace[OFF_SG_SCALAR] = 1.0f / (1.0f + expf(-val));
+                }
+            }
+            __syncthreads();
+        }
+    } else {
+        for (;;) {
+            __shared__ unsigned int my_row_d_s;
+            if (tid == 0) {
+                my_row_d_s = atomicAdd(&counters[0], 1u);
+            }
+            __syncthreads();
+            const int my_row = static_cast<int>(my_row_d_s);
+            if (my_row >= total_rows_d) break;
+
+            const T* w_row = nullptr;
+            const void* i4_slab = nullptr;
+            const hip_bfloat16* i4_scale = nullptr;
+            const hip_bfloat16* i4_zero  = nullptr;
+            int      i4_row = 0;
+            int      write_offset;
+            bool     is_gate_row = false;
+            if (my_row < Is_) {
+                if (shared_gate_proj_scale != nullptr) {
+                    i4_slab  = reinterpret_cast<const void*>(shared_gate_proj_w);
+                    i4_scale = shared_gate_proj_scale;
+                    i4_zero  = shared_gate_proj_zero;
+                    i4_row   = my_row;
+                } else {
+                    w_row = shared_gate_proj_w + static_cast<size_t>(my_row) * hidden;
+                }
+                write_offset = OFF_SGP + my_row;
+            } else if (my_row < 2 * Is_) {
+                const int local = my_row - Is_;
+                if (shared_up_proj_scale != nullptr) {
+                    i4_slab  = reinterpret_cast<const void*>(shared_up_proj_w);
+                    i4_scale = shared_up_proj_scale;
+                    i4_zero  = shared_up_proj_zero;
+                    i4_row   = local;
+                } else {
+                    w_row = shared_up_proj_w + static_cast<size_t>(local) * hidden;
+                }
+                write_offset = OFF_SUP + local;
+            } else {
+                // Single-row "[1, hidden]" weight; dot it with h_norm and apply
+                // sigmoid() before storing into SG_SCALAR. Always BF16 — the
+                // INT4 bake excludes `shared_expert_gate`.
+                w_row        = shared_expert_gate_w;
+                write_offset = OFF_SG_SCALAR;
+                is_gate_row  = true;
+            }
 
             float partial = 0.0f;
-            if (shared_down_proj_scale != nullptr && !fp8_mode) {
+            if (i4_scale != nullptr && !fp8_mode) {
                 partial = int4_dq8_matvec_partial(
-                    reinterpret_cast<const uint8_t*>(shared_down_proj_w),
-                    static_cast<const hip_bfloat16*>(shared_down_proj_scale),
-                    static_cast<const hip_bfloat16*>(shared_down_proj_zero),
-                    workspace + OFF_SHARED_MID,
-                    my_row, Is_, quant_group_size,
+                    static_cast<const uint8_t*>(i4_slab),
+                    i4_scale, i4_zero, h_norm_lds,
+                    i4_row, hidden, quant_group_size,
                     tid, block_size);
-            } else if (shared_down_proj_scale != nullptr) {
+            } else if (i4_scale != nullptr) {
                 partial = fp8_matvec_partial(
-                    reinterpret_cast<const void*>(shared_down_proj_w),
-                    static_cast<const hip_bfloat16*>(shared_down_proj_scale),
-                    workspace + OFF_SHARED_MID,
-                    my_row, Is_, quant_group_size,
+                    i4_slab,
+                    i4_scale,
+                    h_norm_lds,
+                    i4_row, hidden, quant_group_size,
                     tid, block_size);
             } else {
-                const T* w_row =
-                    shared_down_proj_w + static_cast<size_t>(my_row) * Is_;
-                for (int col = tid; col < Is_; col += block_size) {
-                    partial += static_cast<float>(w_row[col])
-                               * workspace[OFF_SHARED_MID + col];
+                for (int col = tid; col < hidden; col += block_size) {
+                    partial += static_cast<float>(w_row[col]) * h_norm_lds[col];
                 }
             }
             shared_scratch[tid] = partial;
@@ -483,13 +475,137 @@ __device__ inline void qwen36_moe_ffn_step_device(
                 __syncthreads();
             }
             if (tid == 0) {
-                const float val = bf16_round_rne_f32(sg_scalar * shared_scratch[0]);
-                workspace[OFF_SHARED_OUT + my_row] = val;
-                if (stage == 2) {
-                    output[my_row] = static_cast<T>(val);
+                float val = shared_scratch[0];
+                if (is_gate_row) {
+                    val = 1.0f / (1.0f + expf(-val));
                 }
+                workspace[write_offset] = val;
             }
             __syncthreads();
+        }
+    }
+
+    if (shared_direct_mid_scalar) {
+        grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
+                                   &counters[0]);
+    } else {
+        // -- Phase E: smid = silu(sgp) * sup  (block-0 only, F32 throughout) ---
+        grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
+                                   &counters[0]);
+        if (blockIdx.x == 0) {
+            for (int i = tid; i < Is_; i += block_size) {
+                const float gp     = workspace[OFF_SGP + i];
+                const float up     = workspace[OFF_SUP + i];
+                const float sigmoid_gp = 1.0f / (1.0f + expf(-gp));
+                const float silu_gp    = gp * sigmoid_gp;
+                workspace[OFF_SHARED_MID + i] = silu_gp * up;
+            }
+            __syncthreads();
+        }
+
+        // -- Phase F: shared_out = sg_scalar * (smid @ down_proj.T) ------------
+        grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
+                                   &counters[0]);
+    }
+
+    {
+        const float sg_scalar = workspace[OFF_SG_SCALAR];
+        bool wmma_handled_f = false;
+#ifdef SUPERSONIC_QWEN36_HAS_WMMA_BF16
+        if constexpr (USE_WMMA) {
+            if (shared_down_proj_scale != nullptr && !fp8_mode) {
+                const int gsc_f = Is_ / quant_group_size;
+                const int wave_id = tid >> 5;
+                const int lane = tid & 31;
+                const int lane_row = lane & 15;
+                const int lane_half = lane >> 4;
+                const uint8_t* packed =
+                    reinterpret_cast<const uint8_t*>(shared_down_proj_w);
+                const float* mid = workspace + OFF_SHARED_MID;
+                for (;;) {
+                    __shared__ unsigned int row_base_f_s;
+                    if (tid == 0) {
+                        row_base_f_s = atomicAdd(&counters[0], 128u);
+                    }
+                    __syncthreads();
+                    const int row_base = static_cast<int>(row_base_f_s);
+                    if (row_base >= hidden) break;
+
+                    const int rhs_row_idx = row_base + wave_id * 16 + lane_row;
+                    const bool rhs_in_range = rhs_row_idx < hidden;
+                    const uint8_t* slab_row = rhs_in_range
+                        ? packed + static_cast<size_t>(rhs_row_idx) * (Is_ / 2)
+                        : nullptr;
+
+                    qwen36_float8 acc = wmma_int4_matvec_partial_16rows(
+                        slab_row,
+                        static_cast<const hip_bfloat16*>(shared_down_proj_scale),
+                        static_cast<const hip_bfloat16*>(shared_down_proj_zero),
+                        rhs_row_idx, rhs_in_range,
+                        mid, Is_, gsc_f, quant_group_size, lane_row);
+
+                    if (lane_half == 0 && rhs_in_range) {
+                        const float val = bf16_round_rne_f32(sg_scalar * acc[0]);
+                        workspace[OFF_SHARED_OUT + rhs_row_idx] = val;
+                        if (stage == 2) {
+                            output[rhs_row_idx] = static_cast<T>(val);
+                        }
+                    }
+                    __syncthreads();
+                }
+                wmma_handled_f = true;
+            }
+        }
+#endif
+        if (!wmma_handled_f) {
+            for (;;) {
+                __shared__ unsigned int my_row_f_s;
+                if (tid == 0) {
+                    my_row_f_s = atomicAdd(&counters[0], 1u);
+                }
+                __syncthreads();
+                const int my_row = static_cast<int>(my_row_f_s);
+                if (my_row >= hidden) break;
+
+                float partial = 0.0f;
+                if (shared_down_proj_scale != nullptr && !fp8_mode) {
+                    partial = int4_dq8_matvec_partial(
+                        reinterpret_cast<const uint8_t*>(shared_down_proj_w),
+                        static_cast<const hip_bfloat16*>(shared_down_proj_scale),
+                        static_cast<const hip_bfloat16*>(shared_down_proj_zero),
+                        workspace + OFF_SHARED_MID,
+                        my_row, Is_, quant_group_size,
+                        tid, block_size);
+                } else if (shared_down_proj_scale != nullptr) {
+                    partial = fp8_matvec_partial(
+                        reinterpret_cast<const void*>(shared_down_proj_w),
+                        static_cast<const hip_bfloat16*>(shared_down_proj_scale),
+                        workspace + OFF_SHARED_MID,
+                        my_row, Is_, quant_group_size,
+                        tid, block_size);
+                } else {
+                    const T* w_row =
+                        shared_down_proj_w + static_cast<size_t>(my_row) * Is_;
+                    for (int col = tid; col < Is_; col += block_size) {
+                        partial += static_cast<float>(w_row[col])
+                                   * workspace[OFF_SHARED_MID + col];
+                    }
+                }
+                shared_scratch[tid] = partial;
+                __syncthreads();
+                for (int s = block_size / 2; s > 0; s >>= 1) {
+                    if (tid < s) shared_scratch[tid] += shared_scratch[tid + s];
+                    __syncthreads();
+                }
+                if (tid == 0) {
+                    const float val = bf16_round_rne_f32(sg_scalar * shared_scratch[0]);
+                    workspace[OFF_SHARED_OUT + my_row] = val;
+                    if (stage == 2) {
+                        output[my_row] = static_cast<T>(val);
+                    }
+                }
+                __syncthreads();
+            }
         }
     }
 
@@ -529,6 +645,17 @@ __device__ inline void qwen36_moe_ffn_step_device(
     // group reads its counter.
     grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
                                &counters[0]);
+
+    bool direct_mid_wmma = false;
+#ifdef SUPERSONIC_QWEN36_HAS_WMMA_BF16
+    if constexpr (USE_WMMA) {
+        // Production INT4 stages can write EXPERT_MID directly from paired
+        // gate/up WMMA tiles. Stage 3 keeps the legacy path because it
+        // profiles only group 0 and all blocks must agree on barrier count.
+        direct_mid_wmma =
+            (stage > 3) && (gate_up_proj_scale != nullptr) && !fp8_mode;
+    }
+#endif
 
     // Each block reads its own group's expert index. All blocks within a
     // group compute the same `e`; different groups compute different `e`.
@@ -573,33 +700,77 @@ __device__ inline void qwen36_moe_ffn_step_device(
                 const int lane = tid & 31;
                 const int lane_row = lane & 15;
                 const int lane_half = lane >> 4;
-                for (;;) {
-                    __shared__ unsigned int row_base_s;
-                    if (tid == 0) {
-                        row_base_s = atomicAdd(&counters[group_id], 128u);
+                if (direct_mid_wmma) {
+                    const int mid_off = OFF_EXPERT_MID + group_id * I_;
+                    for (;;) {
+                        __shared__ unsigned int row_base_s;
+                        if (tid == 0) {
+                            row_base_s = atomicAdd(&counters[group_id], 128u);
+                        }
+                        __syncthreads();
+                        const int row_base_block = static_cast<int>(row_base_s);
+                        if (row_base_block >= I_) break;
+
+                        const int mid_row =
+                            row_base_block + wave_id * 16 + lane_row;
+                        const bool row_in_range = mid_row < I_;
+                        const int gate_row_idx = mid_row;
+                        const int up_row_idx = I_ + mid_row;
+                        const uint8_t* gate_row = row_in_range
+                            ? gu_slab_packed +
+                              static_cast<size_t>(gate_row_idx) * (hidden / 2)
+                            : nullptr;
+                        const uint8_t* up_row = row_in_range
+                            ? gu_slab_packed +
+                              static_cast<size_t>(up_row_idx) * (hidden / 2)
+                            : nullptr;
+
+                        qwen36_float8_pair gate_up_acc =
+                            wmma_int4_pair_matvec_partial_16rows(
+                                gate_row, gate_row_idx,
+                                up_row, up_row_idx,
+                                gu_slab_scale, gu_slab_zero,
+                                row_in_range,
+                                h_norm_lds, hidden,
+                                gsc_gu, quant_group_size, lane_row);
+
+                        if (lane_half == 0 && row_in_range) {
+                            const float gp = gate_up_acc.first[0];
+                            const float up = gate_up_acc.second[0];
+                            const float sigmoid_gp = 1.0f / (1.0f + expf(-gp));
+                            workspace[mid_off + mid_row] = (gp * sigmoid_gp) * up;
+                        }
+                        __syncthreads();
                     }
-                    __syncthreads();
-                    const int row_base_block = static_cast<int>(row_base_s);
-                    if (row_base_block >= two_I) break;
+                } else {
+                    for (;;) {
+                        __shared__ unsigned int row_base_s;
+                        if (tid == 0) {
+                            row_base_s = atomicAdd(&counters[group_id], 128u);
+                        }
+                        __syncthreads();
+                        const int row_base_block = static_cast<int>(row_base_s);
+                        if (row_base_block >= two_I) break;
 
-                    const int rhs_row_idx =
-                        row_base_block + wave_id * 16 + lane_row;
-                    const bool rhs_in_range = rhs_row_idx < two_I;
-                    const uint8_t* slab_row = rhs_in_range
-                        ? gu_slab_packed +
-                          static_cast<size_t>(rhs_row_idx) * (hidden / 2)
-                        : nullptr;
+                        const int rhs_row_idx =
+                            row_base_block + wave_id * 16 + lane_row;
+                        const bool rhs_in_range = rhs_row_idx < two_I;
+                        const uint8_t* slab_row = rhs_in_range
+                            ? gu_slab_packed +
+                              static_cast<size_t>(rhs_row_idx) * (hidden / 2)
+                            : nullptr;
 
-                    qwen36_float8 acc = wmma_int4_matvec_partial_16rows(
-                        slab_row, gu_slab_scale, gu_slab_zero,
-                        rhs_row_idx, rhs_in_range,
-                        h_norm_lds, hidden,
-                        gsc_gu, quant_group_size, lane_row);
+                        qwen36_float8 acc = wmma_int4_matvec_partial_16rows(
+                            slab_row, gu_slab_scale, gu_slab_zero,
+                            rhs_row_idx, rhs_in_range,
+                            h_norm_lds, hidden,
+                            gsc_gu, quant_group_size, lane_row);
 
-                    if (lane_half == 0 && rhs_in_range) {
-                        workspace[gu_off + rhs_row_idx] = acc[0];
+                        if (lane_half == 0 && rhs_in_range) {
+                            workspace[gu_off + rhs_row_idx] = acc[0];
+                        }
+                        __syncthreads();
                     }
-                    __syncthreads();
                 }
                 wmma_handled_g = true;
             }
@@ -650,28 +821,33 @@ __device__ inline void qwen36_moe_ffn_step_device(
         }
     }
 
-    // Barrier 1: publish EXPERT_GU writes (all groups) before Phase H reads.
-    grid_barrier(barrier_counter, barrier_flag, num_blocks);
+    if (direct_mid_wmma) {
+        // Direct paired Phase G wrote EXPERT_MID; publish it before Phase I.
+        grid_barrier(barrier_counter, barrier_flag, num_blocks);
+    } else {
+        // Barrier 1: publish EXPERT_GU writes (all groups) before Phase H reads.
+        grid_barrier(barrier_counter, barrier_flag, num_blocks);
 
-    // Phase H: mid = silu(gu[:I]) * gu[I:], one block per active group.
-    {
-        const int sub_id = blockIdx.x / K_;
-        if (sub_id == 0 && group_active) {
-            const int gu_off  = OFF_EXPERT_GU + group_id * two_I;
-            const int mid_off = OFF_EXPERT_MID + group_id * I_;
-            for (int i = tid; i < I_; i += block_size) {
-                const float gp = workspace[gu_off + i];
-                const float up = workspace[gu_off + I_ + i];
-                const float sigmoid_gp = 1.0f / (1.0f + expf(-gp));
-                const float silu_gp    = gp * sigmoid_gp;
-                workspace[mid_off + i] = silu_gp * up;
+        // Phase H: mid = silu(gu[:I]) * gu[I:], one block per active group.
+        {
+            const int sub_id = blockIdx.x / K_;
+            if (sub_id == 0 && group_active) {
+                const int gu_off  = OFF_EXPERT_GU + group_id * two_I;
+                const int mid_off = OFF_EXPERT_MID + group_id * I_;
+                for (int i = tid; i < I_; i += block_size) {
+                    const float gp = workspace[gu_off + i];
+                    const float up = workspace[gu_off + I_ + i];
+                    const float sigmoid_gp = 1.0f / (1.0f + expf(-gp));
+                    const float silu_gp    = gp * sigmoid_gp;
+                    workspace[mid_off + i] = silu_gp * up;
+                }
+                __syncthreads();
             }
-            __syncthreads();
         }
-    }
 
-    // Barrier 2: publish EXPERT_MID writes (all groups) before Phase I reads.
-    grid_barrier(barrier_counter, barrier_flag, num_blocks);
+        // Barrier 2: publish EXPERT_MID writes (all groups) before Phase I reads.
+        grid_barrier(barrier_counter, barrier_flag, num_blocks);
+    }
 
     // Phase I: matvec down_proj_w[e].T @ mid → EXPERT_STACK[g*hidden..].
     if (group_active) {
@@ -796,66 +972,38 @@ __device__ inline void qwen36_moe_ffn_step_device(
         return;
     }
 
-    // -- Phase J: moe_out = sum_j (topk_w[j] * expert_stack[j])  -----------
+    // -- Phase J/K: weighted MoE sum + final residual add ------------------
     // Single weighted reduction across `k` experts. F32 accumulation,
     // BF16-round once at the store. Matches
     // `(topk_w_renorm.unsqueeze(-1) * expert_stack).sum(0).to(dtype)`.
-    grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
-                               &counters[0]);
-    {
-        for (;;) {
-            __shared__ unsigned int my_row_j_s;
-            if (tid == 0) {
-                my_row_j_s = atomicAdd(&counters[0], 1u);
-            }
-            __syncthreads();
-            const int my_row = static_cast<int>(my_row_j_s);
-            if (my_row >= hidden) break;
-
-            // Sequential per-row sum on a single thread (k=8).
-            if (tid == 0) {
-                float acc = 0.0f;
-                for (int j = 0; j < K_; j++) {
-                    const float w = workspace[OFF_TOPK_VAL + j];
-                    const float v = workspace[OFF_EXPERT_STACK + j * hidden + my_row];
-                    acc += w * v;
-                }
-                const float val = bf16_round_rne_f32(acc);
-                workspace[OFF_MOE_OUT + my_row] = val;
-                if (stage == 4) {
-                    output[my_row] = static_cast<T>(val);
-                }
-            }
-            __syncthreads();
+    //
+    // This phase is row-independent. The original work-stealing loop used
+    // one thread per block to process each hidden row, which paid thousands
+    // of block barriers per token on 35B-A3B. A grid-stride loop keeps the
+    // same arithmetic order per row while letting all lanes cover the 2048
+    // rows directly.
+    grid_barrier(barrier_counter, barrier_flag, num_blocks);
+    for (int row = blockIdx.x * block_size + tid;
+         row < hidden;
+         row += num_blocks * block_size) {
+        float acc = 0.0f;
+        for (int j = 0; j < K_; j++) {
+            const float w = workspace[OFF_TOPK_VAL + j];
+            const float v = workspace[OFF_EXPERT_STACK + j * hidden + row];
+            acc += w * v;
         }
-    }
-
-    if (stage < 5) {
-        return;
-    }
-
-    // -- Phase K: residual add — output_hidden = input + moe + shared  -----
-    // F32 sum with one BF16 round at the store, matching the oracle's
-    // `(input_hidden.f32 + moe_out.f32 + shared_out.f32).to(dtype)`.
-    grid_barrier_reset_counter(barrier_counter, barrier_flag, num_blocks,
-                               &counters[0]);
-    for (;;) {
-        __shared__ unsigned int my_row_k_s;
-        if (tid == 0) {
-            my_row_k_s = atomicAdd(&counters[0], 1u);
+        const float val = bf16_round_rne_f32(acc);
+        if (stage == 4) {
+            workspace[OFF_MOE_OUT + row] = val;
+            output[row] = static_cast<T>(val);
+        } else {
+            // Full decode consumes moe_out immediately for the residual add,
+            // so avoid a global store/read pair and the extra grid barrier.
+            const float in_f   = static_cast<float>(input_hidden[row]);
+            const float shr_f  = workspace[OFF_SHARED_OUT + row];
+            const float result = bf16_round_rne_f32(in_f + val + shr_f);
+            output[row] = static_cast<T>(result);
         }
-        __syncthreads();
-        const int my_row = static_cast<int>(my_row_k_s);
-        if (my_row >= hidden) break;
-
-        if (tid == 0) {
-            const float in_f   = static_cast<float>(input_hidden[my_row]);
-            const float moe_f  = workspace[OFF_MOE_OUT + my_row];
-            const float shr_f  = workspace[OFF_SHARED_OUT + my_row];
-            const float val    = bf16_round_rne_f32(in_f + moe_f + shr_f);
-            output[my_row] = static_cast<T>(val);
-        }
-        __syncthreads();
     }
 }
 

--- a/kernels/qwen36_moe_persistent/full_attn_phase.cuh
+++ b/kernels/qwen36_moe_persistent/full_attn_phase.cuh
@@ -186,28 +186,40 @@ __device__ inline void qwen36_moe_attn_step_device(
             const int lane_half = lane_in_wave >> 4;
             const uint8_t* slab_packed =
                 reinterpret_cast<const uint8_t*>(q_proj_w);
+            const int q_pair_rows = num_heads * head_dim;
             for (;;) {
                 __shared__ unsigned int row_base_s;
                 if (tid == 0) row_base_s = atomicAdd(&counters[0], 128u);
                 __syncthreads();
                 const int row_base = static_cast<int>(row_base_s);
-                if (row_base >= q_out_dim) break;
+                if (row_base >= q_pair_rows) break;
 
-                const int rhs_row = row_base + wave_id * 16 + lane_row;
-                const bool in_range = rhs_row < q_out_dim;
-                const uint8_t* slab_row = in_range
+                const int pair_row = row_base + wave_id * 16 + lane_row;
+                const bool in_range = pair_row < q_pair_rows;
+                const int head = pair_row / head_dim;
+                const int dim = pair_row - head * head_dim;
+                const int q_row = head * 2 * head_dim + dim;
+                const int gate_row = q_row + head_dim;
+                const uint8_t* q_slab_row = in_range
                     ? slab_packed +
-                      static_cast<size_t>(rhs_row) * (hidden / 2)
+                      static_cast<size_t>(q_row) * (hidden / 2)
                     : nullptr;
-                qwen36_float8 acc = wmma_int4_matvec_partial_16rows(
-                    slab_row,
-                    static_cast<const hip_bfloat16*>(q_proj_scale),
-                    static_cast<const hip_bfloat16*>(q_proj_zero),
-                    rhs_row, in_range,
-                    x_norm_lds, hidden,
-                    gsc_q, quant_group_size, lane_row);
+                const uint8_t* gate_slab_row = in_range
+                    ? slab_packed +
+                      static_cast<size_t>(gate_row) * (hidden / 2)
+                    : nullptr;
+                qwen36_float8_pair q_gate_acc =
+                    wmma_int4_pair_matvec_partial_16rows(
+                        q_slab_row, q_row,
+                        gate_slab_row, gate_row,
+                        static_cast<const hip_bfloat16*>(q_proj_scale),
+                        static_cast<const hip_bfloat16*>(q_proj_zero),
+                        in_range,
+                        x_norm_lds, hidden,
+                        gsc_q, quant_group_size, lane_row);
                 if (lane_half == 0 && in_range) {
-                    workspace[rhs_row] = bf16_round_rne_f32(acc[0]);
+                    workspace[q_row] = bf16_round_rne_f32(q_gate_acc.first[0]);
+                    workspace[gate_row] = bf16_round_rne_f32(q_gate_acc.second[0]);
                 }
                 __syncthreads();
             }
@@ -380,6 +392,47 @@ __device__ inline void qwen36_moe_attn_step_device(
         const int lane_row = lane_in_wave & 15;
         const int lane_half = lane_in_wave >> 4;
 
+        // Production INT4 has K and V row counts aligned to the 128-row
+        // WMMA work tile. Run both slabs through one work pool so the tiny
+        // Hkv*d projections expose twice as many block tasks and skip the
+        // internal K->V counter-reset barrier.
+        if (k_proj_scale != nullptr && v_proj_scale != nullptr && !fp8_mode) {
+            const uint8_t* k_slab_packed =
+                reinterpret_cast<const uint8_t*>(k_proj_w);
+            const uint8_t* v_slab_packed =
+                reinterpret_cast<const uint8_t*>(v_proj_w);
+            for (;;) {
+                __shared__ unsigned int row_base_s;
+                if (tid == 0) row_base_s = atomicAdd(&counters[0], 128u);
+                __syncthreads();
+                const int row_base = static_cast<int>(row_base_s);
+                if (row_base >= kv_total_rows) break;
+
+                const int kv_row = row_base + wave_id * 16 + lane_row;
+                const bool in_range = kv_row < kv_total_rows;
+                const bool is_v = kv_row >= Hkv * d;
+                const int rhs_row = is_v ? (kv_row - Hkv * d) : kv_row;
+                const uint8_t* slab_packed = is_v ? v_slab_packed : k_slab_packed;
+                const hip_bfloat16* slab_scale = is_v ? v_proj_scale : k_proj_scale;
+                const hip_bfloat16* slab_zero = is_v ? v_proj_zero : k_proj_zero;
+                const int dst_off = (is_v ? OFF_V_RAW : OFF_K_RAW) + rhs_row;
+                const uint8_t* slab_row = in_range
+                    ? slab_packed +
+                      static_cast<size_t>(rhs_row) * (hidden / 2)
+                    : nullptr;
+                qwen36_float8 acc = wmma_int4_matvec_partial_16rows(
+                    slab_row,
+                    static_cast<const hip_bfloat16*>(slab_scale),
+                    static_cast<const hip_bfloat16*>(slab_zero),
+                    rhs_row, in_range,
+                    x_norm_lds, hidden,
+                    gsc_kv, quant_group_size, lane_row);
+                if (lane_half == 0 && in_range) {
+                    workspace[dst_off] = bf16_round_rne_f32(acc[0]);
+                }
+                __syncthreads();
+            }
+        } else {
         // ------- Sub-pool 1: k_proj -------
         if (k_proj_scale != nullptr && !fp8_mode) {
             const uint8_t* slab_packed =
@@ -516,6 +569,7 @@ __device__ inline void qwen36_moe_attn_step_device(
                 }
                 __syncthreads();
             }
+        }
         }
     } else
 #endif
@@ -671,7 +725,8 @@ __device__ inline void qwen36_moe_attn_step_device(
                 const float b = workspace[src_off + h * d + half + i];
                 // freq = position * theta^(-i/half) = position / theta^(i/half).
                 // Match PyTorch's `theta ** (i/half)` ≡ exp((i/half) * log(theta)).
-                const float exponent = (static_cast<float>(i) / static_cast<float>(half)) * theta_log;
+                const float exponent =
+                    (static_cast<float>(i) / static_cast<float>(half)) * theta_log;
                 const float inv_freq = expf(-exponent);
                 const float freq = static_cast<float>(position) * inv_freq;
                 const float c = bf16_round_rne_f32(cosf(freq));
@@ -836,14 +891,21 @@ __device__ inline void qwen36_moe_attn_step_device(
         // block per head. Long cached contexts split KV into tiles so all CUs
         // can work on one head's history before a second pass combines the
         // tile-local softmax partials.
-        const int attn_tile_t = 384;
+        const int attn_tile_t = 8;
         const int attn_tile_stride = d + 2;
         const int attn_tile_count =
             (kv_len + attn_tile_t - 1) / attn_tile_t;
+        const int max_attn_tile_count =
+            (kv_max_t + attn_tile_t - 1) / attn_tile_t;
+        const int tiled_score_stride = max_attn_tile_count * attn_tile_stride;
+        const int attn_score_stride =
+            ((kv_max_t > attn_tile_t) && (d <= block_size))
+                ? ((kv_max_t > tiled_score_stride) ? kv_max_t : tiled_score_stride)
+                : kv_max_t;
         const bool use_tiled_attn =
             (kv_cache_k != nullptr) && (kv_len > attn_tile_t) &&
             (d <= block_size) &&
-            (attn_tile_count * attn_tile_stride <= kv_max_t);
+            (attn_tile_count * attn_tile_stride <= attn_score_stride);
 
         if (use_tiled_attn) {
             const bool use_fp8_kv = (kv_scale_k != nullptr);
@@ -899,7 +961,7 @@ __device__ inline void qwen36_moe_attn_step_device(
                 const int t0 = tile * attn_tile_t;
                 const int t1 = (t0 + attn_tile_t < kv_len) ? (t0 + attn_tile_t) : kv_len;
                 float* partials =
-                    workspace + OFF_SCORES + hq * kv_max_t + tile * attn_tile_stride;
+                    workspace + OFF_SCORES + hq * attn_score_stride + tile * attn_tile_stride;
 
                 float tile_m = -INFINITY;
                 float tile_l = 0.0f;
@@ -987,7 +1049,7 @@ __device__ inline void qwen36_moe_attn_step_device(
                 float global_m = -INFINITY;
                 for (int tile = 0; tile < attn_tile_count; tile++) {
                     const float* partials =
-                        workspace + OFF_SCORES + hq * kv_max_t + tile * attn_tile_stride;
+                        workspace + OFF_SCORES + hq * attn_score_stride + tile * attn_tile_stride;
                     global_m = fmaxf(global_m, partials[0]);
                 }
 
@@ -995,7 +1057,7 @@ __device__ inline void qwen36_moe_attn_step_device(
                 float global_acc = 0.0f;
                 for (int tile = 0; tile < attn_tile_count; tile++) {
                     const float* partials =
-                        workspace + OFF_SCORES + hq * kv_max_t + tile * attn_tile_stride;
+                        workspace + OFF_SCORES + hq * attn_score_stride + tile * attn_tile_stride;
                     const float w = expf(partials[0] - global_m);
                     global_l += partials[1] * w;
                     if (tid < d) {

--- a/kernels/qwen36_moe_persistent/helpers.cuh
+++ b/kernels/qwen36_moe_persistent/helpers.cuh
@@ -14,15 +14,23 @@
 // namespace and translation unit; they are NOT shared with the qwen35
 // kernels.
 //
-// The numerics match `oracle/bake_int4.py`'s reconstruction exactly:
-//   recon = bf16_round_rne_f32(nibble * scale - zero * scale)
-// (single rounding through BF16 at the end).
+// The production decode path intentionally uses a fast reconstruction:
+//   recon = nibble * scale - zero * scale
+// This differs from the original oracle's per-nibble BF16 RNE but was kept
+// after 35B A3B full-harness benchmarking as a measured decode win.
 
 #pragma once
 
 #include "../qwen36_moe_cuda_prelude.cuh"
 
 namespace qwen36_moe {
+
+__device__ __forceinline__ float qwen36_wave_sum(float value) {
+    for (int offset = warpSize / 2; offset > 0; offset >>= 1) {
+        value += __shfl_down(value, offset);
+    }
+    return value;
+}
 
 // Round an F32 value to BF16 precision (round-to-nearest-even) and widen
 // back to F32. Used at every "BF16 store" point so that intermediate F32
@@ -81,14 +89,14 @@ __device__ inline void int4_dequant_8(
     if (g0 == g7) {
         float s = static_cast<float>(scales[sb + g0]);
         float zs = static_cast<float>(zeros[sb + g0]) * s;
-        out[0] = bf16_round_rne_f32(static_cast<float>(n0) * s - zs);
-        out[1] = bf16_round_rne_f32(static_cast<float>(n1) * s - zs);
-        out[2] = bf16_round_rne_f32(static_cast<float>(n2) * s - zs);
-        out[3] = bf16_round_rne_f32(static_cast<float>(n3) * s - zs);
-        out[4] = bf16_round_rne_f32(static_cast<float>(n4) * s - zs);
-        out[5] = bf16_round_rne_f32(static_cast<float>(n5) * s - zs);
-        out[6] = bf16_round_rne_f32(static_cast<float>(n6) * s - zs);
-        out[7] = bf16_round_rne_f32(static_cast<float>(n7) * s - zs);
+        out[0] = static_cast<float>(n0) * s - zs;
+        out[1] = static_cast<float>(n1) * s - zs;
+        out[2] = static_cast<float>(n2) * s - zs;
+        out[3] = static_cast<float>(n3) * s - zs;
+        out[4] = static_cast<float>(n4) * s - zs;
+        out[5] = static_cast<float>(n5) * s - zs;
+        out[6] = static_cast<float>(n6) * s - zs;
+        out[7] = static_cast<float>(n7) * s - zs;
     } else {
         float s0 = static_cast<float>(scales[sb + g0]);
         float zs0 = static_cast<float>(zeros[sb + g0]) * s0;
@@ -98,7 +106,7 @@ __device__ inline void int4_dequant_8(
             int gi = (col + idx) / gsz; \
             float si = (gi == g0) ? s0 : s1; \
             float zsi = (gi == g0) ? zs0 : zs1; \
-            out[idx] = bf16_round_rne_f32(static_cast<float>(ni) * si - zsi); \
+            out[idx] = static_cast<float>(ni) * si - zsi; \
         } while(0)
         I4DQ(0, n0); I4DQ(1, n1); I4DQ(2, n2); I4DQ(3, n3);
         I4DQ(4, n4); I4DQ(5, n5); I4DQ(6, n6); I4DQ(7, n7);
@@ -118,6 +126,11 @@ __device__ inline void int4_dequant_8(
 #ifdef SUPERSONIC_QWEN36_HAS_WMMA_BF16
 typedef short  qwen36_short16 __attribute__((ext_vector_type(16)));
 typedef float  qwen36_float8  __attribute__((ext_vector_type(8)));
+
+struct qwen36_float8_pair {
+    qwen36_float8 first;
+    qwen36_float8 second;
+};
 #endif
 
 // Work-stealing matvec inner loop for an INT4 slab `[out_rows, in_cols/2]`.
@@ -167,6 +180,50 @@ __device__ inline float int4_dq8_matvec_partial(
     return partial;
 }
 
+struct qwen36_float_pair {
+    float first;
+    float second;
+};
+
+__device__ inline qwen36_float_pair int4_dq8_pair_matvec_partial_same_row(
+    const uint8_t*      __restrict__ packed_a,
+    const hip_bfloat16* __restrict__ scales_a,
+    const hip_bfloat16* __restrict__ zeros_a,
+    const uint8_t*      __restrict__ packed_b,
+    const hip_bfloat16* __restrict__ scales_b,
+    const hip_bfloat16* __restrict__ zeros_b,
+    const float*        __restrict__ x,
+    int my_row, int cols, int gsz,
+    int tid, int block_size
+) {
+    const int byte_cols  = cols / 2;
+    const int scale_cols = cols / gsz;
+    const int scale_row  = my_row / gsz;
+    const size_t row_byte_off = static_cast<size_t>(my_row) * byte_cols;
+
+    float partial_a = 0.0f;
+    float partial_b = 0.0f;
+    for (int col_start = tid * 8; col_start < cols; col_start += block_size * 8) {
+        const uint32_t pk_a = *reinterpret_cast<const uint32_t*>(
+            &packed_a[row_byte_off + col_start / 2]);
+        const uint32_t pk_b = *reinterpret_cast<const uint32_t*>(
+            &packed_b[row_byte_off + col_start / 2]);
+        float dq_a[8];
+        float dq_b[8];
+        int4_dequant_8(pk_a, scales_a, zeros_a,
+                       scale_row, col_start, scale_cols, gsz, dq_a);
+        int4_dequant_8(pk_b, scales_b, zeros_b,
+                       scale_row, col_start, scale_cols, gsz, dq_b);
+        #pragma unroll
+        for (int i = 0; i < 8; ++i) {
+            const float xv = x[col_start + i];
+            partial_a += dq_a[i] * xv;
+            partial_b += dq_b[i] * xv;
+        }
+    }
+    return {partial_a, partial_b};
+}
+
 #ifdef SUPERSONIC_QWEN36_HAS_WMMA_BF16
 // WMMA INT4 GEMV tile: each invocation runs one wave32's worth of work,
 // computing 16 output rows of `acc[0]` (one row of the 16x16 WMMA C tile)
@@ -183,7 +240,7 @@ __device__ inline float int4_dq8_matvec_partial(
 //                 m=1 GEMV pads M=1..15 with zero)
 //     B operand = [16 dequanted rows × 16 cols] of int4 weights at
 //                 (rhs_row_idx + lane_row, kk..kk+16) — same dequant
-//                 formula as int4_dequant_8 (`bf16_round_rne_f32(nibble*s - z*s)`)
+//                 formula as int4_dequant_8 (`nibble*s - z*s`)
 //     acc      += A × B  (F32 accumulate, K=16 per WMMA)
 //
 // Returns: lanes 0..15 (lane_half==0) hold acc[0] = C[0, lane_row], the
@@ -254,8 +311,8 @@ __device__ inline qwen36_float8 wmma_int4_matvec_partial_16rows(
                 uint8_t pk = slab_packed_row[byte_base + i];
                 int n0 = pk & 0xF;
                 int n1 = (pk >> 4) & 0xF;
-                float v0 = bf16_round_rne_f32(static_cast<float>(n0) * s - zs);
-                float v1 = bf16_round_rne_f32(static_cast<float>(n1) * s - zs);
+                float v0 = static_cast<float>(n0) * s - zs;
+                float v1 = static_cast<float>(n1) * s - zs;
                 uint32_t b0_bits, b1_bits;
                 __builtin_memcpy(&b0_bits, &v0, 4);
                 __builtin_memcpy(&b1_bits, &v1, 4);
@@ -271,6 +328,92 @@ __device__ inline qwen36_float8 wmma_int4_matvec_partial_16rows(
     }
     return acc;
 }
+
+__device__ inline qwen36_float8_pair wmma_int4_pair_matvec_partial_16rows(
+    const uint8_t*      __restrict__ slab_packed_row_a,  // [hidden/2] u8 (this lane's row, may be nullptr)
+    int                              rhs_row_idx_a,
+    const uint8_t*      __restrict__ slab_packed_row_b,  // [hidden/2] u8 (this lane's row, may be nullptr)
+    int                              rhs_row_idx_b,
+    const hip_bfloat16* __restrict__ slab_scale,         // [.] BF16 (slab origin)
+    const hip_bfloat16* __restrict__ slab_zero,          // [.] BF16
+    bool                             rhs_in_range,
+    const float*        __restrict__ x_norm_lds_f32,
+    int                              hidden,
+    int                              gsc,
+    int                              group_size,
+    int                              lane_row
+) {
+    qwen36_float8 acc_a = {0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f};
+    qwen36_float8 acc_b = {0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f};
+    const int gsr_idx_a = rhs_row_idx_a / group_size;
+    const int gsr_idx_b = rhs_row_idx_b / group_size;
+
+    for (int kk = 0; kk < hidden; kk += 16) {
+        qwen36_short16 a;
+        if (lane_row == 0) {
+            #pragma unroll
+            for (int i = 0; i < 16; ++i) {
+                uint32_t bits;
+                float v = x_norm_lds_f32[kk + i];
+                __builtin_memcpy(&bits, &v, 4);
+                a[i] = static_cast<short>(bits >> 16);
+            }
+        } else {
+            #pragma unroll
+            for (int i = 0; i < 16; ++i) a[i] = 0;
+        }
+
+        qwen36_short16 b_a;
+        qwen36_short16 b_b;
+        if (rhs_in_range) {
+            const int gsc_idx = kk / group_size;
+            const int scale_idx_a = gsr_idx_a * gsc + gsc_idx;
+            const int scale_idx_b = gsr_idx_b * gsc + gsc_idx;
+            const float s_a  = static_cast<float>(slab_scale[scale_idx_a]);
+            const float z_a  = static_cast<float>(slab_zero[scale_idx_a]);
+            const float zs_a = z_a * s_a;
+            const float s_b  = static_cast<float>(slab_scale[scale_idx_b]);
+            const float z_b  = static_cast<float>(slab_zero[scale_idx_b]);
+            const float zs_b = z_b * s_b;
+            const int byte_base = kk >> 1;
+            #pragma unroll
+            for (int i = 0; i < 8; ++i) {
+                uint8_t pk_a = slab_packed_row_a[byte_base + i];
+                int n0_a = pk_a & 0xF;
+                int n1_a = (pk_a >> 4) & 0xF;
+                float v0_a = static_cast<float>(n0_a) * s_a - zs_a;
+                float v1_a = static_cast<float>(n1_a) * s_a - zs_a;
+                uint32_t b0_bits_a, b1_bits_a;
+                __builtin_memcpy(&b0_bits_a, &v0_a, 4);
+                __builtin_memcpy(&b1_bits_a, &v1_a, 4);
+                b_a[2 * i]     = static_cast<short>(b0_bits_a >> 16);
+                b_a[2 * i + 1] = static_cast<short>(b1_bits_a >> 16);
+
+                uint8_t pk_b = slab_packed_row_b[byte_base + i];
+                int n0_b = pk_b & 0xF;
+                int n1_b = (pk_b >> 4) & 0xF;
+                float v0_b = static_cast<float>(n0_b) * s_b - zs_b;
+                float v1_b = static_cast<float>(n1_b) * s_b - zs_b;
+                uint32_t b0_bits_b, b1_bits_b;
+                __builtin_memcpy(&b0_bits_b, &v0_b, 4);
+                __builtin_memcpy(&b1_bits_b, &v1_b, 4);
+                b_b[2 * i]     = static_cast<short>(b0_bits_b >> 16);
+                b_b[2 * i + 1] = static_cast<short>(b1_bits_b >> 16);
+            }
+        } else {
+            #pragma unroll
+            for (int i = 0; i < 16; ++i) {
+                b_a[i] = 0;
+                b_b[i] = 0;
+            }
+        }
+
+        acc_a = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a, b_a, acc_a);
+        acc_b = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a, b_b, acc_b);
+    }
+    return {acc_a, acc_b};
+}
+
 #endif // SUPERSONIC_QWEN36_HAS_WMMA_BF16
 
 // Single-element dequant for non-8-aligned tails. `cols` is the unpacked
@@ -290,8 +433,7 @@ __device__ inline float int4_dequant_scalar(
     int si = (row / group_size) * ((cols + group_size - 1) / group_size)
            + col / group_size;
     float s = static_cast<float>(scales[si]);
-    return bf16_round_rne_f32(
-        static_cast<float>(nibble) * s - static_cast<float>(zeros[si]) * s);
+    return static_cast<float>(nibble) * s - static_cast<float>(zeros[si]) * s;
 }
 
 __device__ inline float fp8_e4m3_to_float(uint8_t byte) {

--- a/kernels/qwen36_moe_persistent/linear_attn_phase.cuh
+++ b/kernels/qwen36_moe_persistent/linear_attn_phase.cuh
@@ -89,7 +89,9 @@ __device__ inline void qwen36_moe_linear_step_device(
     float* __restrict__            workspace,
     unsigned int* __restrict__     counters,
     unsigned int* __restrict__     barrier_counter,
-    unsigned int* __restrict__     barrier_flag) {
+    unsigned int* __restrict__     barrier_flag,
+    bool                           suppress_stage_publish = false,
+    bool                           mutate_state = true) {
     (void)conv1d_w;
     (void)conv1d_bias;
     (void)dt_bias;
@@ -326,7 +328,7 @@ __device__ inline void qwen36_moe_linear_step_device(
                                    &counters[0]);
 
         // ------- Sub-pool 3: in_proj_a + in_proj_b (always BF16, V each) -
-        // 2*V rows total — small enough that a single fused scalar pool
+        // 2*V rows total -- small enough that a single fused scalar pool
         // beats WMMA tiling overhead. Branches on `is_b` to pick slab
         // and dst offset.
         for (;;) {
@@ -453,10 +455,12 @@ __device__ inline void qwen36_moe_linear_step_device(
     // stages publish their own intermediates and keep qkv_raw in workspace
     // (where Phase C — depthwise conv1d — will read it).
     if (stage == 1) {
-        for (int i = tid + blockIdx.x * block_size;
-             i < qkv_dim;
-             i += block_size * num_blocks) {
-            output[i] = static_cast<T>(workspace[OFF_QKV_RAW + i]);
+        if (!suppress_stage_publish) {
+            for (int i = tid + blockIdx.x * block_size;
+                 i < qkv_dim;
+                 i += block_size * num_blocks) {
+                output[i] = static_cast<T>(workspace[OFF_QKV_RAW + i]);
+            }
         }
         return;
     }
@@ -526,14 +530,16 @@ __device__ inline void qwen36_moe_linear_step_device(
         // Shift conv_state_before left by one and append the new qkv_raw
         // at position kstate-1, store back as BF16. Each thread owns its
         // channel's row — no cross-thread races.
-        for (int t = 0; t < kstate - 1; ++t) {
-            conv_state[ch * kstate + t] =
-                static_cast<T>(conv_in[t + 1]);
+        if (mutate_state) {
+            for (int t = 0; t < kstate - 1; ++t) {
+                conv_state[ch * kstate + t] =
+                    static_cast<T>(conv_in[t + 1]);
+            }
+            conv_state[ch * kstate + (kstate - 1)] = static_cast<T>(new_qkv);
         }
-        conv_state[ch * kstate + (kstate - 1)] = static_cast<T>(new_qkv);
 
         // Stage 2 publishes silu_out to the host-visible output buffer.
-        if (stage == 2) {
+        if (stage == 2 && !suppress_stage_publish) {
             output[ch] = static_cast<T>(silu_out);
         }
     }
@@ -644,14 +650,14 @@ __device__ inline void qwen36_moe_linear_step_device(
                 const float qs = bf16_round_rne_f32(qn * q_scale);
                 workspace[q_dst + i] = qs;
                 workspace[k_dst + i] = kn;
-                if (stage == 3) {
+                if (stage == 3 && !suppress_stage_publish) {
                     output[vhead * k_dim + i]               = static_cast<T>(qs);
                     output[V * k_dim + vhead * k_dim + i]   = static_cast<T>(kn);
                 }
             }
             // V is reshape-only of v_raw (silu_out's third partition); no
             // arithmetic, just publish for stage 3 verification.
-            if (stage == 3) {
+            if (stage == 3 && !suppress_stage_publish) {
                 const int v_src = OFF_QKV_RAW + 2 * key_dim + vhead * v_dim;
                 for (int i = tid; i < v_dim; i += block_size) {
                     const float vv = workspace[v_src + i];
@@ -743,33 +749,34 @@ __device__ inline void qwen36_moe_linear_step_device(
             const int kv_off    = OFF_K_REP + h * k_dim;
             const int qv_off    = OFF_Q_REP + h * k_dim;
             const int v_off     = OFF_QKV_RAW + 2 * key_dim + h * v_dim;
-            const int total_state = k_dim * v_dim;
 
-            // Step 1: decay.
-            for (int e = tid; e < total_state; e += block_size) {
-                recurrent_state[state_off + e] *= head_gstep;
+            // Step 1 is folded into the two consumers below. The recurrent
+            // state is conceptually decayed before the KV reduction, but
+            // writing that whole matrix and then reading it again costs a
+            // large memory pass per linear layer.
+
+            // Step 2: kv_mem[j] = sum_i(decayed_state[h, i, j] * k_rep[h, i]).
+            // Use the block's 8 waves as independent column reducers. The
+            // previous full-block loop paid a block reduction plus several
+            // syncthreads for every j; on 35B that is 128 columns per head.
+            const int wave_id = tid >> 5;
+            const int lane = tid & 31;
+            for (int j_base = 0; j_base < v_dim; j_base += 8) {
+                const int j = j_base + wave_id;
+                float partial = 0.0f;
+                if (j < v_dim) {
+                    for (int i = lane; i < k_dim; i += warpSize) {
+                        const float decayed =
+                            recurrent_state[state_off + i * v_dim + j] * head_gstep;
+                        partial += decayed * workspace[kv_off + i];
+                    }
+                }
+                const float sum = qwen36_wave_sum(partial);
+                if (lane == 0 && j < v_dim) {
+                    kv_mem_lds[j] = sum;
+                }
             }
             __syncthreads();
-
-            // Step 2: kv_mem[j] = sum_i(state[h, i, j] * k_rep[h, i]).
-            // Loop over j; for each j do a block-wide reduction over i.
-            for (int j = 0; j < v_dim; ++j) {
-                float partial = 0.0f;
-                for (int i = tid; i < k_dim; i += block_size) {
-                    partial += recurrent_state[state_off + i * v_dim + j] *
-                               workspace[kv_off + i];
-                }
-                shared_scratch[tid] = partial;
-                __syncthreads();
-                for (int s = block_size / 2; s > 0; s >>= 1) {
-                    if (tid < s) shared_scratch[tid] += shared_scratch[tid + s];
-                    __syncthreads();
-                }
-                if (tid == 0) {
-                    kv_mem_lds[j] = shared_scratch[0];
-                }
-                __syncthreads();
-            }
 
             // Step 3: delta[j] = (v_heads[h, j] - kv_mem[j]) * beta[h].
             for (int j = tid; j < v_dim; j += block_size) {
@@ -778,40 +785,46 @@ __device__ inline void qwen36_moe_linear_step_device(
             }
             __syncthreads();
 
-            // Step 4: state[h, i, j] += k_rep[h, i] * delta[j].
+            // Step 4: state[h, i, j] = decayed_state[h, i, j] +
+            //                          k_rep[h, i] * delta[j].
+            const int total_state = k_dim * v_dim;
             for (int e = tid; e < total_state; e += block_size) {
                 const int i = e / v_dim;
                 const int j = e - i * v_dim;
-                recurrent_state[state_off + e] +=
-                    workspace[kv_off + i] * delta_lds[j];
+                const float decayed = recurrent_state[state_off + e] * head_gstep;
+                if (mutate_state) {
+                    recurrent_state[state_off + e] =
+                        decayed + workspace[kv_off + i] * delta_lds[j];
+                }
             }
             __syncthreads();
 
             // Step 5: recurrent_out[h, j] = sum_i(state[h, i, j] * q_scaled[h, i]).
-            for (int j = 0; j < v_dim; ++j) {
+            for (int j_base = 0; j_base < v_dim; j_base += 8) {
+                const int j = j_base + wave_id;
                 float partial = 0.0f;
-                for (int i = tid; i < k_dim; i += block_size) {
-                    partial += recurrent_state[state_off + i * v_dim + j] *
-                               workspace[qv_off + i];
+                if (j < v_dim) {
+                    for (int i = lane; i < k_dim; i += warpSize) {
+                        const float state_v = mutate_state
+                            ? recurrent_state[state_off + i * v_dim + j]
+                            : recurrent_state[state_off + i * v_dim + j] * head_gstep
+                              + workspace[kv_off + i] * delta_lds[j];
+                        partial += state_v * workspace[qv_off + i];
+                    }
                 }
-                shared_scratch[tid] = partial;
-                __syncthreads();
-                for (int s = block_size / 2; s > 0; s >>= 1) {
-                    if (tid < s) shared_scratch[tid] += shared_scratch[tid + s];
-                    __syncthreads();
-                }
-                if (tid == 0) {
+                const float sum = qwen36_wave_sum(partial);
+                if (lane == 0 && j < v_dim) {
                     // Match oracle's `recurrent_out.to(dtype)` — F32 → BF16
                     // cast happens here so Phase H reads BF16-precision
                     // values regardless of stage.
-                    const float r = bf16_round_rne_f32(shared_scratch[0]);
+                    const float r = bf16_round_rne_f32(sum);
                     workspace[OFF_REC_OUT + h * v_dim + j] = r;
-                    if (stage == 4) {
+                    if (stage == 4 && !suppress_stage_publish) {
                         output[h * v_dim + j] = static_cast<T>(r);
                     }
                 }
-                __syncthreads();
             }
+            __syncthreads();
         }
     }
 
@@ -908,6 +921,8 @@ __device__ inline void qwen36_moe_linear_step_device(
         if constexpr (USE_WMMA) {
             if (out_int4) {
                 const int gsc_o = qd / quant_group_size;
+                constexpr int rows_per_task = 64;
+                constexpr int active_waves = rows_per_task / 16;
                 const int wave_id = tid >> 5;
                 const int lane_in_wave = tid & 31;
                 const int lane_row = lane_in_wave & 15;
@@ -917,13 +932,13 @@ __device__ inline void qwen36_moe_linear_step_device(
                     reinterpret_cast<const uint8_t*>(out_proj_w);
                 for (;;) {
                     __shared__ unsigned int row_base_s;
-                    if (tid == 0) row_base_s = atomicAdd(&counters[0], 128u);
+                    if (tid == 0) row_base_s = atomicAdd(&counters[0], rows_per_task);
                     __syncthreads();
                     const int row_base = static_cast<int>(row_base_s);
                     if (row_base >= hidden) break;
 
                     const int rhs_row = row_base + wave_id * 16 + lane_row;
-                    const bool in_range = rhs_row < hidden;
+                    const bool in_range = (wave_id < active_waves) && (rhs_row < hidden);
                     const uint8_t* slab_row = in_range
                         ? slab_packed +
                           static_cast<size_t>(rhs_row) * (qd / 2)

--- a/kernels/qwen36_moe_persistent/lm_head_phase.cuh
+++ b/kernels/qwen36_moe_persistent/lm_head_phase.cuh
@@ -74,8 +74,13 @@ __device__ inline void qwen36_moe_lm_head_device(
     const T* __restrict__          input_hidden,    // [hidden] BF16
     const T* __restrict__          final_norm_w,    // [hidden] BF16
     const T* __restrict__          lm_head_w,       // [vocab, hidden] BF16
-    T*       __restrict__          logits_out,      // [vocab] BF16
-    unsigned int* __restrict__     counters
+    T*       __restrict__          logits_out,      // [vocab] BF16, nullable
+    unsigned int* __restrict__     top1_out,        // [1] U32, nullable
+    float*   __restrict__          top1_scratch,    // [2 * gridDim.x] F32
+    unsigned int* __restrict__     counters,
+    unsigned int* __restrict__     barrier_counter,
+    unsigned int* __restrict__     barrier_flag,
+    int                            num_blocks
 ) {
     const int tid        = threadIdx.x;
     const int block_size = static_cast<int>(blockDim.x);
@@ -116,6 +121,8 @@ __device__ inline void qwen36_moe_lm_head_device(
     __syncthreads();
 
     // -- Phase B: work-stealing matvec over vocab rows ---------------------
+    float local_best = -INFINITY;
+    int local_best_idx = 0;
 #ifdef SUPERSONIC_QWEN36_HAS_WMMA_BF16
     if constexpr (USE_WMMA) {
         // Same wave32 layout the standalone WMMA kernel uses, dropped
@@ -158,7 +165,8 @@ __device__ inline void qwen36_moe_lm_head_device(
                         // Each F32 occupies 2 u16 slots (LE: low, high);
                         // the BF16 bits are the high u16 (offset
                         // 2*idx + 1).
-                        a[i] = static_cast<short>(x_norm_lds_u16[2 * (kk + i) + 1]);
+                        a[i] = static_cast<short>(
+                            x_norm_lds_u16[2 * (kk + i) + 1]);
                     }
                 } else {
                     #pragma unroll
@@ -189,7 +197,8 @@ __device__ inline void qwen36_moe_lm_head_device(
                     for (int i = 0; i < 16; ++i) {
                         int kc = k_main + i;
                         if (kc < hidden) {
-                            a[i] = static_cast<short>(x_norm_lds_u16[2 * kc + 1]);
+                            a[i] = static_cast<short>(
+                                x_norm_lds_u16[2 * kc + 1]);
                         }
                     }
                 }
@@ -209,8 +218,16 @@ __device__ inline void qwen36_moe_lm_head_device(
             // Lanes with lane_half==0 carry C[0, lane_row]. Each wave's
             // 16 such lanes write the wave's 16-row tile.
             if (lane_half == 0 && in_range) {
-                logits_out[rhs_row] =
-                    static_cast<T>(bf16_round_rne_f32(acc[0]));
+                const float logit = bf16_round_rne_f32(acc[0]);
+                if (logits_out != nullptr) {
+                    logits_out[rhs_row] = static_cast<T>(logit);
+                }
+                if (top1_out != nullptr &&
+                    (logit > local_best ||
+                     (logit == local_best && rhs_row < local_best_idx))) {
+                    local_best = logit;
+                    local_best_idx = rhs_row;
+                }
             }
             __syncthreads();
         }
@@ -239,10 +256,80 @@ __device__ inline void qwen36_moe_lm_head_device(
                 __syncthreads();
             }
             if (tid == 0) {
-                logits_out[my_row] =
-                    static_cast<T>(bf16_round_rne_f32(shared_scratch[0]));
+                const float logit = bf16_round_rne_f32(shared_scratch[0]);
+                if (logits_out != nullptr) {
+                    logits_out[my_row] = static_cast<T>(logit);
+                }
+                if (top1_out != nullptr &&
+                    (logit > local_best ||
+                     (logit == local_best && my_row < local_best_idx))) {
+                    local_best = logit;
+                    local_best_idx = my_row;
+                }
             }
             __syncthreads();
+        }
+    }
+
+    if (top1_out != nullptr) {
+        // Reduce each block's best vocab row. `x_norm_lds` is no longer
+        // needed after the matvec, so reuse its first block_size entries as
+        // integer scratch without increasing dynamic LDS.
+        shared_scratch[tid] = local_best;
+        x_norm_lds[tid] = __int_as_float(local_best_idx);
+        __syncthreads();
+        for (int s = block_size / 2; s > 0; s >>= 1) {
+            if (tid < s) {
+                const float a = shared_scratch[tid];
+                const float b = shared_scratch[tid + s];
+                const int ia = __float_as_int(x_norm_lds[tid]);
+                const int ib = __float_as_int(x_norm_lds[tid + s]);
+                if (b > a || (b == a && ib < ia)) {
+                    shared_scratch[tid] = b;
+                    x_norm_lds[tid] = __int_as_float(ib);
+                }
+            }
+            __syncthreads();
+        }
+
+        if (tid == 0) {
+            top1_scratch[blockIdx.x] = shared_scratch[0];
+            top1_scratch[num_blocks + blockIdx.x] = x_norm_lds[0];
+        }
+        grid_barrier(barrier_counter, barrier_flag, num_blocks);
+
+        // Final grid-wide reduction on block 0. Supports override grids larger
+        // than block_size by first having each thread scan a stride.
+        if (blockIdx.x == 0) {
+            float best = -INFINITY;
+            int best_idx = 0;
+            for (int i = tid; i < num_blocks; i += block_size) {
+                const float v = top1_scratch[i];
+                const int idx = __float_as_int(top1_scratch[num_blocks + i]);
+                if (v > best || (v == best && idx < best_idx)) {
+                    best = v;
+                    best_idx = idx;
+                }
+            }
+            shared_scratch[tid] = best;
+            x_norm_lds[tid] = __int_as_float(best_idx);
+            __syncthreads();
+            for (int s = block_size / 2; s > 0; s >>= 1) {
+                if (tid < s) {
+                    const float a = shared_scratch[tid];
+                    const float b = shared_scratch[tid + s];
+                    const int ia = __float_as_int(x_norm_lds[tid]);
+                    const int ib = __float_as_int(x_norm_lds[tid + s]);
+                    if (b > a || (b == a && ib < ia)) {
+                        shared_scratch[tid] = b;
+                        x_norm_lds[tid] = __int_as_float(ib);
+                    }
+                }
+                __syncthreads();
+            }
+            if (tid == 0) {
+                top1_out[0] = static_cast<unsigned int>(__float_as_int(x_norm_lds[0]));
+            }
         }
     }
 }

--- a/kernels/qwen36_moe_persistent/persistent_decode.hip
+++ b/kernels/qwen36_moe_persistent/persistent_decode.hip
@@ -83,19 +83,39 @@ __device__ inline void reset_counters_16(
     unsigned int* __restrict__ barrier_flag,
     int                        num_blocks
 ) {
-    // Sync: every block has exited the previous phase.
-    grid_barrier(barrier_counter, barrier_flag, num_blocks);
-    if (blockIdx.x == 0 && threadIdx.x < 16) {
-        counters[threadIdx.x] = 0u;
+    __syncthreads();
+    __threadfence();
+    if (threadIdx.x == 0) {
+        unsigned int phase = __atomic_load_n(barrier_flag, __ATOMIC_RELAXED);
+        unsigned int old = atomicAdd(barrier_counter, 1u);
+        if (old == static_cast<unsigned int>(num_blocks) - 1) {
+            for (int i = 0; i < 16; ++i) {
+                __atomic_store_n(counters + i, 0u, __ATOMIC_RELAXED);
+            }
+            __atomic_store_n(barrier_counter, 0u, __ATOMIC_RELAXED);
+            __atomic_store_n(barrier_flag, phase + 1, __ATOMIC_RELEASE);
+        } else {
+            while (__atomic_load_n(barrier_flag, __ATOMIC_ACQUIRE) == phase) {}
+        }
     }
-    // Publish: counter resets visible before the next phase reads them.
-    grid_barrier(barrier_counter, barrier_flag, num_blocks);
+    __syncthreads();
 }
 
 enum PersistentDecodeMode {
     PERSISTENT_MODE_FULL = 0,
     PERSISTENT_MODE_ROUTER_ONLY = 1,
     PERSISTENT_MODE_FFN_ONLY = 2,
+    PERSISTENT_MODE_ATTN_ONLY = 3,
+    PERSISTENT_MODE_FFN_STAGE1 = 4,
+    PERSISTENT_MODE_FFN_STAGE2 = 5,
+    PERSISTENT_MODE_FFN_STAGE3 = 6,
+    PERSISTENT_MODE_FFN_STAGE4 = 7,
+    PERSISTENT_MODE_FFN_STAGE5 = 8,
+    PERSISTENT_MODE_LINEAR_STAGE1 = 9,
+    PERSISTENT_MODE_LINEAR_STAGE2 = 10,
+    PERSISTENT_MODE_LINEAR_STAGE3 = 11,
+    PERSISTENT_MODE_LINEAR_STAGE4 = 12,
+    PERSISTENT_MODE_LINEAR_STAGE5 = 13,
 };
 
 // Persistent decode kernel template. Instantiated by the bridge for
@@ -158,6 +178,7 @@ __global__ void qwen36_moe_persistent_decode_kernel(
     const T* __restrict__                final_norm_w,           // [hidden] BF16, nullable
     const T* __restrict__                lm_head_w,              // [vocab, hidden] BF16, nullable
     T*       __restrict__                logits_out,             // [vocab] BF16, nullable
+    unsigned int* __restrict__           top1_out,               // [1] U32, nullable
     unsigned int* __restrict__           counters,
     unsigned int* __restrict__           barrier_counter,
     unsigned int* __restrict__           barrier_flag) {
@@ -186,14 +207,19 @@ __global__ void qwen36_moe_persistent_decode_kernel(
         grid_barrier(barrier_counter, barrier_flag, num_blocks);
     }
 
-    if (mode == PERSISTENT_MODE_FFN_ONLY) {
+    if (mode == PERSISTENT_MODE_FFN_ONLY ||
+        (mode >= PERSISTENT_MODE_FFN_STAGE1 &&
+         mode <= PERSISTENT_MODE_FFN_STAGE5)) {
         const DecodeLayerDesc& d = layers[start_layer];
         const Int4ScaleDesc* i4 =
             (int4_scales != nullptr) ? &int4_scales[start_layer] : nullptr;
         const int i4_gs = (i4 != nullptr) ? i4->group_size : 0;
+        const int ffn_stage = (mode == PERSISTENT_MODE_FFN_ONLY)
+            ? 5
+            : (mode - PERSISTENT_MODE_FFN_STAGE1 + 1);
 
         qwen36_moe_ffn_step_device<T, USE_WMMA>(
-            /*stage*/ 5,
+            ffn_stage,
             hidden, num_experts,
             moe_intermediate, shared_intermediate, top_k,
             rms_norm_eps,
@@ -221,6 +247,47 @@ __global__ void qwen36_moe_persistent_decode_kernel(
             ffn_topk_idx_scratch,
             workspace,
             counters, barrier_counter, barrier_flag);
+        return;
+    }
+
+    if (mode >= PERSISTENT_MODE_LINEAR_STAGE1 &&
+        mode <= PERSISTENT_MODE_LINEAR_STAGE5) {
+        const DecodeLayerDesc& d = layers[start_layer];
+        const Int4ScaleDesc* i4 =
+            (int4_scales != nullptr) ? &int4_scales[start_layer] : nullptr;
+        const int i4_gs = (i4 != nullptr) ? i4->group_size : 0;
+        const int linear_stage = mode - PERSISTENT_MODE_LINEAR_STAGE1 + 1;
+
+        qwen36_moe_linear_step_device<T, USE_WMMA>(
+            linear_stage,
+            hidden, num_k_heads, num_v_heads,
+            head_k_dim, head_v_dim, conv_kernel_dim, rms_norm_eps,
+            hidden_ping,
+            static_cast<const T*>(d.input_norm_w),
+            static_cast<const T*>(d.linear_in_proj_qkv_w),
+            static_cast<const T*>(d.linear_in_proj_z_w),
+            static_cast<const T*>(d.linear_in_proj_a_w),
+            static_cast<const T*>(d.linear_in_proj_b_w),
+            static_cast<const T*>(d.linear_conv1d_w),
+            /*conv1d_bias*/ static_cast<const T*>(nullptr),
+            static_cast<const T*>(d.linear_dt_bias),
+            static_cast<const T*>(d.linear_a_log_exp),
+            static_cast<const T*>(d.linear_norm_w),
+            static_cast<const T*>(d.linear_out_proj_w),
+            static_cast<T*>(d.linear_conv_state),
+            static_cast<float*>(d.linear_recurrent_state),
+            i4_gs,
+            i4 ? static_cast<const hip_bfloat16*>(i4->linear_in_proj_qkv_scale) : nullptr,
+            i4 ? static_cast<const hip_bfloat16*>(i4->linear_in_proj_qkv_zero)  : nullptr,
+            i4 ? static_cast<const hip_bfloat16*>(i4->linear_in_proj_z_scale)   : nullptr,
+            i4 ? static_cast<const hip_bfloat16*>(i4->linear_in_proj_z_zero)    : nullptr,
+            i4 ? static_cast<const hip_bfloat16*>(i4->linear_out_proj_scale)    : nullptr,
+            i4 ? static_cast<const hip_bfloat16*>(i4->linear_out_proj_zero)     : nullptr,
+            hidden_pong,
+            workspace,
+            counters, barrier_counter, barrier_flag,
+            /*suppress_stage_publish*/ true,
+            /*mutate_state*/ linear_stage == 5);
         return;
     }
 
@@ -301,6 +368,13 @@ __global__ void qwen36_moe_persistent_decode_kernel(
                 counters, barrier_counter, barrier_flag);
         }
 
+        if (mode == PERSISTENT_MODE_ATTN_ONLY) {
+            // Profiling-only split: leave the post-attention residual in
+            // hidden_pong so a following FfnOnly launch can complete the
+            // same layer without rerunning attention.
+            return;
+        }
+
         // Reset counters[0..16] before FFN. Attn/linear only used
         // counters[0]; FFN needs counters[0..2*top_k] all clean.
         reset_counters_16(counters, barrier_counter, barrier_flag, num_blocks);
@@ -371,8 +445,8 @@ __global__ void qwen36_moe_persistent_decode_kernel(
     // Phase 3f: folded final RMSnorm + lm_head GEMV. Skipped when any
     // of the three buffers is null (the engine sets them all null on
     // prefill steps to short-circuit the lm_head work).
-    if (final_norm_w != nullptr && lm_head_w != nullptr && logits_out != nullptr
-        && vocab > 0) {
+    if (final_norm_w != nullptr && lm_head_w != nullptr &&
+        (logits_out != nullptr || top1_out != nullptr) && vocab > 0) {
         // counters[0..16] are dirty from the last layer's ffn phase;
         // reset_counters_16 syncs across blocks AND publishes the layer
         // loop's writes to in_buf (= hidden_ping after the per-layer
@@ -382,7 +456,8 @@ __global__ void qwen36_moe_persistent_decode_kernel(
         qwen36_moe_lm_head_device<T, USE_WMMA>(
             hidden, vocab, rms_norm_eps,
             in_buf, final_norm_w, lm_head_w, logits_out,
-            counters);
+            top1_out, workspace,
+            counters, barrier_counter, barrier_flag, num_blocks);
     }
 }
 

--- a/tests/gfx1100/bench_qwen36_he_supersonic.py
+++ b/tests/gfx1100/bench_qwen36_he_supersonic.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
 """Run SuperSonic Qwen3.6 over the Lucebox HumanEval DFlash prompts.
 
-This is a comparison harness, not a correctness gate: Lucebox benchmarks a
-Qwen3.6-27B GGUF target plus DFlash draft. SuperSonic can run the same
-tokenizer/config/source GGUF through a Q4KM-sourced native INT4 package on HIP.
-The prompt set and generation length are kept identical.
+This is a comparison harness, not a correctness gate. It can run either the
+Lucebox-style Qwen3.6-27B GGUF target plus DFlash draft, or the native
+Qwen3.6-35B-A3B MoE path over the same HumanEval prompt set.
 """
 
 from __future__ import annotations
@@ -26,6 +25,14 @@ DEFAULT_LUCEBOX_HE_JSONL = Path(
 )
 DEFAULT_SUPERSONIC_DFLASH_DRAFT_DIR = Path("/mnt/data/tmp/qwen36-27b-dflash-q8-bf16")
 DEFAULT_LUCEBOX_DRAFT_DIR = Path("/mnt/data/lucebox-hub/models/draft")
+DEFAULT_27B_MODEL = "qwen3.6-27b"
+DEFAULT_27B_MODEL_DIR = Path("/mnt/data/tmp/supersonic-qwen36-27b-lucebox")
+DEFAULT_27B_QUANT = "q4km-gptq"
+DEFAULT_35B_A3B_MODEL = "qwen3.6-35b-a3b"
+DEFAULT_35B_A3B_MODEL_DIR = Path("/mnt/data/models/Qwen3.6-35B-A3B")
+DEFAULT_35B_A3B_QUANT = "int4"
+DEFAULT_OUT_JSON = Path("target/qwen36_he_supersonic.json")
+DEFAULT_35B_A3B_OUT_JSON = Path("target/qwen36_35b_a3b_he_supersonic.json")
 DEFAULT_CONTEXT_SIZE = 512
 LUCEBOX_SERVING_CONTEXT_SIZE = 1024
 LUCEBOX_DRAFT_ALIASES = {
@@ -51,6 +58,22 @@ RESULT_RE = re.compile(
     r"decode_ms=(?P<decode_ms>[0-9.]+)\s+"
     r"ms_per_(?:step|tok)=(?P<ms_per_step>[0-9.]+)"
 )
+
+
+TARGET_PROFILES = {
+    "qwen36-27b-lucebox": {
+        "model": DEFAULT_27B_MODEL,
+        "model_dir": DEFAULT_27B_MODEL_DIR,
+        "quant": DEFAULT_27B_QUANT,
+        "out_json": DEFAULT_OUT_JSON,
+    },
+    "qwen36-35b-a3b": {
+        "model": DEFAULT_35B_A3B_MODEL,
+        "model_dir": DEFAULT_35B_A3B_MODEL_DIR,
+        "quant": DEFAULT_35B_A3B_QUANT,
+        "out_json": DEFAULT_35B_A3B_OUT_JSON,
+    },
+}
 
 
 def load_lucebox_script_prompts(path: Path) -> list[tuple[str, str]]:
@@ -132,6 +155,29 @@ def resolve_dflash_draft(args: argparse.Namespace) -> tuple[Path, Path | None, s
     if config_dir is None:
         config_dir = DEFAULT_SUPERSONIC_DFLASH_DRAFT_DIR
     return Path(config_dir), Path(gguf) if gguf else None, label
+
+
+def apply_target_profile(args: argparse.Namespace) -> None:
+    profile = TARGET_PROFILES[args.target_profile]
+    if args.model is None:
+        args.model = profile["model"]
+    if args.model_dir is None:
+        args.model_dir = profile["model_dir"]
+    if args.quant is None:
+        args.quant = profile["quant"]
+    if args.out_json is None:
+        args.out_json = profile["out_json"]
+
+
+def apply_lucebox_serving_mode(args: argparse.Namespace) -> None:
+    args.prompt_source = "jsonl"
+    args.prompt_format = "chatml-no-thinking"
+    args.ignore_eos = False
+    if args.target_profile == "qwen36-27b-lucebox":
+        args.dflash = True
+        args.dflash_draft_variant = args.dflash_draft_variant or "lucebox-q4-k-m"
+    if args.context_size == DEFAULT_CONTEXT_SIZE:
+        args.context_size = LUCEBOX_SERVING_CONTEXT_SIZE
 
 
 def run_one(args: argparse.Namespace, name: str, prompt: str, warmup: bool = False) -> dict:
@@ -217,19 +263,47 @@ def run_one(args: argparse.Namespace, name: str, prompt: str, warmup: bool = Fal
     return row
 
 
+def build_summary(rows: list[dict]) -> dict:
+    ok = [r for r in rows if r.get("returncode") == 0 and "tok_s" in r]
+    total_generated = sum(r["generated_tokens"] for r in ok)
+    total_decode_ms = sum(r["decode_ms"] for r in ok)
+    return {
+        "count": len(ok),
+        "mean_tok_s": sum(r["tok_s"] for r in ok) / len(ok),
+        "weighted_tok_s": (1000.0 * total_generated / total_decode_ms)
+        if total_decode_ms
+        else 0.0,
+        "mean_ms_per_step": sum(r["ms_per_step"] for r in ok) / len(ok),
+        "min_tok_s": min(r["tok_s"] for r in ok),
+        "max_tok_s": max(r["tok_s"] for r in ok),
+        "total_generated_tokens": total_generated,
+        "total_decode_ms": total_decode_ms,
+        "stopped_early_count": sum(1 for r in ok if r.get("stopped_early")),
+    }
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--binary", type=Path, default=Path("target/release/supersonic"))
-    parser.add_argument("--model", default="qwen3.6-27b")
+    parser.add_argument(
+        "--target-profile",
+        choices=sorted(TARGET_PROFILES),
+        default="qwen36-27b-lucebox",
+        help=(
+            "Default model/model-dir/quant/output bundle. Explicit individual "
+            "arguments still take precedence."
+        ),
+    )
+    parser.add_argument("--model", default=None)
     parser.add_argument(
         "--model-dir",
         type=Path,
-        default=Path("/mnt/data/tmp/supersonic-qwen36-27b-lucebox"),
+        default=None,
     )
     parser.add_argument(
         "--quant",
         choices=["q4km-gptq", "q4km", "int4", "none"],
-        default="q4km-gptq",
+        default=None,
     )
     parser.add_argument("--lucebox-bench", type=Path, default=DEFAULT_LUCEBOX_BENCH)
     parser.add_argument("--lucebox-jsonl", type=Path, default=DEFAULT_LUCEBOX_HE_JSONL)
@@ -292,17 +366,12 @@ def main() -> int:
         ),
     )
     parser.add_argument("--dflash-block", type=int, default=0)
-    parser.add_argument("--out-json", type=Path, default=Path("target/qwen36_he_supersonic.json"))
+    parser.add_argument("--out-json", type=Path, default=None)
     args = parser.parse_args()
 
+    apply_target_profile(args)
     if args.lucebox_serving_mode:
-        args.prompt_source = "jsonl"
-        args.prompt_format = "chatml-no-thinking"
-        args.ignore_eos = False
-        args.dflash = True
-        args.dflash_draft_variant = args.dflash_draft_variant or "lucebox-q4-k-m"
-        if args.context_size == DEFAULT_CONTEXT_SIZE:
-            args.context_size = LUCEBOX_SERVING_CONTEXT_SIZE
+        apply_lucebox_serving_mode(args)
     if args.stop_on_eos:
         args.ignore_eos = False
 
@@ -346,15 +415,7 @@ def main() -> int:
     ok = [r for r in rows if r.get("returncode") == 0 and "tok_s" in r]
     if not ok:
         return 1
-    summary = {
-        "count": len(ok),
-        "mean_tok_s": sum(r["tok_s"] for r in ok) / len(ok),
-        "mean_ms_per_step": sum(r["ms_per_step"] for r in ok) / len(ok),
-        "min_tok_s": min(r["tok_s"] for r in ok),
-        "max_tok_s": max(r["tok_s"] for r in ok),
-        "total_generated_tokens": sum(r["generated_tokens"] for r in ok),
-        "stopped_early_count": sum(1 for r in ok if r.get("stopped_early")),
-    }
+    summary = build_summary(rows)
     dflash_draft_dir, dflash_draft_gguf, dflash_draft_label = resolve_dflash_draft(args)
     payload = {
         "schema": "supersonic-qwen36-he-comparison-v2",

--- a/tests/test_qwen36_he_supersonic_bench.py
+++ b/tests/test_qwen36_he_supersonic_bench.py
@@ -81,6 +81,88 @@ class BenchQwen36HeSuperSonicTests(unittest.TestCase):
             bench.DEFAULT_LUCEBOX_DRAFT_DIR / "dflash-draft-3.6-q4_k_m.gguf",
         )
 
+    def test_apply_target_profile_sets_qwen36_35b_a3b_defaults(self):
+        args = types.SimpleNamespace(
+            target_profile="qwen36-35b-a3b",
+            model=None,
+            model_dir=None,
+            quant=None,
+            out_json=None,
+        )
+
+        bench.apply_target_profile(args)
+
+        self.assertEqual(args.model, "qwen3.6-35b-a3b")
+        self.assertEqual(args.model_dir, bench.DEFAULT_35B_A3B_MODEL_DIR)
+        self.assertEqual(args.quant, "int4")
+        self.assertEqual(args.out_json, bench.DEFAULT_35B_A3B_OUT_JSON)
+
+    def test_apply_target_profile_preserves_explicit_args(self):
+        args = types.SimpleNamespace(
+            target_profile="qwen36-35b-a3b",
+            model="custom-model",
+            model_dir=Path("/custom/model"),
+            quant="none",
+            out_json=Path("/tmp/custom.json"),
+        )
+
+        bench.apply_target_profile(args)
+
+        self.assertEqual(args.model, "custom-model")
+        self.assertEqual(args.model_dir, Path("/custom/model"))
+        self.assertEqual(args.quant, "none")
+        self.assertEqual(args.out_json, Path("/tmp/custom.json"))
+
+    def test_lucebox_serving_mode_does_not_enable_dflash_for_35b_a3b(self):
+        args = types.SimpleNamespace(
+            target_profile="qwen36-35b-a3b",
+            prompt_source="script",
+            prompt_format="raw",
+            ignore_eos=True,
+            dflash=False,
+            dflash_draft_variant=None,
+            context_size=bench.DEFAULT_CONTEXT_SIZE,
+        )
+
+        bench.apply_lucebox_serving_mode(args)
+
+        self.assertEqual(args.prompt_source, "jsonl")
+        self.assertEqual(args.prompt_format, "chatml-no-thinking")
+        self.assertFalse(args.ignore_eos)
+        self.assertFalse(args.dflash)
+        self.assertIsNone(args.dflash_draft_variant)
+        self.assertEqual(args.context_size, bench.LUCEBOX_SERVING_CONTEXT_SIZE)
+
+    def test_build_summary_includes_token_weighted_throughput(self):
+        rows = [
+            {
+                "returncode": 0,
+                "tok_s": 25.0,
+                "generated_tokens": 10,
+                "decode_ms": 400.0,
+                "ms_per_step": 40.0,
+                "stopped_early": False,
+            },
+            {
+                "returncode": 0,
+                "tok_s": 50.0,
+                "generated_tokens": 20,
+                "decode_ms": 400.0,
+                "ms_per_step": 20.0,
+                "stopped_early": True,
+            },
+            {"returncode": 1},
+        ]
+
+        summary = bench.build_summary(rows)
+
+        self.assertEqual(summary["count"], 2)
+        self.assertEqual(summary["mean_tok_s"], 37.5)
+        self.assertEqual(summary["weighted_tok_s"], 37.5)
+        self.assertEqual(summary["total_generated_tokens"], 30)
+        self.assertEqual(summary["total_decode_ms"], 800.0)
+        self.assertEqual(summary["stopped_early_count"], 1)
+
     def test_run_one_sets_gguf_env_and_stop_on_eos_command(self):
         args = types.SimpleNamespace(
             binary=Path("target/release/supersonic"),


### PR DESCRIPTION
## Summary

This PR captures the current Qwen3.6 35B A3B Lucebox-parity progress in Supersonic. It does not claim parity yet, but it moves the raw-script 35B path from the earlier ~48.45 tok/s keeper to a current 63.38 tok/s weighted decode keeper, against the local Lucebox baseline at ~78.18 tok/s.

What changed:

- Adds/extends the local benchmark stack for `qwen36-35b-a3b`, including JSON output and summary fields for weighted throughput and decode time.
- Adds the current persistent decode/kernel improvements for the 35B A3B path, including folded lm-head top1, faster int4 dequant, full-attention tile/cache changes, reset counter cleanup, linear out-proj tiling, direct-mid FFN paths, paired shared/routed gate-up work, combined full-attention K/V work queue, and paired full-attention Q/gate WMMA.
- Adds profiling plumbing and synthetic parity coverage needed to keep iterating safely.
- Updates `docs/qwen36-lucebox-parity-log.md` as the durable experiment ledger, including kept artifacts, Lucebox baseline, AMD profiling evidence, and rejected slices to avoid repeating losing paths.

## Current Benchmark State

- Lucebox 35B A3B local baseline: `78.18 tok/s` decode mean, prefill `970.08 tok/s`.
- Supersonic current keeper: `target/qwen36_35b_a3b_raw_script_10x256_fullattn_q_gate_pair_wmma.json`.
- Supersonic current keeper result: weighted `63.375748873595086 tok/s`, mean `63.37227197518149 tok/s`, total decode `40394 ms`, generated `2560`, stopped early `0`.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `HIP_ARCH=gfx1100 cargo build --release -p runner --bin supersonic`
- `/home/deano/venvs/rocm/bin/python -m unittest -q tests.test_qwen36_he_supersonic_bench`
- Exact multilayer parity during the current iteration: `SUPERSONIC_QWEN36_MULTILAYER_ORACLE_JSON=/tmp/qwen36_ml_direct_mid_check.json HIP_ARCH=gfx1100 cargo test --release -p runner --test qwen36_moe_multilayer_parity multilayer_persistent_decode_matches_chained -- --nocapture`

## Notes

This is a progress checkpoint PR. The remaining gap to Lucebox is still significant, and the log intentionally records rejected experiments such as simple folded lm-head tail-sync removal, router top-k shared buffering, and linear reduction zero-lane skipping so future optimization can start from fresh evidence rather than stale memory.