### PR TITLE
[codex] Add native DFlash OpenCode serving

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2212,6 +2212,7 @@ dependencies = [
  "minijinja-contrib",
  "model-store",
  "qwen35",
+ "qwen35_dflash",
  "rand 0.8.6",
  "rand_chacha 0.3.1",
  "safetensors",

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ to disable network fetches.
 - **[Build and run](docs/build-and-run.md)** — per-backend build commands
   and the validated `supersonic` invocation set.
 - **[OpenAI-compatible server](docs/server.md)** — `supersonic-serve`
-  endpoints and harness compatibility notes.
+  endpoints, OpenCode setup, and harness compatibility notes.
 - **[Producing release bakes](docs/bake-distribution.md)** — how to
   produce, sign, and publish bakes for a new model variant.
 - **[Testing gates](docs/testing.md)** — E2E test runner, prerequisites,
@@ -57,8 +57,8 @@ to disable network fetches.
   staged cleanup plan and non-breaking inventory for current tools.
 - **[Kernel build groups](docs/development/kernel-build-groups.md)** —
   checked scaffold for future backend/model compile groups in `kernel-ffi`.
-- **[DFlash speculative decode](docs/dflash.md)** — Qwen3.5-9B INT4
-  speculative decode design and milestones.
+- **[DFlash speculative decode](docs/dflash.md)** — Qwen3.5/Qwen3.6 INT4
+  speculative decode design, server mode, and milestones.
 - **[Qwen3-30B-A3B HIP bring-up](docs/bringup/qwen3-30b-a3b-hip.md)** —
   separate Qwen3 MoE scaffolding and INT4 bake contract for HIP.
 - **[SpecPrefill](docs/specprefill.md)** — long-prompt TTFT optimization

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -13,6 +13,7 @@ gpu-hal = { path = "../gpu-hal" }
 kernel-ffi = { path = "../kernel-ffi" }
 model-store = { path = "../model-store" }
 qwen35 = { path = "../qwen35" }
+qwen35_dflash = { path = "../qwen35_dflash" }
 gemma4 = { path = "../gemma4" }
 
 anyhow = "1"

--- a/crates/runtime/src/builders.rs
+++ b/crates/runtime/src/builders.rs
@@ -7,6 +7,7 @@ use crate::bakes::{
     ensure_gemma4_int4_bake_available, ensure_qwen35_bake_available, selected_bake_variant,
 };
 use crate::decode_engine::DecodeEngine;
+use crate::dflash::{DFlashOptions, DFlashSession};
 use crate::gemma4_engine::Gemma4Engine;
 use crate::gemma4_int4_engine::Gemma4Int4Engine;
 use crate::session::InferenceSession;
@@ -58,6 +59,9 @@ pub(crate) fn build_qwen(
     )
     .map_err(|e| anyhow!("load baked weights: {e}"))?;
     tracing::info!("weights loaded in {:.0}ms", t0.elapsed().as_millis());
+    if cfg.dflash && !weights.is_int4 {
+        bail!("--dflash target loader did not produce low-bit weights");
+    }
 
     let attn_scratch_floats =
         params
@@ -83,7 +87,27 @@ pub(crate) fn build_qwen(
     .with_context(|| "build Qwen3.5 DecodeEngine")?;
     engine.set_decode_context_limit(context_tokens);
 
-    Ok((InferenceSession::Qwen(engine), eos_ids))
+    if cfg.dflash {
+        let draft_dir = cfg
+            .dflash_draft_dir
+            .clone()
+            .ok_or_else(|| anyhow!("--dflash requires --dflash-draft-dir"))?;
+        let dflash = DFlashSession::new(
+            engine,
+            DFlashOptions {
+                draft_dir,
+                block: cfg.dflash_block,
+                tap_layers: cfg.dflash_tap_layers.clone(),
+            },
+            &entry.model,
+            &text_config,
+            context_tokens,
+            cfg.device,
+        )?;
+        Ok((InferenceSession::QwenDFlash(dflash), eos_ids))
+    } else {
+        Ok((InferenceSession::Qwen(engine), eos_ids))
+    }
 }
 
 pub(crate) fn build_gemma4(

--- a/crates/runtime/src/dflash.rs
+++ b/crates/runtime/src/dflash.rs
@@ -1,0 +1,1067 @@
+//! Native DFlash serving support for dense Qwen low-bit targets.
+//!
+//! The public surface starts small: option normalization that the server
+//! builder and tests can share. The GPU-resident session lives in this module
+//! too so `supersonic-serve` can keep target and draft weights loaded across
+//! OpenAI-compatible requests.
+
+use std::env;
+use std::path::PathBuf;
+use std::sync::{Arc, Once};
+use std::time::Instant;
+
+use anyhow::{anyhow, bail, Result};
+use gpu_hal::{GpuBuffer, ScalarType};
+use qwen35::state::LinearStateSnapshot;
+use qwen35_dflash as draft;
+use supersonic_core::registry::ModelVariant;
+
+use crate::decode_engine::DecodeEngine;
+use crate::prefill_engine::PrefillAppendVerifyResult;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DFlashOptions {
+    pub draft_dir: PathBuf,
+    pub block: Option<usize>,
+    pub tap_layers: Option<String>,
+}
+
+impl DFlashOptions {
+    pub fn effective_block_size(
+        &self,
+        model_variant: &ModelVariant,
+        draft_block_size: usize,
+    ) -> Result<usize> {
+        if draft_block_size == 0 {
+            bail!("DFlash draft block_size must be greater than 0");
+        }
+        let block = match self.block {
+            Some(block) => block,
+            None if matches!(model_variant, ModelVariant::Qwen3_6_27B) => draft_block_size,
+            None => 3.min(draft_block_size),
+        };
+        if block == 0 || block > draft_block_size {
+            bail!("--dflash-block must be in 1..={draft_block_size} (got {block})");
+        }
+        Ok(block)
+    }
+
+    pub fn resolve_tap_layers(
+        &self,
+        draft_layers: &[u32],
+        num_target_layers: usize,
+    ) -> Result<Vec<usize>> {
+        if let Some(raw) = self.tap_layers.as_deref() {
+            parse_tap_layers(raw, num_target_layers)
+        } else {
+            Ok(draft_layers.iter().map(|&layer| layer as usize).collect())
+        }
+    }
+}
+
+pub fn parse_tap_layers(raw: &str, num_target_layers: usize) -> Result<Vec<usize>> {
+    let mut out = Vec::new();
+    for part in raw.split(',') {
+        let trimmed = part.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let layer: usize = trimmed
+            .parse()
+            .map_err(|e| anyhow::anyhow!("--dflash-tap-layers: bad integer '{trimmed}': {e}"))?;
+        if layer >= num_target_layers {
+            bail!("tap layer {layer} out of range (num_target_layers={num_target_layers})");
+        }
+        out.push(layer);
+    }
+    if out.is_empty() {
+        bail!("--dflash-tap-layers must list at least one integer");
+    }
+    Ok(out)
+}
+
+pub struct DFlashSession {
+    target: DecodeEngine,
+    draft_config: draft::DFlashConfig,
+    draft_weights: draft::DFlashWeights,
+    draft_rotary: draft::RotaryTables,
+    draft_scratch: draft::DFlashScratch,
+    draft_noise_embedding: GpuBuffer,
+    draft_state: draft::DFlashState,
+    tap_layers: Vec<usize>,
+    block_size: usize,
+    ordinal: usize,
+    tap_history_gpu: GpuBuffer,
+    tap_history_capacity: usize,
+    per_tap_row_bytes: usize,
+    hidden_size: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct DFlashGenerateOutput {
+    pub token_ids: Vec<u32>,
+    pub rounds_run: usize,
+    pub accepted_total: usize,
+    pub decode_ms: f64,
+}
+
+impl DFlashSession {
+    pub fn new(
+        target: DecodeEngine,
+        options: DFlashOptions,
+        model_variant: &ModelVariant,
+        text_config: &qwen35::config::TextConfig,
+        context_tokens: usize,
+        ordinal: usize,
+    ) -> Result<Self> {
+        let target_embed: Arc<GpuBuffer> = Arc::clone(&target.weights().embed_tokens);
+        let target_lm_head: Arc<GpuBuffer> = Arc::clone(&target.weights().lm_head);
+
+        let draft_config = draft::load_config(&options.draft_dir)
+            .map_err(|e| anyhow!("load draft config.json: {e}"))?;
+        if draft_config.num_target_layers != text_config.num_hidden_layers {
+            bail!(
+                "draft num_target_layers={} != target layers={}",
+                draft_config.num_target_layers,
+                text_config.num_hidden_layers,
+            );
+        }
+        if draft_config.hidden_size != text_config.hidden_size {
+            bail!(
+                "draft hidden_size {} != target hidden_size {}",
+                draft_config.hidden_size,
+                text_config.hidden_size,
+            );
+        }
+        if draft_config.vocab_size != text_config.vocab_size {
+            bail!(
+                "draft vocab_size {} != target vocab_size {} - the draft shares target embeddings",
+                draft_config.vocab_size,
+                text_config.vocab_size,
+            );
+        }
+        let mask_id = draft_config.dflash_config.mask_token_id;
+        if (mask_id as usize) >= text_config.vocab_size {
+            bail!(
+                "draft mask_token_id {mask_id} is out of range for target vocab_size {}",
+                text_config.vocab_size,
+            );
+        }
+
+        let tap_layers = options.resolve_tap_layers(
+            &draft_config.dflash_config.target_layer_ids,
+            draft_config.num_target_layers,
+        )?;
+        if tap_layers.len() != draft_config.num_taps() {
+            bail!(
+                "tap layer count {} mismatches draft fuser tap count {}",
+                tap_layers.len(),
+                draft_config.num_taps(),
+            );
+        }
+        let block_size = options.effective_block_size(model_variant, draft_config.block_size)?;
+
+        let draft_weights = draft::DFlashWeights::load(
+            &options.draft_dir,
+            &draft_config,
+            ordinal,
+            target_embed,
+            target_lm_head,
+        )
+        .map_err(|e| anyhow!("load draft weights: {e}"))?;
+
+        let draft_ctx_capacity = context_tokens.max(1);
+        let draft_max_ctx = (context_tokens + draft_config.block_size)
+            .max(draft_config.block_size * 4)
+            .max(1024);
+        let draft_rotary = draft::RotaryTables::build(&draft_config, ordinal, draft_max_ctx)
+            .map_err(|e| anyhow!("build draft RoPE: {e}"))?;
+        let draft_scratch =
+            draft::DFlashScratch::new_with_ctx_capacity(ordinal, &draft_config, draft_ctx_capacity)
+                .map_err(|e| anyhow!("alloc draft scratch: {e}"))?;
+        let draft_noise_embedding = GpuBuffer::zeros(
+            ordinal,
+            ScalarType::BF16,
+            &[1, draft_config.block_size, draft_config.hidden_size],
+        )
+        .map_err(|e| anyhow!("alloc draft noise embedding scratch: {e}"))?;
+        let draft_state = draft::DFlashState::new(ordinal, &draft_config, draft_max_ctx)
+            .map_err(|e| anyhow!("alloc draft state: {e}"))?;
+
+        let per_tap_row_bytes =
+            tap_layers.len() * text_config.hidden_size * ScalarType::BF16.size_in_bytes();
+        let tap_history_capacity = context_tokens + block_size;
+        let tap_history_gpu = GpuBuffer::zeros(
+            ordinal,
+            ScalarType::BF16,
+            &[
+                tap_history_capacity.max(1),
+                tap_layers.len() * text_config.hidden_size,
+            ],
+        )
+        .map_err(|e| anyhow!("alloc GPU tap history: {e}"))?;
+
+        tracing::info!(
+            draft_dir = %options.draft_dir.display(),
+            block_size,
+            taps = ?tap_layers,
+            context_tokens,
+            "DFlash session ready"
+        );
+
+        Ok(Self {
+            target,
+            draft_config,
+            draft_weights,
+            draft_rotary,
+            draft_scratch,
+            draft_noise_embedding,
+            draft_state,
+            tap_layers,
+            block_size,
+            ordinal,
+            tap_history_gpu,
+            tap_history_capacity,
+            per_tap_row_bytes,
+            hidden_size: text_config.hidden_size,
+        })
+    }
+
+    pub fn reset(&mut self) -> Result<()> {
+        self.target.reset()?;
+        self.draft_state.reset();
+        Ok(())
+    }
+
+    pub fn generate_greedy(
+        &mut self,
+        prompt_ids: &[u32],
+        max_tokens: usize,
+        eos_ids: &[u32],
+    ) -> Result<DFlashGenerateOutput> {
+        if max_tokens == 0 {
+            return Ok(DFlashGenerateOutput {
+                token_ids: Vec::new(),
+                rounds_run: 0,
+                accepted_total: 0,
+                decode_ms: 0.0,
+            });
+        }
+        if prompt_ids.is_empty() {
+            bail!("DFlash generation requires a non-empty prompt");
+        }
+        if prompt_ids.len() + max_tokens + self.block_size > self.tap_history_capacity {
+            bail!(
+                "DFlash tap history capacity {} is too small for prompt {} + max_tokens {} + block {}",
+                self.tap_history_capacity,
+                prompt_ids.len(),
+                max_tokens,
+                self.block_size,
+            );
+        }
+
+        self.reset()?;
+        let prefill_result = self
+            .target
+            .prefill_native_with_taps(prompt_ids, &self.tap_layers)?;
+        let taps = match prefill_result.tap_hiddens_all.as_ref() {
+            Some(per_tap) => flatten_tap_history(per_tap, prompt_ids.len(), self.hidden_size)?,
+            None => flatten_tap_history(
+                &prefill_result.tap_hiddens.unwrap_or_default(),
+                1,
+                self.hidden_size,
+            )?,
+        };
+        upload_taps_to_gpu_history(&mut self.tap_history_gpu, 0, self.per_tap_row_bytes, &taps)?;
+        let mut tap_history_len = if self.per_tap_row_bytes == 0 {
+            0
+        } else {
+            taps.len() / self.per_tap_row_bytes
+        };
+        if tap_history_len == 0 {
+            bail!("DFlash prefill did not produce any target tap history");
+        }
+
+        let mut bonus_seed = DecodeEngine::greedy_sample(&prefill_result.logits);
+        let mut committed_len = prompt_ids.len();
+        let mut generated_ids = Vec::with_capacity(max_tokens);
+        let mut rounds_run = 0usize;
+        let mut accepted_total = 0usize;
+        let decode_start = Instant::now();
+
+        while generated_ids.len() < max_tokens {
+            if eos_ids.contains(&bonus_seed) {
+                generated_ids.push(bonus_seed);
+                break;
+            }
+
+            let remaining_budget = max_tokens - generated_ids.len();
+            if remaining_budget == 1 {
+                generated_ids.push(bonus_seed);
+                break;
+            }
+
+            rounds_run += 1;
+            let l = committed_len;
+            let verify_len = dflash_verify_len_for_round(remaining_budget, self.block_size);
+            let draft_ctx = tap_history_len.min(self.draft_scratch.ctx_capacity);
+            let tap_start_row = tap_history_len - draft_ctx;
+
+            let draft_candidates = draft_forward_and_sample(
+                &mut self.draft_state,
+                &mut self.draft_scratch,
+                &mut self.draft_noise_embedding,
+                &self.draft_rotary,
+                &self.draft_weights,
+                &self.target,
+                &self.tap_history_gpu,
+                tap_start_row,
+                draft_ctx,
+                bonus_seed,
+                self.block_size,
+                self.draft_config.dflash_config.mask_token_id,
+                self.ordinal,
+            )?;
+
+            let gpu_tap_history = if dflash_gpu_tap_history_enabled() {
+                Some((
+                    &mut self.tap_history_gpu,
+                    tap_history_len,
+                    self.per_tap_row_bytes,
+                ))
+            } else {
+                None
+            };
+            let verify_output = verify_block_for_dflash(
+                &mut self.target,
+                &draft_candidates[..verify_len],
+                l,
+                &self.tap_layers,
+                gpu_tap_history,
+            )?;
+            let target_next_ids = verify_output.greedy_ids()?;
+
+            let mut accept_n = 1usize;
+            while accept_n < verify_len {
+                if accept_n > target_next_ids.len() {
+                    bail!(
+                        "DFlash verifier returned {} greedy IDs, insufficient for accept_n={accept_n} verify_len={verify_len}",
+                        target_next_ids.len()
+                    );
+                }
+                if target_next_ids[accept_n - 1] == draft_candidates[accept_n] {
+                    accept_n += 1;
+                } else {
+                    break;
+                }
+            }
+            let carried_seed = *target_next_ids
+                .get(accept_n - 1)
+                .ok_or_else(|| anyhow!("target verifier returned no carried seed"))?;
+
+            let accepted_len = accept_n.min(remaining_budget);
+            let committed_block = draft_candidates[..accepted_len].to_vec();
+            let finish_after_commit = accepted_len >= remaining_budget
+                || committed_block.iter().any(|t| eos_ids.contains(t));
+
+            let mut next_bonus_seed = None;
+            if !finish_after_commit {
+                match verify_output {
+                    DFlashVerifyOutput::Captured(result) => {
+                        if let Some(per_tap) = result.tap_hiddens_all.as_ref() {
+                            let taps_bytes =
+                                flatten_tap_history(per_tap, verify_len, self.hidden_size)?;
+                            let committed_tap_bytes = accepted_len * self.per_tap_row_bytes;
+                            upload_taps_to_gpu_history(
+                                &mut self.tap_history_gpu,
+                                tap_history_len,
+                                self.per_tap_row_bytes,
+                                &taps_bytes[..committed_tap_bytes],
+                            )?;
+                        } else if !dflash_gpu_tap_history_enabled() {
+                            bail!("captured prefill verifier did not return tap history");
+                        }
+                        if accepted_len == verify_len {
+                            self.target
+                                .commit_prefill_append_full_accept_owned(result)?;
+                        } else {
+                            self.target
+                                .commit_prefill_append_verify_owned(result, accepted_len)?;
+                        }
+                        tap_history_len += accepted_len;
+                        next_bonus_seed = Some(carried_seed);
+                    }
+                    DFlashVerifyOutput::CapturedWindowed(result) => {
+                        let mut remaining = accepted_len;
+                        let mut copied_tap_rows = 0usize;
+                        let mut committed = false;
+                        for segment in &result.segments {
+                            if remaining == 0 {
+                                break;
+                            }
+                            let expected_start = accepted_len - remaining;
+                            if segment.start != expected_start {
+                                bail!(
+                                    "windowed prefill segment start {} != expected {}",
+                                    segment.start,
+                                    expected_start
+                                );
+                            }
+                            let take = remaining.min(segment.len);
+                            if let Some(per_tap) = segment.result.tap_hiddens_all.as_ref() {
+                                let taps_bytes =
+                                    flatten_tap_history(per_tap, segment.len, self.hidden_size)?;
+                                let take_bytes = take * self.per_tap_row_bytes;
+                                upload_taps_to_gpu_history(
+                                    &mut self.tap_history_gpu,
+                                    tap_history_len + copied_tap_rows,
+                                    self.per_tap_row_bytes,
+                                    &taps_bytes[..take_bytes],
+                                )?;
+                            } else if !dflash_gpu_tap_history_enabled() {
+                                bail!("windowed prefill verifier did not return tap history");
+                            }
+                            copied_tap_rows += take;
+
+                            if remaining <= segment.len {
+                                if remaining == segment.len {
+                                    self.target
+                                        .commit_prefill_append_full_accept(&segment.result)?;
+                                } else {
+                                    self.target
+                                        .commit_prefill_append_verify(&segment.result, remaining)?;
+                                }
+                                committed = true;
+                                remaining = 0;
+                                break;
+                            }
+                            remaining -= segment.len;
+                        }
+                        if !committed || remaining != 0 || copied_tap_rows != accepted_len {
+                            bail!(
+                                "windowed prefill commit could not cover accepted_len={} with {} segments",
+                                accepted_len,
+                                result.segments.len()
+                            );
+                        }
+                        tap_history_len += accepted_len;
+                        next_bonus_seed = Some(carried_seed);
+                    }
+                    DFlashVerifyOutput::Fallback { snap, .. } => {
+                        self.target
+                            .state_mut()
+                            .restore_linear(&snap, self.ordinal)
+                            .map_err(|e| anyhow!("restore linear: {e}"))?;
+                        self.target.rewind_full_kv_filled(l);
+                        let (logits, taps_bytes) = self.target.decode_block_with_taps_kernel(
+                            &committed_block,
+                            l,
+                            &self.tap_layers,
+                        )?;
+                        let expected_tap_bytes = accepted_len * self.per_tap_row_bytes;
+                        if taps_bytes.len() != expected_tap_bytes {
+                            bail!(
+                                "decode_block_with_taps_kernel returned {} tap bytes, expected {}",
+                                taps_bytes.len(),
+                                expected_tap_bytes,
+                            );
+                        }
+                        upload_taps_to_gpu_history(
+                            &mut self.tap_history_gpu,
+                            tap_history_len,
+                            self.per_tap_row_bytes,
+                            &taps_bytes,
+                        )?;
+                        tap_history_len += accepted_len;
+                        next_bonus_seed = Some(DecodeEngine::greedy_sample(&logits));
+                    }
+                }
+            }
+
+            committed_len = l + accepted_len;
+            accepted_total += accepted_len;
+            let mut hit_eos = false;
+            for &token in &committed_block {
+                generated_ids.push(token);
+                if eos_ids.contains(&token) {
+                    hit_eos = true;
+                    break;
+                }
+                if generated_ids.len() >= max_tokens {
+                    break;
+                }
+            }
+            if hit_eos || finish_after_commit {
+                break;
+            }
+            bonus_seed =
+                next_bonus_seed.ok_or_else(|| anyhow!("missing DFlash next bonus seed"))?;
+            self.draft_state.reset();
+        }
+
+        Ok(DFlashGenerateOutput {
+            token_ids: generated_ids,
+            rounds_run,
+            accepted_total,
+            decode_ms: decode_start.elapsed().as_secs_f64() * 1000.0,
+        })
+    }
+}
+
+enum DFlashVerifyOutput {
+    Captured(PrefillAppendVerifyResult),
+    CapturedWindowed(CapturedWindowedVerifyOutput),
+    Fallback {
+        logits: Vec<Vec<f32>>,
+        snap: LinearStateSnapshot,
+    },
+}
+
+struct CapturedWindowedVerifyOutput {
+    segments: Vec<CapturedWindowSegment>,
+    target_next: Vec<u32>,
+}
+
+struct CapturedWindowSegment {
+    start: usize,
+    len: usize,
+    result: PrefillAppendVerifyResult,
+}
+
+impl DFlashVerifyOutput {
+    fn greedy_ids(&self) -> Result<Vec<u32>> {
+        match self {
+            Self::Captured(result) => result.target_next.clone().ok_or_else(|| {
+                anyhow!("captured prefill verifier did not return greedy target IDs")
+            }),
+            Self::CapturedWindowed(result) => Ok(result.target_next.clone()),
+            Self::Fallback { logits, .. } => Ok(logits
+                .iter()
+                .map(|row| DecodeEngine::greedy_sample(row))
+                .collect()),
+        }
+    }
+}
+
+fn dflash_prefill_window_scan_chunk() -> usize {
+    env::var("SUPERSONIC_DFLASH_VERIFY_SCAN_CHUNK")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|&v| v > 0)
+        .unwrap_or(16)
+}
+
+fn dflash_prefill_window_min_tail() -> usize {
+    env::var("SUPERSONIC_DFLASH_VERIFY_MIN_TAIL")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(4)
+}
+
+fn dflash_final_verify_min_len(block_size: usize) -> Option<usize> {
+    if env::var_os("SUPERSONIC_DFLASH_DISABLE_FINAL_VERIFY_PAD").is_some() {
+        return None;
+    }
+    Some(
+        env::var("SUPERSONIC_DFLASH_FINAL_VERIFY_MIN_LEN")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .filter(|&v| v > 0)
+            .unwrap_or(block_size),
+    )
+}
+
+fn dflash_verify_len_for_round(remaining_budget: usize, block_size: usize) -> usize {
+    let clamped = block_size.min(remaining_budget);
+    if remaining_budget >= block_size {
+        return clamped;
+    }
+    let Some(min_len) = dflash_final_verify_min_len(block_size) else {
+        return clamped;
+    };
+    clamped.max(min_len.min(block_size))
+}
+
+fn dflash_gpu_tap_history_enabled() -> bool {
+    env::var_os("SUPERSONIC_DFLASH_DISABLE_GPU_TAP_HISTORY").is_none()
+}
+
+fn dflash_window_step(remaining: usize, scan_chunk: usize, min_tail: usize) -> usize {
+    let step = scan_chunk.min(remaining);
+    let tail = remaining - step;
+    if tail > 0 && tail < min_tail {
+        remaining
+    } else {
+        step
+    }
+}
+
+fn chain_accept_needs_more(target_next: &[u32], tokens: &[u32], verify_len: usize) -> bool {
+    let mut accept_n = 1usize;
+    while accept_n < verify_len {
+        if accept_n > target_next.len() {
+            return true;
+        }
+        if target_next[accept_n - 1] == tokens[accept_n] {
+            accept_n += 1;
+        } else {
+            return false;
+        }
+    }
+    accept_n > target_next.len()
+}
+
+fn verify_block_prefill_append_windowed(
+    target_engine: &mut DecodeEngine,
+    tokens: &[u32],
+    pos_offset: usize,
+    tap_layers: &[usize],
+    scan_chunk: usize,
+    mut gpu_tap_history: Option<(&mut GpuBuffer, usize, usize)>,
+) -> Result<CapturedWindowedVerifyOutput> {
+    if scan_chunk == 0 {
+        bail!("prefill append window scan chunk must be > 0");
+    }
+
+    let mut segments = Vec::new();
+    let mut target_next = Vec::new();
+    let min_tail = dflash_prefill_window_min_tail();
+    let mut start = 0usize;
+    while start < tokens.len() {
+        let step = dflash_window_step(tokens.len() - start, scan_chunk, min_tail);
+        let result = if let Some((history, base_row, row_bytes)) = gpu_tap_history.as_mut() {
+            target_engine.verify_block_prefill_append_captured_lazy_acceptance_gpu_taps(
+                &tokens[start..start + step],
+                pos_offset + start,
+                tap_layers,
+                &mut **history,
+                *base_row + start,
+                *row_bytes,
+            )?
+        } else {
+            target_engine.verify_block_prefill_append_captured_lazy_acceptance(
+                &tokens[start..start + step],
+                pos_offset + start,
+                tap_layers,
+            )?
+        };
+        let ids = result
+            .target_next
+            .clone()
+            .ok_or_else(|| anyhow!("windowed prefill verifier did not return greedy target IDs"))?;
+        if ids.is_empty() {
+            bail!("windowed prefill verifier returned no greedy target IDs");
+        }
+        target_next.extend(ids);
+        segments.push(CapturedWindowSegment {
+            start,
+            len: step,
+            result,
+        });
+
+        if !chain_accept_needs_more(&target_next, tokens, tokens.len()) {
+            break;
+        }
+        start += step;
+    }
+
+    Ok(CapturedWindowedVerifyOutput {
+        segments,
+        target_next,
+    })
+}
+
+fn verify_block_for_dflash(
+    target_engine: &mut DecodeEngine,
+    tokens: &[u32],
+    pos_offset: usize,
+    tap_layers: &[usize],
+    mut gpu_tap_history: Option<(&mut GpuBuffer, usize, usize)>,
+) -> Result<DFlashVerifyOutput> {
+    let force_prefill = env::var_os("SUPERSONIC_DFLASH_PREFILL_VERIFY").is_some();
+    let disable_prefill = env::var_os("SUPERSONIC_DFLASH_DISABLE_PREFILL_VERIFY").is_some();
+    let chunk_size = dflash_fused_verify_chunk_size(target_engine);
+    let config = &target_engine.weights().config;
+    let prefer_prefill_append = config.hidden_size == 5120 && config.num_hidden_layers == 64;
+    let use_prefill_append = force_prefill
+        || (!disable_prefill
+            && (prefer_prefill_append || (chunk_size > 0 && tokens.len() > chunk_size)));
+
+    if use_prefill_append {
+        static PREFILL_NOTICE: Once = Once::new();
+        PREFILL_NOTICE.call_once(|| {
+            tracing::info!("DFlash using prefill-append target verifier");
+        });
+        let scan_chunk = dflash_prefill_window_scan_chunk();
+        if scan_chunk < tokens.len()
+            && env::var_os("SUPERSONIC_DFLASH_DISABLE_VERIFY_ROW_SCAN").is_none()
+        {
+            let result = verify_block_prefill_append_windowed(
+                target_engine,
+                tokens,
+                pos_offset,
+                tap_layers,
+                scan_chunk,
+                gpu_tap_history
+                    .as_mut()
+                    .map(|(history, start_row, row_bytes)| {
+                        (&mut **history, *start_row, *row_bytes)
+                    }),
+            )?;
+            return Ok(DFlashVerifyOutput::CapturedWindowed(result));
+        }
+        let captured_result =
+            if let Some((history, start_row, row_bytes)) = gpu_tap_history.as_mut() {
+                target_engine.verify_block_prefill_append_captured_lazy_acceptance_gpu_taps(
+                    tokens,
+                    pos_offset,
+                    tap_layers,
+                    &mut **history,
+                    *start_row,
+                    *row_bytes,
+                )
+            } else {
+                target_engine.verify_block_prefill_append_captured_lazy_acceptance(
+                    tokens, pos_offset, tap_layers,
+                )
+            };
+        match captured_result {
+            Ok(result) => return Ok(DFlashVerifyOutput::Captured(result)),
+            Err(err) if force_prefill => {
+                return Err(anyhow!("prefill append verify failed: {err}"));
+            }
+            Err(err) => {
+                static PREFILL_FALLBACK_NOTICE: Once = Once::new();
+                PREFILL_FALLBACK_NOTICE.call_once(|| {
+                    tracing::warn!(
+                        "DFlash prefill-append verifier failed ({err}); falling back to persistent verifier"
+                    );
+                });
+            }
+        }
+    }
+
+    let snap: LinearStateSnapshot = target_engine
+        .state_mut()
+        .snapshot_linear()
+        .map_err(|e| anyhow!("snapshot linear: {e}"))?;
+
+    let needs_sequential = tokens.len() > kernel_ffi::MAX_BATCH_SIZE;
+    if !needs_sequential {
+        match target_engine.verify_block_fused_decode(tokens, pos_offset) {
+            Ok(logits) => return Ok(DFlashVerifyOutput::Fallback { logits, snap }),
+            Err(err) => {
+                let msg = err.to_string();
+                if !msg.contains("shared-memory budget exceeded") {
+                    return Err(err);
+                }
+            }
+        }
+    }
+
+    if chunk_size > 0 && chunk_size < tokens.len() {
+        let mut out = Vec::with_capacity(tokens.len());
+        let mut start = 0usize;
+        while start < tokens.len() {
+            let remaining = tokens.len() - start;
+            let step = if remaining > chunk_size && remaining - chunk_size == 1 && chunk_size > 1 {
+                chunk_size - 1
+            } else {
+                remaining.min(chunk_size)
+            };
+            let end = start + step;
+            match target_engine.verify_block_fused_decode(&tokens[start..end], pos_offset + start) {
+                Ok(mut logits) => {
+                    out.append(&mut logits);
+                    start = end;
+                }
+                Err(err) => {
+                    let msg = err.to_string();
+                    if start == 0 && msg.contains("shared-memory budget exceeded") {
+                        break;
+                    }
+                    return Err(anyhow!(
+                        "chunked fused verify failed at token {start}: {err}"
+                    ));
+                }
+            }
+        }
+        if out.len() == tokens.len() {
+            return Ok(DFlashVerifyOutput::Fallback { logits: out, snap });
+        }
+    }
+
+    static NOTICE: Once = Once::new();
+    NOTICE.call_once(|| {
+        tracing::info!(
+            "DFlash fused verify does not fit this target shape/block; using sequential target verify fallback"
+        );
+    });
+
+    let mut logits = Vec::with_capacity(tokens.len());
+    for (i, &tok) in tokens.iter().enumerate() {
+        let (step_logits, _tap_bytes) = target_engine
+            .decode_step_with_taps_kernel(tok, pos_offset + i, tap_layers)
+            .map_err(|e| anyhow!("sequential verify decode step {i}: {e}"))?;
+        logits.push(step_logits);
+    }
+    Ok(DFlashVerifyOutput::Fallback { logits, snap })
+}
+
+fn dflash_fused_verify_chunk_size(target_engine: &DecodeEngine) -> usize {
+    const MAX_INPUT_CACHE_FLOATS: usize = 15872;
+    let hidden_dim = target_engine.weights().config.hidden_size;
+    if hidden_dim == 0 || 2 * hidden_dim > MAX_INPUT_CACHE_FLOATS {
+        return 0;
+    }
+    (MAX_INPUT_CACHE_FLOATS / hidden_dim).min(kernel_ffi::MAX_BATCH_SIZE)
+}
+
+fn upload_taps_to_gpu_history(
+    tap_history_gpu: &mut GpuBuffer,
+    start_row: usize,
+    row_bytes: usize,
+    taps: &[u8],
+) -> Result<()> {
+    if taps.is_empty() {
+        return Ok(());
+    }
+    if row_bytes == 0 || taps.len() % row_bytes != 0 {
+        bail!(
+            "tap upload byte length {} is not a multiple of row_bytes {}",
+            taps.len(),
+            row_bytes
+        );
+    }
+    let dst_offset = start_row * row_bytes;
+    if dst_offset + taps.len() > tap_history_gpu.len_bytes() {
+        bail!(
+            "GPU tap history write exceeds buffer: offset {} + len {} > {}",
+            dst_offset,
+            taps.len(),
+            tap_history_gpu.len_bytes()
+        );
+    }
+    let dst = unsafe {
+        (tap_history_gpu.as_mut_ptr() as *mut u8).add(dst_offset) as *mut std::ffi::c_void
+    };
+    gpu_hal::copy_h2d(
+        tap_history_gpu.device_ordinal(),
+        dst,
+        taps.as_ptr() as *const std::ffi::c_void,
+        taps.len(),
+    )
+    .map_err(|e| anyhow!("upload tap history: {e}"))
+}
+
+fn flatten_tap_history(
+    per_tap: &[Vec<u8>],
+    num_positions: usize,
+    hidden_dim: usize,
+) -> Result<Vec<u8>> {
+    if per_tap.is_empty() {
+        bail!("flatten_tap_history requires at least one tap layer");
+    }
+    let row_bytes = hidden_dim * ScalarType::BF16.size_in_bytes();
+    let expected = num_positions * row_bytes;
+    for (idx, tap) in per_tap.iter().enumerate() {
+        if tap.len() != expected {
+            bail!(
+                "tap history {idx} has {} bytes, expected {expected} ({num_positions} positions * {hidden_dim} hidden * 2)",
+                tap.len(),
+            );
+        }
+    }
+    let mut out = Vec::with_capacity(num_positions * per_tap.len() * row_bytes);
+    for pos in 0..num_positions {
+        let start = pos * row_bytes;
+        for tap in per_tap {
+            out.extend_from_slice(&tap[start..start + row_bytes]);
+        }
+    }
+    Ok(out)
+}
+
+fn draft_forward_and_sample(
+    draft_state: &mut draft::DFlashState,
+    draft_scratch: &mut draft::DFlashScratch,
+    noise_embedding: &mut GpuBuffer,
+    draft_rotary: &draft::RotaryTables,
+    draft_weights: &draft::DFlashWeights,
+    target_engine: &DecodeEngine,
+    tap_history_gpu: &GpuBuffer,
+    tap_start_row: usize,
+    round_taps_len: usize,
+    bonus_seed: u32,
+    block_size: usize,
+    mask_token_id: u32,
+    ordinal: usize,
+) -> Result<Vec<u32>> {
+    if round_taps_len == 0 {
+        bail!("draft_forward: round_taps_len must be > 0");
+    }
+    let hidden = draft_weights.config.hidden_size;
+    let num_taps = draft_weights.config.num_taps();
+    let tap_row_bytes = num_taps * hidden * ScalarType::BF16.size_in_bytes();
+    let expected_bytes = round_taps_len * tap_row_bytes;
+    let src_offset = tap_start_row * tap_row_bytes;
+    if src_offset + expected_bytes > tap_history_gpu.len_bytes() {
+        bail!(
+            "GPU tap history read exceeds buffer: offset {} + len {} > {}",
+            src_offset,
+            expected_bytes,
+            tap_history_gpu.len_bytes()
+        );
+    }
+
+    let target_embed = &target_engine.weights().embed_tokens;
+    let row_bytes = hidden * ScalarType::BF16.size_in_bytes();
+    let expected_noise_bytes = block_size * row_bytes;
+    if noise_embedding.len_bytes() < expected_noise_bytes {
+        bail!(
+            "draft noise embedding scratch has {} bytes, need {}",
+            noise_embedding.len_bytes(),
+            expected_noise_bytes
+        );
+    }
+    for i in 0..block_size {
+        let tok = if i == 0 { bonus_seed } else { mask_token_id };
+        let src_off = tok as usize * row_bytes;
+        let dst_off = i * row_bytes;
+        gpu_hal::copy_d2d(
+            ordinal,
+            unsafe {
+                (noise_embedding.as_mut_ptr() as *mut u8).add(dst_off) as *mut std::ffi::c_void
+            },
+            target_embed.offset_ptr(src_off),
+            row_bytes,
+        )
+        .map_err(|e| anyhow!("noise_embedding gather slot {i}: {e}"))?;
+    }
+
+    if expected_bytes > draft_scratch.fuser_input.len_bytes() {
+        bail!(
+            "draft fuser_input scratch has {} bytes, need {}",
+            draft_scratch.fuser_input.len_bytes(),
+            expected_bytes
+        );
+    }
+    gpu_hal::copy_d2d(
+        ordinal,
+        draft_scratch.fuser_input.as_mut_ptr(),
+        tap_history_gpu.offset_ptr(src_offset),
+        expected_bytes,
+    )
+    .map_err(|e| anyhow!("copy target_hidden_raw: {e}"))?;
+
+    draft::forward::forward(
+        draft_weights,
+        draft_state,
+        draft_scratch,
+        draft_rotary,
+        noise_embedding,
+        draft::ForwardParams {
+            ctx_len: round_taps_len,
+            q_len: block_size,
+            pos_offset: 0,
+        },
+    )
+    .map_err(|e| anyhow!("draft forward: {e}"))?;
+
+    let target_weights = target_engine.weights();
+    let lm_head_buf: &GpuBuffer = target_weights.lm_head.as_ref();
+    let vocab = draft_weights.config.vocab_size;
+    if draft_scratch.logits.elem_count() < block_size * vocab {
+        bail!(
+            "draft logits scratch has {} elems, need {}",
+            draft_scratch.logits.elem_count(),
+            block_size * vocab
+        );
+    }
+
+    let mut fused_argmax = false;
+    if let Some((lm_head_qtype, scale, zero)) = target_weights.lm_head_lowbit_params(hidden) {
+        if env::var_os("SUPERSONIC_DFLASH_DISABLE_Q6_K_LM_HEAD_ARGMAX_FUSED").is_none()
+            && block_size == 16
+            && vocab % 16 == 0
+            && hidden % 256 == 0
+            && lm_head_qtype == qwen35::weights::LOWBIT_GGML_Q6_K
+            && target_weights.lm_head_awq_inv_scale.is_none()
+        {
+            fused_argmax = kernel_ffi::prefill_ffi::matmul_q6_k_m16_argmax(
+                ordinal,
+                1,
+                block_size,
+                vocab,
+                hidden,
+                &draft_scratch.final_hidden,
+                lm_head_buf,
+                &mut draft_scratch.lm_head_block_best_vals,
+                &mut draft_scratch.lm_head_block_best_indices,
+                &mut draft_scratch.argmax_indices,
+            )
+            .map_err(|e| anyhow!("draft lm_head fused argmax: {e}"))?;
+        }
+        if !fused_argmax {
+            kernel_ffi::prefill_ffi::matmul_rhs_transposed_int4(
+                ordinal,
+                1,
+                block_size,
+                vocab,
+                hidden,
+                &draft_scratch.final_hidden,
+                lm_head_buf,
+                scale,
+                zero,
+                target_weights.lm_head_awq_inv_scale.as_ref(),
+                target_weights.int4_group_size,
+                lm_head_qtype,
+                &mut draft_scratch.logits,
+            )
+            .map_err(|e| anyhow!("draft lm_head low-bit matmul: {e}"))?;
+        }
+    } else {
+        kernel_ffi::matmul_rhs_transposed_4b(
+            ordinal,
+            ScalarType::BF16,
+            1,
+            block_size,
+            vocab,
+            hidden,
+            &draft_scratch.final_hidden,
+            lm_head_buf,
+            &mut draft_scratch.logits,
+        )
+        .map_err(|e| anyhow!("draft lm_head: {e}"))?;
+    }
+
+    if !fused_argmax {
+        kernel_ffi::prefill_ffi::argmax_bf16_rows(
+            ordinal,
+            block_size,
+            vocab,
+            &draft_scratch.logits,
+            &mut draft_scratch.argmax_indices,
+        )
+        .map_err(|e| anyhow!("draft logits argmax: {e}"))?;
+    }
+    let argmax_bytes = draft_scratch
+        .argmax_indices
+        .to_host_bytes()
+        .map_err(|e| anyhow!("draft argmax indices D2H: {e}"))?;
+    let mut candidates: Vec<u32> = argmax_bytes
+        .chunks_exact(4)
+        .take(block_size)
+        .map(|chunk| u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
+        .collect();
+    if candidates.len() != block_size {
+        bail!(
+            "draft argmax returned {} candidates, expected {block_size}",
+            candidates.len()
+        );
+    }
+    if let Some(first) = candidates.first_mut() {
+        *first = bonus_seed;
+    }
+    Ok(candidates)
+}

--- a/crates/runtime/src/generate.rs
+++ b/crates/runtime/src/generate.rs
@@ -311,6 +311,30 @@ fn run(
         .as_ref()
         .ok_or_else(|| anyhow!("no inference session configured"))?;
     let mut guard = session.blocking_lock();
+    if guard.is_dflash() {
+        if cache.is_some() {
+            tracing::debug!("prefix cache skipped for DFlash session");
+        }
+        let output =
+            guard.generate_dflash_greedy(&prompt_ids, params.max_tokens, &state.eos_ids)?;
+        tracing::info!(
+            rounds = output.rounds_run,
+            accepted = output.accepted_total,
+            generated = output.token_ids.len(),
+            decode_ms = output.decode_ms,
+            "DFlash generation complete"
+        );
+        emit_generated_ids(
+            &tokenizer,
+            &state.eos_ids,
+            prompt_tokens,
+            &output.token_ids,
+            &params,
+            &tx,
+        );
+        return Ok(());
+    }
+
     let prefill_logits = if let Some(cache_req) = cache.as_ref() {
         if let Some(hit) = state.prefix_cache.lookup(cache_req, &prompt_ids) {
             match guard.restore_prefix(hit.snapshot) {
@@ -436,6 +460,10 @@ fn run(
             break FinishReason::Stop;
         }
 
+        if finish_after_emitted_token(completion_tokens, params.max_tokens).is_some() {
+            break FinishReason::Length;
+        }
+
         let pos = prompt_ids.len() + emitted_ids.len() - 1;
         let raw_next_logits = guard.decode_step(next_token, pos)?;
         state_token_ids.push(next_token);
@@ -468,6 +496,62 @@ fn run(
         cached_prompt_tokens,
     });
     Ok(())
+}
+
+fn emit_generated_ids(
+    tokenizer: &Tokenizer,
+    eos_ids: &[u32],
+    prompt_tokens: u32,
+    token_ids: &[u32],
+    params: &GenParams,
+    tx: &UnboundedSender<GenEvent>,
+) {
+    let mut emitted_ids: Vec<u32> = Vec::with_capacity(token_ids.len());
+    let mut prev_decoded = String::new();
+    let mut completion_tokens = 0u32;
+    let mut finish = if token_ids.len() >= params.max_tokens {
+        FinishReason::Length
+    } else {
+        FinishReason::Stop
+    };
+
+    for &token_id in token_ids {
+        if eos_ids.contains(&token_id) {
+            finish = FinishReason::Stop;
+            break;
+        }
+        if completion_tokens as usize >= params.max_tokens {
+            finish = FinishReason::Length;
+            break;
+        }
+        emitted_ids.push(token_id);
+        completion_tokens += 1;
+
+        let decoded = detokenize(tokenizer, &emitted_ids);
+        if let Some(stop_at) = find_earliest_stop(&decoded, &params.stop) {
+            let trimmed = &decoded[..stop_at];
+            let delta = incremental_delta(&prev_decoded, trimmed);
+            if !delta.is_empty() {
+                let _ = tx.send(GenEvent::Token(delta));
+            }
+            finish = FinishReason::Stop;
+            break;
+        }
+
+        let delta = incremental_delta(&prev_decoded, &decoded);
+        prev_decoded = decoded;
+        if !delta.is_empty() && tx.send(GenEvent::Token(delta)).is_err() {
+            finish = FinishReason::Stop;
+            break;
+        }
+    }
+
+    let _ = tx.send(GenEvent::Done {
+        reason: finish,
+        prompt_tokens,
+        completion_tokens,
+        cached_prompt_tokens: 0,
+    });
 }
 
 fn prefill_with_cache_anchor(
@@ -556,6 +640,14 @@ fn find_earliest_stop(text: &str, stops: &[String]) -> Option<usize> {
         .min()
 }
 
+fn finish_after_emitted_token(completion_tokens: u32, max_tokens: usize) -> Option<FinishReason> {
+    if completion_tokens as usize >= max_tokens {
+        Some(FinishReason::Length)
+    } else {
+        None
+    }
+}
+
 /// Drain the full event stream and return the concatenated text plus the
 /// terminating event. Used by non-streaming responses.
 ///
@@ -611,7 +703,7 @@ pub type Session = InferenceSession;
 
 #[cfg(test)]
 mod tests {
-    use super::incremental_delta;
+    use super::{finish_after_emitted_token, incremental_delta, FinishReason};
 
     #[test]
     fn prefix_case_returns_suffix() {
@@ -655,5 +747,14 @@ mod tests {
         let prev = "foo";
         let now = "bar";
         assert_eq!(incremental_delta(prev, now), "bar");
+    }
+
+    #[test]
+    fn final_budgeted_token_finishes_before_next_decode_step() {
+        assert!(matches!(
+            finish_after_emitted_token(1, 1),
+            Some(FinishReason::Length)
+        ));
+        assert!(finish_after_emitted_token(1, 2).is_none());
     }
 }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -10,6 +10,7 @@ pub(crate) mod bakes;
 pub(crate) mod builders;
 pub mod chat_template;
 pub mod decode_engine;
+pub mod dflash;
 pub mod gemma4_engine;
 pub mod gemma4_int4_engine;
 pub mod generate;

--- a/crates/runtime/src/session.rs
+++ b/crates/runtime/src/session.rs
@@ -7,11 +7,13 @@
 use anyhow::{anyhow, Result};
 
 use crate::decode_engine::{DecodeEngine, DecodeEngineSnapshot};
+use crate::dflash::{DFlashGenerateOutput, DFlashSession};
 use crate::gemma4_engine::{Gemma4Engine, Gemma4EngineSnapshot};
 use crate::gemma4_int4_engine::{Gemma4Int4Engine, Gemma4Int4EngineSnapshot};
 
 pub enum InferenceSession {
     Qwen(DecodeEngine),
+    QwenDFlash(DFlashSession),
     Gemma4Bf16(Gemma4Engine),
     Gemma4Int4(Gemma4Int4Engine),
 }
@@ -63,6 +65,7 @@ impl InferenceSession {
     pub fn reset(&mut self) -> Result<()> {
         match self {
             Self::Qwen(e) => e.reset(),
+            Self::QwenDFlash(e) => e.reset(),
             Self::Gemma4Bf16(e) => e.reset(),
             Self::Gemma4Int4(e) => e.reset(),
         }
@@ -73,6 +76,9 @@ impl InferenceSession {
     pub fn prefill(&mut self, prompt_ids: &[u32]) -> Result<Vec<f32>> {
         match self {
             Self::Qwen(e) => e.prefill_native(prompt_ids),
+            Self::QwenDFlash(_) => Err(anyhow!(
+                "plain prefill is not exposed for DFlash sessions; use DFlash generation"
+            )),
             Self::Gemma4Bf16(e) => e.prefill(prompt_ids),
             Self::Gemma4Int4(e) => e.prefill(prompt_ids),
         }
@@ -83,6 +89,9 @@ impl InferenceSession {
     pub fn decode_step(&mut self, token_id: u32, pos: usize) -> Result<Vec<f32>> {
         match self {
             Self::Qwen(e) => e.decode_step(token_id, pos),
+            Self::QwenDFlash(_) => Err(anyhow!(
+                "plain decode_step is not exposed for DFlash sessions; use DFlash generation"
+            )),
             Self::Gemma4Bf16(e) => e.decode_step(token_id, pos),
             Self::Gemma4Int4(e) => e.decode_step(token_id, pos),
         }
@@ -96,6 +105,9 @@ impl InferenceSession {
     pub fn decode_step_replay(&mut self, token_history: &[u32]) -> Result<Vec<f32>> {
         match self {
             Self::Qwen(e) => e.decode_step_replay(token_history),
+            Self::QwenDFlash(_) => Err(anyhow!(
+                "replay-prefill decode is not implemented for DFlash sessions"
+            )),
             Self::Gemma4Bf16(_) | Self::Gemma4Int4(_) => Err(anyhow!(
                 "replay-prefill decode is only implemented for the Qwen3.5 engine"
             )),
@@ -105,6 +117,9 @@ impl InferenceSession {
     pub fn snapshot_prefix(&self, logits: Vec<f32>) -> Result<SessionSnapshot> {
         match self {
             Self::Qwen(e) => Ok(SessionSnapshot::Qwen(e.snapshot_prefix(logits)?)),
+            Self::QwenDFlash(_) => Err(anyhow!(
+                "prefix cache snapshots are disabled for DFlash sessions"
+            )),
             Self::Gemma4Bf16(e) => Ok(SessionSnapshot::Gemma4Bf16(e.snapshot_prefix(logits)?)),
             Self::Gemma4Int4(e) => Ok(SessionSnapshot::Gemma4Int4(e.snapshot_prefix(logits)?)),
         }
@@ -113,6 +128,7 @@ impl InferenceSession {
     pub fn prefix_snapshot_bytes(&self, logits_len: usize) -> usize {
         match self {
             Self::Qwen(e) => e.prefix_snapshot_bytes(logits_len),
+            Self::QwenDFlash(_) => usize::MAX,
             Self::Gemma4Bf16(e) => e.prefix_snapshot_bytes(logits_len),
             Self::Gemma4Int4(e) => e.prefix_snapshot_bytes(logits_len),
         }
@@ -121,6 +137,9 @@ impl InferenceSession {
     pub fn restore_prefix(&mut self, snapshot: SessionSnapshot) -> Result<Vec<f32>> {
         match (self, snapshot) {
             (Self::Qwen(e), SessionSnapshot::Qwen(s)) => e.restore_prefix_owned(s),
+            (Self::QwenDFlash(_), _) => Err(anyhow!(
+                "prefix cache restore is disabled for DFlash sessions"
+            )),
             (Self::Gemma4Bf16(e), SessionSnapshot::Gemma4Bf16(s)) => e.restore_prefix(&s),
             (Self::Gemma4Int4(e), SessionSnapshot::Gemma4Int4(s)) => e.restore_prefix(&s),
             _ => Err(anyhow!(
@@ -132,9 +151,28 @@ impl InferenceSession {
     pub fn load_disk_prefix(&self, bytes: &[u8]) -> Result<SessionSnapshot> {
         match self {
             Self::Qwen(e) => Ok(SessionSnapshot::Qwen(e.load_prefix_snapshot_bytes(bytes)?)),
+            Self::QwenDFlash(_) => Err(anyhow!(
+                "disk prefix snapshots are disabled for DFlash sessions"
+            )),
             Self::Gemma4Bf16(_) | Self::Gemma4Int4(_) => Err(anyhow!(
                 "disk prefix snapshots are currently implemented for Qwen only"
             )),
+        }
+    }
+
+    pub fn is_dflash(&self) -> bool {
+        matches!(self, Self::QwenDFlash(_))
+    }
+
+    pub fn generate_dflash_greedy(
+        &mut self,
+        prompt_ids: &[u32],
+        max_tokens: usize,
+        eos_ids: &[u32],
+    ) -> Result<DFlashGenerateOutput> {
+        match self {
+            Self::QwenDFlash(session) => session.generate_greedy(prompt_ids, max_tokens, eos_ids),
+            _ => Err(anyhow!("loaded session is not a DFlash session")),
         }
     }
 }

--- a/crates/runtime/src/state.rs
+++ b/crates/runtime/src/state.rs
@@ -75,6 +75,10 @@ pub struct LoaderConfig {
     pub q4km_gptq: bool,
     pub fp8_runtime: bool,
     pub kv_fp8: bool,
+    pub dflash: bool,
+    pub dflash_draft_dir: Option<PathBuf>,
+    pub dflash_block: Option<usize>,
+    pub dflash_tap_layers: Option<String>,
     pub api_key: Option<String>,
     pub cors_allow_origin: Option<String>,
     pub response_store_max_entries: usize,
@@ -250,6 +254,28 @@ fn validate_runtime_policy(
     backend: Backend,
 ) -> Result<()> {
     let q4km_like = cfg.q4km || cfg.q4km_gptq;
+    if cfg.dflash {
+        if !matches!(
+            variant,
+            ModelVariant::Qwen3_5_9B | ModelVariant::Qwen3_6_27B
+        ) {
+            bail!("--dflash is supported for --model qwen3.5-9b and qwen3.6-27b (got {variant})");
+        }
+        if !(cfg.int4 || q4km_like) {
+            bail!("--dflash requires a low-bit target bake (--int4, --q4km, or --q4km-gptq)");
+        }
+        if cfg.dflash_draft_dir.is_none() {
+            bail!("--dflash requires --dflash-draft-dir");
+        }
+        if cfg.kv_fp8 {
+            bail!("--dflash does not support --kv-fp8");
+        }
+        if let Some(block) = cfg.dflash_block {
+            if block == 0 {
+                bail!("--dflash-block must be greater than 0");
+            }
+        }
+    }
     if q4km_like
         && !matches!(
             variant.family(),
@@ -258,8 +284,17 @@ fn validate_runtime_policy(
     {
         bail!("--q4km/--q4km-gptq are currently supported only for Qwen models");
     }
-    if q4km_like && backend != Backend::Cuda {
-        bail!("--q4km/--q4km-gptq are currently supported only on CUDA");
+    if q4km_like
+        && !(backend == Backend::Cuda
+            || (backend == Backend::Hip
+                && matches!(
+                    variant.family(),
+                    ModelFamily::Qwen35 | ModelFamily::Qwen36Moe
+                )))
+    {
+        bail!(
+            "--q4km/--q4km-gptq are currently supported only on CUDA Qwen paths and HIP Qwen3.5/3.6 paths"
+        );
     }
 
     if backend == Backend::Metal {
@@ -310,6 +345,10 @@ mod tests {
             q4km_gptq: false,
             fp8_runtime: false,
             kv_fp8: false,
+            dflash: false,
+            dflash_draft_dir: None,
+            dflash_block: None,
+            dflash_tap_layers: None,
             api_key: None,
             cors_allow_origin: None,
             response_store_max_entries: 1024,
@@ -363,12 +402,79 @@ mod tests {
     }
 
     #[test]
-    fn policy_rejects_q4km_outside_cuda() {
+    fn policy_allows_q4km_for_qwen35_family_on_hip() {
+        let mut c = cfg();
+        c.q4km_gptq = true;
+        validate_runtime_policy(&c, &ModelVariant::Qwen3_5_0_8B, Backend::Hip).unwrap();
+
+        let mut c = cfg();
+        c.q4km_gptq = true;
+        validate_runtime_policy(&c, &ModelVariant::Qwen3_6_27B, Backend::Hip).unwrap();
+    }
+
+    #[test]
+    fn policy_rejects_q4km_on_unsupported_backend_family_pairs() {
         let mut c = cfg();
         c.q4km_gptq = true;
         err_contains(
+            validate_runtime_policy(&c, &ModelVariant::Qwen3_30B_A3B, Backend::Hip),
+            "CUDA Qwen paths and HIP Qwen3.5/3.6 paths",
+        );
+    }
+
+    #[test]
+    fn policy_rejects_dflash_without_lowbit_target_and_draft_dir() {
+        let mut c = cfg();
+        c.dflash = true;
+        err_contains(
+            validate_runtime_policy(&c, &ModelVariant::Qwen3_6_27B, Backend::Hip),
+            "requires a low-bit target bake",
+        );
+
+        let mut c = cfg();
+        c.dflash = true;
+        c.q4km = true;
+        err_contains(
+            validate_runtime_policy(&c, &ModelVariant::Qwen3_6_27B, Backend::Hip),
+            "requires --dflash-draft-dir",
+        );
+    }
+
+    #[test]
+    fn policy_allows_dflash_for_supported_dense_qwen_lowbit_targets() {
+        let mut c = cfg();
+        c.dflash = true;
+        c.q4km = true;
+        c.dflash_draft_dir = Some(PathBuf::from("/tmp/dflash"));
+        validate_flag_exclusions(&c).unwrap();
+        validate_runtime_policy(&c, &ModelVariant::Qwen3_6_27B, Backend::Hip).unwrap();
+
+        let mut c = cfg();
+        c.dflash = true;
+        c.int4 = true;
+        c.dflash_draft_dir = Some(PathBuf::from("/tmp/dflash"));
+        validate_runtime_policy(&c, &ModelVariant::Qwen3_5_9B, Backend::Cuda).unwrap();
+    }
+
+    #[test]
+    fn policy_rejects_dflash_for_non_dflash_targets_and_kv_fp8() {
+        let mut c = cfg();
+        c.dflash = true;
+        c.q4km = true;
+        c.dflash_draft_dir = Some(PathBuf::from("/tmp/dflash"));
+        err_contains(
             validate_runtime_policy(&c, &ModelVariant::Qwen3_5_0_8B, Backend::Hip),
-            "supported only on CUDA",
+            "supported for --model qwen3.5-9b and qwen3.6-27b",
+        );
+
+        let mut c = cfg();
+        c.dflash = true;
+        c.q4km = true;
+        c.kv_fp8 = true;
+        c.dflash_draft_dir = Some(PathBuf::from("/tmp/dflash"));
+        err_contains(
+            validate_runtime_policy(&c, &ModelVariant::Qwen3_6_27B, Backend::Hip),
+            "does not support --kv-fp8",
         );
     }
 

--- a/crates/runtime/tests/dflash_options.rs
+++ b/crates/runtime/tests/dflash_options.rs
@@ -1,0 +1,56 @@
+use std::path::PathBuf;
+
+use supersonic_runtime::dflash::{parse_tap_layers, DFlashOptions};
+use supersonic_runtime::registry::ModelVariant;
+
+#[test]
+fn parses_comma_separated_tap_layers() {
+    assert_eq!(parse_tap_layers("1, 8,15", 32).unwrap(), vec![1, 8, 15]);
+    assert!(parse_tap_layers("", 32).is_err());
+    assert!(parse_tap_layers("1,32", 32).is_err());
+}
+
+#[test]
+fn dflash_options_pick_model_appropriate_default_block_size() {
+    let options = DFlashOptions {
+        draft_dir: PathBuf::from("/tmp/dflash"),
+        block: None,
+        tap_layers: None,
+    };
+
+    assert_eq!(
+        options
+            .effective_block_size(&ModelVariant::Qwen3_6_27B, 16)
+            .unwrap(),
+        16
+    );
+    assert_eq!(
+        options
+            .effective_block_size(&ModelVariant::Qwen3_5_9B, 16)
+            .unwrap(),
+        3
+    );
+}
+
+#[test]
+fn dflash_options_validate_block_override_against_draft_block() {
+    let options = DFlashOptions {
+        draft_dir: PathBuf::from("/tmp/dflash"),
+        block: Some(8),
+        tap_layers: None,
+    };
+    assert_eq!(
+        options
+            .effective_block_size(&ModelVariant::Qwen3_6_27B, 16)
+            .unwrap(),
+        8
+    );
+
+    let options = DFlashOptions {
+        block: Some(17),
+        ..options
+    };
+    assert!(options
+        .effective_block_size(&ModelVariant::Qwen3_6_27B, 16)
+        .is_err());
+}

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -58,6 +58,23 @@ struct Cli {
     #[arg(long)]
     kv_fp8: bool,
 
+    /// Enable DFlash speculative decoding for dense Qwen low-bit targets.
+    #[arg(long)]
+    dflash: bool,
+
+    /// HuggingFace-style DFlash draft model directory.
+    #[arg(long)]
+    dflash_draft_dir: Option<PathBuf>,
+
+    /// DFlash speculative block size. Defaults to the draft block size for
+    /// qwen3.6-27b and 3 for qwen3.5-9b.
+    #[arg(long)]
+    dflash_block: Option<usize>,
+
+    /// Comma-separated target layer indices used as DFlash draft taps.
+    #[arg(long)]
+    dflash_tap_layers: Option<String>,
+
     /// Listen address.
     #[arg(long, default_value = "127.0.0.1")]
     host: String,
@@ -165,6 +182,10 @@ fn main() -> Result<()> {
         q4km_gptq: cli.q4km_gptq,
         fp8_runtime: cli.fp8_runtime,
         kv_fp8: cli.kv_fp8,
+        dflash: cli.dflash,
+        dflash_draft_dir: cli.dflash_draft_dir,
+        dflash_block: cli.dflash_block,
+        dflash_tap_layers: cli.dflash_tap_layers,
         api_key: cli.api_key,
         cors_allow_origin: cli.cors_allow_origin,
         response_store_max_entries: cli.response_store_max_entries,

--- a/crates/server/tests/chat_integration.rs
+++ b/crates/server/tests/chat_integration.rs
@@ -44,6 +44,7 @@ fn load_test_config() -> Option<LoaderConfig> {
     let q4km_gptq = std::env::var("SUPERSONIC_TEST_Q4KM_GPTQ").is_ok();
     let fp8 = std::env::var("SUPERSONIC_TEST_FP8_RUNTIME").is_ok();
     let kv_fp8 = std::env::var("SUPERSONIC_TEST_KV_FP8").is_ok();
+    let dflash = std::env::var("SUPERSONIC_TEST_DFLASH").is_ok();
     let max_ctx = std::env::var("SUPERSONIC_TEST_MAX_CONTEXT")
         .ok()
         .and_then(|s| s.parse().ok())
@@ -59,6 +60,14 @@ fn load_test_config() -> Option<LoaderConfig> {
         q4km_gptq,
         fp8_runtime: fp8,
         kv_fp8,
+        dflash,
+        dflash_draft_dir: std::env::var("SUPERSONIC_TEST_DFLASH_DRAFT_DIR")
+            .ok()
+            .map(PathBuf::from),
+        dflash_block: std::env::var("SUPERSONIC_TEST_DFLASH_BLOCK")
+            .ok()
+            .and_then(|s| s.parse().ok()),
+        dflash_tap_layers: std::env::var("SUPERSONIC_TEST_DFLASH_TAP_LAYERS").ok(),
         api_key: None,
         cors_allow_origin: None,
         response_store_max_entries: 1024,

--- a/docs/dflash.md
+++ b/docs/dflash.md
@@ -306,7 +306,58 @@ natural home of M3 (speculative loop), not M2. The forward function signature
 should accept `(ctx, noise, position_ids, past_kv)` so M3 can drive it without
 refactoring.
 
-## 9. References
+## 9. Native server and OpenCode mode
+
+The V0 production path is now a native `supersonic-serve` session rather than a
+Python OpenAI shim around repeated CLI calls. The server creates one
+GPU-resident `DFlashSession`, owns the target `DecodeEngine`, draft weights,
+draft scratch/state, rotary tables, and tap-history buffer, then services
+OpenAI-compatible Chat Completions through the normal server queue.
+
+The server path intentionally has a narrower surface than plain generation:
+
+- model support: `qwen3.5-9b` and `qwen3.6-27b`;
+- target weights: low-bit only (`--int4`, `--q4km`, or `--q4km-gptq`);
+- required draft: `--dflash-draft-dir <hf-style-dir>`;
+- rejected features: `--kv-fp8`, prefix-cache snapshot/restore, and the plain
+  incremental prefill/decode session APIs;
+- v0 streaming behavior: generation is computed by the DFlash loop and then
+  emitted through the existing Chat Completions stream shape.
+
+The Qwen3.6 27B OpenCode smoke currently uses:
+
+```bash
+SUPERSONIC_BACKENDS=hip HIP_ARCH=gfx1100,gfx1201 \
+target/release/supersonic-serve \
+  --model qwen3.6-27b \
+  --model-dir /mnt/data/tmp/supersonic-qwen36-27b-lucebox \
+  --backend hip \
+  --device 1 \
+  --max-context 4096 \
+  --q4km \
+  --dflash \
+  --dflash-draft-dir /mnt/data/tmp/qwen36-27b-dflash-q8-bf16 \
+  --host 127.0.0.1 \
+  --port 8013 \
+  --api-key local \
+  --no-download \
+  --prefix-cache-disable
+```
+
+Observed local profile on R9700 / `gfx1201`:
+
+| lane | prompt size | average wall time | note |
+|---|---:|---:|---|
+| direct Chat Completions | ~19 input tokens | ~0.52 s | tiny smoke prompt |
+| direct Chat Completions | ~236 input tokens | ~4.28 s | isolates prefill cost |
+| OpenCode `run` | ~225 input tokens | ~5.81 s | cold OpenCode process |
+| OpenCode `run --attach` | ~225 input tokens | ~4.74 s | warm `opencode serve` |
+
+That makes the next performance target clear: OpenCode wrapper overhead is
+secondary; DFlash/target prefill for 200-300 token prompts dominates first
+token latency.
+
+## 10. References
 
 - `/home/deano/models/qwen35-9b-dflash/dflash.py` (local canonical)
 - `/home/deano/models/qwen35-9b-dflash/config.json`

--- a/docs/server.md
+++ b/docs/server.md
@@ -50,6 +50,83 @@ Optional deployment flags:
   - `--prefix-cache-disk-ttl-secs N` controls `24h` metadata retention. The
     default is `86400`.
 
+### Native DFlash Server Mode
+
+`supersonic-serve` can host the native DFlash speculative decoder directly.
+This is the preferred OpenCode path; it keeps the target and draft resident in
+one long-lived process and avoids the older Python CLI shim.
+
+Current constraints:
+
+- supported targets are `qwen3.5-9b` and `qwen3.6-27b`;
+- the target must be loaded from a low-bit bake (`--int4`, `--q4km`, or
+  `--q4km-gptq`);
+- `--dflash-draft-dir` must point at a HuggingFace-style DFlash draft
+  checkpoint directory;
+- `--kv-fp8` is rejected for DFlash server mode;
+- prefix caching should be disabled for this path until DFlash snapshot/restore
+  support is added to the cache.
+
+Example R9700 / `gfx1201` OpenCode server:
+
+```bash
+SUPERSONIC_BACKENDS=hip HIP_ARCH=gfx1100,gfx1201 \
+target/release/supersonic-serve \
+  --backend hip \
+  --device 1 \
+  --model qwen3.6-27b \
+  --model-dir /mnt/data/tmp/supersonic-qwen36-27b-lucebox \
+  --max-context 4096 \
+  --q4km \
+  --dflash \
+  --dflash-draft-dir /mnt/data/tmp/qwen36-27b-dflash-q8-bf16 \
+  --host 127.0.0.1 \
+  --port 8013 \
+  --api-key local \
+  --no-download \
+  --prefix-cache-disable
+```
+
+Optional DFlash tuning flags:
+
+- `--dflash-block N` overrides the checkpoint block size. The override must
+  divide the draft block size.
+- `--dflash-tap-layers 1,16,31,46,61` overrides target tap layers. By default
+  the runtime uses model-appropriate taps and the draft checkpoint metadata.
+
+For OpenCode, configure an OpenAI-compatible provider with:
+
+```json
+{
+  "provider": {
+    "supersonic-dflash": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "SuperSonic native DFlash server",
+      "options": {
+        "baseURL": "http://127.0.0.1:8013/v1",
+        "apiKey": "local"
+      },
+      "models": {
+        "qwen3.6-27b": {
+          "name": "Qwen3.6 27B via SuperSonic DFlash Q4KM",
+          "limit": {
+            "context": 4096,
+            "output": 512
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+The initial OpenCode smoke profile is functional but prefill-bound: a tiny
+direct chat request returns in about 0.52 s, while a minimal OpenCode agent
+prompt of roughly 225 input tokens spends about 4.3 s in model prefill. Running
+OpenCode attached to a warm `opencode serve` process trims roughly one second
+of wrapper overhead, but the main optimization target is still DFlash/target
+prefill for agent-sized prompts.
+
 ## Endpoints
 
 - `GET /`, `GET /v1`, `GET /health`, `GET /v1/health`, `GET /ready`,


### PR DESCRIPTION
## Summary

- Add a native `DFlashSession` path inside `supersonic-serve` so OpenCode can hit a long-lived OpenAI-compatible server instead of the older Python/CLI shim.
- Wire DFlash loader policy, CLI flags, runtime session dispatch, chat generation, and tests for model/block/tap validation.
- Document the native OpenCode setup, current constraints, and measured first-token/prefill profile for the R9700 `qwen3.6-27b` lane.

## Impact

This gives the local OpenCode workflow a real server process with target and draft weights resident on GPU. V0 is intentionally narrow: `qwen3.5-9b`/`qwen3.6-27b`, low-bit target bakes, required DFlash draft dir, no KV-FP8, and prefix cache disabled for DFlash sessions.

Companion geo-evo PR update: https://github.com/GeometricAGI/geo-evo/pull/234#issuecomment-4818590157

## Validation

- `cargo test -p supersonic-runtime --test dflash_options`
- `cargo test -p supersonic-runtime dflash`
- `SUPERSONIC_BACKENDS=hip HIP_ARCH=gfx1100,gfx1201 cargo build --release --bin supersonic-serve`
- Live smoke on `http://127.0.0.1:8013`: health OK, direct chat OK, OpenCode profile OK

Note: the Rust checks still emit the existing `kernel-ffi` warning noise from CUDA/HIP conditional code.