### PR TITLE
[codex] Add kernel build group scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ to disable network fetches.
   kernels, tests, and docs.
 - **[Consolidation roadmap](docs/development/consolidation-roadmap.md)** —
   staged cleanup plan and non-breaking inventory for current tools.
+- **[Kernel build groups](docs/development/kernel-build-groups.md)** —
+  checked scaffold for future backend/model compile groups in `kernel-ffi`.
 - **[DFlash speculative decode](docs/dflash.md)** — Qwen3.5-9B INT4
   speculative decode design and milestones.
 - **[Qwen3-30B-A3B HIP bring-up](docs/bringup/qwen3-30b-a3b-hip.md)** —

--- a/crates/kernel-ffi/build.rs
+++ b/crates/kernel-ffi/build.rs
@@ -209,45 +209,160 @@ fn archive(out_dir: &Path, lib_name: &str, objects: &[PathBuf], context: &str) {
     println!("cargo:rustc-link-lib=static={lib_name}");
 }
 
+#[derive(Clone, Copy)]
+struct KernelBridge {
+    group: &'static str,
+    src_name: &'static str,
+    obj_name: &'static str,
+    context: &'static str,
+}
+
+// Group ids are an audit scaffold for the future build split. The default build
+// still compiles every bridge listed for the selected backend.
+const HIP_BRIDGES: &[KernelBridge] = &[
+    KernelBridge {
+        group: "hip-qwen35",
+        src_name: "full_attention_bridge.cpp",
+        obj_name: "qwen35_megakernel_hip.o",
+        context: "building qwen35 megakernel HIP bridge",
+    },
+    KernelBridge {
+        group: "hip-qwen35",
+        src_name: "full_attention_bridge_4b.cpp",
+        obj_name: "qwen35_4b_megakernel_hip.o",
+        context: "building qwen35-4b megakernel HIP bridge",
+    },
+    KernelBridge {
+        group: "hip-qwen35",
+        src_name: "prefill_helpers_bridge.cpp",
+        obj_name: "qwen35_prefill_helpers_hip.o",
+        context: "building prefill helpers HIP bridge",
+    },
+    KernelBridge {
+        group: "hip-gemma4",
+        src_name: "gemma4_bridge.cpp",
+        obj_name: "gemma4_hip.o",
+        context: "building Gemma 4 HIP bridge",
+    },
+    KernelBridge {
+        group: "hip-phi4",
+        src_name: "phi4_bridge.cpp",
+        obj_name: "phi4_hip.o",
+        context: "building Phi-4 HIP bridge",
+    },
+    KernelBridge {
+        group: "hip-dflash",
+        src_name: "dflash_draft_bridge.cpp",
+        obj_name: "dflash_draft_hip.o",
+        context: "building DFlash draft HIP bridge",
+    },
+    KernelBridge {
+        group: "hip-qwen36-moe",
+        src_name: "qwen36_moe_bridge.cpp",
+        obj_name: "qwen36_moe_hip.o",
+        context: "building Qwen3.6-MoE HIP bridge",
+    },
+    KernelBridge {
+        group: "hip-qwen3-moe",
+        src_name: "qwen3_moe_bridge.cpp",
+        obj_name: "qwen3_moe_hip.o",
+        context: "building Qwen3-MoE HIP bridge",
+    },
+];
+
+const CUDA_BRIDGES: &[KernelBridge] = &[
+    KernelBridge {
+        group: "cuda-qwen35",
+        src_name: "full_attention_bridge_cuda.cu",
+        obj_name: "qwen35_megakernel_cuda.o",
+        context: "building qwen35 megakernel CUDA bridge",
+    },
+    KernelBridge {
+        group: "cuda-qwen35",
+        src_name: "full_attention_bridge_4b_cuda.cu",
+        obj_name: "qwen35_4b_megakernel_cuda.o",
+        context: "building qwen35-4b megakernel CUDA bridge",
+    },
+    KernelBridge {
+        group: "cuda-qwen35",
+        src_name: "prefill_helpers_bridge_cuda.cu",
+        obj_name: "qwen35_prefill_helpers_cuda.o",
+        context: "building prefill helpers CUDA bridge",
+    },
+    KernelBridge {
+        group: "cuda-llama31",
+        src_name: "certified_kv_bridge_cuda.cu",
+        obj_name: "llama31_certified_kv_cuda.o",
+        context: "building Llama31 certified KV CUDA bridge",
+    },
+    KernelBridge {
+        group: "cuda-phi4",
+        src_name: "phi4_bridge_cuda.cu",
+        obj_name: "phi4_cuda.o",
+        context: "building Phi-4 CUDA bridge",
+    },
+    KernelBridge {
+        group: "cuda-gemma4",
+        src_name: "gemma4_bridge_cuda.cu",
+        obj_name: "gemma4_cuda.o",
+        context: "building Gemma 4 CUDA bridge",
+    },
+    KernelBridge {
+        group: "cuda-qwen36-moe",
+        src_name: "qwen36_moe_bridge_cuda.cu",
+        obj_name: "qwen36_moe_cuda.o",
+        context: "building Qwen3.6-MoE CUDA bridge",
+    },
+];
+
+const KERNEL_RERUN_PATHS: &[&str] = &[
+    "full_attention.hip",
+    "full_attention_4b.hip",
+    "prefill_helpers.hip",
+    "full_attention_bridge.cpp",
+    "full_attention_bridge_4b.cpp",
+    "prefill_helpers_bridge.cpp",
+    "gemma4.hip",
+    "gemma4_bridge.cpp",
+    "phi4.hip",
+    "phi4_bridge.cpp",
+    "dflash_draft.hip",
+    "dflash_draft_bridge.cpp",
+    "qwen36_moe.hip",
+    "qwen36_moe_cuda_prelude.cuh",
+    "qwen36_moe_bridge.cpp",
+    "qwen36_moe_bridge_cuda.cu",
+    "qwen3_moe.hip",
+    "qwen3_moe_bridge.cpp",
+    "qwen36_moe_persistent/helpers.cuh",
+    "qwen36_moe_persistent/full_attn_phase.cuh",
+    "qwen36_moe_persistent/linear_attn_phase.cuh",
+    "qwen36_moe_persistent/ffn_phase.cuh",
+    "qwen36_moe_persistent/lm_head_phase.cuh",
+    "qwen36_moe_persistent/persistent_decode.hip",
+    "qwen36_moe_persistent/batched_prefill_attn_full.cuh",
+    "qwen36_moe_persistent/batched_prefill_grouped_expert.cuh",
+    "qwen36_moe_persistent/batched_prefill_router_permute.cuh",
+    "qwen36_moe_persistent/batched_prefill_unpermute_combine.cuh",
+    "full_attention_cuda.cuh",
+    "full_attention_4b_cuda.cuh",
+    "prefill_helpers_cuda.cuh",
+    "full_attention_bridge_cuda.cu",
+    "full_attention_bridge_4b_cuda.cu",
+    "prefill_helpers_bridge_cuda.cu",
+    "certified_kv_bridge_cuda.cu",
+    "phi4_cuda.cuh",
+    "phi4_bridge_cuda.cu",
+    "gemma4_cuda.cuh",
+    "gemma4_bridge_cuda.cu",
+];
+
+fn bridge_group_list(sources: &[KernelBridge]) -> String {
+    let groups: BTreeSet<&str> = sources.iter().map(|source| source.group).collect();
+    groups.into_iter().collect::<Vec<_>>().join(", ")
+}
+
 fn compile_hip(kernel_dir: &Path, out_dir: &Path) {
-    let sources = [
-        (
-            "full_attention_bridge.cpp",
-            "qwen35_megakernel_hip.o",
-            "building qwen35 megakernel HIP bridge",
-        ),
-        (
-            "full_attention_bridge_4b.cpp",
-            "qwen35_4b_megakernel_hip.o",
-            "building qwen35-4b megakernel HIP bridge",
-        ),
-        (
-            "prefill_helpers_bridge.cpp",
-            "qwen35_prefill_helpers_hip.o",
-            "building prefill helpers HIP bridge",
-        ),
-        (
-            "gemma4_bridge.cpp",
-            "gemma4_hip.o",
-            "building Gemma 4 HIP bridge",
-        ),
-        ("phi4_bridge.cpp", "phi4_hip.o", "building Phi-4 HIP bridge"),
-        (
-            "dflash_draft_bridge.cpp",
-            "dflash_draft_hip.o",
-            "building DFlash draft HIP bridge",
-        ),
-        (
-            "qwen36_moe_bridge.cpp",
-            "qwen36_moe_hip.o",
-            "building Qwen3.6-MoE HIP bridge",
-        ),
-        (
-            "qwen3_moe_bridge.cpp",
-            "qwen3_moe_hip.o",
-            "building Qwen3-MoE HIP bridge",
-        ),
-    ];
     let archs = detect_hip_archs();
     if archs.is_empty() {
         println!("cargo:warning=no HIP arch detected (set HIP_ARCH or install rocminfo); kernel binary may not run on the target GPU");
@@ -257,11 +372,17 @@ fn compile_hip(kernel_dir: &Path, out_dir: &Path) {
             archs.join(", ")
         );
     }
+    if verbose_build_warnings() {
+        println!(
+            "cargo:warning=building HIP bridge groups: {}",
+            bridge_group_list(HIP_BRIDGES)
+        );
+    }
 
     let mut objects = Vec::new();
-    for (src_name, obj_name, context) in sources {
+    for source in HIP_BRIDGES {
         let mut cmd = Command::new("hipcc");
-        let obj_path = out_dir.join(obj_name);
+        let obj_path = out_dir.join(source.obj_name);
         cmd.arg("-std=c++17")
             .arg("-O3")
             .arg("-fPIC")
@@ -270,13 +391,13 @@ fn compile_hip(kernel_dir: &Path, out_dir: &Path) {
             .arg("-x")
             .arg("hip")
             .arg("-c")
-            .arg(kernel_dir.join(src_name))
+            .arg(kernel_dir.join(source.src_name))
             .arg("-o")
             .arg(&obj_path);
         for arch in &archs {
             cmd.arg(format!("--offload-arch={arch}"));
         }
-        run(&mut cmd, context);
+        run(&mut cmd, source.context);
         objects.push(obj_path);
     }
 
@@ -299,55 +420,22 @@ fn compile_hip(kernel_dir: &Path, out_dir: &Path) {
 }
 
 fn compile_cuda(kernel_dir: &Path, out_dir: &Path) {
-    let sources = [
-        (
-            "full_attention_bridge_cuda.cu",
-            "qwen35_megakernel_cuda.o",
-            "building qwen35 megakernel CUDA bridge",
-        ),
-        (
-            "full_attention_bridge_4b_cuda.cu",
-            "qwen35_4b_megakernel_cuda.o",
-            "building qwen35-4b megakernel CUDA bridge",
-        ),
-        (
-            "prefill_helpers_bridge_cuda.cu",
-            "qwen35_prefill_helpers_cuda.o",
-            "building prefill helpers CUDA bridge",
-        ),
-        (
-            "certified_kv_bridge_cuda.cu",
-            "llama31_certified_kv_cuda.o",
-            "building Llama31 certified KV CUDA bridge",
-        ),
-        (
-            "phi4_bridge_cuda.cu",
-            "phi4_cuda.o",
-            "building Phi-4 CUDA bridge",
-        ),
-        (
-            "gemma4_bridge_cuda.cu",
-            "gemma4_cuda.o",
-            "building Gemma 4 CUDA bridge",
-        ),
-        (
-            "qwen36_moe_bridge_cuda.cu",
-            "qwen36_moe_cuda.o",
-            "building Qwen3.6-MoE CUDA bridge",
-        ),
-    ];
     let archs = detect_cuda_archs();
     if verbose_build_warnings() {
         println!(
             "cargo:warning=building CUDA kernels for arch(es): {}",
             archs.join(", ")
         );
+        println!(
+            "cargo:warning=building CUDA bridge groups: {}",
+            bridge_group_list(CUDA_BRIDGES)
+        );
     }
 
     let mut objects = Vec::new();
-    for (src_name, obj_name, context) in sources {
+    for source in CUDA_BRIDGES {
         let mut cmd = Command::new("nvcc");
-        let obj_path = out_dir.join(obj_name);
+        let obj_path = out_dir.join(source.obj_name);
         cmd.arg("-std=c++17")
             .arg("-O3")
             .arg("--use_fast_math")
@@ -356,7 +444,7 @@ fn compile_cuda(kernel_dir: &Path, out_dir: &Path) {
             .arg("-I")
             .arg(kernel_dir)
             .arg("-c")
-            .arg(kernel_dir.join(src_name))
+            .arg(kernel_dir.join(source.src_name))
             .arg("-o")
             .arg(&obj_path);
         for arch in &archs {
@@ -364,7 +452,7 @@ fn compile_cuda(kernel_dir: &Path, out_dir: &Path) {
                 "-gencode=arch=compute_{arch},code=[sm_{arch},compute_{arch}]"
             ));
         }
-        run(&mut cmd, context);
+        run(&mut cmd, source.context);
         objects.push(obj_path);
     }
 
@@ -389,6 +477,9 @@ fn compile_cuda(kernel_dir: &Path, out_dir: &Path) {
 }
 
 fn compile_metal_stubs(manifest_dir: &Path) {
+    if verbose_build_warnings() {
+        println!("cargo:warning=building Metal bridge groups: metal-host-stubs");
+    }
     cc::Build::new()
         .cpp(true)
         .file(manifest_dir.join("src/metal_link_stubs.cc"))
@@ -459,43 +550,7 @@ fn main() {
         .and_then(|p| p.parent())
         .expect("cannot find workspace root")
         .join("kernels");
-    for path in [
-        "full_attention.hip",
-        "full_attention_4b.hip",
-        "prefill_helpers.hip",
-        "full_attention_bridge.cpp",
-        "full_attention_bridge_4b.cpp",
-        "prefill_helpers_bridge.cpp",
-        "gemma4.hip",
-        "gemma4_bridge.cpp",
-        "phi4.hip",
-        "phi4_bridge.cpp",
-        "dflash_draft.hip",
-        "dflash_draft_bridge.cpp",
-        "qwen36_moe.hip",
-        "qwen36_moe_cuda_prelude.cuh",
-        "qwen36_moe_bridge.cpp",
-        "qwen36_moe_bridge_cuda.cu",
-        "qwen3_moe.hip",
-        "qwen3_moe_bridge.cpp",
-        "qwen36_moe_persistent/helpers.cuh",
-        "qwen36_moe_persistent/full_attn_phase.cuh",
-        "qwen36_moe_persistent/linear_attn_phase.cuh",
-        "qwen36_moe_persistent/ffn_phase.cuh",
-        "qwen36_moe_persistent/lm_head_phase.cuh",
-        "qwen36_moe_persistent/persistent_decode.hip",
-        "full_attention_cuda.cuh",
-        "full_attention_4b_cuda.cuh",
-        "prefill_helpers_cuda.cuh",
-        "full_attention_bridge_cuda.cu",
-        "full_attention_bridge_4b_cuda.cu",
-        "prefill_helpers_bridge_cuda.cu",
-        "certified_kv_bridge_cuda.cu",
-        "phi4_cuda.cuh",
-        "phi4_bridge_cuda.cu",
-        "gemma4_cuda.cuh",
-        "gemma4_bridge_cuda.cu",
-    ] {
+    for path in KERNEL_RERUN_PATHS {
         println!("cargo:rerun-if-changed={}", kernel_dir.join(path).display());
     }
     println!(

--- a/crates/kernel-ffi/kernel-groups.toml
+++ b/crates/kernel-ffi/kernel-groups.toml
@@ -1,0 +1,208 @@
+# Machine-readable kernel bridge group scaffold.
+#
+# This manifest documents the current broad compile surface without changing
+# default build behavior. The build script still compiles all groups for the
+# selected backend; later PRs can use these ids for opt-in grouped builds.
+
+version = 1
+
+[[group]]
+id = "hip-qwen35"
+backend = "hip"
+model_family = "qwen3.5"
+default_compiled = true
+notes = "Dense Qwen3.5 HIP attention and prefill bridge family."
+kernel_sources = [
+  "kernels/full_attention.hip",
+  "kernels/full_attention_4b.hip",
+  "kernels/prefill_helpers.hip",
+]
+rust_modules = [
+  "crates/kernel-ffi/src/qwen35.rs",
+  "crates/kernel-ffi/src/prefill_ffi.rs",
+]
+
+[[group.bridge]]
+source = "kernels/full_attention_bridge.cpp"
+object = "qwen35_megakernel_hip.o"
+
+[[group.bridge]]
+source = "kernels/full_attention_bridge_4b.cpp"
+object = "qwen35_4b_megakernel_hip.o"
+
+[[group.bridge]]
+source = "kernels/prefill_helpers_bridge.cpp"
+object = "qwen35_prefill_helpers_hip.o"
+
+[[group]]
+id = "hip-gemma4"
+backend = "hip"
+model_family = "gemma4"
+default_compiled = true
+notes = "Gemma 4 HIP bridge family."
+kernel_sources = ["kernels/gemma4.hip"]
+rust_modules = ["crates/kernel-ffi/src/gemma4.rs"]
+
+[[group.bridge]]
+source = "kernels/gemma4_bridge.cpp"
+object = "gemma4_hip.o"
+
+[[group]]
+id = "hip-phi4"
+backend = "hip"
+model_family = "phi4"
+default_compiled = true
+notes = "Phi-4 HIP bridge family."
+kernel_sources = ["kernels/phi4.hip"]
+rust_modules = ["crates/kernel-ffi/src/phi4.rs"]
+
+[[group.bridge]]
+source = "kernels/phi4_bridge.cpp"
+object = "phi4_hip.o"
+
+[[group]]
+id = "hip-dflash"
+backend = "hip"
+model_family = "qwen3.5-dflash"
+default_compiled = true
+notes = "DFlash draft HIP bridge family."
+kernel_sources = ["kernels/dflash_draft.hip"]
+rust_modules = ["crates/kernel-ffi/src/dflash.rs"]
+
+[[group.bridge]]
+source = "kernels/dflash_draft_bridge.cpp"
+object = "dflash_draft_hip.o"
+
+[[group]]
+id = "hip-qwen36-moe"
+backend = "hip"
+model_family = "qwen3.6-moe"
+default_compiled = true
+notes = "Qwen3.6 MoE HIP bridge, persistent decode, and batched prefill family."
+kernel_sources = [
+  "kernels/qwen36_moe.hip",
+  "kernels/qwen36_moe_persistent/helpers.cuh",
+  "kernels/qwen36_moe_persistent/full_attn_phase.cuh",
+  "kernels/qwen36_moe_persistent/linear_attn_phase.cuh",
+  "kernels/qwen36_moe_persistent/ffn_phase.cuh",
+  "kernels/qwen36_moe_persistent/lm_head_phase.cuh",
+  "kernels/qwen36_moe_persistent/persistent_decode.hip",
+  "kernels/qwen36_moe_persistent/batched_prefill_attn_full.cuh",
+  "kernels/qwen36_moe_persistent/batched_prefill_grouped_expert.cuh",
+  "kernels/qwen36_moe_persistent/batched_prefill_router_permute.cuh",
+  "kernels/qwen36_moe_persistent/batched_prefill_unpermute_combine.cuh",
+]
+rust_modules = ["crates/kernel-ffi/src/qwen36_moe.rs"]
+
+[[group.bridge]]
+source = "kernels/qwen36_moe_bridge.cpp"
+object = "qwen36_moe_hip.o"
+
+[[group]]
+id = "hip-qwen3-moe"
+backend = "hip"
+model_family = "qwen3-moe"
+default_compiled = true
+notes = "Qwen3 MoE HIP bridge family."
+kernel_sources = ["kernels/qwen3_moe.hip"]
+rust_modules = ["crates/kernel-ffi/src/qwen3_moe.rs"]
+
+[[group.bridge]]
+source = "kernels/qwen3_moe_bridge.cpp"
+object = "qwen3_moe_hip.o"
+
+[[group]]
+id = "cuda-qwen35"
+backend = "cuda"
+model_family = "qwen3.5"
+default_compiled = true
+notes = "Dense Qwen3.5 CUDA attention and prefill bridge family."
+kernel_sources = [
+  "kernels/full_attention_cuda.cuh",
+  "kernels/full_attention_4b_cuda.cuh",
+  "kernels/prefill_helpers_cuda.cuh",
+]
+rust_modules = [
+  "crates/kernel-ffi/src/qwen35.rs",
+  "crates/kernel-ffi/src/prefill_ffi.rs",
+]
+
+[[group.bridge]]
+source = "kernels/full_attention_bridge_cuda.cu"
+object = "qwen35_megakernel_cuda.o"
+
+[[group.bridge]]
+source = "kernels/full_attention_bridge_4b_cuda.cu"
+object = "qwen35_4b_megakernel_cuda.o"
+
+[[group.bridge]]
+source = "kernels/prefill_helpers_bridge_cuda.cu"
+object = "qwen35_prefill_helpers_cuda.o"
+
+[[group]]
+id = "cuda-llama31"
+backend = "cuda"
+model_family = "llama3.1"
+default_compiled = true
+notes = "Llama 3.1 certified-KV CUDA bridge family."
+kernel_sources = []
+rust_modules = ["crates/kernel-ffi/src/certified_kv.rs"]
+
+[[group.bridge]]
+source = "kernels/certified_kv_bridge_cuda.cu"
+object = "llama31_certified_kv_cuda.o"
+
+[[group]]
+id = "cuda-phi4"
+backend = "cuda"
+model_family = "phi4"
+default_compiled = true
+notes = "Phi-4 CUDA bridge family."
+kernel_sources = ["kernels/phi4_cuda.cuh"]
+rust_modules = ["crates/kernel-ffi/src/phi4.rs"]
+
+[[group.bridge]]
+source = "kernels/phi4_bridge_cuda.cu"
+object = "phi4_cuda.o"
+
+[[group]]
+id = "cuda-gemma4"
+backend = "cuda"
+model_family = "gemma4"
+default_compiled = true
+notes = "Gemma 4 CUDA bridge family."
+kernel_sources = ["kernels/gemma4_cuda.cuh"]
+rust_modules = ["crates/kernel-ffi/src/gemma4.rs"]
+
+[[group.bridge]]
+source = "kernels/gemma4_bridge_cuda.cu"
+object = "gemma4_cuda.o"
+
+[[group]]
+id = "cuda-qwen36-moe"
+backend = "cuda"
+model_family = "qwen3.6-moe"
+default_compiled = true
+notes = "Qwen3.6 MoE CUDA bridge family."
+kernel_sources = ["kernels/qwen36_moe_cuda_prelude.cuh"]
+rust_modules = ["crates/kernel-ffi/src/qwen36_moe.rs"]
+
+[[group.bridge]]
+source = "kernels/qwen36_moe_bridge_cuda.cu"
+object = "qwen36_moe_cuda.o"
+
+[[group]]
+id = "metal-host-stubs"
+backend = "metal"
+model_family = "metal-host"
+default_compiled = true
+notes = "Metal host/native link layer compiled by cc on macOS."
+kernel_sources = []
+native_sources = [
+  "crates/kernel-ffi/src/metal_link_stubs.cc",
+  "crates/kernel-ffi/src/metal_native.mm",
+]
+rust_modules = [
+  "crates/kernel-ffi/src/metal_host.rs",
+  "crates/kernel-ffi/src/metal_native.rs",
+]

--- a/crates/kernel-ffi/kernel-groups.toml
+++ b/crates/kernel-ffi/kernel-groups.toml
@@ -183,8 +183,22 @@ id = "cuda-qwen36-moe"
 backend = "cuda"
 model_family = "qwen3.6-moe"
 default_compiled = true
-notes = "Qwen3.6 MoE CUDA bridge family."
-kernel_sources = ["kernels/qwen36_moe_cuda_prelude.cuh"]
+notes = "Qwen3.6 MoE CUDA bridge family, including the shared bridge source closure."
+kernel_sources = [
+  "kernels/qwen36_moe_cuda_prelude.cuh",
+  "kernels/qwen36_moe_bridge.cpp",
+  "kernels/qwen36_moe.hip",
+  "kernels/qwen36_moe_persistent/helpers.cuh",
+  "kernels/qwen36_moe_persistent/full_attn_phase.cuh",
+  "kernels/qwen36_moe_persistent/linear_attn_phase.cuh",
+  "kernels/qwen36_moe_persistent/ffn_phase.cuh",
+  "kernels/qwen36_moe_persistent/lm_head_phase.cuh",
+  "kernels/qwen36_moe_persistent/persistent_decode.hip",
+  "kernels/qwen36_moe_persistent/batched_prefill_attn_full.cuh",
+  "kernels/qwen36_moe_persistent/batched_prefill_grouped_expert.cuh",
+  "kernels/qwen36_moe_persistent/batched_prefill_router_permute.cuh",
+  "kernels/qwen36_moe_persistent/batched_prefill_unpermute_combine.cuh",
+]
 rust_modules = ["crates/kernel-ffi/src/qwen36_moe.rs"]
 
 [[group.bridge]]

--- a/docs/development/consolidation-roadmap.md
+++ b/docs/development/consolidation-roadmap.md
@@ -126,6 +126,9 @@ Target behavior:
 - Default builds preserve today's behavior until grouped builds are proven.
 - Feature groups are named by backend and model family, not by incidental file
   layout.
+- The checked group scaffold lives in
+  [`crates/kernel-ffi/kernel-groups.toml`](../../crates/kernel-ffi/kernel-groups.toml)
+  and is validated by `python3 tools/check-kernel-groups.py`.
 - Kernel-lab and architecture smoke scripts identify the minimum coverage for
   each group.
 - Profiling hooks remain available through `kernel-ffi` typed wrappers.
@@ -137,7 +140,7 @@ Target behavior:
 | PR 2 | Add a `tools/` classification path, `crates/runner/src/bin/lab/` convention, or metadata manifest. Keep wrapper aliases for existing binary names. | Existing `cargo run --bin ...` commands continue to work. |
 | PR 3 | Extract shared runtime/generation/session interfaces so `supersonic-runtime` no longer depends on `runner`. | Build runner, runtime, and server; keep CLI behavior unchanged. |
 | PR 4 | Introduce `support/matrix.toml` as the seed capability/support data source used by docs/tests where practical. | Validate the manifest with `python3 tools/check-support-matrix.py`; generated or checked docs must still be easy to review. |
-| PR 5 | Split `kernel-ffi/build.rs` into model/backend compile groups with default behavior preserved. | Compare old default behavior with grouped builds on one representative backend. |
+| PR 5 | Add the `kernel-ffi` model/backend group scaffold and split `build.rs` around named bridge groups with default behavior preserved. | Validate `crates/kernel-ffi/kernel-groups.toml` with `python3 tools/check-kernel-groups.py`; compare old default behavior with grouped builds on one representative backend before narrowing defaults. |
 | PR 6+ | Move larger model-specific runtime implementations out of `runner` once public interfaces are stable. | One benchmark or parity artifact for each moved runtime path. |
 
 ## First PR Test Plan

--- a/docs/development/kernel-build-groups.md
+++ b/docs/development/kernel-build-groups.md
@@ -1,0 +1,47 @@
+# Kernel Build Groups
+
+This page records the first scaffold for splitting `crates/kernel-ffi/build.rs`
+into explicit backend/model compile groups. It does not change default build
+behavior: when a backend is selected, the build script still compiles every
+bridge group for that backend.
+
+The checked source of truth is
+[`crates/kernel-ffi/kernel-groups.toml`](../../crates/kernel-ffi/kernel-groups.toml).
+Validate it with:
+
+```bash
+python3 tools/check-kernel-groups.py
+```
+
+## Current Groups
+
+| Group | Backend | Owns |
+| --- | --- | --- |
+| `hip-qwen35` | HIP | Qwen3.5 dense attention, 4B attention, and prefill helpers. |
+| `hip-gemma4` | HIP | Gemma 4 HIP bridge. |
+| `hip-phi4` | HIP | Phi-4 HIP bridge. |
+| `hip-dflash` | HIP | DFlash draft HIP bridge. |
+| `hip-qwen36-moe` | HIP | Qwen3.6 MoE HIP bridge, persistent decode, and batched prefill support sources. |
+| `hip-qwen3-moe` | HIP | Qwen3 MoE HIP bridge. |
+| `cuda-qwen35` | CUDA | Qwen3.5 dense CUDA attention, 4B attention, and prefill helpers. |
+| `cuda-llama31` | CUDA | Llama 3.1 certified-KV CUDA bridge. |
+| `cuda-phi4` | CUDA | Phi-4 CUDA bridge. |
+| `cuda-gemma4` | CUDA | Gemma 4 CUDA bridge. |
+| `cuda-qwen36-moe` | CUDA | Qwen3.6 MoE CUDA bridge. |
+| `metal-host-stubs` | Metal | Metal host/native link layer compiled by `cc` on macOS. |
+
+## Guardrails
+
+- Existing `SUPERSONIC_BACKENDS=hip`, `cuda`, `metal`, and `auto` behavior must
+  stay compatible until grouped builds have validation coverage.
+- Group ids describe backend and model family, not incidental source layout.
+- The manifest must name bridge sources, support kernel/header sources, and
+  Rust wrapper modules that reviewers should inspect together.
+- A future grouped build must preserve the broad default path until at least one
+  representative backend proves old-vs-new parity.
+
+## Next Split Step
+
+The next code PR can add an opt-in grouped build selector, such as a guarded
+`SUPERSONIC_KERNEL_GROUPS` environment variable, but it should leave unset
+behavior identical to the current broad backend build.

--- a/docs/development/kernel-build-groups.md
+++ b/docs/development/kernel-build-groups.md
@@ -27,7 +27,7 @@ python3 tools/check-kernel-groups.py
 | `cuda-llama31` | CUDA | Llama 3.1 certified-KV CUDA bridge. |
 | `cuda-phi4` | CUDA | Phi-4 CUDA bridge. |
 | `cuda-gemma4` | CUDA | Gemma 4 CUDA bridge. |
-| `cuda-qwen36-moe` | CUDA | Qwen3.6 MoE CUDA bridge. |
+| `cuda-qwen36-moe` | CUDA | Qwen3.6 MoE CUDA bridge and shared Qwen3.6 source closure. |
 | `metal-host-stubs` | Metal | Metal host/native link layer compiled by `cc` on macOS. |
 
 ## Guardrails

--- a/docs/development/repo-architecture.md
+++ b/docs/development/repo-architecture.md
@@ -62,4 +62,5 @@ These are known seams to clean up after this documentation foundation lands:
 - [Testing gates](../testing.md)
 - [Benchmark recipes](../benchmarks.md)
 - [Kernel lab](kernel-lab.md)
+- [Kernel build groups](kernel-build-groups.md)
 - [Consolidation roadmap](consolidation-roadmap.md)

--- a/tools/check-kernel-groups.py
+++ b/tools/check-kernel-groups.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Validate the kernel bridge group scaffold."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    print("error: Python 3.11+ is required for tomllib support", file=sys.stderr)
+    raise SystemExit(1)
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST = ROOT / "crates" / "kernel-ffi" / "kernel-groups.toml"
+BUILD_RS = ROOT / "crates" / "kernel-ffi" / "build.rs"
+VALID_BACKENDS = {"hip", "cuda", "metal"}
+GROUP_ID_RE = re.compile(r"[a-z0-9][a-z0-9.-]*")
+
+
+def rel(path: Path) -> str:
+    return path.relative_to(ROOT).as_posix()
+
+
+def const_block(name: str, build_text: str) -> str:
+    marker = f"const {name}:"
+    start = build_text.find(marker)
+    if start == -1:
+        return ""
+    end_marker = "\n];"
+    end = build_text.find(end_marker, start)
+    if end == -1:
+        return ""
+    return build_text[start:end]
+
+
+def field_values_from_build_rs(name: str, field: str, build_text: str) -> set[str]:
+    block = const_block(name, build_text)
+    if not block:
+        return set()
+    return set(re.findall(rf"{field}:\s*\"([^\"]+)\"", block))
+
+
+def string_values_from_build_rs(name: str, build_text: str) -> set[str]:
+    block = const_block(name, build_text)
+    if not block:
+        return set()
+    return set(re.findall(r'"([^"]+)"', block))
+
+
+def validate_string_list(
+    group_id: str, group: dict[str, object], key: str, errors: list[str]
+) -> list[str]:
+    value = group.get(key, [])
+    if not isinstance(value, list) or not all(isinstance(item, str) and item for item in value):
+        errors.append(f"{group_id}: {key} must be a string list")
+        return []
+    return value
+
+
+def main() -> int:
+    errors: list[str] = []
+    with MANIFEST.open("rb") as handle:
+        data = tomllib.load(handle)
+
+    if data.get("version") != 1:
+        errors.append("version must be 1")
+
+    groups = data.get("group")
+    if not isinstance(groups, list) or not groups:
+        errors.append("group must be a non-empty array of tables")
+        groups = []
+
+    build_text = BUILD_RS.read_text(encoding="utf-8")
+    build_bridge_sources = (
+        field_values_from_build_rs("HIP_BRIDGES", "src_name", build_text)
+        | field_values_from_build_rs("CUDA_BRIDGES", "src_name", build_text)
+    )
+    build_bridge_objects = (
+        field_values_from_build_rs("HIP_BRIDGES", "obj_name", build_text)
+        | field_values_from_build_rs("CUDA_BRIDGES", "obj_name", build_text)
+    )
+    build_rerun_paths = string_values_from_build_rs("KERNEL_RERUN_PATHS", build_text)
+
+    seen_ids: set[str] = set()
+    seen_bridge_sources: set[str] = set()
+    seen_bridge_objects: set[str] = set()
+    manifest_bridge_sources: set[str] = set()
+    manifest_kernel_sources: set[str] = set()
+    manifest_native_sources: set[str] = set()
+
+    for index, group in enumerate(groups, start=1):
+        if not isinstance(group, dict):
+            errors.append(f"group #{index}: must be a table")
+            continue
+
+        group_id = group.get("id")
+        if not isinstance(group_id, str) or not GROUP_ID_RE.fullmatch(group_id):
+            errors.append(f"group #{index}: invalid id {group_id!r}")
+            group_id = f"group #{index}"
+        elif group_id in seen_ids:
+            errors.append(f"{group_id}: duplicate id")
+        else:
+            seen_ids.add(group_id)
+
+        if group_id != f"group #{index}" and group_id not in build_text:
+            errors.append(f"{group_id}: id is not referenced by build.rs")
+
+        backend = group.get("backend")
+        if backend not in VALID_BACKENDS:
+            errors.append(f"{group_id}: backend must be one of {sorted(VALID_BACKENDS)}")
+
+        model_family = group.get("model_family")
+        if not isinstance(model_family, str) or not model_family:
+            errors.append(f"{group_id}: missing string model_family")
+
+        if group.get("default_compiled") is not True:
+            errors.append(f"{group_id}: default_compiled must be true while defaults are broad")
+
+        bridges = group.get("bridge", [])
+        if bridges is None:
+            bridges = []
+        if not isinstance(bridges, list):
+            errors.append(f"{group_id}: bridge must be an array of tables when present")
+            bridges = []
+
+        for bridge_index, bridge in enumerate(bridges, start=1):
+            if not isinstance(bridge, dict):
+                errors.append(f"{group_id}.bridge #{bridge_index}: must be a table")
+                continue
+            source = bridge.get("source")
+            obj = bridge.get("object")
+            if not isinstance(source, str) or not source:
+                errors.append(f"{group_id}.bridge #{bridge_index}: missing string source")
+            else:
+                if not (ROOT / source).is_file():
+                    errors.append(f"{group_id}: bridge source does not exist: {source}")
+                if source in seen_bridge_sources:
+                    errors.append(f"{group_id}: duplicate bridge source {source}")
+                seen_bridge_sources.add(source)
+                manifest_bridge_sources.add(Path(source).name)
+                if Path(source).name not in build_bridge_sources:
+                    errors.append(f"{group_id}: bridge source not compiled by build.rs: {source}")
+            if not isinstance(obj, str) or not obj:
+                errors.append(f"{group_id}.bridge #{bridge_index}: missing string object")
+            else:
+                if obj in seen_bridge_objects:
+                    errors.append(f"{group_id}: duplicate bridge object {obj}")
+                seen_bridge_objects.add(obj)
+                if obj not in build_bridge_objects:
+                    errors.append(f"{group_id}: bridge object not referenced by build.rs: {obj}")
+
+        kernel_sources = validate_string_list(group_id, group, "kernel_sources", errors)
+        native_sources = validate_string_list(group_id, group, "native_sources", errors)
+        rust_modules = validate_string_list(group_id, group, "rust_modules", errors)
+
+        for source in kernel_sources:
+            manifest_kernel_sources.add(source)
+            if not (ROOT / source).is_file():
+                errors.append(f"{group_id}: kernel source does not exist: {source}")
+            if Path(source).name not in build_rerun_paths and source.replace("kernels/", "") not in build_rerun_paths:
+                errors.append(f"{group_id}: kernel source is not tracked by build.rs: {source}")
+        for source in native_sources:
+            manifest_native_sources.add(source)
+            if not (ROOT / source).is_file():
+                errors.append(f"{group_id}: native source does not exist: {source}")
+            build_rs_relative = source.replace("crates/kernel-ffi/", "")
+            if build_rs_relative not in build_text and source not in build_text:
+                errors.append(f"{group_id}: native source is not tracked by build.rs: {source}")
+        for source in rust_modules:
+            if not (ROOT / source).is_file():
+                errors.append(f"{group_id}: rust module does not exist: {source}")
+
+        if backend in {"hip", "cuda"} and not bridges:
+            errors.append(f"{group_id}: {backend} groups require at least one bridge")
+        if backend == "metal" and bridges:
+            errors.append(f"{group_id}: metal groups should use native_sources, not bridge tables")
+
+    missing_from_manifest = build_bridge_sources - manifest_bridge_sources
+    if missing_from_manifest:
+        errors.append(
+            "build.rs bridge source(s) missing from manifest: "
+            + ", ".join(sorted(missing_from_manifest))
+        )
+
+    if errors:
+        for error in errors:
+            print(f"error: {error}", file=sys.stderr)
+        return 1
+
+    print(
+        "kernel groups ok: "
+        f"{len(groups)} groups, "
+        f"{len(manifest_bridge_sources)} bridge sources, "
+        f"{len(manifest_kernel_sources | manifest_native_sources)} tracked support sources"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Refactor `kernel-ffi/build.rs` around named HIP/CUDA bridge groups while preserving the current broad backend compile behavior.
- Add `crates/kernel-ffi/kernel-groups.toml` as the checked scaffold for backend/model compile groups.
- Add `tools/check-kernel-groups.py` and development docs linking the new scaffold into the consolidation roadmap.

## Guardrail

This does not narrow default builds, move kernel files, or introduce new build selectors. `SUPERSONIC_BACKENDS=hip`, `cuda`, `metal`, and `auto` keep the existing selected-backend behavior.

## Validation

- `python3 tools/check-kernel-groups.py`
- `python3 tools/check-support-matrix.py`
- `python3 tools/check-tool-inventory.py`
- `python3 -m py_compile tools/check-kernel-groups.py tools/check-support-matrix.py tools/check-tool-inventory.py`
- `git diff --check`
- `cargo check -p kernel-ffi --no-default-features`
