### PR TITLE
[codex] Harden native FLM loading

### DIFF
--- a/crates/model-store/src/store.rs
+++ b/crates/model-store/src/store.rs
@@ -998,6 +998,16 @@ fn add_stage3_int4_aliases(
                 scale.tensor_name
             ))
         })?;
+        let storage_abi = runtime
+            .storage_abis()
+            .iter()
+            .find(|abi| abi.storage_abi_id == packed.storage_abi_id)
+            .ok_or_else(|| {
+                Error::Other(format!(
+                    "FLM Stage 3 INT4 tensor {} references missing storage ABI {}",
+                    logical.name, packed.storage_abi_id
+                ))
+            })?;
         if packed.storage_dtype == FLM_DTYPE_INT32 {
             shape_binding.ok_or_else(|| {
                 Error::Other(format!(
@@ -1018,16 +1028,6 @@ fn add_stage3_int4_aliases(
                     logical.name, scale.storage_dtype
                 )));
             }
-            let storage_abi = runtime
-                .storage_abis()
-                .iter()
-                .find(|abi| abi.storage_abi_id == packed.storage_abi_id)
-                .ok_or_else(|| {
-                    Error::Other(format!(
-                        "FLM Stage 3 INT4 tensor {} references missing storage ABI {}",
-                        logical.name, packed.storage_abi_id
-                    ))
-                })?;
             if storage_abi.codec_semantic_id != crate::flm::CODEC_SYM_INT4_G128_BF16
                 || storage_abi.bits != 4
             {
@@ -1071,6 +1071,24 @@ fn add_stage3_int4_aliases(
                     group_size,
                 });
             continue;
+        }
+        if packed.storage_dtype != FLM_DTYPE_UINT8 {
+            return Err(Error::Other(format!(
+                "FLM Stage 3 native INT4 tensor {} packed binding dtype {} is unsupported",
+                logical.name, packed.storage_dtype
+            )));
+        }
+        if storage_abi.codec_semantic_id != crate::flm::CODEC_SUPERSONIC_NATIVE_INT4_G128_BF16
+            || storage_abi.bits != 4
+            || storage_abi.group_size != 128
+        {
+            return Err(Error::Other(format!(
+                "FLM Stage 3 native INT4 tensor {} uses unsupported native INT4 ABI codec={} bits={} group_size={}",
+                logical.name,
+                storage_abi.codec_semantic_id,
+                storage_abi.bits,
+                storage_abi.group_size
+            )));
         }
         let packed_view = TensorUploadView {
             dtype: flm_dtype_name(packed_step.target_dtype)?.to_string(),
@@ -3530,25 +3548,34 @@ mod tests {
     }
 
     fn corrupt_first_manifest_shape(data: &mut [u8], value: u32) {
+        let manifest_offset = runtime_section_offset(data, 8);
+        let shape_offset = manifest_offset + 12 + 16;
+        put_u32(data, shape_offset, value);
+    }
+
+    fn runtime_section_offset(data: &[u8], wanted_section_id: u32) -> usize {
         let runtime_offset =
             read_u64(data, 168, "test FLM runtime offset").expect("runtime offset") as usize;
         let runtime = &data[runtime_offset..];
         let section_count =
             read_u16(runtime, 10, "test FLM section count").expect("section count") as usize;
-        let mut manifest_offset = None;
         for idx in 0..section_count {
             let record = 16 + idx * 12;
             let section_id = read_u32(runtime, record, "test FLM section id").expect("section id");
-            if section_id == 8 {
-                manifest_offset = Some(
-                    read_u32(runtime, record + 4, "test FLM manifest offset")
-                        .expect("manifest offset") as usize,
-                );
-                break;
+            if section_id == wanted_section_id {
+                let section_offset = read_u32(runtime, record + 4, "test FLM section offset")
+                    .expect("section offset") as usize;
+                return runtime_offset + section_offset;
             }
         }
-        let shape_offset = runtime_offset + manifest_offset.expect("manifest section") + 12 + 16;
-        put_u32(data, shape_offset, value);
+        panic!("missing runtime section {wanted_section_id}");
+    }
+
+    fn put_first_storage_abi_codec_semantic(data: &mut [u8], codec_semantic_id: u16) {
+        let storage_abi_offset = runtime_section_offset(data, 9);
+        let row_offset = storage_abi_offset + 12;
+        let codec_semantic_offset = row_offset + 4;
+        put_u16(data, codec_semantic_offset, codec_semantic_id);
     }
 
     fn write_temp_flm(data: &[u8]) -> tempfile::NamedTempFile {
@@ -3842,6 +3869,29 @@ mod tests {
         assert_eq!(
             store.raw_bytes(&zero_name).expect("native INT4 zero bytes"),
             test_bf16_bytes([8.0; 4]).as_slice()
+        );
+    }
+
+    #[test]
+    fn open_flm_rejects_native_int4_stage3_binding_with_non_native_abi() {
+        let mut data = build_test_flm_with_stage3_native_int4_bindings();
+        put_first_storage_abi_codec_semantic(&mut data, crate::flm::CODEC_SYM_INT4_G128_BF16);
+        let file = write_temp_flm(&data);
+
+        let err = match BakedStore::open_flm_with_options(
+            file.path(),
+            FlmLoadOptions {
+                flm_int4_logical_aliases: true,
+                verify_block_hashes: false,
+            },
+        ) {
+            Ok(_) => panic!("native INT4 Stage 3 binding with non-native ABI should fail"),
+            Err(err) => err,
+        };
+
+        assert!(
+            err.to_string().contains("unsupported native INT4 ABI"),
+            "unexpected error: {err}"
         );
     }
 
@@ -5089,6 +5139,82 @@ mod tests {
         assert!(store.contains(
             "model.language_model.layers.0.mlp.experts.0.gate_proj.weight_nvfp4_input_scale"
         ));
+    }
+
+    #[test]
+    fn flm_qwen36_35b_native_int4_loadable() {
+        let Ok(flm_path_str) = std::env::var("SUPERSONIC_QWEN36_35B_NATIVE_INT4_FLM") else {
+            eprintln!(
+                "skip: SUPERSONIC_QWEN36_35B_NATIVE_INT4_FLM not set. Point it at a \
+                 SuperSonic-native INT4 Qwen3.6-35B-A3B FLM to validate full MoE \
+                 native aliases."
+            );
+            return;
+        };
+        let store = BakedStore::open_flm_with_options(
+            Path::new(&flm_path_str),
+            FlmLoadOptions {
+                flm_int4_logical_aliases: true,
+                verify_block_hashes: true,
+            },
+        )
+        .expect("open qwen3.6-35b native INT4 FLM");
+
+        let runtime = store.flm_runtime().expect("runtime directory");
+        assert!(runtime.qwen36_config().is_none());
+        let moe = runtime.qwen36_moe_config().expect("MoE runtime config");
+        assert_eq!(moe.hidden_size, 2048);
+        assert_eq!(moe.num_hidden_layers, 40);
+        assert_eq!(moe.num_experts, 256);
+        assert_eq!(moe.num_experts_per_tok, 8);
+
+        let expert_name = "model.language_model.layers.0.mlp.experts.gate_up_proj";
+        let expert = store
+            .meta(expert_name)
+            .expect("native INT4 fused expert logical tensor");
+        assert_eq!(expert.layout, LayoutTag::Int4Quantized);
+        assert_eq!(expert.dtype, "u8");
+        assert_eq!(expert.shape, vec![256, 1024, 1024]);
+        assert_eq!(expert.byte_len, 268_435_456);
+        assert_eq!(
+            store
+                .upload_view(expert_name)
+                .expect("native INT4 fused expert upload view"),
+            &TensorUploadView {
+                dtype: "u8".to_string(),
+                shape: vec![256, 1024, 1024],
+            }
+        );
+
+        let expert_scale = store
+            .meta("model.language_model.layers.0.mlp.experts.gate_up_proj_int4_scale")
+            .expect("native INT4 fused expert scale");
+        assert_eq!(expert_scale.dtype, "bf16");
+        assert_eq!(expert_scale.shape, vec![256, 8, 16]);
+        let expert_zero = store
+            .meta("model.language_model.layers.0.mlp.experts.gate_up_proj_int4_zero")
+            .expect("native INT4 fused expert zero plane");
+        assert_eq!(expert_zero.dtype, "bf16");
+        assert_eq!(expert_zero.shape, vec![256, 8, 16]);
+
+        let qkv_name = "model.language_model.layers.0.linear_attn.in_proj_qkv.weight";
+        let qkv = store.meta(qkv_name).expect("native INT4 linear qkv tensor");
+        assert_eq!(qkv.layout, LayoutTag::Int4Quantized);
+        assert_eq!(qkv.dtype, "u8");
+        assert_eq!(qkv.shape, vec![8192, 1024]);
+        assert_eq!(qkv.byte_len, 8_388_608);
+
+        let embed = store
+            .meta("model.language_model.embed_tokens.weight")
+            .expect("embed_tokens missing");
+        assert_eq!(embed.dtype, "bf16");
+        assert_eq!(embed.shape, vec![248320, 2048]);
+        assert_eq!(embed.byte_len, 1_017_118_720);
+
+        eprintln!(
+            "[flm-validate] OK — {} tensors including 35B native INT4 aliases",
+            store.index.len()
+        );
     }
 
     #[test]

--- a/crates/runner/src/qwen36_moe/engine.rs
+++ b/crates/runner/src/qwen36_moe/engine.rs
@@ -566,8 +566,7 @@ fn decode_text(
         validate_qwen36_decode_weight_mode(flm.weight_mode, backend, &source_label)?;
         println!(
             "[qwen36-moe] loading weights from already-open FLM source at {} ({})",
-            source_label,
-            flm.weight_mode.display_name(),
+            source_label, flm.weight_mode_label,
         );
         (
             DecodeStore::Borrowed(&flm.source.store),

--- a/crates/runner/src/qwen36_moe/flm_source.rs
+++ b/crates/runner/src/qwen36_moe/flm_source.rs
@@ -19,36 +19,58 @@ pub(crate) struct Qwen36MoeFlmSource {
     pub(crate) config: qwen36_moe::config::Config,
     pub(crate) tokenizer: tokenizers::Tokenizer,
     pub(crate) weight_mode: Qwen36WeightMode,
+    pub(crate) weight_mode_label: &'static str,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Qwen36MoeFlmWeightSelection {
+    mode: Qwen36WeightMode,
+    label: &'static str,
 }
 
 #[cfg(test)]
 fn qwen36_moe_flm_weight_mode(profile: QuantProfile) -> Result<Qwen36WeightMode> {
-    qwen36_moe_flm_weight_mode_from_probe(profile, None)
+    Ok(qwen36_moe_flm_weight_selection_from_probe(profile, None)?.mode)
 }
 
-fn qwen36_moe_flm_weight_mode_for_store(
+fn qwen36_moe_flm_weight_selection_for_store(
     store: &BakedStore,
     profile: QuantProfile,
-) -> Result<Qwen36WeightMode> {
+) -> Result<Qwen36MoeFlmWeightSelection> {
     let probe = store
         .meta(QWEN36_MOE_WEIGHT_MODE_PROBE)
         .map(|meta| (&meta.layout, meta.dtype.as_str()));
-    qwen36_moe_flm_weight_mode_from_probe(profile, probe)
+    qwen36_moe_flm_weight_selection_from_probe(profile, probe)
 }
 
-fn qwen36_moe_flm_weight_mode_from_probe(
+fn qwen36_moe_flm_weight_selection_from_probe(
     profile: QuantProfile,
     probe: Option<(&LayoutTag, &str)>,
-) -> Result<Qwen36WeightMode> {
+) -> Result<Qwen36MoeFlmWeightSelection> {
     match profile {
         QuantProfile::Int4Gptq
         | QuantProfile::Int4Awq
         | QuantProfile::Int4Autoround
         | QuantProfile::Int4Hqq => {
             if matches!(probe, Some((LayoutTag::Raw, "bf16"))) {
-                Ok(Qwen36WeightMode::Bf16)
+                Ok(Qwen36MoeFlmWeightSelection {
+                    mode: Qwen36WeightMode::Bf16,
+                    label: "BF16",
+                })
+            } else if matches!(probe, Some((LayoutTag::Int4Quantized, "u8"))) {
+                Ok(Qwen36MoeFlmWeightSelection {
+                    mode: Qwen36WeightMode::Int4,
+                    label: "INT4 native FLM",
+                })
+            } else if probe.is_none() {
+                Ok(Qwen36MoeFlmWeightSelection {
+                    mode: Qwen36WeightMode::Int4,
+                    label: "INT4 native FLM",
+                })
             } else {
-                Ok(Qwen36WeightMode::Int4)
+                Err(anyhow!(
+                    "Qwen3.6 MoE FLM INT4 profile requires a native INT4 or BF16 fallback probe; got {probe:?}"
+                ))
             }
         }
         other => Err(anyhow!(
@@ -83,17 +105,15 @@ pub(crate) fn open_qwen36_moe_flm_source(cli: &Cli) -> Result<Option<Qwen36MoeFl
     let config = source.qwen_moe_config()?;
     eprintln!("[qwen36-moe] loading tokenizer from FLM assets");
     let tokenizer = source.qwen_tokenizer()?;
-    let weight_mode =
-        qwen36_moe_flm_weight_mode_for_store(&source.store, effective_quant_profile(cli)?)?;
-    eprintln!(
-        "[qwen36-moe] FLM weight mode: {}",
-        weight_mode.display_name()
-    );
+    let weight_selection =
+        qwen36_moe_flm_weight_selection_for_store(&source.store, effective_quant_profile(cli)?)?;
+    eprintln!("[qwen36-moe] FLM weight mode: {}", weight_selection.label);
     Ok(Some(Qwen36MoeFlmSource {
         source,
         config,
         tokenizer,
-        weight_mode,
+        weight_mode: weight_selection.mode,
+        weight_mode_label: weight_selection.label,
     }))
 }
 
@@ -113,24 +133,26 @@ mod tests {
 
     #[test]
     fn maps_ct_int4_bf16_fallback_probe_to_bf16_weight_mode() {
-        let mode = qwen36_moe_flm_weight_mode_from_probe(
+        let selection = qwen36_moe_flm_weight_selection_from_probe(
             QuantProfile::Int4Gptq,
             Some((&LayoutTag::Raw, "bf16")),
         )
         .expect("CT INT4 fallback is supported through BF16 load");
 
-        assert_eq!(mode, Qwen36WeightMode::Bf16);
+        assert_eq!(selection.mode, Qwen36WeightMode::Bf16);
+        assert_eq!(selection.label, "BF16");
     }
 
     #[test]
     fn keeps_native_int4_probe_on_int4_weight_mode() {
-        let mode = qwen36_moe_flm_weight_mode_from_probe(
+        let selection = qwen36_moe_flm_weight_selection_from_probe(
             QuantProfile::Int4Gptq,
-            Some((&LayoutTag::Raw, "u8")),
+            Some((&LayoutTag::Int4Quantized, "u8")),
         )
         .expect("native INT4 FLM payload is supported");
 
-        assert_eq!(mode, Qwen36WeightMode::Int4);
+        assert_eq!(selection.mode, Qwen36WeightMode::Int4);
+        assert_eq!(selection.label, "INT4 native FLM");
     }
 
     #[test]

--- a/crates/runner/tests/flm_moe_main_path.rs
+++ b/crates/runner/tests/flm_moe_main_path.rs
@@ -37,8 +37,13 @@ fn assert_moe_flm_main_path_contract(combined: &str) {
         "weights were not loaded from the already-open FLM source:\n{combined}"
     );
     assert!(
-        combined.contains("[qwen36-moe] FLM weight mode: "),
+        combined.contains("[qwen36-moe] FLM weight mode: INT4 native FLM"),
         "FLM weight mode was not reported:\n{combined}"
+    );
+    assert!(
+        combined.contains("loading weights from already-open FLM source")
+            && combined.contains("(INT4 native FLM)"),
+        "native FLM source load was not labeled as native INT4:\n{combined}"
     );
     assert!(
         combined.contains("BLAKE3 hash verification enabled"),
@@ -60,6 +65,7 @@ fn assert_moe_flm_main_path_contract(combined: &str) {
         "tokenizer.json",
         "safetensors",
         ".supersonic",
+        "INT4 GPTQ",
     ] {
         assert!(
             !combined.contains(forbidden),
@@ -75,8 +81,8 @@ fn moe_flm_main_path_output_contract_accepts_expected_logs() {
 [flm] opening model source at /tmp/qwen36-35b-a3b.flm (FLM logical INT4 aliases enabled) (BLAKE3 hash verification enabled)
 [qwen36-moe] loading config from FLM runtime descriptor
 [qwen36-moe] loading tokenizer from FLM assets
-[qwen36-moe] FLM weight mode: INT4 GPTQ
-[qwen36-moe] loading weights from already-open FLM source at /tmp/qwen36-35b-a3b.flm (INT4 GPTQ)
+[qwen36-moe] FLM weight mode: INT4 native FLM
+[qwen36-moe] loading weights from already-open FLM source at /tmp/qwen36-35b-a3b.flm (INT4 native FLM)
   Generated ids: [123]
 [result] prompt_tokens=1 generated_tokens=1 decode_ms=1 ms_per_step=1.0
 ";

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -106,6 +106,14 @@ geo-quant's no-HF profile first:
   --verify-payload-hashes
 ```
 
+The model-store loader can validate the same artifact's native aliases without
+running generation:
+
+```bash
+SUPERSONIC_QWEN36_35B_NATIVE_INT4_FLM=/mnt/data/runs/geo-quant/qwen36-35b-a3b-supersonic-native-int4.flm \
+  cargo test -q -p model-store flm_qwen36_35b_native_int4_loadable -- --nocapture
+```
+
 Then run the env-gated MoE runner smoke:
 
 ```bash


### PR DESCRIPTION
## Summary

- Reject native INT4 Stage 3 FLM bindings unless the storage ABI is the SuperSonic native INT4 codec with INT4 group-128 semantics.
- Add a real-artifact model-store check for the Qwen3.6 35B native INT4 FLM path.
- Keep the no-HF Qwen3.6 MoE runner path labeled as `INT4 native FLM` instead of `INT4 GPTQ`.
- Document the native INT4 FLM model-store validation command.

## Validation

- `rustfmt --check crates/runner/src/qwen36_moe/flm_source.rs crates/runner/src/qwen36_moe/engine.rs crates/runner/tests/flm_moe_main_path.rs crates/model-store/src/store.rs`
- `cargo test -p runner --bin supersonic qwen36_moe_cli::flm_source -- --nocapture` -> 4 passed
- `SUPERSONIC_QWEN36_35B_A3B_NO_HF_FLM=/mnt/data/tmp/flm-native-complete-path/qwen36-35b-a3b-supersonic-native-int4.flm cargo test -q -p runner --test flm_moe_main_path qwen36_moe_flm_model_dir_runs_without_hf_snapshot -- --nocapture` -> 1 passed
- `cargo test -p model-store open_flm_ -- --nocapture` -> 18 passed
- `SUPERSONIC_QWEN36_35B_NATIVE_INT4_FLM=/mnt/data/tmp/flm-native-complete-path/qwen36-35b-a3b-supersonic-native-int4.flm cargo test -q -p model-store flm_qwen36_35b_native_int4_loadable -- --nocapture` -> 1 passed, 1704 tensors
- `git diff --check`

## Notes

Companion geo-quant PR: https://github.com/GeometricAGI/geo-quant/pull/33

Workspace-wide `cargo fmt --check` is still not a useful gate for this branch because an unrelated `crates/runner/src/bin/int4_test.rs` formatting issue exists outside this change set.