### PR TITLE
[codex] Add RDNA4 gfx1201 support path

### DIFF
--- a/crates/bench/src/matrix.rs
+++ b/crates/bench/src/matrix.rs
@@ -16,6 +16,7 @@ use std::process::Command;
 pub enum BenchArch {
     Gfx1100,
     Gfx1150,
+    Gfx1201,
     Sm86,
     AppleM4,
     AppleM5Max,
@@ -26,6 +27,7 @@ impl BenchArch {
         Some(match s {
             "gfx1100" => Self::Gfx1100,
             "gfx1150" => Self::Gfx1150,
+            "gfx1201" => Self::Gfx1201,
             "sm86" => Self::Sm86,
             "apple-m4" => Self::AppleM4,
             "apple-m5-max" => Self::AppleM5Max,
@@ -36,6 +38,7 @@ impl BenchArch {
         match self {
             Self::Gfx1100 => "gfx1100",
             Self::Gfx1150 => "gfx1150",
+            Self::Gfx1201 => "gfx1201",
             Self::Sm86 => "sm86",
             Self::AppleM4 => "apple-m4",
             Self::AppleM5Max => "apple-m5-max",
@@ -44,7 +47,7 @@ impl BenchArch {
 
     pub fn backend(&self) -> Option<&'static str> {
         match self {
-            Self::Gfx1100 | Self::Gfx1150 => Some("hip"),
+            Self::Gfx1100 | Self::Gfx1150 | Self::Gfx1201 => Some("hip"),
             Self::Sm86 => Some("cuda"),
             Self::AppleM4 | Self::AppleM5Max => Some("metal"),
         }
@@ -275,6 +278,15 @@ pub static SUPPORTED_COMBOS: &[ComboDescriptor] = &[
         quant: "kv-fp8",
         arch: BenchArch::Gfx1100,
         min_vram_gib: 21.0,
+    },
+    // RDNA4 starter lane: keep this to the smoke-validated Qwen3.6 27B
+    // Q4KM-GPTQ combo until the wider Qwen3.5 gfx1201 matrix is promoted
+    // from TBM in docs/supported-matrix.md.
+    ComboDescriptor {
+        model: "qwen3.6-27b",
+        quant: "q4km-gptq",
+        arch: BenchArch::Gfx1201,
+        min_vram_gib: 10.0,
     },
     // Apple M5 Max Metal v1: Qwen3.6 INT4 chained decode only. This is the
     // main-target harness lane; persistent decode, KV-FP8, speculative decode,

--- a/crates/bench/tests/registry_filter.rs
+++ b/crates/bench/tests/registry_filter.rs
@@ -21,11 +21,26 @@ fn gfx1100_includes_shipping_models() {
 
 #[test]
 fn min_vram_set_for_every_combo() {
-    for arch in [BenchArch::Gfx1100, BenchArch::Sm86, BenchArch::AppleM5Max] {
+    for arch in [
+        BenchArch::Gfx1100,
+        BenchArch::Gfx1201,
+        BenchArch::Sm86,
+        BenchArch::AppleM5Max,
+    ] {
         for c in combos_for_arch(arch) {
             assert!(c.min_vram_gib > 0.0, "combo {c:?} has zero min_vram_gib");
         }
     }
+}
+
+#[test]
+fn gfx1201_includes_rdna4_starter_qwen36_lane() {
+    let combos = combos_for_arch(BenchArch::Gfx1201);
+    let model_quants: Vec<(&str, &str)> = combos.iter().map(|c| (c.model, c.quant)).collect();
+
+    assert_eq!(BenchArch::Gfx1201.backend(), Some("hip"));
+    assert!(model_quants.contains(&("qwen3.6-27b", "q4km-gptq")));
+    assert!(!model_quants.contains(&("qwen3.5-9b", "kv-fp8")));
 }
 
 #[test]

--- a/crates/core/src/registry.rs
+++ b/crates/core/src/registry.rs
@@ -128,6 +128,7 @@ impl fmt::Display for ModelVariant {
 pub enum GpuArch {
     Gfx1100,
     Gfx1150,
+    Gfx1201,
     Gfx942,
     Sm86,
     Sm90,
@@ -142,6 +143,7 @@ impl GpuArch {
             Backend::Hip => match name.trim().split(':').next().unwrap_or(name.trim()) {
                 "gfx1100" => Self::Gfx1100,
                 "gfx1150" => Self::Gfx1150,
+                "gfx1201" => Self::Gfx1201,
                 "gfx942" => Self::Gfx942,
                 other => Self::Unknown(other.to_owned()),
             },
@@ -164,6 +166,7 @@ impl fmt::Display for GpuArch {
         match self {
             Self::Gfx1100 => write!(f, "gfx1100"),
             Self::Gfx1150 => write!(f, "gfx1150"),
+            Self::Gfx1201 => write!(f, "gfx1201"),
             Self::Gfx942 => write!(f, "gfx942"),
             Self::Sm86 => write!(f, "sm86"),
             Self::Sm90 => write!(f, "sm90"),
@@ -192,9 +195,11 @@ pub struct ArchProfile {
 impl ArchProfile {
     pub fn for_arch(arch: &GpuArch) -> Self {
         let memory = match arch {
-            GpuArch::Gfx1100 | GpuArch::Gfx942 | GpuArch::Sm86 | GpuArch::Sm90 => {
-                MemoryArchitecture::Discrete
-            }
+            GpuArch::Gfx1100
+            | GpuArch::Gfx1201
+            | GpuArch::Gfx942
+            | GpuArch::Sm86
+            | GpuArch::Sm90 => MemoryArchitecture::Discrete,
             GpuArch::Gfx1150 | GpuArch::AppleM4 | GpuArch::AppleM5Max => {
                 MemoryArchitecture::Unified
             }
@@ -420,6 +425,89 @@ static REGISTRY: &[RegistryEntry] = &[
         model: ModelVariant::Qwen3_6_27B,
         backend: Backend::Hip,
         arch: GpuArch::Gfx1100,
+        vram: VramBudget {
+            fixed_bytes: 22 * GIB,
+            overhead_factor: 1.05,
+        },
+        params: FamilyParams::Qwen35(Qwen35KernelParams {
+            // Qwen3.6-27B: qkv 8192 + z 6144 + b/a 48 each.
+            proj_buf_floats: 16480,
+            // Floor for 3*nh*hd + nh*aligned_kv_t at short contexts.
+            // The runner still expands this from --context-size.
+            attn_scratch_floats: 24576,
+            weight_prefix: "model.language_model",
+            kv_chunk_size: 256,
+            use_4b_kernel: true,
+        }),
+    },
+    RegistryEntry {
+        model: ModelVariant::Qwen3_5_0_8B,
+        backend: Backend::Hip,
+        arch: GpuArch::Gfx1201,
+        vram: VramBudget {
+            fixed_bytes: 2 * GIB,
+            overhead_factor: 1.1,
+        },
+        params: FamilyParams::Qwen35(Qwen35KernelParams {
+            proj_buf_floats: 8224,
+            attn_scratch_floats: 16384,
+            weight_prefix: "model.language_model",
+            kv_chunk_size: 256,
+            use_4b_kernel: true,
+        }),
+    },
+    RegistryEntry {
+        model: ModelVariant::Qwen3_5_2B,
+        backend: Backend::Hip,
+        arch: GpuArch::Gfx1201,
+        vram: VramBudget {
+            fixed_bytes: 5 * GIB,
+            overhead_factor: 1.1,
+        },
+        params: FamilyParams::Qwen35(Qwen35KernelParams {
+            proj_buf_floats: 8224,
+            attn_scratch_floats: 16384,
+            weight_prefix: "model.language_model",
+            kv_chunk_size: 256,
+            use_4b_kernel: true,
+        }),
+    },
+    RegistryEntry {
+        model: ModelVariant::Qwen3_5_4B,
+        backend: Backend::Hip,
+        arch: GpuArch::Gfx1201,
+        vram: VramBudget {
+            fixed_bytes: 10 * GIB,
+            overhead_factor: 1.1,
+        },
+        params: FamilyParams::Qwen35(Qwen35KernelParams {
+            proj_buf_floats: 12352,
+            attn_scratch_floats: 16384,
+            weight_prefix: "model.language_model",
+            kv_chunk_size: 256,
+            use_4b_kernel: true,
+        }),
+    },
+    RegistryEntry {
+        model: ModelVariant::Qwen3_5_9B,
+        backend: Backend::Hip,
+        arch: GpuArch::Gfx1201,
+        vram: VramBudget {
+            fixed_bytes: 18 * GIB,
+            overhead_factor: 1.1,
+        },
+        params: FamilyParams::Qwen35(Qwen35KernelParams {
+            proj_buf_floats: 12352,
+            attn_scratch_floats: 16384,
+            weight_prefix: "model.language_model",
+            kv_chunk_size: 256,
+            use_4b_kernel: true,
+        }),
+    },
+    RegistryEntry {
+        model: ModelVariant::Qwen3_6_27B,
+        backend: Backend::Hip,
+        arch: GpuArch::Gfx1201,
         vram: VramBudget {
             fixed_bytes: 22 * GIB,
             overhead_factor: 1.05,
@@ -1250,6 +1338,34 @@ mod tests {
     }
 
     #[test]
+    fn hip_gfx1201_registry_includes_rdna4_dense_qwen_targets() {
+        assert_eq!(
+            GpuArch::from_backend_name(&Backend::Hip, "gfx1201"),
+            GpuArch::Gfx1201
+        );
+        assert_eq!(
+            GpuArch::from_backend_name(&Backend::Hip, "gfx1201:sramecc+:xnack-"),
+            GpuArch::Gfx1201
+        );
+        let profile = ArchProfile::for_arch(&GpuArch::Gfx1201);
+        assert_eq!(profile.memory, MemoryArchitecture::Discrete);
+        assert_eq!(profile.buffer_policy, BufferPolicy::all_default());
+
+        for model in [
+            ModelVariant::Qwen3_5_0_8B,
+            ModelVariant::Qwen3_5_2B,
+            ModelVariant::Qwen3_5_4B,
+            ModelVariant::Qwen3_5_9B,
+            ModelVariant::Qwen3_6_27B,
+        ] {
+            assert!(lookup(&model, &Backend::Hip, &GpuArch::Gfx1201).is_some());
+            assert!(supported_archs_for(&model, &Backend::Hip)
+                .iter()
+                .any(|arch| arch == "gfx1201"));
+        }
+    }
+
+    #[test]
     fn hip_gfx942_registry_includes_cdna_targets() {
         assert_eq!(
             GpuArch::from_backend_name(&Backend::Hip, "gfx942"),
@@ -1295,6 +1411,21 @@ mod tests {
     fn hip_gfx1100_qwen36_27b_registry_params_match_geometry() {
         let entry = lookup(&ModelVariant::Qwen3_6_27B, &Backend::Hip, &GpuArch::Gfx1100)
             .expect("qwen3.6-27b HIP gfx1100 registry entry");
+        match entry.params {
+            FamilyParams::Qwen35(params) => {
+                assert_eq!(params.weight_prefix, "model.language_model");
+                assert!(params.use_4b_kernel);
+                assert_eq!(params.proj_buf_floats, 16_480);
+                assert_eq!(params.attn_scratch_floats, 24_576);
+            }
+            _ => panic!("qwen3.6-27b must use the Qwen hybrid-attention engine"),
+        }
+    }
+
+    #[test]
+    fn hip_gfx1201_qwen36_27b_registry_params_match_geometry() {
+        let entry = lookup(&ModelVariant::Qwen3_6_27B, &Backend::Hip, &GpuArch::Gfx1201)
+            .expect("qwen3.6-27b HIP gfx1201 registry entry");
         match entry.params {
             FamilyParams::Qwen35(params) => {
                 assert_eq!(params.weight_prefix, "model.language_model");

--- a/crates/machine-profile/kernels/wmma_peak.hip
+++ b/crates/machine-profile/kernels/wmma_peak.hip
@@ -7,28 +7,50 @@
 // proven pattern in this repo (see gemma4.hip, qwen36_moe helpers.cuh).
 // Defined unconditionally — they're harmless on archs without wmma builtins.
 typedef _Float16 mp_half16  __attribute__((ext_vector_type(16)));
+typedef _Float16 mp_half8   __attribute__((ext_vector_type(8)));
 typedef short    mp_short16 __attribute__((ext_vector_type(16)));
+typedef short    mp_short8  __attribute__((ext_vector_type(8)));
 typedef float    mp_float8  __attribute__((ext_vector_type(8)));
 typedef int8_t   mp_i8x16   __attribute__((ext_vector_type(16)));
+typedef int32_t  mp_i32x2   __attribute__((ext_vector_type(2)));
 typedef int32_t  mp_i32x8   __attribute__((ext_vector_type(8)));
 
-// Detect wmma builtins per-dtype via clang's __has_builtin. Each --offload-arch=X
-// slice gets its own preprocessor state, so the real-vs-fallback decision is
-// taken per arch by the toolchain — no hardcoded arch list to maintain.
+// Detect wmma builtins per-dtype via clang's __has_builtin, but keep the
+// executable path matched to the generation-specific operand ABI. gfx11 uses
+// the original 256-bit A/B operands; gfx12 uses the new 128-bit `_gfx12`
+// builtins with no explicit A/B replication.
+#if defined(__gfx1100__) || defined(__gfx1101__) || defined(__gfx1102__) || \
+    defined(__gfx1103__) || defined(__gfx1150__) || defined(__gfx1151__) || \
+    defined(__gfx1152__)
+#define MP_ARCH_CAN_SELECT_WMMA 1
+#define MP_ARCH_WMMA_GFX12 0
+#elif defined(__gfx1200__) || defined(__gfx1201__)
+#define MP_ARCH_CAN_SELECT_WMMA 1
+#define MP_ARCH_WMMA_GFX12 1
+#else
+#define MP_ARCH_CAN_SELECT_WMMA 0
+#define MP_ARCH_WMMA_GFX12 0
+#endif
 
-#if defined(__has_builtin) && __has_builtin(__builtin_amdgcn_wmma_f32_16x16x16_f16_w32)
+#if MP_ARCH_CAN_SELECT_WMMA && !MP_ARCH_WMMA_GFX12 && defined(__has_builtin) && __has_builtin(__builtin_amdgcn_wmma_f32_16x16x16_f16_w32)
+#define MP_HAS_WMMA_F16 1
+#elif MP_ARCH_CAN_SELECT_WMMA && MP_ARCH_WMMA_GFX12 && defined(__has_builtin) && __has_builtin(__builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12)
 #define MP_HAS_WMMA_F16 1
 #else
 #define MP_HAS_WMMA_F16 0
 #endif
 
-#if defined(__has_builtin) && __has_builtin(__builtin_amdgcn_wmma_f32_16x16x16_bf16_w32)
+#if MP_ARCH_CAN_SELECT_WMMA && !MP_ARCH_WMMA_GFX12 && defined(__has_builtin) && __has_builtin(__builtin_amdgcn_wmma_f32_16x16x16_bf16_w32)
+#define MP_HAS_WMMA_BF16 1
+#elif MP_ARCH_CAN_SELECT_WMMA && MP_ARCH_WMMA_GFX12 && defined(__has_builtin) && __has_builtin(__builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12)
 #define MP_HAS_WMMA_BF16 1
 #else
 #define MP_HAS_WMMA_BF16 0
 #endif
 
-#if defined(__has_builtin) && __has_builtin(__builtin_amdgcn_wmma_i32_16x16x16_iu8_w32)
+#if MP_ARCH_CAN_SELECT_WMMA && !MP_ARCH_WMMA_GFX12 && defined(__has_builtin) && __has_builtin(__builtin_amdgcn_wmma_i32_16x16x16_iu8_w32)
+#define MP_HAS_WMMA_I8 1
+#elif MP_ARCH_CAN_SELECT_WMMA && MP_ARCH_WMMA_GFX12 && defined(__has_builtin) && __has_builtin(__builtin_amdgcn_wmma_i32_16x16x16_iu8_w32_gfx12)
 #define MP_HAS_WMMA_I8 1
 #else
 #define MP_HAS_WMMA_I8 0
@@ -37,11 +59,20 @@ typedef int32_t  mp_i32x8   __attribute__((ext_vector_type(8)));
 #if MP_HAS_WMMA_F16
 extern "C" __global__ void mp_wmma_peak_f16_kernel(uint64_t iters, float *sink)
 {
+#if MP_ARCH_WMMA_GFX12
+    mp_half8 a = {};
+    mp_half8 b = {};
+#else
     mp_half16 a = {};
     mp_half16 b = {};
+#endif
     mp_float8 c = {};
     for (uint64_t i = 0; i < iters; ++i) {
+#if MP_ARCH_WMMA_GFX12
+        c = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(a, b, c);
+#else
         c = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a, b, c);
+#endif
     }
     if (threadIdx.x == 0 && c[0] < -1e30f) sink[blockIdx.x] = c[0];
 }
@@ -55,11 +86,20 @@ extern "C" __global__ void mp_wmma_peak_f16_kernel(uint64_t iters, float *sink)
 #if MP_HAS_WMMA_BF16
 extern "C" __global__ void mp_wmma_peak_bf16_kernel(uint64_t iters, float *sink)
 {
+#if MP_ARCH_WMMA_GFX12
+    mp_short8 a = {};
+    mp_short8 b = {};
+#else
     mp_short16 a = {};
     mp_short16 b = {};
+#endif
     mp_float8  c = {};
     for (uint64_t i = 0; i < iters; ++i) {
+#if MP_ARCH_WMMA_GFX12
+        c = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(a, b, c);
+#else
         c = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a, b, c);
+#endif
     }
     if (threadIdx.x == 0 && c[0] < -1e30f) sink[blockIdx.x] = c[0];
 }
@@ -73,11 +113,20 @@ extern "C" __global__ void mp_wmma_peak_bf16_kernel(uint64_t iters, float *sink)
 #if MP_HAS_WMMA_I8
 extern "C" __global__ void mp_wmma_peak_i8_kernel(uint64_t iters, int *sink)
 {
+#if MP_ARCH_WMMA_GFX12
+    mp_i32x2 a = {};
+    mp_i32x2 b = {};
+#else
     mp_i8x16 a = {};
     mp_i8x16 b = {};
+#endif
     mp_i32x8 c = {};
     for (uint64_t i = 0; i < iters; ++i) {
+#if MP_ARCH_WMMA_GFX12
+        c = __builtin_amdgcn_wmma_i32_16x16x16_iu8_w32_gfx12(true, a, true, b, c, false);
+#else
         c = __builtin_amdgcn_wmma_i32_16x16x16_iu8_w32(true, a, true, b, c, false);
+#endif
     }
     if (threadIdx.x == 0 && c[0] < -2000000000) sink[blockIdx.x] = c[0];
 }

--- a/crates/runner/tests/bench_combo_parity.rs
+++ b/crates/runner/tests/bench_combo_parity.rs
@@ -51,6 +51,7 @@ fn bench_combo_table_mentions_every_runner_supported_pair() {
         ("phi4-mini", "kv-fp8", "Gfx1100"),
         ("qwen3.6-35b-a3b", "int4", "Gfx1100"),
         ("qwen3.6-35b-a3b", "kv-fp8", "Gfx1100"),
+        ("qwen3.6-27b", "q4km-gptq", "Gfx1201"),
         ("qwen3.6-35b-a3b", "int4", "AppleM5Max"),
         ("qwen3.5-35b-a3b", "q4km-gptq", "AppleM5Max"),
         ("qwen3.5-35b-a3b", "q4km", "AppleM5Max"),

--- a/docs/feature-compatibility.md
+++ b/docs/feature-compatibility.md
@@ -24,6 +24,11 @@ explicitly says otherwise: Qwen3.6 persistent decode, KV-FP8, VMM,
 SpecPrefill/DFlash-style speculative paths, MoE prefetch, and batching are not
 part of the Apple M5 Max feature surface today.
 
+HIP `gfx1201` is a new RDNA 4 bring-up lane. It has first-class registry/build
+support, RDNA4 BF16/i8 WMMA kernel coverage, and Qwen3.6 27B Q4KM-GPTQ/DFlash
+smokes; broader feature cells stay TBM until the `tests/gfx1201` matrix
+promotes them with per-model validation.
+
 ## How to read
 
 - **✅** = validated end-to-end (parity test or oracle agreement).
@@ -66,17 +71,17 @@ Support:
 The `sm86` CUDA column also applies to `sm90` unless a per-arch note says
 otherwise; the current H100 path is an inherited CUDA compatibility lane.
 
-| Model            | gfx1100 | gfx1150 | gfx942 | sm86  | apple-m4 |
-|------------------|:-------:|:-------:|:------:|:-----:|:--------:|
-| qwen3.5-0.8b     |    ✅   |   ✅    |  ✅¹  |  ✅   |    —     |
-| qwen3.5-2b       |    ✅   |   ✅    |  ✅¹  |  ✅   |    —     |
-| qwen3.5-4b       |    ✅   |   ✅    |  ✅¹  |  ✅   |    —     |
-| qwen3.5-9b       |    ✅   |   ✅    |  ✅¹  |  ✅   |    —     |
-| qwen3.6-35b-a3b  |   ✅⁴   |    —    |   —   |   —   |    —     |
-| gemma4-e2b       |   ✅²   |    —    |   —   |   —   |    —     |
-| gemma4-e4b       |   ✅²   |    —    |   —   |   —   |    —     |
-| phi4-mini        |    ✅   |   ✅    |  ✅²  |  ✅   |    —     |
-| llama3.1-8b      |    —    |    —    |   —   |  ✅³  |    —     |
+| Model            | gfx1100 | gfx1150 | gfx1201 | gfx942 | sm86  | apple-m4 |
+|------------------|:-------:|:-------:|:-------:|:------:|:-----:|:--------:|
+| qwen3.5-0.8b     |    ✅   |   ✅    |   TBM   |  ✅¹  |  ✅   |    —     |
+| qwen3.5-2b       |    ✅   |   ✅    |   TBM   |  ✅¹  |  ✅   |    —     |
+| qwen3.5-4b       |    ✅   |   ✅    |   TBM   |  ✅¹  |  ✅   |    —     |
+| qwen3.5-9b       |    ✅   |   ✅    |   TBM   |  ✅¹  |  ✅   |    —     |
+| qwen3.6-35b-a3b  |   ✅⁴   |    —    |    —    |   —   |   —   |    —     |
+| gemma4-e2b       |   ✅²   |    —    |    —    |   —   |   —   |    —     |
+| gemma4-e4b       |   ✅²   |    —    |    —    |   —   |   —   |    —     |
+| phi4-mini        |    ✅   |   ✅    |    —    |  ✅²  |  ✅   |    —     |
+| llama3.1-8b      |    —    |    —    |    —    |   —   |  ✅³  |    —     |
 
 ¹ gfx942 KV-FP8 uses replayed GPU prefill for the single-sequence path.
 ² Gemma 4 KV-FP8 requires `--batch-size 1`, cannot combine with `--int4`.
@@ -103,9 +108,9 @@ Support:
 The CUDA `sm86` column also applies to `sm90` for VMM: no VMM surface is
 registered for CUDA dense/Qwen3.6-MoE today.
 
-| Model            | gfx1100 | gfx1150 | gfx942 | sm86  |
-|------------------|:-------:|:-------:|:------:|:-----:|
-| qwen3.6-35b-a3b  |    ✅   |    —    |   —    |   —   |
+| Model            | gfx1100 | gfx1150 | gfx1201 | gfx942 | sm86  |
+|------------------|:-------:|:-------:|:-------:|:------:|:-----:|
+| qwen3.6-35b-a3b  |    ✅   |    —    |    —    |   —    |   —   |
 
 Other models do not enable VMM today; the dense KV allocator is
 sufficient.
@@ -139,9 +144,9 @@ Support:
 
 The CUDA `sm86` rejection also applies to `sm90`.
 
-| Target × Draft                 | gfx1100 | gfx1150 | gfx942 | sm86 |
-|--------------------------------|:-------:|:-------:|:------:|:----:|
-| qwen3.5-9b BF16 + qwen3.5-0.8b |    ✅   |   TBM   |  TBM   |  ❌¹ |
+| Target × Draft                 | gfx1100 | gfx1150 | gfx1201 | gfx942 | sm86 |
+|--------------------------------|:-------:|:-------:|:-------:|:------:|:----:|
+| qwen3.5-9b BF16 + qwen3.5-0.8b |    ✅   |   TBM   |   TBM   |  TBM   |  ❌¹ |
 
 ¹ CUDA bridge returns "not implemented" for the look-ahead and
 RoPE-indirect kernels. Validation rejects upfront.
@@ -161,12 +166,16 @@ Support:
 
 The CUDA `sm86` rejection also applies to `sm90`.
 
-| Target          | gfx1100 | gfx1150 | gfx942 | sm86 |
-|-----------------|:-------:|:-------:|:------:|:----:|
-| qwen3.5-9b INT4 |    ✅   |   ✅    |  TBM   |  ❌  |
+| Target                                      | gfx1100 | gfx1150 | gfx1201 | gfx942 | sm86 |
+|---------------------------------------------|:-------:|:-------:|:-------:|:------:|:----:|
+| qwen3.5-9b INT4                             |    ✅   |   ✅    |   TBM   |  TBM   |  ❌  |
+| qwen3.6-27b Q4KM-GPTQ + Lucebox q8_0 draft  |    ✅¹  |    —    |    ✅¹   |   —    |  ❌  |
 
 CUDA support is not currently planned; the B-block fused verify is
 HIP-megakernel-specific.
+
+¹ Qwen3.6 27B DFlash is the Lucebox comparison lane. The `gfx1201` cell is a
+  starter RDNA4 smoke, not a completed sustained-decode tuning result.
 
 ### 6. MoE expert prefetch
 
@@ -183,9 +192,9 @@ Support:
 The CUDA `sm86` column also applies to `sm90`: no CUDA MoE prefetch lane is
 registered today.
 
-| Model            | gfx1100 | gfx1150 | gfx942 | sm86 |
-|------------------|:-------:|:-------:|:------:|:----:|
-| qwen3.6-35b-a3b  |    ✅   |    —    |   —    |   —  |
+| Model            | gfx1100 | gfx1150 | gfx1201 | gfx942 | sm86 |
+|------------------|:-------:|:-------:|:-------:|:------:|:----:|
+| qwen3.6-35b-a3b  |    ✅   |    —    |    —    |   —    |   —  |
 
 ### 7. Certified KV (Llama 3.1)
 
@@ -202,9 +211,9 @@ Support:
 The CUDA `sm86` column also applies to `sm90`; H100 inherits the same
 certified-KV feature gates pending dedicated quality/performance runs.
 
-| Model        | gfx1100 | gfx1150 | gfx942 | sm86 |
-|--------------|:-------:|:-------:|:------:|:----:|
-| llama3.1-8b  |    —    |    —    |   —    |  ✅  |
+| Model        | gfx1100 | gfx1150 | gfx1201 | gfx942 | sm86 |
+|--------------|:-------:|:-------:|:-------:|:------:|:----:|
+| llama3.1-8b  |    —    |    —    |    —    |   —    |  ✅  |
 
 CUDA-only; the BF16 step-copy fallback added in PR #177 unblocks the
 non-certified BF16 component decode on HIP, but certified mode itself

--- a/docs/supported-matrix.md
+++ b/docs/supported-matrix.md
@@ -6,9 +6,10 @@ which GPU architecture. The cells below track *correctness* — see
 and [docs/feature-compatibility.md](feature-compatibility.md) for the
 runtime-feature compatibility grid.
 
-Six backend surfaces are validated or in bring-up today:
+Seven backend surfaces are validated or in bring-up today:
 
 - **HIP / `gfx1100`** — AMD Radeon RX 7900 XTX (RDNA 3, 24 GiB)
+- **HIP / `gfx1201`** — AMD Radeon AI PRO R9700 (RDNA 4, 32 GiB bring-up)
 - **HIP / `gfx1150`** — AMD Radeon 890M iGPU (RDNA 3.5)
 - **HIP / `gfx942`** — AMD Instinct MI300X-class (CDNA 3, wave64 bring-up)
 - **CUDA / `sm86`** — NVIDIA RTX 3090-class (Ampere)
@@ -48,6 +49,28 @@ Six backend surfaces are validated or in bring-up today:
   releases (see [docs/bake-distribution.md](bake-distribution.md));
   producer workflow is unchanged. `--fp8-runtime` and `--kv-fp8` are
   not wired for the MoE family.
+
+### HIP on `gfx1201`
+
+RDNA 4 is a new bring-up lane. `gfx1201` is a first-class HIP registry arch
+and uses the gfx12 BF16/i8 WMMA adapter path for low-bit Qwen matmuls. The
+Qwen3.5 rows are registered and buildable, but remain TBM until the
+architecture-specific smoke matrix promotes them with token/parity results.
+
+| Model           | BF16 | INT4 | FP8 runtime | FP8 KV |
+|-----------------|:----:|:----:|:-----------:|:------:|
+| qwen3.5-0.8b    | TBM¹ | TBM¹ |     TBM¹    |  TBM¹  |
+| qwen3.5-2b      | TBM¹ | TBM¹ |     TBM¹    |  TBM¹  |
+| qwen3.5-4b      | TBM¹ | TBM¹ |     TBM¹    |  TBM¹  |
+| qwen3.5-9b      | TBM¹ | TBM¹ |     TBM¹    |  TBM¹  |
+| qwen3.6-27b     |  —   |  ✅² |      —      |   —    |
+
+¹ Registry and dual-arch HIP build coverage are present for `gfx1201`; run
+  `tests/gfx1201/run_matrix.sh` with local model dirs before promoting these
+  cells from TBM to validated support.
+² Validated on R9700 / `gfx1201` on 2026-06-20 with the RDNA4 BF16/i8 WMMA
+  harness, a direct `qwen3.6-27b --q4km-gptq` smoke, and Lucebox/DFlash
+  Qwen3.6 27B smokes. Sustained decode still needs RDNA4-specific profiling.
 
 ### HIP on `gfx1150`
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -21,6 +21,11 @@ export SUPERSONIC_MODEL_DIR_4B=/path/to/Qwen3.5-4B
 ./tests/gfx1150/run.sh
 ./tests/gfx1150/run_4b.sh
 
+# gfx1201 (RDNA 4 / R9700) — starter RDNA4 lane
+HIP_VISIBLE_DEVICES=1 ./tests/gfx1201/run_matrix.sh
+QWEN36_27B_MODEL_DIR=/path/to/supersonic-qwen36-27b-lucebox \
+  HIP_VISIBLE_DEVICES=1 ./tests/gfx1201/run_matrix.sh
+
 # sm86 (RTX 3090-class) — Qwen3.5-0.8B / 4B
 SUPERSONIC_BACKENDS=cuda ./tests/sm86/run.sh /path/to/Qwen3.5-0.8B
 SUPERSONIC_BACKENDS=cuda ./tests/sm86/run_4b.sh /path/to/Qwen3.5-4B
@@ -80,6 +85,13 @@ TIMEOUT=180 ./tests/gfx1150/run.sh /path/to/model
 The persistent decode megakernel can occasionally hang the GPU at 100% utilization. The test script has a timeout (default 120s) and will report failure rather than blocking forever. If this happens you may need to reset the GPU (`rocm-smi --resetgpu`) or reboot before re-running.
 
 For CUDA specifically, treat `sm86` as the validated target for now. Other NVIDIA architectures may work, but they are not yet part of the checked support matrix.
+
+For HIP `gfx1201`, `tests/gfx1201/run_matrix.sh` is the bring-up gate. It
+builds a dual `gfx1100,gfx1201` HIP binary, runs the RDNA4 WMMA/int4 kernel
+harness, then runs a short Qwen3.6 27B Q4KM-GPTQ smoke and the Lucebox/DFlash
+smoke when local artifacts are available. Qwen3.5 rows in
+`supported-matrix.md` should stay TBM until that script grows per-model token
+checks for the local R9700.
 
 For Metal specifically, Apple M4 remains the small Qwen3.5 validation lane.
 Apple M5 Max is the current large-model lane: it covers Qwen3.5 BF16 smokes,

--- a/kernels/full_attention_4b.hip
+++ b/kernels/full_attention_4b.hip
@@ -3010,11 +3010,14 @@ __device__ __forceinline__ supersonic_float8 supersonic_wmma_bf16(
     supersonic_short8 b12;
     supersonic_float8 c12;
 
+    // gfx12 A/B fragments interleave the two 8-row halves as 0..3,8..11
+    // for lanes 0..15 and 4..7,12..15 for lanes 16..31.
     #pragma unroll
     for (int i = 0; i < 8; ++i) {
         const int row = lane_group * 8 + i;
-        a12[i] = a[row];
-        b12[i] = b[row];
+        const int ab_row = lane_group * 4 + (i & 3) + ((i >> 2) * 8);
+        a12[i] = a[ab_row];
+        b12[i] = b[ab_row];
 
         const int old_src_lane = ((row & 1) ? 16 : 0) + lane_col;
         c12[i] = supersonic_shfl_float8_at(acc, row >> 1, old_src_lane);
@@ -3065,9 +3068,10 @@ __device__ __forceinline__ supersonic_i32x8 supersonic_wmma_i8_iu8(
     supersonic_i32x2 b12;
     supersonic_i32x8 c12;
 
+    // Packed i8 uses the same A/B permutation at 4-element word granularity.
     #pragma unroll
     for (int i = 0; i < 2; ++i) {
-        const int packed_idx = lane_group * 2 + i;
+        const int packed_idx = lane_group + 2 * i;
         a12[i] = a[packed_idx];
         b12[i] = b[packed_idx];
     }

--- a/kernels/full_attention_4b.hip
+++ b/kernels/full_attention_4b.hip
@@ -2947,7 +2947,7 @@ __global__ void supersonic_qwen35_matmul_rhs_transposed_tiled_kernel(
 }
 
 // =============================================================================
-// RDNA3 WMMA BF16 prefill matmul (wave32, 16x16x16 f32-accumulate), tiled.
+// RDNA WMMA BF16 prefill matmul (wave32, 16x16x16 f32-accumulate), tiled.
 //
 // Computes: out[batch, m, n] = lhs[batch, m, k] × rhs[batch, n, k]^T
 //
@@ -2967,12 +2967,132 @@ __global__ void supersonic_qwen35_matmul_rhs_transposed_tiled_kernel(
     defined(__gfx1152__)
 #define SUPERSONIC_HAS_WMMA_BF16 1
 #define SUPERSONIC_HAS_WMMA_I8 1
+#define SUPERSONIC_WMMA_GFX12 0
+#elif defined(__gfx1200__) || defined(__gfx1201__)
+#define SUPERSONIC_HAS_WMMA_BF16 1
+#define SUPERSONIC_HAS_WMMA_I8 1
+#define SUPERSONIC_WMMA_GFX12 1
 #endif
 
 typedef short  supersonic_short16 __attribute__((ext_vector_type(16)));
+typedef short  supersonic_short8  __attribute__((ext_vector_type(8)));
 typedef float  supersonic_float8  __attribute__((ext_vector_type(8)));
+typedef int    supersonic_i32x2  __attribute__((ext_vector_type(2)));
 typedef int    supersonic_i32x4  __attribute__((ext_vector_type(4)));
 typedef int    supersonic_i32x8  __attribute__((ext_vector_type(8)));
+
+#ifdef SUPERSONIC_HAS_WMMA_BF16
+__device__ __forceinline__ float supersonic_shfl_float8_at(
+    supersonic_float8 values,
+    int elem,
+    int src_lane
+) {
+    float out = 0.0f;
+    #pragma unroll
+    for (int i = 0; i < 8; ++i) {
+        const float v = __shfl(values[i], src_lane, 32);
+        if (i == elem) out = v;
+    }
+    return out;
+}
+
+__device__ __forceinline__ supersonic_float8 supersonic_wmma_bf16(
+    supersonic_short16 a,
+    supersonic_short16 b,
+    supersonic_float8 acc
+) {
+#if SUPERSONIC_WMMA_GFX12
+    const int lane = threadIdx.x & 31;
+    const int lane_col = lane & 15;
+    const int lane_group = lane >> 4;
+
+    supersonic_short8 a12;
+    supersonic_short8 b12;
+    supersonic_float8 c12;
+
+    #pragma unroll
+    for (int i = 0; i < 8; ++i) {
+        const int row = lane_group * 8 + i;
+        a12[i] = a[row];
+        b12[i] = b[row];
+
+        const int old_src_lane = ((row & 1) ? 16 : 0) + lane_col;
+        c12[i] = supersonic_shfl_float8_at(acc, row >> 1, old_src_lane);
+    }
+
+    supersonic_float8 d12 =
+        __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(a12, b12, c12);
+    supersonic_float8 out;
+    #pragma unroll
+    for (int i = 0; i < 8; ++i) {
+        const int old_row = 2 * i + lane_group;
+        const int new_src_lane = ((old_row >= 8) ? 16 : 0) + lane_col;
+        out[i] = supersonic_shfl_float8_at(d12, old_row & 7, new_src_lane);
+    }
+    return out;
+#else
+    return __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a, b, acc);
+#endif
+}
+#endif
+
+#ifdef SUPERSONIC_HAS_WMMA_I8
+__device__ __forceinline__ int supersonic_shfl_i32x8_at(
+    supersonic_i32x8 values,
+    int elem,
+    int src_lane
+) {
+    int out = 0;
+    #pragma unroll
+    for (int i = 0; i < 8; ++i) {
+        const int v = __shfl(values[i], src_lane, 32);
+        if (i == elem) out = v;
+    }
+    return out;
+}
+
+__device__ __forceinline__ supersonic_i32x8 supersonic_wmma_i8_iu8(
+    supersonic_i32x4 a,
+    supersonic_i32x4 b,
+    supersonic_i32x8 acc
+) {
+#if SUPERSONIC_WMMA_GFX12
+    const int lane = threadIdx.x & 31;
+    const int lane_col = lane & 15;
+    const int lane_group = lane >> 4;
+
+    supersonic_i32x2 a12;
+    supersonic_i32x2 b12;
+    supersonic_i32x8 c12;
+
+    #pragma unroll
+    for (int i = 0; i < 2; ++i) {
+        const int packed_idx = lane_group * 2 + i;
+        a12[i] = a[packed_idx];
+        b12[i] = b[packed_idx];
+    }
+    #pragma unroll
+    for (int i = 0; i < 8; ++i) {
+        const int row = lane_group * 8 + i;
+        const int old_src_lane = ((row & 1) ? 16 : 0) + lane_col;
+        c12[i] = supersonic_shfl_i32x8_at(acc, row >> 1, old_src_lane);
+    }
+
+    supersonic_i32x8 d12 =
+        __builtin_amdgcn_wmma_i32_16x16x16_iu8_w32_gfx12(true, a12, true, b12, c12, false);
+    supersonic_i32x8 out;
+    #pragma unroll
+    for (int i = 0; i < 8; ++i) {
+        const int old_row = 2 * i + lane_group;
+        const int new_src_lane = ((old_row >= 8) ? 16 : 0) + lane_col;
+        out[i] = supersonic_shfl_i32x8_at(d12, old_row & 7, new_src_lane);
+    }
+    return out;
+#else
+    return __builtin_amdgcn_wmma_i32_16x16x16_iu8_w32(true, a, true, b, acc, false);
+#endif
+}
+#endif
 
 __device__ inline uint16_t f32_to_f16_bits_rne(float x) {
     __half h = __float2half_rn(x);
@@ -3381,10 +3501,10 @@ void supersonic_qwen35_matmul_rhs_transposed_tiled_wmma_kernel(
                 b1[i] = static_cast<short>(s_rhs[b1_row * TILED_WMMA_LDS_STRIDE + k_off + i]);
             }
 
-            acc00 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a0, b0, acc00);
-            acc01 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a0, b1, acc01);
-            acc10 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a1, b0, acc10);
-            acc11 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a1, b1, acc11);
+            acc00 = supersonic_wmma_bf16(a0, b0, acc00);
+            acc01 = supersonic_wmma_bf16(a0, b1, acc01);
+            acc10 = supersonic_wmma_bf16(a1, b0, acc10);
+            acc11 = supersonic_wmma_bf16(a1, b1, acc11);
         }
         __syncthreads();
     }
@@ -3442,10 +3562,10 @@ void supersonic_qwen35_matmul_rhs_transposed_tiled_wmma_kernel(
                 b1[i] = static_cast<short>(s_rhs[b1_row * TILED_WMMA_LDS_STRIDE + k_off + i]);
             }
 
-            acc00 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a0, b0, acc00);
-            acc01 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a0, b1, acc01);
-            acc10 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a1, b0, acc10);
-            acc11 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a1, b1, acc11);
+            acc00 = supersonic_wmma_bf16(a0, b0, acc00);
+            acc01 = supersonic_wmma_bf16(a0, b1, acc01);
+            acc10 = supersonic_wmma_bf16(a1, b0, acc10);
+            acc11 = supersonic_wmma_bf16(a1, b1, acc11);
         }
     }
 
@@ -3539,7 +3659,7 @@ __global__ void supersonic_qwen35_matmul_rhs_transposed_wmma_small_m_kernel(
             #pragma unroll
             for (int i = 0; i < 16; ++i) b[i] = 0;
         }
-        acc = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a, b, acc);
+        acc = supersonic_wmma_bf16(a, b, acc);
     }
 
     if (k_main != k) {
@@ -3559,7 +3679,7 @@ __global__ void supersonic_qwen35_matmul_rhs_transposed_wmma_small_m_kernel(
                 if (kc < k) b[i] = static_cast<short>(rhs_row_u16[kc]);
             }
         }
-        acc = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a, b, acc);
+        acc = supersonic_wmma_bf16(a, b, acc);
     }
 
     const int out_col = tile_col + lane_row;
@@ -3875,10 +3995,10 @@ void supersonic_qwen35_matmul_fp8_dequant_wmma_kernel(
                 b1[i] = static_cast<short>(s_rhs[b1_row * TILED_WMMA_LDS_STRIDE + k_off + i]);
             }
 
-            acc00 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a0, b0, acc00);
-            acc01 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a0, b1, acc01);
-            acc10 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a1, b0, acc10);
-            acc11 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a1, b1, acc11);
+            acc00 = supersonic_wmma_bf16(a0, b0, acc00);
+            acc01 = supersonic_wmma_bf16(a0, b1, acc01);
+            acc10 = supersonic_wmma_bf16(a1, b0, acc10);
+            acc11 = supersonic_wmma_bf16(a1, b1, acc11);
         }
         __syncthreads();
     }
@@ -3943,10 +4063,10 @@ void supersonic_qwen35_matmul_fp8_dequant_wmma_kernel(
                 b1[i] = static_cast<short>(s_rhs[b1_row * TILED_WMMA_LDS_STRIDE + k_off + i]);
             }
 
-            acc00 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a0, b0, acc00);
-            acc01 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a0, b1, acc01);
-            acc10 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a1, b0, acc10);
-            acc11 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a1, b1, acc11);
+            acc00 = supersonic_wmma_bf16(a0, b0, acc00);
+            acc01 = supersonic_wmma_bf16(a0, b1, acc01);
+            acc10 = supersonic_wmma_bf16(a1, b0, acc10);
+            acc11 = supersonic_wmma_bf16(a1, b1, acc11);
         }
     }
 
@@ -4202,7 +4322,7 @@ __global__ void supersonic_qwen35_matmul_int4_dequant_wmma_small_m_kernel(
             for (int i = 0; i < 16; ++i) b[i] = 0;
         }
 
-        acc = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a, b, acc);
+        acc = supersonic_wmma_bf16(a, b, acc);
     }
     if (k_main != k) {
         supersonic_short16 a = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
@@ -4251,7 +4371,7 @@ __global__ void supersonic_qwen35_matmul_int4_dequant_wmma_small_m_kernel(
                 }
             }
         }
-        acc = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a, b, acc);
+        acc = supersonic_wmma_bf16(a, b, acc);
     }
 
     const int out_col = tile_col + lane_row;
@@ -4516,8 +4636,7 @@ __device__ __forceinline__ void supersonic_mmq_i8_wmma_16x4(
     supersonic_i32x8* acc = reinterpret_cast<supersonic_i32x8*>(c);
     const supersonic_i32x4* avec = reinterpret_cast<const supersonic_i32x4*>(a);
     const supersonic_i32x4* bvec = reinterpret_cast<const supersonic_i32x4*>(b);
-    acc[0] = __builtin_amdgcn_wmma_i32_16x16x16_iu8_w32(
-        true, avec[0], true, bvec[0], acc[0], false);
+    acc[0] = supersonic_wmma_i8_iu8(avec[0], bvec[0], acc[0]);
 #else
     (void)c; (void)a; (void)b;
 #endif
@@ -4719,7 +4838,7 @@ void supersonic_qwen35_matmul_ggml_dequant_wmma_small_m_qtype_kernel(
             for (int i = 0; i < 16; ++i) b[i] = 0;
         }
 
-        acc = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a, b, acc);
+        acc = supersonic_wmma_bf16(a, b, acc);
     }
 
     if (k_main != k) {
@@ -4747,7 +4866,7 @@ void supersonic_qwen35_matmul_ggml_dequant_wmma_small_m_qtype_kernel(
                 }
             }
         }
-        acc = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a, b, acc);
+        acc = supersonic_wmma_bf16(a, b, acc);
     }
 
     const int out_col = tile_col + lane_row;
@@ -4827,7 +4946,7 @@ void supersonic_qwen35_matmul_ggml_dequant_wmma_m8_qtype_kernel(
                 b[i] = static_cast<short>(bits[i]);
             }
 
-            acc = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a, b, acc);
+            acc = supersonic_wmma_bf16(a, b, acc);
         }
     }
 
@@ -4899,7 +5018,7 @@ void supersonic_qwen35_matmul_ggml_dequant_wmma_m16_qtype_kernel(
                 b[i] = static_cast<short>(bits[i]);
             }
 
-            acc = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a, b, acc);
+            acc = supersonic_wmma_bf16(a, b, acc);
         }
     }
 
@@ -4982,7 +5101,7 @@ void supersonic_qwen35_matmul_q6_k_m16_tile_argmax_kernel(
                 b[i] = static_cast<short>(bits[i]);
             }
 
-            acc = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a, b, acc);
+            acc = supersonic_wmma_bf16(a, b, acc);
         }
     }
 
@@ -5127,7 +5246,7 @@ void supersonic_qwen35_matmul_ggml_pair_wmma_m16_qtype_kernel(
                 b[i] = static_cast<short>(bits[i]);
             }
 
-            acc = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a, b, acc);
+            acc = supersonic_wmma_bf16(a, b, acc);
         }
     }
 
@@ -5202,7 +5321,7 @@ void supersonic_qwen35_matmul_ggml_pair_swiglu_wmma_m16_qtype_kernel(
             for (int i = 0; i < 16; ++i) {
                 gate_b[i] = static_cast<short>(gate_bits[i]);
             }
-            gate_acc = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a, gate_b, gate_acc);
+            gate_acc = supersonic_wmma_bf16(a, gate_b, gate_acc);
 
             uint16_t up_bits[16];
             ggml_k_dequant_16_bf16_bits_from_block_fixed<QTYPE, TRUNC_DEQUANT>(
@@ -5212,7 +5331,7 @@ void supersonic_qwen35_matmul_ggml_pair_swiglu_wmma_m16_qtype_kernel(
             for (int i = 0; i < 16; ++i) {
                 up_b[i] = static_cast<short>(up_bits[i]);
             }
-            up_acc = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a, up_b, up_acc);
+            up_acc = supersonic_wmma_bf16(a, up_b, up_acc);
         }
     }
 
@@ -5299,7 +5418,7 @@ __global__ void supersonic_qwen35_matmul_ggml_pair_wmma_small_m_kernel(
             for (int i = 0; i < 16; ++i) b[i] = 0;
         }
 
-        acc = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a, b, acc);
+        acc = supersonic_wmma_bf16(a, b, acc);
     }
 
     if (k_main != k) {
@@ -5322,7 +5441,7 @@ __global__ void supersonic_qwen35_matmul_ggml_pair_wmma_small_m_kernel(
                 }
             }
         }
-        acc = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a, b, acc);
+        acc = supersonic_wmma_bf16(a, b, acc);
     }
 
     if (out_col_idx < n_out) {
@@ -5447,7 +5566,7 @@ void supersonic_qwen35_matmul_int4_dequant_wmma_small_m_n64_kernel(
             for (int i = 0; i < 16; ++i) b[i] = 0;
         }
 
-        acc = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a, b, acc);
+        acc = supersonic_wmma_bf16(a, b, acc);
         __syncthreads();
     }
 
@@ -5509,7 +5628,7 @@ void supersonic_qwen35_matmul_int4_dequant_wmma_small_m_n64_kernel(
                 }
             }
         }
-        acc = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a, b, acc);
+        acc = supersonic_wmma_bf16(a, b, acc);
     }
 
     const int out_col = rhs_row_idx;
@@ -5701,10 +5820,10 @@ void supersonic_qwen35_matmul_int4_dequant_wmma_kernel(
                 b1[i] = static_cast<short>(s_rhs[b1_row * TILED_WMMA_LDS_STRIDE + k_off + i]);
             }
 
-            acc00 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a0, b0, acc00);
-            acc01 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a0, b1, acc01);
-            acc10 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a1, b0, acc10);
-            acc11 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a1, b1, acc11);
+            acc00 = supersonic_wmma_bf16(a0, b0, acc00);
+            acc01 = supersonic_wmma_bf16(a0, b1, acc01);
+            acc10 = supersonic_wmma_bf16(a1, b0, acc10);
+            acc11 = supersonic_wmma_bf16(a1, b1, acc11);
         }
         __syncthreads();
     }
@@ -5829,10 +5948,10 @@ void supersonic_qwen35_matmul_int4_dequant_wmma_kernel(
                 b1[i] = static_cast<short>(s_rhs[b1_row * TILED_WMMA_LDS_STRIDE + k_off + i]);
             }
 
-            acc00 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a0, b0, acc00);
-            acc01 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a0, b1, acc01);
-            acc10 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a1, b0, acc10);
-            acc11 = __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a1, b1, acc11);
+            acc00 = supersonic_wmma_bf16(a0, b0, acc00);
+            acc01 = supersonic_wmma_bf16(a0, b1, acc01);
+            acc10 = supersonic_wmma_bf16(a1, b0, acc10);
+            acc11 = supersonic_wmma_bf16(a1, b1, acc11);
         }
     }
 

--- a/kernels/full_attention_bridge_4b.cpp
+++ b/kernels/full_attention_bridge_4b.cpp
@@ -3616,11 +3616,13 @@ int matmul_rhs_transposed_tiled_device(
     return 0;
 }
 
-// Cached per-device arch flag: does this device support RDNA3 WMMA intrinsics?
-// gfx11xx (RDNA3 / RDNA3.5) supports v_wmma_f32_16x16x16_bf16; older arches
-// (gfx10, gfx9, CDNA gfx9xx) do not, and gfx12 uses a different opcode the
-// kernel isn't compiled for yet. Env var SUPERSONIC_QWEN4B_DISABLE_WMMA=1
-// forces the scalar path for debugging / perf comparison.
+// Cached per-device arch flag: does this device support the validated RDNA WMMA
+// path? gfx11xx (RDNA3 / RDNA3.5) supports the original wave32 BF16/i8 layout.
+// gfx12xx (RDNA4) uses the new `_gfx12` operand layout, adapted in
+// full_attention_4b.hip.
+//
+// Env var SUPERSONIC_QWEN4B_DISABLE_WMMA=1 forces the scalar path for debugging
+// / perf comparison.
 //
 // `supersonic-serve` can call this concurrently from multiple request threads,
 // so initialization goes through `std::call_once` — plain non-atomic writes
@@ -3638,8 +3640,12 @@ static bool device_supports_wmma_bf16(int device_ordinal) {
         hipDeviceProp_t props;
         if (hipGetDeviceProperties(&props, ordinal) != hipSuccess) return false;
         const char* arch = props.gcnArchName;
-        return arch && arch[0] == 'g' && arch[1] == 'f' && arch[2] == 'x' &&
-               arch[3] == '1' && arch[4] == '1';
+        if (!arch || arch[0] != 'g' || arch[1] != 'f' || arch[2] != 'x' ||
+            arch[3] != '1') {
+            return false;
+        }
+        if (arch[4] == '1') return true;
+        return arch[4] == '2';
     };
 
     if (device_ordinal < 0 || device_ordinal >= 16) {
@@ -3657,11 +3663,29 @@ static bool device_supports_wmma_bf16(int device_ordinal) {
 }
 
 static bool device_supports_wmma_i8(int device_ordinal) {
-    // Keep i8 WMMA aligned with the same runtime gfx11 arch probe used by the
-    // BF16 WMMA paths. Host-side `__gfx1100__` style macros are not a reliable
-    // guard for this bridge function even when the HIP device code is built for
-    // gfx1100.
-    return device_supports_wmma_bf16(device_ordinal);
+    // gfx12 i8 WMMA drops the gfx11 operand replication and uses a narrower
+    // packed A/B operand. The device code adapts the existing four-word packed
+    // fragments to the gfx12 two-word form.
+    if (!device_supports_wmma_bf16(device_ordinal)) return false;
+
+    auto probe_arch = [](int ordinal) -> bool {
+        hipDeviceProp_t props;
+        if (hipGetDeviceProperties(&props, ordinal) != hipSuccess) return false;
+        const char* arch = props.gcnArchName;
+        return arch && arch[0] == 'g' && arch[1] == 'f' && arch[2] == 'x' &&
+               arch[3] == '1' && (arch[4] == '1' || arch[4] == '2');
+    };
+
+    if (device_ordinal < 0 || device_ordinal >= 16) {
+        return probe_arch(device_ordinal);
+    }
+
+    static std::once_flag device_once[16];
+    static bool cached[16] = {false};
+    std::call_once(device_once[device_ordinal], [&] {
+        cached[device_ordinal] = probe_arch(device_ordinal);
+    });
+    return cached[device_ordinal];
 }
 
 static int matmul_rhs_transposed_tiled_wmma_bf16_device(

--- a/tests/gfx1100/bench_qwen36_he_supersonic.py
+++ b/tests/gfx1100/bench_qwen36_he_supersonic.py
@@ -206,6 +206,9 @@ def run_one(args: argparse.Namespace, name: str, prompt: str, warmup: bool = Fal
     ]
     if args.prompt_no_special_tokens:
         cmd.append("--prompt-no-special-tokens")
+    allow_untested_gpu = getattr(args, "allow_untested_gpu", None)
+    if allow_untested_gpu:
+        cmd.extend(["--allow-untested-gpu", allow_untested_gpu])
     if args.quant != "none":
         cmd.append(f"--{args.quant}")
     if args.ignore_eos:
@@ -341,6 +344,14 @@ def main() -> int:
     )
     parser.add_argument("--emit-stage-timings", action="store_true")
     parser.add_argument("--kv-fp8", action="store_true")
+    parser.add_argument(
+        "--allow-untested-gpu",
+        default=None,
+        help=(
+            "Forward SuperSonic's --allow-untested-gpu override, e.g. reuse "
+            "gfx1100 registry policy on a newly detected HIP arch."
+        ),
+    )
     parser.add_argument("--dflash", action="store_true")
     parser.add_argument(
         "--dflash-draft-variant",
@@ -428,6 +439,7 @@ def main() -> int:
         "dflash_draft_gguf": str(dflash_draft_gguf) if args.dflash and dflash_draft_gguf else None,
         "dflash_block": args.dflash_block if args.dflash_block else None,
         "backend": args.backend,
+        "allow_untested_gpu": args.allow_untested_gpu,
         "context_size": args.context_size,
         "n_gen": args.n_gen,
         "eos_policy": "ignore" if args.ignore_eos else "stop",

--- a/tests/gfx1201/run_matrix.sh
+++ b/tests/gfx1201/run_matrix.sh
@@ -27,6 +27,7 @@ LUCEBOX_N_GEN="${LUCEBOX_N_GEN:-16}"
 LUCEBOX_WARMUP_NEW_TOKENS="${LUCEBOX_WARMUP_NEW_TOKENS:-4}"
 LUCEBOX_LIMIT="${LUCEBOX_LIMIT:-1}"
 LUCEBOX_OUT_JSON="${LUCEBOX_OUT_JSON:-$REPO_ROOT/target/qwen36_he_supersonic_gfx1201_smoke.json}"
+LUCEBOX_HE_JSONL="${LUCEBOX_HE_JSONL:-/home/deano/projects/lucebox-hub/harness/benchmarks/prompts/bench_he.jsonl}"
 LUCEBOX_DRAFT_DIR="${LUCEBOX_DRAFT_DIR:-/mnt/data/tmp/qwen36-27b-dflash-q8-bf16}"
 LUCEBOX_Q8_DRAFT_GGUF="${LUCEBOX_Q8_DRAFT_GGUF:-/mnt/data/lucebox-hub/models/draft/dflash-draft-3.6-q8_0.gguf}"
 
@@ -78,6 +79,7 @@ echo ""
 
 lucebox_available=0
 if [ -f "$QWEN36_27B_MODEL_DIR/config.json" ] && \
+   [ -f "$LUCEBOX_HE_JSONL" ] && \
    [ -d "$LUCEBOX_DRAFT_DIR" ] && \
    [ -f "$LUCEBOX_Q8_DRAFT_GGUF" ]; then
     lucebox_available=1
@@ -107,6 +109,7 @@ if [ "$run_lucebox" = "1" ]; then
     if [ "$lucebox_available" != "1" ]; then
         echo "ERROR: Lucebox artifacts are missing:" >&2
         echo "  QWEN36_27B_MODEL_DIR=$QWEN36_27B_MODEL_DIR" >&2
+        echo "  LUCEBOX_HE_JSONL=$LUCEBOX_HE_JSONL" >&2
         echo "  LUCEBOX_DRAFT_DIR=$LUCEBOX_DRAFT_DIR" >&2
         echo "  LUCEBOX_Q8_DRAFT_GGUF=$LUCEBOX_Q8_DRAFT_GGUF" >&2
         exit 1
@@ -117,6 +120,9 @@ if [ "$run_lucebox" = "1" ]; then
         --target-profile qwen36-27b-lucebox \
         --model-dir "$QWEN36_27B_MODEL_DIR" \
         --backend hip \
+        --prompt-source jsonl \
+        --prompt-format chatml-no-thinking \
+        --lucebox-jsonl "$LUCEBOX_HE_JSONL" \
         --dflash \
         --dflash-draft-dir "$LUCEBOX_DRAFT_DIR" \
         --dflash-draft-gguf "$LUCEBOX_Q8_DRAFT_GGUF" \

--- a/tests/gfx1201/run_matrix.sh
+++ b/tests/gfx1201/run_matrix.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+#
+# Starter smoke matrix for HIP gfx1201 (RDNA 4 / Radeon AI PRO R9700).
+#
+# This is intentionally narrower than tests/gfx1100/run_matrix.sh while the
+# target is in bring-up: kernel-level RDNA4 WMMA coverage first, then the
+# Qwen3.6 27B Q4KM-GPTQ/Lucebox lane that motivated the new target. Broader
+# Qwen3.5 matrix promotion should add explicit token/parity checks here.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+INT4_TEST="$REPO_ROOT/target/release/int4_test"
+SUPERSONIC="$REPO_ROOT/target/release/supersonic"
+
+HIP_ARCH="${HIP_ARCH:-gfx1100,gfx1201}"
+BUILD="${BUILD:-1}"
+TIMEOUT="${TIMEOUT:-900}"
+PROMPT="${PROMPT:-The quick brown fox}"
+QWEN36_27B_MODEL_DIR="${QWEN36_27B_MODEL_DIR:-${SUPERSONIC_MODEL_DIR_QWEN36_27B:-/mnt/data/tmp/supersonic-qwen36-27b-lucebox}}"
+QWEN36_CONTEXT="${QWEN36_CONTEXT:-512}"
+QWEN36_DENSE_TOKENS="${QWEN36_DENSE_TOKENS:-2}"
+
+RUN_LUCEBOX="${RUN_LUCEBOX:-auto}"
+LUCEBOX_N_GEN="${LUCEBOX_N_GEN:-16}"
+LUCEBOX_WARMUP_NEW_TOKENS="${LUCEBOX_WARMUP_NEW_TOKENS:-4}"
+LUCEBOX_LIMIT="${LUCEBOX_LIMIT:-1}"
+LUCEBOX_OUT_JSON="${LUCEBOX_OUT_JSON:-$REPO_ROOT/target/qwen36_he_supersonic_gfx1201_smoke.json}"
+LUCEBOX_DRAFT_DIR="${LUCEBOX_DRAFT_DIR:-/mnt/data/tmp/qwen36-27b-dflash-q8-bf16}"
+LUCEBOX_Q8_DRAFT_GGUF="${LUCEBOX_Q8_DRAFT_GGUF:-/mnt/data/lucebox-hub/models/draft/dflash-draft-3.6-q8_0.gguf}"
+
+echo "=== SuperSonic gfx1201 starter matrix (RDNA 4 / R9700) ==="
+echo "HIP_ARCH: ${HIP_ARCH}"
+if [ -n "${HIP_VISIBLE_DEVICES:-}" ]; then
+    echo "HIP_VISIBLE_DEVICES: ${HIP_VISIBLE_DEVICES}"
+fi
+echo ""
+
+if [ "$BUILD" != "0" ]; then
+    echo "--- Build dual-arch HIP binaries ---"
+    env SUPERSONIC_BACKENDS=hip HIP_ARCH="$HIP_ARCH" \
+        cargo build --release --bin int4_test --bin supersonic
+    echo ""
+fi
+
+if [ ! -x "$INT4_TEST" ]; then
+    echo "ERROR: $INT4_TEST not found. Run with BUILD=1 or build int4_test first." >&2
+    exit 1
+fi
+if [ ! -x "$SUPERSONIC" ]; then
+    echo "ERROR: $SUPERSONIC not found. Run with BUILD=1 or build supersonic first." >&2
+    exit 1
+fi
+
+echo "--- RDNA4 WMMA / INT4 kernel harness ---"
+timeout "$TIMEOUT" env SUPERSONIC_BACKENDS=hip "$INT4_TEST"
+echo ""
+
+echo "--- Qwen3.6 27B Q4KM-GPTQ direct smoke ---"
+if [ -f "$QWEN36_27B_MODEL_DIR/config.json" ]; then
+    timeout "$TIMEOUT" env SUPERSONIC_BACKENDS=hip "$SUPERSONIC" \
+        --backend hip \
+        --model qwen3.6-27b \
+        --model-dir "$QWEN36_27B_MODEL_DIR" \
+        --prompt "$PROMPT" \
+        --context-size "$QWEN36_CONTEXT" \
+        --max-new-tokens "$QWEN36_DENSE_TOKENS" \
+        --temperature 0 \
+        --top-k 1 \
+        --sampling-seed 20260620 \
+        --q4km-gptq \
+        --no-download
+else
+    echo "SKIP: QWEN36_27B_MODEL_DIR missing config.json: $QWEN36_27B_MODEL_DIR"
+fi
+echo ""
+
+lucebox_available=0
+if [ -f "$QWEN36_27B_MODEL_DIR/config.json" ] && \
+   [ -d "$LUCEBOX_DRAFT_DIR" ] && \
+   [ -f "$LUCEBOX_Q8_DRAFT_GGUF" ]; then
+    lucebox_available=1
+fi
+
+case "$RUN_LUCEBOX" in
+    auto)
+        run_lucebox="$lucebox_available"
+        require_lucebox=0
+        ;;
+    1|true|TRUE|yes|YES)
+        run_lucebox=1
+        require_lucebox=1
+        ;;
+    0|false|FALSE|no|NO)
+        run_lucebox=0
+        require_lucebox=0
+        ;;
+    *)
+        echo "ERROR: RUN_LUCEBOX must be auto, 1, or 0 (got '$RUN_LUCEBOX')" >&2
+        exit 1
+        ;;
+esac
+
+echo "--- Qwen3.6 27B Lucebox/DFlash smoke ---"
+if [ "$run_lucebox" = "1" ]; then
+    if [ "$lucebox_available" != "1" ]; then
+        echo "ERROR: Lucebox artifacts are missing:" >&2
+        echo "  QWEN36_27B_MODEL_DIR=$QWEN36_27B_MODEL_DIR" >&2
+        echo "  LUCEBOX_DRAFT_DIR=$LUCEBOX_DRAFT_DIR" >&2
+        echo "  LUCEBOX_Q8_DRAFT_GGUF=$LUCEBOX_Q8_DRAFT_GGUF" >&2
+        exit 1
+    fi
+    timeout "$TIMEOUT" env SUPERSONIC_BACKENDS=hip python3 \
+        "$REPO_ROOT/tests/gfx1100/bench_qwen36_he_supersonic.py" \
+        --binary "$SUPERSONIC" \
+        --target-profile qwen36-27b-lucebox \
+        --model-dir "$QWEN36_27B_MODEL_DIR" \
+        --backend hip \
+        --dflash \
+        --dflash-draft-dir "$LUCEBOX_DRAFT_DIR" \
+        --dflash-draft-gguf "$LUCEBOX_Q8_DRAFT_GGUF" \
+        --n-gen "$LUCEBOX_N_GEN" \
+        --warmup-new-tokens "$LUCEBOX_WARMUP_NEW_TOKENS" \
+        --limit "$LUCEBOX_LIMIT" \
+        --no-warmup \
+        --out-json "$LUCEBOX_OUT_JSON"
+else
+    if [ "$require_lucebox" = "1" ]; then
+        exit 1
+    fi
+    echo "SKIP: Lucebox artifacts not available or RUN_LUCEBOX=0"
+fi
+
+echo ""
+echo "gfx1201 starter matrix complete"


### PR DESCRIPTION
## Summary

- Add `gfx1201` as a first-class HIP/RDNA4 registry architecture and wire the RDNA4 WMMA BF16/i8 adapter path for Qwen low-bit matmuls.
- Add machine-profile gfx12 WMMA probes and default runtime WMMA support for `gfx1201`.
- Add the starter support/test matrix for Radeon AI PRO R9700: docs rows, `bench-perf --arch gfx1201` starter combo, and `tests/gfx1201/run_matrix.sh`.

## Impact

This gives the new RDNA4 R9700 lane a real PR-visible target instead of relying on `--allow-untested-gpu` or one-off shell commands. Qwen3.6 27B Q4KM-GPTQ/DFlash is marked validated for `gfx1201`; the wider Qwen3.5 rows are registered but left TBM until the new matrix script grows per-model token/parity checks.

## Validation

- `cargo fmt --check`
- `cargo test -p supersonic-core registry --lib`
- `cargo test -p supersonic-bench --test registry_filter`
- `cargo test -p runner --test bench_combo_parity`
- `python3 -m unittest tests.test_qwen36_he_supersonic_bench`
- `HIP_VISIBLE_DEVICES=1 BUILD=0 RUN_LUCEBOX=1 tests/gfx1201/run_matrix.sh`

R9700 smoke result: RDNA4 kernel harness clean, direct `qwen3.6-27b --q4km-gptq` smoke with zero decode/oracle delta, and Lucebox/DFlash starter smoke at 20.94 tok/s for 16 generated tokens.