### PR TITLE
[codex] Add support matrix manifest

### DIFF
--- a/docs/development/consolidation-roadmap.md
+++ b/docs/development/consolidation-roadmap.md
@@ -136,7 +136,7 @@ Target behavior:
 | --- | --- | --- |
 | PR 2 | Add a `tools/` classification path, `crates/runner/src/bin/lab/` convention, or metadata manifest. Keep wrapper aliases for existing binary names. | Existing `cargo run --bin ...` commands continue to work. |
 | PR 3 | Extract shared runtime/generation/session interfaces so `supersonic-runtime` no longer depends on `runner`. | Build runner, runtime, and server; keep CLI behavior unchanged. |
-| PR 4 | Introduce a single capability/support data source used by docs/tests where practical. | Generated or checked docs must still be easy to review. |
+| PR 4 | Introduce `support/matrix.toml` as the seed capability/support data source used by docs/tests where practical. | Validate the manifest with `python3 tools/check-support-matrix.py`; generated or checked docs must still be easy to review. |
 | PR 5 | Split `kernel-ffi/build.rs` into model/backend compile groups with default behavior preserved. | Compare old default behavior with grouped builds on one representative backend. |
 | PR 6+ | Move larger model-specific runtime implementations out of `runner` once public interfaces are stable. | One benchmark or parity artifact for each moved runtime path. |
 

--- a/docs/supported-matrix.md
+++ b/docs/supported-matrix.md
@@ -6,6 +6,12 @@ which GPU architecture. The cells below track *correctness* — see
 and [docs/feature-compatibility.md](feature-compatibility.md) for the
 runtime-feature compatibility grid.
 
+The first machine-readable seed for this matrix lives in
+[`support/matrix.toml`](../support/matrix.toml). Validate it with
+`python3 tools/check-support-matrix.py`. For now this Markdown table remains
+the reviewed operator-facing source, and the manifest records the high-value
+lanes that already have named gates or benchmark references.
+
 Seven backend surfaces are validated or in bring-up today:
 
 - **HIP / `gfx1100`** — AMD Radeon RX 7900 XTX (RDNA 3, 24 GiB)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -6,6 +6,11 @@ README files (`crates/runner/`, `crates/kernel-ffi/`, etc.).
 For repeatable performance, Lucebox, external-reference, and profiler commands,
 see [benchmarks.md](benchmarks.md).
 
+Support lanes with named gates are being captured in
+[`support/matrix.toml`](../support/matrix.toml). Run
+`python3 tools/check-support-matrix.py` after changing supported architectures,
+gate scripts, or benchmark references.
+
 Tests are machine-specific — each GPU architecture has its own test script under `tests/`. A test runs the full decode pipeline with PyTorch oracle validation and checks that the output delta is below a threshold.
 
 ### Running tests

--- a/support/matrix.toml
+++ b/support/matrix.toml
@@ -48,7 +48,7 @@ models = ["qwen3.6-27b"]
 quants = ["int4"]
 support_doc = "docs/supported-matrix.md#hip-on-gfx1201"
 gate_scripts = ["tests/gfx1201/run_matrix.sh"]
-benchmark_doc = "docs/benchmarks.md#rdna4-r9700-smoke-benchmark"
+benchmark_doc = "docs/benchmarks.md#rdna4--r9700-smoke-benchmark"
 notes = "R9700 starter lane: RDNA4 WMMA/int4 harness, direct smoke, and optional Lucebox/DFlash smoke."
 
 [[entry]]
@@ -107,7 +107,7 @@ gate_scripts = ["tests/sm86/run_gemma4.sh"]
 notes = "Native Gemma 4 CUDA v1 lane; batch size is constrained by the support doc."
 
 [[entry]]
-id = "cuda-sm90-inherited-cuda-lanes"
+id = "cuda-sm90-qwen35-inherited-all-lanes"
 backend = "cuda"
 arch = "sm90"
 status = "inherited"
@@ -116,14 +116,41 @@ models = [
   "qwen3.5-2b",
   "qwen3.5-4b",
   "qwen3.5-9b",
-  "gemma4-e2b",
-  "phi4-mini",
-  "llama3.1-8b",
 ]
 quants = ["bf16", "int4", "fp8-runtime", "kv-fp8"]
 support_doc = "docs/supported-matrix.md#cuda-on-sm90"
-benchmark_doc = "docs/detailed_performance.md#cuda-sm90-nvidia-h100-80gb-hbm3"
-notes = "H100 lane currently inherits CUDA sm86 registry geometry and kernel families unless otherwise noted."
+benchmark_doc = "docs/detailed_performance.md#cuda--sm90-nvidia-h100-80gb-hbm3"
+notes = "H100 Qwen3.5 lanes currently inherit CUDA sm86 registry geometry and kernel families unless otherwise noted."
+
+[[entry]]
+id = "cuda-sm90-gemma4-e2b-inherited-bf16"
+backend = "cuda"
+arch = "sm90"
+status = "inherited"
+models = ["gemma4-e2b"]
+quants = ["bf16"]
+support_doc = "docs/supported-matrix.md#cuda-on-sm90"
+notes = "H100 Gemma 4 E2B inherits the CUDA BF16 lane; INT4, FP8-runtime, and KV-FP8 are not advertised."
+
+[[entry]]
+id = "cuda-sm90-phi4-mini-inherited-non-kv"
+backend = "cuda"
+arch = "sm90"
+status = "inherited"
+models = ["phi4-mini"]
+quants = ["bf16", "int4", "fp8-runtime"]
+support_doc = "docs/supported-matrix.md#cuda-on-sm90"
+notes = "H100 Phi-4 mini inherits BF16, INT4, and FP8-runtime lanes; KV-FP8 remains pending in the support table."
+
+[[entry]]
+id = "cuda-sm90-llama31-8b-inherited-bf16-kv"
+backend = "cuda"
+arch = "sm90"
+status = "inherited"
+models = ["llama3.1-8b"]
+quants = ["bf16", "kv-fp8"]
+support_doc = "docs/supported-matrix.md#cuda-on-sm90"
+notes = "H100 Llama 3.1 8B inherits BF16 and KV-FP8 lanes only."
 
 [[entry]]
 id = "metal-apple-m4-qwen35-bf16"
@@ -132,7 +159,7 @@ arch = "apple-m4"
 status = "validated"
 models = ["qwen3.5-0.8b", "qwen3.5-2b", "qwen3.5-4b", "qwen3.5-9b"]
 quants = ["bf16"]
-support_doc = "docs/supported-matrix.md#metal-on-apple-m4-apple-m5-max"
+support_doc = "docs/supported-matrix.md#metal-on-apple-m4--apple-m5-max"
 gate_scripts = ["tests/metal/qwen35_bughunt_gate.sh"]
 notes = "Apple M4 remains the small Qwen3.5 Metal validation lane."
 
@@ -143,7 +170,7 @@ arch = "apple-m5-max"
 status = "validated"
 models = ["qwen3-30b-a3b"]
 quants = ["int4"]
-support_doc = "docs/supported-matrix.md#metal-on-apple-m4-apple-m5-max"
+support_doc = "docs/supported-matrix.md#metal-on-apple-m4--apple-m5-max"
 gate_commands = [
   "cargo test --release -p runner --test metal_large_model_smoke -- --ignored --nocapture",
 ]
@@ -157,7 +184,7 @@ arch = "apple-m5-max"
 status = "validated"
 models = ["qwen3.6-35b-a3b"]
 quants = ["int4"]
-support_doc = "docs/supported-matrix.md#metal-on-apple-m4-apple-m5-max"
+support_doc = "docs/supported-matrix.md#metal-on-apple-m4--apple-m5-max"
 gate_commands = [
   "cargo test --release -p runner --test qwen36_moe_metal_smoke -- --ignored --nocapture",
 ]
@@ -171,7 +198,7 @@ arch = "apple-m5-max"
 status = "validated"
 models = ["gemma4-e2b", "gemma4-e4b"]
 quants = ["bf16", "int4"]
-support_doc = "docs/supported-matrix.md#metal-on-apple-m4-apple-m5-max"
+support_doc = "docs/supported-matrix.md#metal-on-apple-m4--apple-m5-max"
 gate_commands = [
   "cargo test --release -p runner --test metal_large_model_smoke -- --ignored --nocapture",
 ]
@@ -185,7 +212,7 @@ arch = "apple-m5-max"
 status = "validated"
 models = ["phi4-mini"]
 quants = ["bf16", "int4", "fp8-runtime"]
-support_doc = "docs/supported-matrix.md#metal-on-apple-m4-apple-m5-max"
+support_doc = "docs/supported-matrix.md#metal-on-apple-m4--apple-m5-max"
 gate_commands = [
   "cargo test --release -p runner --test metal_large_model_smoke -- --ignored --nocapture",
 ]

--- a/support/matrix.toml
+++ b/support/matrix.toml
@@ -22,13 +22,11 @@ notes = "RDNA3 7900 XTX Qwen3.5 lanes are the mature HIP baseline."
 id = "hip-gfx1100-qwen36-35b-a3b-int4"
 backend = "hip"
 arch = "gfx1100"
-status = "validated"
+status = "experimental"
 models = ["qwen3.6-35b-a3b"]
 quants = ["int4"]
 support_doc = "docs/supported-matrix.md#hip-on-gfx1100"
-gate_scripts = ["tests/gfx1100/run_matrix.sh"]
-benchmark_doc = "docs/benchmarks.md#lucebox-qwen36-27b-7900-xtx"
-notes = "BF16 is intentionally unsupported for the FP8-native checkpoint; INT4 is the supported HIP lane."
+notes = "BF16 is intentionally unsupported for the FP8-native checkpoint. The Markdown matrix documents the INT4 lane, but this manifest keeps it experimental until a named gfx1100 35B gate exists."
 
 [[entry]]
 id = "hip-gfx1201-qwen35-tbm"
@@ -139,16 +137,57 @@ gate_scripts = ["tests/metal/qwen35_bughunt_gate.sh"]
 notes = "Apple M4 remains the small Qwen3.5 Metal validation lane."
 
 [[entry]]
-id = "metal-apple-m5-max-large-model-smokes"
+id = "metal-apple-m5-max-qwen3-moe-int4"
 backend = "metal"
 arch = "apple-m5-max"
 status = "validated"
-models = ["qwen3-30b-a3b", "qwen3.6-35b-a3b", "gemma4-e2b", "gemma4-e4b", "phi4-mini"]
+models = ["qwen3-30b-a3b"]
+quants = ["int4"]
+support_doc = "docs/supported-matrix.md#metal-on-apple-m4-apple-m5-max"
+gate_commands = [
+  "cargo test --release -p runner --test metal_large_model_smoke -- --ignored --nocapture",
+]
+benchmark_doc = "docs/benchmarks.md#external-references"
+notes = "Apple M5 Max Qwen3 MoE INT4 correctness lane through component and chained Metal paths."
+
+[[entry]]
+id = "metal-apple-m5-max-qwen36-moe-int4"
+backend = "metal"
+arch = "apple-m5-max"
+status = "validated"
+models = ["qwen3.6-35b-a3b"]
+quants = ["int4"]
+support_doc = "docs/supported-matrix.md#metal-on-apple-m4-apple-m5-max"
+gate_commands = [
+  "cargo test --release -p runner --test qwen36_moe_metal_smoke -- --ignored --nocapture",
+]
+benchmark_doc = "docs/benchmarks.md#external-references"
+notes = "Apple M5 Max Qwen3.6 MoE INT4 correctness lane through component and chained Metal paths."
+
+[[entry]]
+id = "metal-apple-m5-max-gemma4-bf16-int4"
+backend = "metal"
+arch = "apple-m5-max"
+status = "validated"
+models = ["gemma4-e2b", "gemma4-e4b"]
+quants = ["bf16", "int4"]
+support_doc = "docs/supported-matrix.md#metal-on-apple-m4-apple-m5-max"
+gate_commands = [
+  "cargo test --release -p runner --test metal_large_model_smoke -- --ignored --nocapture",
+]
+benchmark_doc = "docs/benchmarks.md#external-references"
+notes = "Apple M5 Max Gemma 4 BF16 and INT4 correctness lane."
+
+[[entry]]
+id = "metal-apple-m5-max-phi4-bf16-int4-fp8"
+backend = "metal"
+arch = "apple-m5-max"
+status = "validated"
+models = ["phi4-mini"]
 quants = ["bf16", "int4", "fp8-runtime"]
 support_doc = "docs/supported-matrix.md#metal-on-apple-m4-apple-m5-max"
 gate_commands = [
   "cargo test --release -p runner --test metal_large_model_smoke -- --ignored --nocapture",
-  "cargo test --release -p runner --test qwen36_moe_metal_smoke -- --ignored --nocapture",
 ]
 benchmark_doc = "docs/benchmarks.md#external-references"
-notes = "Apple M5 Max large-model correctness lane through component and chained Metal paths."
+notes = "Apple M5 Max Phi-4 mini BF16, INT4, and FP8-runtime correctness lane."

--- a/support/matrix.toml
+++ b/support/matrix.toml
@@ -1,0 +1,154 @@
+# Machine-readable seed for the SuperSonic support matrix.
+#
+# This is intentionally not generated into docs yet. Keep it aligned with
+# docs/supported-matrix.md while the schema settles, then promote it to the
+# single data source in a later consolidation PR.
+
+version = 1
+
+[[entry]]
+id = "hip-gfx1100-qwen35-all-lanes"
+backend = "hip"
+arch = "gfx1100"
+status = "validated"
+models = ["qwen3.5-0.8b", "qwen3.5-2b", "qwen3.5-4b", "qwen3.5-9b"]
+quants = ["bf16", "int4", "fp8-runtime", "kv-fp8"]
+support_doc = "docs/supported-matrix.md#hip-on-gfx1100"
+gate_scripts = ["tests/gfx1100/run_matrix.sh"]
+benchmark_doc = "docs/benchmarks.md#bench-perf"
+notes = "RDNA3 7900 XTX Qwen3.5 lanes are the mature HIP baseline."
+
+[[entry]]
+id = "hip-gfx1100-qwen36-35b-a3b-int4"
+backend = "hip"
+arch = "gfx1100"
+status = "validated"
+models = ["qwen3.6-35b-a3b"]
+quants = ["int4"]
+support_doc = "docs/supported-matrix.md#hip-on-gfx1100"
+gate_scripts = ["tests/gfx1100/run_matrix.sh"]
+benchmark_doc = "docs/benchmarks.md#lucebox-qwen36-27b-7900-xtx"
+notes = "BF16 is intentionally unsupported for the FP8-native checkpoint; INT4 is the supported HIP lane."
+
+[[entry]]
+id = "hip-gfx1201-qwen35-tbm"
+backend = "hip"
+arch = "gfx1201"
+status = "tbm"
+models = ["qwen3.5-0.8b", "qwen3.5-2b", "qwen3.5-4b", "qwen3.5-9b"]
+quants = ["bf16", "int4", "fp8-runtime", "kv-fp8"]
+support_doc = "docs/supported-matrix.md#hip-on-gfx1201"
+gate_scripts = ["tests/gfx1201/run_matrix.sh"]
+notes = "Registered and buildable on RDNA4, but still TBM until per-model token/parity results promote the cells."
+
+[[entry]]
+id = "hip-gfx1201-qwen36-27b-int4"
+backend = "hip"
+arch = "gfx1201"
+status = "validated"
+models = ["qwen3.6-27b"]
+quants = ["int4"]
+support_doc = "docs/supported-matrix.md#hip-on-gfx1201"
+gate_scripts = ["tests/gfx1201/run_matrix.sh"]
+benchmark_doc = "docs/benchmarks.md#rdna4-r9700-smoke-benchmark"
+notes = "R9700 starter lane: RDNA4 WMMA/int4 harness, direct smoke, and optional Lucebox/DFlash smoke."
+
+[[entry]]
+id = "hip-gfx1150-qwen35-all-lanes"
+backend = "hip"
+arch = "gfx1150"
+status = "validated"
+models = ["qwen3.5-0.8b", "qwen3.5-2b", "qwen3.5-4b", "qwen3.5-9b"]
+quants = ["bf16", "int4", "fp8-runtime", "kv-fp8"]
+support_doc = "docs/supported-matrix.md#hip-on-gfx1150"
+gate_scripts = [
+  "tests/gfx1150/run.sh",
+  "tests/gfx1150/run_4b.sh",
+  "tests/gfx1150/run_4b_fp8.sh",
+  "tests/gfx1150/run_quant_regression.sh",
+]
+benchmark_doc = "docs/benchmarks.md#correctness-gates"
+notes = "RDNA3.5 iGPU correctness lane."
+
+[[entry]]
+id = "hip-gfx942-qwen36-35b-a3b-int4"
+backend = "hip"
+arch = "gfx942"
+status = "experimental"
+models = ["qwen3.6-35b-a3b"]
+quants = ["int4"]
+support_doc = "docs/supported-matrix.md#hip-on-gfx942"
+gate_scripts = ["tests/gfx942/run_qwen36_verify_suite.sh"]
+notes = "CDNA3 host-orchestrated chained decode path; performance work remains pending."
+
+[[entry]]
+id = "cuda-sm86-qwen35-all-lanes"
+backend = "cuda"
+arch = "sm86"
+status = "validated"
+models = ["qwen3.5-0.8b", "qwen3.5-2b", "qwen3.5-4b", "qwen3.5-9b"]
+quants = ["bf16", "int4", "fp8-runtime", "kv-fp8"]
+support_doc = "docs/supported-matrix.md#cuda-on-sm86"
+gate_scripts = [
+  "tests/sm86/run.sh",
+  "tests/sm86/run_4b.sh",
+  "tests/sm86/run_qwen35_matrix.sh",
+]
+benchmark_doc = "docs/benchmarks.md#bench-perf"
+notes = "RTX 3090-class CUDA baseline for Qwen3.5."
+
+[[entry]]
+id = "cuda-sm86-gemma4-e2b-bf16"
+backend = "cuda"
+arch = "sm86"
+status = "validated"
+models = ["gemma4-e2b"]
+quants = ["bf16"]
+support_doc = "docs/supported-matrix.md#cuda-on-sm86"
+gate_scripts = ["tests/sm86/run_gemma4.sh"]
+notes = "Native Gemma 4 CUDA v1 lane; batch size is constrained by the support doc."
+
+[[entry]]
+id = "cuda-sm90-inherited-cuda-lanes"
+backend = "cuda"
+arch = "sm90"
+status = "inherited"
+models = [
+  "qwen3.5-0.8b",
+  "qwen3.5-2b",
+  "qwen3.5-4b",
+  "qwen3.5-9b",
+  "gemma4-e2b",
+  "phi4-mini",
+  "llama3.1-8b",
+]
+quants = ["bf16", "int4", "fp8-runtime", "kv-fp8"]
+support_doc = "docs/supported-matrix.md#cuda-on-sm90"
+benchmark_doc = "docs/detailed_performance.md#cuda-sm90-nvidia-h100-80gb-hbm3"
+notes = "H100 lane currently inherits CUDA sm86 registry geometry and kernel families unless otherwise noted."
+
+[[entry]]
+id = "metal-apple-m4-qwen35-bf16"
+backend = "metal"
+arch = "apple-m4"
+status = "validated"
+models = ["qwen3.5-0.8b", "qwen3.5-2b", "qwen3.5-4b", "qwen3.5-9b"]
+quants = ["bf16"]
+support_doc = "docs/supported-matrix.md#metal-on-apple-m4-apple-m5-max"
+gate_scripts = ["tests/metal/qwen35_bughunt_gate.sh"]
+notes = "Apple M4 remains the small Qwen3.5 Metal validation lane."
+
+[[entry]]
+id = "metal-apple-m5-max-large-model-smokes"
+backend = "metal"
+arch = "apple-m5-max"
+status = "validated"
+models = ["qwen3-30b-a3b", "qwen3.6-35b-a3b", "gemma4-e2b", "gemma4-e4b", "phi4-mini"]
+quants = ["bf16", "int4", "fp8-runtime"]
+support_doc = "docs/supported-matrix.md#metal-on-apple-m4-apple-m5-max"
+gate_commands = [
+  "cargo test --release -p runner --test metal_large_model_smoke -- --ignored --nocapture",
+  "cargo test --release -p runner --test qwen36_moe_metal_smoke -- --ignored --nocapture",
+]
+benchmark_doc = "docs/benchmarks.md#external-references"
+notes = "Apple M5 Max large-model correctness lane through component and chained Metal paths."

--- a/tools/check-support-matrix.py
+++ b/tools/check-support-matrix.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Validate the seed support matrix manifest."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    print("error: Python 3.11+ is required for tomllib support", file=sys.stderr)
+    raise SystemExit(1)
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST = ROOT / "support" / "matrix.toml"
+
+VALID_BACKENDS = {"hip", "cuda", "metal"}
+VALID_STATUSES = {"validated", "tbm", "experimental", "inherited", "pending", "unsupported"}
+VALID_QUANTS = {"bf16", "int4", "fp8-runtime", "kv-fp8", "int8"}
+EXPECTED_ARCHES = {
+    "gfx1100",
+    "gfx1150",
+    "gfx1201",
+    "gfx942",
+    "sm86",
+    "sm90",
+    "apple-m4",
+    "apple-m5-max",
+}
+
+
+def rel(path: Path) -> str:
+    return path.relative_to(ROOT).as_posix()
+
+
+def slugify_heading(text: str) -> str:
+    text = text.strip().lower().replace("`", "")
+    text = re.sub(r"[^a-z0-9 -]", "", text)
+    text = re.sub(r"\s+", "-", text)
+    text = re.sub(r"-+", "-", text)
+    return text.strip("-")
+
+
+def anchors_for(path: Path) -> set[str]:
+    anchors: set[str] = set()
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.startswith("#"):
+            continue
+        heading = line.lstrip("#").strip()
+        if heading:
+            anchors.add(slugify_heading(heading))
+    return anchors
+
+
+def validate_doc_ref(label: str, value: object, errors: list[str]) -> None:
+    if not isinstance(value, str) or not value:
+        errors.append(f"{label}: missing document reference")
+        return
+    path_text, _, anchor = value.partition("#")
+    path = ROOT / path_text
+    if not path.is_file():
+        errors.append(f"{label}: referenced doc does not exist: {path_text}")
+        return
+    if anchor and anchor not in anchors_for(path):
+        errors.append(f"{label}: anchor #{anchor} not found in {path_text}")
+
+
+def require_string_list(entry_id: str, entry: dict[str, object], key: str, errors: list[str]) -> list[str]:
+    value = entry.get(key)
+    if not isinstance(value, list) or not value or not all(isinstance(v, str) and v for v in value):
+        errors.append(f"{entry_id}: {key} must be a non-empty string list")
+        return []
+    return value
+
+
+def main() -> int:
+    errors: list[str] = []
+    with MANIFEST.open("rb") as handle:
+        data = tomllib.load(handle)
+
+    if data.get("version") != 1:
+        errors.append("version must be 1")
+
+    entries = data.get("entry")
+    if not isinstance(entries, list) or not entries:
+        errors.append("entry must be a non-empty array of tables")
+        entries = []
+
+    seen_ids: set[str] = set()
+    seen_arches: set[str] = set()
+    seen_lane_keys: set[tuple[str, str, tuple[str, ...], tuple[str, ...]]] = set()
+
+    for index, entry in enumerate(entries, start=1):
+        if not isinstance(entry, dict):
+            errors.append(f"entry #{index}: must be a table")
+            continue
+
+        entry_id = entry.get("id")
+        if not isinstance(entry_id, str) or not re.fullmatch(r"[a-z0-9][a-z0-9_.-]*", entry_id):
+            errors.append(f"entry #{index}: invalid id {entry_id!r}")
+            entry_id = f"entry #{index}"
+        elif entry_id in seen_ids:
+            errors.append(f"{entry_id}: duplicate id")
+        else:
+            seen_ids.add(entry_id)
+
+        backend = entry.get("backend")
+        if backend not in VALID_BACKENDS:
+            errors.append(f"{entry_id}: backend must be one of {sorted(VALID_BACKENDS)}")
+
+        arch = entry.get("arch")
+        if not isinstance(arch, str) or not arch:
+            errors.append(f"{entry_id}: arch must be a non-empty string")
+        else:
+            seen_arches.add(arch)
+
+        status = entry.get("status")
+        if status not in VALID_STATUSES:
+            errors.append(f"{entry_id}: status must be one of {sorted(VALID_STATUSES)}")
+
+        models = require_string_list(entry_id, entry, "models", errors)
+        quants = require_string_list(entry_id, entry, "quants", errors)
+        for quant in quants:
+            if quant not in VALID_QUANTS:
+                errors.append(f"{entry_id}: unknown quant {quant!r}")
+
+        if isinstance(backend, str) and isinstance(arch, str) and models and quants:
+            lane_key = (backend, arch, tuple(sorted(models)), tuple(sorted(quants)))
+            if lane_key in seen_lane_keys:
+                errors.append(f"{entry_id}: duplicate backend/arch/models/quants lane")
+            seen_lane_keys.add(lane_key)
+
+        validate_doc_ref(f"{entry_id}.support_doc", entry.get("support_doc"), errors)
+        benchmark_doc = entry.get("benchmark_doc")
+        if benchmark_doc is not None:
+            validate_doc_ref(f"{entry_id}.benchmark_doc", benchmark_doc, errors)
+
+        gate_scripts = entry.get("gate_scripts", [])
+        if gate_scripts is None:
+            gate_scripts = []
+        if not isinstance(gate_scripts, list) or not all(isinstance(v, str) and v for v in gate_scripts):
+            errors.append(f"{entry_id}: gate_scripts must be a string list when present")
+            gate_scripts = []
+        for script in gate_scripts:
+            if not (ROOT / script).is_file():
+                errors.append(f"{entry_id}: gate script does not exist: {script}")
+
+        gate_commands = entry.get("gate_commands", [])
+        if gate_commands is None:
+            gate_commands = []
+        if not isinstance(gate_commands, list) or not all(isinstance(v, str) and v for v in gate_commands):
+            errors.append(f"{entry_id}: gate_commands must be a string list when present")
+            gate_commands = []
+
+        if status == "validated" and not gate_scripts and not gate_commands:
+            errors.append(f"{entry_id}: validated entries require gate_scripts or gate_commands")
+
+    missing_arches = EXPECTED_ARCHES - seen_arches
+    if missing_arches:
+        errors.append(f"missing manifest coverage for arch(es): {', '.join(sorted(missing_arches))}")
+
+    if errors:
+        for error in errors:
+            print(f"error: {error}", file=sys.stderr)
+        return 1
+
+    print(f"support matrix ok: {len(entries)} entries cover {len(seen_arches)} arches")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check-support-matrix.py
+++ b/tools/check-support-matrix.py
@@ -38,8 +38,7 @@ def rel(path: Path) -> str:
 def slugify_heading(text: str) -> str:
     text = text.strip().lower().replace("`", "")
     text = re.sub(r"[^a-z0-9 -]", "", text)
-    text = re.sub(r"\s+", "-", text)
-    text = re.sub(r"-+", "-", text)
+    text = re.sub(r"\s", "-", text)
     return text.strip("-")
 
 


### PR DESCRIPTION
## Summary

- add `support/matrix.toml` as the first machine-readable seed for supported/bring-up lanes
- capture representative high-value HIP, CUDA, and Metal lanes with model sets, quant sets, status, support-doc anchors, gate scripts or gate commands, and benchmark references
- add `tools/check-support-matrix.py`, a read-only validator for schema terms, duplicate lanes, referenced docs/anchors, gate script paths, and coverage for every documented architecture surface
- link the manifest/checker from `docs/supported-matrix.md`, `docs/testing.md`, and the consolidation roadmap

## Impact

This does not generate or rewrite the support tables yet. The Markdown support matrix remains the reviewed operator-facing source while the manifest schema settles.

## Validation

- `python3 tools/check-support-matrix.py`
- `tools/check-support-matrix.py`
- `python3 -m py_compile tools/check-support-matrix.py tools/check-tool-inventory.py`
- `python3 tools/check-tool-inventory.py`
- `git diff --check`

The new checker reports: `support matrix ok: 11 entries cover 8 arches`.