### PR TITLE
[codex] Move Qwen3.6 replay positioning helper into runtime

### DIFF
--- a/crates/runner/src/qwen36_moe/decode_loop.rs
+++ b/crates/runner/src/qwen36_moe/decode_loop.rs
@@ -3,6 +3,7 @@ use std::io::Write as _;
 use crate::qwen36_moe_cli::output::print_decoded_token;
 use crate::qwen36_moe_speculative::SpeculativeStepResult;
 use crate::qwen36_moe_types::PositionPair;
+use supersonic_runtime::qwen36_moe::decode_loop::speculative_replay_inputs as runtime_speculative_replay_inputs;
 
 pub struct Qwen36DecodeLoopState {
     pub generated_ids: Vec<u32>,
@@ -43,23 +44,12 @@ impl Qwen36DecodeLoopState {
         base: PositionPair,
         result: &SpeculativeStepResult,
     ) -> Vec<(PositionPair, u32)> {
-        // base = (rope, cache) of `first_token`. Subsequent
-        // accepted-draft tokens advance both timelines by 1 each, so
-        // step i lands at (rope+1+i, cache+1+i). In dense mode the
-        // pair stays a `dense(p)` shape; in SpecPrefill+MTP the rope
-        // and cache stay decoupled.
-        let mut replay = Vec::with_capacity(result.n_accepted + 1);
-        replay.push((base, first_token));
-        for (i, &tok) in result
-            .emitted_tokens
-            .iter()
-            .take(result.n_accepted)
-            .enumerate()
-        {
-            let off = 1 + i as i32;
-            replay.push((PositionPair::split(base.rope + off, base.cache + off), tok));
-        }
-        replay
+        runtime_speculative_replay_inputs(
+            first_token,
+            base,
+            &result.emitted_tokens,
+            result.n_accepted,
+        )
     }
 
     pub fn partial_accept_replay_inputs(

--- a/crates/runtime/src/qwen36_moe/decode_loop.rs
+++ b/crates/runtime/src/qwen36_moe/decode_loop.rs
@@ -1,0 +1,63 @@
+use crate::qwen36_moe::types::PositionPair;
+
+/// Build replay inputs for speculative verification.
+///
+/// `base` is the position of `first_token`. Accepted draft tokens advance both
+/// the RoPE and cache timelines by one token while preserving split positions.
+pub fn speculative_replay_inputs(
+    first_token: u32,
+    base: PositionPair,
+    emitted_tokens: &[u32],
+    n_accepted: usize,
+) -> Vec<(PositionPair, u32)> {
+    let mut replay = Vec::with_capacity(n_accepted + 1);
+    replay.push((base, first_token));
+    for (i, &tok) in emitted_tokens.iter().take(n_accepted).enumerate() {
+        let off = 1 + i as i32;
+        replay.push((PositionPair::split(base.rope + off, base.cache + off), tok));
+    }
+    replay
+}
+
+pub fn partial_accept_replay_inputs(
+    first_token: u32,
+    base: PositionPair,
+    emitted_tokens: &[u32],
+    n_accepted: usize,
+    draft_count: usize,
+) -> Option<Vec<(PositionPair, u32)>> {
+    (n_accepted < draft_count)
+        .then(|| speculative_replay_inputs(first_token, base, emitted_tokens, n_accepted))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn speculative_replay_inputs_preserve_split_timeline() {
+        let replay = speculative_replay_inputs(42, PositionPair::split(11, 3), &[7, 8, 9], 2);
+
+        assert_eq!(
+            replay,
+            vec![
+                (PositionPair::split(11, 3), 42),
+                (PositionPair::split(12, 4), 7),
+                (PositionPair::split(13, 5), 8),
+            ]
+        );
+    }
+
+    #[test]
+    fn partial_accept_replay_inputs_only_for_partial_acceptance() {
+        assert!(partial_accept_replay_inputs(42, PositionPair::dense(5), &[7, 8], 2, 2).is_none());
+
+        assert_eq!(
+            partial_accept_replay_inputs(42, PositionPair::dense(5), &[7, 8], 1, 2),
+            Some(vec![
+                (PositionPair::dense(5), 42),
+                (PositionPair::dense(6), 7),
+            ])
+        );
+    }
+}

--- a/crates/runtime/src/qwen36_moe/mod.rs
+++ b/crates/runtime/src/qwen36_moe/mod.rs
@@ -8,4 +8,5 @@ pub mod config {
     pub use crate::qwen36_moe_config::*;
 }
 
+pub mod decode_loop;
 pub mod types;


### PR DESCRIPTION
## Summary

- Moves the pure Qwen3.6 speculative replay-position builder into `supersonic-runtime` under `qwen36_moe::decode_loop`.
- Keeps the runner decode-loop compatibility method delegating to the runtime helper.
- Adds runtime unit coverage for split RoPE/cache timeline preservation and partial-accept replay gating.

## Test Plan

- [x] `cargo test -p supersonic-runtime qwen36_moe::decode_loop --lib`
- [x] `cargo test -p runner qwen36_moe --lib`
- [x] `cargo check -p supersonic-runtime -p runner -p server`
- [x] `git diff --check`

Note: checks still emit the repository's existing `kernel-ffi` and `machine-profile` warnings.