### PR TITLE
[codex] Add tool inventory check

### DIFF
--- a/docs/development/consolidation-roadmap.md
+++ b/docs/development/consolidation-roadmap.md
@@ -51,6 +51,11 @@ Classification:
 
 Current runner binary inventory:
 
+The checked source of truth is
+[`tools/tool-inventory.toml`](../../tools/tool-inventory.toml). Validate it with
+`python3 tools/check-tool-inventory.py`. The table below is the human-readable
+summary and should stay aligned with the manifest until it is generated.
+
 | Command | Current file | Class | Future home |
 | --- | --- | --- | --- |
 | `supersonic` | `crates/runner/src/main.rs` | stable | Keep as the primary CLI until runtime/server APIs are fully split. |

--- a/tools/check-tool-inventory.py
+++ b/tools/check-tool-inventory.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Validate that runner binaries are represented in tools/tool-inventory.toml."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    print("error: Python 3.11+ is required for tomllib support", file=sys.stderr)
+    raise SystemExit(1)
+
+ROOT = Path(__file__).resolve().parents[1]
+INVENTORY = ROOT / "tools" / "tool-inventory.toml"
+RUNNER_MAIN = ROOT / "crates" / "runner" / "src" / "main.rs"
+RUNNER_BIN_DIR = ROOT / "crates" / "runner" / "src" / "bin"
+VALID_CLASSES = {"stable", "validation", "microbench", "lab", "legacy"}
+
+
+def rel(path: Path) -> str:
+    return path.relative_to(ROOT).as_posix()
+
+
+def expected_runner_bins() -> dict[str, str]:
+    expected = {"supersonic": rel(RUNNER_MAIN)}
+    for path in sorted(RUNNER_BIN_DIR.glob("*.rs")):
+        expected[path.stem] = rel(path)
+    return expected
+
+
+def load_inventory() -> list[dict[str, object]]:
+    with INVENTORY.open("rb") as handle:
+        data = tomllib.load(handle)
+    entries = data.get("runner_bin", [])
+    if not isinstance(entries, list):
+        raise TypeError("runner_bin must be an array of tables")
+    return entries
+
+
+def main() -> int:
+    errors: list[str] = []
+    expected = expected_runner_bins()
+
+    try:
+        entries = load_inventory()
+    except Exception as exc:
+        print(f"error: failed to read {rel(INVENTORY)}: {exc}", file=sys.stderr)
+        return 1
+
+    seen_names: set[str] = set()
+    seen_paths: set[str] = set()
+    by_name: dict[str, dict[str, object]] = {}
+
+    for index, entry in enumerate(entries, start=1):
+        name = entry.get("name")
+        path = entry.get("path")
+        tool_class = entry.get("class")
+        future_home = entry.get("future_home")
+
+        if not isinstance(name, str) or not name:
+            errors.append(f"runner_bin #{index}: missing string name")
+            continue
+        if name in seen_names:
+            errors.append(f"{name}: duplicate name")
+        seen_names.add(name)
+        by_name[name] = entry
+
+        if not isinstance(path, str) or not path:
+            errors.append(f"{name}: missing string path")
+        else:
+            if path in seen_paths:
+                errors.append(f"{name}: duplicate path {path}")
+            seen_paths.add(path)
+            if not (ROOT / path).is_file():
+                errors.append(f"{name}: path does not exist: {path}")
+
+        if tool_class not in VALID_CLASSES:
+            errors.append(
+                f"{name}: class must be one of {sorted(VALID_CLASSES)}, got {tool_class!r}"
+            )
+
+        if not isinstance(future_home, str) or not future_home:
+            errors.append(f"{name}: missing string future_home")
+
+    for name, path in expected.items():
+        entry = by_name.get(name)
+        if entry is None:
+            errors.append(f"{name}: missing inventory entry for {path}")
+            continue
+        if entry.get("path") != path:
+            errors.append(
+                f"{name}: inventory path {entry.get('path')!r} does not match {path!r}"
+            )
+
+    for name in sorted(seen_names - set(expected)):
+        errors.append(f"{name}: inventory entry is not a current runner binary")
+
+    if errors:
+        for error in errors:
+            print(f"error: {error}", file=sys.stderr)
+        return 1
+
+    print(f"tool inventory ok: {len(expected)} runner binaries classified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tool-inventory.toml
+++ b/tools/tool-inventory.toml
@@ -1,0 +1,162 @@
+# Machine-readable inventory for SuperSonic development tools.
+#
+# The first covered surface is the runner binary set. Keep existing command
+# names working until a replacement command is documented, validated, and
+# wrapped by an alias.
+
+version = 1
+
+[[runner_bin]]
+name = "supersonic"
+path = "crates/runner/src/main.rs"
+class = "stable"
+future_home = "crates/runner/src/main.rs"
+notes = "Primary user-facing CLI; keep as the normal entrypoint until runtime/server APIs are fully split."
+
+[[runner_bin]]
+name = "bench_prefill_attn"
+path = "crates/runner/src/bin/bench_prefill_attn.rs"
+class = "microbench"
+future_home = "tools/microbench"
+notes = "Focused prefill attention benchmark."
+
+[[runner_bin]]
+name = "gemma4_batched_divergent_test"
+path = "crates/runner/src/bin/gemma4_batched_divergent_test.rs"
+class = "validation"
+future_home = "tools/validation"
+notes = "Gemma 4 batched divergent correctness coverage."
+
+[[runner_bin]]
+name = "gemma4_bench"
+path = "crates/runner/src/bin/gemma4_bench.rs"
+class = "microbench"
+future_home = "tools/microbench"
+notes = "Gemma 4 focused benchmark harness."
+
+[[runner_bin]]
+name = "gemma4_corpus_test"
+path = "crates/runner/src/bin/gemma4_corpus_test.rs"
+class = "validation"
+future_home = "tools/validation"
+notes = "Gemma 4 corpus validation coverage."
+
+[[runner_bin]]
+name = "gemma4_decode_validate"
+path = "crates/runner/src/bin/gemma4_decode_validate.rs"
+class = "validation"
+future_home = "tools/validation"
+notes = "Gemma 4 decode validation."
+
+[[runner_bin]]
+name = "gemma4_e2e_validate"
+path = "crates/runner/src/bin/gemma4_e2e_validate.rs"
+class = "validation"
+future_home = "tools/validation"
+notes = "Gemma 4 end-to-end validation."
+
+[[runner_bin]]
+name = "gemma4_fused_decode_validate"
+path = "crates/runner/src/bin/gemma4_fused_decode_validate.rs"
+class = "validation"
+future_home = "tools/validation"
+notes = "Gemma 4 fused decode validation."
+
+[[runner_bin]]
+name = "gemma4_fused_int4_validate"
+path = "crates/runner/src/bin/gemma4_fused_int4_validate.rs"
+class = "validation"
+future_home = "tools/validation"
+notes = "Gemma 4 fused INT4 validation."
+
+[[runner_bin]]
+name = "gemma4_int4_layer_diag"
+path = "crates/runner/src/bin/gemma4_int4_layer_diag.rs"
+class = "lab"
+future_home = "tools/lab"
+notes = "Gemma 4 INT4 layer diagnostic."
+
+[[runner_bin]]
+name = "gemma4_int4_matvec_test"
+path = "crates/runner/src/bin/gemma4_int4_matvec_test.rs"
+class = "validation"
+future_home = "tools/validation"
+notes = "Gemma 4 INT4 matvec validation."
+
+[[runner_bin]]
+name = "gemma4_layer0_validate"
+path = "crates/runner/src/bin/gemma4_layer0_validate.rs"
+class = "validation"
+future_home = "tools/validation"
+notes = "Gemma 4 layer zero validation."
+
+[[runner_bin]]
+name = "gemma4_mega_decode_validate"
+path = "crates/runner/src/bin/gemma4_mega_decode_validate.rs"
+class = "validation"
+future_home = "tools/validation"
+notes = "Gemma 4 mega decode validation."
+
+[[runner_bin]]
+name = "gemma4_primitive_test"
+path = "crates/runner/src/bin/gemma4_primitive_test.rs"
+class = "validation"
+future_home = "tools/validation"
+notes = "Gemma 4 primitive validation."
+
+[[runner_bin]]
+name = "int4_real_test"
+path = "crates/runner/src/bin/int4_real_test.rs"
+class = "validation"
+future_home = "tools/validation"
+notes = "INT4 validation against real model artifacts."
+
+[[runner_bin]]
+name = "int4_test"
+path = "crates/runner/src/bin/int4_test.rs"
+class = "validation"
+future_home = "tools/validation"
+notes = "INT4 validation harness."
+
+[[runner_bin]]
+name = "llama31_certified_kv_microbench"
+path = "crates/runner/src/bin/llama31_certified_kv_microbench.rs"
+class = "microbench"
+future_home = "tools/microbench"
+notes = "Llama 3.1 certified KV focused benchmark."
+
+[[runner_bin]]
+name = "llama31_int8_downproj_diag"
+path = "crates/runner/src/bin/llama31_int8_downproj_diag.rs"
+class = "lab"
+future_home = "tools/lab"
+notes = "Llama 3.1 INT8 down-projection diagnostic."
+
+[[runner_bin]]
+name = "llama31_int8_matmul_test"
+path = "crates/runner/src/bin/llama31_int8_matmul_test.rs"
+class = "validation"
+future_home = "tools/validation"
+notes = "Llama 3.1 INT8 matmul validation."
+
+[[runner_bin]]
+name = "qwen35_bughunt"
+path = "crates/runner/src/bin/qwen35_bughunt.rs"
+class = "lab"
+future_home = "tools/lab"
+required_features = ["bughunt"]
+notes = "Qwen3.5 feature-gated bughunt tool."
+
+[[runner_bin]]
+name = "qwen36_ffn_expert_microbench"
+path = "crates/runner/src/bin/qwen36_ffn_expert_microbench.rs"
+class = "microbench"
+future_home = "tools/microbench"
+notes = "Qwen3.6 MoE FFN expert focused benchmark."
+
+[[runner_bin]]
+name = "qwen36_q4km_manifest_audit"
+path = "crates/runner/src/bin/qwen36_q4km_manifest_audit.rs"
+class = "validation"
+future_home = "tools/validation"
+notes = "Qwen3.6 Q4_K_M manifest audit."


### PR DESCRIPTION
## Summary

- add `tools/tool-inventory.toml` as a machine-readable inventory for current runner binaries
- classify every current `supersonic`/`crates/runner/src/bin/*.rs` command as `stable`, `validation`, `microbench`, `lab`, or `legacy`
- add `tools/check-tool-inventory.py`, a read-only verifier that checks inventory coverage, duplicate names/paths, valid classes, and existing paths
- update the consolidation roadmap to point at the manifest and verifier as the checked source of truth

## Impact

This is intentionally non-moving and non-breaking. It does not rename commands, move binaries or scripts, change CLI flags, change Rust module layout, or alter build behavior. Existing `cargo run --bin ...` command names remain untouched.

## Validation

- `python3 tools/check-tool-inventory.py`
- `tools/check-tool-inventory.py`
- `git diff --check`
- verified referenced inventory/check paths exist