### PR TITLE
[codex] Optimize RDNA4 Lucebox Qwen draft path

### DIFF
--- a/crates/kernel-ffi/build.rs
+++ b/crates/kernel-ffi/build.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -35,11 +36,18 @@ fn detect_hip_archs() -> Vec<String> {
         return Vec::new();
     }
     let stdout = String::from_utf8_lossy(&output.stdout);
-    stdout
+    let archs: BTreeSet<String> = stdout
         .split_whitespace()
-        .find(|token| token.starts_with("gfx"))
-        .map(|s| vec![s.to_owned()])
-        .unwrap_or_default()
+        .filter_map(|token| {
+            let token = token.trim_matches(|c: char| !c.is_ascii_alphanumeric());
+            let suffix = token.strip_prefix("gfx")?;
+            if suffix.is_empty() || !suffix.chars().all(|c| c.is_ascii_hexdigit()) {
+                return None;
+            }
+            Some(token.to_owned())
+        })
+        .collect();
+    archs.into_iter().collect()
 }
 
 fn detect_cuda_archs() -> Vec<String> {

--- a/crates/kernel-ffi/src/prefill_ffi.rs
+++ b/crates/kernel-ffi/src/prefill_ffi.rs
@@ -3192,36 +3192,40 @@ pub fn delta_recurrent_prefill_capture_q8_trace_attn(
     {
         return Ok(false);
     }
-    ffi_profile_time_result(
-        "qwen.delta_recurrent_prefill_capture_q8_trace_attn",
-        ordinal,
-        || {
-            let status = unsafe {
-                supersonic_qwen35_hip_delta_recurrent_prefill_capture_q8_trace_attn(
-                    dtype.kernel_dtype_code(),
-                    ordinal,
-                    batch_heads,
-                    seq_len,
-                    k_head_dim,
-                    v_head_dim,
-                    recurrent_state.as_mut_ptr(),
-                    query.as_ptr(),
-                    key.as_ptr(),
-                    value.as_ptr(),
-                    beta.as_ptr(),
-                    g.as_ptr(),
-                    attn_output.as_mut_ptr(),
-                    state_trace.as_mut_ptr(),
-                )
-            };
-            if status != 0 {
-                return Err(ffi_error(format!(
-                    "delta_recurrent_prefill_capture_q8_trace_attn failed: {status}"
-                )));
-            }
-            Ok(())
-        },
-    )?;
+    let profile_key = if std::env::var_os("SUPERSONIC_DFLASH_PROFILE_FFI_SHAPES").is_some() {
+        format!(
+            "qwen.delta_recurrent_prefill_capture_q8_trace_attn[bh={} s={} k={} v={}]",
+            batch_heads, seq_len, k_head_dim, v_head_dim
+        )
+    } else {
+        "qwen.delta_recurrent_prefill_capture_q8_trace_attn".to_string()
+    };
+    ffi_profile_time_result_key(profile_key, ordinal, || {
+        let status = unsafe {
+            supersonic_qwen35_hip_delta_recurrent_prefill_capture_q8_trace_attn(
+                dtype.kernel_dtype_code(),
+                ordinal,
+                batch_heads,
+                seq_len,
+                k_head_dim,
+                v_head_dim,
+                recurrent_state.as_mut_ptr(),
+                query.as_ptr(),
+                key.as_ptr(),
+                value.as_ptr(),
+                beta.as_ptr(),
+                g.as_ptr(),
+                attn_output.as_mut_ptr(),
+                state_trace.as_mut_ptr(),
+            )
+        };
+        if status != 0 {
+            return Err(ffi_error(format!(
+                "delta_recurrent_prefill_capture_q8_trace_attn failed: {status}"
+            )));
+        }
+        Ok(())
+    })?;
     Ok(true)
 }
 
@@ -5076,7 +5080,15 @@ pub fn rms_norm_rows(
             metal_host::rms_norm_rows(dtype, n_rows, n_cols, eps, true, input, weight, out)
         });
     }
-    ffi_profile_time_result("qwen.rms_norm_rows", ordinal, || {
+    let profile_key = if std::env::var_os("SUPERSONIC_DFLASH_PROFILE_FFI_SHAPES").is_some() {
+        format!(
+            "qwen.rms_norm_rows[rows={} cols={} dtype={:?}]",
+            n_rows, n_cols, dtype
+        )
+    } else {
+        "qwen.rms_norm_rows".to_string()
+    };
+    ffi_profile_time_result_key(profile_key, ordinal, || {
         let status = unsafe {
             supersonic_qwen35_hip_rms_norm(
                 dtype.kernel_dtype_code(),
@@ -5138,7 +5150,15 @@ pub fn rms_norm_rows_plain(
             metal_host::rms_norm_rows(dtype, n_rows, n_cols, eps, false, input, weight, out)
         });
     }
-    ffi_profile_time_result("qwen.rms_norm_rows_plain", ordinal, || {
+    let profile_key = if std::env::var_os("SUPERSONIC_DFLASH_PROFILE_FFI_SHAPES").is_some() {
+        format!(
+            "qwen.rms_norm_rows_plain[rows={} cols={} dtype={:?}]",
+            n_rows, n_cols, dtype
+        )
+    } else {
+        "qwen.rms_norm_rows_plain".to_string()
+    };
+    ffi_profile_time_result_key(profile_key, ordinal, || {
         let status = unsafe {
             supersonic_qwen35_hip_rms_norm(
                 dtype.kernel_dtype_code(),
@@ -5201,26 +5221,36 @@ pub fn rms_norm_rows_plain_inplace(
             metal_host::rms_norm_rows(dtype, n_rows, n_cols, eps, false, &input, weight, data)
         });
     }
-    let ptr = data.as_mut_ptr();
-    let status = unsafe {
-        supersonic_qwen35_hip_rms_norm(
-            dtype.kernel_dtype_code(),
-            ordinal,
-            n_rows,
-            n_cols,
-            eps,
-            0,
-            ptr,
-            weight.as_ptr(),
-            ptr,
+    let profile_key = if std::env::var_os("SUPERSONIC_DFLASH_PROFILE_FFI_SHAPES").is_some() {
+        format!(
+            "qwen.rms_norm_rows_plain_inplace[rows={} cols={} dtype={:?}]",
+            n_rows, n_cols, dtype
         )
+    } else {
+        "qwen.rms_norm_rows_plain_inplace".to_string()
     };
-    if status != 0 {
-        return Err(ffi_error(format!(
-            "rms_norm_rows_plain_inplace failed: {status}"
-        )));
-    }
-    Ok(())
+    ffi_profile_time_result_key(profile_key, ordinal, || {
+        let ptr = data.as_mut_ptr();
+        let status = unsafe {
+            supersonic_qwen35_hip_rms_norm(
+                dtype.kernel_dtype_code(),
+                ordinal,
+                n_rows,
+                n_cols,
+                eps,
+                0,
+                ptr,
+                weight.as_ptr(),
+                ptr,
+            )
+        };
+        if status != 0 {
+            return Err(ffi_error(format!(
+                "rms_norm_rows_plain_inplace failed: {status}"
+            )));
+        }
+        Ok(())
+    })
 }
 
 /// In-place `lhs += rhs`. Aliasing lhs and out in the underlying kernel is

--- a/crates/runner/src/bin/int4_test.rs
+++ b/crates/runner/src/bin/int4_test.rs
@@ -18,6 +18,21 @@ fn f32_to_bf16_bytes(vals: &[f32]) -> Vec<u8> {
     out
 }
 
+fn f32_to_le_bytes(vals: &[f32]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(vals.len() * 4);
+    for &v in vals {
+        out.extend_from_slice(&v.to_le_bytes());
+    }
+    out
+}
+
+fn f32_bytes_to_f32(bytes: &[u8]) -> Vec<f32> {
+    bytes
+        .chunks_exact(4)
+        .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+        .collect()
+}
+
 fn bf16_bytes_to_f32(bytes: &[u8]) -> Vec<f32> {
     bytes
         .chunks_exact(2)
@@ -448,6 +463,199 @@ fn make_bench_lhs(m: usize, k: usize) -> Vec<f32> {
     lhs
 }
 
+fn make_bench_rhs(n: usize, k: usize) -> Vec<f32> {
+    let mut rhs = vec![0f32; n * k];
+    for ni in 0..n {
+        for ki in 0..k {
+            let x = (ni as f32 + 3.0) * 0.013 + (ki as f32) * 0.0021;
+            rhs[ni * k + ki] = bf16_round(x.cos() * 0.5);
+        }
+    }
+    rhs
+}
+
+fn make_recurrent_state(batch_heads: usize, k: usize, v: usize) -> Vec<f32> {
+    let mut data = vec![0f32; batch_heads * k * v];
+    for bh in 0..batch_heads {
+        for ki in 0..k {
+            for vi in 0..v {
+                let x = (bh as f32 + 1.0) * 0.0031
+                    + (ki as f32) * 0.0013
+                    + (vi as f32) * 0.0007;
+                data[(bh * k + ki) * v + vi] = x.sin() * 0.015;
+            }
+        }
+    }
+    data
+}
+
+fn make_recurrent_tokens(batch_heads: usize, seq_len: usize, dim: usize, seed: f32) -> Vec<f32> {
+    let mut data = vec![0f32; batch_heads * seq_len * dim];
+    for bh in 0..batch_heads {
+        for t in 0..seq_len {
+            for d in 0..dim {
+                let x = seed
+                    + (bh as f32 + 1.0) * 0.007
+                    + (t as f32 + 1.0) * 0.011
+                    + (d as f32) * 0.0019;
+                data[(bh * seq_len + t) * dim + d] = x.cos() * 0.04;
+            }
+        }
+    }
+    data
+}
+
+fn make_recurrent_scalars(batch_heads: usize, seq_len: usize, seed: f32) -> Vec<f32> {
+    let mut data = vec![0f32; batch_heads * seq_len];
+    for bh in 0..batch_heads {
+        for t in 0..seq_len {
+            let x = seed + (bh as f32) * 0.013 + (t as f32) * 0.017;
+            data[bh * seq_len + t] = 0.45 + x.sin() * 0.05;
+        }
+    }
+    data
+}
+
+fn make_recurrent_decay(batch_heads: usize, seq_len: usize) -> Vec<f32> {
+    let mut data = vec![0f32; batch_heads * seq_len];
+    for bh in 0..batch_heads {
+        for t in 0..seq_len {
+            let x = (bh as f32) * 0.003 + (t as f32) * 0.019;
+            data[bh * seq_len + t] = -0.015 - x.sin().abs() * 0.01;
+        }
+    }
+    data
+}
+
+fn wave_sum32_lane0(vals: &[f32; 32]) -> f32 {
+    let mut tmp = *vals;
+    for offset in [16usize, 8, 4, 2, 1] {
+        let prev = tmp;
+        for lane in 0..(32 - offset) {
+            tmp[lane] = prev[lane] + prev[lane + offset];
+        }
+    }
+    tmp[0]
+}
+
+struct RecurrentRef {
+    state: Vec<f32>,
+    attn_bytes: Vec<u8>,
+    trace_bytes: Vec<u8>,
+}
+
+fn recurrent_attn_hot_reference(
+    batch_heads: usize,
+    seq_len: usize,
+    state_host: &[f32],
+    query: &[f32],
+    key: &[f32],
+    value: &[f32],
+    beta: &[f32],
+    g: &[f32],
+) -> RecurrentRef {
+    const K: usize = 128;
+    const V: usize = 128;
+    const QK8_0: usize = 32;
+    const Q8_0_BLOCK_BYTES: usize = 34;
+    let mut state = state_host.to_vec();
+    let mut attn_bytes = vec![0u8; batch_heads * seq_len * V * 2];
+    let mut trace_bytes = vec![0u8; batch_heads * seq_len * V * (K / QK8_0) * Q8_0_BLOCK_BYTES];
+
+    for bh in 0..batch_heads {
+        for v_idx in 0..V {
+            for t in 0..seq_len {
+                let key_row = (bh * seq_len + t) * K;
+                let value_row = (bh * seq_len + t) * V;
+                let beta_row = bh * seq_len + t;
+                let g_t = g[beta_row].exp();
+                let beta_t = beta[beta_row];
+
+                let mut kv = [0.0f32; 4];
+                for block in 0..4 {
+                    let mut vals = [0.0f32; 32];
+                    for lane in 0..QK8_0 {
+                        let k_idx = block * QK8_0 + lane;
+                        let state_idx = (bh * K + k_idx) * V + v_idx;
+                        state[state_idx] *= g_t;
+                        vals[lane] = state[state_idx] * key[key_row + k_idx];
+                    }
+                    kv[block] = wave_sum32_lane0(&vals);
+                }
+
+                let kv_mem = (kv[0] + kv[2]) + (kv[1] + kv[3]);
+                let delta = (value[value_row + v_idx] - kv_mem) * beta_t;
+
+                for k_idx in 0..K {
+                    let state_idx = (bh * K + k_idx) * V + v_idx;
+                    state[state_idx] += key[key_row + k_idx] * delta;
+                }
+
+                let trace_row = (bh * seq_len + t) * V + v_idx;
+                for block in 0..4 {
+                    let mut amax = 0.0f32;
+                    for lane in 0..QK8_0 {
+                        let k_idx = block * QK8_0 + lane;
+                        let state_idx = (bh * K + k_idx) * V + v_idx;
+                        amax = amax.max(state[state_idx].abs());
+                    }
+                    let d = amax / 127.0;
+                    let id = if d == 0.0 { 0.0 } else { 1.0 / d };
+                    let row_base = (trace_row * 4 + block) * Q8_0_BLOCK_BYTES;
+                    trace_bytes[row_base..row_base + 2]
+                        .copy_from_slice(&f16::from_f32(d).to_bits().to_le_bytes());
+                    for lane in 0..QK8_0 {
+                        let k_idx = block * QK8_0 + lane;
+                        let state_idx = (bh * K + k_idx) * V + v_idx;
+                        let q = (state[state_idx] * id).round() as i8;
+                        trace_bytes[row_base + 2 + lane] = q as u8;
+                    }
+                }
+
+                let mut out = [0.0f32; 4];
+                for block in 0..4 {
+                    let mut vals = [0.0f32; 32];
+                    for lane in 0..QK8_0 {
+                        let k_idx = block * QK8_0 + lane;
+                        let state_idx = (bh * K + k_idx) * V + v_idx;
+                        vals[lane] = state[state_idx] * query[key_row + k_idx];
+                    }
+                    out[block] = wave_sum32_lane0(&vals);
+                }
+                let attn = bf16::from_f32((out[0] + out[2]) + (out[1] + out[3])).to_bits();
+                let attn_idx = ((bh * seq_len + t) * V + v_idx) * 2;
+                attn_bytes[attn_idx..attn_idx + 2].copy_from_slice(&attn.to_le_bytes());
+            }
+        }
+    }
+
+    RecurrentRef {
+        state,
+        attn_bytes,
+        trace_bytes,
+    }
+}
+
+fn reference_bf16_rhs_transposed(
+    m: usize,
+    n: usize,
+    k: usize,
+    lhs: &[f32],
+    rhs: &[f32],
+) -> Vec<f32> {
+    let mut out = vec![0f32; m * n];
+    for mi in 0..m {
+        for ni in 0..n {
+            let mut acc = 0f32;
+            for ki in 0..k {
+                acc += lhs[mi * k + ki] * rhs[ni * k + ki];
+            }
+            out[mi * n + ni] = bf16_round(acc);
+        }
+    }
+    out
+}
+
 fn expected_q8_1_group(vals: &[f32]) -> (f32, f32, Vec<i8>) {
     let amax = vals
         .iter()
@@ -634,6 +842,22 @@ fn run_mmq_q8_quant_case(ordinal: usize, name: &str, qtype: i32) -> Result<()> {
     Ok(())
 }
 
+fn bench_warmup_iters() -> usize {
+    std::env::var("SUPERSONIC_INT4_TEST_BENCH_WARMUP_ITERS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(2048)
+        .max(1)
+}
+
+fn bench_env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(default)
+        .max(1)
+}
+
 fn bench_ggml_hot_shape(
     ordinal: usize,
     name: &str,
@@ -664,7 +888,7 @@ fn bench_ggml_hot_shape(
     let mut out_gpu = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[m, n])
         .map_err(|e| anyhow!("out alloc: {e}"))?;
 
-    for _ in 0..3 {
+    for _ in 0..bench_warmup_iters() {
         prefill_ffi::matmul_rhs_transposed_int4(
             ordinal,
             1,
@@ -704,6 +928,360 @@ fn bench_ggml_hot_shape(
         )
         .map_err(|e| anyhow!("bench ggml matmul: {e}"))?;
         gpu_hal::sync(ordinal).map_err(|e| anyhow!("bench sync: {e}"))?;
+        samples.push(start.elapsed().as_secs_f64() * 1000.0);
+    }
+
+    samples.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let mean = samples.iter().sum::<f64>() / samples.len() as f64;
+    let p50 = samples[samples.len() / 2];
+    let p90 = samples[((samples.len() * 9) / 10).min(samples.len() - 1)];
+    println!("  mean_ms={mean:.4} p50_ms={p50:.4} p90_ms={p90:.4}");
+    Ok(())
+}
+
+fn bench_ggml_residual_hot_shape(
+    ordinal: usize,
+    name: &str,
+    qtype: i32,
+    row_fn: fn(usize) -> (Vec<u8>, Vec<f32>),
+    m: usize,
+    n: usize,
+    k: usize,
+    iterations: usize,
+) -> Result<()> {
+    let row_bytes = ggml_row_bytes_for(qtype, k)?;
+    println!(
+        "=== bench {name} residual m16: m={m} n={n} k={k} row_bytes={row_bytes} iters={iterations} ==="
+    );
+
+    let lhs = make_bench_lhs(m, k);
+    let rhs = make_ggml_k_slab(n, k, qtype, row_fn)?;
+    let residual = make_bench_lhs(m, n);
+    let lhs_gpu =
+        GpuBuffer::from_host_bytes(ordinal, ScalarType::BF16, &[m, k], &f32_to_bf16_bytes(&lhs))
+            .map_err(|e| anyhow!("lhs upload: {e}"))?;
+    let rhs_gpu = GpuBuffer::from_host_bytes(ordinal, ScalarType::U8, &[n, row_bytes], &rhs)
+        .map_err(|e| anyhow!("rhs upload: {e}"))?;
+    let residual_gpu = GpuBuffer::from_host_bytes(
+        ordinal,
+        ScalarType::BF16,
+        &[m, n],
+        &f32_to_bf16_bytes(&residual),
+    )
+    .map_err(|e| anyhow!("residual upload: {e}"))?;
+    let dummy_gpu = GpuBuffer::from_host_bytes(
+        ordinal,
+        ScalarType::BF16,
+        &[1, 1],
+        &f32_to_bf16_bytes(&[0.0]),
+    )
+    .map_err(|e| anyhow!("dummy upload: {e}"))?;
+    let mut proj_gpu = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[m, n])
+        .map_err(|e| anyhow!("proj alloc: {e}"))?;
+    let mut ref_gpu = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[m, n])
+        .map_err(|e| anyhow!("ref alloc: {e}"))?;
+    let mut fused_gpu = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[m, n])
+        .map_err(|e| anyhow!("fused alloc: {e}"))?;
+
+    for _ in 0..bench_warmup_iters() {
+        prefill_ffi::matmul_rhs_transposed_int4(
+            ordinal,
+            1,
+            m,
+            n,
+            k,
+            &lhs_gpu,
+            &rhs_gpu,
+            &dummy_gpu,
+            &dummy_gpu,
+            None,
+            128,
+            qtype,
+            &mut proj_gpu,
+        )
+        .map_err(|e| anyhow!("warmup residual ref matmul: {e}"))?;
+        prefill_ffi::element_add(
+            ordinal,
+            ScalarType::BF16,
+            m * n,
+            &residual_gpu,
+            &proj_gpu,
+            &mut ref_gpu,
+        )
+        .map_err(|e| anyhow!("warmup residual ref add: {e}"))?;
+        let handled = prefill_ffi::matmul_rhs_transposed_int4_residual_add(
+            ordinal,
+            1,
+            m,
+            n,
+            k,
+            &lhs_gpu,
+            &rhs_gpu,
+            &dummy_gpu,
+            &dummy_gpu,
+            None,
+            128,
+            qtype,
+            &residual_gpu,
+            &mut fused_gpu,
+        )
+        .map_err(|e| anyhow!("warmup residual fused matmul: {e}"))?;
+        if !handled {
+            return Err(anyhow!("{name} residual fused path unsupported"));
+        }
+    }
+    gpu_hal::sync(ordinal).map_err(|e| anyhow!("warmup sync: {e}"))?;
+
+    prefill_ffi::matmul_rhs_transposed_int4(
+        ordinal,
+        1,
+        m,
+        n,
+        k,
+        &lhs_gpu,
+        &rhs_gpu,
+        &dummy_gpu,
+        &dummy_gpu,
+        None,
+        128,
+        qtype,
+        &mut proj_gpu,
+    )
+    .map_err(|e| anyhow!("parity residual ref matmul: {e}"))?;
+    prefill_ffi::element_add(
+        ordinal,
+        ScalarType::BF16,
+        m * n,
+        &residual_gpu,
+        &proj_gpu,
+        &mut ref_gpu,
+    )
+    .map_err(|e| anyhow!("parity residual ref add: {e}"))?;
+    prefill_ffi::matmul_rhs_transposed_int4_residual_add(
+        ordinal,
+        1,
+        m,
+        n,
+        k,
+        &lhs_gpu,
+        &rhs_gpu,
+        &dummy_gpu,
+        &dummy_gpu,
+        None,
+        128,
+        qtype,
+        &residual_gpu,
+        &mut fused_gpu,
+    )
+    .map_err(|e| anyhow!("parity residual fused matmul: {e}"))?;
+    gpu_hal::sync(ordinal).map_err(|e| anyhow!("residual parity sync: {e}"))?;
+
+    let ref_bytes = ref_gpu
+        .to_host_bytes()
+        .map_err(|e| anyhow!("residual ref d2h: {e}"))?;
+    let fused_bytes = fused_gpu
+        .to_host_bytes()
+        .map_err(|e| anyhow!("residual fused d2h: {e}"))?;
+    let ref_host = bf16_bytes_to_f32(&ref_bytes);
+    let fused_host = bf16_bytes_to_f32(&fused_bytes);
+    let mut byte_mismatch = 0usize;
+    let mut max_abs = 0f32;
+    for idx in 0..m * n {
+        max_abs = max_abs.max((ref_host[idx] - fused_host[idx]).abs());
+        if ref_bytes[2 * idx..2 * idx + 2] != fused_bytes[2 * idx..2 * idx + 2] {
+            byte_mismatch += 1;
+        }
+    }
+    println!(
+        "  residual_fused_vs_matmul_plus_add max_abs={max_abs:.5e} byte_mismatch={byte_mismatch}/{}",
+        m * n
+    );
+    if byte_mismatch != 0 {
+        return Err(anyhow!("{name} residual fused byte mismatch"));
+    }
+
+    let mut ref_samples = Vec::with_capacity(iterations);
+    for _ in 0..iterations {
+        let start = Instant::now();
+        prefill_ffi::matmul_rhs_transposed_int4(
+            ordinal,
+            1,
+            m,
+            n,
+            k,
+            &lhs_gpu,
+            &rhs_gpu,
+            &dummy_gpu,
+            &dummy_gpu,
+            None,
+            128,
+            qtype,
+            &mut proj_gpu,
+        )
+        .map_err(|e| anyhow!("bench residual ref matmul: {e}"))?;
+        prefill_ffi::element_add(
+            ordinal,
+            ScalarType::BF16,
+            m * n,
+            &residual_gpu,
+            &proj_gpu,
+            &mut ref_gpu,
+        )
+        .map_err(|e| anyhow!("bench residual ref add: {e}"))?;
+        gpu_hal::sync(ordinal).map_err(|e| anyhow!("bench residual ref sync: {e}"))?;
+        ref_samples.push(start.elapsed().as_secs_f64() * 1000.0);
+    }
+
+    let mut fused_samples = Vec::with_capacity(iterations);
+    for _ in 0..iterations {
+        let start = Instant::now();
+        prefill_ffi::matmul_rhs_transposed_int4_residual_add(
+            ordinal,
+            1,
+            m,
+            n,
+            k,
+            &lhs_gpu,
+            &rhs_gpu,
+            &dummy_gpu,
+            &dummy_gpu,
+            None,
+            128,
+            qtype,
+            &residual_gpu,
+            &mut fused_gpu,
+        )
+        .map_err(|e| anyhow!("bench residual fused matmul: {e}"))?;
+        gpu_hal::sync(ordinal).map_err(|e| anyhow!("bench residual fused sync: {e}"))?;
+        fused_samples.push(start.elapsed().as_secs_f64() * 1000.0);
+    }
+
+    ref_samples.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    fused_samples.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let ref_mean = ref_samples.iter().sum::<f64>() / ref_samples.len() as f64;
+    let fused_mean = fused_samples.iter().sum::<f64>() / fused_samples.len() as f64;
+    let ref_p50 = ref_samples[ref_samples.len() / 2];
+    let fused_p50 = fused_samples[fused_samples.len() / 2];
+    let ref_p90 = ref_samples[((ref_samples.len() * 9) / 10).min(ref_samples.len() - 1)];
+    let fused_p90 = fused_samples[((fused_samples.len() * 9) / 10).min(fused_samples.len() - 1)];
+    println!("  matmul_plus_add mean_ms={ref_mean:.4} p50_ms={ref_p50:.4} p90_ms={ref_p90:.4}");
+    println!(
+        "  residual_fused mean_ms={fused_mean:.4} p50_ms={fused_p50:.4} p90_ms={fused_p90:.4}"
+    );
+    println!(
+        "  residual_fused_vs_matmul_plus_add speedup={:.3}x",
+        ref_mean / fused_mean
+    );
+    Ok(())
+}
+
+fn run_bf16_rhs_transposed_case(
+    ordinal: usize,
+    name: &str,
+    m: usize,
+    n: usize,
+    k: usize,
+) -> Result<()> {
+    println!("=== {name}: m={m} n={n} k={k} ===");
+    let lhs = make_bench_lhs(m, k);
+    let rhs = make_bench_rhs(n, k);
+    let lhs_gpu =
+        GpuBuffer::from_host_bytes(ordinal, ScalarType::BF16, &[m, k], &f32_to_bf16_bytes(&lhs))
+            .map_err(|e| anyhow!("bf16 lhs upload: {e}"))?;
+    let rhs_gpu =
+        GpuBuffer::from_host_bytes(ordinal, ScalarType::BF16, &[n, k], &f32_to_bf16_bytes(&rhs))
+            .map_err(|e| anyhow!("bf16 rhs upload: {e}"))?;
+    let mut out_gpu = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[m, n])
+        .map_err(|e| anyhow!("bf16 out alloc: {e}"))?;
+
+    prefill_ffi::matmul_rhs_transposed(
+        ordinal,
+        ScalarType::BF16,
+        1,
+        m,
+        n,
+        k,
+        &lhs_gpu,
+        &rhs_gpu,
+        &mut out_gpu,
+    )
+    .map_err(|e| anyhow!("bf16 matmul_rhs_transposed: {e}"))?;
+
+    let out_host = bf16_bytes_to_f32(
+        &out_gpu
+            .to_host_bytes()
+            .map_err(|e| anyhow!("bf16 out d2h: {e}"))?,
+    );
+    let ref_out = reference_bf16_rhs_transposed(m, n, k, &lhs, &rhs);
+
+    let mut max_abs = 0f32;
+    let mut bad = 0usize;
+    for (got, exp) in out_host.iter().zip(ref_out.iter()) {
+        let abs = (got - exp).abs();
+        max_abs = max_abs.max(abs);
+        if abs > 0.0 {
+            bad += 1;
+        }
+    }
+    println!("  max_abs={max_abs:.5e} bad={bad}/{}", m * n);
+    if bad > 0 {
+        return Err(anyhow!("{name} BF16 matmul mismatches"));
+    }
+    Ok(())
+}
+
+fn bench_bf16_rhs_transposed_hot_shape(
+    ordinal: usize,
+    name: &str,
+    m: usize,
+    n: usize,
+    k: usize,
+    iterations: usize,
+) -> Result<()> {
+    println!("=== bench {name}: m={m} n={n} k={k} iters={iterations} ===");
+    let lhs = make_bench_lhs(m, k);
+    let rhs = make_bench_rhs(n, k);
+    let lhs_gpu =
+        GpuBuffer::from_host_bytes(ordinal, ScalarType::BF16, &[m, k], &f32_to_bf16_bytes(&lhs))
+            .map_err(|e| anyhow!("bf16 bench lhs upload: {e}"))?;
+    let rhs_gpu =
+        GpuBuffer::from_host_bytes(ordinal, ScalarType::BF16, &[n, k], &f32_to_bf16_bytes(&rhs))
+            .map_err(|e| anyhow!("bf16 bench rhs upload: {e}"))?;
+    let mut out_gpu = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[m, n])
+        .map_err(|e| anyhow!("bf16 bench out alloc: {e}"))?;
+
+    for _ in 0..bench_warmup_iters() {
+        prefill_ffi::matmul_rhs_transposed(
+            ordinal,
+            ScalarType::BF16,
+            1,
+            m,
+            n,
+            k,
+            &lhs_gpu,
+            &rhs_gpu,
+            &mut out_gpu,
+        )
+        .map_err(|e| anyhow!("bf16 bench warmup: {e}"))?;
+    }
+    gpu_hal::sync(ordinal).map_err(|e| anyhow!("bf16 bench warmup sync: {e}"))?;
+
+    let mut samples = Vec::with_capacity(iterations);
+    for _ in 0..iterations {
+        let start = Instant::now();
+        prefill_ffi::matmul_rhs_transposed(
+            ordinal,
+            ScalarType::BF16,
+            1,
+            m,
+            n,
+            k,
+            &lhs_gpu,
+            &rhs_gpu,
+            &mut out_gpu,
+        )
+        .map_err(|e| anyhow!("bf16 bench matmul: {e}"))?;
+        gpu_hal::sync(ordinal).map_err(|e| anyhow!("bf16 bench sync: {e}"))?;
         samples.push(start.elapsed().as_secs_f64() * 1000.0);
     }
 
@@ -760,7 +1338,7 @@ fn bench_ggml_pair_m16_hot_shape(
     let mut out_swiglu_fused = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[m, n_each])
         .map_err(|e| anyhow!("out_swiglu_fused alloc: {e}"))?;
 
-    for _ in 0..3 {
+    for _ in 0..bench_warmup_iters() {
         prefill_ffi::matmul_rhs_transposed_int4(
             ordinal,
             1,
@@ -815,7 +1393,7 @@ fn bench_ggml_pair_m16_hot_shape(
             &mut out_swiglu_ref,
         )
         .map_err(|e| anyhow!("warmup pair swiglu split: {e}"))?;
-        let fused = prefill_ffi::matmul_rhs_transposed_ggml_pair_swiglu(
+        let _ = prefill_ffi::matmul_rhs_transposed_ggml_pair_swiglu(
             ordinal,
             1,
             m,
@@ -828,9 +1406,6 @@ fn bench_ggml_pair_m16_hot_shape(
             &mut out_swiglu_fused,
         )
         .map_err(|e| anyhow!("warmup fused pair swiglu: {e}"))?;
-        if !fused {
-            return Err(anyhow!("fused pair swiglu unsupported for {name}"));
-        }
     }
     gpu_hal::sync(ordinal).map_err(|e| anyhow!("warmup sync: {e}"))?;
 
@@ -881,7 +1456,7 @@ fn bench_ggml_pair_m16_hot_shape(
         &mut out_swiglu_ref,
     )
     .map_err(|e| anyhow!("reference pair swiglu split: {e}"))?;
-    let fused = prefill_ffi::matmul_rhs_transposed_ggml_pair_swiglu(
+    let fused_swiglu_supported = prefill_ffi::matmul_rhs_transposed_ggml_pair_swiglu(
         ordinal,
         1,
         m,
@@ -894,32 +1469,34 @@ fn bench_ggml_pair_m16_hot_shape(
         &mut out_swiglu_fused,
     )
     .map_err(|e| anyhow!("fused pair swiglu: {e}"))?;
-    if !fused {
-        return Err(anyhow!("fused pair swiglu unsupported for {name}"));
-    }
-    gpu_hal::sync(ordinal).map_err(|e| anyhow!("fused parity sync: {e}"))?;
-    let swiglu_ref_bytes = out_swiglu_ref
-        .to_host_bytes()
-        .map_err(|e| anyhow!("swiglu ref d2h: {e}"))?;
-    let swiglu_fused_bytes = out_swiglu_fused
-        .to_host_bytes()
-        .map_err(|e| anyhow!("swiglu fused d2h: {e}"))?;
-    let swiglu_ref_host = bf16_bytes_to_f32(&swiglu_ref_bytes);
-    let swiglu_fused_host = bf16_bytes_to_f32(&swiglu_fused_bytes);
-    let mut swiglu_byte_mismatch = 0usize;
-    let mut swiglu_max_abs = 0f32;
-    for idx in 0..m * n_each {
-        swiglu_max_abs = swiglu_max_abs.max((swiglu_ref_host[idx] - swiglu_fused_host[idx]).abs());
-        if swiglu_ref_bytes[2 * idx..2 * idx + 2] != swiglu_fused_bytes[2 * idx..2 * idx + 2] {
-            swiglu_byte_mismatch += 1;
+    if fused_swiglu_supported {
+        gpu_hal::sync(ordinal).map_err(|e| anyhow!("fused parity sync: {e}"))?;
+        let swiglu_ref_bytes = out_swiglu_ref
+            .to_host_bytes()
+            .map_err(|e| anyhow!("swiglu ref d2h: {e}"))?;
+        let swiglu_fused_bytes = out_swiglu_fused
+            .to_host_bytes()
+            .map_err(|e| anyhow!("swiglu fused d2h: {e}"))?;
+        let swiglu_ref_host = bf16_bytes_to_f32(&swiglu_ref_bytes);
+        let swiglu_fused_host = bf16_bytes_to_f32(&swiglu_fused_bytes);
+        let mut swiglu_byte_mismatch = 0usize;
+        let mut swiglu_max_abs = 0f32;
+        for idx in 0..m * n_each {
+            swiglu_max_abs =
+                swiglu_max_abs.max((swiglu_ref_host[idx] - swiglu_fused_host[idx]).abs());
+            if swiglu_ref_bytes[2 * idx..2 * idx + 2] != swiglu_fused_bytes[2 * idx..2 * idx + 2] {
+                swiglu_byte_mismatch += 1;
+            }
         }
-    }
-    println!(
-        "  fused_swiglu_vs_pair_split max_abs={swiglu_max_abs:.5e} byte_mismatch={swiglu_byte_mismatch}/{}",
-        m * n_each
-    );
-    if swiglu_byte_mismatch != 0 {
-        return Err(anyhow!("fused pair swiglu byte mismatch for {name}"));
+        println!(
+            "  fused_swiglu_vs_pair_split max_abs={swiglu_max_abs:.5e} byte_mismatch={swiglu_byte_mismatch}/{}",
+            m * n_each
+        );
+        if swiglu_byte_mismatch != 0 {
+            return Err(anyhow!("fused pair swiglu byte mismatch for {name}"));
+        }
+    } else {
+        println!("  fused_swiglu_vs_pair_split unsupported");
     }
 
     let mut separate_samples = Vec::with_capacity(iterations);
@@ -1011,28 +1588,30 @@ fn bench_ggml_pair_m16_hot_shape(
     }
 
     let mut fused_swiglu_samples = Vec::with_capacity(iterations);
-    for _ in 0..iterations {
-        let start = Instant::now();
-        let fused = prefill_ffi::matmul_rhs_transposed_ggml_pair_swiglu(
-            ordinal,
-            1,
-            m,
-            n_each,
-            k,
-            &lhs_gpu,
-            &rhs_first_gpu,
-            &rhs_second_gpu,
-            qtype,
-            &mut out_swiglu_fused,
-        )
-        .map_err(|e| anyhow!("bench fused pair swiglu: {e}"))?;
-        if !fused {
-            return Err(anyhow!(
-                "fused pair swiglu unsupported during bench for {name}"
-            ));
+    if fused_swiglu_supported {
+        for _ in 0..iterations {
+            let start = Instant::now();
+            let fused = prefill_ffi::matmul_rhs_transposed_ggml_pair_swiglu(
+                ordinal,
+                1,
+                m,
+                n_each,
+                k,
+                &lhs_gpu,
+                &rhs_first_gpu,
+                &rhs_second_gpu,
+                qtype,
+                &mut out_swiglu_fused,
+            )
+            .map_err(|e| anyhow!("bench fused pair swiglu: {e}"))?;
+            if !fused {
+                return Err(anyhow!(
+                    "fused pair swiglu support changed during bench for {name}"
+                ));
+            }
+            gpu_hal::sync(ordinal).map_err(|e| anyhow!("bench fused swiglu sync: {e}"))?;
+            fused_swiglu_samples.push(start.elapsed().as_secs_f64() * 1000.0);
         }
-        gpu_hal::sync(ordinal).map_err(|e| anyhow!("bench fused swiglu sync: {e}"))?;
-        fused_swiglu_samples.push(start.elapsed().as_secs_f64() * 1000.0);
     }
 
     separate_samples.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
@@ -1043,19 +1622,14 @@ fn bench_ggml_pair_m16_hot_shape(
     let pair_mean = pair_samples.iter().sum::<f64>() / pair_samples.len() as f64;
     let pair_swiglu_mean =
         pair_swiglu_samples.iter().sum::<f64>() / pair_swiglu_samples.len() as f64;
-    let fused_swiglu_mean =
-        fused_swiglu_samples.iter().sum::<f64>() / fused_swiglu_samples.len() as f64;
     let separate_p50 = separate_samples[separate_samples.len() / 2];
     let pair_p50 = pair_samples[pair_samples.len() / 2];
     let pair_swiglu_p50 = pair_swiglu_samples[pair_swiglu_samples.len() / 2];
-    let fused_swiglu_p50 = fused_swiglu_samples[fused_swiglu_samples.len() / 2];
     let separate_p90 =
         separate_samples[((separate_samples.len() * 9) / 10).min(separate_samples.len() - 1)];
     let pair_p90 = pair_samples[((pair_samples.len() * 9) / 10).min(pair_samples.len() - 1)];
     let pair_swiglu_p90 = pair_swiglu_samples
         [((pair_swiglu_samples.len() * 9) / 10).min(pair_swiglu_samples.len() - 1)];
-    let fused_swiglu_p90 = fused_swiglu_samples
-        [((fused_swiglu_samples.len() * 9) / 10).min(fused_swiglu_samples.len() - 1)];
     println!(
         "  two_fixed_m16 mean_ms={separate_mean:.4} p50_ms={separate_p50:.4} p90_ms={separate_p90:.4}"
     );
@@ -1067,13 +1641,22 @@ fn bench_ggml_pair_m16_hot_shape(
     println!(
         "  pair_plus_swiglu mean_ms={pair_swiglu_mean:.4} p50_ms={pair_swiglu_p50:.4} p90_ms={pair_swiglu_p90:.4}"
     );
-    println!(
-        "  fused_pair_swiglu mean_ms={fused_swiglu_mean:.4} p50_ms={fused_swiglu_p50:.4} p90_ms={fused_swiglu_p90:.4}"
-    );
-    println!(
-        "  fused_pair_swiglu_vs_pair_plus_swiglu speedup={:.3}x",
-        pair_swiglu_mean / fused_swiglu_mean
-    );
+    if fused_swiglu_supported {
+        let fused_swiglu_mean =
+            fused_swiglu_samples.iter().sum::<f64>() / fused_swiglu_samples.len() as f64;
+        let fused_swiglu_p50 = fused_swiglu_samples[fused_swiglu_samples.len() / 2];
+        let fused_swiglu_p90 = fused_swiglu_samples
+            [((fused_swiglu_samples.len() * 9) / 10).min(fused_swiglu_samples.len() - 1)];
+        println!(
+            "  fused_pair_swiglu mean_ms={fused_swiglu_mean:.4} p50_ms={fused_swiglu_p50:.4} p90_ms={fused_swiglu_p90:.4}"
+        );
+        println!(
+            "  fused_pair_swiglu_vs_pair_plus_swiglu speedup={:.3}x",
+            pair_swiglu_mean / fused_swiglu_mean
+        );
+    } else {
+        println!("  fused_pair_swiglu unsupported");
+    }
     Ok(())
 }
 
@@ -1106,7 +1689,7 @@ fn bench_mmq_q8_quant_hot_shape(
     let mut q8_gpu = GpuBuffer::alloc(ordinal, ScalarType::U8, &[workspace_bytes])
         .map_err(|e| anyhow!("q8 workspace alloc: {e}"))?;
 
-    for _ in 0..3 {
+    for _ in 0..bench_warmup_iters() {
         prefill_ffi::quantize_mmq_q8_1(ordinal, 1, m, k, &lhs_gpu, qtype, &mut q8_gpu)
             .map_err(|e| anyhow!("warmup q8_1 quant: {e}"))?;
     }
@@ -1177,7 +1760,7 @@ fn bench_mmq_q6_matmul_hot_shape(
         &mut q8_gpu,
     )
     .map_err(|e| anyhow!("q8_1 quant: {e}"))?;
-    for _ in 0..3 {
+    for _ in 0..bench_warmup_iters() {
         prefill_ffi::matmul_mmq_q8_1_q6_k(ordinal, 1, m, n, k, &q8_gpu, &rhs_gpu, &mut out_gpu)
             .map_err(|e| anyhow!("warmup q6 mmq matmul: {e}"))?;
         prefill_ffi::element_add(
@@ -1423,6 +2006,447 @@ fn run_q6_k_m16_argmax_case(ordinal: usize) -> Result<()> {
     Ok(())
 }
 
+fn bench_q6_k_m16_argmax_hot_shape(
+    ordinal: usize,
+    name: &str,
+    n: usize,
+    k: usize,
+    iterations: usize,
+) -> Result<()> {
+    let m = 16usize;
+    let row_bytes = ggml_row_bytes_for(qwen35::weights::LOWBIT_GGML_Q6_K, k)?;
+    let tiles = n / 16;
+    println!(
+        "=== bench {name} fused argmax: m={m} n={n} k={k} row_bytes={row_bytes} tiles={tiles} iters={iterations} ==="
+    );
+
+    let lhs = make_bench_lhs(m, k);
+    let rhs = make_ggml_k_slab(n, k, qwen35::weights::LOWBIT_GGML_Q6_K, ggml_q6k_row)?;
+    let lhs_gpu =
+        GpuBuffer::from_host_bytes(ordinal, ScalarType::BF16, &[m, k], &f32_to_bf16_bytes(&lhs))
+            .map_err(|e| anyhow!("argmax bench lhs upload: {e}"))?;
+    let rhs_gpu = GpuBuffer::from_host_bytes(ordinal, ScalarType::U8, &[n, row_bytes], &rhs)
+        .map_err(|e| anyhow!("argmax bench rhs upload: {e}"))?;
+    let mut fused_indices = GpuBuffer::zeros(ordinal, ScalarType::U32, &[m])
+        .map_err(|e| anyhow!("argmax bench indices alloc: {e}"))?;
+    let mut block_best_vals = GpuBuffer::zeros(ordinal, ScalarType::F32, &[m, tiles])
+        .map_err(|e| anyhow!("argmax bench block vals alloc: {e}"))?;
+    let mut block_best_indices = GpuBuffer::zeros(ordinal, ScalarType::U32, &[m, tiles])
+        .map_err(|e| anyhow!("argmax bench block indices alloc: {e}"))?;
+
+    for _ in 0..bench_warmup_iters() {
+        let handled = prefill_ffi::matmul_q6_k_m16_argmax(
+            ordinal,
+            1,
+            m,
+            n,
+            k,
+            &lhs_gpu,
+            &rhs_gpu,
+            &mut block_best_vals,
+            &mut block_best_indices,
+            &mut fused_indices,
+        )
+        .map_err(|e| anyhow!("argmax bench warmup: {e}"))?;
+        if !handled {
+            return Err(anyhow!("{name} fused argmax unsupported"));
+        }
+    }
+    gpu_hal::sync(ordinal).map_err(|e| anyhow!("argmax bench warmup sync: {e}"))?;
+
+    let mut samples = Vec::with_capacity(iterations);
+    for _ in 0..iterations {
+        let start = Instant::now();
+        prefill_ffi::matmul_q6_k_m16_argmax(
+            ordinal,
+            1,
+            m,
+            n,
+            k,
+            &lhs_gpu,
+            &rhs_gpu,
+            &mut block_best_vals,
+            &mut block_best_indices,
+            &mut fused_indices,
+        )
+        .map_err(|e| anyhow!("argmax bench fused: {e}"))?;
+        gpu_hal::sync(ordinal).map_err(|e| anyhow!("argmax bench sync: {e}"))?;
+        samples.push(start.elapsed().as_secs_f64() * 1000.0);
+    }
+
+    samples.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let mean = samples.iter().sum::<f64>() / samples.len() as f64;
+    let p50 = samples[samples.len() / 2];
+    let p90 = samples[((samples.len() * 9) / 10).min(samples.len() - 1)];
+    println!("  fused_argmax mean_ms={mean:.4} p50_ms={p50:.4} p90_ms={p90:.4}");
+    Ok(())
+}
+
+fn bench_recurrent_attn_hot_shape(
+    ordinal: usize,
+    name: &str,
+    batch_heads: usize,
+    seq_len: usize,
+    iterations: usize,
+) -> Result<()> {
+    const K: usize = 128;
+    const V: usize = 128;
+    const Q8_0_BLOCK_BYTES: usize = 34;
+    let trace_bytes = batch_heads * seq_len * V * (K / 32) * Q8_0_BLOCK_BYTES;
+    println!(
+        "=== bench {name}: bh={batch_heads} seq={seq_len} k={K} v={V} trace_bytes={trace_bytes} iters={iterations} ==="
+    );
+
+    let state_host = make_recurrent_state(batch_heads, K, V);
+    let query_host = make_recurrent_tokens(batch_heads, seq_len, K, 0.25);
+    let key_host = make_recurrent_tokens(batch_heads, seq_len, K, 0.75);
+    let value_host = make_recurrent_tokens(batch_heads, seq_len, V, 1.25);
+    let beta_host = make_recurrent_scalars(batch_heads, seq_len, 1.75);
+    let g_host = make_recurrent_decay(batch_heads, seq_len);
+
+    let mut state_gpu = GpuBuffer::from_host_bytes(
+        ordinal,
+        ScalarType::F32,
+        &[batch_heads, K, V],
+        &f32_to_le_bytes(&state_host),
+    )
+    .map_err(|e| anyhow!("recurrent state upload: {e}"))?;
+    let query_gpu = GpuBuffer::from_host_bytes(
+        ordinal,
+        ScalarType::F32,
+        &[batch_heads, seq_len, K],
+        &f32_to_le_bytes(&query_host),
+    )
+    .map_err(|e| anyhow!("recurrent query upload: {e}"))?;
+    let key_gpu = GpuBuffer::from_host_bytes(
+        ordinal,
+        ScalarType::F32,
+        &[batch_heads, seq_len, K],
+        &f32_to_le_bytes(&key_host),
+    )
+    .map_err(|e| anyhow!("recurrent key upload: {e}"))?;
+    let value_gpu = GpuBuffer::from_host_bytes(
+        ordinal,
+        ScalarType::F32,
+        &[batch_heads, seq_len, V],
+        &f32_to_le_bytes(&value_host),
+    )
+    .map_err(|e| anyhow!("recurrent value upload: {e}"))?;
+    let beta_gpu = GpuBuffer::from_host_bytes(
+        ordinal,
+        ScalarType::F32,
+        &[batch_heads, seq_len],
+        &f32_to_le_bytes(&beta_host),
+    )
+    .map_err(|e| anyhow!("recurrent beta upload: {e}"))?;
+    let g_gpu = GpuBuffer::from_host_bytes(
+        ordinal,
+        ScalarType::F32,
+        &[batch_heads, seq_len],
+        &f32_to_le_bytes(&g_host),
+    )
+    .map_err(|e| anyhow!("recurrent g upload: {e}"))?;
+    let mut attn_gpu = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[batch_heads, seq_len, V])
+        .map_err(|e| anyhow!("recurrent attn alloc: {e}"))?;
+    let mut trace_gpu = GpuBuffer::alloc(ordinal, ScalarType::U8, &[trace_bytes])
+        .map_err(|e| anyhow!("recurrent trace alloc: {e}"))?;
+
+    if std::env::var_os("SUPERSONIC_INT4_TEST_SKIP_RECURRENT_PARITY").is_none() {
+        let reference = recurrent_attn_hot_reference(
+            batch_heads,
+            seq_len,
+            &state_host,
+            &query_host,
+            &key_host,
+            &value_host,
+            &beta_host,
+            &g_host,
+        );
+        let handled = prefill_ffi::delta_recurrent_prefill_capture_q8_trace_attn(
+            ordinal,
+            ScalarType::F32,
+            batch_heads,
+            seq_len,
+            K,
+            V,
+            &mut state_gpu,
+            &query_gpu,
+            &key_gpu,
+            &value_gpu,
+            &beta_gpu,
+            &g_gpu,
+            &mut attn_gpu,
+            &mut trace_gpu,
+        )
+        .map_err(|e| anyhow!("recurrent parity: {e}"))?;
+        if !handled {
+            return Err(anyhow!("recurrent append-attn kernel was not handled"));
+        }
+        gpu_hal::sync(ordinal).map_err(|e| anyhow!("recurrent parity sync: {e}"))?;
+
+        let attn_bytes = attn_gpu
+            .to_host_bytes()
+            .map_err(|e| anyhow!("recurrent attn parity d2h: {e}"))?;
+        let trace_bytes_gpu = trace_gpu
+            .to_host_bytes()
+            .map_err(|e| anyhow!("recurrent trace parity d2h: {e}"))?;
+        let state_bytes = state_gpu
+            .to_host_bytes()
+            .map_err(|e| anyhow!("recurrent state parity d2h: {e}"))?;
+        let state_gpu_host = f32_bytes_to_f32(&state_bytes);
+        let mut attn_byte_mismatch = 0usize;
+        let mut trace_byte_mismatch = 0usize;
+        let mut state_byte_mismatch = 0usize;
+        let mut state_max_abs = 0.0f32;
+        for idx in 0..reference.attn_bytes.len() / 2 {
+            if attn_bytes[2 * idx..2 * idx + 2]
+                != reference.attn_bytes[2 * idx..2 * idx + 2]
+            {
+                attn_byte_mismatch += 1;
+            }
+        }
+        for idx in 0..reference.trace_bytes.len() {
+            if trace_bytes_gpu[idx] != reference.trace_bytes[idx] {
+                trace_byte_mismatch += 1;
+            }
+        }
+        for idx in 0..reference.state.len() {
+            state_max_abs = state_max_abs.max((state_gpu_host[idx] - reference.state[idx]).abs());
+            if state_bytes[4 * idx..4 * idx + 4]
+                != reference.state[idx].to_le_bytes()
+            {
+                state_byte_mismatch += 1;
+            }
+        }
+        println!(
+            "  recurrent_ref attn_byte_mismatch={attn_byte_mismatch}/{} trace_byte_mismatch={trace_byte_mismatch}/{} state_byte_mismatch={state_byte_mismatch}/{} state_max_abs={state_max_abs:.5e}",
+            reference.attn_bytes.len() / 2,
+            reference.trace_bytes.len(),
+            reference.state.len()
+        );
+        if attn_byte_mismatch != 0 || trace_byte_mismatch > 64 || state_max_abs > 1.0e-6 {
+            return Err(anyhow!("recurrent append-attn parity mismatch"));
+        }
+
+        state_gpu = GpuBuffer::from_host_bytes(
+            ordinal,
+            ScalarType::F32,
+            &[batch_heads, K, V],
+            &f32_to_le_bytes(&state_host),
+        )
+        .map_err(|e| anyhow!("recurrent state reset upload: {e}"))?;
+    }
+
+    for _ in 0..bench_warmup_iters() {
+        let handled = prefill_ffi::delta_recurrent_prefill_capture_q8_trace_attn(
+            ordinal,
+            ScalarType::F32,
+            batch_heads,
+            seq_len,
+            K,
+            V,
+            &mut state_gpu,
+            &query_gpu,
+            &key_gpu,
+            &value_gpu,
+            &beta_gpu,
+            &g_gpu,
+            &mut attn_gpu,
+            &mut trace_gpu,
+        )
+        .map_err(|e| anyhow!("recurrent warmup: {e}"))?;
+        if !handled {
+            return Err(anyhow!("recurrent append-attn kernel was not handled"));
+        }
+    }
+    gpu_hal::sync(ordinal).map_err(|e| anyhow!("recurrent warmup sync: {e}"))?;
+
+    let mut samples = Vec::with_capacity(iterations);
+    for _ in 0..iterations {
+        let start = Instant::now();
+        prefill_ffi::delta_recurrent_prefill_capture_q8_trace_attn(
+            ordinal,
+            ScalarType::F32,
+            batch_heads,
+            seq_len,
+            K,
+            V,
+            &mut state_gpu,
+            &query_gpu,
+            &key_gpu,
+            &value_gpu,
+            &beta_gpu,
+            &g_gpu,
+            &mut attn_gpu,
+            &mut trace_gpu,
+        )
+        .map_err(|e| anyhow!("recurrent bench: {e}"))?;
+        gpu_hal::sync(ordinal).map_err(|e| anyhow!("recurrent bench sync: {e}"))?;
+        samples.push(start.elapsed().as_secs_f64() * 1000.0);
+    }
+
+    samples.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let mean = samples.iter().sum::<f64>() / samples.len() as f64;
+    let p50 = samples[samples.len() / 2];
+    let p90 = samples[((samples.len() * 9) / 10).min(samples.len() - 1)];
+    println!("  mean_ms={mean:.4} p50_ms={p50:.4} p90_ms={p90:.4}");
+    Ok(())
+}
+
+fn bench_rms_norm_hot_shape(
+    ordinal: usize,
+    name: &str,
+    n_rows: usize,
+    n_cols: usize,
+    iterations: usize,
+) -> Result<()> {
+    println!("=== bench {name}: rows={n_rows} cols={n_cols} iters={iterations} ===");
+    let input_host = make_bench_lhs(n_rows, n_cols);
+    let mut weight_host = vec![0f32; n_cols];
+    for (col, val) in weight_host.iter_mut().enumerate() {
+        let x = 0.75 + ((col % 197) as f32) * 0.0011;
+        *val = bf16_round(x);
+    }
+    let input_gpu = GpuBuffer::from_host_bytes(
+        ordinal,
+        ScalarType::BF16,
+        &[n_rows, n_cols],
+        &f32_to_bf16_bytes(&input_host),
+    )
+    .map_err(|e| anyhow!("rms input upload: {e}"))?;
+    let weight_gpu = GpuBuffer::from_host_bytes(
+        ordinal,
+        ScalarType::BF16,
+        &[n_cols],
+        &f32_to_bf16_bytes(&weight_host),
+    )
+    .map_err(|e| anyhow!("rms weight upload: {e}"))?;
+    let mut out_gpu = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[n_rows, n_cols])
+        .map_err(|e| anyhow!("rms out alloc: {e}"))?;
+
+    for _ in 0..bench_warmup_iters() {
+        prefill_ffi::rms_norm_rows_plain(
+            ordinal,
+            ScalarType::BF16,
+            n_rows,
+            n_cols,
+            1.0e-6,
+            &input_gpu,
+            &weight_gpu,
+            &mut out_gpu,
+        )
+        .map_err(|e| anyhow!("rms warmup: {e}"))?;
+    }
+    gpu_hal::sync(ordinal).map_err(|e| anyhow!("rms warmup sync: {e}"))?;
+
+    let mut samples = Vec::with_capacity(iterations);
+    for _ in 0..iterations {
+        let start = Instant::now();
+        prefill_ffi::rms_norm_rows_plain(
+            ordinal,
+            ScalarType::BF16,
+            n_rows,
+            n_cols,
+            1.0e-6,
+            &input_gpu,
+            &weight_gpu,
+            &mut out_gpu,
+        )
+        .map_err(|e| anyhow!("rms bench: {e}"))?;
+        gpu_hal::sync(ordinal).map_err(|e| anyhow!("rms bench sync: {e}"))?;
+        samples.push(start.elapsed().as_secs_f64() * 1000.0);
+    }
+
+    samples.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let mean = samples.iter().sum::<f64>() / samples.len() as f64;
+    let p50 = samples[samples.len() / 2];
+    let p90 = samples[((samples.len() * 9) / 10).min(samples.len() - 1)];
+    println!("  mean_ms={mean:.4} p50_ms={p50:.4} p90_ms={p90:.4}");
+    Ok(())
+}
+
+fn bench_rms_norm_gated_hot_shape(
+    ordinal: usize,
+    name: &str,
+    n_rows: usize,
+    n_cols: usize,
+    iterations: usize,
+) -> Result<()> {
+    println!("=== bench {name}: rows={n_rows} cols={n_cols} iters={iterations} ===");
+    let hidden_host = make_bench_lhs(n_rows, n_cols);
+    let gate_host = make_bench_rhs(n_rows, n_cols);
+    let mut weight_host = vec![0f32; n_cols];
+    for (col, val) in weight_host.iter_mut().enumerate() {
+        let x = 0.55 + ((col % 211) as f32) * 0.0013;
+        *val = bf16_round(x);
+    }
+    let hidden_gpu = GpuBuffer::from_host_bytes(
+        ordinal,
+        ScalarType::BF16,
+        &[n_rows, n_cols],
+        &f32_to_bf16_bytes(&hidden_host),
+    )
+    .map_err(|e| anyhow!("gated rms hidden upload: {e}"))?;
+    let gate_gpu = GpuBuffer::from_host_bytes(
+        ordinal,
+        ScalarType::BF16,
+        &[n_rows, n_cols],
+        &f32_to_bf16_bytes(&gate_host),
+    )
+    .map_err(|e| anyhow!("gated rms gate upload: {e}"))?;
+    let weight_gpu = GpuBuffer::from_host_bytes(
+        ordinal,
+        ScalarType::BF16,
+        &[n_cols],
+        &f32_to_bf16_bytes(&weight_host),
+    )
+    .map_err(|e| anyhow!("gated rms weight upload: {e}"))?;
+    let mut out_gpu = GpuBuffer::zeros(ordinal, ScalarType::BF16, &[n_rows, n_cols])
+        .map_err(|e| anyhow!("gated rms out alloc: {e}"))?;
+
+    for _ in 0..bench_warmup_iters() {
+        prefill_ffi::rms_norm_gated(
+            ordinal,
+            ScalarType::BF16,
+            n_rows,
+            n_cols,
+            1.0e-6,
+            &hidden_gpu,
+            &gate_gpu,
+            &weight_gpu,
+            &mut out_gpu,
+        )
+        .map_err(|e| anyhow!("gated rms warmup: {e}"))?;
+    }
+    gpu_hal::sync(ordinal).map_err(|e| anyhow!("gated rms warmup sync: {e}"))?;
+
+    let mut samples = Vec::with_capacity(iterations);
+    for _ in 0..iterations {
+        let start = Instant::now();
+        prefill_ffi::rms_norm_gated(
+            ordinal,
+            ScalarType::BF16,
+            n_rows,
+            n_cols,
+            1.0e-6,
+            &hidden_gpu,
+            &gate_gpu,
+            &weight_gpu,
+            &mut out_gpu,
+        )
+        .map_err(|e| anyhow!("gated rms bench: {e}"))?;
+        gpu_hal::sync(ordinal).map_err(|e| anyhow!("gated rms bench sync: {e}"))?;
+        samples.push(start.elapsed().as_secs_f64() * 1000.0);
+    }
+
+    samples.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let mean = samples.iter().sum::<f64>() / samples.len() as f64;
+    let p50 = samples[samples.len() / 2];
+    let p90 = samples[((samples.len() * 9) / 10).min(samples.len() - 1)];
+    println!("  mean_ms={mean:.4} p50_ms={p50:.4} p90_ms={p90:.4}");
+    Ok(())
+}
+
 fn maybe_run_ggml_hot_benches(ordinal: usize) -> Result<()> {
     if std::env::var_os("SUPERSONIC_INT4_TEST_BENCH_GGML_HOT").is_none() {
         return Ok(());
@@ -1432,8 +2456,127 @@ fn maybe_run_ggml_hot_benches(ordinal: usize) -> Result<()> {
         .and_then(|v| v.parse::<usize>().ok())
         .unwrap_or(20)
         .max(1);
+    if std::env::var_os("SUPERSONIC_INT4_TEST_BENCH_RECURRENT_ONLY").is_some() {
+        let batch_heads = bench_env_usize("SUPERSONIC_INT4_TEST_BENCH_RECURRENT_BH", 48);
+        let seq_len = bench_env_usize("SUPERSONIC_INT4_TEST_BENCH_RECURRENT_SEQ", 16);
+        bench_recurrent_attn_hot_shape(
+            ordinal,
+            "delta recurrent append-attn hot",
+            batch_heads,
+            seq_len,
+            iterations,
+        )?;
+        return Ok(());
+    }
+    if std::env::var_os("SUPERSONIC_INT4_TEST_BENCH_RMS_ONLY").is_some() {
+        bench_rms_norm_hot_shape(ordinal, "RMS BF16 hot", 16, 5120, iterations)?;
+        return Ok(());
+    }
+    if std::env::var_os("SUPERSONIC_INT4_TEST_BENCH_RMS_GATED_ONLY").is_some() {
+        bench_rms_norm_gated_hot_shape(ordinal, "RMS gated BF16 hot", 16, 5120, iterations)?;
+        return Ok(());
+    }
     if std::env::var_os("SUPERSONIC_INT4_TEST_BENCH_Q6_DOWN_M16_ONLY").is_some() {
         bench_mmq_q6_matmul_hot_shape(ordinal, "Q6_K down hot m16", 16, 5_120, 17_408, iterations)?;
+        return Ok(());
+    }
+    if std::env::var_os("SUPERSONIC_INT4_TEST_BENCH_GGML_PAIR_M16_ONLY").is_some() {
+        bench_ggml_pair_m16_hot_shape(
+            ordinal,
+            "Q4_K mlp gate/up hot",
+            qwen35::weights::LOWBIT_GGML_Q4_K,
+            ggml_q4k_row,
+            17_408,
+            5_120,
+            iterations,
+        )?;
+        return Ok(());
+    }
+    if std::env::var_os("SUPERSONIC_INT4_TEST_BENCH_GGML_Q8_0_M16_ONLY").is_some() {
+        bench_ggml_hot_shape(
+            ordinal,
+            "Q8_0 mlp gate/up hot m16",
+            qwen35::weights::LOWBIT_GGML_Q8_0,
+            ggml_q8_0_row,
+            16,
+            17_408,
+            5_120,
+            iterations,
+        )?;
+        bench_ggml_hot_shape(
+            ordinal,
+            "Q8_0 down hot m16",
+            qwen35::weights::LOWBIT_GGML_Q8_0,
+            ggml_q8_0_row,
+            16,
+            5_120,
+            17_408,
+            iterations,
+        )?;
+        bench_ggml_hot_shape(
+            ordinal,
+            "Q8_0 attention projection hot m16",
+            qwen35::weights::LOWBIT_GGML_Q8_0,
+            ggml_q8_0_row,
+            16,
+            4_096,
+            5_120,
+            iterations,
+        )?;
+        return Ok(());
+    }
+    if std::env::var_os("SUPERSONIC_INT4_TEST_BENCH_GGML_RESIDUAL_M16_ONLY").is_some() {
+        bench_ggml_residual_hot_shape(
+            ordinal,
+            "Q4_K down hot",
+            qwen35::weights::LOWBIT_GGML_Q4_K,
+            ggml_q4k_row,
+            16,
+            5_120,
+            17_408,
+            iterations,
+        )?;
+        bench_ggml_residual_hot_shape(
+            ordinal,
+            "Q5_K linear hot",
+            qwen35::weights::LOWBIT_GGML_Q5_K,
+            ggml_q5k_row,
+            16,
+            5_120,
+            6_144,
+            iterations,
+        )?;
+        bench_ggml_residual_hot_shape(
+            ordinal,
+            "Q4_K linear hot",
+            qwen35::weights::LOWBIT_GGML_Q4_K,
+            ggml_q4k_row,
+            16,
+            5_120,
+            6_144,
+            iterations,
+        )?;
+        return Ok(());
+    }
+    if std::env::var_os("SUPERSONIC_INT4_TEST_BENCH_Q6_ARGMAX_M16_ONLY").is_some() {
+        bench_q6_k_m16_argmax_hot_shape(
+            ordinal,
+            "Q6_K vocab row-scan hot m16",
+            248_320,
+            5_120,
+            iterations,
+        )?;
+        return Ok(());
+    }
+    if std::env::var_os("SUPERSONIC_INT4_TEST_BENCH_BF16_SMALL_M_ONLY").is_some() {
+        bench_bf16_rhs_transposed_hot_shape(
+            ordinal,
+            "BF16 small-m projection hot",
+            16,
+            96,
+            5_120,
+            iterations,
+        )?;
         return Ok(());
     }
     bench_ggml_hot_shape(
@@ -1506,6 +2649,16 @@ fn maybe_run_ggml_hot_benches(ordinal: usize) -> Result<()> {
         5_120,
         iterations,
     )?;
+    if std::env::var_os("SUPERSONIC_INT4_TEST_BENCH_BF16_SMALL_M").is_some() {
+        bench_bf16_rhs_transposed_hot_shape(
+            ordinal,
+            "BF16 small-m projection hot",
+            16,
+            96,
+            5_120,
+            iterations,
+        )?;
+    }
     if std::env::var_os("SUPERSONIC_INT4_TEST_BENCH_MMQ_Q8").is_some() {
         bench_mmq_q8_quant_hot_shape(
             ordinal,
@@ -1552,8 +2705,24 @@ fn maybe_run_ggml_hot_benches(ordinal: usize) -> Result<()> {
         bench_mmq_q6_matmul_hot_shape(ordinal, "Q6_K down hot", 8, 5_120, 17_408, iterations)?;
         bench_mmq_q6_matmul_hot_shape(
             ordinal,
+            "Q6_K down hot m16",
+            16,
+            5_120,
+            17_408,
+            iterations,
+        )?;
+        bench_mmq_q6_matmul_hot_shape(
+            ordinal,
             "Q6_K vocab row-scan hot",
             8,
+            248_320,
+            5_120,
+            iterations,
+        )?;
+        bench_mmq_q6_matmul_hot_shape(
+            ordinal,
+            "Q6_K vocab row-scan hot m16",
+            16,
             248_320,
             5_120,
             iterations,
@@ -1568,9 +2737,26 @@ fn maybe_run_ggml_hot_benches(ordinal: usize) -> Result<()> {
         )?;
         bench_mmq_q6_matmul_hot_shape(
             ordinal,
+            "Q6_K mid linear hot m16",
+            16,
+            10_240,
+            5_120,
+            iterations,
+        )?;
+        bench_mmq_q6_matmul_hot_shape(
+            ordinal,
             "Q6_K small linear hot",
             8,
             1_024,
+            5_120,
+            iterations,
+        )?;
+    }
+    if std::env::var_os("SUPERSONIC_INT4_TEST_BENCH_Q6_ARGMAX_M16").is_some() {
+        bench_q6_k_m16_argmax_hot_shape(
+            ordinal,
+            "Q6_K vocab row-scan hot m16",
+            248_320,
             5_120,
             iterations,
         )?;
@@ -1678,6 +2864,38 @@ fn maybe_run_ggml_hot_benches(ordinal: usize) -> Result<()> {
             ggml_q4k_row,
             17_408,
             5_120,
+            iterations,
+        )?;
+    }
+    if std::env::var_os("SUPERSONIC_INT4_TEST_BENCH_GGML_RESIDUAL_M16").is_some() {
+        bench_ggml_residual_hot_shape(
+            ordinal,
+            "Q4_K down hot",
+            qwen35::weights::LOWBIT_GGML_Q4_K,
+            ggml_q4k_row,
+            16,
+            5_120,
+            17_408,
+            iterations,
+        )?;
+        bench_ggml_residual_hot_shape(
+            ordinal,
+            "Q5_K linear hot",
+            qwen35::weights::LOWBIT_GGML_Q5_K,
+            ggml_q5k_row,
+            16,
+            5_120,
+            6_144,
+            iterations,
+        )?;
+        bench_ggml_residual_hot_shape(
+            ordinal,
+            "Q4_K linear hot",
+            qwen35::weights::LOWBIT_GGML_Q4_K,
+            ggml_q4k_row,
+            16,
+            5_120,
+            6_144,
             iterations,
         )?;
     }
@@ -1967,6 +3185,15 @@ fn main() -> Result<()> {
     )?;
     run_ggml_case_shape(
         ordinal,
+        "GGML Q8_0 large-m aligned",
+        qwen35::weights::LOWBIT_GGML_Q8_0,
+        ggml_q8_0_row,
+        64,
+        64,
+        256,
+    )?;
+    run_ggml_case_shape(
+        ordinal,
         "GGML Q4_K m16 aligned",
         qwen35::weights::LOWBIT_GGML_Q4_K,
         ggml_q4k_row,
@@ -2016,6 +3243,8 @@ fn main() -> Result<()> {
     run_mmq_q6_matmul_case(ordinal, "GGML Q6_K MMQ m8", 8, 128, 256)?;
     run_mmq_q6_matmul_case(ordinal, "GGML Q6_K MMQ m16", 16, 128, 512)?;
     run_q6_k_m16_argmax_case(ordinal)?;
+    run_bf16_rhs_transposed_case(ordinal, "BF16 small-m aligned", 16, 32, 256)?;
+    run_bf16_rhs_transposed_case(ordinal, "BF16 small-m tail", 13, 31, 258)?;
     maybe_run_ggml_hot_benches(ordinal)?;
 
     Ok(())

--- a/kernels/full_attention.hip
+++ b/kernels/full_attention.hip
@@ -1864,6 +1864,9 @@ void supersonic_qwen35_delta_recurrent_prefill_capture_q8_trace_attn_bf16_transp
     const int token_stride_v = seq_len * V;
     const int token_stride_s = seq_len;
     const int state_base = bh * state_stride + v_idx;
+    const int query_key_base = bh * token_stride_k;
+    const int value_base = bh * token_stride_v;
+    const int scalar_base = bh * token_stride_s;
 
     float state0 = recurrent_state[state_base + (lane + 0 * QK8_0) * V];
     float state1 = recurrent_state[state_base + (lane + 1 * QK8_0) * V];
@@ -1871,9 +1874,9 @@ void supersonic_qwen35_delta_recurrent_prefill_capture_q8_trace_attn_bf16_transp
     float state3 = recurrent_state[state_base + (lane + 3 * QK8_0) * V];
 
     for (int t = 0; t < seq_len; ++t) {
-        const int key_row = bh * token_stride_k + t * K;
-        const int value_row = bh * token_stride_v + t * V;
-        const int beta_row = bh * token_stride_s + t;
+        const int key_row = query_key_base + t * K;
+        const int value_row = value_base + t * V;
+        const int beta_row = scalar_base + t;
         const float g_t = expf(g[beta_row]);
         const float beta_t = beta[beta_row];
         const float value_t = value[value_row + v_idx];
@@ -1887,11 +1890,10 @@ void supersonic_qwen35_delta_recurrent_prefill_capture_q8_trace_attn_bf16_transp
         state2 *= g_t;
         state3 *= g_t;
 
-        const float kv0 = supersonic_qwen35_wave_sum(state0 * k0);
-        const float kv1 = supersonic_qwen35_wave_sum(state1 * k1);
-        const float kv2 = supersonic_qwen35_wave_sum(state2 * k2);
-        const float kv3 = supersonic_qwen35_wave_sum(state3 * k3);
-        const float kv_mem = __shfl((kv0 + kv2) + (kv1 + kv3), 0);
+        const float kv_mem = __shfl(
+            supersonic_qwen35_wave_sum(
+                (state0 * k0 + state2 * k2) + (state1 * k1 + state3 * k3)),
+            0);
         const float delta = (value_t - kv_mem) * beta_t;
 
         state0 += k0 * delta;
@@ -1913,19 +1915,19 @@ void supersonic_qwen35_delta_recurrent_prefill_capture_q8_trace_attn_bf16_transp
         const float d1 = amax1 / 127.0f;
         const float d2 = amax2 / 127.0f;
         const float d3 = amax3 / 127.0f;
-        const float id0 = d0 == 0.0f ? 0.0f : 1.0f / d0;
-        const float id1 = d1 == 0.0f ? 0.0f : 1.0f / d1;
-        const float id2 = d2 == 0.0f ? 0.0f : 1.0f / d2;
-        const float id3 = d3 == 0.0f ? 0.0f : 1.0f / d3;
+        const float id0 = amax0 == 0.0f ? 0.0f : __builtin_amdgcn_rcpf(amax0) * 127.0f;
+        const float id1 = amax1 == 0.0f ? 0.0f : __builtin_amdgcn_rcpf(amax1) * 127.0f;
+        const float id2 = amax2 == 0.0f ? 0.0f : __builtin_amdgcn_rcpf(amax2) * 127.0f;
+        const float id3 = amax3 == 0.0f ? 0.0f : __builtin_amdgcn_rcpf(amax3) * 127.0f;
         const int q0 = static_cast<int>(roundf(state0 * id0));
         const int q1 = static_cast<int>(roundf(state1 * id1));
         const int q2 = static_cast<int>(roundf(state2 * id2));
         const int q3 = static_cast<int>(roundf(state3 * id3));
-        const int trace_row = (bh * seq_len + t) * V + v_idx;
-        const int row_base0 = (trace_row * (K / QK8_0) + 0) * Q8_0_BLOCK_BYTES;
-        const int row_base1 = (trace_row * (K / QK8_0) + 1) * Q8_0_BLOCK_BYTES;
-        const int row_base2 = (trace_row * (K / QK8_0) + 2) * Q8_0_BLOCK_BYTES;
-        const int row_base3 = (trace_row * (K / QK8_0) + 3) * Q8_0_BLOCK_BYTES;
+        const int row_base0 =
+            (((scalar_base + t) * V + v_idx) * (K / QK8_0)) * Q8_0_BLOCK_BYTES;
+        const int row_base1 = row_base0 + Q8_0_BLOCK_BYTES;
+        const int row_base2 = row_base1 + Q8_0_BLOCK_BYTES;
+        const int row_base3 = row_base2 + Q8_0_BLOCK_BYTES;
         if (lane == 0) {
             qwen35_store_q8_0_block_scale(state_trace + row_base0, __float2half(d0));
             qwen35_store_q8_0_block_scale(state_trace + row_base1, __float2half(d1));
@@ -1941,13 +1943,10 @@ void supersonic_qwen35_delta_recurrent_prefill_capture_q8_trace_attn_bf16_transp
         const float q1v = query[key_row + lane + 1 * QK8_0];
         const float q2v = query[key_row + lane + 2 * QK8_0];
         const float q3v = query[key_row + lane + 3 * QK8_0];
-        const float out0 = supersonic_qwen35_wave_sum(state0 * q0v);
-        const float out1 = supersonic_qwen35_wave_sum(state1 * q1v);
-        const float out2 = supersonic_qwen35_wave_sum(state2 * q2v);
-        const float out3 = supersonic_qwen35_wave_sum(state3 * q3v);
+        const float out = supersonic_qwen35_wave_sum(
+            (state0 * q0v + state2 * q2v) + (state1 * q1v + state3 * q3v));
         if (lane == 0) {
-            attn_output[(bh * seq_len + t) * V + v_idx] =
-                hip_bfloat16((out0 + out2) + (out1 + out3));
+            attn_output[(bh * seq_len + t) * V + v_idx] = hip_bfloat16(out);
         }
     }
 
@@ -2311,11 +2310,10 @@ void supersonic_qwen35_delta_recurrent_tree_prefill_capture_q8_trace_attn_bf16_t
         state2 *= g_t;
         state3 *= g_t;
 
-        const float kv0 = supersonic_qwen35_wave_sum(state0 * k0);
-        const float kv1 = supersonic_qwen35_wave_sum(state1 * k1);
-        const float kv2 = supersonic_qwen35_wave_sum(state2 * k2);
-        const float kv3 = supersonic_qwen35_wave_sum(state3 * k3);
-        const float kv_mem = __shfl((kv0 + kv2) + (kv1 + kv3), 0);
+        const float kv_mem = __shfl(
+            supersonic_qwen35_wave_sum(
+                (state0 * k0 + state2 * k2) + (state1 * k1 + state3 * k3)),
+            0);
         const float delta = (value_t - kv_mem) * beta_t;
 
         state0 += k0 * delta;
@@ -2360,19 +2358,15 @@ void supersonic_qwen35_delta_recurrent_tree_prefill_capture_q8_trace_attn_bf16_t
         state_trace[row_base1 + 2 + lane] = static_cast<uint8_t>(static_cast<int8_t>(q1));
         state_trace[row_base2 + 2 + lane] = static_cast<uint8_t>(static_cast<int8_t>(q2));
         state_trace[row_base3 + 2 + lane] = static_cast<uint8_t>(static_cast<int8_t>(q3));
-        __syncthreads();
 
         const float q0v = query[key_row + lane + 0 * QK8_0];
         const float q1v = query[key_row + lane + 1 * QK8_0];
         const float q2v = query[key_row + lane + 2 * QK8_0];
         const float q3v = query[key_row + lane + 3 * QK8_0];
-        const float out0 = supersonic_qwen35_wave_sum(state0 * q0v);
-        const float out1 = supersonic_qwen35_wave_sum(state1 * q1v);
-        const float out2 = supersonic_qwen35_wave_sum(state2 * q2v);
-        const float out3 = supersonic_qwen35_wave_sum(state3 * q3v);
+        const float out = supersonic_qwen35_wave_sum(
+            (state0 * q0v + state2 * q2v) + (state1 * q1v + state3 * q3v));
         if (lane == 0) {
-            attn_output[(bh * seq_len + t) * V + v_idx] =
-                hip_bfloat16((out0 + out2) + (out1 + out3));
+            attn_output[(bh * seq_len + t) * V + v_idx] = hip_bfloat16(out);
         }
     }
 }

--- a/kernels/full_attention_4b.hip
+++ b/kernels/full_attention_4b.hip
@@ -3037,6 +3037,37 @@ __device__ __forceinline__ supersonic_float8 supersonic_wmma_bf16(
     return __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(a, b, acc);
 #endif
 }
+
+#if SUPERSONIC_WMMA_GFX12
+__device__ __forceinline__ supersonic_float8 supersonic_wmma_bf16_gfx12_acc(
+    supersonic_short16 a,
+    supersonic_short16 b,
+    supersonic_float8 acc12
+) {
+    const int lane = threadIdx.x & 31;
+    const int lane_group = lane >> 4;
+
+    supersonic_short8 a12;
+    supersonic_short8 b12;
+
+    #pragma unroll
+    for (int i = 0; i < 8; ++i) {
+        const int ab_row = lane_group * 4 + (i & 3) + ((i >> 2) * 8);
+        a12[i] = a[ab_row];
+        b12[i] = b[ab_row];
+    }
+
+    return __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(a12, b12, acc12);
+}
+
+__device__ __forceinline__ supersonic_float8 supersonic_wmma_bf16_gfx12_native_acc(
+    supersonic_short8 a12,
+    supersonic_short8 b12,
+    supersonic_float8 acc12
+) {
+    return __builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(a12, b12, acc12);
+}
+#endif
 #endif
 
 #ifdef SUPERSONIC_HAS_WMMA_I8
@@ -3399,6 +3430,146 @@ __device__ inline void ggml_k_dequant_16_bf16_bits_from_row_fixed(
     ggml_k_dequant_16_bf16_bits_from_block_fixed<QTYPE, TRUNC_DEQUANT>(b, inb, out);
 }
 
+#if SUPERSONIC_WMMA_GFX12
+template <bool TRUNC_DEQUANT = true>
+__device__ inline supersonic_short8 ggml_q8_0_dequant_bf16_gfx12_fragment(
+    const uint8_t* block_data,
+    int inb,
+    int lane_group
+) {
+    const int subblock = inb / 32;
+    const int idx = inb - subblock * 32;
+    const uint8_t* b = block_data + subblock * 34;
+    const float d = ggml_f16_to_f32_unaligned(b);
+    const int8_t* qs = reinterpret_cast<const int8_t*>(b + 2);
+
+    supersonic_short8 out;
+    #pragma unroll
+    for (int i = 0; i < 8; ++i) {
+        const int ab_row = lane_group * 4 + (i & 3) + ((i >> 2) * 8);
+        out[i] = static_cast<short>(
+            ggml_small_m_bf16_bits<TRUNC_DEQUANT>(
+                d * static_cast<float>(qs[idx + ab_row])));
+    }
+    return out;
+}
+
+template <bool TRUNC_DEQUANT = true>
+__device__ inline supersonic_short8 ggml_q4_k_dequant_bf16_gfx12_fragment(
+    const uint8_t* block_data,
+    int inb,
+    int lane_group
+) {
+    const float d = ggml_f16_to_f32_unaligned(block_data);
+    const float dmin = ggml_f16_to_f32_unaligned(block_data + 2);
+    const uint8_t* sc = block_data + 4;
+    const uint8_t* qs = block_data + 16;
+    const int g = inb / 64;
+    const int sub = (inb % 64) / 32;
+    const int idx = inb % 32;
+    const int j = 2 * g + sub;
+    int scale = 0;
+    int minv = 0;
+    ggml_q4_k_scale_min(sc, j, scale, minv);
+    const float ds = d * static_cast<float>(scale);
+    const float dminv = dmin * static_cast<float>(minv);
+
+    supersonic_short8 out;
+    #pragma unroll
+    for (int i = 0; i < 8; ++i) {
+        const int ab_row = lane_group * 4 + (i & 3) + ((i >> 2) * 8);
+        const uint8_t qbyte = qs[g * 32 + idx + ab_row];
+        const int q = sub != 0 ? ((qbyte >> 4) & 0x0F) : (qbyte & 0x0F);
+        out[i] = static_cast<short>(
+            ggml_small_m_bf16_bits<TRUNC_DEQUANT>(ds * static_cast<float>(q) - dminv));
+    }
+    return out;
+}
+
+template <bool TRUNC_DEQUANT = true>
+__device__ inline supersonic_short8 ggml_q5_k_dequant_bf16_gfx12_fragment(
+    const uint8_t* block_data,
+    int inb,
+    int lane_group
+) {
+    const float d = ggml_f16_to_f32_unaligned(block_data);
+    const float dmin = ggml_f16_to_f32_unaligned(block_data + 2);
+    const uint8_t* sc = block_data + 4;
+    const uint8_t* qh = block_data + 16;
+    const uint8_t* ql = block_data + 48;
+    const int g = inb / 64;
+    const int sub = (inb % 64) / 32;
+    const int idx = inb % 32;
+    const int j = 2 * g + sub;
+    int scale = 0;
+    int minv = 0;
+    ggml_q4_k_scale_min(sc, j, scale, minv);
+    const int hi_mask = sub != 0 ? (2 << (2 * g)) : (1 << (2 * g));
+    const float ds = d * static_cast<float>(scale);
+    const float dminv = dmin * static_cast<float>(minv);
+
+    supersonic_short8 out;
+    #pragma unroll
+    for (int i = 0; i < 8; ++i) {
+        const int ab_row = lane_group * 4 + (i & 3) + ((i >> 2) * 8);
+        const uint8_t qbyte = ql[g * 32 + idx + ab_row];
+        const int lo = sub != 0 ? ((qbyte >> 4) & 0x0F) : (qbyte & 0x0F);
+        const int hi = (qh[idx + ab_row] & hi_mask) ? 16 : 0;
+        out[i] = static_cast<short>(
+            ggml_small_m_bf16_bits<TRUNC_DEQUANT>(ds * static_cast<float>(lo + hi) - dminv));
+    }
+    return out;
+}
+
+template <bool TRUNC_DEQUANT = true>
+__device__ inline supersonic_short8 ggml_q6_k_dequant_bf16_gfx12_fragment(
+    const uint8_t* block_data,
+    int inb,
+    int lane_group
+) {
+    const uint8_t* ql = block_data;
+    const uint8_t* qh = block_data + 128;
+    const int8_t* sc = reinterpret_cast<const int8_t*>(block_data + 192);
+    const float d = ggml_f16_to_f32_unaligned(block_data + 208);
+    const int half_idx = inb / 128;
+    const int pos = inb - half_idx * 128;
+    const int idx = pos % 32;
+    int scale_idx = half_idx * 8 + idx / 16;
+    const uint8_t* ql_base = ql + half_idx * 64 + idx;
+    int qh_shift = 0;
+    bool high_nibble = false;
+    if (pos < 32) {
+        qh_shift = 0;
+    } else if (pos < 64) {
+        ql_base += 32;
+        qh_shift = 2;
+        scale_idx += 2;
+    } else if (pos < 96) {
+        qh_shift = 4;
+        scale_idx += 4;
+        high_nibble = true;
+    } else {
+        ql_base += 32;
+        qh_shift = 6;
+        scale_idx += 6;
+        high_nibble = true;
+    }
+    const uint8_t* qh_base = qh + half_idx * 32 + idx;
+    const float ds = d * static_cast<float>(sc[scale_idx]);
+
+    supersonic_short8 out;
+    #pragma unroll
+    for (int i = 0; i < 8; ++i) {
+        const int ab_row = lane_group * 4 + (i & 3) + ((i >> 2) * 8);
+        const int lo = high_nibble ? ((ql_base[ab_row] >> 4) & 0x0F) : (ql_base[ab_row] & 0x0F);
+        const int hi = static_cast<int>(((qh_base[ab_row] >> qh_shift) & 3) << 4);
+        out[i] = static_cast<short>(
+            ggml_small_m_bf16_bits<TRUNC_DEQUANT>(ds * static_cast<float>(lo + hi - 32)));
+    }
+    return out;
+}
+#endif
+
 // Tile dimensions.
 constexpr int TILED_WMMA_BM = 64;   // output tile rows (m)
 constexpr int TILED_WMMA_BN = 64;   // output tile cols (n)
@@ -3692,6 +3863,128 @@ __global__ void supersonic_qwen35_matmul_rhs_transposed_wmma_small_m_kernel(
         #pragma unroll
         for (int i = 0; i < 8; ++i) {
             int out_row = tile_row + 2 * i + lane_half;
+            if (out_row < m) {
+                out[out_batch_base + static_cast<size_t>(out_row) * n + out_col] =
+                    hip_bfloat16(acc[i]);
+            }
+        }
+    }
+#else
+    (void)batch_elems; (void)m; (void)n; (void)k;
+    (void)lhs; (void)rhs; (void)out;
+#endif
+}
+
+template <bool HOT_EXACT = false>
+__global__ void supersonic_qwen35_matmul_rhs_transposed_wmma_small_m_gfx12_kernel(
+    size_t batch_elems,
+    int m,
+    int n,
+    int k,
+    const hip_bfloat16* __restrict__ lhs,
+    const hip_bfloat16* __restrict__ rhs,
+    hip_bfloat16* __restrict__ out
+) {
+#if defined(SUPERSONIC_HAS_WMMA_BF16) && SUPERSONIC_WMMA_GFX12
+    const int lane = threadIdx.x;
+    const int lane_row = lane & 15;
+    const int lane_group = lane >> 4;
+    const int batch = blockIdx.z;
+    const int tile_row = blockIdx.y * 16;
+    const int tile_col = blockIdx.x * 16;
+
+    const int lhs_row_idx = tile_row + lane_row;
+    const int rhs_row_idx = tile_col + lane_row;
+    const bool lhs_in_range = HOT_EXACT || lhs_row_idx < m;
+    const bool rhs_in_range = HOT_EXACT || rhs_row_idx < n;
+
+    const size_t lhs_row_base = static_cast<size_t>(batch) * m * k +
+                                static_cast<size_t>(lhs_row_idx) * k;
+    const size_t rhs_row_base = static_cast<size_t>(batch) * n * k +
+                                static_cast<size_t>(rhs_row_idx) * k;
+
+    const uint16_t* lhs_row_u16 = reinterpret_cast<const uint16_t*>(lhs) + lhs_row_base;
+    const uint16_t* rhs_row_u16 = reinterpret_cast<const uint16_t*>(rhs) + rhs_row_base;
+
+    supersonic_float8 acc = {0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f};
+
+    const int k_main = k & ~15;
+    for (int kk = 0; kk < k_main; kk += 16) {
+        supersonic_short8 a;
+        supersonic_short8 b;
+        if constexpr (HOT_EXACT) {
+            #pragma unroll
+            for (int i = 0; i < 8; ++i) {
+                const int ab_row = lane_group * 4 + (i & 3) + ((i >> 2) * 8);
+                a[i] = static_cast<short>(lhs_row_u16[kk + ab_row]);
+            }
+        } else if (lhs_in_range) {
+            #pragma unroll
+            for (int i = 0; i < 8; ++i) {
+                const int ab_row = lane_group * 4 + (i & 3) + ((i >> 2) * 8);
+                a[i] = static_cast<short>(lhs_row_u16[kk + ab_row]);
+            }
+        } else {
+            #pragma unroll
+            for (int i = 0; i < 8; ++i) a[i] = 0;
+        }
+        if constexpr (HOT_EXACT) {
+            #pragma unroll
+            for (int i = 0; i < 8; ++i) {
+                const int ab_row = lane_group * 4 + (i & 3) + ((i >> 2) * 8);
+                b[i] = static_cast<short>(rhs_row_u16[kk + ab_row]);
+            }
+        } else if (rhs_in_range) {
+            #pragma unroll
+            for (int i = 0; i < 8; ++i) {
+                const int ab_row = lane_group * 4 + (i & 3) + ((i >> 2) * 8);
+                b[i] = static_cast<short>(rhs_row_u16[kk + ab_row]);
+            }
+        } else {
+            #pragma unroll
+            for (int i = 0; i < 8; ++i) b[i] = 0;
+        }
+        acc = supersonic_wmma_bf16_gfx12_native_acc(a, b, acc);
+    }
+
+    if constexpr (!HOT_EXACT) {
+        if (k_main != k) {
+            supersonic_short8 a = {0, 0, 0, 0, 0, 0, 0, 0};
+            supersonic_short8 b = {0, 0, 0, 0, 0, 0, 0, 0};
+            if (lhs_in_range) {
+                #pragma unroll
+                for (int i = 0; i < 8; ++i) {
+                    const int ab_row = lane_group * 4 + (i & 3) + ((i >> 2) * 8);
+                    int kc = k_main + ab_row;
+                    if (kc < k) a[i] = static_cast<short>(lhs_row_u16[kc]);
+                }
+            }
+            if (rhs_in_range) {
+                #pragma unroll
+                for (int i = 0; i < 8; ++i) {
+                    const int ab_row = lane_group * 4 + (i & 3) + ((i >> 2) * 8);
+                    int kc = k_main + ab_row;
+                    if (kc < k) b[i] = static_cast<short>(rhs_row_u16[kc]);
+                }
+            }
+            acc = supersonic_wmma_bf16_gfx12_native_acc(a, b, acc);
+        }
+    }
+
+    const int out_col = tile_col + lane_row;
+    if constexpr (HOT_EXACT) {
+        const size_t out_batch_base = static_cast<size_t>(batch) * m * n;
+        #pragma unroll
+        for (int i = 0; i < 8; ++i) {
+            int out_row = tile_row + lane_group * 8 + i;
+            out[out_batch_base + static_cast<size_t>(out_row) * n + out_col] =
+                hip_bfloat16(acc[i]);
+        }
+    } else if (out_col < n) {
+        const size_t out_batch_base = static_cast<size_t>(batch) * m * n;
+        #pragma unroll
+        for (int i = 0; i < 8; ++i) {
+            int out_row = tile_row + lane_group * 8 + i;
             if (out_row < m) {
                 out[out_batch_base + static_cast<size_t>(out_row) * n + out_col] =
                     hip_bfloat16(acc[i]);
@@ -4527,15 +4820,26 @@ __device__ __forceinline__ void supersonic_mmq_load_q6_k_tile_128(
     for (int i0 = 0; i0 < MMQ_Y; i0 += nrows * NWARPS) {
         const int i = i0 + threadIdx.y * nrows + threadIdx.x / threads_per_row;
         const int row = tile_n + i;
-        const bool valid = HOT_EXACT_N || row < n;
-        const int safe_row = HOT_EXACT_N ? row : (row < n ? row : n - 1);
-        const uint8_t* b = rhs_q6 + batch_base +
-                           static_cast<size_t>(safe_row) * row_bytes +
-                           static_cast<size_t>(q6_block) * Q6_BLOCK_BYTES;
 
         int q0 = 0;
         int q1 = 0;
-        if (valid) {
+        if constexpr (HOT_EXACT_N) {
+            const uint8_t* b = rhs_q6 + batch_base +
+                               static_cast<size_t>(row) * row_bytes +
+                               static_cast<size_t>(q6_block) * Q6_BLOCK_BYTES;
+            const int ql = supersonic_get_int_b2(b, txi);
+            const int ql0 = (ql >> 0) & 0x0F0F0F0F;
+            const int ql1 = (ql >> 4) & 0x0F0F0F0F;
+            const int qh = supersonic_get_int_b2(
+                b + 128, (QI6_K / 4) * (txi / (QI6_K / 2)) + txi % (QI6_K / 4));
+            const int qh0 = ((qh >> ((txi & 0x08) >> 2)) << 4) & 0x30303030;
+            const int qh1 =  (qh >> ((txi & 0x08) >> 2))       & 0x30303030;
+            q0 = supersonic_sub_i8x4(ql0 | qh0, 32);
+            q1 = supersonic_sub_i8x4(ql1 | qh1, 32);
+        } else if (row < n) {
+            const uint8_t* b = rhs_q6 + batch_base +
+                               static_cast<size_t>(row) * row_bytes +
+                               static_cast<size_t>(q6_block) * Q6_BLOCK_BYTES;
             const int ql = supersonic_get_int_b2(b, txi);
             const int ql0 = (ql >> 0) & 0x0F0F0F0F;
             const int ql1 = (ql >> 4) & 0x0F0F0F0F;
@@ -4605,6 +4909,34 @@ __device__ __forceinline__ void supersonic_mmq_load_q8_1_tile_16(
     constexpr int Q8_BLOCK_BYTES = 144;
     const int blocks_per_row = k / 128;
 
+    if constexpr (HOT_EXACT_M16) {
+        const int tid = threadIdx.y * 32 + threadIdx.x;
+        const size_t batch_q8_base =
+            static_cast<size_t>(batch) * blocks_per_row * m +
+            static_cast<size_t>(q8_block) * m;
+
+        int l = tid;
+        int row = l / MMQ_TILE_Y_K;
+        int word = l - row * MMQ_TILE_Y_K;
+        size_t block = (batch_q8_base + static_cast<size_t>(tile_m + row)) * Q8_BLOCK_BYTES;
+        tile_y[l] = reinterpret_cast<const int*>(q8 + block)[word];
+
+        l = tid + 8 * 32;
+        row = l / MMQ_TILE_Y_K;
+        word = l - row * MMQ_TILE_Y_K;
+        block = (batch_q8_base + static_cast<size_t>(tile_m + row)) * Q8_BLOCK_BYTES;
+        tile_y[l] = reinterpret_cast<const int*>(q8 + block)[word];
+
+        if (tid < MMQ_X * MMQ_TILE_Y_K - 2 * 8 * 32) {
+            l = tid + 2 * 8 * 32;
+            row = l / MMQ_TILE_Y_K;
+            word = l - row * MMQ_TILE_Y_K;
+            block = (batch_q8_base + static_cast<size_t>(tile_m + row)) * Q8_BLOCK_BYTES;
+            tile_y[l] = reinterpret_cast<const int*>(q8 + block)[word];
+        }
+        return;
+    }
+
     for (int l0 = 0; l0 < MMQ_X * MMQ_TILE_Y_K; l0 += 8 * 32) {
         const int l = l0 + threadIdx.y * 32 + threadIdx.x;
         if (l >= MMQ_X * MMQ_TILE_Y_K) {
@@ -4614,13 +4946,7 @@ __device__ __forceinline__ void supersonic_mmq_load_q8_1_tile_16(
         const int word = l - row * MMQ_TILE_Y_K;
         const int global_row = tile_m + row;
         int v = 0;
-        if constexpr (HOT_EXACT_M16) {
-            const size_t block =
-                (static_cast<size_t>(batch) * blocks_per_row * m +
-                 static_cast<size_t>(q8_block) * m + global_row) *
-                Q8_BLOCK_BYTES;
-            v = reinterpret_cast<const int*>(q8 + block)[word];
-        } else if (global_row < m) {
+        if (global_row < m) {
             const size_t block =
                 (static_cast<size_t>(batch) * blocks_per_row * m +
                  static_cast<size_t>(q8_block) * m + global_row) *
@@ -4645,6 +4971,35 @@ __device__ __forceinline__ void supersonic_mmq_i8_wmma_16x4(
     (void)c; (void)a; (void)b;
 #endif
 }
+
+#if SUPERSONIC_WMMA_GFX12
+__device__ __forceinline__ supersonic_i32x8 supersonic_mmq_i8_wmma_16x4_gfx12_native(
+    const int a[4],
+    const int b[4]
+) {
+#ifdef SUPERSONIC_HAS_WMMA_I8
+    const int lane = threadIdx.x & 31;
+    const int lane_group = lane >> 4;
+
+    supersonic_i32x2 a12;
+    supersonic_i32x2 b12;
+    supersonic_i32x8 c12 = {0, 0, 0, 0, 0, 0, 0, 0};
+
+    #pragma unroll
+    for (int i = 0; i < 2; ++i) {
+        const int packed_idx = lane_group + 2 * i;
+        a12[i] = a[packed_idx];
+        b12[i] = b[packed_idx];
+    }
+
+    return __builtin_amdgcn_wmma_i32_16x16x16_iu8_w32_gfx12(
+        true, a12, true, b12, c12, false);
+#else
+    (void)a; (void)b;
+    return {0, 0, 0, 0, 0, 0, 0, 0};
+#endif
+}
+#endif
 
 __device__ __forceinline__ void supersonic_mmq_vec_dot_q6_k_q8_1_wmma(
     const int* __restrict__ tile_x,
@@ -4694,7 +5049,58 @@ __device__ __forceinline__ void supersonic_mmq_vec_dot_q6_k_q8_1_wmma(
     }
 }
 
-template <bool HOT_EXACT = false>
+#if SUPERSONIC_WMMA_GFX12
+__device__ __forceinline__ void supersonic_mmq_vec_dot_q6_k_q8_1_wmma_gfx12_native(
+    const int* __restrict__ tile_x,
+    const int* __restrict__ tile_y,
+    float sum[8],
+    int k00
+) {
+    constexpr int MMQ_TILE_NE_K = 32;
+    constexpr int MMQ_TILE_Y_K = 36;
+    constexpr int QI6_K = 32;
+    constexpr int QI8_1 = 8;
+    constexpr int MMQ_MMA_TILE_X_K_Q6_K =
+        2 * MMQ_TILE_NE_K + MMQ_TILE_NE_K / QI6_K + MMQ_TILE_NE_K / 8 + 7;
+
+    const int* x_qs = tile_x;
+    const float* x_df = reinterpret_cast<const float*>(x_qs + 2 * MMQ_TILE_NE_K);
+    const int* x_sc = reinterpret_cast<const int*>(x_df + MMQ_TILE_NE_K / QI6_K);
+    const int* y_qs = tile_y + 4;
+    const float* y_df = reinterpret_cast<const float*>(tile_y);
+    const int lane = threadIdx.x & 31;
+    const int lane_row = lane & 15;
+    const int lane_group = lane >> 4;
+    const int i0 = threadIdx.y * 16;
+
+    for (int k01 = 0; k01 < MMQ_TILE_NE_K; k01 += 4) {
+        const int k0 = k00 + k01;
+        int a[4];
+        int b[4];
+        #pragma unroll
+        for (int l = 0; l < 4; ++l) {
+            a[l] = x_qs[(i0 + lane_row) * MMQ_MMA_TILE_X_K_Q6_K + k0 + l];
+            b[l] = y_qs[lane_row * MMQ_TILE_Y_K + k01 + l];
+        }
+
+        const supersonic_i32x8 c = supersonic_mmq_i8_wmma_16x4_gfx12_native(a, b);
+
+        const int j = lane_row;
+        const float dB = y_df[j * MMQ_TILE_Y_K + k01 / QI8_1];
+        #pragma unroll
+        for (int l = 0; l < 8; ++l) {
+            const int i = i0 + lane_group * 8 + l;
+            const int8_t* sc =
+                reinterpret_cast<const int8_t*>(x_sc + i * MMQ_MMA_TILE_X_K_Q6_K + k00 / 16);
+            const float dA = x_df[i * MMQ_MMA_TILE_X_K_Q6_K];
+            sum[l] += static_cast<float>(c[l]) * static_cast<float>(sc[k01 / 4]) * dA * dB;
+        }
+    }
+}
+
+#endif
+
+template <bool HOT_EXACT = false, bool HAS_RESIDUAL = false>
 __global__ __launch_bounds__(256, 2)
 void supersonic_qwen35_matmul_mmq_q8_1_q6_k_kernel(
     size_t batch_elems,
@@ -4751,7 +5157,7 @@ void supersonic_qwen35_matmul_mmq_q8_1_q6_k_kernel(
         if constexpr (HOT_EXACT) {
             const size_t out_idx = out_base + static_cast<size_t>(out_row) * n + out_col;
             const hip_bfloat16 projected(sum[l]);
-            if (residual != nullptr) {
+            if constexpr (HAS_RESIDUAL) {
                 out[out_idx] = hip_bfloat16(static_cast<float>(residual[out_idx]) +
                                            static_cast<float>(projected));
             } else {
@@ -4760,7 +5166,87 @@ void supersonic_qwen35_matmul_mmq_q8_1_q6_k_kernel(
         } else if (out_row < m && out_col < n) {
             const size_t out_idx = out_base + static_cast<size_t>(out_row) * n + out_col;
             const hip_bfloat16 projected(sum[l]);
-            if (residual != nullptr) {
+            if constexpr (HAS_RESIDUAL) {
+                out[out_idx] = hip_bfloat16(static_cast<float>(residual[out_idx]) +
+                                           static_cast<float>(projected));
+            } else {
+                out[out_idx] = projected;
+            }
+        }
+    }
+#else
+    (void)batch_elems; (void)m; (void)n; (void)k;
+    (void)q8; (void)rhs_q6; (void)residual; (void)out;
+#endif
+}
+
+template <bool HOT_EXACT = false, bool HAS_RESIDUAL = false>
+__global__ __launch_bounds__(256, 2)
+void supersonic_qwen35_matmul_mmq_q8_1_q6_k_gfx12_kernel(
+    size_t batch_elems,
+    int m,
+    int n,
+    int k,
+    const uint8_t* __restrict__ q8,
+    const uint8_t* __restrict__ rhs_q6,
+    const hip_bfloat16* __restrict__ residual,
+    hip_bfloat16* __restrict__ out
+) {
+#if defined(SUPERSONIC_HAS_WMMA_I8) && SUPERSONIC_WMMA_GFX12
+    constexpr int MMQ_X = 16;
+    constexpr int MMQ_Y = 128;
+    constexpr int MMQ_MMA_TILE_X_K_Q6_K = 76;
+    constexpr int PADDED_TILE_Y_INTS = 768;
+
+    const int tile_n = blockIdx.x * MMQ_Y;
+    const int tile_m = blockIdx.y * MMQ_X;
+    const int batch = blockIdx.z;
+    if (static_cast<size_t>(batch) >= batch_elems) {
+        return;
+    }
+
+    extern __shared__ int supersonic_mmq_smem[];
+    int* tile_y = supersonic_mmq_smem;
+    int* tile_x = supersonic_mmq_smem + PADDED_TILE_Y_INTS;
+    float sum[8] = {0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f};
+
+    const int q6_blocks = k / 256;
+    for (int block = 0; block < q6_blocks; ++block) {
+        supersonic_mmq_load_q6_k_tile_128<HOT_EXACT>(
+            rhs_q6, tile_x, batch, tile_n, n, k, block);
+        supersonic_mmq_load_q8_1_tile_16<HOT_EXACT>(
+            q8, tile_y, batch, tile_m, m, k, 2 * block);
+        __syncthreads();
+        supersonic_mmq_vec_dot_q6_k_q8_1_wmma_gfx12_native(tile_x, tile_y, sum, 0);
+        __syncthreads();
+
+        supersonic_mmq_load_q8_1_tile_16<HOT_EXACT>(
+            q8, tile_y, batch, tile_m, m, k, 2 * block + 1);
+        __syncthreads();
+        supersonic_mmq_vec_dot_q6_k_q8_1_wmma_gfx12_native(tile_x, tile_y, sum, 32);
+        __syncthreads();
+    }
+
+    const int lane = threadIdx.x & 31;
+    const int out_row = tile_m + (lane & 15);
+    const int lane_group = lane >> 4;
+    const size_t out_base = static_cast<size_t>(batch) * m * static_cast<size_t>(n);
+    #pragma unroll
+    for (int l = 0; l < 8; ++l) {
+        const int out_col = tile_n + threadIdx.y * 16 + lane_group * 8 + l;
+        if constexpr (HOT_EXACT) {
+            const size_t out_idx = out_base + static_cast<size_t>(out_row) * n + out_col;
+            const hip_bfloat16 projected(sum[l]);
+            if constexpr (HAS_RESIDUAL) {
+                out[out_idx] = hip_bfloat16(static_cast<float>(residual[out_idx]) +
+                                           static_cast<float>(projected));
+            } else {
+                out[out_idx] = projected;
+            }
+        } else if (out_row < m && out_col < n) {
+            const size_t out_idx = out_base + static_cast<size_t>(out_row) * n + out_col;
+            const hip_bfloat16 projected(sum[l]);
+            if constexpr (HAS_RESIDUAL) {
                 out[out_idx] = hip_bfloat16(static_cast<float>(residual[out_idx]) +
                                            static_cast<float>(projected));
             } else {
@@ -4968,6 +5454,100 @@ void supersonic_qwen35_matmul_ggml_dequant_wmma_m8_qtype_kernel(
 #endif
 }
 
+template <int QTYPE, bool TRUNC_DEQUANT = false>
+__global__ __launch_bounds__(32, 4)
+void supersonic_qwen35_matmul_ggml_dequant_wmma_m8_qtype_gfx12_kernel(
+    size_t batch_elems,
+    int n,
+    int k,
+    const hip_bfloat16* __restrict__ lhs,
+    const uint8_t* __restrict__ rhs_int4,
+    hip_bfloat16* __restrict__ out
+) {
+#if defined(SUPERSONIC_HAS_WMMA_BF16) && SUPERSONIC_WMMA_GFX12
+    const int lane = threadIdx.x;
+    const int lane_row = lane & 15;
+    const int lane_group = lane >> 4;
+    const int batch = blockIdx.z;
+    const int tile_col = blockIdx.x * 16;
+    const int rhs_row_idx = tile_col + lane_row;
+
+    const int block_bytes = ggml_k_block_bytes_fixed<QTYPE>();
+    const int blocks = k / 256;
+    const int row_bytes = blocks * block_bytes;
+
+    const size_t lhs_row_base = static_cast<size_t>(batch) * 8 * static_cast<size_t>(k) +
+                                static_cast<size_t>(lane_row) * k;
+    const size_t rhs_row_base = static_cast<size_t>(batch) * n * static_cast<size_t>(row_bytes) +
+                                static_cast<size_t>(rhs_row_idx) * row_bytes;
+
+    const uint16_t* lhs_row_u16 = reinterpret_cast<const uint16_t*>(lhs) + lhs_row_base;
+    const uint8_t* rhs_row_u8 = rhs_int4 + rhs_row_base;
+    const bool lhs_in_range = lane_row < 8;
+
+    supersonic_float8 acc = {0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f};
+
+    for (int block = 0; block < blocks; ++block) {
+        const uint8_t* rhs_block = rhs_row_u8 + block * block_bytes;
+        const int kk_block = block * 256;
+        #pragma unroll
+        for (int sub = 0; sub < 16; ++sub) {
+            const int kk = kk_block + sub * 16;
+            supersonic_short8 a;
+            if (lhs_in_range) {
+                #pragma unroll
+                for (int i = 0; i < 8; ++i) {
+                    const int ab_row = lane_group * 4 + (i & 3) + ((i >> 2) * 8);
+                    a[i] = static_cast<short>(lhs_row_u16[kk + ab_row]);
+                }
+            } else {
+                #pragma unroll
+                for (int i = 0; i < 8; ++i) a[i] = 0;
+            }
+
+            supersonic_short8 b;
+            if constexpr (QTYPE == QWEN35_LOWBIT_GGML_Q8_0) {
+                b = ggml_q8_0_dequant_bf16_gfx12_fragment<TRUNC_DEQUANT>(
+                    rhs_block, sub * 16, lane_group);
+            } else if constexpr (QTYPE == QWEN35_LOWBIT_GGML_Q4_K) {
+                b = ggml_q4_k_dequant_bf16_gfx12_fragment<TRUNC_DEQUANT>(
+                    rhs_block, sub * 16, lane_group);
+            } else if constexpr (QTYPE == QWEN35_LOWBIT_GGML_Q5_K) {
+                b = ggml_q5_k_dequant_bf16_gfx12_fragment<TRUNC_DEQUANT>(
+                    rhs_block, sub * 16, lane_group);
+            } else if constexpr (QTYPE == QWEN35_LOWBIT_GGML_Q6_K) {
+                b = ggml_q6_k_dequant_bf16_gfx12_fragment<TRUNC_DEQUANT>(
+                    rhs_block, sub * 16, lane_group);
+            } else {
+                uint16_t bits[16];
+                ggml_k_dequant_16_bf16_bits_from_block_fixed<QTYPE, TRUNC_DEQUANT>(
+                    rhs_block, sub * 16, bits);
+                #pragma unroll
+                for (int i = 0; i < 8; ++i) {
+                    const int ab_row = lane_group * 4 + (i & 3) + ((i >> 2) * 8);
+                    b[i] = static_cast<short>(bits[ab_row]);
+                }
+            }
+
+            acc = supersonic_wmma_bf16_gfx12_native_acc(a, b, acc);
+        }
+    }
+
+    if (lane_group == 0) {
+        const int out_col = tile_col + lane_row;
+        const size_t out_batch_base = static_cast<size_t>(batch) * 8 * static_cast<size_t>(n);
+        #pragma unroll
+        for (int i = 0; i < 8; ++i) {
+            out[out_batch_base + static_cast<size_t>(i) * n + out_col] =
+                hip_bfloat16(acc[i]);
+        }
+    }
+#else
+    (void)batch_elems; (void)n; (void)k;
+    (void)lhs; (void)rhs_int4; (void)out;
+#endif
+}
+
 template <int QTYPE, bool TRUNC_DEQUANT = false, bool ADD_RESIDUAL = false>
 __global__ __launch_bounds__(32, 4)
 void supersonic_qwen35_matmul_ggml_dequant_wmma_m16_qtype_kernel(
@@ -5031,6 +5611,100 @@ void supersonic_qwen35_matmul_ggml_dequant_wmma_m16_qtype_kernel(
     #pragma unroll
     for (int i = 0; i < 8; ++i) {
         const int out_row = 2 * i + lane_half;
+        const size_t out_idx = out_batch_base + static_cast<size_t>(out_row) * n + out_col;
+        hip_bfloat16 projected(acc[i]);
+        if constexpr (ADD_RESIDUAL) {
+            const float summed = static_cast<float>(residual[out_idx]) + static_cast<float>(projected);
+            out[out_idx] = hip_bfloat16(summed);
+        } else {
+            out[out_idx] = projected;
+        }
+    }
+#else
+    (void)batch_elems; (void)n; (void)k;
+    (void)lhs; (void)rhs_int4; (void)residual; (void)out;
+#endif
+}
+
+template <int QTYPE, bool TRUNC_DEQUANT = false, bool ADD_RESIDUAL = false>
+__global__ __launch_bounds__(32, 4)
+void supersonic_qwen35_matmul_ggml_dequant_wmma_m16_qtype_gfx12_kernel(
+    size_t batch_elems,
+    int n,
+    int k,
+    const hip_bfloat16* __restrict__ lhs,
+    const uint8_t* __restrict__ rhs_int4,
+    const hip_bfloat16* __restrict__ residual,
+    hip_bfloat16* __restrict__ out
+) {
+#if defined(SUPERSONIC_HAS_WMMA_BF16) && SUPERSONIC_WMMA_GFX12
+    const int lane = threadIdx.x;
+    const int lane_row = lane & 15;
+    const int lane_group = lane >> 4;
+    const int batch = blockIdx.z;
+    const int tile_col = blockIdx.x * 16;
+    const int rhs_row_idx = tile_col + lane_row;
+
+    const int block_bytes = ggml_k_block_bytes_fixed<QTYPE>();
+    const int blocks = k / 256;
+    const int row_bytes = blocks * block_bytes;
+
+    const size_t lhs_row_base = static_cast<size_t>(batch) * 16 * static_cast<size_t>(k) +
+                                static_cast<size_t>(lane_row) * k;
+    const size_t rhs_row_base = static_cast<size_t>(batch) * n * static_cast<size_t>(row_bytes) +
+                                static_cast<size_t>(rhs_row_idx) * row_bytes;
+
+    const uint16_t* lhs_row_u16 = reinterpret_cast<const uint16_t*>(lhs) + lhs_row_base;
+    const uint8_t* rhs_row_u8 = rhs_int4 + rhs_row_base;
+
+    supersonic_float8 acc = {0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f};
+
+    for (int block = 0; block < blocks; ++block) {
+        const uint8_t* rhs_block = rhs_row_u8 + block * block_bytes;
+        const int kk_block = block * 256;
+        #pragma unroll
+        for (int sub = 0; sub < 16; ++sub) {
+            const int kk = kk_block + sub * 16;
+            supersonic_short8 a;
+            #pragma unroll
+            for (int i = 0; i < 8; ++i) {
+                const int ab_row = lane_group * 4 + (i & 3) + ((i >> 2) * 8);
+                a[i] = static_cast<short>(lhs_row_u16[kk + ab_row]);
+            }
+
+            supersonic_short8 b;
+            if constexpr (QTYPE == QWEN35_LOWBIT_GGML_Q8_0) {
+                b = ggml_q8_0_dequant_bf16_gfx12_fragment<TRUNC_DEQUANT>(
+                    rhs_block, sub * 16, lane_group);
+            } else if constexpr (QTYPE == QWEN35_LOWBIT_GGML_Q4_K) {
+                b = ggml_q4_k_dequant_bf16_gfx12_fragment<TRUNC_DEQUANT>(
+                    rhs_block, sub * 16, lane_group);
+            } else if constexpr (QTYPE == QWEN35_LOWBIT_GGML_Q5_K) {
+                b = ggml_q5_k_dequant_bf16_gfx12_fragment<TRUNC_DEQUANT>(
+                    rhs_block, sub * 16, lane_group);
+            } else if constexpr (QTYPE == QWEN35_LOWBIT_GGML_Q6_K) {
+                b = ggml_q6_k_dequant_bf16_gfx12_fragment<TRUNC_DEQUANT>(
+                    rhs_block, sub * 16, lane_group);
+            } else {
+                uint16_t bits[16];
+                ggml_k_dequant_16_bf16_bits_from_block_fixed<QTYPE, TRUNC_DEQUANT>(
+                    rhs_block, sub * 16, bits);
+                #pragma unroll
+                for (int i = 0; i < 8; ++i) {
+                    const int ab_row = lane_group * 4 + (i & 3) + ((i >> 2) * 8);
+                    b[i] = static_cast<short>(bits[ab_row]);
+                }
+            }
+
+            acc = supersonic_wmma_bf16_gfx12_native_acc(a, b, acc);
+        }
+    }
+
+    const int out_col = tile_col + lane_row;
+    const size_t out_batch_base = static_cast<size_t>(batch) * 16 * static_cast<size_t>(n);
+    #pragma unroll
+    for (int i = 0; i < 8; ++i) {
+        const int out_row = lane_group * 8 + i;
         const size_t out_idx = out_batch_base + static_cast<size_t>(out_row) * n + out_col;
         hip_bfloat16 projected(acc[i]);
         if constexpr (ADD_RESIDUAL) {
@@ -5141,6 +5815,98 @@ void supersonic_qwen35_matmul_q6_k_m16_tile_argmax_kernel(
 #endif
 }
 
+template <bool TRUNC_DEQUANT = true>
+__global__ __launch_bounds__(32, 4)
+void supersonic_qwen35_matmul_q6_k_m16_tile_argmax_gfx12_kernel(
+    size_t batch_elems,
+    int n,
+    int k,
+    const hip_bfloat16* __restrict__ lhs,
+    const uint8_t* __restrict__ rhs_q6,
+    float* __restrict__ block_best_vals,
+    uint32_t* __restrict__ block_best_indices
+) {
+#if defined(SUPERSONIC_HAS_WMMA_BF16) && SUPERSONIC_WMMA_GFX12
+    __shared__ float tile_vals[16][16];
+
+    const int lane = threadIdx.x;
+    const int lane_row = lane & 15;
+    const int lane_group = lane >> 4;
+    const int batch = blockIdx.z;
+    if (static_cast<size_t>(batch) >= batch_elems) {
+        return;
+    }
+
+    const int tile_col = blockIdx.x * 16;
+    const int rhs_row_idx = tile_col + lane_row;
+    const int block_bytes = ggml_k_block_bytes_fixed<QWEN35_LOWBIT_GGML_Q6_K>();
+    const int blocks = k / 256;
+    const int row_bytes = blocks * block_bytes;
+
+    const size_t lhs_row_base = static_cast<size_t>(batch) * 16 * static_cast<size_t>(k) +
+                                static_cast<size_t>(lane_row) * k;
+    const size_t rhs_row_base = static_cast<size_t>(batch) * n * static_cast<size_t>(row_bytes) +
+                                static_cast<size_t>(rhs_row_idx) * row_bytes;
+
+    const uint16_t* lhs_row_u16 = reinterpret_cast<const uint16_t*>(lhs) + lhs_row_base;
+    const uint8_t* rhs_row_u8 = rhs_q6 + rhs_row_base;
+
+    supersonic_float8 acc = {0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f};
+
+    for (int block = 0; block < blocks; ++block) {
+        const uint8_t* rhs_block = rhs_row_u8 + block * block_bytes;
+        const int kk_block = block * 256;
+        #pragma unroll
+        for (int sub = 0; sub < 16; ++sub) {
+            const int kk = kk_block + sub * 16;
+            supersonic_short8 a;
+            #pragma unroll
+            for (int i = 0; i < 8; ++i) {
+                const int ab_row = lane_group * 4 + (i & 3) + ((i >> 2) * 8);
+                a[i] = static_cast<short>(lhs_row_u16[kk + ab_row]);
+            }
+
+            const supersonic_short8 b =
+                ggml_q6_k_dequant_bf16_gfx12_fragment<TRUNC_DEQUANT>(
+                    rhs_block, sub * 16, lane_group);
+
+            acc = supersonic_wmma_bf16_gfx12_native_acc(a, b, acc);
+        }
+    }
+
+    #pragma unroll
+    for (int i = 0; i < 8; ++i) {
+        const int out_row = lane_group * 8 + i;
+        const hip_bfloat16 rounded(acc[i]);
+        tile_vals[out_row][lane_row] = static_cast<float>(rounded);
+    }
+    __syncthreads();
+
+    if (lane < 16) {
+        const int row = lane;
+        float best_val = -1.0e30f;
+        uint32_t best_idx = 0;
+        #pragma unroll
+        for (int c = 0; c < 16; ++c) {
+            const float val = tile_vals[row][c];
+            const uint32_t idx = static_cast<uint32_t>(tile_col + c);
+            if (val > best_val || (val == best_val && idx < best_idx)) {
+                best_val = val;
+                best_idx = idx;
+            }
+        }
+        const size_t tiles = gridDim.x;
+        const size_t out =
+            (static_cast<size_t>(batch) * tiles + blockIdx.x) * 16 + row;
+        block_best_vals[out] = best_val;
+        block_best_indices[out] = best_idx;
+    }
+#else
+    (void)batch_elems; (void)n; (void)k; (void)lhs; (void)rhs_q6;
+    (void)block_best_vals; (void)block_best_indices;
+#endif
+}
+
 __global__ void supersonic_qwen35_reduce_m16_tile_argmax_kernel(
     size_t batch_elems,
     int tiles,
@@ -5164,6 +5930,58 @@ __global__ void supersonic_qwen35_reduce_m16_tile_argmax_kernel(
     for (int tile = static_cast<int>(tid); tile < tiles; tile += blockDim.x) {
         const float val = block_best_vals[base + tile];
         const uint32_t idx = block_best_indices[base + tile];
+        if (val > best_val || (val == best_val && idx < best_idx)) {
+            best_val = val;
+            best_idx = idx;
+        }
+    }
+
+    shared_vals[tid] = best_val;
+    shared_idx[tid] = best_idx;
+    __syncthreads();
+
+    for (unsigned int offset = blockDim.x / 2; offset > 0; offset >>= 1) {
+        if (tid < offset) {
+            const float rhs_val = shared_vals[tid + offset];
+            const uint32_t rhs_idx = shared_idx[tid + offset];
+            if (rhs_val > shared_vals[tid] ||
+                (rhs_val == shared_vals[tid] && rhs_idx < shared_idx[tid])) {
+                shared_vals[tid] = rhs_val;
+                shared_idx[tid] = rhs_idx;
+            }
+        }
+        __syncthreads();
+    }
+
+    if (tid == 0) {
+        out_indices[static_cast<size_t>(batch) * 16 + row] = shared_idx[0];
+    }
+}
+
+__global__ void supersonic_qwen35_reduce_m16_tile_argmax_tile_major_kernel(
+    size_t batch_elems,
+    int tiles,
+    const float* __restrict__ block_best_vals,
+    const uint32_t* __restrict__ block_best_indices,
+    uint32_t* __restrict__ out_indices
+) {
+    __shared__ float shared_vals[256];
+    __shared__ uint32_t shared_idx[256];
+
+    const int row = blockIdx.x;
+    const int batch = blockIdx.y;
+    if (row >= 16 || static_cast<size_t>(batch) >= batch_elems) {
+        return;
+    }
+    const unsigned int tid = threadIdx.x;
+    const size_t base = static_cast<size_t>(batch) * 16 * static_cast<size_t>(tiles) + row;
+
+    float best_val = -1.0e30f;
+    uint32_t best_idx = 0;
+    for (int tile = static_cast<int>(tid); tile < tiles; tile += blockDim.x) {
+        const size_t offset = base + static_cast<size_t>(tile) * 16;
+        const float val = block_best_vals[offset];
+        const uint32_t idx = block_best_indices[offset];
         if (val > best_val || (val == best_val && idx < best_idx)) {
             best_val = val;
             best_idx = idx;
@@ -5271,6 +6089,93 @@ void supersonic_qwen35_matmul_ggml_pair_wmma_m16_qtype_kernel(
 
 template <int QTYPE, bool TRUNC_DEQUANT = false>
 __global__ __launch_bounds__(32, 8)
+void supersonic_qwen35_matmul_ggml_pair_wmma_m16_qtype_gfx12_kernel(
+    size_t batch_elems,
+    int n_each,
+    int k,
+    const hip_bfloat16* __restrict__ lhs,
+    const uint8_t* __restrict__ rhs_first,
+    const uint8_t* __restrict__ rhs_second,
+    hip_bfloat16* __restrict__ out
+) {
+#if defined(SUPERSONIC_HAS_WMMA_BF16) && SUPERSONIC_WMMA_GFX12
+    const int lane = threadIdx.x;
+    const int lane_row = lane & 15;
+    const int lane_group = lane >> 4;
+    const int batch = blockIdx.z;
+    const int tile_col = blockIdx.x * 16;
+    const int out_col_idx = tile_col + lane_row;
+    const int n_out = n_each * 2;
+    const bool second = out_col_idx >= n_each;
+    const int rhs_row_idx = second ? out_col_idx - n_each : out_col_idx;
+    const uint8_t* rhs_base_ptr = second ? rhs_second : rhs_first;
+
+    const int block_bytes = ggml_k_block_bytes_fixed<QTYPE>();
+    const int blocks = k / 256;
+    const int row_bytes = blocks * block_bytes;
+
+    const size_t lhs_row_base = static_cast<size_t>(batch) * 16 * static_cast<size_t>(k) +
+                                static_cast<size_t>(lane_row) * k;
+    const size_t rhs_row_base = static_cast<size_t>(batch) * n_each * static_cast<size_t>(row_bytes) +
+                                static_cast<size_t>(rhs_row_idx) * row_bytes;
+
+    const uint16_t* lhs_row_u16 = reinterpret_cast<const uint16_t*>(lhs) + lhs_row_base;
+    const uint8_t* rhs_row_u8 = rhs_base_ptr + rhs_row_base;
+
+    supersonic_float8 acc = {0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f};
+
+    for (int block = 0; block < blocks; ++block) {
+        const uint8_t* rhs_block = rhs_row_u8 + block * block_bytes;
+        const int kk_block = block * 256;
+        #pragma unroll
+        for (int sub = 0; sub < 16; ++sub) {
+            const int kk = kk_block + sub * 16;
+            supersonic_short8 a;
+            #pragma unroll
+            for (int i = 0; i < 8; ++i) {
+                const int ab_row = lane_group * 4 + (i & 3) + ((i >> 2) * 8);
+                a[i] = static_cast<short>(lhs_row_u16[kk + ab_row]);
+            }
+
+            supersonic_short8 b;
+            if constexpr (QTYPE == QWEN35_LOWBIT_GGML_Q4_K) {
+                b = ggml_q4_k_dequant_bf16_gfx12_fragment<TRUNC_DEQUANT>(
+                    rhs_block, sub * 16, lane_group);
+            } else if constexpr (QTYPE == QWEN35_LOWBIT_GGML_Q5_K) {
+                b = ggml_q5_k_dequant_bf16_gfx12_fragment<TRUNC_DEQUANT>(
+                    rhs_block, sub * 16, lane_group);
+            } else {
+                uint16_t bits[16];
+                ggml_k_dequant_16_bf16_bits_from_block_fixed<QTYPE, TRUNC_DEQUANT>(
+                    rhs_block, sub * 16, bits);
+                #pragma unroll
+                for (int i = 0; i < 8; ++i) {
+                    const int ab_row = lane_group * 4 + (i & 3) + ((i >> 2) * 8);
+                    b[i] = static_cast<short>(bits[ab_row]);
+                }
+            }
+
+            acc = supersonic_wmma_bf16_gfx12_native_acc(a, b, acc);
+        }
+    }
+
+    if (out_col_idx < n_out) {
+        const size_t out_batch_base = static_cast<size_t>(batch) * 16 * static_cast<size_t>(n_out);
+        #pragma unroll
+        for (int i = 0; i < 8; ++i) {
+            const int out_row = lane_group * 8 + i;
+            out[out_batch_base + static_cast<size_t>(out_row) * n_out + out_col_idx] =
+                hip_bfloat16(acc[i]);
+        }
+    }
+#else
+    (void)batch_elems; (void)n_each; (void)k;
+    (void)lhs; (void)rhs_first; (void)rhs_second; (void)out;
+#endif
+}
+
+template <int QTYPE, bool TRUNC_DEQUANT = false>
+__global__ __launch_bounds__(32, 8)
 void supersonic_qwen35_matmul_ggml_pair_swiglu_wmma_m16_qtype_kernel(
     size_t batch_elems,
     int n_each,
@@ -5344,6 +6249,117 @@ void supersonic_qwen35_matmul_ggml_pair_swiglu_wmma_m16_qtype_kernel(
         #pragma unroll
         for (int i = 0; i < 8; ++i) {
             const int out_row = 2 * i + lane_half;
+            const hip_bfloat16 gate_bf16(gate_acc[i]);
+            const hip_bfloat16 up_bf16(up_acc[i]);
+            const float gate_x = static_cast<float>(gate_bf16);
+            const float up_x = static_cast<float>(up_bf16);
+            const float silu = gate_x / (1.0f + expf(-gate_x));
+            out[out_batch_base + static_cast<size_t>(out_row) * n_each + out_col_idx] =
+                hip_bfloat16(silu * up_x);
+        }
+    }
+#else
+    (void)batch_elems; (void)n_each; (void)k;
+    (void)lhs; (void)rhs_gate; (void)rhs_up; (void)out;
+#endif
+}
+
+template <int QTYPE, bool TRUNC_DEQUANT = false>
+__global__ __launch_bounds__(32, 8)
+void supersonic_qwen35_matmul_ggml_pair_swiglu_wmma_m16_qtype_gfx12_kernel(
+    size_t batch_elems,
+    int n_each,
+    int k,
+    const hip_bfloat16* __restrict__ lhs,
+    const uint8_t* __restrict__ rhs_gate,
+    const uint8_t* __restrict__ rhs_up,
+    hip_bfloat16* __restrict__ out
+) {
+#if defined(SUPERSONIC_HAS_WMMA_BF16) && SUPERSONIC_WMMA_GFX12
+    const int lane = threadIdx.x;
+    const int lane_row = lane & 15;
+    const int lane_group = lane >> 4;
+    const int batch = blockIdx.z;
+    const int tile_col = blockIdx.x * 16;
+    const int out_col_idx = tile_col + lane_row;
+
+    const int block_bytes = ggml_k_block_bytes_fixed<QTYPE>();
+    const int blocks = k / 256;
+    const int row_bytes = blocks * block_bytes;
+
+    const size_t lhs_row_base = static_cast<size_t>(batch) * 16 * static_cast<size_t>(k) +
+                                static_cast<size_t>(lane_row) * k;
+    const size_t rhs_row_base = static_cast<size_t>(batch) * n_each * static_cast<size_t>(row_bytes) +
+                                static_cast<size_t>(out_col_idx) * row_bytes;
+
+    const uint16_t* lhs_row_u16 = reinterpret_cast<const uint16_t*>(lhs) + lhs_row_base;
+    const uint8_t* rhs_gate_row_u8 = rhs_gate + rhs_row_base;
+    const uint8_t* rhs_up_row_u8 = rhs_up + rhs_row_base;
+
+    supersonic_float8 gate_acc = {0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f};
+    supersonic_float8 up_acc = {0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f};
+
+    for (int block = 0; block < blocks; ++block) {
+        const uint8_t* rhs_gate_block = rhs_gate_row_u8 + block * block_bytes;
+        const uint8_t* rhs_up_block = rhs_up_row_u8 + block * block_bytes;
+        const int kk_block = block * 256;
+        #pragma unroll
+        for (int sub = 0; sub < 16; ++sub) {
+            const int kk = kk_block + sub * 16;
+            supersonic_short8 a;
+            #pragma unroll
+            for (int i = 0; i < 8; ++i) {
+                const int ab_row = lane_group * 4 + (i & 3) + ((i >> 2) * 8);
+                a[i] = static_cast<short>(lhs_row_u16[kk + ab_row]);
+            }
+
+            supersonic_short8 gate_b;
+            supersonic_short8 up_b;
+            if constexpr (QTYPE == QWEN35_LOWBIT_GGML_Q8_0) {
+                gate_b = ggml_q8_0_dequant_bf16_gfx12_fragment<TRUNC_DEQUANT>(
+                    rhs_gate_block, sub * 16, lane_group);
+                up_b = ggml_q8_0_dequant_bf16_gfx12_fragment<TRUNC_DEQUANT>(
+                    rhs_up_block, sub * 16, lane_group);
+            } else if constexpr (QTYPE == QWEN35_LOWBIT_GGML_Q4_K) {
+                gate_b = ggml_q4_k_dequant_bf16_gfx12_fragment<TRUNC_DEQUANT>(
+                    rhs_gate_block, sub * 16, lane_group);
+                up_b = ggml_q4_k_dequant_bf16_gfx12_fragment<TRUNC_DEQUANT>(
+                    rhs_up_block, sub * 16, lane_group);
+            } else if constexpr (QTYPE == QWEN35_LOWBIT_GGML_Q5_K) {
+                gate_b = ggml_q5_k_dequant_bf16_gfx12_fragment<TRUNC_DEQUANT>(
+                    rhs_gate_block, sub * 16, lane_group);
+                up_b = ggml_q5_k_dequant_bf16_gfx12_fragment<TRUNC_DEQUANT>(
+                    rhs_up_block, sub * 16, lane_group);
+            } else if constexpr (QTYPE == QWEN35_LOWBIT_GGML_Q6_K) {
+                gate_b = ggml_q6_k_dequant_bf16_gfx12_fragment<TRUNC_DEQUANT>(
+                    rhs_gate_block, sub * 16, lane_group);
+                up_b = ggml_q6_k_dequant_bf16_gfx12_fragment<TRUNC_DEQUANT>(
+                    rhs_up_block, sub * 16, lane_group);
+            } else {
+                uint16_t gate_bits[16];
+                uint16_t up_bits[16];
+                ggml_k_dequant_16_bf16_bits_from_block_fixed<QTYPE, TRUNC_DEQUANT>(
+                    rhs_gate_block, sub * 16, gate_bits);
+                ggml_k_dequant_16_bf16_bits_from_block_fixed<QTYPE, TRUNC_DEQUANT>(
+                    rhs_up_block, sub * 16, up_bits);
+                #pragma unroll
+                for (int i = 0; i < 8; ++i) {
+                    const int ab_row = lane_group * 4 + (i & 3) + ((i >> 2) * 8);
+                    gate_b[i] = static_cast<short>(gate_bits[ab_row]);
+                    up_b[i] = static_cast<short>(up_bits[ab_row]);
+                }
+            }
+
+            gate_acc = supersonic_wmma_bf16_gfx12_native_acc(a, gate_b, gate_acc);
+            up_acc = supersonic_wmma_bf16_gfx12_native_acc(a, up_b, up_acc);
+        }
+    }
+
+    if (out_col_idx < n_each) {
+        const size_t out_batch_base = static_cast<size_t>(batch) * 16 * static_cast<size_t>(n_each);
+        #pragma unroll
+        for (int i = 0; i < 8; ++i) {
+            const int out_row = lane_group * 8 + i;
             const hip_bfloat16 gate_bf16(gate_acc[i]);
             const hip_bfloat16 up_bf16(up_acc[i]);
             const float gate_x = static_cast<float>(gate_bf16);
@@ -5987,6 +7003,134 @@ void supersonic_qwen35_matmul_int4_dequant_wmma_kernel(
 #endif
 }
 
+__global__ __launch_bounds__(128, 2)
+void supersonic_qwen35_matmul_ggml_q8_0_wmma_gfx12_large_m_kernel(
+    size_t batch_elems,
+    int m,
+    int n,
+    int k,
+    const hip_bfloat16* __restrict__ lhs,    // [batch, m, k]
+    const uint8_t* __restrict__ rhs_q8,      // [batch, n, row_bytes]
+    hip_bfloat16* __restrict__ out           // [batch, m, n]
+) {
+#if defined(SUPERSONIC_HAS_WMMA_BF16) && SUPERSONIC_WMMA_GFX12
+    const int tid      = threadIdx.x;
+    const int lane     = tid & 31;
+    const int wid      = tid >> 5;
+    const int wave_row = wid >> 1;
+    const int wave_col = wid & 1;
+    const int lane_row = lane & 15;
+    const int lane_group = lane >> 4;
+
+    const int batch   = blockIdx.z;
+    const int blk_row = blockIdx.y * TILED_WMMA_BM;
+    const int blk_col = blockIdx.x * TILED_WMMA_BN;
+
+    __shared__ uint16_t s_lhs[TILED_WMMA_BM * TILED_WMMA_LDS_STRIDE];
+    __shared__ uint16_t s_rhs[TILED_WMMA_BN * TILED_WMMA_LDS_STRIDE];
+
+    const uint16_t* lhs_u16 = reinterpret_cast<const uint16_t*>(lhs);
+    const int row_bytes = (k / 32) * 34;
+    const size_t lhs_batch_base = static_cast<size_t>(batch) * m * k;
+    const size_t rhs_batch_base = static_cast<size_t>(batch) * n * static_cast<size_t>(row_bytes);
+
+    supersonic_float8 acc00 = {0.f,0.f,0.f,0.f,0.f,0.f,0.f,0.f};
+    supersonic_float8 acc01 = {0.f,0.f,0.f,0.f,0.f,0.f,0.f,0.f};
+    supersonic_float8 acc10 = {0.f,0.f,0.f,0.f,0.f,0.f,0.f,0.f};
+    supersonic_float8 acc11 = {0.f,0.f,0.f,0.f,0.f,0.f,0.f,0.f};
+
+    constexpr int K_COL_HALVES = TILED_WMMA_BK / 32;
+    constexpr int K_Q8_PASSES = TILED_WMMA_BK / 32;
+    constexpr int K_CHUNKS = TILED_WMMA_BK / 16;
+
+    for (int kk0 = 0; kk0 < k; kk0 += TILED_WMMA_BK) {
+        #pragma unroll
+        for (int iter = 0; iter < 16; ++iter) {
+            const int lds_row = wid * 16 + iter;
+            const int gr = blk_row + lds_row;
+            #pragma unroll
+            for (int ch = 0; ch < K_COL_HALVES; ++ch) {
+                const int col = ch * 32 + lane;
+                uint16_t v = 0;
+                if (gr < m) {
+                    v = lhs_u16[lhs_batch_base + static_cast<size_t>(gr) * k + kk0 + col];
+                }
+                s_lhs[lds_row * TILED_WMMA_LDS_STRIDE + col] = v;
+            }
+        }
+
+        #pragma unroll
+        for (int iter = 0; iter < 16; ++iter) {
+            const int lds_row = wid * 16 + iter;
+            const int gc = blk_col + lds_row;
+            #pragma unroll
+            for (int pass = 0; pass < K_Q8_PASSES; ++pass) {
+                const int col0 = pass * 32;
+                uint16_t qbits = 0;
+                if (gc < n) {
+                    const uint8_t* block = rhs_q8 + rhs_batch_base +
+                        static_cast<size_t>(gc) * row_bytes + ((kk0 + col0) / 32) * 34;
+                    const float d = ggml_f16_to_f32_unaligned(block);
+                    const int8_t q = reinterpret_cast<const int8_t*>(block + 2)[lane];
+                    qbits = f32_to_bf16_bits_rne_finite(d * static_cast<float>(q));
+                }
+                s_rhs[lds_row * TILED_WMMA_LDS_STRIDE + col0 + lane] = qbits;
+            }
+        }
+        __syncthreads();
+
+        #pragma unroll
+        for (int kchunk = 0; kchunk < K_CHUNKS; ++kchunk) {
+            const int k_off = kchunk * 16;
+            supersonic_short8 a0, a1, b0, b1;
+            const int a0_row = wave_row * 32 + lane_row;
+            const int a1_row = wave_row * 32 + 16 + lane_row;
+            const int b0_row = wave_col * 32 + lane_row;
+            const int b1_row = wave_col * 32 + 16 + lane_row;
+
+            #pragma unroll
+            for (int i = 0; i < 8; ++i) {
+                const int ab_col = lane_group * 4 + (i & 3) + ((i >> 2) * 8);
+                a0[i] = static_cast<short>(s_lhs[a0_row * TILED_WMMA_LDS_STRIDE + k_off + ab_col]);
+                a1[i] = static_cast<short>(s_lhs[a1_row * TILED_WMMA_LDS_STRIDE + k_off + ab_col]);
+                b0[i] = static_cast<short>(s_rhs[b0_row * TILED_WMMA_LDS_STRIDE + k_off + ab_col]);
+                b1[i] = static_cast<short>(s_rhs[b1_row * TILED_WMMA_LDS_STRIDE + k_off + ab_col]);
+            }
+
+            acc00 = supersonic_wmma_bf16_gfx12_native_acc(a0, b0, acc00);
+            acc01 = supersonic_wmma_bf16_gfx12_native_acc(a0, b1, acc01);
+            acc10 = supersonic_wmma_bf16_gfx12_native_acc(a1, b0, acc10);
+            acc11 = supersonic_wmma_bf16_gfx12_native_acc(a1, b1, acc11);
+        }
+        __syncthreads();
+    }
+
+    const size_t out_batch_base = static_cast<size_t>(batch) * m * n;
+    const int sub_row_base = blk_row + wave_row * 32;
+    const int sub_col_base = blk_col + wave_col * 32;
+
+    auto store_sub = [&](const supersonic_float8& acc, int sub_row_off, int sub_col_off) {
+        const int out_col = sub_col_base + sub_col_off + lane_row;
+        if (out_col < n) {
+            #pragma unroll
+            for (int i = 0; i < 8; ++i) {
+                const int out_row = sub_row_base + sub_row_off + lane_group * 8 + i;
+                if (out_row < m) {
+                    out[out_batch_base + static_cast<size_t>(out_row) * n + out_col] =
+                        hip_bfloat16(acc[i]);
+                }
+            }
+        }
+    };
+    store_sub(acc00, 0,  0);
+    store_sub(acc01, 0,  16);
+    store_sub(acc10, 16, 0);
+    store_sub(acc11, 16, 16);
+#else
+    (void)batch_elems; (void)m; (void)n; (void)k; (void)lhs; (void)rhs_q8; (void)out;
+#endif
+}
+
 template <typename T>
 __global__ void supersonic_qwen35_int4_sparse_outlier_add_kernel(
     int rows,
@@ -6394,21 +7538,23 @@ __global__ void supersonic_qwen35_rms_norm_kernel(
         partial += x * x;
     }
 
-    __shared__ float shared_sum[256];
-    shared_sum[tid] = partial;
+    __shared__ float shared_inv_rms;
+    __shared__ float shared_warp_sum[8];
+    const int lane = tid & 31;
+    const int warp = tid >> 5;
+    const float warp_sum = supersonic_qwen35_wave_sum(partial);
+    if (lane == 0) {
+        shared_warp_sum[warp] = warp_sum;
+    }
     __syncthreads();
 
-    for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
-        if (tid < stride) {
-            shared_sum[tid] += shared_sum[tid + stride];
+    if (warp == 0) {
+        float block_sum = lane < (blockDim.x + 31) / 32 ? shared_warp_sum[lane] : 0.0f;
+        block_sum = supersonic_qwen35_wave_sum(block_sum);
+        if (lane == 0) {
+            const float mean = block_sum / static_cast<float>(n_cols);
+            shared_inv_rms = rsqrtf(mean + eps);
         }
-        __syncthreads();
-    }
-
-    __shared__ float shared_inv_rms;
-    if (tid == 0) {
-        const float mean = shared_sum[0] / static_cast<float>(n_cols);
-        shared_inv_rms = rsqrtf(mean + eps);
     }
     __syncthreads();
 
@@ -6543,28 +7689,30 @@ __global__ void supersonic_qwen35_rms_norm_gated_kernel(
         partial += x * x;
     }
 
-    __shared__ float shared_sum[256];
-    shared_sum[tid] = partial;
+    __shared__ float shared_inv_rms;
+    __shared__ float shared_warp_sum[8];
+    const int lane = tid & 31;
+    const int warp = tid >> 5;
+    const float warp_sum = supersonic_qwen35_wave_sum(partial);
+    if (lane == 0) {
+        shared_warp_sum[warp] = warp_sum;
+    }
     __syncthreads();
 
-    for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
-        if (tid < stride) {
-            shared_sum[tid] += shared_sum[tid + stride];
+    if (warp == 0) {
+        float block_sum = lane < (blockDim.x + 31) / 32 ? shared_warp_sum[lane] : 0.0f;
+        block_sum = supersonic_qwen35_wave_sum(block_sum);
+        if (lane == 0) {
+            const float mean = block_sum / static_cast<float>(n_cols);
+            shared_inv_rms = rsqrtf(mean + eps);
         }
-        __syncthreads();
-    }
-
-    __shared__ float shared_inv_rms;
-    if (tid == 0) {
-        const float mean = shared_sum[0] / static_cast<float>(n_cols);
-        shared_inv_rms = rsqrtf(mean + eps);
     }
     __syncthreads();
 
     for (int col = tid; col < n_cols; col += blockDim.x) {
         const float x = supersonic_qwen35_to_float(row_hidden[col]);
         const float gate_x = supersonic_qwen35_to_float(row_gate[col]);
-    const float gate_silu = gate_x * supersonic_qwen35_sigmoid_fast(gate_x);
+        const float gate_silu = gate_x * supersonic_qwen35_sigmoid_fast(gate_x);
         const float weight_val = supersonic_qwen35_to_float(weight[col]);
         row_out[col] =
             supersonic_qwen35_from_float<T>(x * shared_inv_rms * weight_val * gate_silu);

--- a/kernels/full_attention_bridge_4b.cpp
+++ b/kernels/full_attention_bridge_4b.cpp
@@ -3688,6 +3688,27 @@ static bool device_supports_wmma_i8(int device_ordinal) {
     return cached[device_ordinal];
 }
 
+bool device_is_gfx12(int device_ordinal) {
+    auto probe_arch = [](int ordinal) -> bool {
+        hipDeviceProp_t props;
+        if (hipGetDeviceProperties(&props, ordinal) != hipSuccess) return false;
+        const char* arch = props.gcnArchName;
+        return arch && arch[0] == 'g' && arch[1] == 'f' && arch[2] == 'x' &&
+               arch[3] == '1' && arch[4] == '2';
+    };
+
+    if (device_ordinal < 0 || device_ordinal >= 16) {
+        return probe_arch(device_ordinal);
+    }
+
+    static std::once_flag device_once[16];
+    static bool cached[16] = {false};
+    std::call_once(device_once[device_ordinal], [&] {
+        cached[device_ordinal] = probe_arch(device_ordinal);
+    });
+    return cached[device_ordinal];
+}
+
 static int matmul_rhs_transposed_tiled_wmma_bf16_device(
     int device_ordinal,
     size_t batch_elems,
@@ -3732,13 +3753,36 @@ static int matmul_rhs_transposed_wmma_small_m_bf16_device(
     const int grid_x = (n + TILE_N - 1) / TILE_N;
     const int grid_y = (m + TILE_M - 1) / TILE_M;
     const int grid_z = static_cast<int>(batch_elems);
-    hipLaunchKernelGGL(
-        supersonic_qwen35_matmul_rhs_transposed_wmma_small_m_kernel,
-        dim3(grid_x, grid_y, grid_z), dim3(32), 0, 0,
-        batch_elems, m, n, k,
-        static_cast<const hip_bfloat16*>(lhs),
-        static_cast<const hip_bfloat16*>(rhs),
-        static_cast<hip_bfloat16*>(out));
+    if (device_is_gfx12(device_ordinal)) {
+        const bool hot_exact =
+            m == TILE_M && (n % TILE_N) == 0 && (k % 16) == 0 &&
+            std::getenv("SUPERSONIC_DFLASH_DISABLE_BF16_SMALL_M_HOT_EXACT") == nullptr;
+        if (hot_exact) {
+            hipLaunchKernelGGL(
+                HIP_KERNEL_NAME(supersonic_qwen35_matmul_rhs_transposed_wmma_small_m_gfx12_kernel<true>),
+                dim3(grid_x, grid_y, grid_z), dim3(32), 0, 0,
+                batch_elems, m, n, k,
+                static_cast<const hip_bfloat16*>(lhs),
+                static_cast<const hip_bfloat16*>(rhs),
+                static_cast<hip_bfloat16*>(out));
+        } else {
+            hipLaunchKernelGGL(
+                HIP_KERNEL_NAME(supersonic_qwen35_matmul_rhs_transposed_wmma_small_m_gfx12_kernel<false>),
+                dim3(grid_x, grid_y, grid_z), dim3(32), 0, 0,
+                batch_elems, m, n, k,
+                static_cast<const hip_bfloat16*>(lhs),
+                static_cast<const hip_bfloat16*>(rhs),
+                static_cast<hip_bfloat16*>(out));
+        }
+    } else {
+        hipLaunchKernelGGL(
+            supersonic_qwen35_matmul_rhs_transposed_wmma_small_m_kernel,
+            dim3(grid_x, grid_y, grid_z), dim3(32), 0, 0,
+            batch_elems, m, n, k,
+            static_cast<const hip_bfloat16*>(lhs),
+            static_cast<const hip_bfloat16*>(rhs),
+            static_cast<hip_bfloat16*>(out));
+    }
     hipError_t launch_err = hipGetLastError();
     hipError_t sync_err = maybe_sync();
     if (launch_err != hipSuccess) return 282;
@@ -4005,6 +4049,7 @@ static int matmul_int4_dequant_wmma_bf16_device(
             const int grid_y = (m + TILE_M - 1) / TILE_M;
             const int grid_z = static_cast<int>(batch_elems);
             const int threads = 32;
+            const bool use_gfx12_acc = device_is_gfx12(device_ordinal);
             const bool enable_m8_block =
                 m == 8 && (n % TILE_N) == 0 && (k % 256) == 0 && awq_inv_scale == nullptr &&
                 std::getenv("SUPERSONIC_DFLASH_DISABLE_GGML_M8_BLOCK") == nullptr;
@@ -4014,83 +4059,171 @@ static int matmul_int4_dequant_wmma_bf16_device(
             if (enable_m16_block) {
                 if (quant_type == QWEN35_LOWBIT_GGML_Q8_0) {
                     if (trunc_dequant) {
-                        hipLaunchKernelGGL(
-                            HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m16_qtype_kernel<QWEN35_LOWBIT_GGML_Q8_0, true>),
-                            dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
-                            batch_elems, n, k,
-                            static_cast<const hip_bfloat16*>(lhs),
-                            static_cast<const uint8_t*>(rhs_int4),
-                            nullptr,
-                            static_cast<hip_bfloat16*>(out));
+                        if (use_gfx12_acc) {
+                            hipLaunchKernelGGL(
+                                HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m16_qtype_gfx12_kernel<QWEN35_LOWBIT_GGML_Q8_0, true>),
+                                dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                                batch_elems, n, k,
+                                static_cast<const hip_bfloat16*>(lhs),
+                                static_cast<const uint8_t*>(rhs_int4),
+                                nullptr,
+                                static_cast<hip_bfloat16*>(out));
+                        } else {
+                            hipLaunchKernelGGL(
+                                HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m16_qtype_kernel<QWEN35_LOWBIT_GGML_Q8_0, true>),
+                                dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                                batch_elems, n, k,
+                                static_cast<const hip_bfloat16*>(lhs),
+                                static_cast<const uint8_t*>(rhs_int4),
+                                nullptr,
+                                static_cast<hip_bfloat16*>(out));
+                        }
                     } else {
-                        hipLaunchKernelGGL(
-                            HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m16_qtype_kernel<QWEN35_LOWBIT_GGML_Q8_0, false>),
-                            dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
-                            batch_elems, n, k,
-                            static_cast<const hip_bfloat16*>(lhs),
-                            static_cast<const uint8_t*>(rhs_int4),
-                            nullptr,
-                            static_cast<hip_bfloat16*>(out));
+                        if (use_gfx12_acc) {
+                            hipLaunchKernelGGL(
+                                HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m16_qtype_gfx12_kernel<QWEN35_LOWBIT_GGML_Q8_0, false>),
+                                dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                                batch_elems, n, k,
+                                static_cast<const hip_bfloat16*>(lhs),
+                                static_cast<const uint8_t*>(rhs_int4),
+                                nullptr,
+                                static_cast<hip_bfloat16*>(out));
+                        } else {
+                            hipLaunchKernelGGL(
+                                HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m16_qtype_kernel<QWEN35_LOWBIT_GGML_Q8_0, false>),
+                                dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                                batch_elems, n, k,
+                                static_cast<const hip_bfloat16*>(lhs),
+                                static_cast<const uint8_t*>(rhs_int4),
+                                nullptr,
+                                static_cast<hip_bfloat16*>(out));
+                        }
                     }
                 } else if (quant_type == QWEN35_LOWBIT_GGML_Q4_K) {
                     if (trunc_dequant) {
-                        hipLaunchKernelGGL(
-                            HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m16_qtype_kernel<QWEN35_LOWBIT_GGML_Q4_K, true>),
-                            dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
-                            batch_elems, n, k,
-                            static_cast<const hip_bfloat16*>(lhs),
-                            static_cast<const uint8_t*>(rhs_int4),
-                            nullptr,
-                            static_cast<hip_bfloat16*>(out));
+                        if (use_gfx12_acc) {
+                            hipLaunchKernelGGL(
+                                HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m16_qtype_gfx12_kernel<QWEN35_LOWBIT_GGML_Q4_K, true>),
+                                dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                                batch_elems, n, k,
+                                static_cast<const hip_bfloat16*>(lhs),
+                                static_cast<const uint8_t*>(rhs_int4),
+                                nullptr,
+                                static_cast<hip_bfloat16*>(out));
+                        } else {
+                            hipLaunchKernelGGL(
+                                HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m16_qtype_kernel<QWEN35_LOWBIT_GGML_Q4_K, true>),
+                                dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                                batch_elems, n, k,
+                                static_cast<const hip_bfloat16*>(lhs),
+                                static_cast<const uint8_t*>(rhs_int4),
+                                nullptr,
+                                static_cast<hip_bfloat16*>(out));
+                        }
                     } else {
-                        hipLaunchKernelGGL(
-                            HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m16_qtype_kernel<QWEN35_LOWBIT_GGML_Q4_K, false>),
-                            dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
-                            batch_elems, n, k,
-                            static_cast<const hip_bfloat16*>(lhs),
-                            static_cast<const uint8_t*>(rhs_int4),
-                            nullptr,
-                            static_cast<hip_bfloat16*>(out));
+                        if (use_gfx12_acc) {
+                            hipLaunchKernelGGL(
+                                HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m16_qtype_gfx12_kernel<QWEN35_LOWBIT_GGML_Q4_K, false>),
+                                dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                                batch_elems, n, k,
+                                static_cast<const hip_bfloat16*>(lhs),
+                                static_cast<const uint8_t*>(rhs_int4),
+                                nullptr,
+                                static_cast<hip_bfloat16*>(out));
+                        } else {
+                            hipLaunchKernelGGL(
+                                HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m16_qtype_kernel<QWEN35_LOWBIT_GGML_Q4_K, false>),
+                                dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                                batch_elems, n, k,
+                                static_cast<const hip_bfloat16*>(lhs),
+                                static_cast<const uint8_t*>(rhs_int4),
+                                nullptr,
+                                static_cast<hip_bfloat16*>(out));
+                        }
                     }
                 } else if (quant_type == QWEN35_LOWBIT_GGML_Q5_K) {
                     if (trunc_dequant) {
-                        hipLaunchKernelGGL(
-                            HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m16_qtype_kernel<QWEN35_LOWBIT_GGML_Q5_K, true>),
-                            dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
-                            batch_elems, n, k,
-                            static_cast<const hip_bfloat16*>(lhs),
-                            static_cast<const uint8_t*>(rhs_int4),
-                            nullptr,
-                            static_cast<hip_bfloat16*>(out));
+                        if (use_gfx12_acc) {
+                            hipLaunchKernelGGL(
+                                HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m16_qtype_gfx12_kernel<QWEN35_LOWBIT_GGML_Q5_K, true>),
+                                dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                                batch_elems, n, k,
+                                static_cast<const hip_bfloat16*>(lhs),
+                                static_cast<const uint8_t*>(rhs_int4),
+                                nullptr,
+                                static_cast<hip_bfloat16*>(out));
+                        } else {
+                            hipLaunchKernelGGL(
+                                HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m16_qtype_kernel<QWEN35_LOWBIT_GGML_Q5_K, true>),
+                                dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                                batch_elems, n, k,
+                                static_cast<const hip_bfloat16*>(lhs),
+                                static_cast<const uint8_t*>(rhs_int4),
+                                nullptr,
+                                static_cast<hip_bfloat16*>(out));
+                        }
                     } else {
-                        hipLaunchKernelGGL(
-                            HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m16_qtype_kernel<QWEN35_LOWBIT_GGML_Q5_K, false>),
-                            dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
-                            batch_elems, n, k,
-                            static_cast<const hip_bfloat16*>(lhs),
-                            static_cast<const uint8_t*>(rhs_int4),
-                            nullptr,
-                            static_cast<hip_bfloat16*>(out));
+                        if (use_gfx12_acc) {
+                            hipLaunchKernelGGL(
+                                HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m16_qtype_gfx12_kernel<QWEN35_LOWBIT_GGML_Q5_K, false>),
+                                dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                                batch_elems, n, k,
+                                static_cast<const hip_bfloat16*>(lhs),
+                                static_cast<const uint8_t*>(rhs_int4),
+                                nullptr,
+                                static_cast<hip_bfloat16*>(out));
+                        } else {
+                            hipLaunchKernelGGL(
+                                HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m16_qtype_kernel<QWEN35_LOWBIT_GGML_Q5_K, false>),
+                                dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                                batch_elems, n, k,
+                                static_cast<const hip_bfloat16*>(lhs),
+                                static_cast<const uint8_t*>(rhs_int4),
+                                nullptr,
+                                static_cast<hip_bfloat16*>(out));
+                        }
                     }
                 } else if (quant_type == QWEN35_LOWBIT_GGML_Q6_K) {
                     if (trunc_dequant) {
-                        hipLaunchKernelGGL(
-                            HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m16_qtype_kernel<QWEN35_LOWBIT_GGML_Q6_K, true>),
-                            dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
-                            batch_elems, n, k,
-                            static_cast<const hip_bfloat16*>(lhs),
-                            static_cast<const uint8_t*>(rhs_int4),
-                            nullptr,
-                            static_cast<hip_bfloat16*>(out));
+                        if (use_gfx12_acc) {
+                            hipLaunchKernelGGL(
+                                HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m16_qtype_gfx12_kernel<QWEN35_LOWBIT_GGML_Q6_K, true>),
+                                dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                                batch_elems, n, k,
+                                static_cast<const hip_bfloat16*>(lhs),
+                                static_cast<const uint8_t*>(rhs_int4),
+                                nullptr,
+                                static_cast<hip_bfloat16*>(out));
+                        } else {
+                            hipLaunchKernelGGL(
+                                HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m16_qtype_kernel<QWEN35_LOWBIT_GGML_Q6_K, true>),
+                                dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                                batch_elems, n, k,
+                                static_cast<const hip_bfloat16*>(lhs),
+                                static_cast<const uint8_t*>(rhs_int4),
+                                nullptr,
+                                static_cast<hip_bfloat16*>(out));
+                        }
                     } else {
-                        hipLaunchKernelGGL(
-                            HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m16_qtype_kernel<QWEN35_LOWBIT_GGML_Q6_K, false>),
-                            dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
-                            batch_elems, n, k,
-                            static_cast<const hip_bfloat16*>(lhs),
-                            static_cast<const uint8_t*>(rhs_int4),
-                            nullptr,
-                            static_cast<hip_bfloat16*>(out));
+                        if (use_gfx12_acc) {
+                            hipLaunchKernelGGL(
+                                HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m16_qtype_gfx12_kernel<QWEN35_LOWBIT_GGML_Q6_K, false>),
+                                dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                                batch_elems, n, k,
+                                static_cast<const hip_bfloat16*>(lhs),
+                                static_cast<const uint8_t*>(rhs_int4),
+                                nullptr,
+                                static_cast<hip_bfloat16*>(out));
+                        } else {
+                            hipLaunchKernelGGL(
+                                HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m16_qtype_kernel<QWEN35_LOWBIT_GGML_Q6_K, false>),
+                                dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                                batch_elems, n, k,
+                                static_cast<const hip_bfloat16*>(lhs),
+                                static_cast<const uint8_t*>(rhs_int4),
+                                nullptr,
+                                static_cast<hip_bfloat16*>(out));
+                        }
                     }
                 }
                 hipError_t launch_err = hipGetLastError();
@@ -4100,77 +4233,160 @@ static int matmul_int4_dequant_wmma_bf16_device(
                 return 0;
             }
             if (enable_m8_block) {
+                const bool use_m8_gfx12 =
+                    use_gfx12_acc &&
+                    std::getenv("SUPERSONIC_DFLASH_DISABLE_GGML_M8_GFX12_NATIVE") == nullptr;
                 if (quant_type == QWEN35_LOWBIT_GGML_Q8_0) {
                     if (trunc_dequant) {
-                        hipLaunchKernelGGL(
-                            HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m8_qtype_kernel<QWEN35_LOWBIT_GGML_Q8_0, true>),
-                            dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
-                            batch_elems, n, k,
-                            static_cast<const hip_bfloat16*>(lhs),
-                            static_cast<const uint8_t*>(rhs_int4),
-                            static_cast<hip_bfloat16*>(out));
+                        if (use_m8_gfx12) {
+                            hipLaunchKernelGGL(
+                                HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m8_qtype_gfx12_kernel<QWEN35_LOWBIT_GGML_Q8_0, true>),
+                                dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                                batch_elems, n, k,
+                                static_cast<const hip_bfloat16*>(lhs),
+                                static_cast<const uint8_t*>(rhs_int4),
+                                static_cast<hip_bfloat16*>(out));
+                        } else {
+                            hipLaunchKernelGGL(
+                                HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m8_qtype_kernel<QWEN35_LOWBIT_GGML_Q8_0, true>),
+                                dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                                batch_elems, n, k,
+                                static_cast<const hip_bfloat16*>(lhs),
+                                static_cast<const uint8_t*>(rhs_int4),
+                                static_cast<hip_bfloat16*>(out));
+                        }
                     } else {
-                        hipLaunchKernelGGL(
-                            HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m8_qtype_kernel<QWEN35_LOWBIT_GGML_Q8_0, false>),
-                            dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
-                            batch_elems, n, k,
-                            static_cast<const hip_bfloat16*>(lhs),
-                            static_cast<const uint8_t*>(rhs_int4),
-                            static_cast<hip_bfloat16*>(out));
+                        if (use_m8_gfx12) {
+                            hipLaunchKernelGGL(
+                                HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m8_qtype_gfx12_kernel<QWEN35_LOWBIT_GGML_Q8_0, false>),
+                                dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                                batch_elems, n, k,
+                                static_cast<const hip_bfloat16*>(lhs),
+                                static_cast<const uint8_t*>(rhs_int4),
+                                static_cast<hip_bfloat16*>(out));
+                        } else {
+                            hipLaunchKernelGGL(
+                                HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m8_qtype_kernel<QWEN35_LOWBIT_GGML_Q8_0, false>),
+                                dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                                batch_elems, n, k,
+                                static_cast<const hip_bfloat16*>(lhs),
+                                static_cast<const uint8_t*>(rhs_int4),
+                                static_cast<hip_bfloat16*>(out));
+                        }
                     }
                 } else if (quant_type == QWEN35_LOWBIT_GGML_Q4_K) {
                     if (trunc_dequant) {
-                        hipLaunchKernelGGL(
-                            HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m8_qtype_kernel<QWEN35_LOWBIT_GGML_Q4_K, true>),
-                            dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
-                            batch_elems, n, k,
-                            static_cast<const hip_bfloat16*>(lhs),
-                            static_cast<const uint8_t*>(rhs_int4),
-                            static_cast<hip_bfloat16*>(out));
+                        if (use_m8_gfx12) {
+                            hipLaunchKernelGGL(
+                                HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m8_qtype_gfx12_kernel<QWEN35_LOWBIT_GGML_Q4_K, true>),
+                                dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                                batch_elems, n, k,
+                                static_cast<const hip_bfloat16*>(lhs),
+                                static_cast<const uint8_t*>(rhs_int4),
+                                static_cast<hip_bfloat16*>(out));
+                        } else {
+                            hipLaunchKernelGGL(
+                                HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m8_qtype_kernel<QWEN35_LOWBIT_GGML_Q4_K, true>),
+                                dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                                batch_elems, n, k,
+                                static_cast<const hip_bfloat16*>(lhs),
+                                static_cast<const uint8_t*>(rhs_int4),
+                                static_cast<hip_bfloat16*>(out));
+                        }
                     } else {
-                        hipLaunchKernelGGL(
-                            HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m8_qtype_kernel<QWEN35_LOWBIT_GGML_Q4_K, false>),
-                            dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
-                            batch_elems, n, k,
-                            static_cast<const hip_bfloat16*>(lhs),
-                            static_cast<const uint8_t*>(rhs_int4),
-                            static_cast<hip_bfloat16*>(out));
+                        if (use_m8_gfx12) {
+                            hipLaunchKernelGGL(
+                                HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m8_qtype_gfx12_kernel<QWEN35_LOWBIT_GGML_Q4_K, false>),
+                                dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                                batch_elems, n, k,
+                                static_cast<const hip_bfloat16*>(lhs),
+                                static_cast<const uint8_t*>(rhs_int4),
+                                static_cast<hip_bfloat16*>(out));
+                        } else {
+                            hipLaunchKernelGGL(
+                                HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m8_qtype_kernel<QWEN35_LOWBIT_GGML_Q4_K, false>),
+                                dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                                batch_elems, n, k,
+                                static_cast<const hip_bfloat16*>(lhs),
+                                static_cast<const uint8_t*>(rhs_int4),
+                                static_cast<hip_bfloat16*>(out));
+                        }
                     }
                 } else if (quant_type == QWEN35_LOWBIT_GGML_Q5_K) {
                     if (trunc_dequant) {
-                        hipLaunchKernelGGL(
-                            HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m8_qtype_kernel<QWEN35_LOWBIT_GGML_Q5_K, true>),
-                            dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
-                            batch_elems, n, k,
-                            static_cast<const hip_bfloat16*>(lhs),
-                            static_cast<const uint8_t*>(rhs_int4),
-                            static_cast<hip_bfloat16*>(out));
+                        if (use_m8_gfx12) {
+                            hipLaunchKernelGGL(
+                                HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m8_qtype_gfx12_kernel<QWEN35_LOWBIT_GGML_Q5_K, true>),
+                                dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                                batch_elems, n, k,
+                                static_cast<const hip_bfloat16*>(lhs),
+                                static_cast<const uint8_t*>(rhs_int4),
+                                static_cast<hip_bfloat16*>(out));
+                        } else {
+                            hipLaunchKernelGGL(
+                                HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m8_qtype_kernel<QWEN35_LOWBIT_GGML_Q5_K, true>),
+                                dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                                batch_elems, n, k,
+                                static_cast<const hip_bfloat16*>(lhs),
+                                static_cast<const uint8_t*>(rhs_int4),
+                                static_cast<hip_bfloat16*>(out));
+                        }
                     } else {
-                        hipLaunchKernelGGL(
-                            HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m8_qtype_kernel<QWEN35_LOWBIT_GGML_Q5_K, false>),
-                            dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
-                            batch_elems, n, k,
-                            static_cast<const hip_bfloat16*>(lhs),
-                            static_cast<const uint8_t*>(rhs_int4),
-                            static_cast<hip_bfloat16*>(out));
+                        if (use_m8_gfx12) {
+                            hipLaunchKernelGGL(
+                                HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m8_qtype_gfx12_kernel<QWEN35_LOWBIT_GGML_Q5_K, false>),
+                                dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                                batch_elems, n, k,
+                                static_cast<const hip_bfloat16*>(lhs),
+                                static_cast<const uint8_t*>(rhs_int4),
+                                static_cast<hip_bfloat16*>(out));
+                        } else {
+                            hipLaunchKernelGGL(
+                                HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m8_qtype_kernel<QWEN35_LOWBIT_GGML_Q5_K, false>),
+                                dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                                batch_elems, n, k,
+                                static_cast<const hip_bfloat16*>(lhs),
+                                static_cast<const uint8_t*>(rhs_int4),
+                                static_cast<hip_bfloat16*>(out));
+                        }
                     }
                 } else if (quant_type == QWEN35_LOWBIT_GGML_Q6_K) {
                     if (trunc_dequant) {
-                        hipLaunchKernelGGL(
-                            HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m8_qtype_kernel<QWEN35_LOWBIT_GGML_Q6_K, true>),
-                            dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
-                            batch_elems, n, k,
-                            static_cast<const hip_bfloat16*>(lhs),
-                            static_cast<const uint8_t*>(rhs_int4),
-                            static_cast<hip_bfloat16*>(out));
+                        if (use_m8_gfx12) {
+                            hipLaunchKernelGGL(
+                                HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m8_qtype_gfx12_kernel<QWEN35_LOWBIT_GGML_Q6_K, true>),
+                                dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                                batch_elems, n, k,
+                                static_cast<const hip_bfloat16*>(lhs),
+                                static_cast<const uint8_t*>(rhs_int4),
+                                static_cast<hip_bfloat16*>(out));
+                        } else {
+                            hipLaunchKernelGGL(
+                                HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m8_qtype_kernel<QWEN35_LOWBIT_GGML_Q6_K, true>),
+                                dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                                batch_elems, n, k,
+                                static_cast<const hip_bfloat16*>(lhs),
+                                static_cast<const uint8_t*>(rhs_int4),
+                                static_cast<hip_bfloat16*>(out));
+                        }
                     } else {
-                        hipLaunchKernelGGL(
-                            HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m8_qtype_kernel<QWEN35_LOWBIT_GGML_Q6_K, false>),
-                            dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
-                            batch_elems, n, k,
-                            static_cast<const hip_bfloat16*>(lhs),
-                            static_cast<const uint8_t*>(rhs_int4),
-                            static_cast<hip_bfloat16*>(out));
+                        if (use_m8_gfx12) {
+                            hipLaunchKernelGGL(
+                                HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m8_qtype_gfx12_kernel<QWEN35_LOWBIT_GGML_Q6_K, false>),
+                                dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                                batch_elems, n, k,
+                                static_cast<const hip_bfloat16*>(lhs),
+                                static_cast<const uint8_t*>(rhs_int4),
+                                static_cast<hip_bfloat16*>(out));
+                        } else {
+                            hipLaunchKernelGGL(
+                                HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m8_qtype_kernel<QWEN35_LOWBIT_GGML_Q6_K, false>),
+                                dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                                batch_elems, n, k,
+                                static_cast<const hip_bfloat16*>(lhs),
+                                static_cast<const uint8_t*>(rhs_int4),
+                                static_cast<hip_bfloat16*>(out));
+                        }
                     }
                 }
                 hipError_t launch_err = hipGetLastError();
@@ -4299,6 +4515,27 @@ static int matmul_int4_dequant_wmma_bf16_device(
     const int grid_y = (m + TILE_M - 1) / TILE_M;
     const int grid_z = static_cast<int>(batch_elems);
     const int threads = 128;
+    const bool use_gfx12_large_q8 =
+        device_is_gfx12(device_ordinal) &&
+        quant_type == QWEN35_LOWBIT_GGML_Q8_0 &&
+        awq_inv_scale == nullptr &&
+        (n % TILE_N) == 0 &&
+        (k % 64) == 0 &&
+        std::getenv("SUPERSONIC_DFLASH_DISABLE_GGML_Q8_LARGE_M_GFX12_NATIVE") == nullptr;
+    if (use_gfx12_large_q8) {
+        hipLaunchKernelGGL(
+            supersonic_qwen35_matmul_ggml_q8_0_wmma_gfx12_large_m_kernel,
+            dim3(grid_x, grid_y, grid_z), dim3(threads), 0, 0,
+            batch_elems, m, n, k,
+            static_cast<const hip_bfloat16*>(lhs),
+            static_cast<const uint8_t*>(rhs_int4),
+            static_cast<hip_bfloat16*>(out));
+        hipError_t launch_err = hipGetLastError();
+        hipError_t sync_err = maybe_sync();
+        if (launch_err != hipSuccess) return 300;
+        if (sync_err != hipSuccess) return 301;
+        return 0;
+    }
     hipLaunchKernelGGL(
         supersonic_qwen35_matmul_int4_dequant_wmma_kernel,
         dim3(grid_x, grid_y, grid_z), dim3(threads), 0, 0,
@@ -4352,6 +4589,7 @@ static int matmul_int4_dequant_residual_add_bf16_device(
     const int grid_x = (n + TILE_N - 1) / TILE_N;
     const int grid_z = static_cast<int>(batch_elems);
     const int threads = 32;
+    const bool use_gfx12_acc = device_is_gfx12(device_ordinal);
 
     if (quant_type == QWEN35_LOWBIT_GGML_Q8_0) {
         if (trunc_dequant) {
@@ -4375,43 +4613,87 @@ static int matmul_int4_dequant_residual_add_bf16_device(
         }
     } else if (quant_type == QWEN35_LOWBIT_GGML_Q4_K) {
         if (trunc_dequant) {
-            hipLaunchKernelGGL(
-                HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m16_qtype_kernel<QWEN35_LOWBIT_GGML_Q4_K, true, true>),
-                dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
-                batch_elems, n, k,
-                static_cast<const hip_bfloat16*>(lhs),
-                static_cast<const uint8_t*>(rhs_int4),
-                static_cast<const hip_bfloat16*>(residual),
-                static_cast<hip_bfloat16*>(out));
+            if (use_gfx12_acc) {
+                hipLaunchKernelGGL(
+                    HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m16_qtype_gfx12_kernel<QWEN35_LOWBIT_GGML_Q4_K, true, true>),
+                    dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                    batch_elems, n, k,
+                    static_cast<const hip_bfloat16*>(lhs),
+                    static_cast<const uint8_t*>(rhs_int4),
+                    static_cast<const hip_bfloat16*>(residual),
+                    static_cast<hip_bfloat16*>(out));
+            } else {
+                hipLaunchKernelGGL(
+                    HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m16_qtype_kernel<QWEN35_LOWBIT_GGML_Q4_K, true, true>),
+                    dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                    batch_elems, n, k,
+                    static_cast<const hip_bfloat16*>(lhs),
+                    static_cast<const uint8_t*>(rhs_int4),
+                    static_cast<const hip_bfloat16*>(residual),
+                    static_cast<hip_bfloat16*>(out));
+            }
         } else {
-            hipLaunchKernelGGL(
-                HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m16_qtype_kernel<QWEN35_LOWBIT_GGML_Q4_K, false, true>),
-                dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
-                batch_elems, n, k,
-                static_cast<const hip_bfloat16*>(lhs),
-                static_cast<const uint8_t*>(rhs_int4),
-                static_cast<const hip_bfloat16*>(residual),
-                static_cast<hip_bfloat16*>(out));
+            if (use_gfx12_acc) {
+                hipLaunchKernelGGL(
+                    HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m16_qtype_gfx12_kernel<QWEN35_LOWBIT_GGML_Q4_K, false, true>),
+                    dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                    batch_elems, n, k,
+                    static_cast<const hip_bfloat16*>(lhs),
+                    static_cast<const uint8_t*>(rhs_int4),
+                    static_cast<const hip_bfloat16*>(residual),
+                    static_cast<hip_bfloat16*>(out));
+            } else {
+                hipLaunchKernelGGL(
+                    HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m16_qtype_kernel<QWEN35_LOWBIT_GGML_Q4_K, false, true>),
+                    dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                    batch_elems, n, k,
+                    static_cast<const hip_bfloat16*>(lhs),
+                    static_cast<const uint8_t*>(rhs_int4),
+                    static_cast<const hip_bfloat16*>(residual),
+                    static_cast<hip_bfloat16*>(out));
+            }
         }
     } else if (quant_type == QWEN35_LOWBIT_GGML_Q5_K) {
         if (trunc_dequant) {
-            hipLaunchKernelGGL(
-                HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m16_qtype_kernel<QWEN35_LOWBIT_GGML_Q5_K, true, true>),
-                dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
-                batch_elems, n, k,
-                static_cast<const hip_bfloat16*>(lhs),
-                static_cast<const uint8_t*>(rhs_int4),
-                static_cast<const hip_bfloat16*>(residual),
-                static_cast<hip_bfloat16*>(out));
+            if (use_gfx12_acc) {
+                hipLaunchKernelGGL(
+                    HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m16_qtype_gfx12_kernel<QWEN35_LOWBIT_GGML_Q5_K, true, true>),
+                    dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                    batch_elems, n, k,
+                    static_cast<const hip_bfloat16*>(lhs),
+                    static_cast<const uint8_t*>(rhs_int4),
+                    static_cast<const hip_bfloat16*>(residual),
+                    static_cast<hip_bfloat16*>(out));
+            } else {
+                hipLaunchKernelGGL(
+                    HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m16_qtype_kernel<QWEN35_LOWBIT_GGML_Q5_K, true, true>),
+                    dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                    batch_elems, n, k,
+                    static_cast<const hip_bfloat16*>(lhs),
+                    static_cast<const uint8_t*>(rhs_int4),
+                    static_cast<const hip_bfloat16*>(residual),
+                    static_cast<hip_bfloat16*>(out));
+            }
         } else {
-            hipLaunchKernelGGL(
-                HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m16_qtype_kernel<QWEN35_LOWBIT_GGML_Q5_K, false, true>),
-                dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
-                batch_elems, n, k,
-                static_cast<const hip_bfloat16*>(lhs),
-                static_cast<const uint8_t*>(rhs_int4),
-                static_cast<const hip_bfloat16*>(residual),
-                static_cast<hip_bfloat16*>(out));
+            if (use_gfx12_acc) {
+                hipLaunchKernelGGL(
+                    HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m16_qtype_gfx12_kernel<QWEN35_LOWBIT_GGML_Q5_K, false, true>),
+                    dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                    batch_elems, n, k,
+                    static_cast<const hip_bfloat16*>(lhs),
+                    static_cast<const uint8_t*>(rhs_int4),
+                    static_cast<const hip_bfloat16*>(residual),
+                    static_cast<hip_bfloat16*>(out));
+            } else {
+                hipLaunchKernelGGL(
+                    HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_dequant_wmma_m16_qtype_kernel<QWEN35_LOWBIT_GGML_Q5_K, false, true>),
+                    dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                    batch_elems, n, k,
+                    static_cast<const hip_bfloat16*>(lhs),
+                    static_cast<const uint8_t*>(rhs_int4),
+                    static_cast<const hip_bfloat16*>(residual),
+                    static_cast<hip_bfloat16*>(out));
+            }
         }
     } else if (quant_type == QWEN35_LOWBIT_GGML_Q6_K) {
         if (trunc_dequant) {
@@ -4475,6 +4757,7 @@ static int matmul_ggml_pair_wmma_bf16_device(
         const int grid_x = (n_out + TILE_N - 1) / TILE_N;
         const int grid_z = static_cast<int>(batch_elems);
         const int threads = 32;
+        const bool use_gfx12_acc = device_is_gfx12(device_ordinal);
         const bool trunc_dequant =
             quant_type != QWEN35_LOWBIT_GGML_Q8_0 &&
             std::getenv("SUPERSONIC_DFLASH_DISABLE_GGML_TRUNC_DEQUANT") == nullptr;
@@ -4489,43 +4772,87 @@ static int matmul_ggml_pair_wmma_bf16_device(
                 static_cast<hip_bfloat16*>(out));
         } else if (quant_type == QWEN35_LOWBIT_GGML_Q4_K) {
             if (trunc_dequant) {
-                hipLaunchKernelGGL(
-                    HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_pair_wmma_m16_qtype_kernel<QWEN35_LOWBIT_GGML_Q4_K, true>),
-                    dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
-                    batch_elems, n_each, k,
-                    static_cast<const hip_bfloat16*>(lhs),
-                    static_cast<const uint8_t*>(rhs_first),
-                    static_cast<const uint8_t*>(rhs_second),
-                    static_cast<hip_bfloat16*>(out));
+                if (use_gfx12_acc) {
+                    hipLaunchKernelGGL(
+                        HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_pair_wmma_m16_qtype_gfx12_kernel<QWEN35_LOWBIT_GGML_Q4_K, true>),
+                        dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                        batch_elems, n_each, k,
+                        static_cast<const hip_bfloat16*>(lhs),
+                        static_cast<const uint8_t*>(rhs_first),
+                        static_cast<const uint8_t*>(rhs_second),
+                        static_cast<hip_bfloat16*>(out));
+                } else {
+                    hipLaunchKernelGGL(
+                        HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_pair_wmma_m16_qtype_kernel<QWEN35_LOWBIT_GGML_Q4_K, true>),
+                        dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                        batch_elems, n_each, k,
+                        static_cast<const hip_bfloat16*>(lhs),
+                        static_cast<const uint8_t*>(rhs_first),
+                        static_cast<const uint8_t*>(rhs_second),
+                        static_cast<hip_bfloat16*>(out));
+                }
             } else {
-                hipLaunchKernelGGL(
-                    HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_pair_wmma_m16_qtype_kernel<QWEN35_LOWBIT_GGML_Q4_K, false>),
-                    dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
-                    batch_elems, n_each, k,
-                    static_cast<const hip_bfloat16*>(lhs),
-                    static_cast<const uint8_t*>(rhs_first),
-                    static_cast<const uint8_t*>(rhs_second),
-                    static_cast<hip_bfloat16*>(out));
+                if (use_gfx12_acc) {
+                    hipLaunchKernelGGL(
+                        HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_pair_wmma_m16_qtype_gfx12_kernel<QWEN35_LOWBIT_GGML_Q4_K, false>),
+                        dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                        batch_elems, n_each, k,
+                        static_cast<const hip_bfloat16*>(lhs),
+                        static_cast<const uint8_t*>(rhs_first),
+                        static_cast<const uint8_t*>(rhs_second),
+                        static_cast<hip_bfloat16*>(out));
+                } else {
+                    hipLaunchKernelGGL(
+                        HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_pair_wmma_m16_qtype_kernel<QWEN35_LOWBIT_GGML_Q4_K, false>),
+                        dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                        batch_elems, n_each, k,
+                        static_cast<const hip_bfloat16*>(lhs),
+                        static_cast<const uint8_t*>(rhs_first),
+                        static_cast<const uint8_t*>(rhs_second),
+                        static_cast<hip_bfloat16*>(out));
+                }
             }
         } else if (quant_type == QWEN35_LOWBIT_GGML_Q5_K) {
             if (trunc_dequant) {
-                hipLaunchKernelGGL(
-                    HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_pair_wmma_m16_qtype_kernel<QWEN35_LOWBIT_GGML_Q5_K, true>),
-                    dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
-                    batch_elems, n_each, k,
-                    static_cast<const hip_bfloat16*>(lhs),
-                    static_cast<const uint8_t*>(rhs_first),
-                    static_cast<const uint8_t*>(rhs_second),
-                    static_cast<hip_bfloat16*>(out));
+                if (use_gfx12_acc) {
+                    hipLaunchKernelGGL(
+                        HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_pair_wmma_m16_qtype_gfx12_kernel<QWEN35_LOWBIT_GGML_Q5_K, true>),
+                        dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                        batch_elems, n_each, k,
+                        static_cast<const hip_bfloat16*>(lhs),
+                        static_cast<const uint8_t*>(rhs_first),
+                        static_cast<const uint8_t*>(rhs_second),
+                        static_cast<hip_bfloat16*>(out));
+                } else {
+                    hipLaunchKernelGGL(
+                        HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_pair_wmma_m16_qtype_kernel<QWEN35_LOWBIT_GGML_Q5_K, true>),
+                        dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                        batch_elems, n_each, k,
+                        static_cast<const hip_bfloat16*>(lhs),
+                        static_cast<const uint8_t*>(rhs_first),
+                        static_cast<const uint8_t*>(rhs_second),
+                        static_cast<hip_bfloat16*>(out));
+                }
             } else {
-                hipLaunchKernelGGL(
-                    HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_pair_wmma_m16_qtype_kernel<QWEN35_LOWBIT_GGML_Q5_K, false>),
-                    dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
-                    batch_elems, n_each, k,
-                    static_cast<const hip_bfloat16*>(lhs),
-                    static_cast<const uint8_t*>(rhs_first),
-                    static_cast<const uint8_t*>(rhs_second),
-                    static_cast<hip_bfloat16*>(out));
+                if (use_gfx12_acc) {
+                    hipLaunchKernelGGL(
+                        HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_pair_wmma_m16_qtype_gfx12_kernel<QWEN35_LOWBIT_GGML_Q5_K, false>),
+                        dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                        batch_elems, n_each, k,
+                        static_cast<const hip_bfloat16*>(lhs),
+                        static_cast<const uint8_t*>(rhs_first),
+                        static_cast<const uint8_t*>(rhs_second),
+                        static_cast<hip_bfloat16*>(out));
+                } else {
+                    hipLaunchKernelGGL(
+                        HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_pair_wmma_m16_qtype_kernel<QWEN35_LOWBIT_GGML_Q5_K, false>),
+                        dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                        batch_elems, n_each, k,
+                        static_cast<const hip_bfloat16*>(lhs),
+                        static_cast<const uint8_t*>(rhs_first),
+                        static_cast<const uint8_t*>(rhs_second),
+                        static_cast<hip_bfloat16*>(out));
+                }
             }
         } else if (quant_type == QWEN35_LOWBIT_GGML_Q6_K) {
             if (trunc_dequant) {
@@ -4609,19 +4936,11 @@ static int matmul_ggml_pair_swiglu_wmma_bf16_device(
     const bool trunc_dequant =
         quant_type != QWEN35_LOWBIT_GGML_Q8_0 &&
         std::getenv("SUPERSONIC_DFLASH_DISABLE_GGML_TRUNC_DEQUANT") == nullptr;
+    const bool use_gfx12_acc = device_is_gfx12(device_ordinal);
     if (quant_type == QWEN35_LOWBIT_GGML_Q8_0) {
-        hipLaunchKernelGGL(
-            HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_pair_swiglu_wmma_m16_qtype_kernel<QWEN35_LOWBIT_GGML_Q8_0, false>),
-            dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
-            batch_elems, n_each, k,
-            static_cast<const hip_bfloat16*>(lhs),
-            static_cast<const uint8_t*>(rhs_gate),
-                static_cast<const uint8_t*>(rhs_up),
-                static_cast<hip_bfloat16*>(out));
-    } else if (quant_type == QWEN35_LOWBIT_GGML_Q4_K) {
-        if (trunc_dequant) {
+        if (use_gfx12_acc) {
             hipLaunchKernelGGL(
-                HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_pair_swiglu_wmma_m16_qtype_kernel<QWEN35_LOWBIT_GGML_Q4_K, true>),
+                HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_pair_swiglu_wmma_m16_qtype_gfx12_kernel<QWEN35_LOWBIT_GGML_Q8_0, false>),
                 dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
                 batch_elems, n_each, k,
                 static_cast<const hip_bfloat16*>(lhs),
@@ -4630,53 +4949,139 @@ static int matmul_ggml_pair_swiglu_wmma_bf16_device(
                 static_cast<hip_bfloat16*>(out));
         } else {
             hipLaunchKernelGGL(
-                HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_pair_swiglu_wmma_m16_qtype_kernel<QWEN35_LOWBIT_GGML_Q4_K, false>),
+                HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_pair_swiglu_wmma_m16_qtype_kernel<QWEN35_LOWBIT_GGML_Q8_0, false>),
                 dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
                 batch_elems, n_each, k,
                 static_cast<const hip_bfloat16*>(lhs),
                 static_cast<const uint8_t*>(rhs_gate),
                 static_cast<const uint8_t*>(rhs_up),
                 static_cast<hip_bfloat16*>(out));
+        }
+    } else if (quant_type == QWEN35_LOWBIT_GGML_Q4_K) {
+        if (trunc_dequant) {
+            if (use_gfx12_acc) {
+                hipLaunchKernelGGL(
+                    HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_pair_swiglu_wmma_m16_qtype_gfx12_kernel<QWEN35_LOWBIT_GGML_Q4_K, true>),
+                    dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                    batch_elems, n_each, k,
+                    static_cast<const hip_bfloat16*>(lhs),
+                    static_cast<const uint8_t*>(rhs_gate),
+                    static_cast<const uint8_t*>(rhs_up),
+                    static_cast<hip_bfloat16*>(out));
+            } else {
+                hipLaunchKernelGGL(
+                    HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_pair_swiglu_wmma_m16_qtype_kernel<QWEN35_LOWBIT_GGML_Q4_K, true>),
+                    dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                    batch_elems, n_each, k,
+                    static_cast<const hip_bfloat16*>(lhs),
+                    static_cast<const uint8_t*>(rhs_gate),
+                    static_cast<const uint8_t*>(rhs_up),
+                    static_cast<hip_bfloat16*>(out));
+            }
+        } else {
+            if (use_gfx12_acc) {
+                hipLaunchKernelGGL(
+                    HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_pair_swiglu_wmma_m16_qtype_gfx12_kernel<QWEN35_LOWBIT_GGML_Q4_K, false>),
+                    dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                    batch_elems, n_each, k,
+                    static_cast<const hip_bfloat16*>(lhs),
+                    static_cast<const uint8_t*>(rhs_gate),
+                    static_cast<const uint8_t*>(rhs_up),
+                    static_cast<hip_bfloat16*>(out));
+            } else {
+                hipLaunchKernelGGL(
+                    HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_pair_swiglu_wmma_m16_qtype_kernel<QWEN35_LOWBIT_GGML_Q4_K, false>),
+                    dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                    batch_elems, n_each, k,
+                    static_cast<const hip_bfloat16*>(lhs),
+                    static_cast<const uint8_t*>(rhs_gate),
+                    static_cast<const uint8_t*>(rhs_up),
+                    static_cast<hip_bfloat16*>(out));
+            }
         }
     } else if (quant_type == QWEN35_LOWBIT_GGML_Q5_K) {
         if (trunc_dequant) {
-            hipLaunchKernelGGL(
-                HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_pair_swiglu_wmma_m16_qtype_kernel<QWEN35_LOWBIT_GGML_Q5_K, true>),
-                dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
-                batch_elems, n_each, k,
-                static_cast<const hip_bfloat16*>(lhs),
-                static_cast<const uint8_t*>(rhs_gate),
-                static_cast<const uint8_t*>(rhs_up),
-                static_cast<hip_bfloat16*>(out));
+            if (use_gfx12_acc) {
+                hipLaunchKernelGGL(
+                    HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_pair_swiglu_wmma_m16_qtype_gfx12_kernel<QWEN35_LOWBIT_GGML_Q5_K, true>),
+                    dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                    batch_elems, n_each, k,
+                    static_cast<const hip_bfloat16*>(lhs),
+                    static_cast<const uint8_t*>(rhs_gate),
+                    static_cast<const uint8_t*>(rhs_up),
+                    static_cast<hip_bfloat16*>(out));
+            } else {
+                hipLaunchKernelGGL(
+                    HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_pair_swiglu_wmma_m16_qtype_kernel<QWEN35_LOWBIT_GGML_Q5_K, true>),
+                    dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                    batch_elems, n_each, k,
+                    static_cast<const hip_bfloat16*>(lhs),
+                    static_cast<const uint8_t*>(rhs_gate),
+                    static_cast<const uint8_t*>(rhs_up),
+                    static_cast<hip_bfloat16*>(out));
+            }
         } else {
-            hipLaunchKernelGGL(
-                HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_pair_swiglu_wmma_m16_qtype_kernel<QWEN35_LOWBIT_GGML_Q5_K, false>),
-                dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
-                batch_elems, n_each, k,
-                static_cast<const hip_bfloat16*>(lhs),
-                static_cast<const uint8_t*>(rhs_gate),
-                static_cast<const uint8_t*>(rhs_up),
-                static_cast<hip_bfloat16*>(out));
+            if (use_gfx12_acc) {
+                hipLaunchKernelGGL(
+                    HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_pair_swiglu_wmma_m16_qtype_gfx12_kernel<QWEN35_LOWBIT_GGML_Q5_K, false>),
+                    dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                    batch_elems, n_each, k,
+                    static_cast<const hip_bfloat16*>(lhs),
+                    static_cast<const uint8_t*>(rhs_gate),
+                    static_cast<const uint8_t*>(rhs_up),
+                    static_cast<hip_bfloat16*>(out));
+            } else {
+                hipLaunchKernelGGL(
+                    HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_pair_swiglu_wmma_m16_qtype_kernel<QWEN35_LOWBIT_GGML_Q5_K, false>),
+                    dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                    batch_elems, n_each, k,
+                    static_cast<const hip_bfloat16*>(lhs),
+                    static_cast<const uint8_t*>(rhs_gate),
+                    static_cast<const uint8_t*>(rhs_up),
+                    static_cast<hip_bfloat16*>(out));
+            }
         }
     } else if (quant_type == QWEN35_LOWBIT_GGML_Q6_K) {
         if (trunc_dequant) {
-            hipLaunchKernelGGL(
-                HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_pair_swiglu_wmma_m16_qtype_kernel<QWEN35_LOWBIT_GGML_Q6_K, true>),
-                dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
-                batch_elems, n_each, k,
-                static_cast<const hip_bfloat16*>(lhs),
-                static_cast<const uint8_t*>(rhs_gate),
-                static_cast<const uint8_t*>(rhs_up),
-                static_cast<hip_bfloat16*>(out));
+            if (use_gfx12_acc) {
+                hipLaunchKernelGGL(
+                    HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_pair_swiglu_wmma_m16_qtype_gfx12_kernel<QWEN35_LOWBIT_GGML_Q6_K, true>),
+                    dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                    batch_elems, n_each, k,
+                    static_cast<const hip_bfloat16*>(lhs),
+                    static_cast<const uint8_t*>(rhs_gate),
+                    static_cast<const uint8_t*>(rhs_up),
+                    static_cast<hip_bfloat16*>(out));
+            } else {
+                hipLaunchKernelGGL(
+                    HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_pair_swiglu_wmma_m16_qtype_kernel<QWEN35_LOWBIT_GGML_Q6_K, true>),
+                    dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                    batch_elems, n_each, k,
+                    static_cast<const hip_bfloat16*>(lhs),
+                    static_cast<const uint8_t*>(rhs_gate),
+                    static_cast<const uint8_t*>(rhs_up),
+                    static_cast<hip_bfloat16*>(out));
+            }
         } else {
-            hipLaunchKernelGGL(
-                HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_pair_swiglu_wmma_m16_qtype_kernel<QWEN35_LOWBIT_GGML_Q6_K, false>),
-                dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
-                batch_elems, n_each, k,
-                static_cast<const hip_bfloat16*>(lhs),
-                static_cast<const uint8_t*>(rhs_gate),
-                static_cast<const uint8_t*>(rhs_up),
-                static_cast<hip_bfloat16*>(out));
+            if (use_gfx12_acc) {
+                hipLaunchKernelGGL(
+                    HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_pair_swiglu_wmma_m16_qtype_gfx12_kernel<QWEN35_LOWBIT_GGML_Q6_K, false>),
+                    dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                    batch_elems, n_each, k,
+                    static_cast<const hip_bfloat16*>(lhs),
+                    static_cast<const uint8_t*>(rhs_gate),
+                    static_cast<const uint8_t*>(rhs_up),
+                    static_cast<hip_bfloat16*>(out));
+            } else {
+                hipLaunchKernelGGL(
+                    HIP_KERNEL_NAME(supersonic_qwen35_matmul_ggml_pair_swiglu_wmma_m16_qtype_kernel<QWEN35_LOWBIT_GGML_Q6_K, false>),
+                    dim3(grid_x, 1, grid_z), dim3(threads), 0, 0,
+                    batch_elems, n_each, k,
+                    static_cast<const hip_bfloat16*>(lhs),
+                    static_cast<const uint8_t*>(rhs_gate),
+                    static_cast<const uint8_t*>(rhs_up),
+                    static_cast<hip_bfloat16*>(out));
+            }
         }
     }
     hipError_t launch_err = hipGetLastError();
@@ -4753,10 +5158,75 @@ static int matmul_mmq_q8_1_q6_k_device(
     const bool hot_exact =
         m == MMQ_X && (n % MMQ_Y) == 0 &&
         std::getenv("SUPERSONIC_DFLASH_DISABLE_Q6_K_MMQ_HOT_EXACT") == nullptr;
+    const bool use_gfx12_native =
+        hot_exact &&
+        device_is_gfx12(device_ordinal) &&
+        std::getenv("SUPERSONIC_DFLASH_DISABLE_Q6_K_MMQ_GFX12_NATIVE") == nullptr;
+    const bool has_residual = residual != nullptr;
 
-    if (hot_exact) {
+    if (use_gfx12_native && has_residual) {
         hipLaunchKernelGGL(
-            HIP_KERNEL_NAME(supersonic_qwen35_matmul_mmq_q8_1_q6_k_kernel<true>),
+            HIP_KERNEL_NAME(supersonic_qwen35_matmul_mmq_q8_1_q6_k_gfx12_kernel<true, true>),
+            dim3(grid_x, grid_y, grid_z),
+            dim3(32, 8),
+            shared_bytes,
+            0,
+            batch_elems,
+            m,
+            n,
+            k,
+            static_cast<const uint8_t*>(q8),
+            static_cast<const uint8_t*>(rhs_q6),
+            static_cast<const hip_bfloat16*>(residual),
+            static_cast<hip_bfloat16*>(out));
+    } else if (use_gfx12_native) {
+        hipLaunchKernelGGL(
+            HIP_KERNEL_NAME(supersonic_qwen35_matmul_mmq_q8_1_q6_k_gfx12_kernel<true, false>),
+            dim3(grid_x, grid_y, grid_z),
+            dim3(32, 8),
+            shared_bytes,
+            0,
+            batch_elems,
+            m,
+            n,
+            k,
+            static_cast<const uint8_t*>(q8),
+            static_cast<const uint8_t*>(rhs_q6),
+            static_cast<const hip_bfloat16*>(residual),
+            static_cast<hip_bfloat16*>(out));
+    } else if (hot_exact && has_residual) {
+        hipLaunchKernelGGL(
+            HIP_KERNEL_NAME(supersonic_qwen35_matmul_mmq_q8_1_q6_k_kernel<true, true>),
+            dim3(grid_x, grid_y, grid_z),
+            dim3(32, 8),
+            shared_bytes,
+            0,
+            batch_elems,
+            m,
+            n,
+            k,
+            static_cast<const uint8_t*>(q8),
+            static_cast<const uint8_t*>(rhs_q6),
+            static_cast<const hip_bfloat16*>(residual),
+            static_cast<hip_bfloat16*>(out));
+    } else if (hot_exact) {
+        hipLaunchKernelGGL(
+            HIP_KERNEL_NAME(supersonic_qwen35_matmul_mmq_q8_1_q6_k_kernel<true, false>),
+            dim3(grid_x, grid_y, grid_z),
+            dim3(32, 8),
+            shared_bytes,
+            0,
+            batch_elems,
+            m,
+            n,
+            k,
+            static_cast<const uint8_t*>(q8),
+            static_cast<const uint8_t*>(rhs_q6),
+            static_cast<const hip_bfloat16*>(residual),
+            static_cast<hip_bfloat16*>(out));
+    } else if (has_residual) {
+        hipLaunchKernelGGL(
+            HIP_KERNEL_NAME(supersonic_qwen35_matmul_mmq_q8_1_q6_k_kernel<false, true>),
             dim3(grid_x, grid_y, grid_z),
             dim3(32, 8),
             shared_bytes,
@@ -4771,7 +5241,7 @@ static int matmul_mmq_q8_1_q6_k_device(
             static_cast<hip_bfloat16*>(out));
     } else {
         hipLaunchKernelGGL(
-            HIP_KERNEL_NAME(supersonic_qwen35_matmul_mmq_q8_1_q6_k_kernel<false>),
+            HIP_KERNEL_NAME(supersonic_qwen35_matmul_mmq_q8_1_q6_k_kernel<false, false>),
             dim3(grid_x, grid_y, grid_z),
             dim3(32, 8),
             shared_bytes,
@@ -4814,49 +5284,96 @@ static int matmul_q6_k_m16_argmax_device(
     const int grid_z = static_cast<int>(batch_elems);
     const bool trunc_dequant =
         std::getenv("SUPERSONIC_DFLASH_DISABLE_GGML_TRUNC_DEQUANT") == nullptr;
+    const bool use_gfx12_acc = device_is_gfx12(device_ordinal);
     if (trunc_dequant) {
-        hipLaunchKernelGGL(
-            HIP_KERNEL_NAME(supersonic_qwen35_matmul_q6_k_m16_tile_argmax_kernel<true>),
-            dim3(tiles, 1, grid_z),
-            dim3(32),
-            0,
-            0,
-            batch_elems,
-            n,
-            k,
-            static_cast<const hip_bfloat16*>(lhs),
-            static_cast<const uint8_t*>(rhs_q6),
-            static_cast<float*>(block_best_vals),
-            static_cast<uint32_t*>(block_best_indices));
+        if (use_gfx12_acc) {
+            hipLaunchKernelGGL(
+                HIP_KERNEL_NAME(supersonic_qwen35_matmul_q6_k_m16_tile_argmax_gfx12_kernel<true>),
+                dim3(tiles, 1, grid_z),
+                dim3(32),
+                0,
+                0,
+                batch_elems,
+                n,
+                k,
+                static_cast<const hip_bfloat16*>(lhs),
+                static_cast<const uint8_t*>(rhs_q6),
+                static_cast<float*>(block_best_vals),
+                static_cast<uint32_t*>(block_best_indices));
+        } else {
+            hipLaunchKernelGGL(
+                HIP_KERNEL_NAME(supersonic_qwen35_matmul_q6_k_m16_tile_argmax_kernel<true>),
+                dim3(tiles, 1, grid_z),
+                dim3(32),
+                0,
+                0,
+                batch_elems,
+                n,
+                k,
+                static_cast<const hip_bfloat16*>(lhs),
+                static_cast<const uint8_t*>(rhs_q6),
+                static_cast<float*>(block_best_vals),
+                static_cast<uint32_t*>(block_best_indices));
+        }
     } else {
-        hipLaunchKernelGGL(
-            HIP_KERNEL_NAME(supersonic_qwen35_matmul_q6_k_m16_tile_argmax_kernel<false>),
-            dim3(tiles, 1, grid_z),
-            dim3(32),
-            0,
-            0,
-            batch_elems,
-            n,
-            k,
-            static_cast<const hip_bfloat16*>(lhs),
-            static_cast<const uint8_t*>(rhs_q6),
-            static_cast<float*>(block_best_vals),
-            static_cast<uint32_t*>(block_best_indices));
+        if (use_gfx12_acc) {
+            hipLaunchKernelGGL(
+                HIP_KERNEL_NAME(supersonic_qwen35_matmul_q6_k_m16_tile_argmax_gfx12_kernel<false>),
+                dim3(tiles, 1, grid_z),
+                dim3(32),
+                0,
+                0,
+                batch_elems,
+                n,
+                k,
+                static_cast<const hip_bfloat16*>(lhs),
+                static_cast<const uint8_t*>(rhs_q6),
+                static_cast<float*>(block_best_vals),
+                static_cast<uint32_t*>(block_best_indices));
+        } else {
+            hipLaunchKernelGGL(
+                HIP_KERNEL_NAME(supersonic_qwen35_matmul_q6_k_m16_tile_argmax_kernel<false>),
+                dim3(tiles, 1, grid_z),
+                dim3(32),
+                0,
+                0,
+                batch_elems,
+                n,
+                k,
+                static_cast<const hip_bfloat16*>(lhs),
+                static_cast<const uint8_t*>(rhs_q6),
+                static_cast<float*>(block_best_vals),
+                static_cast<uint32_t*>(block_best_indices));
+        }
     }
     hipError_t launch_err = hipGetLastError();
     if (launch_err != hipSuccess) return 343;
 
-    hipLaunchKernelGGL(
-        supersonic_qwen35_reduce_m16_tile_argmax_kernel,
-        dim3(16, grid_z),
-        dim3(256),
-        0,
-        0,
-        batch_elems,
-        tiles,
-        static_cast<const float*>(block_best_vals),
-        static_cast<const uint32_t*>(block_best_indices),
-        static_cast<uint32_t*>(out_indices));
+    if (use_gfx12_acc) {
+        hipLaunchKernelGGL(
+            supersonic_qwen35_reduce_m16_tile_argmax_tile_major_kernel,
+            dim3(16, grid_z),
+            dim3(256),
+            0,
+            0,
+            batch_elems,
+            tiles,
+            static_cast<const float*>(block_best_vals),
+            static_cast<const uint32_t*>(block_best_indices),
+            static_cast<uint32_t*>(out_indices));
+    } else {
+        hipLaunchKernelGGL(
+            supersonic_qwen35_reduce_m16_tile_argmax_kernel,
+            dim3(16, grid_z),
+            dim3(256),
+            0,
+            0,
+            batch_elems,
+            tiles,
+            static_cast<const float*>(block_best_vals),
+            static_cast<const uint32_t*>(block_best_indices),
+            static_cast<uint32_t*>(out_indices));
+    }
     launch_err = hipGetLastError();
     hipError_t sync_err = maybe_sync();
     if (launch_err != hipSuccess) return 344;


### PR DESCRIPTION
## Summary

This brings the R9700 / gfx1201 Lucebox Qwen3.6 27B path into line with the existing 7900XTX / gfx11 optimization state.

The major remaining slowdown was isolated to the Lucebox Q8_0 draft fuser prefill matmul. On gfx1201 the generic large-M GGML Q8_0 path was paying the gfx11 accumulator shuffle/repack cost on every WMMA step. This PR adds a gfx12-native large-M Q8_0 WMMA kernel and dispatches aligned no-AWQ Q8_0 fuser shapes to it behind `SUPERSONIC_DFLASH_DISABLE_GGML_Q8_LARGE_M_GFX12_NATIVE`.

It also keeps the earlier RDNA4 work in this branch: gfx12 WMMA helpers, m8/m16 GGML improvements, Q6 MMQ tuning, recurrent/RMS coverage, and expanded `int4_test` hot-shape/parity coverage.

## Result

Corrected Lucebox Qwen3.6 27B 10x256, `--lucebox-serving-mode --dflash-draft-variant lucebox-q8-0 --quant q4km`:

| GPU | Artifact | Mean tok/s | Weighted tok/s | Tokens | Early stops |
| --- | --- | ---: | ---: | ---: | ---: |
| R9700 / gfx1201 | `target/qwen36_100tok_profile2/gfx1201_q8_large_gfx12_10x256.json` | 97.66 | 96.57 | 1654 | 10/10 |
| 7900XTX / gfx1100 current build | `target/qwen36_100tok_profile2/gfx1100_current_after_q8_large_10x256.json` | 94.85 | 93.97 | 1654 | 10/10 |
| 7900XTX historical reference | `target/qwen36_100tok_profile2/append_recurrent_warp32_direct_10x256.json` | 100.86 | n/a | 1654 | 10/10 |

FFI profiling on R9700 for the Q8_0 fuser shape `m≈142-168 n=5120 k=25600` dropped from about `21.9 ms` per call to `5.3-5.5 ms`; the profiled draft phase dropped from `175 ms` to `76 ms`.

## Validation

- `cargo build --release --bin int4_test --bin supersonic`
- `HIP_VISIBLE_DEVICES=1 SUPERSONIC_BACKENDS=hip target/release/int4_test`
- `HIP_VISIBLE_DEVICES=0 SUPERSONIC_BACKENDS=hip target/release/int4_test`
- Corrected Lucebox 10x256 on R9700 / gfx1201
- Corrected Lucebox 10x256 on 7900XTX / gfx1100
- `git diff --check`
- stale-experiment marker scan clean