### PR TITLE
[codex] make FLM weight mode file-driven

### DIFF
--- a/crates/gpu-hal/build.rs
+++ b/crates/gpu-hal/build.rs
@@ -81,13 +81,65 @@ fn has_libcudart(dir: &Path) -> bool {
         })
 }
 
+fn detect_hipfile_root() -> Option<PathBuf> {
+    for var in ["HIPFILE_ROOT", "ROCM_PATH", "ROCM_HOME"] {
+        if let Ok(value) = env::var(var) {
+            let path = PathBuf::from(value);
+            if path.join("include/hipfile.h").exists() && has_libhipfile(&path.join("lib")) {
+                return Some(path);
+            }
+            if path.join("include/hipfile.h").exists() && has_libhipfile(&path.join("lib64")) {
+                return Some(path);
+            }
+        }
+    }
+
+    [
+        PathBuf::from("/opt/rocm"),
+        PathBuf::from("/usr"),
+        PathBuf::from("/usr/local"),
+    ]
+    .into_iter()
+    .find(|path| {
+        path.join("include/hipfile.h").exists()
+            && (has_libhipfile(&path.join("lib")) || has_libhipfile(&path.join("lib64")))
+    })
+}
+
+fn detect_hipfile_lib_dir(root: &Path) -> Option<PathBuf> {
+    [root.join("lib"), root.join("lib64")]
+        .into_iter()
+        .find(|path| has_libhipfile(path))
+}
+
+fn has_libhipfile(dir: &Path) -> bool {
+    if dir.join("libhipfile.so").exists() {
+        return true;
+    }
+    fs::read_dir(dir)
+        .ok()
+        .into_iter()
+        .flat_map(|entries| entries.filter_map(Result::ok))
+        .any(|entry| {
+            entry
+                .file_name()
+                .to_string_lossy()
+                .starts_with("libhipfile.so.")
+        })
+}
+
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=src/metal_bridge.mm");
+    println!("cargo:rerun-if-changed=src/hipfile_bridge.cc");
     println!("cargo:rerun-if-env-changed=SUPERSONIC_BACKENDS");
     println!("cargo:rerun-if-env-changed=CUDA_HOME");
     println!("cargo:rerun-if-env-changed=CUDA_PATH");
+    println!("cargo:rerun-if-env-changed=HIPFILE_ROOT");
+    println!("cargo:rerun-if-env-changed=ROCM_PATH");
+    println!("cargo:rerun-if-env-changed=ROCM_HOME");
     println!("cargo:rustc-check-cfg=cfg(supersonic_backend_hip)");
+    println!("cargo:rustc-check-cfg=cfg(supersonic_backend_hipfile)");
     println!("cargo:rustc-check-cfg=cfg(supersonic_backend_cuda)");
     println!("cargo:rustc-check-cfg=cfg(supersonic_backend_metal)");
 
@@ -134,6 +186,20 @@ fn main() {
 
     if enable_hip {
         println!("cargo:rustc-cfg=supersonic_backend_hip");
+        if let Some(hipfile_root) = detect_hipfile_root() {
+            if let Some(hipfile_lib_dir) = detect_hipfile_lib_dir(&hipfile_root) {
+                let mut build = cc::Build::new();
+                build
+                    .cpp(true)
+                    .file("src/hipfile_bridge.cc")
+                    .include(hipfile_root.join("include"))
+                    .flag("-std=c++17");
+                build.compile("gpu_hal_hipfile");
+                println!("cargo:rustc-link-search=native={}", hipfile_lib_dir.display());
+                println!("cargo:rustc-link-lib=hipfile");
+                println!("cargo:rustc-cfg=supersonic_backend_hipfile");
+            }
+        }
     }
     if enable_cuda {
         if let Some(cuda_lib_dir) = detect_cuda_lib_dir() {

--- a/crates/gpu-hal/src/hip_sys.rs
+++ b/crates/gpu-hal/src/hip_sys.rs
@@ -65,6 +65,8 @@ unsafe extern "C" {
         host_ptr: *mut c_void,
         flags: c_uint,
     ) -> c_int;
+    pub(crate) fn hipHostRegister(ptr: *mut c_void, size: usize, flags: c_uint) -> c_int;
+    pub(crate) fn hipHostUnregister(ptr: *mut c_void) -> c_int;
     pub(crate) fn hipMemcpy(
         dst: *mut c_void,
         src: *const c_void,

--- a/crates/gpu-hal/src/hipfile_bridge.cc
+++ b/crates/gpu-hal/src/hipfile_bridge.cc
@@ -1,0 +1,124 @@
+#include <hipfile.h>
+#include <hip/hip_runtime_api.h>
+
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+#include <fcntl.h>
+#include <string>
+#include <unistd.h>
+
+#ifndef O_DIRECT
+#define O_DIRECT 00040000
+#endif
+
+namespace {
+
+void set_error(char *err_buf, size_t err_buf_len, const std::string &message) {
+    if (err_buf == nullptr || err_buf_len == 0) {
+        return;
+    }
+    std::snprintf(err_buf, err_buf_len, "%s", message.c_str());
+}
+
+std::string hipfile_error(const char *op, hipFileError_t err) {
+    std::string message(op);
+    message += " failed: ";
+    message += hipFileGetOpErrorString(err.err);
+    if (err.hip_drv_err != hipSuccess) {
+        message += " (hip error ";
+        message += std::to_string(static_cast<int>(err.hip_drv_err));
+        message += ")";
+    }
+    return message;
+}
+
+std::string hipfile_read_error(ssize_t result) {
+    std::string message("hipFileRead failed: ");
+    if (IS_HIPFILE_ERR(result)) {
+        message += HIPFILE_ERRSTR(result);
+    } else {
+        message += std::strerror(errno);
+    }
+    message += " (";
+    message += std::to_string(result);
+    message += ")";
+    return message;
+}
+
+} // namespace
+
+extern "C" int supersonic_hipfile_read_to_device(
+    int ordinal,
+    const char *path,
+    void *dst,
+    unsigned long long source_offset,
+    size_t len,
+    char *err_buf,
+    size_t err_buf_len) {
+    if (path == nullptr || dst == nullptr || len == 0) {
+        set_error(err_buf, err_buf_len, "invalid null pointer or zero length");
+        return 1;
+    }
+
+    hipError_t hip_status = hipSetDevice(ordinal);
+    if (hip_status != hipSuccess) {
+        set_error(
+            err_buf,
+            err_buf_len,
+            "hipSetDevice failed: " + std::to_string(static_cast<int>(hip_status)));
+        return 1;
+    }
+
+    int fd = open(path, O_RDONLY | O_DIRECT);
+    if (fd < 0) {
+        set_error(
+            err_buf,
+            err_buf_len,
+            std::string("open(O_DIRECT) failed for ") + path + ": " + std::strerror(errno));
+        return 1;
+    }
+
+    hipFileDescr_t desc{};
+    desc.type = hipFileHandleTypeOpaqueFD;
+    desc.handle.fd = fd;
+    desc.fs_ops = nullptr;
+
+    hipFileHandle_t handle = nullptr;
+    hipFileError_t status = hipFileHandleRegister(&handle, &desc);
+    if (status.err != hipFileSuccess) {
+        set_error(err_buf, err_buf_len, hipfile_error("hipFileHandleRegister", status));
+        close(fd);
+        return 1;
+    }
+
+    size_t copied = 0;
+    while (copied < len) {
+        ssize_t nread = hipFileRead(
+            handle,
+            dst,
+            len - copied,
+            static_cast<hoff_t>(source_offset + copied),
+            static_cast<hoff_t>(copied));
+        if (nread < 0) {
+            set_error(err_buf, err_buf_len, hipfile_read_error(nread));
+            hipFileHandleDeregister(handle);
+            close(fd);
+            return 1;
+        }
+        if (nread == 0) {
+            set_error(err_buf, err_buf_len, "hipFileRead reached EOF before requested length");
+            hipFileHandleDeregister(handle);
+            close(fd);
+            return 1;
+        }
+        copied += static_cast<size_t>(nread);
+    }
+
+    hipFileHandleDeregister(handle);
+    if (close(fd) != 0) {
+        set_error(err_buf, err_buf_len, std::string("close failed: ") + std::strerror(errno));
+        return 1;
+    }
+    return 0;
+}

--- a/crates/gpu-hal/src/hipfile_bridge.cc
+++ b/crates/gpu-hal/src/hipfile_bridge.cc
@@ -79,6 +79,17 @@ extern "C" int supersonic_hipfile_read_to_device(
         return 1;
     }
 
+    hipFileError_t compat_status =
+        hipFileSetParameterBool(hipFileParamPropertiesAllowCompatMode, false);
+    if (compat_status.err != hipFileSuccess) {
+        set_error(
+            err_buf,
+            err_buf_len,
+            hipfile_error("hipFileSetParameterBool(AllowCompatMode=false)", compat_status));
+        close(fd);
+        return 1;
+    }
+
     hipFileDescr_t desc{};
     desc.type = hipFileHandleTypeOpaqueFD;
     desc.handle.fd = fd;
@@ -88,6 +99,14 @@ extern "C" int supersonic_hipfile_read_to_device(
     hipFileError_t status = hipFileHandleRegister(&handle, &desc);
     if (status.err != hipFileSuccess) {
         set_error(err_buf, err_buf_len, hipfile_error("hipFileHandleRegister", status));
+        close(fd);
+        return 1;
+    }
+
+    hipFileError_t buf_status = hipFileBufRegister(dst, len, 0);
+    if (buf_status.err != hipFileSuccess) {
+        set_error(err_buf, err_buf_len, hipfile_error("hipFileBufRegister", buf_status));
+        hipFileHandleDeregister(handle);
         close(fd);
         return 1;
     }
@@ -102,17 +121,29 @@ extern "C" int supersonic_hipfile_read_to_device(
             static_cast<hoff_t>(copied));
         if (nread < 0) {
             set_error(err_buf, err_buf_len, hipfile_read_error(nread));
+            hipFileError_t cleanup_status = hipFileBufDeregister(dst);
+            (void)cleanup_status;
             hipFileHandleDeregister(handle);
             close(fd);
             return 1;
         }
         if (nread == 0) {
             set_error(err_buf, err_buf_len, "hipFileRead reached EOF before requested length");
+            hipFileError_t cleanup_status = hipFileBufDeregister(dst);
+            (void)cleanup_status;
             hipFileHandleDeregister(handle);
             close(fd);
             return 1;
         }
         copied += static_cast<size_t>(nread);
+    }
+
+    hipFileError_t dereg_status = hipFileBufDeregister(dst);
+    if (dereg_status.err != hipFileSuccess) {
+        set_error(err_buf, err_buf_len, hipfile_error("hipFileBufDeregister", dereg_status));
+        hipFileHandleDeregister(handle);
+        close(fd);
+        return 1;
     }
 
     hipFileHandleDeregister(handle);

--- a/crates/gpu-hal/src/lib.rs
+++ b/crates/gpu-hal/src/lib.rs
@@ -23,6 +23,7 @@ pub use ops::{
     copy_d2d, copy_d2h, copy_h2d, copy_h2d_async, hal_profile_reset, hal_profile_set_enabled,
     hal_profile_snapshot, memset_zeros, memset_zeros_async, query_device_info, set_device, sync,
     GpuEvent, GpuStream, HalProfileEntry, HalProfileSnapshot, PinnedHostBuffer,
+    RegisteredHostBuffer,
 };
 pub use scalar_type::ScalarType;
 pub use vmm::{

--- a/crates/gpu-hal/src/lib.rs
+++ b/crates/gpu-hal/src/lib.rs
@@ -20,10 +20,10 @@ pub use backend::{
 pub use buffer::{GpuBuffer, HostBuffer};
 pub use error::GpuError;
 pub use ops::{
-    copy_d2d, copy_d2h, copy_h2d, copy_h2d_async, hal_profile_reset, hal_profile_set_enabled,
-    hal_profile_snapshot, memset_zeros, memset_zeros_async, query_device_info, set_device, sync,
-    GpuEvent, GpuStream, HalProfileEntry, HalProfileSnapshot, PinnedHostBuffer,
-    RegisteredHostBuffer,
+    copy_d2d, copy_d2h, copy_h2d, copy_h2d_async, copy_storage_to_device, hal_profile_reset,
+    hal_profile_set_enabled, hal_profile_snapshot, memset_zeros, memset_zeros_async,
+    query_device_info, set_device, storage_to_device_is_supported, sync, GpuEvent, GpuStream,
+    HalProfileEntry, HalProfileSnapshot, PinnedHostBuffer, RegisteredHostBuffer,
 };
 pub use scalar_type::ScalarType;
 pub use vmm::{

--- a/crates/gpu-hal/src/ops.rs
+++ b/crates/gpu-hal/src/ops.rs
@@ -1,6 +1,11 @@
 use std::alloc::{alloc_zeroed, dealloc, Layout};
 use std::collections::BTreeMap;
+#[cfg(supersonic_backend_hipfile)]
+use std::ffi::{c_char, CStr, CString};
 use std::ffi::{c_int, c_void};
+#[cfg(all(unix, supersonic_backend_hipfile))]
+use std::os::unix::ffi::OsStrExt;
+use std::path::Path;
 use std::ptr::NonNull;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Mutex, OnceLock};
@@ -17,6 +22,19 @@ use crate::hip_sys::*;
 #[cfg(supersonic_backend_metal)]
 use crate::metal_sys::*;
 use crate::scalar_type::ScalarType;
+
+#[cfg(supersonic_backend_hipfile)]
+unsafe extern "C" {
+    fn supersonic_hipfile_read_to_device(
+        ordinal: c_int,
+        path: *const c_char,
+        dst: *mut c_void,
+        source_offset: u64,
+        len: usize,
+        err_buf: *mut c_char,
+        err_buf_len: usize,
+    ) -> c_int;
+}
 
 static HAL_PROFILE_ENABLED: AtomicBool = AtomicBool::new(false);
 static HAL_PROFILE: OnceLock<Mutex<HalProfileAccumulator>> = OnceLock::new();
@@ -889,6 +907,134 @@ pub fn copy_h2d_async(
             )),
         })
     })
+}
+
+pub fn storage_to_device_is_supported(backend: Backend) -> bool {
+    match backend {
+        Backend::Hip => hipfile_is_compiled(),
+        Backend::Cuda | Backend::Metal => false,
+    }
+}
+
+#[cfg(supersonic_backend_hipfile)]
+fn hipfile_is_compiled() -> bool {
+    true
+}
+
+#[cfg(not(supersonic_backend_hipfile))]
+fn hipfile_is_compiled() -> bool {
+    false
+}
+
+pub(crate) fn ensure_storage_to_device_supported(
+    backend: Backend,
+    source_path: &Path,
+    source_offset: u64,
+    len: usize,
+) -> Result<()> {
+    if storage_to_device_is_supported(backend) {
+        return Ok(());
+    }
+    Err(GpuError::Unsupported(format!(
+        "GPU-direct storage-to-device transfer is not implemented for {backend} \
+         (source={} offset={} len={})",
+        source_path.display(),
+        source_offset,
+        len
+    )))
+}
+
+pub fn copy_storage_to_device(
+    ordinal: usize,
+    dst: *mut c_void,
+    source_path: &Path,
+    source_offset: u64,
+    len: usize,
+) -> Result<()> {
+    if dst.is_null() || len == 0 {
+        return Err(GpuError::InvalidArg(
+            "copy_storage_to_device: null pointer or zero len".into(),
+        ));
+    }
+    if source_path.as_os_str().is_empty() {
+        return Err(GpuError::InvalidArg(
+            "copy_storage_to_device: source path must not be empty".into(),
+        ));
+    }
+    let backend = current_backend();
+    ensure_storage_to_device_supported(backend, source_path, source_offset, len)?;
+    hal_profile_time("copy_storage_to_device", len, || {
+        with_device_impl(backend, ordinal, || match backend {
+            Backend::Hip => {
+                copy_storage_to_device_hipfile(ordinal, dst, source_path, source_offset, len)
+            }
+            Backend::Cuda => Err(GpuError::Unsupported(
+                "copy_storage_to_device is not implemented for CUDA yet".into(),
+            )),
+            Backend::Metal => Err(GpuError::Unsupported(
+                "copy_storage_to_device is not implemented for Metal".into(),
+            )),
+        })
+    })
+}
+
+#[cfg(supersonic_backend_hipfile)]
+fn copy_storage_to_device_hipfile(
+    ordinal: usize,
+    dst: *mut c_void,
+    source_path: &Path,
+    source_offset: u64,
+    len: usize,
+) -> Result<()> {
+    #[cfg(unix)]
+    let path_bytes = source_path.as_os_str().as_bytes();
+    #[cfg(not(unix))]
+    let path_bytes = source_path
+        .to_str()
+        .ok_or_else(|| GpuError::InvalidArg("hipFile source path is not valid UTF-8".into()))?
+        .as_bytes();
+    let path = CString::new(path_bytes).map_err(|_| {
+        GpuError::InvalidArg(format!(
+            "hipFile source path contains an interior NUL: {}",
+            source_path.display()
+        ))
+    })?;
+    let mut err_buf = vec![0i8; 512];
+    let status = unsafe {
+        supersonic_hipfile_read_to_device(
+            ordinal as c_int,
+            path.as_ptr(),
+            dst,
+            source_offset,
+            len,
+            err_buf.as_mut_ptr(),
+            err_buf.len(),
+        )
+    };
+    if status == 0 {
+        return Ok(());
+    }
+    let message = unsafe { CStr::from_ptr(err_buf.as_ptr()) }
+        .to_string_lossy()
+        .into_owned();
+    Err(GpuError::backend(
+        Backend::Hip,
+        format!("hipFile storage-to-device transfer failed: {message}"),
+    ))
+}
+
+#[cfg(not(supersonic_backend_hipfile))]
+fn copy_storage_to_device_hipfile(
+    _ordinal: usize,
+    _dst: *mut c_void,
+    _source_path: &Path,
+    _source_offset: u64,
+    _len: usize,
+) -> Result<()> {
+    Err(GpuError::Unsupported(
+        "hipFile support is not compiled; ROCm >= 7.2 with hipfile.h and libhipfile is required"
+            .into(),
+    ))
 }
 
 /// Copy from device memory to host memory.

--- a/crates/gpu-hal/src/ops.rs
+++ b/crates/gpu-hal/src/ops.rs
@@ -935,8 +935,15 @@ pub(crate) fn ensure_storage_to_device_supported(
     if storage_to_device_is_supported(backend) {
         return Ok(());
     }
+    let reason = match backend {
+        Backend::Hip => {
+            "hipFile support is not compiled; ROCm >= 7.2 with hipfile.h and libhipfile is required"
+        }
+        Backend::Cuda => "CUDA storage-to-device transfer is not implemented yet",
+        Backend::Metal => "Metal storage-to-device transfer is not implemented",
+    };
     Err(GpuError::Unsupported(format!(
-        "GPU-direct storage-to-device transfer is not implemented for {backend} \
+        "GPU-direct storage-to-device transfer is not available for {backend}: {reason} \
          (source={} offset={} len={})",
         source_path.display(),
         source_offset,

--- a/crates/gpu-hal/src/ops.rs
+++ b/crates/gpu-hal/src/ops.rs
@@ -622,6 +622,104 @@ impl Drop for PinnedHostBuffer {
     }
 }
 
+/// RAII wrapper around externally owned host memory registered for faster H2D.
+///
+/// The wrapper does not own the underlying bytes. It only owns the backend
+/// registration and unregisters the exact pointer at drop time.
+pub struct RegisteredHostBuffer {
+    backend: Backend,
+    ordinal: usize,
+    ptr: NonNull<c_void>,
+    len_bytes: usize,
+}
+
+unsafe impl Send for RegisteredHostBuffer {}
+unsafe impl Sync for RegisteredHostBuffer {}
+
+impl RegisteredHostBuffer {
+    /// Register an externally owned host range with the active backend.
+    ///
+    /// # Safety
+    ///
+    /// `ptr..ptr+len_bytes` must stay valid and mapped for the lifetime of the
+    /// returned wrapper, and it must satisfy the backend's host-registration
+    /// alignment requirements. The same range must not be concurrently
+    /// unregistered elsewhere.
+    pub unsafe fn new(ordinal: usize, ptr: *mut c_void, len_bytes: usize) -> Result<Self> {
+        let ptr = NonNull::new(ptr).ok_or_else(|| {
+            GpuError::InvalidArg("RegisteredHostBuffer::new: null host pointer".into())
+        })?;
+        if len_bytes == 0 {
+            return Err(GpuError::InvalidArg(
+                "RegisteredHostBuffer::new: len_bytes must be > 0".into(),
+            ));
+        }
+        let backend = current_backend();
+        hal_profile_time("host_register", len_bytes, || {
+            with_device_impl(backend, ordinal, || match backend {
+                Backend::Hip => {
+                    #[cfg(supersonic_backend_hip)]
+                    {
+                        let status = unsafe { hipHostRegister(ptr.as_ptr(), len_bytes, 0) };
+                        if status != 0 {
+                            return Err(backend_error(Backend::Hip, "hipHostRegister", status));
+                        }
+                        Ok(())
+                    }
+                    #[cfg(not(supersonic_backend_hip))]
+                    Err(GpuError::InvalidArg("HIP backend not compiled".into()))
+                }
+                Backend::Cuda => Err(GpuError::Unsupported(
+                    "RegisteredHostBuffer is not implemented for CUDA yet".into(),
+                )),
+                Backend::Metal => Err(GpuError::Unsupported(
+                    "RegisteredHostBuffer is not implemented for Metal".into(),
+                )),
+            })
+        })?;
+        Ok(Self {
+            backend,
+            ordinal,
+            ptr,
+            len_bytes,
+        })
+    }
+
+    pub fn len(&self) -> usize {
+        self.len_bytes
+    }
+
+    pub fn as_ptr(&self) -> *const c_void {
+        self.ptr.as_ptr()
+    }
+}
+
+impl Drop for RegisteredHostBuffer {
+    fn drop(&mut self) {
+        let backend = self.backend;
+        let ordinal = self.ordinal;
+        let ptr = self.ptr.as_ptr();
+        let len_bytes = self.len_bytes;
+        let _ = hal_profile_time("host_unregister", len_bytes, || {
+            with_device_impl(backend, ordinal, || match backend {
+                Backend::Hip => {
+                    #[cfg(supersonic_backend_hip)]
+                    {
+                        let status = unsafe { hipHostUnregister(ptr) };
+                        if status != 0 {
+                            return Err(backend_error(Backend::Hip, "hipHostUnregister", status));
+                        }
+                        Ok(())
+                    }
+                    #[cfg(not(supersonic_backend_hip))]
+                    Err(GpuError::InvalidArg("HIP backend not compiled".into()))
+                }
+                Backend::Cuda | Backend::Metal => Ok(()),
+            })
+        });
+    }
+}
+
 /// Allocate `len_bytes` of device memory, zeroed. Same allocator-dispatch
 /// behavior as [`alloc`].
 pub(crate) fn alloc_zeros(

--- a/crates/gpu-hal/src/ops.rs
+++ b/crates/gpu-hal/src/ops.rs
@@ -38,6 +38,7 @@ unsafe extern "C" {
 
 static HAL_PROFILE_ENABLED: AtomicBool = AtomicBool::new(false);
 static HAL_PROFILE: OnceLock<Mutex<HalProfileAccumulator>> = OnceLock::new();
+const STORAGE_DIRECT_BLOCK_ALIGNMENT: usize = 4096;
 
 #[derive(Debug, Clone)]
 pub struct HalProfileEntry {
@@ -967,6 +968,16 @@ pub fn copy_storage_to_device(
         return Err(GpuError::InvalidArg(
             "copy_storage_to_device: source path must not be empty".into(),
         ));
+    }
+    if source_offset % STORAGE_DIRECT_BLOCK_ALIGNMENT as u64 != 0 {
+        return Err(GpuError::InvalidArg(format!(
+            "copy_storage_to_device: source offset {source_offset} is not {STORAGE_DIRECT_BLOCK_ALIGNMENT}-byte aligned"
+        )));
+    }
+    if len % STORAGE_DIRECT_BLOCK_ALIGNMENT != 0 {
+        return Err(GpuError::InvalidArg(format!(
+            "copy_storage_to_device: length {len} is not {STORAGE_DIRECT_BLOCK_ALIGNMENT}-byte aligned"
+        )));
     }
     let backend = current_backend();
     ensure_storage_to_device_supported(backend, source_path, source_offset, len)?;

--- a/crates/gpu-hal/src/vmm.rs
+++ b/crates/gpu-hal/src/vmm.rs
@@ -1,6 +1,7 @@
 #[cfg(supersonic_backend_cuda)]
 use std::ffi::c_int;
 use std::ffi::c_void;
+use std::path::Path;
 use std::ptr::NonNull;
 
 use crate::backend::{current_backend, Backend};
@@ -437,6 +438,35 @@ impl VirtualBuffer {
             self.mappings.push(mapping);
             self.mapped_bytes = self.mapped_bytes.max(seg_offset + seg_len);
         }
+        Ok(())
+    }
+
+    /// Copy a source file range into this virtual buffer without staging
+    /// through a pageable host slice.
+    ///
+    /// Unsupported backends return before mapping any virtual pages, so callers
+    /// cannot accidentally get a pageable H2D fallback when they requested a
+    /// storage-direct transfer.
+    pub fn copy_storage_range_bytes_no_sync(
+        &mut self,
+        dst_offset: usize,
+        source_path: &Path,
+        source_offset: u64,
+        len: usize,
+    ) -> Result<()> {
+        if len == 0 {
+            return Ok(());
+        }
+        ops::ensure_storage_to_device_supported(self.backend, source_path, source_offset, len)?;
+        self.map_range_bytes_no_sync(dst_offset, len)?;
+        ops::copy_storage_to_device(
+            self.device_ordinal,
+            self.offset_mut_ptr(dst_offset),
+            source_path,
+            source_offset,
+            len,
+        )?;
+        ops::sync(self.device_ordinal)?;
         Ok(())
     }
 

--- a/crates/gpu-hal/tests/async_primitives.rs
+++ b/crates/gpu-hal/tests/async_primitives.rs
@@ -1,13 +1,39 @@
 use gpu_hal::{
     copy_d2h, copy_h2d_async, current_backend, memset_zeros_async, set_backend, Backend, GpuBuffer,
-    GpuEvent, GpuStream, PinnedHostBuffer, ScalarType,
+    GpuEvent, GpuStream, PinnedHostBuffer, RegisteredHostBuffer, ScalarType,
 };
+use std::alloc::{alloc_zeroed, dealloc, Layout};
+use std::ptr::NonNull;
 
 struct BackendRestore(Backend);
 
 impl Drop for BackendRestore {
     fn drop(&mut self) {
         set_backend(self.0);
+    }
+}
+
+struct AlignedHostPage {
+    ptr: NonNull<u8>,
+    layout: Layout,
+}
+
+impl AlignedHostPage {
+    fn new(len: usize, align: usize) -> Self {
+        let layout = Layout::from_size_align(len, align).expect("aligned host page layout");
+        let ptr = NonNull::new(unsafe { alloc_zeroed(layout) })
+            .expect("allocate aligned host page for registration smoke");
+        Self { ptr, layout }
+    }
+
+    fn as_mut_ptr(&mut self) -> *mut u8 {
+        self.ptr.as_ptr()
+    }
+}
+
+impl Drop for AlignedHostPage {
+    fn drop(&mut self) {
+        unsafe { dealloc(self.ptr.as_ptr(), self.layout) };
     }
 }
 
@@ -26,6 +52,22 @@ fn pinned_host_buffer_smoke() {
     pinned.as_mut_slice()[4095] = 23;
     assert_eq!(pinned.as_slice()[0], 17);
     assert_eq!(pinned.as_slice()[4095], 23);
+}
+
+#[test]
+fn registered_host_buffer_smoke() {
+    let _restore = BackendRestore(current_backend());
+    set_backend(Backend::Hip);
+    let mut page = AlignedHostPage::new(4096, 4096);
+    let registered = match unsafe { RegisteredHostBuffer::new(0, page.as_mut_ptr().cast(), 4096) } {
+        Ok(buffer) => buffer,
+        Err(err) => {
+            eprintln!("skip: HIP host registration unavailable: {err}");
+            return;
+        }
+    };
+    assert_eq!(registered.len(), 4096);
+    assert_eq!(registered.as_ptr(), page.as_mut_ptr().cast());
 }
 
 #[test]

--- a/crates/gpu-hal/tests/hipfile_bridge_contract.rs
+++ b/crates/gpu-hal/tests/hipfile_bridge_contract.rs
@@ -1,0 +1,304 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn cxx_compiler() -> Option<String> {
+    for candidate in ["c++", "g++", "clang++"] {
+        if Command::new("sh")
+            .arg("-lc")
+            .arg(format!("command -v {candidate} >/dev/null 2>&1"))
+            .status()
+            .map(|status| status.success())
+            .unwrap_or(false)
+        {
+            return Some(candidate.to_string());
+        }
+    }
+    None
+}
+
+fn temp_dir(name: &str) -> PathBuf {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock before epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!("supersonic-{name}-{}-{unique}", std::process::id()))
+}
+
+fn write_stub_headers(root: &Path) {
+    let include = root.join("include");
+    fs::create_dir_all(include.join("hip")).expect("create stub include tree");
+    fs::write(
+        include.join("hip/hip_runtime_api.h"),
+        r#"
+#pragma once
+
+typedef int hipError_t;
+static const hipError_t hipSuccess = 0;
+
+extern "C" hipError_t hipSetDevice(int ordinal);
+"#,
+    )
+    .expect("write stub HIP header");
+    fs::write(
+        include.join("hipfile.h"),
+        r#"
+#pragma once
+
+#include <hip/hip_runtime_api.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <sys/types.h>
+
+typedef off_t hoff_t;
+
+typedef enum hipFileOpError {
+    hipFileSuccess = 0,
+    hipFileInvalidValue = 5022
+} hipFileOpError_t;
+
+typedef struct hipFileError {
+    hipFileOpError_t err;
+    hipError_t hip_drv_err;
+} hipFileError_t;
+
+typedef enum hipFileFileHandleType {
+    hipFileHandleTypeOpaqueFD = 1
+} hipFileFileHandleType_t;
+
+typedef struct hipFileFSOps hipFileFSOps_t;
+
+typedef struct hipFileDescr {
+    hipFileFileHandleType_t type;
+    union {
+        int fd;
+        void *hFile;
+    } handle;
+    const hipFileFSOps_t *fs_ops;
+} hipFileDescr_t;
+
+typedef void *hipFileHandle_t;
+
+typedef enum hipFileBoolConfigParameter {
+    hipFileParamPropertiesUsePollMode,
+    hipFileParamPropertiesAllowCompatMode,
+    hipFileParamForceCompatMode
+} hipFileBoolConfigParameter_t;
+
+#define IS_HIPFILE_ERR(result) ((result) < -5000)
+#define HIPFILE_ERRSTR(result) hipFileGetOpErrorString((hipFileOpError_t)(-(result)))
+
+extern "C" const char *hipFileGetOpErrorString(hipFileOpError_t status);
+extern "C" hipFileError_t hipFileSetParameterBool(hipFileBoolConfigParameter_t param, bool value);
+extern "C" hipFileError_t hipFileHandleRegister(hipFileHandle_t *fh, hipFileDescr_t *descr);
+extern "C" void hipFileHandleDeregister(hipFileHandle_t fh);
+extern "C" hipFileError_t hipFileBufRegister(const void *buffer_base, size_t length, int flags);
+extern "C" hipFileError_t hipFileBufDeregister(const void *buffer_base);
+extern "C" ssize_t hipFileRead(
+    hipFileHandle_t fh,
+    void *buffer_base,
+    size_t size,
+    hoff_t file_offset,
+    hoff_t buffer_offset);
+"#,
+    )
+    .expect("write stub hipFile header");
+}
+
+#[test]
+fn hipfile_bridge_configures_strict_registered_read() {
+    let Some(cxx) = cxx_compiler() else {
+        eprintln!("skip: no C++ compiler available for hipFile bridge contract test");
+        return;
+    };
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let bridge = repo_root.join("src/hipfile_bridge.cc");
+    let temp = temp_dir("hipfile-bridge-contract");
+    let _cleanup = TempCleanup(temp.clone());
+    fs::create_dir_all(&temp).expect("create temp dir");
+    write_stub_headers(&temp);
+
+    let probe = temp.join("probe.cc");
+    fs::write(
+        &probe,
+        format!(
+            r#"
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fcntl.h>
+#include <fstream>
+#include <string>
+#include <unistd.h>
+#include <vector>
+
+static int strict_calls = 0;
+static int buf_register_calls = 0;
+static int buf_deregister_calls = 0;
+static int handle_register_calls = 0;
+static int handle_deregister_calls = 0;
+static int read_calls = 0;
+static const void *registered_base = nullptr;
+static size_t registered_len = 0;
+
+#include "{bridge}"
+
+extern "C" hipError_t hipSetDevice(int ordinal) {{
+    return ordinal == 0 ? hipSuccess : 1;
+}}
+
+extern "C" const char *hipFileGetOpErrorString(hipFileOpError_t status) {{
+    return status == hipFileSuccess ? "success" : "stub hipFile error";
+}}
+
+extern "C" hipFileError_t hipFileSetParameterBool(
+    hipFileBoolConfigParameter_t param,
+    bool value) {{
+    if (param == hipFileParamPropertiesAllowCompatMode && value == false) {{
+        strict_calls += 1;
+    }}
+    return {{hipFileSuccess, hipSuccess}};
+}}
+
+extern "C" hipFileError_t hipFileHandleRegister(hipFileHandle_t *fh, hipFileDescr_t *descr) {{
+    if (descr == nullptr || descr->type != hipFileHandleTypeOpaqueFD || descr->handle.fd < 0) {{
+        return {{hipFileInvalidValue, hipSuccess}};
+    }}
+    handle_register_calls += 1;
+    *fh = reinterpret_cast<void *>(0x1234);
+    return {{hipFileSuccess, hipSuccess}};
+}}
+
+extern "C" void hipFileHandleDeregister(hipFileHandle_t fh) {{
+    if (fh == reinterpret_cast<void *>(0x1234)) {{
+        handle_deregister_calls += 1;
+    }}
+}}
+
+extern "C" hipFileError_t hipFileBufRegister(
+    const void *buffer_base,
+    size_t length,
+    int flags) {{
+    if (buffer_base == nullptr || length == 0 || flags != 0) {{
+        return {{hipFileInvalidValue, hipSuccess}};
+    }}
+    buf_register_calls += 1;
+    registered_base = buffer_base;
+    registered_len = length;
+    return {{hipFileSuccess, hipSuccess}};
+}}
+
+extern "C" hipFileError_t hipFileBufDeregister(const void *buffer_base) {{
+    if (buffer_base == registered_base) {{
+        buf_deregister_calls += 1;
+    }}
+    return {{hipFileSuccess, hipSuccess}};
+}}
+
+extern "C" ssize_t hipFileRead(
+    hipFileHandle_t fh,
+    void *buffer_base,
+    size_t size,
+    hoff_t file_offset,
+    hoff_t buffer_offset) {{
+    if (fh != reinterpret_cast<void *>(0x1234)) {{
+        return -hipFileInvalidValue;
+    }}
+    if (registered_base != buffer_base || registered_len < size + static_cast<size_t>(buffer_offset)) {{
+        return -hipFileInvalidValue;
+    }}
+    if (file_offset != 4096 || buffer_offset != 0) {{
+        return -hipFileInvalidValue;
+    }}
+    read_calls += 1;
+    std::memset(static_cast<char *>(buffer_base) + buffer_offset, 0xab, size);
+    return static_cast<ssize_t>(size);
+}}
+
+int main(int argc, char **argv) {{
+    if (argc != 2) {{
+        std::fprintf(stderr, "usage: %s file\n", argv[0]);
+        return 2;
+    }}
+    std::vector<char> dst(8192);
+    char err[512] = {{0}};
+    int status = supersonic_hipfile_read_to_device(
+        0,
+        argv[1],
+        dst.data(),
+        4096,
+        8192,
+        err,
+        sizeof(err));
+    if (status != 0) {{
+        std::fprintf(stderr, "bridge returned error: %s\n", err);
+        return 3;
+    }}
+    if (strict_calls != 1) {{
+        std::fprintf(stderr, "expected strict compat disable once, got %d\n", strict_calls);
+        return 4;
+    }}
+    if (buf_register_calls != 1 || buf_deregister_calls != 1) {{
+        std::fprintf(
+            stderr,
+            "expected one buffer register/deregister, got %d/%d\n",
+            buf_register_calls,
+            buf_deregister_calls);
+        return 5;
+    }}
+    if (handle_register_calls != 1 || handle_deregister_calls != 1 || read_calls != 1) {{
+        std::fprintf(
+            stderr,
+            "unexpected handle/read calls %d/%d/%d\n",
+            handle_register_calls,
+            handle_deregister_calls,
+            read_calls);
+        return 6;
+    }}
+    return 0;
+}}
+"#,
+            bridge = bridge.display()
+        ),
+    )
+    .expect("write probe source");
+
+    let exe = temp.join("probe");
+    let compile = Command::new(&cxx)
+        .arg("-std=c++17")
+        .arg("-I")
+        .arg(temp.join("include"))
+        .arg(&probe)
+        .arg("-o")
+        .arg(&exe)
+        .output()
+        .expect("run C++ compiler");
+    assert!(
+        compile.status.success(),
+        "compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let source = temp.join("source.flm");
+    fs::write(&source, vec![0u8; 16 * 1024]).expect("write source file");
+    let run = Command::new(&exe)
+        .arg(&source)
+        .output()
+        .expect("run bridge probe");
+    assert!(
+        run.status.success(),
+        "probe failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+}
+
+struct TempCleanup(PathBuf);
+
+impl Drop for TempCleanup {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}

--- a/crates/gpu-hal/tests/vmm_round_trip.rs
+++ b/crates/gpu-hal/tests/vmm_round_trip.rs
@@ -1,9 +1,11 @@
 #![cfg(supersonic_backend_hip)]
 
 use gpu_hal::{
-    copy_h2d, set_backend, sync, vmm_is_supported, Backend, ScalarType, VirtualAllocationRole,
-    VirtualArena, VirtualBacking, VirtualBuffer,
+    copy_h2d, hal_profile_reset, hal_profile_set_enabled, hal_profile_snapshot, set_backend, sync,
+    vmm_is_supported, Backend, ScalarType, VirtualAllocationRole, VirtualArena, VirtualBacking,
+    VirtualBuffer,
 };
+use std::path::Path;
 
 fn pattern_bytes(n: usize) -> Vec<u8> {
     (0..n)
@@ -135,6 +137,46 @@ fn vmm_sparse_range_round_trip_stable_pointer() {
             "coarse HIP VMM pages map both test islands into one readable prefix"
         );
     }
+}
+
+#[test]
+fn vmm_storage_direct_copy_is_explicit_without_pageable_fallback() {
+    set_backend(Backend::Hip);
+    if !vmm_is_supported(Backend::Hip, 0) {
+        eprintln!("skip: HIP VMM unsupported on this device/runtime");
+        return;
+    }
+
+    let mut buf = VirtualBuffer::reserve(0, ScalarType::U8, &[1 << 20], VirtualBacking::Discard)
+        .expect("reserve virtual buffer");
+
+    hal_profile_set_enabled(true);
+    hal_profile_reset();
+    let err = buf
+        .copy_storage_range_bytes_no_sync(
+            0,
+            Path::new("/tmp/supersonic-test-storage-direct.flm"),
+            4096,
+            4096,
+        )
+        .expect_err("storage-direct copy should be named but not silently emulated");
+    let profile = hal_profile_snapshot();
+    hal_profile_set_enabled(false);
+
+    assert!(
+        err.to_string()
+            .contains("GPU-direct storage-to-device transfer"),
+        "unexpected error: {err}"
+    );
+    assert!(
+        profile
+            .entries
+            .iter()
+            .all(|entry| entry.op != "copy_h2d" && entry.op != "vmm_map_no_sync"),
+        "storage-direct copy must not fall back to pageable mapping/copy: {:?}",
+        profile.entries
+    );
+    assert_eq!(buf.stats().logical_resident_bytes, 0);
 }
 
 #[test]

--- a/crates/gpu-hal/tests/vmm_round_trip.rs
+++ b/crates/gpu-hal/tests/vmm_round_trip.rs
@@ -1,9 +1,9 @@
 #![cfg(supersonic_backend_hip)]
 
 use gpu_hal::{
-    copy_h2d, hal_profile_reset, hal_profile_set_enabled, hal_profile_snapshot, set_backend, sync,
-    vmm_is_supported, Backend, ScalarType, VirtualAllocationRole, VirtualArena, VirtualBacking,
-    VirtualBuffer,
+    copy_h2d, hal_profile_reset, hal_profile_set_enabled, hal_profile_snapshot, set_backend,
+    storage_to_device_is_supported, sync, vmm_is_supported, Backend, ScalarType,
+    VirtualAllocationRole, VirtualArena, VirtualBacking, VirtualBuffer,
 };
 use std::path::Path;
 
@@ -168,6 +168,13 @@ fn vmm_storage_direct_copy_is_explicit_without_pageable_fallback() {
             .contains("GPU-direct storage-to-device transfer"),
         "unexpected error: {err}"
     );
+    if !storage_to_device_is_supported(Backend::Hip) {
+        assert!(
+            err.to_string().contains("hipFile support is not compiled")
+                && err.to_string().contains("ROCm >= 7.2"),
+            "unsupported HIP storage-direct error should explain the missing hipFile build support: {err}"
+        );
+    }
     assert!(
         profile
             .entries

--- a/crates/gpu-hal/tests/vmm_round_trip.rs
+++ b/crates/gpu-hal/tests/vmm_round_trip.rs
@@ -1,9 +1,9 @@
 #![cfg(supersonic_backend_hip)]
 
 use gpu_hal::{
-    copy_h2d, hal_profile_reset, hal_profile_set_enabled, hal_profile_snapshot, set_backend,
-    storage_to_device_is_supported, sync, vmm_is_supported, Backend, ScalarType,
-    VirtualAllocationRole, VirtualArena, VirtualBacking, VirtualBuffer,
+    copy_h2d, copy_storage_to_device, hal_profile_reset, hal_profile_set_enabled,
+    hal_profile_snapshot, set_backend, storage_to_device_is_supported, sync, vmm_is_supported,
+    Backend, ScalarType, VirtualAllocationRole, VirtualArena, VirtualBacking, VirtualBuffer,
 };
 use std::path::Path;
 
@@ -32,6 +32,40 @@ fn assert_bytes_eq(label: &str, got: &[u8], expected: &[u8]) {
         &expected[..expected.len().min(16)],
         &got[start..end],
         &expected[start..end]
+    );
+}
+
+#[test]
+fn storage_direct_copy_rejects_unaligned_direct_io_ranges() {
+    set_backend(Backend::Hip);
+    let ptr = std::ptr::NonNull::<u8>::dangling().as_ptr().cast();
+
+    let err = copy_storage_to_device(
+        0,
+        ptr,
+        Path::new("/tmp/supersonic-test-storage-direct.flm"),
+        4096,
+        64,
+    )
+    .expect_err("sub-block direct-I/O length should be rejected before backend dispatch");
+    assert!(
+        err.to_string()
+            .contains("length 64 is not 4096-byte aligned"),
+        "{err}"
+    );
+
+    let err = copy_storage_to_device(
+        0,
+        ptr,
+        Path::new("/tmp/supersonic-test-storage-direct.flm"),
+        512,
+        4096,
+    )
+    .expect_err("unaligned direct-I/O offset should be rejected before backend dispatch");
+    assert!(
+        err.to_string()
+            .contains("source offset 512 is not 4096-byte aligned"),
+        "{err}"
     );
 }
 

--- a/crates/model-store/src/flm.rs
+++ b/crates/model-store/src/flm.rs
@@ -308,6 +308,76 @@ pub struct FlmRuntimeDirectory {
     logical_tensors: Vec<FlmLogicalTensor>,
     storage_bindings: Vec<FlmStorageBinding>,
     plan_steps: Vec<FlmPlanStep>,
+    stage3_indexes: FlmRuntimeStage3Indexes,
+}
+
+#[derive(Debug, Clone, Default)]
+struct FlmRuntimeStage3Indexes {
+    logical_by_name: HashMap<String, usize>,
+    storage_abi_by_id: HashMap<u16, usize>,
+    storage_binding_by_logical_role: HashMap<(u32, u16), usize>,
+    direct_plan_by_logical_role: HashMap<(u32, u16), usize>,
+}
+
+impl FlmRuntimeStage3Indexes {
+    fn build(
+        storage_abis: &[FlmStorageAbi],
+        logical_tensors: &[FlmLogicalTensor],
+        storage_bindings: &[FlmStorageBinding],
+        plan_steps: &[FlmPlanStep],
+    ) -> Result<Self, Error> {
+        let mut indexes = Self::default();
+
+        for (idx, abi) in storage_abis.iter().enumerate() {
+            indexes.storage_abi_by_id.insert(abi.storage_abi_id, idx);
+        }
+
+        for (idx, logical) in logical_tensors.iter().enumerate() {
+            if indexes
+                .logical_by_name
+                .insert(logical.name.clone(), idx)
+                .is_some()
+            {
+                return Err(Error::Other(format!(
+                    "FLM Stage 3 has duplicate logical tensor name {}",
+                    logical.name
+                )));
+            }
+        }
+
+        for (idx, binding) in storage_bindings.iter().enumerate() {
+            let key = (binding.logical_tensor_id, binding.storage_role);
+            if indexes
+                .storage_binding_by_logical_role
+                .insert(key, idx)
+                .is_some()
+            {
+                return Err(Error::Other(format!(
+                    "FLM Stage 3 has duplicate storage binding for logical tensor {} role {}",
+                    binding.logical_tensor_id, binding.storage_role
+                )));
+            }
+        }
+
+        for (idx, step) in plan_steps.iter().enumerate() {
+            if step.consume_strategy != CONSUME_STRATEGY_DIRECT {
+                continue;
+            }
+            let key = (step.logical_tensor_id, step.storage_role);
+            if indexes
+                .direct_plan_by_logical_role
+                .insert(key, idx)
+                .is_some()
+            {
+                return Err(Error::Other(format!(
+                    "FLM Stage 3 has duplicate direct plan for logical tensor {} role {}",
+                    step.logical_tensor_id, step.storage_role
+                )));
+            }
+        }
+
+        Ok(indexes)
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -394,6 +464,13 @@ impl FlmRuntimeDirectory {
             (Vec::new(), Vec::new(), Vec::new(), Vec::new())
         };
 
+        let stage3_indexes = FlmRuntimeStage3Indexes::build(
+            &storage_abis,
+            &logical_tensors,
+            &storage_bindings,
+            &plan_steps,
+        )?;
+
         Ok(Self {
             architecture_id,
             config,
@@ -408,6 +485,7 @@ impl FlmRuntimeDirectory {
             logical_tensors,
             storage_bindings,
             plan_steps,
+            stage3_indexes,
         })
     }
 
@@ -479,13 +557,10 @@ impl FlmRuntimeDirectory {
         &self,
         logical_name: &str,
     ) -> Result<Option<FlmStage3DirectWeightKind>, Error> {
-        let Some(logical) = self
-            .logical_tensors
-            .iter()
-            .find(|logical| logical.name == logical_name)
-        else {
+        let Some(logical_idx) = self.stage3_indexes.logical_by_name.get(logical_name) else {
             return Ok(None);
         };
+        let logical = &self.logical_tensors[*logical_idx];
 
         match logical.value_format_id {
             VALUE_FORMAT_RAW_DENSE => {
@@ -513,9 +588,10 @@ impl FlmRuntimeDirectory {
         let packed_step = self.required_direct_plan_step(logical, STORAGE_ROLE_PACKED)?;
         let scale_step = self.required_direct_plan_step(logical, STORAGE_ROLE_SCALE)?;
         let storage_abi = self
-            .storage_abis
-            .iter()
-            .find(|abi| abi.storage_abi_id == packed.storage_abi_id)
+            .stage3_indexes
+            .storage_abi_by_id
+            .get(&packed.storage_abi_id)
+            .map(|idx| &self.storage_abis[*idx])
             .ok_or_else(|| {
                 Error::Other(format!(
                     "FLM Stage 3 tensor {} references missing storage ABI {}",
@@ -578,12 +654,10 @@ impl FlmRuntimeDirectory {
         logical: &FlmLogicalTensor,
         storage_role: u16,
     ) -> Result<&FlmStorageBinding, Error> {
-        self.storage_bindings
-            .iter()
-            .find(|binding| {
-                binding.logical_tensor_id == logical.tensor_id
-                    && binding.storage_role == storage_role
-            })
+        self.stage3_indexes
+            .storage_binding_by_logical_role
+            .get(&(logical.tensor_id, storage_role))
+            .map(|idx| &self.storage_bindings[*idx])
             .ok_or_else(|| {
                 Error::Other(format!(
                     "FLM Stage 3 tensor {} missing storage binding role {}",
@@ -597,13 +671,10 @@ impl FlmRuntimeDirectory {
         logical: &FlmLogicalTensor,
         storage_role: u16,
     ) -> Result<&FlmPlanStep, Error> {
-        self.plan_steps
-            .iter()
-            .find(|step| {
-                step.logical_tensor_id == logical.tensor_id
-                    && step.storage_role == storage_role
-                    && step.consume_strategy == CONSUME_STRATEGY_DIRECT
-            })
+        self.stage3_indexes
+            .direct_plan_by_logical_role
+            .get(&(logical.tensor_id, storage_role))
+            .map(|idx| &self.plan_steps[*idx])
             .ok_or_else(|| {
                 Error::Other(format!(
                     "FLM Stage 3 tensor {} missing direct plan role {}",
@@ -2399,6 +2470,36 @@ mod tests {
         }
     }
 
+    fn duplicate_string_table_row(runtime: &mut Vec<u8>, section_id: u32, header_len: usize) {
+        let (section_offset, section_len) = section_range(runtime, section_id);
+        let row_stride = read_u16_at(runtime, section_offset + 2) as usize;
+        let row_count = read_u32_at(runtime, section_offset + 4) as usize;
+        let insert_offset = section_offset + header_len + row_count * row_stride;
+        let row_copy =
+            runtime[section_offset + header_len..section_offset + header_len + row_stride].to_vec();
+
+        runtime.splice(insert_offset..insert_offset, row_copy);
+        shift_sections_after(runtime, insert_offset, row_stride);
+        put_u32_at(runtime, section_offset + 4, (row_count + 1) as u32);
+        let record = section_record_offset(runtime, section_id);
+        put_u32_at(runtime, record + 8, (section_len + row_stride) as u32);
+    }
+
+    fn duplicate_fixed_row(runtime: &mut Vec<u8>, section_id: u32, header_len: usize) {
+        let (section_offset, section_len) = section_range(runtime, section_id);
+        let row_stride = read_u16_at(runtime, section_offset + 2) as usize;
+        let row_count = read_u32_at(runtime, section_offset + 4) as usize;
+        let insert_offset = section_offset + section_len;
+        let row_copy =
+            runtime[section_offset + header_len..section_offset + header_len + row_stride].to_vec();
+
+        runtime.splice(insert_offset..insert_offset, row_copy);
+        shift_sections_after(runtime, insert_offset, row_stride);
+        put_u32_at(runtime, section_offset + 4, (row_count + 1) as u32);
+        let record = section_record_offset(runtime, section_id);
+        put_u32_at(runtime, record + 8, (section_len + row_stride) as u32);
+    }
+
     fn asset_payload_record(runtime: &[u8], asset_id: u32) -> (usize, usize, usize) {
         let (table_offset, _) = section_range(runtime, SECTION_ASSET_TABLE);
         let count = read_u32_at(runtime, table_offset) as usize;
@@ -2547,6 +2648,41 @@ mod tests {
         assert_eq!(parsed.plan_steps()[1].storage_role, STORAGE_ROLE_SCALE);
         assert_eq!(parsed.plan_steps()[1].target_dtype, FLM_DTYPE_BF16);
         assert_eq!(parsed.plan_steps()[1].target_shape, [128, 1, 0, 0]);
+    }
+
+    #[test]
+    fn rejects_duplicate_stage3_logical_tensor_names() {
+        let mut runtime = build_test_runtime_directory_with_stage3_tables();
+        duplicate_string_table_row(
+            &mut runtime,
+            SECTION_LOGICAL_TENSOR_TABLE,
+            LOGICAL_TENSOR_HEADER_SIZE,
+        );
+        let (logical_offset, _) = section_range(&runtime, SECTION_LOGICAL_TENSOR_TABLE);
+        let duplicate_row = logical_offset + LOGICAL_TENSOR_HEADER_SIZE + LOGICAL_TENSOR_ROW_SIZE;
+        put_u32_at(&mut runtime, duplicate_row, 2);
+
+        expect_parse_error_contains(&runtime, "duplicate logical tensor name");
+    }
+
+    #[test]
+    fn rejects_duplicate_stage3_storage_binding_roles() {
+        let mut runtime = build_test_runtime_directory_with_stage3_tables();
+        duplicate_string_table_row(
+            &mut runtime,
+            SECTION_STORAGE_BINDING_TABLE,
+            STORAGE_BINDING_HEADER_SIZE,
+        );
+
+        expect_parse_error_contains(&runtime, "duplicate storage binding");
+    }
+
+    #[test]
+    fn rejects_duplicate_stage3_direct_plan_roles() {
+        let mut runtime = build_test_runtime_directory_with_stage3_tables();
+        duplicate_fixed_row(&mut runtime, SECTION_PLAN_STEP_TABLE, PLAN_STEP_HEADER_SIZE);
+
+        expect_parse_error_contains(&runtime, "duplicate direct plan");
     }
 
     #[test]

--- a/crates/model-store/src/flm.rs
+++ b/crates/model-store/src/flm.rs
@@ -286,6 +286,13 @@ pub struct FlmRuntimeIdentity {
     pub model_id: u16,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FlmStage3DirectWeightKind {
+    RawDense,
+    CtInt4Bf16Fallback,
+    NativeInt4,
+}
+
 #[derive(Debug, Clone)]
 pub struct FlmRuntimeDirectory {
     pub architecture_id: u32,
@@ -466,6 +473,143 @@ impl FlmRuntimeDirectory {
 
     pub fn plan_steps(&self) -> &[FlmPlanStep] {
         &self.plan_steps
+    }
+
+    pub fn stage3_direct_weight_kind(
+        &self,
+        logical_name: &str,
+    ) -> Result<Option<FlmStage3DirectWeightKind>, Error> {
+        let Some(logical) = self
+            .logical_tensors
+            .iter()
+            .find(|logical| logical.name == logical_name)
+        else {
+            return Ok(None);
+        };
+
+        match logical.value_format_id {
+            VALUE_FORMAT_RAW_DENSE => {
+                let value = self.required_storage_binding(logical, STORAGE_ROLE_VALUE)?;
+                let value_step = self.required_direct_plan_step(logical, STORAGE_ROLE_VALUE)?;
+                if value.storage_dtype != value_step.target_dtype {
+                    return Err(Error::Other(format!(
+                        "FLM Stage 3 raw tensor {} storage dtype {} does not match direct target dtype {}",
+                        logical.name, value.storage_dtype, value_step.target_dtype
+                    )));
+                }
+                Ok(Some(FlmStage3DirectWeightKind::RawDense))
+            }
+            VALUE_FORMAT_SYM_INT4 => self.stage3_direct_int4_weight_kind(logical),
+            _ => Ok(None),
+        }
+    }
+
+    fn stage3_direct_int4_weight_kind(
+        &self,
+        logical: &FlmLogicalTensor,
+    ) -> Result<Option<FlmStage3DirectWeightKind>, Error> {
+        let packed = self.required_storage_binding(logical, STORAGE_ROLE_PACKED)?;
+        let scale = self.required_storage_binding(logical, STORAGE_ROLE_SCALE)?;
+        let packed_step = self.required_direct_plan_step(logical, STORAGE_ROLE_PACKED)?;
+        let scale_step = self.required_direct_plan_step(logical, STORAGE_ROLE_SCALE)?;
+        let storage_abi = self
+            .storage_abis
+            .iter()
+            .find(|abi| abi.storage_abi_id == packed.storage_abi_id)
+            .ok_or_else(|| {
+                Error::Other(format!(
+                    "FLM Stage 3 tensor {} references missing storage ABI {}",
+                    logical.name, packed.storage_abi_id
+                ))
+            })?;
+
+        if packed.storage_dtype == FLM_DTYPE_INT32 {
+            self.required_storage_binding(logical, STORAGE_ROLE_SHAPE)?;
+            if scale.storage_dtype != FLM_DTYPE_BF16 || scale_step.target_dtype != FLM_DTYPE_BF16 {
+                return Err(Error::Other(format!(
+                    "FLM Stage 3 CT INT4 tensor {} requires BF16 scale storage/direct dtype",
+                    logical.name
+                )));
+            }
+            if storage_abi.codec_semantic_id != CODEC_SYM_INT4_G128_BF16 || storage_abi.bits != 4 {
+                return Err(Error::Other(format!(
+                    "FLM Stage 3 CT INT4 tensor {} uses unsupported ABI codec={} bits={}",
+                    logical.name, storage_abi.codec_semantic_id, storage_abi.bits
+                )));
+            }
+            return Ok(Some(FlmStage3DirectWeightKind::CtInt4Bf16Fallback));
+        }
+
+        if packed.storage_dtype != FLM_DTYPE_UINT8 || packed_step.target_dtype != FLM_DTYPE_UINT8 {
+            return Err(Error::Other(format!(
+                "FLM Stage 3 native INT4 tensor {} requires u8 packed storage/direct dtype",
+                logical.name
+            )));
+        }
+        if storage_abi.codec_semantic_id != CODEC_SUPERSONIC_NATIVE_INT4_G128_BF16
+            || storage_abi.bits != 4
+            || storage_abi.group_size != 128
+        {
+            return Err(Error::Other(format!(
+                "FLM Stage 3 native INT4 tensor {} uses unsupported ABI codec={} bits={} group_size={}",
+                logical.name,
+                storage_abi.codec_semantic_id,
+                storage_abi.bits,
+                storage_abi.group_size
+            )));
+        }
+        let zero = self.required_storage_binding(logical, STORAGE_ROLE_ZERO)?;
+        let zero_step = self.required_direct_plan_step(logical, STORAGE_ROLE_ZERO)?;
+        if scale.storage_dtype != FLM_DTYPE_BF16
+            || scale_step.target_dtype != FLM_DTYPE_BF16
+            || zero.storage_dtype != FLM_DTYPE_BF16
+            || zero_step.target_dtype != FLM_DTYPE_BF16
+        {
+            return Err(Error::Other(format!(
+                "FLM Stage 3 native INT4 tensor {} requires BF16 scale/zero storage and direct dtypes",
+                logical.name
+            )));
+        }
+        Ok(Some(FlmStage3DirectWeightKind::NativeInt4))
+    }
+
+    fn required_storage_binding(
+        &self,
+        logical: &FlmLogicalTensor,
+        storage_role: u16,
+    ) -> Result<&FlmStorageBinding, Error> {
+        self.storage_bindings
+            .iter()
+            .find(|binding| {
+                binding.logical_tensor_id == logical.tensor_id
+                    && binding.storage_role == storage_role
+            })
+            .ok_or_else(|| {
+                Error::Other(format!(
+                    "FLM Stage 3 tensor {} missing storage binding role {}",
+                    logical.name, storage_role
+                ))
+            })
+    }
+
+    fn required_direct_plan_step(
+        &self,
+        logical: &FlmLogicalTensor,
+        storage_role: u16,
+    ) -> Result<&FlmPlanStep, Error> {
+        self.plan_steps
+            .iter()
+            .find(|step| {
+                step.logical_tensor_id == logical.tensor_id
+                    && step.storage_role == storage_role
+                    && step.consume_strategy == CONSUME_STRATEGY_DIRECT
+            })
+            .ok_or_else(|| {
+                Error::Other(format!(
+                    "FLM Stage 3 tensor {} missing direct plan role {}",
+                    logical.name, storage_role
+                ))
+            })
     }
 }
 

--- a/crates/model-store/src/flm.rs
+++ b/crates/model-store/src/flm.rs
@@ -280,6 +280,12 @@ pub struct FlmPlanStep {
     pub flags: u32,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FlmRuntimeIdentity {
+    pub architecture_id: u32,
+    pub model_id: u16,
+}
+
 #[derive(Debug, Clone)]
 pub struct FlmRuntimeDirectory {
     pub architecture_id: u32,
@@ -304,6 +310,31 @@ struct SectionRange {
 }
 
 impl FlmRuntimeDirectory {
+    pub fn parse_identity(buf: &[u8]) -> Result<FlmRuntimeIdentity, Error> {
+        let (architecture_id, sections) = parse_section_table(buf)?;
+        let model_descriptor =
+            parse_model_descriptor(section(buf, &sections, SECTION_MODEL_DESCRIPTOR)?)?;
+        let expected_model_id = match architecture_id {
+            ARCH_QWEN3_6_DENSE => MODEL_QWEN3_6_DENSE_V1,
+            ARCH_QWEN3_6_MOE => MODEL_QWEN3_6_MOE_V1,
+            other => {
+                return Err(Error::Other(format!(
+                    "unsupported FLM runtime architecture {other}"
+                )));
+            }
+        };
+        if model_descriptor.model_id != expected_model_id {
+            return Err(Error::Other(format!(
+                "FLM model descriptor model_id {} does not match architecture {} (expected {})",
+                model_descriptor.model_id, architecture_id, expected_model_id
+            )));
+        }
+        Ok(FlmRuntimeIdentity {
+            architecture_id,
+            model_id: model_descriptor.model_id,
+        })
+    }
+
     pub fn parse(buf: &[u8]) -> Result<Self, Error> {
         let (architecture_id, sections) = parse_section_table(buf)?;
         let (config, moe_config) = if architecture_id == ARCH_QWEN3_6_MOE {

--- a/crates/model-store/src/lib.rs
+++ b/crates/model-store/src/lib.rs
@@ -14,7 +14,10 @@ pub use flm::{
     FlmAsset, FlmQwen36DenseConfig, FlmQwen36MoeConfig, FlmRuntimeDirectory, FlmRuntimeIdentity,
     FlmTokenizerDescriptor,
 };
-pub use store::{read_flm_runtime_identity, BakedStore, FlmLoadOptions};
+pub use store::{
+    read_flm_runtime_identity, BakedStore, FlmLoadOptions, TensorStorageExtent,
+    TensorStorageSourceKind,
+};
 
 /// Error type for bake and load operations.
 #[derive(Debug, thiserror::Error)]

--- a/crates/model-store/src/lib.rs
+++ b/crates/model-store/src/lib.rs
@@ -11,9 +11,10 @@ use manifest::{Manifest, QuantProfile, CONVERTER_VERSION, FORMAT_VERSION};
 
 pub use baker::{bake_phi4, bake_qwen35};
 pub use flm::{
-    FlmAsset, FlmQwen36DenseConfig, FlmQwen36MoeConfig, FlmRuntimeDirectory, FlmTokenizerDescriptor,
+    FlmAsset, FlmQwen36DenseConfig, FlmQwen36MoeConfig, FlmRuntimeDirectory, FlmRuntimeIdentity,
+    FlmTokenizerDescriptor,
 };
-pub use store::{BakedStore, FlmLoadOptions};
+pub use store::{read_flm_runtime_identity, BakedStore, FlmLoadOptions};
 
 /// Error type for bake and load operations.
 #[derive(Debug, thiserror::Error)]

--- a/crates/model-store/src/lib.rs
+++ b/crates/model-store/src/lib.rs
@@ -15,7 +15,7 @@ pub use flm::{
     FlmTokenizerDescriptor,
 };
 pub use store::{
-    read_flm_runtime_identity, BakedStore, FlmLoadOptions, TensorStorageExtent,
+    read_flm_runtime_identity, BakedStore, FlmLoadOptions, TensorStorageExtent, TensorStorageRange,
     TensorStorageSourceKind,
 };
 

--- a/crates/model-store/src/lib.rs
+++ b/crates/model-store/src/lib.rs
@@ -16,7 +16,7 @@ pub use flm::{
 };
 pub use store::{
     read_flm_runtime_identity, BakedStore, FlmLoadOptions, TensorStorageExtent, TensorStorageRange,
-    TensorStorageSourceKind,
+    TensorStorageSourceKind, VirtualArenaTransferBackend,
 };
 
 /// Error type for bake and load operations.

--- a/crates/model-store/src/store.rs
+++ b/crates/model-store/src/store.rs
@@ -1,10 +1,14 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
+#[cfg(unix)]
+use std::ffi::c_int;
+use std::ffi::c_void;
 use std::fs::File;
 use std::path::Path;
 
 use gpu_hal::{
-    copy_h2d, sync, GpuBuffer, ScalarType, VirtualAllocationRole, VirtualArena, VirtualBacking,
+    copy_h2d, copy_h2d_async, current_backend, sync, Backend, GpuBuffer, GpuStream,
+    RegisteredHostBuffer, ScalarType, VirtualAllocationRole, VirtualArena, VirtualBacking,
 };
 use memmap2::Mmap;
 
@@ -23,6 +27,92 @@ const FLM_DTYPE_FP8_E4M3: u16 = 3;
 const FLM_DTYPE_UINT8: u16 = 4;
 const FLM_DTYPE_INT32: u16 = 5;
 const FLM_DTYPE_INT64: u16 = 6;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct HostRegistrationRange {
+    ptr: *mut c_void,
+    len: usize,
+    data_offset: usize,
+}
+
+#[cfg(unix)]
+unsafe extern "C" {
+    fn getpagesize() -> c_int;
+}
+
+fn host_page_size() -> usize {
+    #[cfg(unix)]
+    {
+        let page_size = unsafe { getpagesize() };
+        if page_size > 0 {
+            return page_size as usize;
+        }
+    }
+    4096
+}
+
+fn round_up_to(value: usize, align: usize) -> Result<usize, Error> {
+    if align == 0 {
+        return Err(Error::Other("alignment must be > 0".into()));
+    }
+    let remainder = value % align;
+    if remainder == 0 {
+        return Ok(value);
+    }
+    value
+        .checked_add(align - remainder)
+        .ok_or_else(|| Error::Other("round_up_to overflow".into()))
+}
+
+fn host_registration_range_for_mmap_slice(
+    mmap_start: usize,
+    mmap_len: usize,
+    data_start: usize,
+    data_len: usize,
+    page_size: usize,
+) -> Result<HostRegistrationRange, Error> {
+    if mmap_len == 0 {
+        return Err(Error::Other(
+            "host registration requires a non-empty mmap backing".into(),
+        ));
+    }
+    if data_len == 0 {
+        return Err(Error::Other(
+            "host registration requires a non-empty data slice".into(),
+        ));
+    }
+    if page_size == 0 {
+        return Err(Error::Other(
+            "host registration requires page_size > 0".into(),
+        ));
+    }
+    let mmap_end = mmap_start
+        .checked_add(mmap_len)
+        .ok_or_else(|| Error::Other("mmap backing range overflows".into()))?;
+    let data_end = data_start
+        .checked_add(data_len)
+        .ok_or_else(|| Error::Other("data slice range overflows".into()))?;
+    if data_start < mmap_start || data_end > mmap_end {
+        return Err(Error::Other(format!(
+            "data slice [{data_start:#x}, {data_end:#x}) is outside mmap backing \
+             [{mmap_start:#x}, {mmap_end:#x})"
+        )));
+    }
+    let register_start = data_start - (data_start % page_size);
+    let register_end = round_up_to(data_end, page_size)?;
+    let mmap_page_end = round_up_to(mmap_end, page_size)?;
+    if register_start < mmap_start - (mmap_start % page_size) || register_end > mmap_page_end {
+        return Err(Error::Other(format!(
+            "host registration range [{register_start:#x}, {register_end:#x}) is outside \
+             page-rounded mmap backing ending at {mmap_page_end:#x}"
+        )));
+    }
+    Ok(HostRegistrationRange {
+        ptr: register_start as *mut c_void,
+        len: register_end - register_start,
+        data_offset: data_start - register_start,
+    })
+}
 
 #[derive(Debug, Clone, Copy, Default)]
 pub struct FlmLoadOptions {
@@ -1727,6 +1817,78 @@ impl BakedStore {
         let (dtype, upload_shape, payload) = self.upload_payload(name, meta)?;
         let buf = GpuBuffer::from_host_bytes(ordinal, dtype, &upload_shape, payload.as_ref())?;
         Ok(buf)
+    }
+
+    /// Load a direct mmap-backed tensor through backend host registration.
+    ///
+    /// This is an opt-in diagnostic/experimental path for callers that have
+    /// already determined registration is worthwhile for the tensor
+    /// shape/layout. It is not the first-class FLM fast-load target; direct FLM
+    /// plans should still prefer GPU-resident layouts such as virtual expert
+    /// slabs. The registered path deliberately rejects transformed or
+    /// synthetic payloads because those are not backed by this store's mmap.
+    pub fn load_to_gpu_registered_mmap(
+        &self,
+        name: &str,
+        ordinal: usize,
+    ) -> Result<GpuBuffer, Error> {
+        if current_backend() != Backend::Hip {
+            return Err(Error::Gpu(gpu_hal::GpuError::Unsupported(
+                "registered mmap upload is currently implemented for HIP only".into(),
+            )));
+        }
+        let meta = self
+            .index
+            .get(name)
+            .ok_or_else(|| Error::NotFound(name.to_string()))?;
+        let (dtype, upload_shape, payload) = self.upload_payload(name, meta)?;
+        let Cow::Borrowed(bytes) = payload else {
+            return Err(Error::Other(format!(
+                "tensor '{name}' is not backed by the store mmap and cannot use registered upload"
+            )));
+        };
+        let range = host_registration_range_for_mmap_slice(
+            self.data as usize,
+            self.data_len,
+            bytes.as_ptr() as usize,
+            bytes.len(),
+            host_page_size(),
+        )?;
+        let elems = upload_shape
+            .iter()
+            .try_fold(1usize, |acc, dim| acc.checked_mul(*dim))
+            .ok_or_else(|| {
+                Error::Other(format!(
+                    "tensor '{name}' upload shape {:?} overflows element count",
+                    upload_shape
+                ))
+            })?;
+        let expected_bytes = elems.checked_mul(dtype.size_in_bytes()).ok_or_else(|| {
+            Error::Other(format!(
+                "tensor '{name}' upload shape {:?} overflows byte count",
+                upload_shape
+            ))
+        })?;
+        if bytes.len() != expected_bytes {
+            return Err(Error::Other(format!(
+                "tensor '{name}' registered upload expected {expected_bytes} bytes from dtype={dtype:?} shape={upload_shape:?}, got {}",
+                bytes.len()
+            )));
+        }
+
+        let stream = GpuStream::new_nonblocking(ordinal)?;
+        let mut buffer = GpuBuffer::alloc(ordinal, dtype, &upload_shape)?;
+        let registered = unsafe { RegisteredHostBuffer::new(ordinal, range.ptr, range.len)? };
+        copy_h2d_async(
+            ordinal,
+            &stream,
+            buffer.as_mut_ptr(),
+            bytes.as_ptr() as *const c_void,
+            bytes.len(),
+        )?;
+        stream.synchronize()?;
+        drop(registered);
+        Ok(buffer)
     }
 
     /// Load a tensor into a role-tagged virtual allocation.
@@ -3681,6 +3843,23 @@ mod tests {
         let norm = store.meta("model.norm.weight").unwrap();
         assert_eq!(norm.dtype, "bf16");
         assert_eq!(norm.shape, vec![2]);
+    }
+
+    #[test]
+    fn host_registration_range_is_bounded_by_page_rounded_mmap() {
+        let range = host_registration_range_for_mmap_slice(0x1000, 0x2500, 0x2234, 0x40, 4096)
+            .expect("registration range");
+
+        assert_eq!(range.ptr as usize, 0x2000);
+        assert_eq!(range.len, 0x1000);
+        assert_eq!(range.data_offset, 0x234);
+
+        let err = host_registration_range_for_mmap_slice(0x1000, 0x100, 0x0fff, 0x20, 4096)
+            .expect_err("slice outside mmap should fail");
+        assert!(
+            err.to_string().contains("outside mmap backing"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]
@@ -6208,12 +6387,18 @@ mod tests {
         gpu_hal::hal_profile_set_enabled(false);
 
         assert!(
-            profile.entries.iter().any(|entry| entry.op == "vmm_map_no_sync"),
+            profile
+                .entries
+                .iter()
+                .any(|entry| entry.op == "vmm_map_no_sync"),
             "expected virtual upload to map pages with no-clear initialization, got {:?}",
             profile.entries
         );
         assert!(
-            profile.entries.iter().all(|entry| entry.op != "memset_zeros"),
+            profile
+                .entries
+                .iter()
+                .all(|entry| entry.op != "memset_zeros"),
             "virtual upload should not clear pages before immediately copying tensor bytes: {:?}",
             profile.entries
         );

--- a/crates/model-store/src/store.rs
+++ b/crates/model-store/src/store.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::ffi::c_int;
 use std::ffi::c_void;
 use std::fs::File;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use gpu_hal::{
     copy_h2d, copy_h2d_async, current_backend, sync, Backend, GpuBuffer, GpuStream,
@@ -174,10 +174,32 @@ struct CtSymInt4Bf16Fallback {
 }
 
 /// A memory-mapped baked weight store for fast GPU loading.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TensorStorageSourceKind {
+    BakedWeights,
+    FlmContainer,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TensorStorageExtent {
+    pub source_kind: TensorStorageSourceKind,
+    pub source_path: PathBuf,
+    pub name: String,
+    pub file_offset: u64,
+    pub byte_len: u64,
+    pub storage_dtype: String,
+    pub storage_shape: Vec<usize>,
+    pub layout: LayoutTag,
+    pub upload_dtype: String,
+    pub upload_shape: Vec<usize>,
+}
+
 pub struct BakedStore {
     _mmap: Mmap,
     data: *const u8,
     data_len: usize,
+    source_kind: TensorStorageSourceKind,
+    source_path: PathBuf,
     index: HashMap<String, TensorMeta>,
     synthetic: HashMap<String, Vec<u8>>,
     upload_views: HashMap<String, TensorUploadView>,
@@ -1558,7 +1580,10 @@ impl BakedStore {
         let manifest_text = std::fs::read_to_string(crate::manifest_path(bake_dir))?;
         let manifest: Manifest = serde_json::from_str(&manifest_text)?;
 
-        let weights_file = File::open(crate::weights_bin_path(bake_dir))?;
+        let weights_path = crate::weights_bin_path(bake_dir);
+        let weights_file = File::open(&weights_path)?;
+        let source_path =
+            std::fs::canonicalize(&weights_path).unwrap_or_else(|_| weights_path.clone());
         let mmap = unsafe { Mmap::map(&weights_file)? };
 
         let data = mmap.as_ptr();
@@ -1573,6 +1598,8 @@ impl BakedStore {
             _mmap: mmap,
             data,
             data_len,
+            source_kind: TensorStorageSourceKind::BakedWeights,
+            source_path,
             index,
             synthetic: HashMap::new(),
             upload_views: HashMap::new(),
@@ -1589,6 +1616,7 @@ impl BakedStore {
     /// Open an FLM container with optional compatibility aliases.
     pub fn open_flm_with_options(path: &Path, options: FlmLoadOptions) -> Result<Self, Error> {
         let file = File::open(path)?;
+        let source_path = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
         let mmap = unsafe { Mmap::map(&file)? };
         let data = mmap.as_ptr();
         let data_len = mmap.len();
@@ -1643,6 +1671,8 @@ impl BakedStore {
             _mmap: mmap,
             data,
             data_len,
+            source_kind: TensorStorageSourceKind::FlmContainer,
+            source_path,
             index,
             synthetic,
             upload_views,
@@ -1806,6 +1836,41 @@ impl BakedStore {
         Ok(&bytes[byte_offset..range_end])
     }
 
+    /// Return the concrete file extent for a direct file-backed tensor.
+    ///
+    /// This is the storage-side descriptor future transfer backends need: the
+    /// source file identity plus byte extent, alongside both the bytes-on-disk
+    /// metadata and the runtime upload view. Synthesized and transformed
+    /// aliases return `Ok(None)` because there is no single source-file extent
+    /// that can be transferred directly.
+    pub fn tensor_storage_extent(&self, name: &str) -> Result<Option<TensorStorageExtent>, Error> {
+        let meta = self
+            .index
+            .get(name)
+            .ok_or_else(|| Error::NotFound(name.to_string()))?;
+        if self.synthetic.contains_key(name) || self.ct_int4_bf16_fallbacks.contains_key(name) {
+            return Ok(None);
+        }
+        self.tensor_bytes(name, meta)?;
+        let (upload_dtype, upload_shape) = if let Some(view) = self.upload_views.get(name) {
+            (view.dtype.clone(), view.shape.clone())
+        } else {
+            (meta.dtype.clone(), gpu_upload_shape(meta)?)
+        };
+        Ok(Some(TensorStorageExtent {
+            source_kind: self.source_kind,
+            source_path: self.source_path.clone(),
+            name: name.to_string(),
+            file_offset: meta.offset,
+            byte_len: meta.byte_len,
+            storage_dtype: meta.dtype.clone(),
+            storage_shape: meta.shape.clone(),
+            layout: meta.layout.clone(),
+            upload_dtype,
+            upload_shape,
+        }))
+    }
+
     /// Load a tensor from the baked store to GPU memory.
     /// Direct tensors borrow mmap bytes; transformed FLM logical aliases
     /// materialize a temporary host fallback payload before upload.
@@ -1837,21 +1902,24 @@ impl BakedStore {
                 "registered mmap upload is currently implemented for HIP only".into(),
             )));
         }
-        let meta = self
-            .index
-            .get(name)
-            .ok_or_else(|| Error::NotFound(name.to_string()))?;
-        let (dtype, upload_shape, payload) = self.upload_payload(name, meta)?;
-        let Cow::Borrowed(bytes) = payload else {
-            return Err(Error::Other(format!(
-                "tensor '{name}' is not backed by the store mmap and cannot use registered upload"
-            )));
-        };
+        let extent = self.tensor_storage_extent(name)?.ok_or_else(|| {
+            Error::Other(format!(
+                "tensor '{name}' is not a direct file-backed extent and cannot use registered upload"
+            ))
+        })?;
+        let byte_offset = u64_to_usize(extent.file_offset, "registered upload file offset")?;
+        let byte_len = u64_to_usize(extent.byte_len, "registered upload byte length")?;
+        let dtype = parse_dtype(&extent.upload_dtype)?;
+        let upload_shape = extent.upload_shape;
+        let bytes = self.raw_byte_range(name, 0, byte_len)?;
+        let data_start = (self.data as usize)
+            .checked_add(byte_offset)
+            .ok_or_else(|| Error::Other("registered upload data pointer overflows".into()))?;
         let range = host_registration_range_for_mmap_slice(
             self.data as usize,
             self.data_len,
-            bytes.as_ptr() as usize,
-            bytes.len(),
+            data_start,
+            byte_len,
             host_page_size(),
         )?;
         let elems = upload_shape
@@ -3846,6 +3914,45 @@ mod tests {
     }
 
     #[test]
+    fn open_flm_exposes_file_storage_extent_for_direct_tensor() {
+        let data = build_test_flm(&[
+            TestFlmTensor {
+                name: "model.embed_tokens.weight",
+                shape: vec![2, 4],
+                dtype: 4,
+                codec: 0,
+                payload: (0u8..8).collect(),
+            },
+            TestFlmTensor {
+                name: "model.norm.weight",
+                shape: vec![2],
+                dtype: 2,
+                codec: 0,
+                payload: vec![0x00, 0x3f, 0x00, 0x40],
+            },
+        ]);
+        let file = write_temp_flm(&data);
+        let store = BakedStore::open_flm(file.path()).expect("open FLM");
+        let meta = store.meta("model.norm.weight").expect("norm meta");
+
+        let extent = store
+            .tensor_storage_extent("model.norm.weight")
+            .expect("storage extent")
+            .expect("direct FLM tensor should expose a file extent");
+
+        assert_eq!(extent.source_kind, TensorStorageSourceKind::FlmContainer);
+        assert_eq!(extent.source_path, file.path());
+        assert_eq!(extent.name, "model.norm.weight");
+        assert_eq!(extent.file_offset, meta.offset);
+        assert_eq!(extent.byte_len, meta.byte_len);
+        assert_eq!(extent.storage_dtype, "bf16");
+        assert_eq!(extent.storage_shape, vec![2]);
+        assert_eq!(extent.layout, LayoutTag::Raw);
+        assert_eq!(extent.upload_dtype, "bf16");
+        assert_eq!(extent.upload_shape, vec![2]);
+    }
+
+    #[test]
     fn host_registration_range_is_bounded_by_page_rounded_mmap() {
         let range = host_registration_range_for_mmap_slice(0x1000, 0x2500, 0x2234, 0x40, 4096)
             .expect("registration range");
@@ -4145,6 +4252,13 @@ mod tests {
             kind,
             Some(crate::flm::FlmStage3DirectWeightKind::CtInt4Bf16Fallback)
         );
+        assert!(
+            store
+                .tensor_storage_extent("model.language_model.layers.0.mlp.gate_proj.weight")
+                .expect("CT fallback storage extent")
+                .is_none(),
+            "CT fallback aliases are materialized transforms and must not expose a single file extent"
+        );
     }
 
     #[test]
@@ -4171,6 +4285,17 @@ mod tests {
             kind,
             Some(crate::flm::FlmStage3DirectWeightKind::NativeInt4)
         );
+        let extent = store
+            .tensor_storage_extent("model.language_model.layers.0.mlp.experts.gate_up_proj")
+            .expect("native INT4 extent")
+            .expect("native INT4 direct tensor should expose file extent");
+        assert_eq!(extent.source_kind, TensorStorageSourceKind::FlmContainer);
+        assert_eq!(extent.source_path, file.path());
+        assert_eq!(extent.storage_dtype, "u8");
+        assert_eq!(extent.storage_shape, vec![2, 256, 64]);
+        assert_eq!(extent.layout, LayoutTag::Int4Quantized);
+        assert_eq!(extent.upload_dtype, "u8");
+        assert_eq!(extent.upload_shape, vec![2, 256, 64]);
     }
 
     #[test]

--- a/crates/model-store/src/store.rs
+++ b/crates/model-store/src/store.rs
@@ -2049,13 +2049,30 @@ impl BakedStore {
         name: &str,
         role: VirtualAllocationRole,
     ) -> Result<usize, Error> {
+        self.load_to_virtual_arena_with_backend(
+            arena,
+            name,
+            role,
+            VirtualArenaTransferBackend::PageableH2d,
+        )
+    }
+
+    /// Load a tensor into a role-tagged virtual allocation through an explicit
+    /// transfer backend.
+    pub fn load_to_virtual_arena_with_backend(
+        &self,
+        arena: &mut VirtualArena,
+        name: &str,
+        role: VirtualAllocationRole,
+        backend: VirtualArenaTransferBackend,
+    ) -> Result<usize, Error> {
         let id = self.reserve_virtual_arena(arena, name, role)?;
         let len = self
             .index
             .get(name)
             .ok_or_else(|| Error::NotFound(name.to_string()))?
             .byte_len as usize;
-        self.load_range_to_virtual_arena(arena, id, name, 0, len)?;
+        self.load_range_to_virtual_arena_with_backend(arena, id, name, 0, len, backend)?;
         Ok(id)
     }
 
@@ -6875,6 +6892,75 @@ mod tests {
                 VirtualArenaTransferBackend::GpuDirectStorage,
             )
             .expect_err("GPU-direct storage backend should be named but not silently emulated");
+        let profile = gpu_hal::hal_profile_snapshot();
+        gpu_hal::hal_profile_set_enabled(false);
+
+        assert!(
+            err.to_string().contains("GPU-direct storage"),
+            "unexpected error: {err}"
+        );
+        assert!(
+            profile
+                .entries
+                .iter()
+                .all(|entry| entry.op != "copy_h2d" && entry.op != "vmm_map_no_sync"),
+            "GPU-direct backend must not fall back to pageable mapping/copy: {:?}",
+            profile.entries
+        );
+        assert_eq!(arena.stats().logical_resident_bytes, 0);
+    }
+
+    #[test]
+    fn virtual_arena_full_load_honors_explicit_gpu_direct_backend() {
+        gpu_hal::set_backend(gpu_hal::Backend::Hip);
+        if !gpu_hal::vmm_is_supported(gpu_hal::Backend::Hip, 0) {
+            eprintln!("skip: HIP VMM unsupported on this device/runtime");
+            return;
+        }
+        if gpu_hal::storage_to_device_is_supported(gpu_hal::Backend::Hip) {
+            eprintln!("skip: native storage-to-device transfer available on this runtime");
+            return;
+        }
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let bake_dir = tmp.path();
+        std::fs::write(crate::weights_bin_path(bake_dir), vec![9u8; 4096])
+            .expect("write weights.bin");
+        let manifest = Manifest {
+            format_version: FORMAT_VERSION,
+            converter_version: 1,
+            model_family: "test".to_string(),
+            quant_profile: None,
+            source_format: None,
+            source_quant: None,
+            quant_method: None,
+            tensors: vec![TensorMeta {
+                name: "model.layers.0.mlp.experts.down_proj".to_string(),
+                shape: vec![4096],
+                dtype: "u8".to_string(),
+                layout: LayoutTag::Int4Quantized,
+                offset: 0,
+                byte_len: 4096,
+            }],
+        };
+        std::fs::write(
+            crate::manifest_path(bake_dir),
+            serde_json::to_string(&manifest).expect("serialize manifest"),
+        )
+        .expect("write manifest");
+
+        let store = BakedStore::open(bake_dir).expect("open synthetic bake");
+        let mut arena = BakedStore::virtual_weight_arena(0);
+        gpu_hal::hal_profile_set_enabled(true);
+        gpu_hal::hal_profile_reset();
+        let err = store
+            .load_to_virtual_arena_with_backend(
+                &mut arena,
+                "model.layers.0.mlp.experts.down_proj",
+                gpu_hal::VirtualAllocationRole::MoeExpert,
+                VirtualArenaTransferBackend::GpuDirectStorage,
+            )
+            .expect_err("full virtual load should honor explicit GPU-direct backend");
         let profile = gpu_hal::hal_profile_snapshot();
         gpu_hal::hal_profile_set_enabled(false);
 

--- a/crates/model-store/src/store.rs
+++ b/crates/model-store/src/store.rs
@@ -99,6 +99,27 @@ pub struct BakedStore {
 unsafe impl Send for BakedStore {}
 unsafe impl Sync for BakedStore {}
 
+pub fn read_flm_runtime_identity(
+    path: &Path,
+) -> Result<Option<crate::flm::FlmRuntimeIdentity>, Error> {
+    let file = File::open(path)?;
+    let mmap = unsafe { Mmap::map(&file)? };
+    let sb = flm_parse_superblock(&mmap)?;
+    match (sb.runtime_dir_offset, sb.runtime_dir_len) {
+        (0, 0) => Ok(None),
+        (0, len) => Err(Error::Other(format!(
+            "FLM runtime directory length is {len} but offset is zero"
+        ))),
+        (offset, 0) => Err(Error::Other(format!(
+            "FLM runtime directory offset is {offset} but length is zero"
+        ))),
+        (offset, len) => {
+            let runtime = read_exact_range(&mmap, offset, len, "FLM runtime directory")?;
+            crate::flm::FlmRuntimeDirectory::parse_identity(runtime).map(Some)
+        }
+    }
+}
+
 fn parse_dtype(name: &str) -> Result<ScalarType, Error> {
     ScalarType::from_name(name).ok_or_else(|| Error::UnsupportedDtype(name.to_string()))
 }
@@ -3690,6 +3711,27 @@ mod tests {
             runtime.asset_by_kind("tokenizer_regex").unwrap().asset_id,
             4
         );
+    }
+
+    #[test]
+    fn read_flm_runtime_identity_reads_model_descriptor_without_store_open() {
+        let mut data = build_test_flm(&[TestFlmTensor {
+            name: "model.embed_tokens.weight",
+            shape: vec![2, 4],
+            dtype: 4,
+            codec: 0,
+            payload: (0u8..8).collect(),
+        }]);
+        let runtime = build_test_runtime_directory();
+        append_runtime_directory(&mut data, &runtime);
+        let file = write_temp_flm(&data);
+
+        let identity = read_flm_runtime_identity(file.path())
+            .expect("read runtime identity")
+            .unwrap();
+
+        assert_eq!(identity.architecture_id, crate::flm::ARCH_QWEN3_6_DENSE);
+        assert_eq!(identity.model_id, crate::flm::MODEL_QWEN3_6_DENSE_V1);
     }
 
     #[test]

--- a/crates/model-store/src/store.rs
+++ b/crates/model-store/src/store.rs
@@ -2161,24 +2161,24 @@ impl BakedStore {
                 transfer_range.extent.storage_shape
             )));
         }
-        match backend {
-            VirtualArenaTransferBackend::PageableH2d => {}
-            VirtualArenaTransferBackend::GpuDirectStorage => {
-                return Err(Error::Gpu(gpu_hal::GpuError::Unsupported(format!(
-                    "GPU-direct storage-to-virtual-arena transfer is not implemented yet \
-                     (source={} offset={} len={})",
-                    transfer_range.extent.source_path.display(),
-                    transfer_range.file_offset,
-                    transfer_range.byte_len
-                ))));
-            }
-        }
         let src_byte_offset = u64_to_usize(
             transfer_range.tensor_byte_offset,
             "virtual arena source byte offset",
         )?;
         let src_byte_len =
             u64_to_usize(transfer_range.byte_len, "virtual arena source byte length")?;
+        match backend {
+            VirtualArenaTransferBackend::PageableH2d => {}
+            VirtualArenaTransferBackend::GpuDirectStorage => {
+                buffer.copy_storage_range_bytes_no_sync(
+                    byte_offset,
+                    &transfer_range.extent.source_path,
+                    transfer_range.file_offset,
+                    src_byte_len,
+                )?;
+                return Ok(());
+            }
+        }
         let src_bytes = self.raw_byte_range(name, src_byte_offset, src_byte_len)?;
         // The source tensor bytes are copied into the mapped range before the
         // allocation is observed as loaded, so clearing new pages first only

--- a/crates/model-store/src/store.rs
+++ b/crates/model-store/src/store.rs
@@ -206,6 +206,18 @@ pub struct TensorStorageRange {
     pub byte_len: u64,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VirtualArenaTransferBackend {
+    /// Map virtual pages and copy from the mmap-backed host slice with normal H2D.
+    PageableH2d,
+    /// Storage-to-device transfer from the source file range into virtual memory.
+    ///
+    /// This backend is named now so callers can select and test the boundary,
+    /// but it returns `Unsupported` until gpu-hal grows the corresponding
+    /// storage-to-device primitive.
+    GpuDirectStorage,
+}
+
 pub struct BakedStore {
     _mmap: Mmap,
     data: *const u8,
@@ -2101,6 +2113,31 @@ impl BakedStore {
         byte_offset: usize,
         byte_len: usize,
     ) -> Result<(), Error> {
+        self.load_range_to_virtual_arena_with_backend(
+            arena,
+            allocation_id,
+            name,
+            byte_offset,
+            byte_len,
+            VirtualArenaTransferBackend::PageableH2d,
+        )
+    }
+
+    /// Load a direct file-backed tensor range into a virtual allocation through
+    /// an explicit transfer backend.
+    ///
+    /// `PageableH2d` is the current implementation. `GpuDirectStorage` is the
+    /// first-class FLM target backend, but currently reports `Unsupported`
+    /// instead of silently falling back to pageable H2D.
+    pub fn load_range_to_virtual_arena_with_backend(
+        &self,
+        arena: &mut VirtualArena,
+        allocation_id: usize,
+        name: &str,
+        byte_offset: usize,
+        byte_len: usize,
+        backend: VirtualArenaTransferBackend,
+    ) -> Result<(), Error> {
         let transfer_range = self.tensor_storage_range(name, byte_offset, byte_len)?.ok_or_else(|| {
             Error::Other(format!(
                 "tensor '{name}' is not a direct file-backed extent and cannot be range-loaded into a virtual arena"
@@ -2123,6 +2160,18 @@ impl BakedStore {
                 transfer_range.extent.storage_dtype,
                 transfer_range.extent.storage_shape
             )));
+        }
+        match backend {
+            VirtualArenaTransferBackend::PageableH2d => {}
+            VirtualArenaTransferBackend::GpuDirectStorage => {
+                return Err(Error::Gpu(gpu_hal::GpuError::Unsupported(format!(
+                    "GPU-direct storage-to-virtual-arena transfer is not implemented yet \
+                     (source={} offset={} len={})",
+                    transfer_range.extent.source_path.display(),
+                    transfer_range.file_offset,
+                    transfer_range.byte_len
+                ))));
+            }
         }
         let src_byte_offset = u64_to_usize(
             transfer_range.tensor_byte_offset,
@@ -6688,6 +6737,160 @@ mod tests {
             .to_host_bytes()
             .expect("read virtual expert");
         assert_eq!(loaded, weights);
+    }
+
+    #[test]
+    fn virtual_arena_range_load_supports_explicit_pageable_backend() {
+        gpu_hal::set_backend(gpu_hal::Backend::Hip);
+        if !gpu_hal::vmm_is_supported(gpu_hal::Backend::Hip, 0) {
+            eprintln!("skip: HIP VMM unsupported on this device/runtime");
+            return;
+        }
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let bake_dir = tmp.path();
+        let weights = (0..4096)
+            .map(|idx| (idx as u8).wrapping_mul(19).wrapping_add(11))
+            .collect::<Vec<_>>();
+        std::fs::write(crate::weights_bin_path(bake_dir), &weights).expect("write weights.bin");
+        let manifest = Manifest {
+            format_version: FORMAT_VERSION,
+            converter_version: 1,
+            model_family: "test".to_string(),
+            quant_profile: None,
+            source_format: None,
+            source_quant: None,
+            quant_method: None,
+            tensors: vec![TensorMeta {
+                name: "model.layers.0.mlp.experts.gate_up_proj".to_string(),
+                shape: vec![4096],
+                dtype: "u8".to_string(),
+                layout: LayoutTag::Int4Quantized,
+                offset: 0,
+                byte_len: 4096,
+            }],
+        };
+        std::fs::write(
+            crate::manifest_path(bake_dir),
+            serde_json::to_string(&manifest).expect("serialize manifest"),
+        )
+        .expect("write manifest");
+
+        let store = BakedStore::open(bake_dir).expect("open synthetic bake");
+        let mut arena = BakedStore::virtual_weight_arena(0);
+        let allocation_id = store
+            .reserve_virtual_arena(
+                &mut arena,
+                "model.layers.0.mlp.experts.gate_up_proj",
+                gpu_hal::VirtualAllocationRole::MoeExpert,
+            )
+            .expect("reserve virtual expert");
+
+        gpu_hal::hal_profile_set_enabled(true);
+        gpu_hal::hal_profile_reset();
+        store
+            .load_range_to_virtual_arena_with_backend(
+                &mut arena,
+                allocation_id,
+                "model.layers.0.mlp.experts.gate_up_proj",
+                0,
+                2048,
+                VirtualArenaTransferBackend::PageableH2d,
+            )
+            .expect("explicit pageable range load");
+        let profile = gpu_hal::hal_profile_snapshot();
+        gpu_hal::hal_profile_set_enabled(false);
+
+        assert!(
+            profile
+                .entries
+                .iter()
+                .any(|entry| entry.op == "vmm_map_no_sync"),
+            "expected explicit pageable backend to map virtual pages for upload, got {:?}",
+            profile.entries
+        );
+        let loaded = arena
+            .allocation(allocation_id)
+            .expect("expert allocation")
+            .buffer()
+            .to_host_prefix_bytes(2048)
+            .expect("read virtual expert");
+        assert_eq!(loaded, weights[..2048]);
+    }
+
+    #[test]
+    fn virtual_arena_range_load_names_gpu_direct_backend_without_fallback() {
+        gpu_hal::set_backend(gpu_hal::Backend::Hip);
+        if !gpu_hal::vmm_is_supported(gpu_hal::Backend::Hip, 0) {
+            eprintln!("skip: HIP VMM unsupported on this device/runtime");
+            return;
+        }
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let bake_dir = tmp.path();
+        std::fs::write(crate::weights_bin_path(bake_dir), vec![7u8; 4096])
+            .expect("write weights.bin");
+        let manifest = Manifest {
+            format_version: FORMAT_VERSION,
+            converter_version: 1,
+            model_family: "test".to_string(),
+            quant_profile: None,
+            source_format: None,
+            source_quant: None,
+            quant_method: None,
+            tensors: vec![TensorMeta {
+                name: "model.layers.0.mlp.experts.gate_up_proj".to_string(),
+                shape: vec![4096],
+                dtype: "u8".to_string(),
+                layout: LayoutTag::Int4Quantized,
+                offset: 0,
+                byte_len: 4096,
+            }],
+        };
+        std::fs::write(
+            crate::manifest_path(bake_dir),
+            serde_json::to_string(&manifest).expect("serialize manifest"),
+        )
+        .expect("write manifest");
+
+        let store = BakedStore::open(bake_dir).expect("open synthetic bake");
+        let mut arena = BakedStore::virtual_weight_arena(0);
+        let allocation_id = store
+            .reserve_virtual_arena(
+                &mut arena,
+                "model.layers.0.mlp.experts.gate_up_proj",
+                gpu_hal::VirtualAllocationRole::MoeExpert,
+            )
+            .expect("reserve virtual expert");
+
+        gpu_hal::hal_profile_set_enabled(true);
+        gpu_hal::hal_profile_reset();
+        let err = store
+            .load_range_to_virtual_arena_with_backend(
+                &mut arena,
+                allocation_id,
+                "model.layers.0.mlp.experts.gate_up_proj",
+                0,
+                4096,
+                VirtualArenaTransferBackend::GpuDirectStorage,
+            )
+            .expect_err("GPU-direct storage backend should be named but not silently emulated");
+        let profile = gpu_hal::hal_profile_snapshot();
+        gpu_hal::hal_profile_set_enabled(false);
+
+        assert!(
+            err.to_string().contains("GPU-direct storage"),
+            "unexpected error: {err}"
+        );
+        assert!(
+            profile
+                .entries
+                .iter()
+                .all(|entry| entry.op != "copy_h2d" && entry.op != "vmm_map_no_sync"),
+            "GPU-direct backend must not fall back to pageable mapping/copy: {:?}",
+            profile.entries
+        );
+        assert_eq!(arena.stats().logical_resident_bytes, 0);
     }
 
     #[test]

--- a/crates/model-store/src/store.rs
+++ b/crates/model-store/src/store.rs
@@ -212,9 +212,10 @@ pub enum VirtualArenaTransferBackend {
     PageableH2d,
     /// Storage-to-device transfer from the source file range into virtual memory.
     ///
-    /// This backend is named now so callers can select and test the boundary,
-    /// but it returns `Unsupported` until gpu-hal grows the corresponding
-    /// storage-to-device primitive.
+    /// On HIP this routes through the optional hipFile storage-to-device
+    /// primitive when it is compiled in. Builds or backends without a concrete
+    /// storage-direct implementation return `Unsupported` before pageable
+    /// mapping/copy fallback.
     GpuDirectStorage,
 }
 
@@ -2143,9 +2144,10 @@ impl BakedStore {
     /// Load a direct file-backed tensor range into a virtual allocation through
     /// an explicit transfer backend.
     ///
-    /// `PageableH2d` is the current implementation. `GpuDirectStorage` is the
-    /// first-class FLM target backend, but currently reports `Unsupported`
-    /// instead of silently falling back to pageable H2D.
+    /// `PageableH2d` is the portable fallback. `GpuDirectStorage` is the
+    /// first-class FLM target backend and reports `Unsupported` instead of
+    /// silently falling back when the selected HAL backend has no concrete
+    /// storage-to-device implementation.
     pub fn load_range_to_virtual_arena_with_backend(
         &self,
         arena: &mut VirtualArena,

--- a/crates/model-store/src/store.rs
+++ b/crates/model-store/src/store.rs
@@ -1843,7 +1843,10 @@ impl BakedStore {
                 meta.shape
             )));
         }
-        buffer.map_range_bytes(byte_offset, byte_len)?;
+        // The source tensor bytes are copied into the mapped range before the
+        // allocation is observed as loaded, so clearing new pages first only
+        // adds startup bandwidth.
+        buffer.map_range_bytes_no_sync(byte_offset, byte_len)?;
         let src = unsafe { src_bytes.as_ptr().add(byte_offset) as *const _ };
         copy_h2d(ordinal, buffer.offset_mut_ptr(byte_offset), src, byte_len)?;
         sync(ordinal)?;
@@ -6150,6 +6153,78 @@ mod tests {
             .expect("read virtual expert");
         assert_eq!(weight, weights[..4096]);
         assert_eq!(expert, weights[4096..]);
+    }
+
+    #[test]
+    fn virtual_arena_load_initializes_mapped_pages_by_copy_without_clearing() {
+        gpu_hal::set_backend(gpu_hal::Backend::Hip);
+        if !gpu_hal::vmm_is_supported(gpu_hal::Backend::Hip, 0) {
+            eprintln!("skip: HIP VMM unsupported on this device/runtime");
+            return;
+        }
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let bake_dir = tmp.path();
+        let weights = (0..4096)
+            .map(|idx| (idx as u8).wrapping_mul(17).wrapping_add(3))
+            .collect::<Vec<_>>();
+        std::fs::write(crate::weights_bin_path(bake_dir), &weights).expect("write weights.bin");
+        let manifest = Manifest {
+            format_version: FORMAT_VERSION,
+            converter_version: 1,
+            model_family: "test".to_string(),
+            quant_profile: None,
+            source_format: None,
+            source_quant: None,
+            quant_method: None,
+            tensors: vec![TensorMeta {
+                name: "model.layers.0.mlp.experts.gate_up_proj".to_string(),
+                shape: vec![4096],
+                dtype: "u8".to_string(),
+                layout: LayoutTag::Int4Quantized,
+                offset: 0,
+                byte_len: 4096,
+            }],
+        };
+        std::fs::write(
+            crate::manifest_path(bake_dir),
+            serde_json::to_string(&manifest).expect("serialize manifest"),
+        )
+        .expect("write manifest");
+
+        let store = BakedStore::open(bake_dir).expect("open synthetic bake");
+        let mut arena = BakedStore::virtual_weight_arena(0);
+
+        gpu_hal::hal_profile_set_enabled(true);
+        gpu_hal::hal_profile_reset();
+        let allocation_id = store
+            .load_to_virtual_arena(
+                &mut arena,
+                "model.layers.0.mlp.experts.gate_up_proj",
+                gpu_hal::VirtualAllocationRole::MoeExpert,
+            )
+            .expect("load virtual expert");
+        let profile = gpu_hal::hal_profile_snapshot();
+        gpu_hal::hal_profile_set_enabled(false);
+
+        assert!(
+            profile.entries.iter().any(|entry| entry.op == "vmm_map_no_sync"),
+            "expected virtual upload to map pages with no-clear initialization, got {:?}",
+            profile.entries
+        );
+        assert!(
+            profile.entries.iter().all(|entry| entry.op != "memset_zeros"),
+            "virtual upload should not clear pages before immediately copying tensor bytes: {:?}",
+            profile.entries
+        );
+
+        let loaded = arena
+            .allocation(allocation_id)
+            .expect("expert allocation")
+            .buffer()
+            .to_host_bytes()
+            .expect("read virtual expert");
+        assert_eq!(loaded, weights);
     }
 
     #[test]

--- a/crates/model-store/src/store.rs
+++ b/crates/model-store/src/store.rs
@@ -3940,6 +3940,86 @@ mod tests {
     }
 
     #[test]
+    fn flm_runtime_classifies_ct_int4_stage3_plan_as_bf16_fallback() {
+        let data = build_test_flm_with_stage3_logical_bindings();
+        let file = write_temp_flm(&data);
+
+        let store = BakedStore::open_flm_with_options(
+            file.path(),
+            FlmLoadOptions {
+                flm_int4_logical_aliases: true,
+                verify_block_hashes: false,
+            },
+        )
+        .expect("open CT INT4 Stage 3 FLM");
+
+        let kind = store
+            .flm_runtime()
+            .expect("runtime directory")
+            .stage3_direct_weight_kind("model.language_model.layers.0.mlp.gate_proj.weight")
+            .expect("classify direct weight kind");
+
+        assert_eq!(
+            kind,
+            Some(crate::flm::FlmStage3DirectWeightKind::CtInt4Bf16Fallback)
+        );
+    }
+
+    #[test]
+    fn flm_runtime_classifies_native_int4_stage3_plan() {
+        let data = build_test_flm_with_stage3_native_int4_bindings();
+        let file = write_temp_flm(&data);
+
+        let store = BakedStore::open_flm_with_options(
+            file.path(),
+            FlmLoadOptions {
+                flm_int4_logical_aliases: true,
+                verify_block_hashes: false,
+            },
+        )
+        .expect("open native INT4 Stage 3 FLM");
+
+        let kind = store
+            .flm_runtime()
+            .expect("runtime directory")
+            .stage3_direct_weight_kind("model.language_model.layers.0.mlp.experts.gate_up_proj")
+            .expect("classify direct weight kind");
+
+        assert_eq!(
+            kind,
+            Some(crate::flm::FlmStage3DirectWeightKind::NativeInt4)
+        );
+    }
+
+    #[test]
+    fn flm_runtime_classifies_raw_dense_stage3_plan() {
+        let data = build_test_flm_with_stage3_raw_value_binding();
+        let file = write_temp_flm(&data);
+
+        let store = BakedStore::open_flm_with_options(
+            file.path(),
+            FlmLoadOptions {
+                flm_int4_logical_aliases: true,
+                verify_block_hashes: false,
+            },
+        )
+        .expect("open raw dense Stage 3 FLM");
+
+        let runtime = store.flm_runtime().expect("runtime directory");
+        let kind = runtime
+            .stage3_direct_weight_kind("model.language_model.layers.0.linear_attn.A_log")
+            .expect("classify direct weight kind");
+
+        assert_eq!(kind, Some(crate::flm::FlmStage3DirectWeightKind::RawDense));
+        assert_eq!(
+            runtime
+                .stage3_direct_weight_kind("model.language_model.layers.0.missing.weight")
+                .expect("missing logical tensor is not an error"),
+            None
+        );
+    }
+
+    #[test]
     fn open_flm_rejects_native_int4_stage3_binding_with_non_native_abi() {
         let mut data = build_test_flm_with_stage3_native_int4_bindings();
         put_first_storage_abi_codec_semantic(&mut data, crate::flm::CODEC_SYM_INT4_G128_BF16);

--- a/crates/model-store/src/store.rs
+++ b/crates/model-store/src/store.rs
@@ -912,16 +912,18 @@ fn add_stage3_raw_value_aliases(
         })?;
         let view_dtype = flm_dtype_name(value_step.target_dtype)?.to_string();
         let view_shape = flm_plan_target_shape(value_step)?;
-        index
-            .entry(logical.name.clone())
-            .or_insert_with(|| TensorMeta {
+        let view_layout = stage3_raw_value_alias_layout(&logical.name, &view_shape);
+        index.insert(
+            logical.name.clone(),
+            TensorMeta {
                 name: logical.name.clone(),
                 shape: view_shape.clone(),
                 dtype: view_dtype.clone(),
-                layout: LayoutTag::Raw,
+                layout: view_layout,
                 offset: value_meta.offset,
                 byte_len: value_meta.byte_len,
-            });
+            },
+        );
         upload_views
             .entry(logical.name.clone())
             .or_insert(TensorUploadView {
@@ -930,6 +932,29 @@ fn add_stage3_raw_value_aliases(
             });
     }
     Ok(())
+}
+
+fn stage3_raw_value_alias_layout(name: &str, shape: &[usize]) -> LayoutTag {
+    if name.contains(".linear_attn.") {
+        if name.ends_with(".conv1d.weight") && shape.len() == 2 {
+            return LayoutTag::DepthwiseConvSqueezed;
+        }
+        if name.ends_with(".dt_bias")
+            && shape.len() == 3
+            && shape.first() == Some(&1)
+            && shape.get(1) == Some(&1)
+        {
+            return LayoutTag::HeadBiasReshaped;
+        }
+        if name.ends_with(".A_log")
+            && shape.len() == 3
+            && shape.first() == Some(&1)
+            && shape.get(1) == Some(&1)
+        {
+            return LayoutTag::HeadExpReshaped;
+        }
+    }
+    LayoutTag::Raw
 }
 
 fn stage3_int4_sidecar_alias(logical_name: &str, suffix: &str) -> String {
@@ -4029,6 +4054,35 @@ mod tests {
             .expect("raw logical value upload view");
         assert_eq!(upload_view.dtype, "f32");
         assert_eq!(upload_view.shape, vec![4]);
+    }
+
+    #[test]
+    fn stage3_raw_value_alias_layout_marks_qwen_linear_attention_runtime_shapes() {
+        assert_eq!(
+            stage3_raw_value_alias_layout(
+                "model.language_model.layers.0.linear_attn.conv1d.weight",
+                &[8192, 4],
+            ),
+            LayoutTag::DepthwiseConvSqueezed
+        );
+        assert_eq!(
+            stage3_raw_value_alias_layout(
+                "model.language_model.layers.0.linear_attn.dt_bias",
+                &[1, 1, 32],
+            ),
+            LayoutTag::HeadBiasReshaped
+        );
+        assert_eq!(
+            stage3_raw_value_alias_layout(
+                "model.language_model.layers.0.linear_attn.A_log",
+                &[1, 1, 32],
+            ),
+            LayoutTag::HeadExpReshaped
+        );
+        assert_eq!(
+            stage3_raw_value_alias_layout("model.language_model.layers.0.linear_attn.A_log", &[32],),
+            LayoutTag::Raw
+        );
     }
 
     #[test]

--- a/crates/model-store/src/store.rs
+++ b/crates/model-store/src/store.rs
@@ -194,6 +194,18 @@ pub struct TensorStorageExtent {
     pub upload_shape: Vec<usize>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TensorStorageRange {
+    /// Full direct file-backed tensor extent this range comes from.
+    pub extent: TensorStorageExtent,
+    /// Byte offset inside the tensor payload.
+    pub tensor_byte_offset: u64,
+    /// Absolute byte offset in the source file for this range.
+    pub file_offset: u64,
+    /// Number of bytes in this range.
+    pub byte_len: u64,
+}
+
 pub struct BakedStore {
     _mmap: Mmap,
     data: *const u8,
@@ -1871,6 +1883,60 @@ impl BakedStore {
         }))
     }
 
+    /// Return the concrete file range for a direct tensor subrange.
+    ///
+    /// Virtual allocation loaders use this as the source-side transfer
+    /// descriptor: current backends copy from the mmap, while future
+    /// storage-to-GPU backends can use `file_offset` and `byte_len` directly.
+    pub fn tensor_storage_range(
+        &self,
+        name: &str,
+        byte_offset: usize,
+        byte_len: usize,
+    ) -> Result<Option<TensorStorageRange>, Error> {
+        let Some(extent) = self.tensor_storage_extent(name)? else {
+            return Ok(None);
+        };
+        let tensor_byte_offset = u64::try_from(byte_offset).map_err(|_| {
+            Error::Other(format!(
+                "tensor '{name}' storage range offset does not fit u64: {byte_offset}"
+            ))
+        })?;
+        let byte_len_u64 = u64::try_from(byte_len).map_err(|_| {
+            Error::Other(format!(
+                "tensor '{name}' storage range length does not fit u64: {byte_len}"
+            ))
+        })?;
+        let range_end = tensor_byte_offset
+            .checked_add(byte_len_u64)
+            .ok_or_else(|| {
+                Error::Other(format!(
+                    "tensor '{name}' storage range overflows: offset={byte_offset} len={byte_len}"
+                ))
+            })?;
+        if range_end > extent.byte_len {
+            return Err(Error::Other(format!(
+                "tensor '{name}' storage range [{byte_offset}, {range_end}) exceeds byte_len={}",
+                extent.byte_len
+            )));
+        }
+        let file_offset = extent
+            .file_offset
+            .checked_add(tensor_byte_offset)
+            .ok_or_else(|| {
+                Error::Other(format!(
+                    "tensor '{name}' storage range file offset overflows: base={} offset={byte_offset}",
+                    extent.file_offset
+                ))
+            })?;
+        Ok(Some(TensorStorageRange {
+            extent,
+            tensor_byte_offset,
+            file_offset,
+            byte_len: byte_len_u64,
+        }))
+    }
+
     /// Load a tensor from the baked store to GPU memory.
     /// Direct tensors borrow mmap bytes; transformed FLM logical aliases
     /// materialize a temporary host fallback payload before upload.
@@ -1989,39 +2055,39 @@ impl BakedStore {
         name: &str,
         role: VirtualAllocationRole,
     ) -> Result<usize, Error> {
-        let meta = self
-            .index
-            .get(name)
-            .ok_or_else(|| Error::NotFound(name.to_string()))?;
         if self.ct_int4_bf16_fallbacks.contains_key(name) {
             return Err(Error::Other(format!(
                 "tensor '{name}' is a transformed FLM logical alias and cannot be reserved in a virtual arena"
             )));
         }
-        let slice = self.tensor_bytes(name, meta)?;
-        let dtype = parse_dtype(&meta.dtype)?;
-        let expected_len = meta
-            .shape
+        let extent = self.tensor_storage_extent(name)?.ok_or_else(|| {
+            Error::Other(format!(
+                "tensor '{name}' is not a direct file-backed extent and cannot be reserved in a virtual arena"
+            ))
+        })?;
+        let dtype = parse_dtype(&extent.storage_dtype)?;
+        let expected_len = extent
+            .storage_shape
             .iter()
             .try_fold(dtype.size_in_bytes(), |acc, dim| acc.checked_mul(*dim))
             .ok_or_else(|| {
                 Error::Other(format!(
                     "tensor '{}' shape {:?} overflows byte-size calculation",
-                    name, meta.shape
+                    name, extent.storage_shape
                 ))
             })?;
-        if slice.len() != expected_len {
+        if extent.byte_len != expected_len as u64 {
             return Err(Error::Other(format!(
                 "tensor '{}' manifest byte_len={} does not match dtype={} shape={:?} expected_bytes={}",
                 name,
-                slice.len(),
-                meta.dtype,
-                meta.shape,
+                extent.byte_len,
+                extent.storage_dtype,
+                extent.storage_shape,
                 expected_len,
             )));
         }
         arena
-            .reserve(name.to_string(), role, dtype, &meta.shape)
+            .reserve(name.to_string(), role, dtype, &extent.storage_shape)
             .map_err(Error::from)
     }
 
@@ -2035,50 +2101,47 @@ impl BakedStore {
         byte_offset: usize,
         byte_len: usize,
     ) -> Result<(), Error> {
-        let meta = self
-            .index
-            .get(name)
-            .ok_or_else(|| Error::NotFound(name.to_string()))?;
-        if self.ct_int4_bf16_fallbacks.contains_key(name) {
-            return Err(Error::Other(format!(
-                "tensor '{name}' is a transformed FLM logical alias and cannot be range-loaded into a virtual arena"
-            )));
-        }
-        let range_end = byte_offset.checked_add(byte_len).ok_or_else(|| {
+        let transfer_range = self.tensor_storage_range(name, byte_offset, byte_len)?.ok_or_else(|| {
             Error::Other(format!(
-                "tensor '{name}' load range overflows: offset={byte_offset} len={byte_len}"
+                "tensor '{name}' is not a direct file-backed extent and cannot be range-loaded into a virtual arena"
             ))
         })?;
-        if range_end > meta.byte_len as usize {
-            return Err(Error::Other(format!(
-                "tensor '{name}' load range [{byte_offset}, {range_end}) exceeds byte_len={}",
-                meta.byte_len
-            )));
-        }
-        let src_bytes = self.tensor_bytes(name, meta)?;
-
-        let dtype = parse_dtype(&meta.dtype)?;
+        let dtype = parse_dtype(&transfer_range.extent.storage_dtype)?;
         let ordinal = arena.device_ordinal();
         let allocation = arena.allocation_mut(allocation_id).ok_or_else(|| {
             Error::Other(format!("virtual allocation id {allocation_id} missing"))
         })?;
         let buffer = allocation.buffer_mut();
-        if buffer.dtype() != dtype || buffer.shape() != meta.shape.as_slice() {
+        if buffer.dtype() != dtype
+            || buffer.shape() != transfer_range.extent.storage_shape.as_slice()
+        {
             return Err(Error::Other(format!(
                 "virtual allocation id {allocation_id} does not match tensor '{name}' \
                  (allocation dtype={:?} shape={:?}, tensor dtype={} shape={:?})",
                 buffer.dtype(),
                 buffer.shape(),
-                meta.dtype,
-                meta.shape
+                transfer_range.extent.storage_dtype,
+                transfer_range.extent.storage_shape
             )));
         }
+        let src_byte_offset = u64_to_usize(
+            transfer_range.tensor_byte_offset,
+            "virtual arena source byte offset",
+        )?;
+        let src_byte_len =
+            u64_to_usize(transfer_range.byte_len, "virtual arena source byte length")?;
+        let src_bytes = self.raw_byte_range(name, src_byte_offset, src_byte_len)?;
         // The source tensor bytes are copied into the mapped range before the
         // allocation is observed as loaded, so clearing new pages first only
         // adds startup bandwidth.
-        buffer.map_range_bytes_no_sync(byte_offset, byte_len)?;
-        let src = unsafe { src_bytes.as_ptr().add(byte_offset) as *const _ };
-        copy_h2d(ordinal, buffer.offset_mut_ptr(byte_offset), src, byte_len)?;
+        buffer.map_range_bytes_no_sync(byte_offset, src_byte_len)?;
+        let src = src_bytes.as_ptr() as *const _;
+        copy_h2d(
+            ordinal,
+            buffer.offset_mut_ptr(byte_offset),
+            src,
+            src_byte_len,
+        )?;
         sync(ordinal)?;
         Ok(())
     }
@@ -3953,6 +4016,42 @@ mod tests {
     }
 
     #[test]
+    fn open_flm_exposes_file_storage_range_for_direct_tensor_slice() {
+        let data = build_test_flm(&[TestFlmTensor {
+            name: "model.norm.weight",
+            shape: vec![4],
+            dtype: 2,
+            codec: 0,
+            payload: vec![0x00, 0x3f, 0x00, 0x40, 0x00, 0x41, 0x00, 0x42],
+        }]);
+        let file = write_temp_flm(&data);
+        let store = BakedStore::open_flm(file.path()).expect("open FLM");
+        let meta = store.meta("model.norm.weight").expect("norm meta");
+
+        let range = store
+            .tensor_storage_range("model.norm.weight", 2, 4)
+            .expect("storage range")
+            .expect("direct FLM tensor slice should expose a file range");
+
+        assert_eq!(
+            range.extent.source_kind,
+            TensorStorageSourceKind::FlmContainer
+        );
+        assert_eq!(range.extent.source_path, file.path());
+        assert_eq!(range.extent.name, "model.norm.weight");
+        assert_eq!(range.extent.file_offset, meta.offset);
+        assert_eq!(range.extent.byte_len, meta.byte_len);
+        assert_eq!(range.tensor_byte_offset, 2);
+        assert_eq!(range.byte_len, 4);
+        assert_eq!(range.file_offset, meta.offset + 2);
+        assert_eq!(range.extent.storage_dtype, "bf16");
+        assert_eq!(range.extent.storage_shape, vec![4]);
+        assert_eq!(range.extent.layout, LayoutTag::Raw);
+        assert_eq!(range.extent.upload_dtype, "bf16");
+        assert_eq!(range.extent.upload_shape, vec![4]);
+    }
+
+    #[test]
     fn host_registration_range_is_bounded_by_page_rounded_mmap() {
         let range = host_registration_range_for_mmap_slice(0x1000, 0x2500, 0x2234, 0x40, 4096)
             .expect("registration range");
@@ -4411,6 +4510,37 @@ mod tests {
     }
 
     #[test]
+    fn open_flm_rejects_virtual_arena_for_synthesized_manifest_alias() {
+        let data = build_test_flm_with_runtime_manifest_group();
+        let file = write_temp_flm(&data);
+
+        let store = BakedStore::open_flm_with_options(
+            file.path(),
+            crate::store::FlmLoadOptions {
+                flm_int4_logical_aliases: true,
+                ..Default::default()
+            },
+        )
+        .expect("open FLM with manifest aliases");
+
+        let mut arena = BakedStore::virtual_weight_arena(0);
+        let err = store
+            .reserve_virtual_arena(
+                &mut arena,
+                "model.language_model.layers.0.mlp.gate_proj.weight_int4_zero",
+                VirtualAllocationRole::Weights,
+            )
+            .expect_err("synthetic aliases must not reserve virtual direct storage")
+            .to_string();
+
+        assert!(
+            err.contains("not a direct file-backed extent"),
+            "unexpected error: {err}"
+        );
+        assert_eq!(arena.stats().allocations, 0);
+    }
+
+    #[test]
     fn open_flm_builds_raw_fp32_value_alias_from_stage3_binding() {
         let data = build_test_flm_with_stage3_raw_value_binding();
         let file = write_temp_flm(&data);
@@ -4777,6 +4907,29 @@ mod tests {
                 .raw_bytes("model.language_model.layers.0.mlp.gate_proj.weight_int4_zero")
                 .unwrap(),
             vec![0x00, 0x41].repeat(128).as_slice()
+        );
+        assert!(store
+            .tensor_storage_range("model.language_model.layers.0.mlp.gate_proj.weight", 0, 64)
+            .expect("packed alias storage range")
+            .is_some());
+        assert!(store
+            .tensor_storage_range(
+                "model.language_model.layers.0.mlp.gate_proj.weight_int4_scale",
+                0,
+                64,
+            )
+            .expect("scale alias storage range")
+            .is_some());
+        assert!(
+            store
+                .tensor_storage_range(
+                    "model.language_model.layers.0.mlp.gate_proj.weight_int4_zero",
+                    0,
+                    64,
+                )
+                .expect("synthetic zero storage range")
+                .is_none(),
+            "synthesized zero aliases must not expose direct file-backed transfer ranges"
         );
     }
 

--- a/crates/model-store/tests/flm_qwen36_native_layout.rs
+++ b/crates/model-store/tests/flm_qwen36_native_layout.rs
@@ -1,0 +1,61 @@
+use std::path::Path;
+
+use model_store::manifest::LayoutTag;
+use model_store::{BakedStore, FlmLoadOptions};
+
+#[test]
+fn qwen36_35b_native_flm_linear_attention_aliases_match_supersonic_runtime_layout() {
+    let Ok(flm_path) = std::env::var("SUPERSONIC_QWEN36_35B_NATIVE_INT4_FLM") else {
+        eprintln!("skip: SUPERSONIC_QWEN36_35B_NATIVE_INT4_FLM unset");
+        return;
+    };
+    let Ok(bake_dir) = std::env::var("SUPERSONIC_QWEN36_35B_NATIVE_INT4_BAKE_DIR") else {
+        eprintln!("skip: SUPERSONIC_QWEN36_35B_NATIVE_INT4_BAKE_DIR unset");
+        return;
+    };
+
+    let flm = BakedStore::open_flm_with_options(
+        Path::new(&flm_path),
+        FlmLoadOptions {
+            flm_int4_logical_aliases: true,
+            verify_block_hashes: false,
+        },
+    )
+    .expect("open native Qwen3.6 MoE FLM");
+    let bake = BakedStore::open(Path::new(&bake_dir)).expect("open SuperSonic native bake");
+
+    for (name, expected_layout, expected_shape) in [
+        (
+            "model.language_model.layers.0.linear_attn.conv1d.weight",
+            LayoutTag::DepthwiseConvSqueezed,
+            vec![8192, 4],
+        ),
+        (
+            "model.language_model.layers.0.linear_attn.dt_bias",
+            LayoutTag::HeadBiasReshaped,
+            vec![1, 1, 32],
+        ),
+        (
+            "model.language_model.layers.0.linear_attn.A_log",
+            LayoutTag::HeadExpReshaped,
+            vec![1, 1, 32],
+        ),
+    ] {
+        let flm_meta = flm
+            .meta(name)
+            .unwrap_or_else(|| panic!("FLM missing {name}"));
+        let bake_meta = bake
+            .meta(name)
+            .unwrap_or_else(|| panic!("bake missing {name}"));
+
+        assert_eq!(bake_meta.layout, expected_layout, "bake layout for {name}");
+        assert_eq!(bake_meta.shape, expected_shape, "bake shape for {name}");
+        assert_eq!(flm_meta.layout, expected_layout, "FLM layout for {name}");
+        assert_eq!(flm_meta.shape, expected_shape, "FLM shape for {name}");
+        assert_eq!(
+            flm.raw_bytes(name),
+            bake.raw_bytes(name),
+            "FLM bytes should match SuperSonic runtime bake for {name}",
+        );
+    }
+}

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -81,6 +81,10 @@ name = "qwen36_ffn_expert_microbench"
 path = "src/bin/qwen36_ffn_expert_microbench.rs"
 
 [[bin]]
+name = "qwen36_flm_upload_probe"
+path = "src/bin/qwen36_flm_upload_probe.rs"
+
+[[bin]]
 name = "qwen36_q4km_manifest_audit"
 path = "src/bin/qwen36_q4km_manifest_audit.rs"
 

--- a/crates/runner/src/bakes.rs
+++ b/crates/runner/src/bakes.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
@@ -178,6 +179,74 @@ pub(crate) fn effective_flm_source(cli: &Cli) -> Option<&Path> {
     cli.flm_file
         .as_deref()
         .or_else(|| is_flm_model_path(&cli.model_dir).then_some(cli.model_dir.as_path()))
+}
+
+pub(crate) fn cli_args_include_model<I, S>(args: I) -> bool
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    args.into_iter().any(|arg| {
+        let arg = arg.as_ref();
+        arg == OsStr::new("--model")
+            || arg
+                .to_str()
+                .map(|arg| arg.starts_with("--model="))
+                .unwrap_or(false)
+    })
+}
+
+fn parse_cli_model_variant(model: &str) -> Result<ModelVariant> {
+    ModelVariant::from_cli_str(model).ok_or_else(|| {
+        anyhow::anyhow!(
+            "Unknown model '{}'. Supported models: {}",
+            model,
+            crate::registry::supported_models_list().join(", ")
+        )
+    })
+}
+
+pub(crate) fn model_variant_from_flm_identity(
+    identity: model_store::FlmRuntimeIdentity,
+) -> Option<ModelVariant> {
+    match (identity.architecture_id, identity.model_id) {
+        (model_store::flm::ARCH_QWEN3_6_DENSE, model_store::flm::MODEL_QWEN3_6_DENSE_V1) => {
+            Some(ModelVariant::Qwen3_6_27B)
+        }
+        (model_store::flm::ARCH_QWEN3_6_MOE, model_store::flm::MODEL_QWEN3_6_MOE_V1) => {
+            Some(ModelVariant::Qwen3_6_35B_A3B)
+        }
+        _ => None,
+    }
+}
+
+pub(crate) fn resolve_model_variant(cli: &Cli, model_arg_present: bool) -> Result<ModelVariant> {
+    if model_arg_present {
+        return parse_cli_model_variant(&cli.model);
+    }
+
+    if let Some(flm_source) = effective_flm_source(cli) {
+        let identity = model_store::read_flm_runtime_identity(flm_source)
+            .map_err(|e| anyhow::anyhow!("read FLM runtime identity: {e}"))?
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "FLM source {} has no runtime descriptor; pass --model explicitly",
+                    flm_source.display()
+                )
+            })?;
+        let model_variant = model_variant_from_flm_identity(identity).ok_or_else(|| {
+            anyhow::anyhow!(
+                "FLM source {} has unsupported runtime identity architecture_id={} model_id={}",
+                flm_source.display(),
+                identity.architecture_id,
+                identity.model_id
+            )
+        })?;
+        eprintln!("[flm] inferred model {model_variant} from runtime descriptor");
+        return Ok(model_variant);
+    }
+
+    parse_cli_model_variant(&cli.model)
 }
 
 pub(crate) fn flm_source_is_authoritative_for_model(
@@ -536,10 +605,10 @@ mod tests {
     use model_store::manifest::QuantProfile;
 
     use super::{
-        effective_flm_source, effective_quant_profile, ensure_hf_metadata_present,
-        flm_source_is_authoritative_for_model, flm_source_open_options, should_fetch_bake,
-        should_fetch_exact_bake, validate_effective_flm_source_model,
-        validate_flm_weight_source_options,
+        cli_args_include_model, effective_flm_source, effective_quant_profile,
+        ensure_hf_metadata_present, flm_source_is_authoritative_for_model, flm_source_open_options,
+        model_variant_from_flm_identity, should_fetch_bake, should_fetch_exact_bake,
+        validate_effective_flm_source_model, validate_flm_weight_source_options,
     };
     use crate::registry::ModelVariant;
     use crate::Cli;
@@ -554,6 +623,53 @@ mod tests {
         let mut args = vec!["supersonic", "--model-dir", model_dir, "--dry-run"];
         args.extend_from_slice(extra);
         Cli::parse_from(args)
+    }
+
+    #[test]
+    fn cli_args_include_model_detects_separate_and_equals_forms() {
+        assert!(cli_args_include_model([
+            "supersonic",
+            "--model",
+            "qwen3.6-27b"
+        ]));
+        assert!(cli_args_include_model([
+            "supersonic",
+            "--model=qwen3.6-35b-a3b"
+        ]));
+        assert!(!cli_args_include_model([
+            "supersonic",
+            "--model-dir",
+            "/tmp/model.flm"
+        ]));
+    }
+
+    #[test]
+    fn flm_runtime_identity_selects_model_variant() {
+        assert_eq!(
+            model_variant_from_flm_identity(model_store::FlmRuntimeIdentity {
+                architecture_id: model_store::flm::ARCH_QWEN3_6_DENSE,
+                model_id: model_store::flm::MODEL_QWEN3_6_DENSE_V1,
+            }),
+            Some(ModelVariant::Qwen3_6_27B)
+        );
+        assert_eq!(
+            model_variant_from_flm_identity(model_store::FlmRuntimeIdentity {
+                architecture_id: model_store::flm::ARCH_QWEN3_6_MOE,
+                model_id: model_store::flm::MODEL_QWEN3_6_MOE_V1,
+            }),
+            Some(ModelVariant::Qwen3_6_35B_A3B)
+        );
+    }
+
+    #[test]
+    fn flm_runtime_identity_rejects_mismatched_model_id() {
+        assert_eq!(
+            model_variant_from_flm_identity(model_store::FlmRuntimeIdentity {
+                architecture_id: model_store::flm::ARCH_QWEN3_6_MOE,
+                model_id: model_store::flm::MODEL_QWEN3_6_DENSE_V1,
+            }),
+            None
+        );
     }
 
     #[test]

--- a/crates/runner/src/bakes.rs
+++ b/crates/runner/src/bakes.rs
@@ -234,7 +234,7 @@ pub(crate) fn validate_flm_weight_source_options(cli: &Cli, q4km_like: bool) -> 
 pub(crate) fn flm_source_open_options(cli: &Cli) -> Result<FlmModelSourceOptions> {
     let profile = effective_quant_profile(cli)?;
     Ok(FlmModelSourceOptions {
-        int4_runtime: profile.is_native_int4_runtime(),
+        int4_runtime: effective_flm_source(cli).is_some() || profile.is_native_int4_runtime(),
         verify_block_hashes: cli.verify_flm_hashes,
     })
 }
@@ -594,10 +594,7 @@ mod tests {
 
     #[test]
     fn qwen36_flm_model_dir_skips_hf_metadata_bootstrap_even_without_config() {
-        let cli = cli_with_model_dir(
-            "/tmp/qwen36-27b-no-hf.flm",
-            &["--int4", "--verify-flm-hashes"],
-        );
+        let cli = cli_with_model_dir("/tmp/qwen36-27b-no-hf.flm", &["--verify-flm-hashes"]);
 
         let downloaded = ensure_hf_metadata_present(&cli, &ModelVariant::Qwen3_6_27B)
             .expect("authoritative FLM source should bypass HF metadata bootstrap");
@@ -608,17 +605,14 @@ mod tests {
     #[test]
     fn flm_model_dir_is_authoritative_for_qwen36_moe_hf_metadata_bootstrap() {
         assert!(flm_source_is_authoritative_for_model(
-            &cli_with_model_dir("/tmp/qwen36-35b-a3b.flm", &["--int4"]),
+            &cli_with_model_dir("/tmp/qwen36-35b-a3b.flm", &[]),
             &ModelVariant::Qwen3_6_35B_A3B
         ));
     }
 
     #[test]
     fn qwen36_moe_flm_model_dir_skips_hf_metadata_bootstrap_even_without_config() {
-        let cli = cli_with_model_dir(
-            "/tmp/qwen36-35b-a3b-no-hf.flm",
-            &["--int4", "--verify-flm-hashes"],
-        );
+        let cli = cli_with_model_dir("/tmp/qwen36-35b-a3b-no-hf.flm", &["--verify-flm-hashes"]);
 
         let downloaded = ensure_hf_metadata_present(&cli, &ModelVariant::Qwen3_6_35B_A3B)
             .expect("authoritative MoE FLM source should bypass HF metadata bootstrap");
@@ -629,7 +623,7 @@ mod tests {
     #[test]
     fn effective_flm_source_accepts_qwen36_moe_model_variant() {
         validate_effective_flm_source_model(
-            &cli_with_model_dir("/tmp/qwen36-35b-a3b.flm", &["--int4"]),
+            &cli_with_model_dir("/tmp/qwen36-35b-a3b.flm", &[]),
             &ModelVariant::Qwen3_6_35B_A3B,
         )
         .expect("qwen3.6-35b-a3b FLM should be accepted");
@@ -683,7 +677,7 @@ mod tests {
 
     #[test]
     fn flm_source_open_options_keep_hash_verification_opt_in() {
-        let cli = cli_with_model_dir("/tmp/model.flm", &["--int4"]);
+        let cli = cli_with_model_dir("/tmp/model.flm", &[]);
 
         let options = flm_source_open_options(&cli).expect("valid FLM source options");
 

--- a/crates/runner/src/bin/qwen36_flm_upload_probe.rs
+++ b/crates/runner/src/bin/qwen36_flm_upload_probe.rs
@@ -2,10 +2,12 @@ use anyhow::{bail, Context, Result};
 use clap::Parser;
 use gpu_hal::{
     copy_h2d_async, hal_profile_reset, hal_profile_set_enabled, hal_profile_snapshot, sync,
-    Backend, GpuBuffer, GpuStream, PinnedHostBuffer, ScalarType,
+    Backend, GpuBuffer, GpuStream, PinnedHostBuffer, RegisteredHostBuffer, ScalarType,
 };
 use model_store::{BakedStore, FlmLoadOptions};
 use serde::Serialize;
+#[cfg(unix)]
+use std::ffi::c_int;
 use std::{ffi::c_void, path::PathBuf, time::Instant};
 
 const MIB: f64 = 1024.0 * 1024.0;
@@ -25,6 +27,8 @@ struct Args {
     iters: usize,
     #[arg(long)]
     json: bool,
+    #[arg(long)]
+    registered: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -38,6 +42,7 @@ struct UploadProbeRecord {
     mib_per_s: f64,
     host_stage_ms: f64,
     host_pinned_alloc_ms: f64,
+    host_register_ms: f64,
     device_wait_ms: f64,
     hal_total_ms: f64,
     copy_h2d_ms: f64,
@@ -46,6 +51,29 @@ struct UploadProbeRecord {
     copy_h2d_async_bytes: u64,
     alloc_ms: f64,
     alloc_bytes: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct HostRegistrationRange {
+    ptr: *mut c_void,
+    len: usize,
+    data_offset: usize,
+}
+
+#[cfg(unix)]
+unsafe extern "C" {
+    fn getpagesize() -> c_int;
+}
+
+fn host_page_size() -> usize {
+    #[cfg(unix)]
+    {
+        let page_size = unsafe { getpagesize() };
+        if page_size > 0 {
+            return page_size as usize;
+        }
+    }
+    4096
 }
 
 fn parse_backend_arg(value: &str) -> Result<Backend> {
@@ -65,6 +93,46 @@ fn mib_per_second(bytes: usize, elapsed_ms: f64) -> f64 {
         return 0.0;
     }
     (bytes as f64 / MIB) / (elapsed_ms / 1000.0)
+}
+
+fn round_up_to(value: usize, align: usize) -> Result<usize> {
+    if align == 0 {
+        bail!("alignment must be > 0");
+    }
+    let remainder = value % align;
+    if remainder == 0 {
+        return Ok(value);
+    }
+    value
+        .checked_add(align - remainder)
+        .context("round_up_to overflow")
+}
+
+fn host_registration_range_for_slice(
+    ptr: *const u8,
+    len: usize,
+    page_size: usize,
+) -> Result<HostRegistrationRange> {
+    if ptr.is_null() {
+        bail!("host registration range requires a non-null pointer");
+    }
+    if len == 0 {
+        bail!("host registration range requires len > 0");
+    }
+    if page_size == 0 {
+        bail!("host registration range requires page_size > 0");
+    }
+    let data_start = ptr as usize;
+    let data_end = data_start
+        .checked_add(len)
+        .context("host registration data range overflow")?;
+    let register_start = data_start - (data_start % page_size);
+    let register_end = round_up_to(data_end, page_size)?;
+    Ok(HostRegistrationRange {
+        ptr: register_start as *mut c_void,
+        len: register_end - register_start,
+        data_offset: data_start - register_start,
+    })
 }
 
 fn entry_total_ms(snapshot: &gpu_hal::HalProfileSnapshot, op: &str) -> f64 {
@@ -131,6 +199,7 @@ fn run_pageable_upload(
         0.0,
         0.0,
         0.0,
+        0.0,
         &snapshot,
     ))
 }
@@ -192,6 +261,79 @@ fn run_pinned_upload(
         total_ms,
         host_stage_ms,
         host_pinned_alloc_ms,
+        0.0,
+        device_wait_ms,
+        &snapshot,
+    ))
+}
+
+fn run_registered_upload(
+    store: &BakedStore,
+    tensor: &str,
+    device: usize,
+    iters: usize,
+) -> Result<UploadProbeRecord> {
+    let meta = store
+        .meta(tensor)
+        .with_context(|| format!("tensor not found: {tensor}"))?;
+    let bytes = store
+        .raw_bytes(tensor)
+        .with_context(|| format!("tensor {tensor} has no raw byte payload"))?;
+    let dtype = dtype_for_tensor(store, tensor)?;
+    let shape = upload_shape_for_bytes(dtype, bytes.len())?;
+    let stream = GpuStream::new_nonblocking(device).context("create registered upload stream")?;
+    let register_range =
+        host_registration_range_for_slice(bytes.as_ptr(), bytes.len(), host_page_size())?;
+    let mut host_register_ms = 0.0;
+    let mut device_wait_ms = 0.0;
+
+    hal_profile_set_enabled(true);
+    hal_profile_reset();
+    let start = Instant::now();
+    let register_start = Instant::now();
+    let registered = unsafe {
+        RegisteredHostBuffer::new(device, register_range.ptr, register_range.len).with_context(
+            || {
+                format!(
+                    "register host range for tensor {tensor} (ptr={:?} len={} data_offset={})",
+                    register_range.ptr, register_range.len, register_range.data_offset
+                )
+            },
+        )?
+    };
+    host_register_ms += register_start.elapsed().as_secs_f64() * 1000.0;
+    for _ in 0..iters {
+        let mut buffer =
+            GpuBuffer::alloc(device, dtype, &shape).context("allocate probe device buffer")?;
+        let wait_start = Instant::now();
+        copy_h2d_async(
+            device,
+            &stream,
+            buffer.as_mut_ptr(),
+            bytes.as_ptr() as *const c_void,
+            bytes.len(),
+        )
+        .context("async registered H2D upload")?;
+        stream
+            .synchronize()
+            .context("sync registered upload stream")?;
+        device_wait_ms += wait_start.elapsed().as_secs_f64() * 1000.0;
+        drop(buffer);
+    }
+    drop(registered);
+    let total_ms = start.elapsed().as_secs_f64() * 1000.0;
+    let snapshot = hal_profile_snapshot();
+    hal_profile_set_enabled(false);
+    Ok(record_from_snapshot(
+        tensor,
+        "registered",
+        meta.dtype.clone(),
+        bytes.len(),
+        iters,
+        total_ms,
+        0.0,
+        0.0,
+        host_register_ms,
         device_wait_ms,
         &snapshot,
     ))
@@ -206,6 +348,7 @@ fn record_from_snapshot(
     total_ms: f64,
     host_stage_ms: f64,
     host_pinned_alloc_ms: f64,
+    host_register_ms: f64,
     device_wait_ms: f64,
     snapshot: &gpu_hal::HalProfileSnapshot,
 ) -> UploadProbeRecord {
@@ -219,6 +362,7 @@ fn record_from_snapshot(
         mib_per_s: mib_per_second(bytes * iters, total_ms),
         host_stage_ms,
         host_pinned_alloc_ms,
+        host_register_ms,
         device_wait_ms,
         hal_total_ms: snapshot.total_ms,
         copy_h2d_ms: entry_total_ms(snapshot, "copy_h2d"),
@@ -264,13 +408,21 @@ fn main() -> Result<()> {
             args.iters,
         )?);
         records.push(run_pinned_upload(&store, tensor, args.device, args.iters)?);
+        if args.registered {
+            records.push(run_registered_upload(
+                &store,
+                tensor,
+                args.device,
+                args.iters,
+            )?);
+        }
     }
     if args.json {
         println!("{}", serde_json::to_string_pretty(&records)?);
     } else {
         for record in &records {
             println!(
-                "[upload-probe] tensor={} mode={} dtype={} bytes={} iters={} total_ms={:.3} mib_s={:.1} host_stage_ms={:.3} host_pinned_alloc_ms={:.3} device_wait_ms={:.3} copy_h2d_ms={:.3} copy_h2d_async_ms={:.3} alloc_ms={:.3}",
+                "[upload-probe] tensor={} mode={} dtype={} bytes={} iters={} total_ms={:.3} mib_s={:.1} host_stage_ms={:.3} host_pinned_alloc_ms={:.3} host_register_ms={:.3} device_wait_ms={:.3} copy_h2d_ms={:.3} copy_h2d_async_ms={:.3} alloc_ms={:.3}",
                 record.tensor,
                 record.mode,
                 record.dtype,
@@ -280,6 +432,7 @@ fn main() -> Result<()> {
                 record.mib_per_s,
                 record.host_stage_ms,
                 record.host_pinned_alloc_ms,
+                record.host_register_ms,
                 record.device_wait_ms,
                 record.copy_h2d_ms,
                 record.copy_h2d_async_ms,
@@ -329,11 +482,47 @@ mod tests {
             10.0,
             2.0,
             1.5,
+            0.75,
             7.5,
             &snapshot,
         );
 
         assert_eq!(record.host_pinned_alloc_ms, 1.5);
+        assert_eq!(record.host_register_ms, 0.75);
         assert_eq!(record.device_wait_ms, 7.5);
+    }
+
+    #[test]
+    fn registered_mode_is_opt_in() {
+        let args = Args::try_parse_from([
+            "qwen36_flm_upload_probe",
+            "--model-dir",
+            "model.flm",
+            "--tensor",
+            "tensor",
+        ])
+        .unwrap();
+        assert!(!args.registered);
+
+        let args = Args::try_parse_from([
+            "qwen36_flm_upload_probe",
+            "--model-dir",
+            "model.flm",
+            "--tensor",
+            "tensor",
+            "--registered",
+        ])
+        .unwrap();
+        assert!(args.registered);
+    }
+
+    #[test]
+    fn host_registration_range_covers_unaligned_slice() {
+        let range = host_registration_range_for_slice(0x1003usize as *const u8, 8192, 4096)
+            .expect("aligned registration range");
+
+        assert_eq!(range.ptr as usize, 0x1000);
+        assert_eq!(range.len, 12288);
+        assert_eq!(range.data_offset, 3);
     }
 }

--- a/crates/runner/src/bin/qwen36_flm_upload_probe.rs
+++ b/crates/runner/src/bin/qwen36_flm_upload_probe.rs
@@ -33,6 +33,16 @@ struct Args {
     registered: bool,
     #[arg(long)]
     storage_direct: bool,
+    #[arg(long)]
+    only_storage_direct: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum UploadMode {
+    Pageable,
+    Pinned,
+    Registered,
+    StorageDirect,
 }
 
 #[derive(Debug, Serialize)]
@@ -114,6 +124,20 @@ fn ensure_storage_direct_range_alignment(tensor: &str, file_offset: u64, len: us
         );
     }
     Ok(())
+}
+
+fn selected_upload_modes(args: &Args) -> Vec<UploadMode> {
+    if args.only_storage_direct {
+        return vec![UploadMode::StorageDirect];
+    }
+    let mut modes = vec![UploadMode::Pageable, UploadMode::Pinned];
+    if args.registered {
+        modes.push(UploadMode::Registered);
+    }
+    if args.storage_direct {
+        modes.push(UploadMode::StorageDirect);
+    }
+    modes
 }
 
 fn round_up_to(value: usize, align: usize) -> Result<usize> {
@@ -500,29 +524,21 @@ fn main() -> Result<()> {
     .with_context(|| format!("open store {}", args.model_dir.display()))?;
 
     let mut records = Vec::new();
+    let modes = selected_upload_modes(&args);
     for tensor in &args.tensor {
-        records.push(run_pageable_upload(
-            &store,
-            tensor,
-            args.device,
-            args.iters,
-        )?);
-        records.push(run_pinned_upload(&store, tensor, args.device, args.iters)?);
-        if args.registered {
-            records.push(run_registered_upload(
-                &store,
-                tensor,
-                args.device,
-                args.iters,
-            )?);
-        }
-        if args.storage_direct {
-            records.push(run_storage_direct_upload(
-                &store,
-                tensor,
-                args.device,
-                args.iters,
-            )?);
+        for mode in &modes {
+            records.push(match mode {
+                UploadMode::Pageable => {
+                    run_pageable_upload(&store, tensor, args.device, args.iters)?
+                }
+                UploadMode::Pinned => run_pinned_upload(&store, tensor, args.device, args.iters)?,
+                UploadMode::Registered => {
+                    run_registered_upload(&store, tensor, args.device, args.iters)?
+                }
+                UploadMode::StorageDirect => {
+                    run_storage_direct_upload(&store, tensor, args.device, args.iters)?
+                }
+            });
         }
     }
     if args.json {
@@ -656,6 +672,36 @@ mod tests {
         ])
         .unwrap();
         assert!(args.storage_direct);
+    }
+
+    #[test]
+    fn only_storage_direct_selects_no_baseline_upload_modes() {
+        let default_args = Args::try_parse_from([
+            "qwen36_flm_upload_probe",
+            "--model-dir",
+            "model.flm",
+            "--tensor",
+            "tensor",
+        ])
+        .unwrap();
+        assert_eq!(
+            selected_upload_modes(&default_args),
+            vec![UploadMode::Pageable, UploadMode::Pinned]
+        );
+
+        let direct_args = Args::try_parse_from([
+            "qwen36_flm_upload_probe",
+            "--model-dir",
+            "model.flm",
+            "--tensor",
+            "tensor",
+            "--only-storage-direct",
+        ])
+        .unwrap();
+        assert_eq!(
+            selected_upload_modes(&direct_args),
+            vec![UploadMode::StorageDirect]
+        );
     }
 
     #[test]

--- a/crates/runner/src/bin/qwen36_flm_upload_probe.rs
+++ b/crates/runner/src/bin/qwen36_flm_upload_probe.rs
@@ -12,6 +12,7 @@ use std::ffi::c_int;
 use std::{ffi::c_void, path::PathBuf, time::Instant};
 
 const MIB: f64 = 1024.0 * 1024.0;
+const STORAGE_DIRECT_BLOCK_ALIGNMENT: usize = 4096;
 
 #[derive(Debug, Parser)]
 #[command(about = "Probe FLM/BakedStore tensor upload modes for selected tensors")]
@@ -98,6 +99,21 @@ fn mib_per_second(bytes: usize, elapsed_ms: f64) -> f64 {
         return 0.0;
     }
     (bytes as f64 / MIB) / (elapsed_ms / 1000.0)
+}
+
+fn ensure_storage_direct_range_alignment(tensor: &str, file_offset: u64, len: usize) -> Result<()> {
+    let block = STORAGE_DIRECT_BLOCK_ALIGNMENT as u64;
+    if file_offset % block != 0 {
+        bail!(
+            "tensor {tensor} storage-direct file offset {file_offset} is not {STORAGE_DIRECT_BLOCK_ALIGNMENT}-byte aligned"
+        );
+    }
+    if len % STORAGE_DIRECT_BLOCK_ALIGNMENT != 0 {
+        bail!(
+            "tensor {tensor} storage-direct length {len} is not {STORAGE_DIRECT_BLOCK_ALIGNMENT}-byte aligned"
+        );
+    }
+    Ok(())
 }
 
 fn round_up_to(value: usize, align: usize) -> Result<usize> {
@@ -375,6 +391,7 @@ fn run_storage_direct_upload(
             "tensor {tensor} storage-direct probe expected {expected_bytes} bytes from upload dtype/shape, got {bytes}"
         );
     }
+    ensure_storage_direct_range_alignment(tensor, range.file_offset, bytes)?;
 
     hal_profile_set_enabled(true);
     hal_profile_reset();
@@ -639,6 +656,27 @@ mod tests {
         ])
         .unwrap();
         assert!(args.storage_direct);
+    }
+
+    #[test]
+    fn storage_direct_range_requires_block_aligned_offset_and_length() {
+        assert!(ensure_storage_direct_range_alignment("expert", 4096, 8192).is_ok());
+
+        let err = ensure_storage_direct_range_alignment("dt_bias", 4096, 64)
+            .expect_err("sub-block tensor length must not be sent to direct storage");
+        assert!(
+            err.to_string()
+                .contains("length 64 is not 4096-byte aligned"),
+            "{err}"
+        );
+
+        let err = ensure_storage_direct_range_alignment("expert", 512, 8192)
+            .expect_err("unaligned file offset must not be sent to direct storage");
+        assert!(
+            err.to_string()
+                .contains("file offset 512 is not 4096-byte aligned"),
+            "{err}"
+        );
     }
 
     #[test]

--- a/crates/runner/src/bin/qwen36_flm_upload_probe.rs
+++ b/crates/runner/src/bin/qwen36_flm_upload_probe.rs
@@ -1,0 +1,339 @@
+use anyhow::{bail, Context, Result};
+use clap::Parser;
+use gpu_hal::{
+    copy_h2d_async, hal_profile_reset, hal_profile_set_enabled, hal_profile_snapshot, sync,
+    Backend, GpuBuffer, GpuStream, PinnedHostBuffer, ScalarType,
+};
+use model_store::{BakedStore, FlmLoadOptions};
+use serde::Serialize;
+use std::{ffi::c_void, path::PathBuf, time::Instant};
+
+const MIB: f64 = 1024.0 * 1024.0;
+
+#[derive(Debug, Parser)]
+#[command(about = "Probe FLM/BakedStore H2D upload modes for selected tensors")]
+struct Args {
+    #[arg(long)]
+    model_dir: PathBuf,
+    #[arg(long, default_value = "hip")]
+    backend: String,
+    #[arg(long, default_value_t = 0)]
+    device: usize,
+    #[arg(long, value_delimiter = ',', required = true)]
+    tensor: Vec<String>,
+    #[arg(long, default_value_t = 1)]
+    iters: usize,
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct UploadProbeRecord {
+    tensor: String,
+    mode: &'static str,
+    dtype: String,
+    bytes: usize,
+    iters: usize,
+    total_ms: f64,
+    mib_per_s: f64,
+    host_stage_ms: f64,
+    host_pinned_alloc_ms: f64,
+    device_wait_ms: f64,
+    hal_total_ms: f64,
+    copy_h2d_ms: f64,
+    copy_h2d_async_ms: f64,
+    copy_h2d_bytes: u64,
+    copy_h2d_async_bytes: u64,
+    alloc_ms: f64,
+    alloc_bytes: u64,
+}
+
+fn parse_backend_arg(value: &str) -> Result<Backend> {
+    Backend::parse(value).ok_or_else(|| anyhow::anyhow!("unknown backend: {value}"))
+}
+
+fn upload_shape_for_bytes(dtype: ScalarType, byte_len: usize) -> Result<Vec<usize>> {
+    let elem_size = dtype.size_in_bytes();
+    if byte_len % elem_size != 0 {
+        bail!("byte_len={byte_len} is not divisible by dtype element size {elem_size}");
+    }
+    Ok(vec![byte_len / elem_size])
+}
+
+fn mib_per_second(bytes: usize, elapsed_ms: f64) -> f64 {
+    if elapsed_ms <= 0.0 {
+        return 0.0;
+    }
+    (bytes as f64 / MIB) / (elapsed_ms / 1000.0)
+}
+
+fn entry_total_ms(snapshot: &gpu_hal::HalProfileSnapshot, op: &str) -> f64 {
+    snapshot
+        .entries
+        .iter()
+        .find(|entry| entry.op == op)
+        .map(|entry| entry.total_ms)
+        .unwrap_or(0.0)
+}
+
+fn entry_total_bytes(snapshot: &gpu_hal::HalProfileSnapshot, op: &str) -> u64 {
+    snapshot
+        .entries
+        .iter()
+        .find(|entry| entry.op == op)
+        .map(|entry| entry.total_bytes)
+        .unwrap_or(0)
+}
+
+fn dtype_for_tensor(store: &BakedStore, tensor: &str) -> Result<ScalarType> {
+    let meta = store
+        .meta(tensor)
+        .with_context(|| format!("tensor not found: {tensor}"))?;
+    ScalarType::from_name(&meta.dtype).with_context(|| {
+        format!(
+            "tensor {tensor} has unsupported dtype {} for upload probe",
+            meta.dtype
+        )
+    })
+}
+
+fn run_pageable_upload(
+    store: &BakedStore,
+    tensor: &str,
+    device: usize,
+    iters: usize,
+) -> Result<UploadProbeRecord> {
+    let meta = store
+        .meta(tensor)
+        .with_context(|| format!("tensor not found: {tensor}"))?;
+    let bytes = usize::try_from(meta.byte_len)
+        .with_context(|| format!("tensor {tensor} byte_len does not fit usize"))?;
+    hal_profile_set_enabled(true);
+    hal_profile_reset();
+    let start = Instant::now();
+    for _ in 0..iters {
+        let buffer = store
+            .load_to_gpu(tensor, device)
+            .with_context(|| format!("pageable upload tensor {tensor}"))?;
+        sync(device).context("sync after pageable upload")?;
+        drop(buffer);
+    }
+    let total_ms = start.elapsed().as_secs_f64() * 1000.0;
+    let snapshot = hal_profile_snapshot();
+    hal_profile_set_enabled(false);
+    Ok(record_from_snapshot(
+        tensor,
+        "pageable",
+        meta.dtype.clone(),
+        bytes,
+        iters,
+        total_ms,
+        0.0,
+        0.0,
+        0.0,
+        &snapshot,
+    ))
+}
+
+fn run_pinned_upload(
+    store: &BakedStore,
+    tensor: &str,
+    device: usize,
+    iters: usize,
+) -> Result<UploadProbeRecord> {
+    let meta = store
+        .meta(tensor)
+        .with_context(|| format!("tensor not found: {tensor}"))?;
+    let bytes = store
+        .raw_bytes(tensor)
+        .with_context(|| format!("tensor {tensor} has no raw byte payload"))?;
+    let dtype = dtype_for_tensor(store, tensor)?;
+    let shape = upload_shape_for_bytes(dtype, bytes.len())?;
+    let stream = GpuStream::new_nonblocking(device).context("create pinned upload stream")?;
+    let mut host_stage_ms = 0.0;
+    let mut host_pinned_alloc_ms = 0.0;
+    let mut device_wait_ms = 0.0;
+
+    hal_profile_set_enabled(true);
+    hal_profile_reset();
+    let start = Instant::now();
+    let alloc_start = Instant::now();
+    let mut staging =
+        PinnedHostBuffer::new(device, bytes.len()).context("allocate pinned staging")?;
+    host_pinned_alloc_ms += alloc_start.elapsed().as_secs_f64() * 1000.0;
+    for _ in 0..iters {
+        let stage_start = Instant::now();
+        staging.as_mut_slice().copy_from_slice(bytes);
+        host_stage_ms += stage_start.elapsed().as_secs_f64() * 1000.0;
+        let mut buffer =
+            GpuBuffer::alloc(device, dtype, &shape).context("allocate probe device buffer")?;
+        let wait_start = Instant::now();
+        copy_h2d_async(
+            device,
+            &stream,
+            buffer.as_mut_ptr(),
+            staging.as_ptr() as *const c_void,
+            bytes.len(),
+        )
+        .context("async pinned H2D upload")?;
+        stream.synchronize().context("sync pinned upload stream")?;
+        device_wait_ms += wait_start.elapsed().as_secs_f64() * 1000.0;
+        drop(buffer);
+    }
+    let total_ms = start.elapsed().as_secs_f64() * 1000.0;
+    let snapshot = hal_profile_snapshot();
+    hal_profile_set_enabled(false);
+    Ok(record_from_snapshot(
+        tensor,
+        "pinned",
+        meta.dtype.clone(),
+        bytes.len(),
+        iters,
+        total_ms,
+        host_stage_ms,
+        host_pinned_alloc_ms,
+        device_wait_ms,
+        &snapshot,
+    ))
+}
+
+fn record_from_snapshot(
+    tensor: &str,
+    mode: &'static str,
+    dtype: String,
+    bytes: usize,
+    iters: usize,
+    total_ms: f64,
+    host_stage_ms: f64,
+    host_pinned_alloc_ms: f64,
+    device_wait_ms: f64,
+    snapshot: &gpu_hal::HalProfileSnapshot,
+) -> UploadProbeRecord {
+    UploadProbeRecord {
+        tensor: tensor.to_string(),
+        mode,
+        dtype,
+        bytes,
+        iters,
+        total_ms,
+        mib_per_s: mib_per_second(bytes * iters, total_ms),
+        host_stage_ms,
+        host_pinned_alloc_ms,
+        device_wait_ms,
+        hal_total_ms: snapshot.total_ms,
+        copy_h2d_ms: entry_total_ms(snapshot, "copy_h2d"),
+        copy_h2d_async_ms: entry_total_ms(snapshot, "copy_h2d_async"),
+        copy_h2d_bytes: entry_total_bytes(snapshot, "copy_h2d"),
+        copy_h2d_async_bytes: entry_total_bytes(snapshot, "copy_h2d_async"),
+        alloc_ms: entry_total_ms(snapshot, "alloc"),
+        alloc_bytes: entry_total_bytes(snapshot, "alloc"),
+    }
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    if args.iters == 0 {
+        bail!("--iters must be > 0");
+    }
+    let backend = parse_backend_arg(&args.backend)?;
+    if !gpu_hal::is_backend_compiled(backend) {
+        bail!("backend {backend} is not compiled into this build");
+    }
+    gpu_hal::set_backend(backend);
+    gpu_hal::set_device(args.device)
+        .with_context(|| format!("set {backend} device {}", args.device))?;
+    let store = if args.model_dir.extension().and_then(|ext| ext.to_str()) == Some("flm") {
+        BakedStore::open_flm_with_options(
+            &args.model_dir,
+            FlmLoadOptions {
+                verify_block_hashes: false,
+                flm_int4_logical_aliases: true,
+            },
+        )
+    } else {
+        BakedStore::open(&args.model_dir)
+    }
+    .with_context(|| format!("open store {}", args.model_dir.display()))?;
+
+    let mut records = Vec::new();
+    for tensor in &args.tensor {
+        records.push(run_pageable_upload(
+            &store,
+            tensor,
+            args.device,
+            args.iters,
+        )?);
+        records.push(run_pinned_upload(&store, tensor, args.device, args.iters)?);
+    }
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&records)?);
+    } else {
+        for record in &records {
+            println!(
+                "[upload-probe] tensor={} mode={} dtype={} bytes={} iters={} total_ms={:.3} mib_s={:.1} host_stage_ms={:.3} host_pinned_alloc_ms={:.3} device_wait_ms={:.3} copy_h2d_ms={:.3} copy_h2d_async_ms={:.3} alloc_ms={:.3}",
+                record.tensor,
+                record.mode,
+                record.dtype,
+                record.bytes,
+                record.iters,
+                record.total_ms,
+                record.mib_per_s,
+                record.host_stage_ms,
+                record.host_pinned_alloc_ms,
+                record.device_wait_ms,
+                record.copy_h2d_ms,
+                record.copy_h2d_async_ms,
+                record.alloc_ms,
+            );
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_backend_names_case_insensitively() {
+        assert_eq!(parse_backend_arg("HIP").unwrap(), Backend::Hip);
+        assert_eq!(parse_backend_arg("cuda").unwrap(), Backend::Cuda);
+        assert!(parse_backend_arg("vulkan").is_err());
+    }
+
+    #[test]
+    fn builds_linear_upload_shape_from_byte_len() {
+        assert_eq!(
+            upload_shape_for_bytes(ScalarType::BF16, 8).unwrap(),
+            vec![4]
+        );
+        assert_eq!(upload_shape_for_bytes(ScalarType::U8, 5).unwrap(), vec![5]);
+        assert!(upload_shape_for_bytes(ScalarType::BF16, 7).is_err());
+    }
+
+    #[test]
+    fn reports_mib_per_second() {
+        assert_eq!(mib_per_second(128 * 1024 * 1024, 64.0), 2000.0);
+        assert_eq!(mib_per_second(128 * 1024 * 1024, 0.0), 0.0);
+    }
+
+    #[test]
+    fn records_device_wait_wall_time() {
+        let snapshot = gpu_hal::HalProfileSnapshot::default();
+        let record = record_from_snapshot(
+            "tensor",
+            "pinned",
+            "u8".to_string(),
+            1024,
+            1,
+            10.0,
+            2.0,
+            1.5,
+            7.5,
+            &snapshot,
+        );
+
+        assert_eq!(record.host_pinned_alloc_ms, 1.5);
+        assert_eq!(record.device_wait_ms, 7.5);
+    }
+}

--- a/crates/runner/src/bin/qwen36_flm_upload_probe.rs
+++ b/crates/runner/src/bin/qwen36_flm_upload_probe.rs
@@ -1,8 +1,9 @@
 use anyhow::{bail, Context, Result};
 use clap::Parser;
 use gpu_hal::{
-    copy_h2d_async, hal_profile_reset, hal_profile_set_enabled, hal_profile_snapshot, sync,
-    Backend, GpuBuffer, GpuStream, PinnedHostBuffer, RegisteredHostBuffer, ScalarType,
+    copy_h2d_async, copy_storage_to_device, hal_profile_reset, hal_profile_set_enabled,
+    hal_profile_snapshot, sync, Backend, GpuBuffer, GpuStream, PinnedHostBuffer,
+    RegisteredHostBuffer, ScalarType,
 };
 use model_store::{BakedStore, FlmLoadOptions};
 use serde::Serialize;
@@ -13,7 +14,7 @@ use std::{ffi::c_void, path::PathBuf, time::Instant};
 const MIB: f64 = 1024.0 * 1024.0;
 
 #[derive(Debug, Parser)]
-#[command(about = "Probe FLM/BakedStore H2D upload modes for selected tensors")]
+#[command(about = "Probe FLM/BakedStore tensor upload modes for selected tensors")]
 struct Args {
     #[arg(long)]
     model_dir: PathBuf,
@@ -29,6 +30,8 @@ struct Args {
     json: bool,
     #[arg(long)]
     registered: bool,
+    #[arg(long)]
+    storage_direct: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -47,8 +50,10 @@ struct UploadProbeRecord {
     hal_total_ms: f64,
     copy_h2d_ms: f64,
     copy_h2d_async_ms: f64,
+    copy_storage_to_device_ms: f64,
     copy_h2d_bytes: u64,
     copy_h2d_async_bytes: u64,
+    copy_storage_to_device_bytes: u64,
     alloc_ms: f64,
     alloc_bytes: u64,
 }
@@ -339,6 +344,82 @@ fn run_registered_upload(
     ))
 }
 
+fn run_storage_direct_upload(
+    store: &BakedStore,
+    tensor: &str,
+    device: usize,
+    iters: usize,
+) -> Result<UploadProbeRecord> {
+    let meta = store
+        .meta(tensor)
+        .with_context(|| format!("tensor not found: {tensor}"))?;
+    let bytes = usize::try_from(meta.byte_len)
+        .with_context(|| format!("tensor {tensor} byte_len does not fit usize"))?;
+    let range = store
+        .tensor_storage_range(tensor, 0, bytes)
+        .with_context(|| format!("storage range for tensor {tensor}"))?
+        .with_context(|| format!("tensor {tensor} is not backed by a direct storage range"))?;
+    let dtype = ScalarType::from_name(&range.extent.upload_dtype).with_context(|| {
+        format!(
+            "tensor {tensor} has unsupported upload dtype {} for storage-direct probe",
+            range.extent.upload_dtype
+        )
+    })?;
+    let shape = range.extent.upload_shape.clone();
+    let expected_bytes = shape
+        .iter()
+        .try_fold(dtype.size_in_bytes(), |acc, dim| acc.checked_mul(*dim))
+        .with_context(|| format!("tensor {tensor} upload shape {:?} overflows", shape))?;
+    if expected_bytes != bytes {
+        bail!(
+            "tensor {tensor} storage-direct probe expected {expected_bytes} bytes from upload dtype/shape, got {bytes}"
+        );
+    }
+
+    hal_profile_set_enabled(true);
+    hal_profile_reset();
+    let start = Instant::now();
+    let mut device_wait_ms = 0.0;
+    for _ in 0..iters {
+        let mut buffer =
+            GpuBuffer::alloc(device, dtype, &shape).context("allocate probe device buffer")?;
+        let wait_start = Instant::now();
+        copy_storage_to_device(
+            device,
+            buffer.as_mut_ptr(),
+            &range.extent.source_path,
+            range.file_offset,
+            bytes,
+        )
+        .with_context(|| {
+            format!(
+                "storage-direct upload tensor {tensor} from {} offset={} bytes={bytes}",
+                range.extent.source_path.display(),
+                range.file_offset
+            )
+        })?;
+        sync(device).context("sync after storage-direct upload")?;
+        device_wait_ms += wait_start.elapsed().as_secs_f64() * 1000.0;
+        drop(buffer);
+    }
+    let total_ms = start.elapsed().as_secs_f64() * 1000.0;
+    let snapshot = hal_profile_snapshot();
+    hal_profile_set_enabled(false);
+    Ok(record_from_snapshot(
+        tensor,
+        "storage-direct",
+        range.extent.upload_dtype,
+        bytes,
+        iters,
+        total_ms,
+        0.0,
+        0.0,
+        0.0,
+        device_wait_ms,
+        &snapshot,
+    ))
+}
+
 fn record_from_snapshot(
     tensor: &str,
     mode: &'static str,
@@ -367,8 +448,10 @@ fn record_from_snapshot(
         hal_total_ms: snapshot.total_ms,
         copy_h2d_ms: entry_total_ms(snapshot, "copy_h2d"),
         copy_h2d_async_ms: entry_total_ms(snapshot, "copy_h2d_async"),
+        copy_storage_to_device_ms: entry_total_ms(snapshot, "copy_storage_to_device"),
         copy_h2d_bytes: entry_total_bytes(snapshot, "copy_h2d"),
         copy_h2d_async_bytes: entry_total_bytes(snapshot, "copy_h2d_async"),
+        copy_storage_to_device_bytes: entry_total_bytes(snapshot, "copy_storage_to_device"),
         alloc_ms: entry_total_ms(snapshot, "alloc"),
         alloc_bytes: entry_total_bytes(snapshot, "alloc"),
     }
@@ -416,13 +499,21 @@ fn main() -> Result<()> {
                 args.iters,
             )?);
         }
+        if args.storage_direct {
+            records.push(run_storage_direct_upload(
+                &store,
+                tensor,
+                args.device,
+                args.iters,
+            )?);
+        }
     }
     if args.json {
         println!("{}", serde_json::to_string_pretty(&records)?);
     } else {
         for record in &records {
             println!(
-                "[upload-probe] tensor={} mode={} dtype={} bytes={} iters={} total_ms={:.3} mib_s={:.1} host_stage_ms={:.3} host_pinned_alloc_ms={:.3} host_register_ms={:.3} device_wait_ms={:.3} copy_h2d_ms={:.3} copy_h2d_async_ms={:.3} alloc_ms={:.3}",
+                "[upload-probe] tensor={} mode={} dtype={} bytes={} iters={} total_ms={:.3} mib_s={:.1} host_stage_ms={:.3} host_pinned_alloc_ms={:.3} host_register_ms={:.3} device_wait_ms={:.3} copy_h2d_ms={:.3} copy_h2d_async_ms={:.3} copy_storage_to_device_ms={:.3} alloc_ms={:.3}",
                 record.tensor,
                 record.mode,
                 record.dtype,
@@ -436,6 +527,7 @@ fn main() -> Result<()> {
                 record.device_wait_ms,
                 record.copy_h2d_ms,
                 record.copy_h2d_async_ms,
+                record.copy_storage_to_device_ms,
                 record.alloc_ms,
             );
         }
@@ -472,7 +564,14 @@ mod tests {
 
     #[test]
     fn records_device_wait_wall_time() {
-        let snapshot = gpu_hal::HalProfileSnapshot::default();
+        let mut snapshot = gpu_hal::HalProfileSnapshot::default();
+        snapshot.entries.push(gpu_hal::HalProfileEntry {
+            op: "copy_storage_to_device".to_string(),
+            calls: 2,
+            total_ms: 3.25,
+            max_ms: 2.0,
+            total_bytes: 8192,
+        });
         let record = record_from_snapshot(
             "tensor",
             "pinned",
@@ -490,6 +589,8 @@ mod tests {
         assert_eq!(record.host_pinned_alloc_ms, 1.5);
         assert_eq!(record.host_register_ms, 0.75);
         assert_eq!(record.device_wait_ms, 7.5);
+        assert_eq!(record.copy_storage_to_device_ms, 3.25);
+        assert_eq!(record.copy_storage_to_device_bytes, 8192);
     }
 
     #[test]
@@ -514,6 +615,30 @@ mod tests {
         ])
         .unwrap();
         assert!(args.registered);
+    }
+
+    #[test]
+    fn storage_direct_mode_is_opt_in() {
+        let args = Args::try_parse_from([
+            "qwen36_flm_upload_probe",
+            "--model-dir",
+            "model.flm",
+            "--tensor",
+            "tensor",
+        ])
+        .unwrap();
+        assert!(!args.storage_direct);
+
+        let args = Args::try_parse_from([
+            "qwen36_flm_upload_probe",
+            "--model-dir",
+            "model.flm",
+            "--tensor",
+            "tensor",
+            "--storage-direct",
+        ])
+        .unwrap();
+        assert!(args.storage_direct);
     }
 
     #[test]

--- a/crates/runner/src/cli.rs
+++ b/crates/runner/src/cli.rs
@@ -7,7 +7,7 @@ use crate::certified_kv;
 #[derive(Parser)]
 #[command(name = "supersonic", about = "SuperSonic — optimized LLM inference")]
 pub(crate) struct Cli {
-    /// Model variant (e.g. "qwen3.5-0.8b")
+    /// Model variant (e.g. "qwen3.5-0.8b"). Omitted FLM sources infer this from the runtime descriptor.
     #[arg(long, default_value = "qwen3.5-0.8b")]
     pub(crate) model: String,
 

--- a/crates/runner/src/cli.rs
+++ b/crates/runner/src/cli.rs
@@ -23,6 +23,10 @@ pub(crate) struct Cli {
     #[arg(long)]
     pub(crate) verify_flm_hashes: bool,
 
+    /// FLM virtual tensor transfer backend: pageable-h2d, gpu-direct-storage, gds, or hipfile.
+    #[arg(long)]
+    pub(crate) flm_virtual_transfer_backend: Option<String>,
+
     /// Text prompt (will be tokenized). Required unless --dry-run is set.
     #[arg(long, required_unless_present = "dry_run", default_value = "")]
     pub(crate) prompt: String,
@@ -556,6 +560,7 @@ pub(crate) struct Cli {
 #[cfg(test)]
 mod tests {
     use clap::CommandFactory;
+    use clap::Parser;
 
     use super::Cli;
 
@@ -569,5 +574,20 @@ mod tests {
         assert!(help.contains("self-contained FLM container"), "{help}");
         assert!(help.contains("Prefer --model-dir model.flm"), "{help}");
         assert!(help.contains("--verify-flm-hashes"), "{help}");
+    }
+
+    #[test]
+    fn parses_flm_virtual_transfer_backend_flag() {
+        let cli = Cli::try_parse_from([
+            "supersonic",
+            "--model-dir",
+            "model.flm",
+            "--flm-virtual-transfer-backend",
+            "hipfile",
+            "--dry-run",
+        ])
+        .unwrap();
+
+        assert_eq!(cli.flm_virtual_transfer_backend.as_deref(), Some("hipfile"));
     }
 }

--- a/crates/runner/src/flm_model_source.rs
+++ b/crates/runner/src/flm_model_source.rs
@@ -75,6 +75,13 @@ impl FlmModelSource {
         crate::flm_tokenizer::load_qwen_bpe_from_flm(self.runtime()?)
             .map_err(|e| anyhow::anyhow!("loading FLM Qwen tokenizer: {e}"))
     }
+
+    pub fn qwen_tokenizer_timed(
+        &self,
+    ) -> anyhow::Result<crate::flm_tokenizer::QwenBpeTokenizerLoad> {
+        crate::flm_tokenizer::load_qwen_bpe_from_flm_timed(self.runtime()?)
+            .map_err(|e| anyhow::anyhow!("loading FLM Qwen tokenizer: {e}"))
+    }
 }
 
 #[cfg(test)]

--- a/crates/runner/src/flm_tokenizer.rs
+++ b/crates/runner/src/flm_tokenizer.rs
@@ -43,7 +43,22 @@ struct QwenAddedToken {
 pub struct QwenBpeTokenizerTimings {
     pub asset_lookup: Duration,
     pub parse: Duration,
+    pub parse_vocab: Duration,
+    pub parse_vocab_ids: Duration,
+    pub parse_merges: Duration,
+    pub parse_added_tokens: Duration,
+    pub parse_regex: Duration,
     pub build: Duration,
+}
+
+impl QwenBpeTokenizerTimings {
+    pub fn parse_phase_total(&self) -> Duration {
+        self.parse_vocab
+            + self.parse_vocab_ids
+            + self.parse_merges
+            + self.parse_added_tokens
+            + self.parse_regex
+    }
 }
 
 pub struct QwenBpeTokenizerLoad {
@@ -52,6 +67,7 @@ pub struct QwenBpeTokenizerLoad {
 }
 
 impl QwenBpeAssets {
+    #[cfg(test)]
     fn parse(
         algorithm_id: u32,
         descriptor_vocab_size: u32,
@@ -60,18 +76,47 @@ impl QwenBpeAssets {
         added_tokens: &[u8],
         regex: &[u8],
     ) -> Result<Self> {
+        let mut timings = QwenBpeTokenizerTimings::default();
+        Self::parse_timed(
+            algorithm_id,
+            descriptor_vocab_size,
+            vocab,
+            merges,
+            added_tokens,
+            regex,
+            &mut timings,
+        )
+    }
+
+    fn parse_timed(
+        algorithm_id: u32,
+        descriptor_vocab_size: u32,
+        vocab: &[u8],
+        merges: &[u8],
+        added_tokens: &[u8],
+        regex: &[u8],
+        timings: &mut QwenBpeTokenizerTimings,
+    ) -> Result<Self> {
         if algorithm_id != TOKENIZER_QWEN_BPE_V1 {
             bail!(
                 "unsupported FLM tokenizer algorithm_id {algorithm_id}; expected TOKENIZER_QWEN_BPE_V1 ({TOKENIZER_QWEN_BPE_V1})"
             );
         }
-        let vocab = parse_vocab(vocab)?;
-        validate_vocab_ids(&vocab, descriptor_vocab_size)?;
+        let vocab = timed_tokenizer_phase(&mut timings.parse_vocab, || parse_vocab(vocab))?;
+        timed_tokenizer_phase(&mut timings.parse_vocab_ids, || {
+            validate_vocab_ids(&vocab, descriptor_vocab_size)
+        })?;
+        let merges = timed_tokenizer_phase(&mut timings.parse_merges, || parse_merges(merges))?;
+        let added_tokens = timed_tokenizer_phase(&mut timings.parse_added_tokens, || {
+            parse_added_tokens(added_tokens)
+        })?;
+        let regex = timed_tokenizer_phase(&mut timings.parse_regex, || parse_regex(regex))?;
+        timings.parse = timings.parse_phase_total();
         Ok(Self {
             vocab,
-            merges: parse_merges(merges)?,
-            added_tokens: parse_added_tokens(added_tokens)?,
-            regex: parse_regex(regex)?,
+            merges,
+            added_tokens,
+            regex,
         })
     }
 }
@@ -116,22 +161,28 @@ pub fn load_qwen_bpe_from_flm_timed(
     )?;
     timings.asset_lookup = asset_start.elapsed();
 
-    let parse_start = Instant::now();
-    let assets = QwenBpeAssets::parse(
+    let assets = QwenBpeAssets::parse_timed(
         descriptor.algorithm_id,
         descriptor.vocab_size,
         vocab,
         merges,
         added_tokens,
         regex,
+        &mut timings,
     )?;
-    timings.parse = parse_start.elapsed();
 
     let build_start = Instant::now();
     let tokenizer = build_qwen_bpe_tokenizer(assets)?;
     timings.build = build_start.elapsed();
 
     Ok(QwenBpeTokenizerLoad { tokenizer, timings })
+}
+
+fn timed_tokenizer_phase<T>(slot: &mut Duration, f: impl FnOnce() -> Result<T>) -> Result<T> {
+    let start = Instant::now();
+    let value = f()?;
+    *slot = start.elapsed();
+    Ok(value)
 }
 
 fn asset_payload<'a>(
@@ -466,6 +517,32 @@ mod tests {
         out
     }
 
+    fn generated_vocab_asset(count: u32) -> Vec<u8> {
+        let mut out = Vec::new();
+        u32_le(&mut out, count);
+        for id in 0..count {
+            let token = format!("tok{id}");
+            u32_le(&mut out, id);
+            u32_le(&mut out, token.len() as u32);
+            out.extend_from_slice(token.as_bytes());
+        }
+        out
+    }
+
+    fn generated_merges_asset(count: u32) -> Vec<u8> {
+        let mut out = Vec::new();
+        u32_le(&mut out, count);
+        for index in 0..count {
+            let left = format!("l{index}");
+            let right = format!("r{index}");
+            u32_le(&mut out, left.len() as u32);
+            out.extend_from_slice(left.as_bytes());
+            u32_le(&mut out, right.len() as u32);
+            out.extend_from_slice(right.as_bytes());
+        }
+        out
+    }
+
     #[test]
     fn parses_synthetic_assets_and_builds_qwen_bpe_tokenizer() {
         let assets = QwenBpeAssets::parse(
@@ -496,6 +573,36 @@ mod tests {
             tokenizer.encode("<|endoftext|>", false).unwrap().get_ids(),
             &[8]
         );
+    }
+
+    #[test]
+    fn timed_parse_records_tokenizer_asset_phase_breakdown() {
+        let vocab = generated_vocab_asset(1024);
+        let merges = generated_merges_asset(512);
+        let added_tokens = added_tokens_asset(&[(1024, "<|endoftext|>", [0, 0, 0, 0, 1])]);
+        let mut timings = QwenBpeTokenizerTimings::default();
+
+        let assets = QwenBpeAssets::parse_timed(
+            TOKENIZER_QWEN_BPE_V1,
+            1024,
+            &vocab,
+            &merges,
+            &added_tokens,
+            br"\S+",
+            &mut timings,
+        )
+        .expect("timed parse synthetic assets");
+
+        assert_eq!(timings.parse, timings.parse_phase_total());
+        assert!(timings.parse > std::time::Duration::ZERO);
+        assert!(timings.parse_vocab > std::time::Duration::ZERO);
+        assert!(timings.parse_vocab_ids > std::time::Duration::ZERO);
+        assert!(timings.parse_merges > std::time::Duration::ZERO);
+        assert!(timings.parse_added_tokens > std::time::Duration::ZERO);
+        assert!(timings.parse_regex > std::time::Duration::ZERO);
+        assert_eq!(assets.vocab.len(), 1024);
+        assert_eq!(assets.merges.len(), 512);
+        assert_eq!(assets.added_tokens.len(), 1);
     }
 
     #[test]

--- a/crates/runner/src/flm_tokenizer.rs
+++ b/crates/runner/src/flm_tokenizer.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, bail, Context, Result};
 use model_store::flm::{
@@ -38,6 +39,18 @@ struct QwenAddedToken {
     special: bool,
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct QwenBpeTokenizerTimings {
+    pub asset_lookup: Duration,
+    pub parse: Duration,
+    pub build: Duration,
+}
+
+pub struct QwenBpeTokenizerLoad {
+    pub tokenizer: Tokenizer,
+    pub timings: QwenBpeTokenizerTimings,
+}
+
 impl QwenBpeAssets {
     fn parse(
         algorithm_id: u32,
@@ -66,6 +79,14 @@ impl QwenBpeAssets {
 pub fn load_qwen_bpe_from_flm(
     runtime: &model_store::FlmRuntimeDirectory,
 ) -> Result<tokenizers::Tokenizer> {
+    Ok(load_qwen_bpe_from_flm_timed(runtime)?.tokenizer)
+}
+
+pub fn load_qwen_bpe_from_flm_timed(
+    runtime: &model_store::FlmRuntimeDirectory,
+) -> Result<QwenBpeTokenizerLoad> {
+    let mut timings = QwenBpeTokenizerTimings::default();
+    let asset_start = Instant::now();
     let descriptor = runtime
         .tokenizer()
         .ok_or_else(|| anyhow!("FLM runtime has no tokenizer descriptor"))?;
@@ -93,7 +114,9 @@ pub fn load_qwen_bpe_from_flm(
         ASSET_TOKENIZER_REGEX,
         "tokenizer_regex",
     )?;
+    timings.asset_lookup = asset_start.elapsed();
 
+    let parse_start = Instant::now();
     let assets = QwenBpeAssets::parse(
         descriptor.algorithm_id,
         descriptor.vocab_size,
@@ -102,7 +125,13 @@ pub fn load_qwen_bpe_from_flm(
         added_tokens,
         regex,
     )?;
-    build_qwen_bpe_tokenizer(assets)
+    timings.parse = parse_start.elapsed();
+
+    let build_start = Instant::now();
+    let tokenizer = build_qwen_bpe_tokenizer(assets)?;
+    timings.build = build_start.elapsed();
+
+    Ok(QwenBpeTokenizerLoad { tokenizer, timings })
 }
 
 fn asset_payload<'a>(

--- a/crates/runner/src/main.rs
+++ b/crates/runner/src/main.rs
@@ -89,9 +89,10 @@ use policy::{
 };
 use profiling::MetalProfileScope;
 use qwen35_runtime::run_qwen35;
-use registry::{ModelFamily, ModelVariant};
+use registry::ModelFamily;
 use supersonic_core::backend::{BackendChoice, BACKEND_CHOICES};
 fn main() -> Result<()> {
+    let model_arg_present = bakes::cli_args_include_model(std::env::args_os());
     let cli = Cli::parse();
     let _metal_profile_scope = MetalProfileScope::new();
     let ordinal = cli.device;
@@ -105,14 +106,8 @@ fn main() -> Result<()> {
     let backend = resolve_backend(backend_choice, ordinal)?;
     gpu_hal::set_backend(backend);
 
-    // 1. Parse model variant
-    let model_variant = ModelVariant::from_cli_str(&cli.model).ok_or_else(|| {
-        anyhow::anyhow!(
-            "Unknown model '{}'. Supported models: {}",
-            cli.model,
-            registry::supported_models_list().join(", ")
-        )
-    })?;
+    // 1. Resolve model variant from explicit CLI choice or a self-contained FLM descriptor.
+    let model_variant = bakes::resolve_model_variant(&cli, model_arg_present)?;
 
     validate_global_flags(&cli, &model_variant, backend)?;
     let q4km_like = q4km_like(&cli);

--- a/crates/runner/src/qwen36_moe/dry_run.rs
+++ b/crates/runner/src/qwen36_moe/dry_run.rs
@@ -12,6 +12,7 @@ use qwen36_moe::weights::{
     checkpoint_dtype_acceptable, expected_tensor_specs, CheckpointAccount, CheckpointDtype,
 };
 
+use crate::qwen36_moe_cli::flm_source::Qwen36MoeFlmDirectProfile;
 use crate::qwen36_moe_cli::layers::{
     resolve_qwen36_store_name, store_contains_qwen36, store_layout_qwen36,
 };
@@ -24,6 +25,7 @@ pub struct DryRunReport {
     pub config: Config,
     pub kernel_params: Qwen36MoeKernelParams,
     pub flm_source_label: Option<PathBuf>,
+    pub flm_direct_profile: Option<Qwen36MoeFlmDirectProfile>,
     pub checkpoint: CheckpointAccount,
     pub int4_projected_bytes: u64,
     pub state: StateAccount,
@@ -124,6 +126,7 @@ pub fn run_qwen36_moe_dry_run(
     run_qwen36_moe_dry_run_with_config(
         model_dir,
         None,
+        None,
         config,
         entry,
         total_vram,
@@ -139,6 +142,7 @@ pub fn run_qwen36_moe_dry_run(
 pub fn run_qwen36_moe_dry_run_with_config(
     model_dir: &Path,
     flm_source_label: Option<&Path>,
+    flm_direct_profile: Option<Qwen36MoeFlmDirectProfile>,
     config: Config,
     entry: &RegistryEntry,
     total_vram: u64,
@@ -264,6 +268,7 @@ pub fn run_qwen36_moe_dry_run_with_config(
         config,
         kernel_params,
         flm_source_label: flm_source_label.map(Path::to_path_buf),
+        flm_direct_profile,
         checkpoint,
         int4_projected_bytes,
         state,
@@ -536,6 +541,7 @@ mod tests {
         let report = run_qwen36_moe_dry_run_with_config(
             temp.path(),
             Some(&flm_path),
+            None,
             small_moe_config(),
             entry,
             24 * 1024 * 1024 * 1024,
@@ -563,6 +569,42 @@ mod tests {
         assert!(report.on_disk_tensor_count.is_none());
         assert!(report.missing_tensors.is_empty());
         assert!(report.dtype_mismatches.is_empty());
+    }
+
+    #[test]
+    fn flm_dry_run_keeps_direct_plan_profile() {
+        let temp = tempfile::tempdir().expect("temp model dir");
+        let flm_path = temp.path().join("model.flm");
+        let entry = lookup(
+            &ModelVariant::Qwen3_6_35B_A3B,
+            &Backend::Hip,
+            &GpuArch::Gfx1100,
+        )
+        .expect("qwen3.6 MoE HIP registry entry");
+        let direct_profile = crate::qwen36_moe_cli::flm_source::Qwen36MoeFlmDirectProfile {
+            required_tensors: 693,
+            raw_dense: 363,
+            native_int4: 330,
+            bf16_fallback: 0,
+        };
+
+        let report = run_qwen36_moe_dry_run_with_config(
+            temp.path(),
+            Some(&flm_path),
+            Some(direct_profile),
+            small_moe_config(),
+            entry,
+            24 * 1024 * 1024 * 1024,
+            16,
+            ContextSizeSource::Explicit,
+            1,
+            false,
+            false,
+            0,
+        )
+        .expect("dry-run from FLM config");
+
+        assert_eq!(report.flm_direct_profile, Some(direct_profile));
     }
 }
 
@@ -700,6 +742,9 @@ pub fn print_report(report: &DryRunReport) {
         println!("[FLM source]");
         println!("  path:            {}", path.display());
         println!("  runtime:         config, tokenizer, and tensor table supplied by FLM");
+        if let Some(profile) = report.flm_direct_profile {
+            println!("  direct plans:    {profile}");
+        }
         if let Some(w) = &report.loader_warning {
             println!("  WARNING: {w}");
         }
@@ -744,10 +789,18 @@ pub fn print_report(report: &DryRunReport) {
         println!();
     }
     if let Some(path) = &report.flm_source_label {
-        println!(
-            "[FLM runtime weights] ready-for-decode: YES (source={})",
-            path.display()
-        );
+        if let Some(profile) = report.flm_direct_profile {
+            println!(
+                "[FLM runtime weights] ready-for-decode: YES (source={} direct_plans={})",
+                path.display(),
+                profile
+            );
+        } else {
+            println!(
+                "[FLM runtime weights] ready-for-decode: YES (source={})",
+                path.display()
+            );
+        }
         println!();
     } else if let Some(bake) = &report.bake {
         println!("[INT4 baked package]");

--- a/crates/runner/src/qwen36_moe/engine.rs
+++ b/crates/runner/src/qwen36_moe/engine.rs
@@ -386,6 +386,7 @@ fn run_inner(
         run_qwen36_moe_dry_run_with_config(
             &cli.model_dir,
             Some(&flm.source.path),
+            Some(flm.direct_profile),
             flm.config.clone(),
             entry,
             total_vram,

--- a/crates/runner/src/qwen36_moe/engine.rs
+++ b/crates/runner/src/qwen36_moe/engine.rs
@@ -836,6 +836,7 @@ fn run_inner(
         cli.ignore_eos,
         keep_mask,
         cli.progress_heartbeat_seconds,
+        cli.flm_virtual_transfer_backend.as_deref(),
     )?;
     Ok(())
 }
@@ -880,6 +881,7 @@ fn decode_text(
     ignore_eos: bool,
     keep_mask: Option<Vec<bool>>,
     progress_heartbeat_seconds: f64,
+    flm_virtual_transfer_backend_cli: Option<&str>,
 ) -> Result<()> {
     validate_speculative_sampling(speculative_decode, sampling)?;
 
@@ -1006,6 +1008,7 @@ fn decode_text(
         persistent_decode,
         backend,
         geom.top_k as usize,
+        flm_virtual_transfer_backend_cli,
     )?;
     let kv_vmm = should_use_qwen36_kv_vmm(backend, ordinal)?;
     progress(

--- a/crates/runner/src/qwen36_moe/engine.rs
+++ b/crates/runner/src/qwen36_moe/engine.rs
@@ -942,6 +942,24 @@ fn decode_text(
     };
     print_prompt_summary(prompt, &prompt_ids);
 
+    let geom = build_multi_layer_geom(&report.config.text_config, &report.kernel_params);
+
+    set_backend(backend);
+
+    // KV cache size: needs to fit prompt_len + max_new past tokens. Sized
+    // generously here since per-layer KV is small (10 full-attn layers ×
+    // [kv_max_t, Hkv*d=512] BF16 = 10 KiB per token of context).
+    let kv_max_t = prompt_ids.len() + max_new;
+
+    let mut moe_runtime = prepare_moe_runtime_config(
+        speculative_decode,
+        persistent_decode,
+        backend,
+        geom.top_k as usize,
+        flm_virtual_transfer_backend_cli,
+    )?;
+    let kv_vmm = should_use_qwen36_kv_vmm(backend, ordinal)?;
+
     progress(
         "prompt_setup",
         format!("done prompt_tokens={}", prompt_ids.len()),
@@ -983,15 +1001,6 @@ fn decode_text(
     let model_source_elapsed = source_open_start.elapsed();
     progress(source_phase, format!("done source={source_label}"), true);
 
-    let geom = build_multi_layer_geom(&report.config.text_config, &report.kernel_params);
-
-    set_backend(backend);
-
-    // KV cache size: needs to fit prompt_len + max_new past tokens. Sized
-    // generously here since per-layer KV is small (10 full-attn layers ×
-    // [kv_max_t, Hkv*d=512] BF16 = 10 KiB per token of context).
-    let kv_max_t = prompt_ids.len() + max_new;
-
     println!(
         "  loading {} layers ({} INT4 sidecar sets, KV cache cap = {} tokens)…",
         geom.num_layers,
@@ -1003,14 +1012,6 @@ fn decode_text(
         kv_max_t,
     );
 
-    let mut moe_runtime = prepare_moe_runtime_config(
-        speculative_decode,
-        persistent_decode,
-        backend,
-        geom.top_k as usize,
-        flm_virtual_transfer_backend_cli,
-    )?;
-    let kv_vmm = should_use_qwen36_kv_vmm(backend, ordinal)?;
     progress(
         "layer_load",
         format!(

--- a/crates/runner/src/qwen36_moe/engine.rs
+++ b/crates/runner/src/qwen36_moe/engine.rs
@@ -198,6 +198,11 @@ struct Qwen36StartupTimings {
     flm_tokenizer: std::time::Duration,
     flm_tokenizer_assets: std::time::Duration,
     flm_tokenizer_parse: std::time::Duration,
+    flm_tokenizer_parse_vocab: std::time::Duration,
+    flm_tokenizer_parse_vocab_ids: std::time::Duration,
+    flm_tokenizer_parse_merges: std::time::Duration,
+    flm_tokenizer_parse_added_tokens: std::time::Duration,
+    flm_tokenizer_parse_regex: std::time::Duration,
     flm_tokenizer_build: std::time::Duration,
     flm_direct_plan: std::time::Duration,
     bake_prepare: std::time::Duration,
@@ -229,6 +234,11 @@ fn format_qwen36_startup_timings(timings: &Qwen36StartupTimings) -> String {
         "flm_source_open_ms={:.3} flm_store_open_ms={:.3} \
          flm_config_ms={:.3} flm_tokenizer_ms={:.3} \
          flm_tokenizer_assets_ms={:.3} flm_tokenizer_parse_ms={:.3} \
+         flm_tokenizer_parse_vocab_ms={:.3} \
+         flm_tokenizer_parse_vocab_ids_ms={:.3} \
+         flm_tokenizer_parse_merges_ms={:.3} \
+         flm_tokenizer_parse_added_tokens_ms={:.3} \
+         flm_tokenizer_parse_regex_ms={:.3} \
          flm_tokenizer_build_ms={:.3} flm_direct_plan_ms={:.3} \
          bake_prepare_ms={:.3} \
          dry_run_ms={:.3} pre_decode_total_ms={:.3}",
@@ -238,6 +248,11 @@ fn format_qwen36_startup_timings(timings: &Qwen36StartupTimings) -> String {
         qwen36_duration_ms(timings.flm_tokenizer),
         qwen36_duration_ms(timings.flm_tokenizer_assets),
         qwen36_duration_ms(timings.flm_tokenizer_parse),
+        qwen36_duration_ms(timings.flm_tokenizer_parse_vocab),
+        qwen36_duration_ms(timings.flm_tokenizer_parse_vocab_ids),
+        qwen36_duration_ms(timings.flm_tokenizer_parse_merges),
+        qwen36_duration_ms(timings.flm_tokenizer_parse_added_tokens),
+        qwen36_duration_ms(timings.flm_tokenizer_parse_regex),
         qwen36_duration_ms(timings.flm_tokenizer_build),
         qwen36_duration_ms(timings.flm_direct_plan),
         qwen36_duration_ms(timings.bake_prepare),
@@ -252,6 +267,11 @@ struct Qwen36LifecycleTimings {
     flm_tokenizer: std::time::Duration,
     flm_tokenizer_assets: std::time::Duration,
     flm_tokenizer_parse: std::time::Duration,
+    flm_tokenizer_parse_vocab: std::time::Duration,
+    flm_tokenizer_parse_vocab_ids: std::time::Duration,
+    flm_tokenizer_parse_merges: std::time::Duration,
+    flm_tokenizer_parse_added_tokens: std::time::Duration,
+    flm_tokenizer_parse_regex: std::time::Duration,
     flm_tokenizer_build: std::time::Duration,
     model_source: std::time::Duration,
     layer_load: std::time::Duration,
@@ -273,6 +293,11 @@ fn format_qwen36_lifecycle_timings(timings: &Qwen36LifecycleTimings) -> String {
     format!(
         "prompt_setup_ms={:.3} flm_tokenizer_ms={:.3} \
          flm_tokenizer_assets_ms={:.3} flm_tokenizer_parse_ms={:.3} \
+         flm_tokenizer_parse_vocab_ms={:.3} \
+         flm_tokenizer_parse_vocab_ids_ms={:.3} \
+         flm_tokenizer_parse_merges_ms={:.3} \
+         flm_tokenizer_parse_added_tokens_ms={:.3} \
+         flm_tokenizer_parse_regex_ms={:.3} \
          flm_tokenizer_build_ms={:.3} model_source_ms={:.3} \
          layer_load_ms={:.3} session_ms={:.3} prefill_steps={} \
          prefill_embed_ms={:.3} prefill_chain_ms={:.3} \
@@ -281,6 +306,11 @@ fn format_qwen36_lifecycle_timings(timings: &Qwen36LifecycleTimings) -> String {
         qwen36_duration_ms(timings.flm_tokenizer),
         qwen36_duration_ms(timings.flm_tokenizer_assets),
         qwen36_duration_ms(timings.flm_tokenizer_parse),
+        qwen36_duration_ms(timings.flm_tokenizer_parse_vocab),
+        qwen36_duration_ms(timings.flm_tokenizer_parse_vocab_ids),
+        qwen36_duration_ms(timings.flm_tokenizer_parse_merges),
+        qwen36_duration_ms(timings.flm_tokenizer_parse_added_tokens),
+        qwen36_duration_ms(timings.flm_tokenizer_parse_regex),
         qwen36_duration_ms(timings.flm_tokenizer_build),
         qwen36_duration_ms(timings.model_source),
         qwen36_duration_ms(timings.layer_load),
@@ -326,6 +356,11 @@ mod tests {
             flm_tokenizer: std::time::Duration::from_micros(625),
             flm_tokenizer_assets: std::time::Duration::from_micros(25),
             flm_tokenizer_parse: std::time::Duration::from_micros(275),
+            flm_tokenizer_parse_vocab: std::time::Duration::from_micros(100),
+            flm_tokenizer_parse_vocab_ids: std::time::Duration::from_micros(25),
+            flm_tokenizer_parse_merges: std::time::Duration::from_micros(75),
+            flm_tokenizer_parse_added_tokens: std::time::Duration::from_micros(50),
+            flm_tokenizer_parse_regex: std::time::Duration::from_micros(25),
             flm_tokenizer_build: std::time::Duration::from_micros(325),
             flm_direct_plan: std::time::Duration::from_micros(125),
             bake_prepare: std::time::Duration::ZERO,
@@ -337,6 +372,11 @@ mod tests {
             "flm_source_open_ms=1.500 flm_store_open_ms=0.500 \
              flm_config_ms=0.250 flm_tokenizer_ms=0.625 \
              flm_tokenizer_assets_ms=0.025 flm_tokenizer_parse_ms=0.275 \
+             flm_tokenizer_parse_vocab_ms=0.100 \
+             flm_tokenizer_parse_vocab_ids_ms=0.025 \
+             flm_tokenizer_parse_merges_ms=0.075 \
+             flm_tokenizer_parse_added_tokens_ms=0.050 \
+             flm_tokenizer_parse_regex_ms=0.025 \
              flm_tokenizer_build_ms=0.325 flm_direct_plan_ms=0.125 \
              bake_prepare_ms=0.000 \
              dry_run_ms=2.250 pre_decode_total_ms=3.750"
@@ -350,6 +390,11 @@ mod tests {
             flm_tokenizer: std::time::Duration::from_micros(625),
             flm_tokenizer_assets: std::time::Duration::from_micros(25),
             flm_tokenizer_parse: std::time::Duration::from_micros(275),
+            flm_tokenizer_parse_vocab: std::time::Duration::from_micros(100),
+            flm_tokenizer_parse_vocab_ids: std::time::Duration::from_micros(25),
+            flm_tokenizer_parse_merges: std::time::Duration::from_micros(75),
+            flm_tokenizer_parse_added_tokens: std::time::Duration::from_micros(50),
+            flm_tokenizer_parse_regex: std::time::Duration::from_micros(25),
             flm_tokenizer_build: std::time::Duration::from_micros(325),
             model_source: std::time::Duration::from_micros(1_500),
             layer_load: std::time::Duration::from_micros(2_500),
@@ -365,6 +410,11 @@ mod tests {
             format_qwen36_lifecycle_timings(&timings),
             "prompt_setup_ms=5.000 flm_tokenizer_ms=0.625 \
              flm_tokenizer_assets_ms=0.025 flm_tokenizer_parse_ms=0.275 \
+             flm_tokenizer_parse_vocab_ms=0.100 \
+             flm_tokenizer_parse_vocab_ids_ms=0.025 \
+             flm_tokenizer_parse_merges_ms=0.075 \
+             flm_tokenizer_parse_added_tokens_ms=0.050 \
+             flm_tokenizer_parse_regex_ms=0.025 \
              flm_tokenizer_build_ms=0.325 model_source_ms=1.500 \
              layer_load_ms=2.500 session_ms=3.500 prefill_steps=2 \
              prefill_embed_ms=0.100 prefill_chain_ms=0.200 \
@@ -1405,6 +1455,11 @@ fn decode_text(
             flm_tokenizer: flm_tokenizer_elapsed,
             flm_tokenizer_assets: flm_tokenizer_timings.asset_lookup,
             flm_tokenizer_parse: flm_tokenizer_timings.parse,
+            flm_tokenizer_parse_vocab: flm_tokenizer_timings.parse_vocab,
+            flm_tokenizer_parse_vocab_ids: flm_tokenizer_timings.parse_vocab_ids,
+            flm_tokenizer_parse_merges: flm_tokenizer_timings.parse_merges,
+            flm_tokenizer_parse_added_tokens: flm_tokenizer_timings.parse_added_tokens,
+            flm_tokenizer_parse_regex: flm_tokenizer_timings.parse_regex,
             flm_tokenizer_build: flm_tokenizer_timings.build,
             model_source: model_source_elapsed,
             layer_load: layer_load_elapsed,

--- a/crates/runner/src/qwen36_moe/engine.rs
+++ b/crates/runner/src/qwen36_moe/engine.rs
@@ -190,6 +190,44 @@ fn validate_qwen36_decode_weight_mode(
     }
 }
 
+#[derive(Clone, Copy, Debug, Default)]
+struct Qwen36StartupTimings {
+    flm_source_open: std::time::Duration,
+    bake_prepare: std::time::Duration,
+    dry_run: std::time::Duration,
+}
+
+impl Qwen36StartupTimings {
+    fn pre_decode_total(self) -> std::time::Duration {
+        self.flm_source_open + self.bake_prepare + self.dry_run
+    }
+
+    fn print_if_requested(self, emit_stage_timings: bool) {
+        if !emit_stage_timings {
+            return;
+        }
+        eprintln!(
+            "[qwen36-moe startup-timings] {}",
+            format_qwen36_startup_timings(&self)
+        );
+    }
+}
+
+fn qwen36_duration_ms(duration: std::time::Duration) -> f64 {
+    duration.as_secs_f64() * 1000.0
+}
+
+fn format_qwen36_startup_timings(timings: &Qwen36StartupTimings) -> String {
+    format!(
+        "flm_source_open_ms={:.3} bake_prepare_ms={:.3} \
+         dry_run_ms={:.3} pre_decode_total_ms={:.3}",
+        qwen36_duration_ms(timings.flm_source_open),
+        qwen36_duration_ms(timings.bake_prepare),
+        qwen36_duration_ms(timings.dry_run),
+        qwen36_duration_ms(timings.pre_decode_total()),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -211,6 +249,21 @@ mod tests {
     fn hip_decode_allows_non_int4_weight_mode_for_development_path() {
         validate_qwen36_decode_weight_mode(Qwen36WeightMode::Bf16, Backend::Hip, "model.flm")
             .expect("HIP development path can still choose BF16/FP8");
+    }
+
+    #[test]
+    fn formats_startup_timings_for_machine_parsing() {
+        let timings = Qwen36StartupTimings {
+            flm_source_open: std::time::Duration::from_micros(1_500),
+            bake_prepare: std::time::Duration::ZERO,
+            dry_run: std::time::Duration::from_micros(2_250),
+        };
+
+        assert_eq!(
+            format_qwen36_startup_timings(&timings),
+            "flm_source_open_ms=1.500 bake_prepare_ms=0.000 \
+             dry_run_ms=2.250 pre_decode_total_ms=3.750"
+        );
     }
 }
 
@@ -377,11 +430,20 @@ fn run_inner(
     validate_persistent_kv_fp8_flags(cli)?;
     validate_cuda_v1_flags(cli, entry)?;
     validate_metal_v1_flags(cli, entry)?;
+
+    let mut startup_timings = Qwen36StartupTimings::default();
+    let flm_source_open_start = std::time::Instant::now();
     let flm_source = open_qwen36_moe_flm_source(cli)?;
+    if flm_source.is_some() {
+        startup_timings.flm_source_open = flm_source_open_start.elapsed();
+    }
     if flm_source.is_none() {
+        let bake_prepare_start = std::time::Instant::now();
         ensure_qwen36_bake(cli, entry)?;
+        startup_timings.bake_prepare = bake_prepare_start.elapsed();
     }
 
+    let dry_run_start = std::time::Instant::now();
     let report = if let Some(flm) = flm_source.as_ref() {
         run_qwen36_moe_dry_run_with_config(
             &cli.model_dir,
@@ -410,7 +472,9 @@ fn run_inner(
             cli.device,
         )?
     };
+    startup_timings.dry_run = dry_run_start.elapsed();
     print_report(&report);
+    startup_timings.print_if_requested(cli.emit_stage_timings);
     if cli.dry_run {
         return Ok(());
     }

--- a/crates/runner/src/qwen36_moe/engine.rs
+++ b/crates/runner/src/qwen36_moe/engine.rs
@@ -48,7 +48,10 @@ use crate::qwen36_moe_cli::vmm::{
     load_decode_layers_with_vmm_strategy, print_virtual_kv_stats_if_active,
     virtual_kv_stats_for_layers, Qwen36LayerLoadTimings,
 };
-use crate::qwen36_moe_cli::vmm_config::{prepare_moe_runtime_config, should_use_qwen36_kv_vmm};
+use crate::qwen36_moe_cli::vmm_config::{
+    effective_moe_expert_vmm_mode_for_transfer_backend, prepare_moe_runtime_config,
+    should_use_qwen36_kv_vmm,
+};
 use crate::qwen36_moe_logits::XorshiftRng;
 use crate::qwen36_moe_speculative::SpeculativeStepResult;
 use crate::qwen36_moe_telemetry::{print_and_write_moe_residency_summary, MoeRouteRuntime};
@@ -1022,6 +1025,11 @@ fn decode_text(
         gpu_hal::hal_profile_set_enabled(true);
         gpu_hal::hal_profile_reset();
     }
+    let effective_moe_vmm_mode = effective_moe_expert_vmm_mode_for_transfer_backend(
+        moe_runtime.vmm_mode,
+        moe_runtime.island_cap_experts,
+        moe_runtime.virtual_transfer_backend,
+    )?;
     let loaded_layers = match load_decode_layers_with_vmm_strategy(
         &store,
         ordinal,
@@ -1033,7 +1041,7 @@ fn decode_text(
         kv_max_t,
         kv_fp8,
         kv_vmm,
-        moe_runtime.vmm_mode,
+        effective_moe_vmm_mode,
         moe_runtime.island_cap_experts,
         moe_runtime.protected_experts,
         moe_runtime.fixed_hot_experts,
@@ -1044,6 +1052,7 @@ fn decode_text(
         moe_runtime.async_staging_pages,
         moe_runtime.prefetch_evict,
         moe_runtime.prefetch_evict_min_probability,
+        moe_runtime.virtual_transfer_backend,
         persistent_decode,
     ) {
         Ok(loaded_layers) => loaded_layers,

--- a/crates/runner/src/qwen36_moe/engine.rs
+++ b/crates/runner/src/qwen36_moe/engine.rs
@@ -46,7 +46,7 @@ use crate::qwen36_moe_cli::spec_verify::{run_speculative_extension, Qwen36Specul
 use crate::qwen36_moe_cli::timing::{Qwen36StageTimingTotals, SamplingParams};
 use crate::qwen36_moe_cli::vmm::{
     load_decode_layers_with_vmm_strategy, print_virtual_kv_stats_if_active,
-    virtual_kv_stats_for_layers,
+    virtual_kv_stats_for_layers, Qwen36LayerLoadTimings,
 };
 use crate::qwen36_moe_cli::vmm_config::{prepare_moe_runtime_config, should_use_qwen36_kv_vmm};
 use crate::qwen36_moe_logits::XorshiftRng;
@@ -275,6 +275,7 @@ struct Qwen36LifecycleTimings {
     flm_tokenizer_build: std::time::Duration,
     model_source: std::time::Duration,
     layer_load: std::time::Duration,
+    layer_load_profile: Qwen36LayerLoadTimings,
     session: std::time::Duration,
     prefill_steps: usize,
     prefill_embed: std::time::Duration,
@@ -299,7 +300,13 @@ fn format_qwen36_lifecycle_timings(timings: &Qwen36LifecycleTimings) -> String {
          flm_tokenizer_parse_added_tokens_ms={:.3} \
          flm_tokenizer_parse_regex_ms={:.3} \
          flm_tokenizer_build_ms={:.3} model_source_ms={:.3} \
-         layer_load_ms={:.3} session_ms={:.3} prefill_steps={} \
+         layer_load_ms={:.3} layer_load_buffers_ms={:.3} \
+         layer_load_vmm_setup_ms={:.3} layer_load_prewarm_ms={:.3} \
+         layer_load_hal_ms={:.3} layer_load_alloc_ms={:.3} \
+         layer_load_copy_h_to_d_ms={:.3} layer_load_memset_ms={:.3} \
+         layer_load_vmm_ms={:.3} layer_load_alloc_bytes={} \
+         layer_load_copy_h_to_d_bytes={} layer_load_memset_bytes={} \
+         layer_load_vmm_bytes={} session_ms={:.3} prefill_steps={} \
          prefill_embed_ms={:.3} prefill_chain_ms={:.3} \
          prefill_total_ms={:.3} generation_wall_ms={:.3} total_wall_ms={:.3}",
         qwen36_duration_ms(timings.prompt_setup),
@@ -314,6 +321,18 @@ fn format_qwen36_lifecycle_timings(timings: &Qwen36LifecycleTimings) -> String {
         qwen36_duration_ms(timings.flm_tokenizer_build),
         qwen36_duration_ms(timings.model_source),
         qwen36_duration_ms(timings.layer_load),
+        qwen36_duration_ms(timings.layer_load_profile.buffers),
+        qwen36_duration_ms(timings.layer_load_profile.vmm_setup),
+        qwen36_duration_ms(timings.layer_load_profile.prewarm),
+        qwen36_duration_ms(timings.layer_load_profile.hal_total),
+        qwen36_duration_ms(timings.layer_load_profile.hal_alloc),
+        qwen36_duration_ms(timings.layer_load_profile.hal_copy_h_to_d),
+        qwen36_duration_ms(timings.layer_load_profile.hal_memset),
+        qwen36_duration_ms(timings.layer_load_profile.hal_vmm),
+        timings.layer_load_profile.hal_alloc_bytes,
+        timings.layer_load_profile.hal_copy_h_to_d_bytes,
+        timings.layer_load_profile.hal_memset_bytes,
+        timings.layer_load_profile.hal_vmm_bytes,
         qwen36_duration_ms(timings.session),
         timings.prefill_steps,
         qwen36_duration_ms(timings.prefill_embed),
@@ -322,6 +341,44 @@ fn format_qwen36_lifecycle_timings(timings: &Qwen36LifecycleTimings) -> String {
         timings.generation_wall.unwrap_or(0.0),
         qwen36_duration_ms(timings.total_wall),
     )
+}
+
+fn qwen36_layer_load_hal_timings(snapshot: &gpu_hal::HalProfileSnapshot) -> Qwen36LayerLoadTimings {
+    let mut timings = Qwen36LayerLoadTimings {
+        hal_total: std::time::Duration::from_secs_f64(snapshot.total_ms / 1000.0),
+        hal_alloc_bytes: snapshot.alloc_bytes,
+        hal_copy_h_to_d_bytes: snapshot.h2d_bytes,
+        hal_memset_bytes: snapshot.memset_bytes,
+        ..Default::default()
+    };
+
+    for entry in &snapshot.entries {
+        let duration = std::time::Duration::from_secs_f64(entry.total_ms / 1000.0);
+        match entry.op.as_str() {
+            "alloc" => timings.hal_alloc += duration,
+            "copy_h2d" => timings.hal_copy_h_to_d += duration,
+            "memset_zeros" => timings.hal_memset += duration,
+            op if op.starts_with("vmm_") => {
+                timings.hal_vmm += duration;
+                timings.hal_vmm_bytes += entry.total_bytes;
+            }
+            _ => {}
+        }
+    }
+
+    timings
+}
+
+fn qwen36_should_profile_layer_load_hal(
+    emit_stage_timings: bool,
+    external_hal_profile_active: bool,
+) -> bool {
+    emit_stage_timings && !external_hal_profile_active
+}
+
+fn qwen36_external_hal_profile_env_active() -> bool {
+    std::env::var_os("SUPERSONIC_HAL_PROFILE").is_some()
+        || std::env::var_os("SUPERSONIC_METAL_PROFILE").is_some()
 }
 
 #[cfg(test)]
@@ -398,6 +455,20 @@ mod tests {
             flm_tokenizer_build: std::time::Duration::from_micros(325),
             model_source: std::time::Duration::from_micros(1_500),
             layer_load: std::time::Duration::from_micros(2_500),
+            layer_load_profile: Qwen36LayerLoadTimings {
+                buffers: std::time::Duration::from_micros(1_100),
+                vmm_setup: std::time::Duration::from_micros(200),
+                prewarm: std::time::Duration::from_micros(300),
+                hal_total: std::time::Duration::from_micros(1_000),
+                hal_alloc: std::time::Duration::from_micros(400),
+                hal_copy_h_to_d: std::time::Duration::from_micros(500),
+                hal_memset: std::time::Duration::from_micros(50),
+                hal_vmm: std::time::Duration::from_micros(50),
+                hal_alloc_bytes: 1_024,
+                hal_copy_h_to_d_bytes: 2_048,
+                hal_memset_bytes: 512,
+                hal_vmm_bytes: 4_096,
+            },
             session: std::time::Duration::from_micros(3_500),
             prefill_steps: 2,
             prefill_embed: std::time::Duration::from_micros(100),
@@ -416,11 +487,92 @@ mod tests {
              flm_tokenizer_parse_added_tokens_ms=0.050 \
              flm_tokenizer_parse_regex_ms=0.025 \
              flm_tokenizer_build_ms=0.325 model_source_ms=1.500 \
-             layer_load_ms=2.500 session_ms=3.500 prefill_steps=2 \
+             layer_load_ms=2.500 layer_load_buffers_ms=1.100 \
+             layer_load_vmm_setup_ms=0.200 layer_load_prewarm_ms=0.300 \
+             layer_load_hal_ms=1.000 layer_load_alloc_ms=0.400 \
+             layer_load_copy_h_to_d_ms=0.500 layer_load_memset_ms=0.050 \
+             layer_load_vmm_ms=0.050 layer_load_alloc_bytes=1024 \
+             layer_load_copy_h_to_d_bytes=2048 layer_load_memset_bytes=512 \
+             layer_load_vmm_bytes=4096 session_ms=3.500 prefill_steps=2 \
              prefill_embed_ms=0.100 prefill_chain_ms=0.200 \
              prefill_total_ms=0.300 generation_wall_ms=4.500 \
              total_wall_ms=9.000"
         );
+    }
+
+    #[test]
+    fn layer_load_hal_timings_group_transfer_and_vmm_ops() {
+        let snapshot = gpu_hal::HalProfileSnapshot {
+            total_calls: 5,
+            total_ms: 7.0,
+            alloc_calls: 1,
+            alloc_bytes: 1_024,
+            free_calls: 0,
+            h2d_bytes: 2_048,
+            d2h_bytes: 0,
+            d2d_bytes: 0,
+            memset_bytes: 512,
+            sync_calls: 0,
+            entries: vec![
+                gpu_hal::HalProfileEntry {
+                    op: "alloc".to_string(),
+                    calls: 1,
+                    total_ms: 1.5,
+                    max_ms: 1.5,
+                    total_bytes: 1_024,
+                },
+                gpu_hal::HalProfileEntry {
+                    op: "copy_h2d".to_string(),
+                    calls: 1,
+                    total_ms: 2.5,
+                    max_ms: 2.5,
+                    total_bytes: 2_048,
+                },
+                gpu_hal::HalProfileEntry {
+                    op: "memset_zeros".to_string(),
+                    calls: 1,
+                    total_ms: 0.75,
+                    max_ms: 0.75,
+                    total_bytes: 512,
+                },
+                gpu_hal::HalProfileEntry {
+                    op: "vmm_reserve".to_string(),
+                    calls: 1,
+                    total_ms: 1.0,
+                    max_ms: 1.0,
+                    total_bytes: 3_000,
+                },
+                gpu_hal::HalProfileEntry {
+                    op: "vmm_map".to_string(),
+                    calls: 1,
+                    total_ms: 1.25,
+                    max_ms: 1.25,
+                    total_bytes: 1_096,
+                },
+            ],
+        };
+
+        let timings = qwen36_layer_load_hal_timings(&snapshot);
+
+        assert_eq!(timings.hal_total, std::time::Duration::from_micros(7_000));
+        assert_eq!(timings.hal_alloc, std::time::Duration::from_micros(1_500));
+        assert_eq!(
+            timings.hal_copy_h_to_d,
+            std::time::Duration::from_micros(2_500)
+        );
+        assert_eq!(timings.hal_memset, std::time::Duration::from_micros(750));
+        assert_eq!(timings.hal_vmm, std::time::Duration::from_micros(2_250));
+        assert_eq!(timings.hal_alloc_bytes, 1_024);
+        assert_eq!(timings.hal_copy_h_to_d_bytes, 2_048);
+        assert_eq!(timings.hal_memset_bytes, 512);
+        assert_eq!(timings.hal_vmm_bytes, 4_096);
+    }
+
+    #[test]
+    fn layer_load_hal_profile_only_enables_for_isolated_stage_timings() {
+        assert!(qwen36_should_profile_layer_load_hal(true, false));
+        assert!(!qwen36_should_profile_layer_load_hal(false, false));
+        assert!(!qwen36_should_profile_layer_load_hal(true, true));
     }
 }
 
@@ -862,7 +1014,15 @@ fn decode_text(
         true,
     );
     let layer_load_start = std::time::Instant::now();
-    let loaded_layers = load_decode_layers_with_vmm_strategy(
+    let profile_layer_load_hal = qwen36_should_profile_layer_load_hal(
+        emit_stage_timings,
+        qwen36_external_hal_profile_env_active(),
+    );
+    if profile_layer_load_hal {
+        gpu_hal::hal_profile_set_enabled(true);
+        gpu_hal::hal_profile_reset();
+    }
+    let loaded_layers = match load_decode_layers_with_vmm_strategy(
         &store,
         ordinal,
         backend,
@@ -885,10 +1045,44 @@ fn decode_text(
         moe_runtime.prefetch_evict,
         moe_runtime.prefetch_evict_min_probability,
         persistent_decode,
-    )?;
+    ) {
+        Ok(loaded_layers) => loaded_layers,
+        Err(err) => {
+            if profile_layer_load_hal {
+                gpu_hal::hal_profile_set_enabled(false);
+            }
+            return Err(err);
+        }
+    };
     let mut layers = loaded_layers.layers;
-    let _ffn_prewarm_elapsed =
-        prewarm_qwen36_mps_static_topn_if_requested(ordinal, backend, &geom, &mut layers)?;
+    let mut layer_load_profile = loaded_layers.timings;
+    let ffn_prewarm_elapsed =
+        match prewarm_qwen36_mps_static_topn_if_requested(ordinal, backend, &geom, &mut layers) {
+            Ok(elapsed) => elapsed,
+            Err(err) => {
+                if profile_layer_load_hal {
+                    gpu_hal::hal_profile_set_enabled(false);
+                }
+                return Err(err);
+            }
+        };
+    layer_load_profile.prewarm = ffn_prewarm_elapsed;
+    if profile_layer_load_hal {
+        let hal_timings = qwen36_layer_load_hal_timings(&gpu_hal::hal_profile_snapshot());
+        layer_load_profile = Qwen36LayerLoadTimings {
+            hal_total: hal_timings.hal_total,
+            hal_alloc: hal_timings.hal_alloc,
+            hal_copy_h_to_d: hal_timings.hal_copy_h_to_d,
+            hal_memset: hal_timings.hal_memset,
+            hal_vmm: hal_timings.hal_vmm,
+            hal_alloc_bytes: hal_timings.hal_alloc_bytes,
+            hal_copy_h_to_d_bytes: hal_timings.hal_copy_h_to_d_bytes,
+            hal_memset_bytes: hal_timings.hal_memset_bytes,
+            hal_vmm_bytes: hal_timings.hal_vmm_bytes,
+            ..layer_load_profile
+        };
+        gpu_hal::hal_profile_set_enabled(false);
+    }
     let layer_load_elapsed = layer_load_start.elapsed();
     let _moe_expert_arena = loaded_layers.moe_expert_arena;
     let mut _moe_expert_residency = loaded_layers.moe_expert_residency;
@@ -1463,6 +1657,7 @@ fn decode_text(
             flm_tokenizer_build: flm_tokenizer_timings.build,
             model_source: model_source_elapsed,
             layer_load: layer_load_elapsed,
+            layer_load_profile,
             session: session_elapsed,
             prefill_steps,
             prefill_embed: prefill_embed_elapsed,

--- a/crates/runner/src/qwen36_moe/engine.rs
+++ b/crates/runner/src/qwen36_moe/engine.rs
@@ -193,6 +193,13 @@ fn validate_qwen36_decode_weight_mode(
 #[derive(Clone, Copy, Debug, Default)]
 struct Qwen36StartupTimings {
     flm_source_open: std::time::Duration,
+    flm_store_open: std::time::Duration,
+    flm_config: std::time::Duration,
+    flm_tokenizer: std::time::Duration,
+    flm_tokenizer_assets: std::time::Duration,
+    flm_tokenizer_parse: std::time::Duration,
+    flm_tokenizer_build: std::time::Duration,
+    flm_direct_plan: std::time::Duration,
     bake_prepare: std::time::Duration,
     dry_run: std::time::Duration,
 }
@@ -219,12 +226,71 @@ fn qwen36_duration_ms(duration: std::time::Duration) -> f64 {
 
 fn format_qwen36_startup_timings(timings: &Qwen36StartupTimings) -> String {
     format!(
-        "flm_source_open_ms={:.3} bake_prepare_ms={:.3} \
+        "flm_source_open_ms={:.3} flm_store_open_ms={:.3} \
+         flm_config_ms={:.3} flm_tokenizer_ms={:.3} \
+         flm_tokenizer_assets_ms={:.3} flm_tokenizer_parse_ms={:.3} \
+         flm_tokenizer_build_ms={:.3} flm_direct_plan_ms={:.3} \
+         bake_prepare_ms={:.3} \
          dry_run_ms={:.3} pre_decode_total_ms={:.3}",
         qwen36_duration_ms(timings.flm_source_open),
+        qwen36_duration_ms(timings.flm_store_open),
+        qwen36_duration_ms(timings.flm_config),
+        qwen36_duration_ms(timings.flm_tokenizer),
+        qwen36_duration_ms(timings.flm_tokenizer_assets),
+        qwen36_duration_ms(timings.flm_tokenizer_parse),
+        qwen36_duration_ms(timings.flm_tokenizer_build),
+        qwen36_duration_ms(timings.flm_direct_plan),
         qwen36_duration_ms(timings.bake_prepare),
         qwen36_duration_ms(timings.dry_run),
         qwen36_duration_ms(timings.pre_decode_total()),
+    )
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct Qwen36LifecycleTimings {
+    prompt_setup: std::time::Duration,
+    flm_tokenizer: std::time::Duration,
+    flm_tokenizer_assets: std::time::Duration,
+    flm_tokenizer_parse: std::time::Duration,
+    flm_tokenizer_build: std::time::Duration,
+    model_source: std::time::Duration,
+    layer_load: std::time::Duration,
+    session: std::time::Duration,
+    prefill_steps: usize,
+    prefill_embed: std::time::Duration,
+    prefill_chain: std::time::Duration,
+    generation_wall: Option<f64>,
+    total_wall: std::time::Duration,
+}
+
+impl Qwen36LifecycleTimings {
+    fn prefill_total(self) -> std::time::Duration {
+        self.prefill_embed + self.prefill_chain
+    }
+}
+
+fn format_qwen36_lifecycle_timings(timings: &Qwen36LifecycleTimings) -> String {
+    format!(
+        "prompt_setup_ms={:.3} flm_tokenizer_ms={:.3} \
+         flm_tokenizer_assets_ms={:.3} flm_tokenizer_parse_ms={:.3} \
+         flm_tokenizer_build_ms={:.3} model_source_ms={:.3} \
+         layer_load_ms={:.3} session_ms={:.3} prefill_steps={} \
+         prefill_embed_ms={:.3} prefill_chain_ms={:.3} \
+         prefill_total_ms={:.3} generation_wall_ms={:.3} total_wall_ms={:.3}",
+        qwen36_duration_ms(timings.prompt_setup),
+        qwen36_duration_ms(timings.flm_tokenizer),
+        qwen36_duration_ms(timings.flm_tokenizer_assets),
+        qwen36_duration_ms(timings.flm_tokenizer_parse),
+        qwen36_duration_ms(timings.flm_tokenizer_build),
+        qwen36_duration_ms(timings.model_source),
+        qwen36_duration_ms(timings.layer_load),
+        qwen36_duration_ms(timings.session),
+        timings.prefill_steps,
+        qwen36_duration_ms(timings.prefill_embed),
+        qwen36_duration_ms(timings.prefill_chain),
+        qwen36_duration_ms(timings.prefill_total()),
+        timings.generation_wall.unwrap_or(0.0),
+        qwen36_duration_ms(timings.total_wall),
     )
 }
 
@@ -255,14 +321,55 @@ mod tests {
     fn formats_startup_timings_for_machine_parsing() {
         let timings = Qwen36StartupTimings {
             flm_source_open: std::time::Duration::from_micros(1_500),
+            flm_store_open: std::time::Duration::from_micros(500),
+            flm_config: std::time::Duration::from_micros(250),
+            flm_tokenizer: std::time::Duration::from_micros(625),
+            flm_tokenizer_assets: std::time::Duration::from_micros(25),
+            flm_tokenizer_parse: std::time::Duration::from_micros(275),
+            flm_tokenizer_build: std::time::Duration::from_micros(325),
+            flm_direct_plan: std::time::Duration::from_micros(125),
             bake_prepare: std::time::Duration::ZERO,
             dry_run: std::time::Duration::from_micros(2_250),
         };
 
         assert_eq!(
             format_qwen36_startup_timings(&timings),
-            "flm_source_open_ms=1.500 bake_prepare_ms=0.000 \
+            "flm_source_open_ms=1.500 flm_store_open_ms=0.500 \
+             flm_config_ms=0.250 flm_tokenizer_ms=0.625 \
+             flm_tokenizer_assets_ms=0.025 flm_tokenizer_parse_ms=0.275 \
+             flm_tokenizer_build_ms=0.325 flm_direct_plan_ms=0.125 \
+             bake_prepare_ms=0.000 \
              dry_run_ms=2.250 pre_decode_total_ms=3.750"
+        );
+    }
+
+    #[test]
+    fn formats_lifecycle_timings_with_lazy_flm_tokenizer_breakdown() {
+        let timings = Qwen36LifecycleTimings {
+            prompt_setup: std::time::Duration::from_micros(5_000),
+            flm_tokenizer: std::time::Duration::from_micros(625),
+            flm_tokenizer_assets: std::time::Duration::from_micros(25),
+            flm_tokenizer_parse: std::time::Duration::from_micros(275),
+            flm_tokenizer_build: std::time::Duration::from_micros(325),
+            model_source: std::time::Duration::from_micros(1_500),
+            layer_load: std::time::Duration::from_micros(2_500),
+            session: std::time::Duration::from_micros(3_500),
+            prefill_steps: 2,
+            prefill_embed: std::time::Duration::from_micros(100),
+            prefill_chain: std::time::Duration::from_micros(200),
+            generation_wall: Some(4.5),
+            total_wall: std::time::Duration::from_micros(9_000),
+        };
+
+        assert_eq!(
+            format_qwen36_lifecycle_timings(&timings),
+            "prompt_setup_ms=5.000 flm_tokenizer_ms=0.625 \
+             flm_tokenizer_assets_ms=0.025 flm_tokenizer_parse_ms=0.275 \
+             flm_tokenizer_build_ms=0.325 model_source_ms=1.500 \
+             layer_load_ms=2.500 session_ms=3.500 prefill_steps=2 \
+             prefill_embed_ms=0.100 prefill_chain_ms=0.200 \
+             prefill_total_ms=0.300 generation_wall_ms=4.500 \
+             total_wall_ms=9.000"
         );
     }
 }
@@ -434,8 +541,15 @@ fn run_inner(
     let mut startup_timings = Qwen36StartupTimings::default();
     let flm_source_open_start = std::time::Instant::now();
     let flm_source = open_qwen36_moe_flm_source(cli)?;
-    if flm_source.is_some() {
+    if let Some(flm) = flm_source.as_ref() {
         startup_timings.flm_source_open = flm_source_open_start.elapsed();
+        startup_timings.flm_store_open = flm.timings.store_open;
+        startup_timings.flm_config = flm.timings.config;
+        startup_timings.flm_tokenizer = flm.timings.tokenizer;
+        startup_timings.flm_tokenizer_assets = flm.timings.tokenizer_assets;
+        startup_timings.flm_tokenizer_parse = flm.timings.tokenizer_parse;
+        startup_timings.flm_tokenizer_build = flm.timings.tokenizer_build;
+        startup_timings.flm_direct_plan = flm.timings.direct_plan;
     }
     if flm_source.is_none() {
         let bake_prepare_start = std::time::Instant::now();
@@ -595,9 +709,16 @@ fn decode_text(
 
     progress("prompt_setup", "start".to_string(), true);
     let prompt_setup_start = std::time::Instant::now();
+    let mut flm_tokenizer_elapsed = std::time::Duration::ZERO;
+    let mut flm_tokenizer_timings = crate::flm_tokenizer::QwenBpeTokenizerTimings::default();
     let prompt_setup = if let Some(flm) = flm_source {
+        eprintln!("[qwen36-moe] loading tokenizer from FLM assets");
+        let tokenizer_start = std::time::Instant::now();
+        let tokenizer_load = flm.load_tokenizer_timed()?;
+        flm_tokenizer_elapsed = tokenizer_start.elapsed();
+        flm_tokenizer_timings = tokenizer_load.timings;
         prepare_prompt_with_tokenizer(
-            Some(flm.tokenizer.clone()),
+            Some(tokenizer_load.tokenizer),
             &report.config.text_config,
             prompt,
         )?
@@ -1279,23 +1400,24 @@ fn decode_text(
     }
     stage_timings.print_if_requested(emit_stage_timings);
     if emit_stage_timings {
-        let to_ms = |d: std::time::Duration| d.as_secs_f64() * 1000.0;
-        let prefill_total_ms = to_ms(prefill_embed_elapsed + prefill_chain_elapsed);
-        eprintln!(
-            "[qwen36-moe lifecycle-timings] prompt_setup_ms={:.3} \
-             model_source_ms={:.3} layer_load_ms={:.3} session_ms={:.3} \
-             prefill_steps={} prefill_embed_ms={:.3} prefill_chain_ms={:.3} \
-             prefill_total_ms={:.3} generation_wall_ms={:.3} total_wall_ms={:.3}",
-            to_ms(prompt_setup_elapsed),
-            to_ms(model_source_elapsed),
-            to_ms(layer_load_elapsed),
-            to_ms(session_elapsed),
+        let lifecycle_timings = Qwen36LifecycleTimings {
+            prompt_setup: prompt_setup_elapsed,
+            flm_tokenizer: flm_tokenizer_elapsed,
+            flm_tokenizer_assets: flm_tokenizer_timings.asset_lookup,
+            flm_tokenizer_parse: flm_tokenizer_timings.parse,
+            flm_tokenizer_build: flm_tokenizer_timings.build,
+            model_source: model_source_elapsed,
+            layer_load: layer_load_elapsed,
+            session: session_elapsed,
             prefill_steps,
-            to_ms(prefill_embed_elapsed),
-            to_ms(prefill_chain_elapsed),
-            prefill_total_ms,
-            generation_wall_ms.unwrap_or(0.0),
-            to_ms(decode_wall_start.elapsed()),
+            prefill_embed: prefill_embed_elapsed,
+            prefill_chain: prefill_chain_elapsed,
+            generation_wall: generation_wall_ms,
+            total_wall: decode_wall_start.elapsed(),
+        };
+        eprintln!(
+            "[qwen36-moe lifecycle-timings] {}",
+            format_qwen36_lifecycle_timings(&lifecycle_timings),
         );
     }
     if let Some(stats) = mtp_acceptance_stats.as_ref() {

--- a/crates/runner/src/qwen36_moe/flm_source.rs
+++ b/crates/runner/src/qwen36_moe/flm_source.rs
@@ -1,4 +1,6 @@
 use anyhow::{anyhow, Result};
+use model_store::flm::FlmStage3DirectWeightKind;
+#[cfg(test)]
 use model_store::manifest::LayoutTag;
 use model_store::BakedStore;
 
@@ -36,12 +38,45 @@ fn qwen36_moe_flm_weight_mode(probe: Option<(&LayoutTag, &str)>) -> Result<Qwen3
 fn qwen36_moe_flm_weight_selection_for_store(
     store: &BakedStore,
 ) -> Result<Qwen36MoeFlmWeightSelection> {
-    let probe = store
-        .meta(QWEN36_MOE_WEIGHT_MODE_PROBE)
-        .map(|meta| (&meta.layout, meta.dtype.as_str()));
-    qwen36_moe_flm_weight_selection_from_probe(probe)
+    let runtime = store.flm_runtime().ok_or_else(|| {
+        anyhow!(
+            "Qwen3.6 MoE FLM source requires a runtime direct weight plan for {}",
+            QWEN36_MOE_WEIGHT_MODE_PROBE
+        )
+    })?;
+    let kind = runtime
+        .stage3_direct_weight_kind(QWEN36_MOE_WEIGHT_MODE_PROBE)
+        .map_err(|err| {
+            anyhow!(
+                "Qwen3.6 MoE FLM direct weight plan for {} is unsupported: {err}",
+                QWEN36_MOE_WEIGHT_MODE_PROBE
+            )
+        })?;
+    qwen36_moe_flm_weight_selection_from_stage3_kind(kind)
 }
 
+fn qwen36_moe_flm_weight_selection_from_stage3_kind(
+    kind: Option<FlmStage3DirectWeightKind>,
+) -> Result<Qwen36MoeFlmWeightSelection> {
+    match kind {
+        Some(FlmStage3DirectWeightKind::NativeInt4) => Ok(Qwen36MoeFlmWeightSelection {
+            mode: Qwen36WeightMode::Int4,
+            label: "INT4 native FLM",
+        }),
+        Some(
+            FlmStage3DirectWeightKind::CtInt4Bf16Fallback | FlmStage3DirectWeightKind::RawDense,
+        ) => Ok(Qwen36MoeFlmWeightSelection {
+            mode: Qwen36WeightMode::Bf16,
+            label: "BF16",
+        }),
+        None => Err(anyhow!(
+            "Qwen3.6 MoE FLM source requires a compatible direct weight plan for {}",
+            QWEN36_MOE_WEIGHT_MODE_PROBE
+        )),
+    }
+}
+
+#[cfg(test)]
 fn qwen36_moe_flm_weight_selection_from_probe(
     probe: Option<(&LayoutTag, &str)>,
 ) -> Result<Qwen36MoeFlmWeightSelection> {
@@ -101,6 +136,7 @@ pub(crate) fn open_qwen36_moe_flm_source(cli: &Cli) -> Result<Option<Qwen36MoeFl
 #[cfg(test)]
 mod tests {
     use clap::Parser;
+    use model_store::flm::FlmStage3DirectWeightKind;
     use model_store::manifest::LayoutTag;
 
     use super::*;
@@ -119,11 +155,46 @@ mod tests {
     }
 
     #[test]
-    fn maps_moe_mixed_lowbit_flm_to_int4_weight_mode() {
-        let mode =
-            qwen36_moe_flm_weight_mode(None).expect("missing probe fixtures default to INT4");
+    fn maps_native_stage3_direct_plan_to_int4_weight_mode() {
+        let selection = qwen36_moe_flm_weight_selection_from_stage3_kind(Some(
+            FlmStage3DirectWeightKind::NativeInt4,
+        ))
+        .expect("native Stage 3 direct plan should select native INT4");
 
-        assert_eq!(mode, Qwen36WeightMode::Int4);
+        assert_eq!(selection.mode, Qwen36WeightMode::Int4);
+        assert_eq!(selection.label, "INT4 native FLM");
+    }
+
+    #[test]
+    fn maps_ct_stage3_direct_plan_to_bf16_fallback_weight_mode() {
+        let selection = qwen36_moe_flm_weight_selection_from_stage3_kind(Some(
+            FlmStage3DirectWeightKind::CtInt4Bf16Fallback,
+        ))
+        .expect("CT Stage 3 direct plan should select BF16 fallback");
+
+        assert_eq!(selection.mode, Qwen36WeightMode::Bf16);
+        assert_eq!(selection.label, "BF16");
+    }
+
+    #[test]
+    fn maps_raw_dense_stage3_direct_plan_to_bf16_weight_mode() {
+        let selection = qwen36_moe_flm_weight_selection_from_stage3_kind(Some(
+            FlmStage3DirectWeightKind::RawDense,
+        ))
+        .expect("raw dense Stage 3 direct plan should select BF16");
+
+        assert_eq!(selection.mode, Qwen36WeightMode::Bf16);
+        assert_eq!(selection.label, "BF16");
+    }
+
+    #[test]
+    fn rejects_missing_stage3_direct_weight_plan() {
+        let err = qwen36_moe_flm_weight_selection_from_stage3_kind(None)
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("direct weight plan"), "{err}");
+        assert!(err.contains(QWEN36_MOE_WEIGHT_MODE_PROBE), "{err}");
     }
 
     #[test]

--- a/crates/runner/src/qwen36_moe/flm_source.rs
+++ b/crates/runner/src/qwen36_moe/flm_source.rs
@@ -7,6 +7,7 @@ use qwen36_moe::weights::{
     expected_tensor_specs, TensorRole, DEFAULT_PREFIX as QWEN36_MOE_WEIGHT_PREFIX,
 };
 use std::fmt;
+use std::time::{Duration, Instant};
 
 use crate::bakes::{
     effective_flm_source, flm_source_open_options, validate_effective_flm_source_model,
@@ -24,10 +25,29 @@ const QWEN36_MOE_WEIGHT_MODE_PROBE: &str =
 pub(crate) struct Qwen36MoeFlmSource {
     pub(crate) source: FlmModelSource,
     pub(crate) config: qwen36_moe::config::Config,
-    pub(crate) tokenizer: tokenizers::Tokenizer,
     pub(crate) weight_mode: Qwen36WeightMode,
     pub(crate) weight_mode_label: &'static str,
     pub(crate) direct_profile: Qwen36MoeFlmDirectProfile,
+    pub(crate) timings: Qwen36MoeFlmSourceOpenTimings,
+}
+
+impl Qwen36MoeFlmSource {
+    pub(crate) fn load_tokenizer_timed(
+        &self,
+    ) -> Result<crate::flm_tokenizer::QwenBpeTokenizerLoad> {
+        self.source.qwen_tokenizer_timed()
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct Qwen36MoeFlmSourceOpenTimings {
+    pub(crate) store_open: Duration,
+    pub(crate) config: Duration,
+    pub(crate) tokenizer: Duration,
+    pub(crate) tokenizer_assets: Duration,
+    pub(crate) tokenizer_parse: Duration,
+    pub(crate) tokenizer_build: Duration,
+    pub(crate) direct_plan: Duration,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -310,14 +330,19 @@ pub(crate) fn open_qwen36_moe_flm_source(cli: &Cli) -> Result<Option<Qwen36MoeFl
             ""
         }
     );
+    let mut timings = Qwen36MoeFlmSourceOpenTimings::default();
+    let store_open_start = Instant::now();
     let source = FlmModelSource::open_with_options(path, options)
         .map_err(|e| anyhow!("opening Qwen3.6 MoE FLM source {}: {e}", path.display()))?;
+    timings.store_open = store_open_start.elapsed();
     eprintln!("[qwen36-moe] loading config from FLM runtime descriptor");
+    let config_start = Instant::now();
     let config = source.qwen_moe_config()?;
-    eprintln!("[qwen36-moe] loading tokenizer from FLM assets");
-    let tokenizer = source.qwen_tokenizer()?;
+    timings.config = config_start.elapsed();
+    let direct_plan_start = Instant::now();
     let weight_selection =
         qwen36_moe_flm_weight_selection_for_store(&source.store, &config.text_config)?;
+    timings.direct_plan = direct_plan_start.elapsed();
     eprintln!("[qwen36-moe] FLM weight mode: {}", weight_selection.label);
     eprintln!(
         "[qwen36-moe] FLM direct plans: {}",
@@ -326,10 +351,10 @@ pub(crate) fn open_qwen36_moe_flm_source(cli: &Cli) -> Result<Option<Qwen36MoeFl
     Ok(Some(Qwen36MoeFlmSource {
         source,
         config,
-        tokenizer,
         weight_mode: weight_selection.mode,
         weight_mode_label: weight_selection.label,
         direct_profile: weight_selection.direct_profile,
+        timings,
     }))
 }
 

--- a/crates/runner/src/qwen36_moe/flm_source.rs
+++ b/crates/runner/src/qwen36_moe/flm_source.rs
@@ -3,6 +3,9 @@ use model_store::flm::FlmStage3DirectWeightKind;
 #[cfg(test)]
 use model_store::manifest::LayoutTag;
 use model_store::BakedStore;
+use qwen36_moe::weights::{
+    expected_tensor_specs, TensorRole, DEFAULT_PREFIX as QWEN36_MOE_WEIGHT_PREFIX,
+};
 
 use crate::bakes::{
     effective_flm_source, flm_source_open_options, validate_effective_flm_source_model,
@@ -13,6 +16,7 @@ use crate::qwen36_moe_cli::layers::Qwen36WeightMode;
 use crate::registry::ModelVariant;
 use crate::Cli;
 
+#[cfg(test)]
 const QWEN36_MOE_WEIGHT_MODE_PROBE: &str =
     "model.language_model.layers.0.linear_attn.in_proj_qkv.weight";
 
@@ -30,6 +34,18 @@ struct Qwen36MoeFlmWeightSelection {
     label: &'static str,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RequiredFlmDirectWeightKind {
+    RawDense,
+    QuantizedProjection,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct RequiredFlmDirectWeight {
+    name: String,
+    expected: RequiredFlmDirectWeightKind,
+}
+
 #[cfg(test)]
 fn qwen36_moe_flm_weight_mode(probe: Option<(&LayoutTag, &str)>) -> Result<Qwen36WeightMode> {
     Ok(qwen36_moe_flm_weight_selection_from_probe(probe)?.mode)
@@ -37,24 +53,143 @@ fn qwen36_moe_flm_weight_mode(probe: Option<(&LayoutTag, &str)>) -> Result<Qwen3
 
 fn qwen36_moe_flm_weight_selection_for_store(
     store: &BakedStore,
+    text_config: &qwen36_moe::config::TextConfig,
 ) -> Result<Qwen36MoeFlmWeightSelection> {
     let runtime = store.flm_runtime().ok_or_else(|| {
         anyhow!(
-            "Qwen3.6 MoE FLM source requires a runtime direct weight plan for {}",
-            QWEN36_MOE_WEIGHT_MODE_PROBE
+            "Qwen3.6 MoE FLM source requires runtime direct weight plans for SuperSonic loading"
         )
     })?;
-    let kind = runtime
-        .stage3_direct_weight_kind(QWEN36_MOE_WEIGHT_MODE_PROBE)
-        .map_err(|err| {
-            anyhow!(
-                "Qwen3.6 MoE FLM direct weight plan for {} is unsupported: {err}",
-                QWEN36_MOE_WEIGHT_MODE_PROBE
-            )
-        })?;
-    qwen36_moe_flm_weight_selection_from_stage3_kind(kind)
+    let required = qwen36_moe_required_flm_direct_weights(text_config, QWEN36_MOE_WEIGHT_PREFIX);
+    let mut plan_kinds = Vec::with_capacity(required.len());
+    for required in required {
+        let kind = runtime
+            .stage3_direct_weight_kind(&required.name)
+            .map_err(|err| {
+                anyhow!(
+                    "Qwen3.6 MoE FLM direct weight plan for {} is unsupported: {err}",
+                    required.name
+                )
+            })?;
+        plan_kinds.push((required.name, required.expected, kind));
+    }
+    qwen36_moe_flm_weight_selection_from_required_plan_kinds(plan_kinds)
 }
 
+fn qwen36_moe_required_flm_direct_weights(
+    text_config: &qwen36_moe::config::TextConfig,
+    weight_prefix: &str,
+) -> Vec<RequiredFlmDirectWeight> {
+    expected_tensor_specs(text_config, weight_prefix)
+        .into_iter()
+        .map(|spec| RequiredFlmDirectWeight {
+            name: spec.name,
+            expected: qwen36_moe_required_flm_direct_weight_kind(spec.role),
+        })
+        .collect()
+}
+
+fn qwen36_moe_required_flm_direct_weight_kind(role: TensorRole) -> RequiredFlmDirectWeightKind {
+    match role {
+        TensorRole::FullQProj
+        | TensorRole::FullKProj
+        | TensorRole::FullVProj
+        | TensorRole::FullOProj
+        | TensorRole::LinearInQkvProj
+        | TensorRole::LinearInZProj
+        | TensorRole::LinearOutProj
+        | TensorRole::SharedExpertGateProj
+        | TensorRole::SharedExpertUpProj
+        | TensorRole::SharedExpertDownProj
+        | TensorRole::ExpertGateUpProj
+        | TensorRole::ExpertDownProj => RequiredFlmDirectWeightKind::QuantizedProjection,
+        TensorRole::Embed
+        | TensorRole::Norm
+        | TensorRole::LmHead
+        | TensorRole::LayerInputNorm
+        | TensorRole::LayerPostAttnNorm
+        | TensorRole::FullQNorm
+        | TensorRole::FullKNorm
+        | TensorRole::LinearInBProj
+        | TensorRole::LinearInAProj
+        | TensorRole::LinearConv1d
+        | TensorRole::LinearDtBias
+        | TensorRole::LinearALog
+        | TensorRole::LinearNorm
+        | TensorRole::Router
+        | TensorRole::SharedExpertGate => RequiredFlmDirectWeightKind::RawDense,
+    }
+}
+
+fn qwen36_moe_flm_weight_selection_from_required_plan_kinds<I, S>(
+    plans: I,
+) -> Result<Qwen36MoeFlmWeightSelection>
+where
+    I: IntoIterator<
+        Item = (
+            S,
+            RequiredFlmDirectWeightKind,
+            Option<FlmStage3DirectWeightKind>,
+        ),
+    >,
+    S: Into<String>,
+{
+    let mut native_int4_name: Option<String> = None;
+    let mut fallback_name: Option<String> = None;
+
+    for (name, expected, kind) in plans {
+        let name = name.into();
+        match (expected, kind) {
+            (RequiredFlmDirectWeightKind::RawDense, Some(FlmStage3DirectWeightKind::RawDense)) => {}
+            (RequiredFlmDirectWeightKind::RawDense, Some(other)) => {
+                return Err(anyhow!(
+                    "Qwen3.6 MoE FLM expected raw dense direct plan for {name}, got {other:?}"
+                ));
+            }
+            (RequiredFlmDirectWeightKind::RawDense, None) => {
+                return Err(anyhow!("missing direct weight plan for {name}"));
+            }
+            (
+                RequiredFlmDirectWeightKind::QuantizedProjection,
+                Some(FlmStage3DirectWeightKind::NativeInt4),
+            ) => {
+                native_int4_name.get_or_insert(name);
+            }
+            (
+                RequiredFlmDirectWeightKind::QuantizedProjection,
+                Some(
+                    FlmStage3DirectWeightKind::CtInt4Bf16Fallback
+                    | FlmStage3DirectWeightKind::RawDense,
+                ),
+            ) => {
+                fallback_name.get_or_insert(name);
+            }
+            (RequiredFlmDirectWeightKind::QuantizedProjection, None) => {
+                return Err(anyhow!("missing direct weight plan for {name}"));
+            }
+        }
+    }
+
+    if let (Some(native), Some(fallback)) = (native_int4_name.as_ref(), fallback_name.as_ref()) {
+        return Err(anyhow!(
+            "mixed FLM direct projection modes: native INT4 example {native}; BF16 fallback example {fallback}"
+        ));
+    }
+
+    if native_int4_name.is_some() {
+        Ok(Qwen36MoeFlmWeightSelection {
+            mode: Qwen36WeightMode::Int4,
+            label: "INT4 native FLM",
+        })
+    } else {
+        Ok(Qwen36MoeFlmWeightSelection {
+            mode: Qwen36WeightMode::Bf16,
+            label: "BF16",
+        })
+    }
+}
+
+#[cfg(test)]
 fn qwen36_moe_flm_weight_selection_from_stage3_kind(
     kind: Option<FlmStage3DirectWeightKind>,
 ) -> Result<Qwen36MoeFlmWeightSelection> {
@@ -122,7 +257,8 @@ pub(crate) fn open_qwen36_moe_flm_source(cli: &Cli) -> Result<Option<Qwen36MoeFl
     let config = source.qwen_moe_config()?;
     eprintln!("[qwen36-moe] loading tokenizer from FLM assets");
     let tokenizer = source.qwen_tokenizer()?;
-    let weight_selection = qwen36_moe_flm_weight_selection_for_store(&source.store)?;
+    let weight_selection =
+        qwen36_moe_flm_weight_selection_for_store(&source.store, &config.text_config)?;
     eprintln!("[qwen36-moe] FLM weight mode: {}", weight_selection.label);
     Ok(Some(Qwen36MoeFlmSource {
         source,
@@ -138,6 +274,7 @@ mod tests {
     use clap::Parser;
     use model_store::flm::FlmStage3DirectWeightKind;
     use model_store::manifest::LayoutTag;
+    use qwen36_moe::config::{Activation, TextConfig};
 
     use super::*;
 
@@ -152,6 +289,179 @@ mod tests {
         ];
         args.extend_from_slice(extra);
         Cli::parse_from(args)
+    }
+
+    fn small_text_config() -> TextConfig {
+        TextConfig {
+            vocab_size: 1024,
+            hidden_size: 256,
+            num_hidden_layers: 4,
+            num_attention_heads: 4,
+            num_key_value_heads: 2,
+            max_position_embeddings: 4096,
+            rms_norm_eps: 1e-6,
+            hidden_act: Activation::Silu,
+            tie_word_embeddings: false,
+            eos_token_id: None,
+            bos_token_id: None,
+            head_dim: 64,
+            full_attention_interval: 4,
+            attn_output_gate: false,
+            linear_conv_kernel_dim: 4,
+            linear_key_head_dim: 64,
+            linear_value_head_dim: 64,
+            linear_num_key_heads: 2,
+            linear_num_value_heads: 4,
+            layer_types: Vec::new(),
+            rope_parameters: None,
+            num_experts: 4,
+            num_experts_per_tok: 2,
+            moe_intermediate_size: 64,
+            shared_expert_intermediate_size: 64,
+            norm_topk_prob: true,
+            router_aux_loss_coef: 0.001,
+            mlp_only_layers: Vec::new(),
+            decoder_sparse_step: None,
+        }
+        .normalized()
+    }
+
+    fn has_required(
+        required: &[RequiredFlmDirectWeight],
+        name: &str,
+        expected: RequiredFlmDirectWeightKind,
+    ) -> bool {
+        required
+            .iter()
+            .any(|item| item.name == name && item.expected == expected)
+    }
+
+    #[test]
+    fn required_direct_plan_names_cover_qwen36_moe_runtime_path() {
+        let required =
+            qwen36_moe_required_flm_direct_weights(&small_text_config(), "model.language_model");
+
+        assert_eq!(required.len(), 72);
+        assert!(has_required(
+            &required,
+            "model.language_model.embed_tokens.weight",
+            RequiredFlmDirectWeightKind::RawDense
+        ));
+        assert!(has_required(
+            &required,
+            "lm_head.weight",
+            RequiredFlmDirectWeightKind::RawDense
+        ));
+        assert!(has_required(
+            &required,
+            "model.language_model.layers.0.linear_attn.in_proj_qkv.weight",
+            RequiredFlmDirectWeightKind::QuantizedProjection
+        ));
+        assert!(has_required(
+            &required,
+            "model.language_model.layers.0.linear_attn.in_proj_z.weight",
+            RequiredFlmDirectWeightKind::QuantizedProjection
+        ));
+        assert!(has_required(
+            &required,
+            "model.language_model.layers.0.linear_attn.out_proj.weight",
+            RequiredFlmDirectWeightKind::QuantizedProjection
+        ));
+        assert!(has_required(
+            &required,
+            "model.language_model.layers.0.linear_attn.in_proj_a.weight",
+            RequiredFlmDirectWeightKind::RawDense
+        ));
+        assert!(has_required(
+            &required,
+            "model.language_model.layers.0.linear_attn.in_proj_b.weight",
+            RequiredFlmDirectWeightKind::RawDense
+        ));
+        assert!(has_required(
+            &required,
+            "model.language_model.layers.0.linear_attn.A_log",
+            RequiredFlmDirectWeightKind::RawDense
+        ));
+        assert!(has_required(
+            &required,
+            "model.language_model.layers.0.mlp.experts.gate_up_proj",
+            RequiredFlmDirectWeightKind::QuantizedProjection
+        ));
+        assert!(has_required(
+            &required,
+            "model.language_model.layers.3.self_attn.q_proj.weight",
+            RequiredFlmDirectWeightKind::QuantizedProjection
+        ));
+        assert!(has_required(
+            &required,
+            "model.language_model.layers.3.self_attn.q_norm.weight",
+            RequiredFlmDirectWeightKind::RawDense
+        ));
+        assert!(!required
+            .iter()
+            .any(|item| item.name == "model.language_model.layers.3.linear_attn.A_log"));
+    }
+
+    #[test]
+    fn required_direct_plan_selection_uses_complete_native_int4_coverage() {
+        let selection = qwen36_moe_flm_weight_selection_from_required_plan_kinds([
+            (
+                "model.language_model.embed_tokens.weight",
+                RequiredFlmDirectWeightKind::RawDense,
+                Some(FlmStage3DirectWeightKind::RawDense),
+            ),
+            (
+                "model.language_model.layers.0.linear_attn.in_proj_qkv.weight",
+                RequiredFlmDirectWeightKind::QuantizedProjection,
+                Some(FlmStage3DirectWeightKind::NativeInt4),
+            ),
+            (
+                "model.language_model.layers.0.mlp.experts.gate_up_proj",
+                RequiredFlmDirectWeightKind::QuantizedProjection,
+                Some(FlmStage3DirectWeightKind::NativeInt4),
+            ),
+        ])
+        .expect("complete native INT4 direct coverage should select native mode");
+
+        assert_eq!(selection.mode, Qwen36WeightMode::Int4);
+        assert_eq!(selection.label, "INT4 native FLM");
+    }
+
+    #[test]
+    fn required_direct_plan_selection_rejects_missing_required_tensor() {
+        let err = qwen36_moe_flm_weight_selection_from_required_plan_kinds([(
+            "model.language_model.layers.0.linear_attn.in_proj_qkv.weight",
+            RequiredFlmDirectWeightKind::QuantizedProjection,
+            None,
+        )])
+        .unwrap_err()
+        .to_string();
+
+        assert!(err.contains("missing direct weight plan"), "{err}");
+        assert!(
+            err.contains("model.language_model.layers.0.linear_attn.in_proj_qkv.weight"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn required_direct_plan_selection_rejects_mixed_projection_modes() {
+        let err = qwen36_moe_flm_weight_selection_from_required_plan_kinds([
+            (
+                "model.language_model.layers.0.linear_attn.in_proj_qkv.weight",
+                RequiredFlmDirectWeightKind::QuantizedProjection,
+                Some(FlmStage3DirectWeightKind::NativeInt4),
+            ),
+            (
+                "model.language_model.layers.0.mlp.experts.gate_up_proj",
+                RequiredFlmDirectWeightKind::QuantizedProjection,
+                Some(FlmStage3DirectWeightKind::RawDense),
+            ),
+        ])
+        .unwrap_err()
+        .to_string();
+
+        assert!(err.contains("mixed FLM direct projection modes"), "{err}");
     }
 
     #[test]

--- a/crates/runner/src/qwen36_moe/flm_source.rs
+++ b/crates/runner/src/qwen36_moe/flm_source.rs
@@ -4,6 +4,7 @@ use model_store::BakedStore;
 
 use crate::bakes::{
     effective_flm_source, flm_source_open_options, validate_effective_flm_source_model,
+    validate_flm_weight_source_options,
 };
 use crate::flm_model_source::FlmModelSource;
 use crate::qwen36_moe_cli::layers::Qwen36WeightMode;
@@ -64,6 +65,7 @@ pub(crate) fn open_qwen36_moe_flm_source(cli: &Cli) -> Result<Option<Qwen36MoeFl
         return Ok(None);
     };
     validate_effective_flm_source_model(cli, &ModelVariant::Qwen3_6_35B_A3B)?;
+    validate_flm_weight_source_options(cli, crate::policy::q4km_like(cli))?;
     let options = flm_source_open_options(cli)?;
     eprintln!(
         "[flm] opening model source at {}{}{}",
@@ -98,9 +100,23 @@ pub(crate) fn open_qwen36_moe_flm_source(cli: &Cli) -> Result<Option<Qwen36MoeFl
 
 #[cfg(test)]
 mod tests {
+    use clap::Parser;
     use model_store::manifest::LayoutTag;
 
     use super::*;
+
+    fn cli(extra: &[&str]) -> Cli {
+        let mut args = vec![
+            "supersonic",
+            "--model",
+            "qwen3.6-35b-a3b",
+            "--model-dir",
+            "/tmp/qwen36-moe-missing.flm",
+            "--dry-run",
+        ];
+        args.extend_from_slice(extra);
+        Cli::parse_from(args)
+    }
 
     #[test]
     fn maps_moe_mixed_lowbit_flm_to_int4_weight_mode() {
@@ -157,5 +173,25 @@ mod tests {
         assert!(err.contains("Qwen3.6 MoE FLM"), "{err}");
         assert!(err.contains("INT4"), "{err}");
         assert!(err.contains("Raw"), "{err}");
+    }
+
+    #[test]
+    fn rejects_incompatible_quant_flags_before_opening_flm_source() {
+        for flag in ["--q4km", "--q4km-gptq", "--int8"] {
+            let err = match open_qwen36_moe_flm_source(&cli(&[flag])) {
+                Ok(_) => panic!("incompatible FLM quant flag {flag} should fail before file open"),
+                Err(err) => err.to_string(),
+            };
+
+            assert!(err.contains("FLM"), "{err}");
+            assert!(
+                err.contains(flag) || err.contains("--q4km/--q4km-gptq"),
+                "error should identify {flag}: {err}"
+            );
+            assert!(
+                !err.contains("opening Qwen3.6 MoE FLM source"),
+                "validation should run before source open: {err}"
+            );
+        }
     }
 }

--- a/crates/runner/src/qwen36_moe/flm_source.rs
+++ b/crates/runner/src/qwen36_moe/flm_source.rs
@@ -6,6 +6,7 @@ use model_store::BakedStore;
 use qwen36_moe::weights::{
     expected_tensor_specs, TensorRole, DEFAULT_PREFIX as QWEN36_MOE_WEIGHT_PREFIX,
 };
+use std::fmt;
 
 use crate::bakes::{
     effective_flm_source, flm_source_open_options, validate_effective_flm_source_model,
@@ -26,12 +27,35 @@ pub(crate) struct Qwen36MoeFlmSource {
     pub(crate) tokenizer: tokenizers::Tokenizer,
     pub(crate) weight_mode: Qwen36WeightMode,
     pub(crate) weight_mode_label: &'static str,
+    pub(crate) direct_profile: Qwen36MoeFlmDirectProfile,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct Qwen36MoeFlmWeightSelection {
     mode: Qwen36WeightMode,
     label: &'static str,
+    direct_profile: Qwen36MoeFlmDirectProfile,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct Qwen36MoeFlmDirectProfile {
+    /// SuperSonic runtime-required logical weights covered by direct plans.
+    /// This is intentionally smaller than the full FLM tensor table, which
+    /// also contains storage sidecars and compatibility/runtime assets.
+    pub(crate) required_tensors: usize,
+    pub(crate) raw_dense: usize,
+    pub(crate) native_int4: usize,
+    pub(crate) bf16_fallback: usize,
+}
+
+impl fmt::Display for Qwen36MoeFlmDirectProfile {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "required={} raw_dense={} native_int4={} bf16_fallback={}",
+            self.required_tensors, self.raw_dense, self.native_int4, self.bf16_fallback
+        )
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -136,11 +160,15 @@ where
 {
     let mut native_int4_name: Option<String> = None;
     let mut fallback_name: Option<String> = None;
+    let mut direct_profile = Qwen36MoeFlmDirectProfile::default();
 
     for (name, expected, kind) in plans {
         let name = name.into();
+        direct_profile.required_tensors += 1;
         match (expected, kind) {
-            (RequiredFlmDirectWeightKind::RawDense, Some(FlmStage3DirectWeightKind::RawDense)) => {}
+            (RequiredFlmDirectWeightKind::RawDense, Some(FlmStage3DirectWeightKind::RawDense)) => {
+                direct_profile.raw_dense += 1;
+            }
             (RequiredFlmDirectWeightKind::RawDense, Some(other)) => {
                 return Err(anyhow!(
                     "Qwen3.6 MoE FLM expected raw dense direct plan for {name}, got {other:?}"
@@ -154,6 +182,7 @@ where
                 Some(FlmStage3DirectWeightKind::NativeInt4),
             ) => {
                 native_int4_name.get_or_insert(name);
+                direct_profile.native_int4 += 1;
             }
             (
                 RequiredFlmDirectWeightKind::QuantizedProjection,
@@ -163,6 +192,7 @@ where
                 ),
             ) => {
                 fallback_name.get_or_insert(name);
+                direct_profile.bf16_fallback += 1;
             }
             (RequiredFlmDirectWeightKind::QuantizedProjection, None) => {
                 return Err(anyhow!("missing direct weight plan for {name}"));
@@ -180,11 +210,13 @@ where
         Ok(Qwen36MoeFlmWeightSelection {
             mode: Qwen36WeightMode::Int4,
             label: "INT4 native FLM",
+            direct_profile,
         })
     } else {
         Ok(Qwen36MoeFlmWeightSelection {
             mode: Qwen36WeightMode::Bf16,
             label: "BF16",
+            direct_profile,
         })
     }
 }
@@ -197,12 +229,29 @@ fn qwen36_moe_flm_weight_selection_from_stage3_kind(
         Some(FlmStage3DirectWeightKind::NativeInt4) => Ok(Qwen36MoeFlmWeightSelection {
             mode: Qwen36WeightMode::Int4,
             label: "INT4 native FLM",
+            direct_profile: Qwen36MoeFlmDirectProfile {
+                required_tensors: 1,
+                native_int4: 1,
+                ..Qwen36MoeFlmDirectProfile::default()
+            },
         }),
-        Some(
-            FlmStage3DirectWeightKind::CtInt4Bf16Fallback | FlmStage3DirectWeightKind::RawDense,
-        ) => Ok(Qwen36MoeFlmWeightSelection {
+        Some(FlmStage3DirectWeightKind::CtInt4Bf16Fallback) => Ok(Qwen36MoeFlmWeightSelection {
             mode: Qwen36WeightMode::Bf16,
             label: "BF16",
+            direct_profile: Qwen36MoeFlmDirectProfile {
+                required_tensors: 1,
+                bf16_fallback: 1,
+                ..Qwen36MoeFlmDirectProfile::default()
+            },
+        }),
+        Some(FlmStage3DirectWeightKind::RawDense) => Ok(Qwen36MoeFlmWeightSelection {
+            mode: Qwen36WeightMode::Bf16,
+            label: "BF16",
+            direct_profile: Qwen36MoeFlmDirectProfile {
+                required_tensors: 1,
+                raw_dense: 1,
+                ..Qwen36MoeFlmDirectProfile::default()
+            },
         }),
         None => Err(anyhow!(
             "Qwen3.6 MoE FLM source requires a compatible direct weight plan for {}",
@@ -219,10 +268,20 @@ fn qwen36_moe_flm_weight_selection_from_probe(
         Some((LayoutTag::Raw, "bf16")) => Ok(Qwen36MoeFlmWeightSelection {
             mode: Qwen36WeightMode::Bf16,
             label: "BF16",
+            direct_profile: Qwen36MoeFlmDirectProfile {
+                required_tensors: 1,
+                bf16_fallback: 1,
+                ..Qwen36MoeFlmDirectProfile::default()
+            },
         }),
         Some((LayoutTag::Int4Quantized, "u8")) | None => Ok(Qwen36MoeFlmWeightSelection {
             mode: Qwen36WeightMode::Int4,
             label: "INT4 native FLM",
+            direct_profile: Qwen36MoeFlmDirectProfile {
+                required_tensors: 1,
+                native_int4: 1,
+                ..Qwen36MoeFlmDirectProfile::default()
+            },
         }),
         other => Err(anyhow!(
             "Qwen3.6 MoE FLM source requires a native INT4 or BF16 fallback probe; got {other:?}"
@@ -260,12 +319,17 @@ pub(crate) fn open_qwen36_moe_flm_source(cli: &Cli) -> Result<Option<Qwen36MoeFl
     let weight_selection =
         qwen36_moe_flm_weight_selection_for_store(&source.store, &config.text_config)?;
     eprintln!("[qwen36-moe] FLM weight mode: {}", weight_selection.label);
+    eprintln!(
+        "[qwen36-moe] FLM direct plans: {}",
+        weight_selection.direct_profile
+    );
     Ok(Some(Qwen36MoeFlmSource {
         source,
         config,
         tokenizer,
         weight_mode: weight_selection.mode,
         weight_mode_label: weight_selection.label,
+        direct_profile: weight_selection.direct_profile,
     }))
 }
 
@@ -425,6 +489,19 @@ mod tests {
 
         assert_eq!(selection.mode, Qwen36WeightMode::Int4);
         assert_eq!(selection.label, "INT4 native FLM");
+        assert_eq!(
+            selection.direct_profile,
+            Qwen36MoeFlmDirectProfile {
+                required_tensors: 3,
+                raw_dense: 1,
+                native_int4: 2,
+                bf16_fallback: 0,
+            }
+        );
+        assert_eq!(
+            selection.direct_profile.to_string(),
+            "required=3 raw_dense=1 native_int4=2 bf16_fallback=0"
+        );
     }
 
     #[test]

--- a/crates/runner/src/qwen36_moe/flm_source.rs
+++ b/crates/runner/src/qwen36_moe/flm_source.rs
@@ -1,10 +1,9 @@
 use anyhow::{anyhow, Result};
-use model_store::manifest::{LayoutTag, QuantProfile};
+use model_store::manifest::LayoutTag;
 use model_store::BakedStore;
 
 use crate::bakes::{
-    effective_flm_source, effective_quant_profile, flm_source_open_options,
-    validate_effective_flm_source_model,
+    effective_flm_source, flm_source_open_options, validate_effective_flm_source_model,
 };
 use crate::flm_model_source::FlmModelSource;
 use crate::qwen36_moe_cli::layers::Qwen36WeightMode;
@@ -29,52 +28,33 @@ struct Qwen36MoeFlmWeightSelection {
 }
 
 #[cfg(test)]
-fn qwen36_moe_flm_weight_mode(profile: QuantProfile) -> Result<Qwen36WeightMode> {
-    Ok(qwen36_moe_flm_weight_selection_from_probe(profile, None)?.mode)
+fn qwen36_moe_flm_weight_mode(probe: Option<(&LayoutTag, &str)>) -> Result<Qwen36WeightMode> {
+    Ok(qwen36_moe_flm_weight_selection_from_probe(probe)?.mode)
 }
 
 fn qwen36_moe_flm_weight_selection_for_store(
     store: &BakedStore,
-    profile: QuantProfile,
 ) -> Result<Qwen36MoeFlmWeightSelection> {
     let probe = store
         .meta(QWEN36_MOE_WEIGHT_MODE_PROBE)
         .map(|meta| (&meta.layout, meta.dtype.as_str()));
-    qwen36_moe_flm_weight_selection_from_probe(profile, probe)
+    qwen36_moe_flm_weight_selection_from_probe(probe)
 }
 
 fn qwen36_moe_flm_weight_selection_from_probe(
-    profile: QuantProfile,
     probe: Option<(&LayoutTag, &str)>,
 ) -> Result<Qwen36MoeFlmWeightSelection> {
-    match profile {
-        QuantProfile::Int4Gptq
-        | QuantProfile::Int4Awq
-        | QuantProfile::Int4Autoround
-        | QuantProfile::Int4Hqq => {
-            if matches!(probe, Some((LayoutTag::Raw, "bf16"))) {
-                Ok(Qwen36MoeFlmWeightSelection {
-                    mode: Qwen36WeightMode::Bf16,
-                    label: "BF16",
-                })
-            } else if matches!(probe, Some((LayoutTag::Int4Quantized, "u8"))) {
-                Ok(Qwen36MoeFlmWeightSelection {
-                    mode: Qwen36WeightMode::Int4,
-                    label: "INT4 native FLM",
-                })
-            } else if probe.is_none() {
-                Ok(Qwen36MoeFlmWeightSelection {
-                    mode: Qwen36WeightMode::Int4,
-                    label: "INT4 native FLM",
-                })
-            } else {
-                Err(anyhow!(
-                    "Qwen3.6 MoE FLM INT4 profile requires a native INT4 or BF16 fallback probe; got {probe:?}"
-                ))
-            }
-        }
+    match probe {
+        Some((LayoutTag::Raw, "bf16")) => Ok(Qwen36MoeFlmWeightSelection {
+            mode: Qwen36WeightMode::Bf16,
+            label: "BF16",
+        }),
+        Some((LayoutTag::Int4Quantized, "u8")) | None => Ok(Qwen36MoeFlmWeightSelection {
+            mode: Qwen36WeightMode::Int4,
+            label: "INT4 native FLM",
+        }),
         other => Err(anyhow!(
-            "Qwen3.6 MoE FLM main path currently supports only INT4-compatible profiles; got {other}"
+            "Qwen3.6 MoE FLM source requires a native INT4 or BF16 fallback probe; got {other:?}"
         )),
     }
 }
@@ -105,8 +85,7 @@ pub(crate) fn open_qwen36_moe_flm_source(cli: &Cli) -> Result<Option<Qwen36MoeFl
     let config = source.qwen_moe_config()?;
     eprintln!("[qwen36-moe] loading tokenizer from FLM assets");
     let tokenizer = source.qwen_tokenizer()?;
-    let weight_selection =
-        qwen36_moe_flm_weight_selection_for_store(&source.store, effective_quant_profile(cli)?)?;
+    let weight_selection = qwen36_moe_flm_weight_selection_for_store(&source.store)?;
     eprintln!("[qwen36-moe] FLM weight mode: {}", weight_selection.label);
     Ok(Some(Qwen36MoeFlmSource {
         source,
@@ -119,25 +98,22 @@ pub(crate) fn open_qwen36_moe_flm_source(cli: &Cli) -> Result<Option<Qwen36MoeFl
 
 #[cfg(test)]
 mod tests {
-    use model_store::manifest::{LayoutTag, QuantProfile};
+    use model_store::manifest::LayoutTag;
 
     use super::*;
 
     #[test]
     fn maps_moe_mixed_lowbit_flm_to_int4_weight_mode() {
         let mode =
-            qwen36_moe_flm_weight_mode(QuantProfile::Int4Gptq).expect("INT4 profile is supported");
+            qwen36_moe_flm_weight_mode(None).expect("missing probe fixtures default to INT4");
 
         assert_eq!(mode, Qwen36WeightMode::Int4);
     }
 
     #[test]
     fn maps_ct_int4_bf16_fallback_probe_to_bf16_weight_mode() {
-        let selection = qwen36_moe_flm_weight_selection_from_probe(
-            QuantProfile::Int4Gptq,
-            Some((&LayoutTag::Raw, "bf16")),
-        )
-        .expect("CT INT4 fallback is supported through BF16 load");
+        let selection = qwen36_moe_flm_weight_selection_from_probe(Some((&LayoutTag::Raw, "bf16")))
+            .expect("CT INT4 fallback is supported through BF16 load");
 
         assert_eq!(selection.mode, Qwen36WeightMode::Bf16);
         assert_eq!(selection.label, "BF16");
@@ -145,23 +121,41 @@ mod tests {
 
     #[test]
     fn keeps_native_int4_probe_on_int4_weight_mode() {
-        let selection = qwen36_moe_flm_weight_selection_from_probe(
-            QuantProfile::Int4Gptq,
-            Some((&LayoutTag::Int4Quantized, "u8")),
-        )
-        .expect("native INT4 FLM payload is supported");
+        let selection =
+            qwen36_moe_flm_weight_selection_from_probe(Some((&LayoutTag::Int4Quantized, "u8")))
+                .expect("native INT4 FLM payload is supported");
 
         assert_eq!(selection.mode, Qwen36WeightMode::Int4);
         assert_eq!(selection.label, "INT4 native FLM");
     }
 
     #[test]
-    fn rejects_q4km_flm_weight_mode_for_this_stage() {
-        let err = qwen36_moe_flm_weight_mode(QuantProfile::Q4Km)
+    fn native_int4_probe_overrides_default_bf16_cli_profile() {
+        let selection =
+            qwen36_moe_flm_weight_selection_from_probe(Some((&LayoutTag::Int4Quantized, "u8")))
+                .expect("native INT4 FLM payload should select native mode without --int4");
+
+        assert_eq!(selection.mode, Qwen36WeightMode::Int4);
+        assert_eq!(selection.label, "INT4 native FLM");
+    }
+
+    #[test]
+    fn raw_bf16_probe_selects_fallback_without_int4_cli_profile() {
+        let selection = qwen36_moe_flm_weight_selection_from_probe(Some((&LayoutTag::Raw, "bf16")))
+            .expect("BF16 FLM fallback should be file-driven without --int4");
+
+        assert_eq!(selection.mode, Qwen36WeightMode::Bf16);
+        assert_eq!(selection.label, "BF16");
+    }
+
+    #[test]
+    fn rejects_unknown_flm_weight_mode_probe_for_this_stage() {
+        let err = qwen36_moe_flm_weight_mode(Some((&LayoutTag::Raw, "u8")))
             .unwrap_err()
             .to_string();
 
         assert!(err.contains("Qwen3.6 MoE FLM"), "{err}");
         assert!(err.contains("INT4"), "{err}");
+        assert!(err.contains("Raw"), "{err}");
     }
 }

--- a/crates/runner/src/qwen36_moe/layers.rs
+++ b/crates/runner/src/qwen36_moe/layers.rs
@@ -5,7 +5,7 @@ use gpu_hal::{
     current_backend, Backend, GpuBuffer, ScalarType, VirtualAllocationRole, VirtualArena,
 };
 use model_store::manifest::LayoutTag;
-use model_store::BakedStore;
+use model_store::{BakedStore, TensorStorageExtent};
 use qwen36_moe::config::TextConfig;
 
 use crate::qwen36_moe_residency::MoeExpertResidencyManager;
@@ -22,8 +22,8 @@ use crate::qwen36_moe_types::{
 pub(crate) fn load_to_gpu(store: &BakedStore, ordinal: usize, name: &str) -> Result<GpuBuffer> {
     let resolved = resolve_qwen36_store_name(store, name);
     if registered_mmap_upload_enabled() && current_backend() == Backend::Hip {
-        if let Some(meta) = store.meta(resolved.as_ref()) {
-            if should_use_registered_mmap_upload(resolved.as_ref(), &meta.dtype, meta.byte_len) {
+        if let Ok(Some(extent)) = store.tensor_storage_extent(resolved.as_ref()) {
+            if should_use_registered_mmap_upload_for_extent(&extent) {
                 match store.load_to_gpu_registered_mmap(resolved.as_ref(), ordinal) {
                     Ok(buffer) => return Ok(buffer),
                     Err(err) => {
@@ -119,38 +119,82 @@ fn registered_mmap_upload_env_value_enabled(value: Option<&str>) -> bool {
     )
 }
 
-fn should_use_registered_mmap_upload(name: &str, dtype: &str, byte_len: u64) -> bool {
-    dtype == "u8"
-        && byte_len >= REGISTERED_MMAP_UPLOAD_MIN_BYTES
-        && name.ends_with(".mlp.experts.gate_up_proj")
+fn should_use_registered_mmap_upload_for_extent(extent: &TensorStorageExtent) -> bool {
+    extent.storage_dtype == "u8"
+        && extent.upload_dtype == "u8"
+        && extent.byte_len >= REGISTERED_MMAP_UPLOAD_MIN_BYTES
+        && matches!(extent.layout, LayoutTag::Int4Quantized)
+        && extent.name.ends_with(".mlp.experts.gate_up_proj")
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use model_store::{TensorStorageExtent, TensorStorageSourceKind};
+    use std::path::PathBuf;
+
+    fn test_extent(
+        name: &str,
+        byte_len: u64,
+        storage_dtype: &str,
+        layout: LayoutTag,
+    ) -> TensorStorageExtent {
+        TensorStorageExtent {
+            source_kind: TensorStorageSourceKind::FlmContainer,
+            source_path: PathBuf::from("/tmp/model.flm"),
+            name: name.to_string(),
+            file_offset: 4096,
+            byte_len,
+            storage_dtype: storage_dtype.to_string(),
+            storage_shape: vec![128, 8192, 256],
+            layout,
+            upload_dtype: storage_dtype.to_string(),
+            upload_shape: vec![128, 8192, 256],
+        }
+    }
 
     #[test]
     fn registered_mmap_upload_policy_targets_native_int4_gate_up_slabs() {
-        assert!(should_use_registered_mmap_upload(
+        assert!(should_use_registered_mmap_upload_for_extent(&test_extent(
             "model.language_model.layers.0.mlp.experts.gate_up_proj",
-            "u8",
             268_435_456,
-        ));
-        assert!(!should_use_registered_mmap_upload(
+            "u8",
+            LayoutTag::Int4Quantized,
+        )));
+        assert!(!should_use_registered_mmap_upload_for_extent(&test_extent(
             "model.language_model.layers.0.mlp.experts.down_proj",
+            268_435_456,
             "u8",
-            134_217_728,
-        ));
-        assert!(!should_use_registered_mmap_upload(
+            LayoutTag::Int4Quantized,
+        )));
+        assert!(!should_use_registered_mmap_upload_for_extent(&test_extent(
             "lm_head.weight",
-            "bf16",
             1_017_118_720,
-        ));
-        assert!(!should_use_registered_mmap_upload(
+            "bf16",
+            LayoutTag::Raw,
+        )));
+        assert!(!should_use_registered_mmap_upload_for_extent(&test_extent(
             "mtp.layers.0.mlp.experts.gate_up_proj",
-            "u8",
             524_288,
-        ));
+            "u8",
+            LayoutTag::Int4Quantized,
+        )));
+    }
+
+    #[test]
+    fn registered_mmap_upload_policy_requires_native_int4_extent() {
+        assert!(!should_use_registered_mmap_upload_for_extent(&test_extent(
+            "model.language_model.layers.0.mlp.experts.gate_up_proj",
+            268_435_456,
+            "u8",
+            LayoutTag::Raw,
+        )));
+        assert!(should_use_registered_mmap_upload_for_extent(&test_extent(
+            "model.language_model.layers.0.mlp.experts.gate_up_proj",
+            268_435_456,
+            "u8",
+            LayoutTag::Int4Quantized,
+        )));
     }
 
     #[test]

--- a/crates/runner/src/qwen36_moe/layers.rs
+++ b/crates/runner/src/qwen36_moe/layers.rs
@@ -5,7 +5,7 @@ use gpu_hal::{
     current_backend, Backend, GpuBuffer, ScalarType, VirtualAllocationRole, VirtualArena,
 };
 use model_store::manifest::LayoutTag;
-use model_store::{BakedStore, TensorStorageExtent};
+use model_store::{BakedStore, TensorStorageExtent, VirtualArenaTransferBackend};
 use qwen36_moe::config::TextConfig;
 
 use crate::qwen36_moe_residency::MoeExpertResidencyManager;
@@ -53,10 +53,16 @@ fn load_to_virtual_resident_weight(
     store: &BakedStore,
     arena: &mut VirtualArena,
     name: &str,
+    transfer_backend: VirtualArenaTransferBackend,
 ) -> Result<ResidentWeight> {
     let resolved = resolve_qwen36_store_name(store, name);
     let id = store
-        .load_to_virtual_arena(arena, resolved.as_ref(), VirtualAllocationRole::MoeExpert)
+        .load_to_virtual_arena_with_backend(
+            arena,
+            resolved.as_ref(),
+            VirtualAllocationRole::MoeExpert,
+            transfer_backend,
+        )
         .with_context(|| format!("BakedStore::load_to_virtual_arena({name})"))?;
     let allocation = arena
         .allocation(id)
@@ -338,6 +344,7 @@ pub(crate) fn load_layer_buffers(
     kv_vmm: bool,
     mut expert_arena: Option<&mut VirtualArena>,
     mut expert_residency: Option<&mut MoeExpertResidencyManager>,
+    expert_virtual_transfer_backend: VirtualArenaTransferBackend,
 ) -> Result<LayerBuffers> {
     let lp = format!("{weight_prefix}.layers.{layer_idx}");
 
@@ -923,6 +930,7 @@ pub(crate) fn load_layer_buffers(
                     store,
                     &mut **arena,
                     &format!("{mp}.experts.gate_up_proj"),
+                    expert_virtual_transfer_backend,
                 )?,
                 None => {
                     load_to_resident_weight(store, ordinal, &format!("{mp}.experts.gate_up_proj"))?
@@ -944,6 +952,7 @@ pub(crate) fn load_layer_buffers(
                     store,
                     &mut **arena,
                     &format!("{mp}.experts.down_proj"),
+                    expert_virtual_transfer_backend,
                 )?,
                 None => {
                     load_to_resident_weight(store, ordinal, &format!("{mp}.experts.down_proj"))?
@@ -988,6 +997,7 @@ pub(crate) fn load_all_layer_buffers(
     kv_vmm: bool,
     mut expert_arena: Option<&mut VirtualArena>,
     mut expert_residency: Option<&mut MoeExpertResidencyManager>,
+    expert_virtual_transfer_backend: VirtualArenaTransferBackend,
 ) -> Result<Vec<LayerBuffers>> {
     let mut layers = Vec::with_capacity(geom.num_layers as usize);
     for li in 0..geom.num_layers as usize {
@@ -1004,6 +1014,7 @@ pub(crate) fn load_all_layer_buffers(
             kv_vmm,
             expert_arena.as_deref_mut(),
             expert_residency.as_deref_mut(),
+            expert_virtual_transfer_backend,
         )
         .with_context(|| format!("load layer {li} weights"))?;
         layers.push(layer);

--- a/crates/runner/src/qwen36_moe/layers.rs
+++ b/crates/runner/src/qwen36_moe/layers.rs
@@ -1,7 +1,9 @@
 use std::borrow::Cow;
 
 use anyhow::{anyhow, Context, Result};
-use gpu_hal::{GpuBuffer, ScalarType, VirtualAllocationRole, VirtualArena};
+use gpu_hal::{
+    current_backend, Backend, GpuBuffer, ScalarType, VirtualAllocationRole, VirtualArena,
+};
 use model_store::manifest::LayoutTag;
 use model_store::BakedStore;
 use qwen36_moe::config::TextConfig;
@@ -19,6 +21,21 @@ use crate::qwen36_moe_types::{
 /// runs as part of the dry-run, so a missing tensor here is a real bug).
 pub(crate) fn load_to_gpu(store: &BakedStore, ordinal: usize, name: &str) -> Result<GpuBuffer> {
     let resolved = resolve_qwen36_store_name(store, name);
+    if registered_mmap_upload_enabled() && current_backend() == Backend::Hip {
+        if let Some(meta) = store.meta(resolved.as_ref()) {
+            if should_use_registered_mmap_upload(resolved.as_ref(), &meta.dtype, meta.byte_len) {
+                match store.load_to_gpu_registered_mmap(resolved.as_ref(), ordinal) {
+                    Ok(buffer) => return Ok(buffer),
+                    Err(err) => {
+                        eprintln!(
+                            "[flm] registered mmap upload failed for {}; falling back to pageable upload: {err}",
+                            resolved.as_ref()
+                        );
+                    }
+                }
+            }
+        }
+    }
     store
         .load_to_gpu(resolved.as_ref(), ordinal)
         .with_context(|| format!("BakedStore::load_to_gpu({name})"))
@@ -83,6 +100,71 @@ pub(crate) fn store_contains_qwen36(store: &BakedStore, name: &str) -> bool {
 
 pub(crate) fn store_layout_qwen36<'a>(store: &'a BakedStore, name: &str) -> Option<&'a LayoutTag> {
     store.layout(resolve_qwen36_store_name(store, name).as_ref())
+}
+
+const REGISTERED_MMAP_UPLOAD_MIN_BYTES: u64 = 256 * 1024 * 1024;
+
+fn registered_mmap_upload_enabled() -> bool {
+    registered_mmap_upload_env_value_enabled(
+        std::env::var("SUPERSONIC_FLM_REGISTERED_UPLOAD")
+            .ok()
+            .as_deref(),
+    )
+}
+
+fn registered_mmap_upload_env_value_enabled(value: Option<&str>) -> bool {
+    matches!(
+        value.map(|value| value.to_ascii_lowercase()),
+        Some(value) if matches!(value.as_str(), "1" | "true" | "on" | "yes")
+    )
+}
+
+fn should_use_registered_mmap_upload(name: &str, dtype: &str, byte_len: u64) -> bool {
+    dtype == "u8"
+        && byte_len >= REGISTERED_MMAP_UPLOAD_MIN_BYTES
+        && name.ends_with(".mlp.experts.gate_up_proj")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registered_mmap_upload_policy_targets_native_int4_gate_up_slabs() {
+        assert!(should_use_registered_mmap_upload(
+            "model.language_model.layers.0.mlp.experts.gate_up_proj",
+            "u8",
+            268_435_456,
+        ));
+        assert!(!should_use_registered_mmap_upload(
+            "model.language_model.layers.0.mlp.experts.down_proj",
+            "u8",
+            134_217_728,
+        ));
+        assert!(!should_use_registered_mmap_upload(
+            "lm_head.weight",
+            "bf16",
+            1_017_118_720,
+        ));
+        assert!(!should_use_registered_mmap_upload(
+            "mtp.layers.0.mlp.experts.gate_up_proj",
+            "u8",
+            524_288,
+        ));
+    }
+
+    #[test]
+    fn registered_mmap_upload_is_opt_in() {
+        assert!(!registered_mmap_upload_env_value_enabled(None));
+        assert!(registered_mmap_upload_env_value_enabled(Some("1")));
+        assert!(registered_mmap_upload_env_value_enabled(Some("true")));
+        assert!(registered_mmap_upload_env_value_enabled(Some("on")));
+        assert!(registered_mmap_upload_env_value_enabled(Some("yes")));
+        assert!(!registered_mmap_upload_env_value_enabled(Some("0")));
+        assert!(!registered_mmap_upload_env_value_enabled(Some("false")));
+        assert!(!registered_mmap_upload_env_value_enabled(Some("off")));
+        assert!(!registered_mmap_upload_env_value_enabled(Some("no")));
+    }
 }
 
 pub(crate) fn resolve_qwen36_store_name<'a>(store: &BakedStore, name: &'a str) -> Cow<'a, str> {

--- a/crates/runner/src/qwen36_moe/legacy.rs
+++ b/crates/runner/src/qwen36_moe/legacy.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use anyhow::{anyhow, Context, Result};
 use gpu_hal::{set_backend, Backend};
-use model_store::BakedStore;
+use model_store::{BakedStore, VirtualArenaTransferBackend};
 
 use crate::qwen36_moe_cli::dry_run::DryRunReport;
 use crate::qwen36_moe_cli::geom::build_multi_layer_geom;
@@ -80,6 +80,7 @@ pub(crate) fn decode_first_token(
             false,
             None,
             None,
+            VirtualArenaTransferBackend::PageableH2d,
         )
         .with_context(|| format!("load layer {li} weights"))?;
         layers.push(layer);

--- a/crates/runner/src/qwen36_moe/residency.rs
+++ b/crates/runner/src/qwen36_moe/residency.rs
@@ -12,7 +12,7 @@ use gpu_hal::{
     copy_h2d_async, memset_zeros_async, Backend, GpuEvent, GpuStream, PinnedHostBuffer,
     VirtualAllocationRole, VirtualArena, VirtualBacking,
 };
-use model_store::BakedStore;
+use model_store::{BakedStore, VirtualArenaTransferBackend};
 
 use crate::qwen36_moe_residency_pages::{
     oldest_protected_page, page_spans, prune_protected_pages, ranges_overlap,
@@ -66,6 +66,7 @@ pub struct MoeExpertResidencyManager {
     fixed_hot_misses: u64,
     fixed_hot_skipped: u64,
     fixed_hot_evicted_pages: u64,
+    virtual_transfer_backend: VirtualArenaTransferBackend,
     async_page_in: Option<AsyncPageIn>,
     pending_pages: HashMap<ResidentPageKey, PendingPage>,
     async_scheduled_pages: u64,
@@ -134,6 +135,7 @@ impl MoeExpertResidencyManager {
             fixed_hot_misses: 0,
             fixed_hot_skipped: 0,
             fixed_hot_evicted_pages: 0,
+            virtual_transfer_backend: VirtualArenaTransferBackend::PageableH2d,
             async_page_in: None,
             pending_pages: HashMap::new(),
             async_scheduled_pages: 0,
@@ -144,6 +146,11 @@ impl MoeExpertResidencyManager {
             async_uploaded_bytes: 0,
             async_pending_pages_peak: 0,
         }
+    }
+
+    pub fn with_virtual_transfer_backend(mut self, backend: VirtualArenaTransferBackend) -> Self {
+        self.virtual_transfer_backend = backend;
+        self
     }
 
     pub fn arena(&self) -> &VirtualArena {
@@ -650,12 +657,13 @@ impl MoeExpertResidencyManager {
             }
 
             store
-                .load_range_to_virtual_arena(
+                .load_range_to_virtual_arena_with_backend(
                     &mut self.arena,
                     allocation_id,
                     &name,
                     span.offset,
                     span.copy_len,
+                    self.virtual_transfer_backend,
                 )
                 .with_context(|| {
                     format!(
@@ -707,6 +715,9 @@ impl MoeExpertResidencyManager {
         span: PageSpan,
     ) -> Result<bool> {
         if self.async_page_in.is_none() {
+            return Ok(false);
+        }
+        if self.virtual_transfer_backend != VirtualArenaTransferBackend::PageableH2d {
             return Ok(false);
         }
         self.promote_completed_pending_pages()?;

--- a/crates/runner/src/qwen36_moe/residency_tests.rs
+++ b/crates/runner/src/qwen36_moe/residency_tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use gpu_hal::{Backend, VirtualAllocationRole};
 use model_store::manifest::{LayoutTag, Manifest, TensorMeta, FORMAT_VERSION};
+use model_store::VirtualArenaTransferBackend;
 use std::sync::Mutex;
 
 static VMM_BACKEND_TEST_LOCK: Mutex<()> = Mutex::new(());
@@ -859,6 +860,63 @@ fn store_range_upload_keeps_stable_virtual_pointer() {
                 .to_host_range_bytes(4096, 4096)
                 .expect("read expert 1");
             assert!(bytes.iter().all(|b| *b == 2));
+        },
+    );
+}
+
+#[test]
+fn direct_storage_transfer_backend_does_not_pageable_fallback() {
+    with_supported_vmm_backend(
+        "direct_storage_transfer_backend_does_not_pageable_fallback",
+        |_backend| {
+            if gpu_hal::storage_to_device_is_supported(gpu_hal::current_backend()) {
+                eprintln!("skip: native storage-to-device transfer available on this runtime");
+                return;
+            }
+            gpu_hal::hal_profile_set_enabled(true);
+            gpu_hal::hal_profile_reset();
+            let tmp = synthetic_store(2, 4096);
+            let store = BakedStore::open(tmp.path()).expect("open synthetic store");
+            let mut manager =
+                MoeExpertResidencyManager::new(0, MoeExpertResidencyConfig::new(1).unwrap())
+                    .with_virtual_transfer_backend(VirtualArenaTransferBackend::GpuDirectStorage);
+            manager
+                .register_tensor(
+                    &store,
+                    0,
+                    MoeExpertProjection::GateUp,
+                    "model.layers.0.mlp.experts.gate_up_proj",
+                    2,
+                )
+                .expect("register tensor");
+
+            let err = manager
+                .ensure_resident(
+                    &store,
+                    MoeExpertKey {
+                        layer_idx: 0,
+                        expert_idx: 0,
+                        projection: MoeExpertProjection::GateUp,
+                    },
+                )
+                .expect_err("unsupported direct storage backend should fail");
+            let profile = gpu_hal::hal_profile_snapshot();
+            gpu_hal::hal_profile_set_enabled(false);
+            let err_chain = format!("{err:#}");
+            assert!(
+                err_chain.contains("GPU-direct storage-to-device"),
+                "unexpected direct storage error: {err_chain}"
+            );
+            assert!(
+                profile
+                    .entries
+                    .iter()
+                    .all(|entry| entry.op != "copy_h2d" && entry.op != "vmm_map_no_sync"),
+                "GPU-direct backend must not fall back to pageable mapping/copy: {:?}",
+                profile.entries
+            );
+            assert_eq!(manager.stats().resident_pages, 0);
+            assert_eq!(manager.arena().stats().logical_resident_bytes, 0);
         },
     );
 }

--- a/crates/runner/src/qwen36_moe/vmm.rs
+++ b/crates/runner/src/qwen36_moe/vmm.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use gpu_hal::{Backend, VirtualArena};
-use model_store::BakedStore;
+use model_store::{BakedStore, VirtualArenaTransferBackend};
 use qwen36_moe::config::TextConfig;
 
 use crate::qwen36_moe_cli::layers::{load_all_layer_buffers, Qwen36WeightMode};
@@ -58,6 +58,7 @@ pub(crate) fn load_decode_layers_with_vmm_strategy(
     moe_async_staging_pages: usize,
     moe_prefetch_evict: bool,
     moe_prefetch_evict_min_probability: f64,
+    moe_virtual_transfer_backend: VirtualArenaTransferBackend,
     persistent_decode: bool,
 ) -> Result<Qwen36DecodeLayers> {
     if let Some(cap_experts) = moe_island_cap_experts {
@@ -78,7 +79,8 @@ pub(crate) fn load_decode_layers_with_vmm_strategy(
             unreachable!("forced VMM expert check should either return true or error");
         }
         let config = MoeExpertResidencyConfig::new(1)?.with_prefetch_evict(moe_prefetch_evict);
-        let mut manager = MoeExpertResidencyManager::new(ordinal, config);
+        let mut manager = MoeExpertResidencyManager::new(ordinal, config)
+            .with_virtual_transfer_backend(moe_virtual_transfer_backend);
         let buffers_start = std::time::Instant::now();
         let layers = load_all_layer_buffers(
             store,
@@ -92,6 +94,7 @@ pub(crate) fn load_decode_layers_with_vmm_strategy(
             kv_vmm,
             None,
             Some(&mut manager),
+            moe_virtual_transfer_backend,
         )
         .context("reserve Qwen3.6-MoE routed experts for sparse VMM residency")?;
         let buffers_elapsed = buffers_start.elapsed();
@@ -102,7 +105,9 @@ pub(crate) fn load_decode_layers_with_vmm_strategy(
         manager
             .set_max_resident_pages(max_resident_pages)
             .context("apply sparse MoE page budget")?;
-        if moe_async_prefetch {
+        let storage_direct =
+            moe_virtual_transfer_backend == VirtualArenaTransferBackend::GpuDirectStorage;
+        if moe_async_prefetch && !storage_direct {
             manager
                 .enable_async_prefetch(moe_async_staging_pages)
                 .context("enable sparse MoE async prefetch")?;
@@ -165,10 +170,18 @@ pub(crate) fn load_decode_layers_with_vmm_strategy(
                 );
             }
         }
-        if moe_async_prefetch {
+        if moe_async_prefetch && !storage_direct {
             println!(
                 "  [vmm] sparse MoE async page-in active (staging_pages={moe_async_staging_pages})"
             );
+        }
+        if storage_direct {
+            println!("  [vmm] sparse MoE virtual page-in transfer backend: gpu-direct-storage");
+            if moe_async_prefetch {
+                println!(
+                    "  [vmm] sparse MoE async page-in disabled for gpu-direct-storage backend"
+                );
+            }
         }
         if moe_prefetch_evict {
             println!(
@@ -210,6 +223,7 @@ pub(crate) fn load_decode_layers_with_vmm_strategy(
             kv_vmm,
             Some(&mut arena),
             None,
+            moe_virtual_transfer_backend,
         ) {
             Ok(layers) => {
                 let buffers_elapsed = buffers_start.elapsed();
@@ -260,6 +274,7 @@ pub(crate) fn load_decode_layers_with_vmm_strategy(
         kv_vmm,
         None,
         None,
+        moe_virtual_transfer_backend,
     )?;
     let buffers_elapsed = buffers_start.elapsed();
     Ok(Qwen36DecodeLayers {

--- a/crates/runner/src/qwen36_moe/vmm.rs
+++ b/crates/runner/src/qwen36_moe/vmm.rs
@@ -12,10 +12,27 @@ use crate::qwen36_moe_types::{AttnLayerBuffers, LayerBuffers, MultiLayerGeom};
 
 const MIB: f64 = (1024 * 1024) as f64;
 
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct Qwen36LayerLoadTimings {
+    pub(crate) buffers: std::time::Duration,
+    pub(crate) vmm_setup: std::time::Duration,
+    pub(crate) prewarm: std::time::Duration,
+    pub(crate) hal_total: std::time::Duration,
+    pub(crate) hal_alloc: std::time::Duration,
+    pub(crate) hal_copy_h_to_d: std::time::Duration,
+    pub(crate) hal_memset: std::time::Duration,
+    pub(crate) hal_vmm: std::time::Duration,
+    pub(crate) hal_alloc_bytes: u64,
+    pub(crate) hal_copy_h_to_d_bytes: u64,
+    pub(crate) hal_memset_bytes: u64,
+    pub(crate) hal_vmm_bytes: u64,
+}
+
 pub(crate) struct Qwen36DecodeLayers {
     pub(crate) layers: Vec<LayerBuffers>,
     pub(crate) moe_expert_arena: Option<VirtualArena>,
     pub(crate) moe_expert_residency: Option<MoeExpertResidencyManager>,
+    pub(crate) timings: Qwen36LayerLoadTimings,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -62,6 +79,7 @@ pub(crate) fn load_decode_layers_with_vmm_strategy(
         }
         let config = MoeExpertResidencyConfig::new(1)?.with_prefetch_evict(moe_prefetch_evict);
         let mut manager = MoeExpertResidencyManager::new(ordinal, config);
+        let buffers_start = std::time::Instant::now();
         let layers = load_all_layer_buffers(
             store,
             ordinal,
@@ -76,6 +94,8 @@ pub(crate) fn load_decode_layers_with_vmm_strategy(
             Some(&mut manager),
         )
         .context("reserve Qwen3.6-MoE routed experts for sparse VMM residency")?;
+        let buffers_elapsed = buffers_start.elapsed();
+        let vmm_setup_start = std::time::Instant::now();
         let max_resident_pages = manager
             .page_budget_for_routed_experts(cap_experts)
             .context("derive sparse MoE page budget from routed expert tensor layout")?;
@@ -156,10 +176,16 @@ pub(crate) fn load_decode_layers_with_vmm_strategy(
                  (transition_min_probability={moe_prefetch_evict_min_probability:.2})"
             );
         }
+        let vmm_setup_elapsed = vmm_setup_start.elapsed();
         return Ok(Qwen36DecodeLayers {
             layers,
             moe_expert_arena: None,
             moe_expert_residency: Some(manager),
+            timings: Qwen36LayerLoadTimings {
+                buffers: buffers_elapsed,
+                vmm_setup: vmm_setup_elapsed,
+                ..Default::default()
+            },
         });
     }
 
@@ -171,6 +197,7 @@ pub(crate) fn load_decode_layers_with_vmm_strategy(
         ordinal,
     )? {
         let mut arena = BakedStore::virtual_weight_arena(ordinal);
+        let buffers_start = std::time::Instant::now();
         match load_all_layer_buffers(
             store,
             ordinal,
@@ -185,6 +212,8 @@ pub(crate) fn load_decode_layers_with_vmm_strategy(
             None,
         ) {
             Ok(layers) => {
+                let buffers_elapsed = buffers_start.elapsed();
+                let vmm_setup_start = std::time::Instant::now();
                 let stats = arena.stats();
                 println!(
                     "  [vmm] Qwen3.6-MoE routed expert slabs active on backend={} device {ordinal}: \
@@ -196,10 +225,16 @@ pub(crate) fn load_decode_layers_with_vmm_strategy(
                     stats.resident_bytes as f64 / MIB,
                     stats.reserved_bytes as f64 / MIB,
                 );
+                let vmm_setup_elapsed = vmm_setup_start.elapsed();
                 return Ok(Qwen36DecodeLayers {
                     layers,
                     moe_expert_arena: Some(arena),
                     moe_expert_residency: None,
+                    timings: Qwen36LayerLoadTimings {
+                        buffers: buffers_elapsed,
+                        vmm_setup: vmm_setup_elapsed,
+                        ..Default::default()
+                    },
                 });
             }
             Err(err) if moe_vmm_mode == MoeExpertVmmMode::Auto => {
@@ -212,6 +247,7 @@ pub(crate) fn load_decode_layers_with_vmm_strategy(
         }
     }
 
+    let buffers_start = std::time::Instant::now();
     let layers = load_all_layer_buffers(
         store,
         ordinal,
@@ -225,10 +261,15 @@ pub(crate) fn load_decode_layers_with_vmm_strategy(
         None,
         None,
     )?;
+    let buffers_elapsed = buffers_start.elapsed();
     Ok(Qwen36DecodeLayers {
         layers,
         moe_expert_arena: None,
         moe_expert_residency: None,
+        timings: Qwen36LayerLoadTimings {
+            buffers: buffers_elapsed,
+            ..Default::default()
+        },
     })
 }
 

--- a/crates/runner/src/qwen36_moe/vmm_config.rs
+++ b/crates/runner/src/qwen36_moe/vmm_config.rs
@@ -2,6 +2,7 @@ use std::ops::{Deref, DerefMut};
 
 use anyhow::Result;
 use gpu_hal::Backend;
+use model_store::VirtualArenaTransferBackend;
 use supersonic_runtime::qwen36_moe_config::{
     qwen36_kv_vmm_mode_from_env_value, should_use_qwen36_kv_vmm as should_use_qwen36_kv_vmm_mode,
     Qwen36MoeRuntimeConfig, Qwen36MoeRuntimeConfigInputs,
@@ -16,6 +17,7 @@ pub(crate) use supersonic_runtime::qwen36_moe_config::{
 pub(crate) struct MoeRuntimeConfig {
     policy: Qwen36MoeRuntimeConfig,
     pub(crate) sparse_telemetry: Option<MoeSparseTelemetry>,
+    pub(crate) virtual_transfer_backend: VirtualArenaTransferBackend,
 }
 
 impl Deref for MoeRuntimeConfig {
@@ -54,6 +56,7 @@ pub(crate) fn prepare_moe_runtime_config(
     let protect_demand_routes = std::env::var("SUPERSONIC_MOE_ISLAND_PROTECT_DEMAND").ok();
     let hot_protect_min_hits = std::env::var("SUPERSONIC_MOE_ISLAND_HOT_PROTECT_MIN_HITS").ok();
     let fixed_hot_min_hits = std::env::var("SUPERSONIC_MOE_ISLAND_FIXED_HOT_MIN_HITS").ok();
+    let virtual_transfer_backend = std::env::var("SUPERSONIC_FLM_VIRTUAL_TRANSFER_BACKEND").ok();
 
     let inputs = Qwen36MoeRuntimeConfigInputs {
         vmm_mode: vmm_mode.as_deref(),
@@ -92,6 +95,9 @@ pub(crate) fn prepare_moe_runtime_config(
     Ok(MoeRuntimeConfig {
         policy,
         sparse_telemetry,
+        virtual_transfer_backend: virtual_arena_transfer_backend_from_env_value(
+            virtual_transfer_backend.as_deref(),
+        )?,
     })
 }
 
@@ -99,4 +105,121 @@ pub(crate) fn should_use_qwen36_kv_vmm(backend: Backend, ordinal: usize) -> Resu
     let raw = std::env::var("SUPERSONIC_VMM_KV").ok();
     let mode = qwen36_kv_vmm_mode_from_env_value(raw.as_deref(), backend)?;
     should_use_qwen36_kv_vmm_mode(mode, backend, ordinal)
+}
+
+pub(crate) fn effective_moe_expert_vmm_mode_for_transfer_backend(
+    mode: MoeExpertVmmMode,
+    island_cap_experts: Option<usize>,
+    backend: VirtualArenaTransferBackend,
+) -> Result<MoeExpertVmmMode> {
+    if backend == VirtualArenaTransferBackend::PageableH2d || island_cap_experts.is_some() {
+        return Ok(mode);
+    }
+    match mode {
+        MoeExpertVmmMode::Auto => Ok(MoeExpertVmmMode::Force),
+        MoeExpertVmmMode::Force => Ok(MoeExpertVmmMode::Force),
+        MoeExpertVmmMode::Disabled => anyhow::bail!(
+            "SUPERSONIC_FLM_VIRTUAL_TRANSFER_BACKEND=gpu-direct-storage requires MoE expert VMM; \
+             unset SUPERSONIC_VMM_MOE_ISLANDS=0"
+        ),
+    }
+}
+
+pub(crate) fn virtual_arena_transfer_backend_from_env_value(
+    value: Option<&str>,
+) -> Result<VirtualArenaTransferBackend> {
+    let Some(value) = value else {
+        return Ok(VirtualArenaTransferBackend::PageableH2d);
+    };
+    let value = value.trim().to_ascii_lowercase();
+    if value.is_empty() {
+        return Ok(VirtualArenaTransferBackend::PageableH2d);
+    }
+    match value.as_str() {
+        "pageable" | "pageable-h2d" | "h2d" => Ok(VirtualArenaTransferBackend::PageableH2d),
+        "gpu-direct-storage" | "gpu_direct_storage" | "gds" | "hipfile" => {
+            Ok(VirtualArenaTransferBackend::GpuDirectStorage)
+        }
+        _ => anyhow::bail!(
+            "SUPERSONIC_FLM_VIRTUAL_TRANSFER_BACKEND must be one of \
+             pageable-h2d, gpu-direct-storage, gds, or hipfile (got {value:?})"
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use model_store::VirtualArenaTransferBackend;
+
+    #[test]
+    fn flm_virtual_transfer_backend_env_defaults_to_pageable_h2d() {
+        assert_eq!(
+            virtual_arena_transfer_backend_from_env_value(None).unwrap(),
+            VirtualArenaTransferBackend::PageableH2d
+        );
+        assert_eq!(
+            virtual_arena_transfer_backend_from_env_value(Some("")).unwrap(),
+            VirtualArenaTransferBackend::PageableH2d
+        );
+        assert_eq!(
+            virtual_arena_transfer_backend_from_env_value(Some("pageable-h2d")).unwrap(),
+            VirtualArenaTransferBackend::PageableH2d
+        );
+    }
+
+    #[test]
+    fn flm_virtual_transfer_backend_env_accepts_direct_storage_aliases() {
+        for value in ["gpu-direct-storage", "gds", "hipfile"] {
+            assert_eq!(
+                virtual_arena_transfer_backend_from_env_value(Some(value)).unwrap(),
+                VirtualArenaTransferBackend::GpuDirectStorage
+            );
+        }
+    }
+
+    #[test]
+    fn flm_virtual_transfer_backend_env_rejects_unknown_values() {
+        let err = virtual_arena_transfer_backend_from_env_value(Some("maybe")).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("SUPERSONIC_FLM_VIRTUAL_TRANSFER_BACKEND"));
+    }
+
+    #[test]
+    fn flm_direct_transfer_backend_forces_eager_virtual_expert_route() {
+        assert_eq!(
+            effective_moe_expert_vmm_mode_for_transfer_backend(
+                MoeExpertVmmMode::Auto,
+                None,
+                VirtualArenaTransferBackend::GpuDirectStorage,
+            )
+            .unwrap(),
+            MoeExpertVmmMode::Force
+        );
+        assert_eq!(
+            effective_moe_expert_vmm_mode_for_transfer_backend(
+                MoeExpertVmmMode::Auto,
+                None,
+                VirtualArenaTransferBackend::PageableH2d,
+            )
+            .unwrap(),
+            MoeExpertVmmMode::Auto
+        );
+        assert!(effective_moe_expert_vmm_mode_for_transfer_backend(
+            MoeExpertVmmMode::Disabled,
+            None,
+            VirtualArenaTransferBackend::GpuDirectStorage,
+        )
+        .is_err());
+        assert_eq!(
+            effective_moe_expert_vmm_mode_for_transfer_backend(
+                MoeExpertVmmMode::Auto,
+                Some(8),
+                VirtualArenaTransferBackend::GpuDirectStorage,
+            )
+            .unwrap(),
+            MoeExpertVmmMode::Auto
+        );
+    }
 }

--- a/crates/runner/src/qwen36_moe/vmm_config.rs
+++ b/crates/runner/src/qwen36_moe/vmm_config.rs
@@ -94,13 +94,16 @@ pub(crate) fn prepare_moe_runtime_config(
         );
     }
 
+    let virtual_transfer_backend = virtual_arena_transfer_backend_from_cli_or_env_value(
+        flm_virtual_transfer_backend_cli,
+        virtual_transfer_backend_env.as_deref(),
+    )?;
+    validate_virtual_transfer_backend_supported(backend, virtual_transfer_backend)?;
+
     Ok(MoeRuntimeConfig {
         policy,
         sparse_telemetry,
-        virtual_transfer_backend: virtual_arena_transfer_backend_from_cli_or_env_value(
-            flm_virtual_transfer_backend_cli,
-            virtual_transfer_backend_env.as_deref(),
-        )?,
+        virtual_transfer_backend,
     })
 }
 
@@ -126,6 +129,27 @@ pub(crate) fn effective_moe_expert_vmm_mode_for_transfer_backend(
              unset SUPERSONIC_VMM_MOE_ISLANDS=0"
         ),
     }
+}
+
+pub(crate) fn validate_virtual_transfer_backend_supported(
+    backend: Backend,
+    transfer_backend: VirtualArenaTransferBackend,
+) -> Result<()> {
+    if transfer_backend == VirtualArenaTransferBackend::PageableH2d
+        || gpu_hal::storage_to_device_is_supported(backend)
+    {
+        return Ok(());
+    }
+    let reason = match backend {
+        Backend::Hip => {
+            "hipFile support is not compiled; ROCm >= 7.2 with hipfile.h and libhipfile is required"
+        }
+        Backend::Cuda => "CUDA storage-to-device transfer is not implemented yet",
+        Backend::Metal => "Metal storage-to-device transfer is not implemented",
+    };
+    anyhow::bail!(
+        "FLM virtual transfer backend gpu-direct-storage is not available for {backend}: {reason}"
+    )
 }
 
 pub(crate) fn virtual_arena_transfer_backend_from_env_value(
@@ -240,6 +264,28 @@ mod tests {
                 .unwrap_err();
 
         assert!(err.to_string().contains("--flm-virtual-transfer-backend"));
+    }
+
+    #[test]
+    fn flm_direct_transfer_backend_requires_storage_to_device_support() {
+        assert!(validate_virtual_transfer_backend_supported(
+            Backend::Hip,
+            VirtualArenaTransferBackend::PageableH2d,
+        )
+        .is_ok());
+
+        if !gpu_hal::storage_to_device_is_supported(Backend::Hip) {
+            let err = validate_virtual_transfer_backend_supported(
+                Backend::Hip,
+                VirtualArenaTransferBackend::GpuDirectStorage,
+            )
+            .expect_err("HIP direct transfer should be rejected when hipFile is unavailable");
+
+            assert!(
+                err.to_string().contains("hipFile support is not compiled"),
+                "{err}"
+            );
+        }
     }
 
     #[test]

--- a/crates/runner/src/qwen36_moe/vmm_config.rs
+++ b/crates/runner/src/qwen36_moe/vmm_config.rs
@@ -39,6 +39,7 @@ pub(crate) fn prepare_moe_runtime_config(
     persistent_decode: bool,
     backend: Backend,
     top_k: usize,
+    flm_virtual_transfer_backend_cli: Option<&str>,
 ) -> Result<MoeRuntimeConfig> {
     let vmm_mode = std::env::var("SUPERSONIC_VMM_MOE_ISLANDS").ok();
     let island_cap_experts = std::env::var("SUPERSONIC_MOE_ISLAND_CAP_EXPERTS").ok();
@@ -56,7 +57,8 @@ pub(crate) fn prepare_moe_runtime_config(
     let protect_demand_routes = std::env::var("SUPERSONIC_MOE_ISLAND_PROTECT_DEMAND").ok();
     let hot_protect_min_hits = std::env::var("SUPERSONIC_MOE_ISLAND_HOT_PROTECT_MIN_HITS").ok();
     let fixed_hot_min_hits = std::env::var("SUPERSONIC_MOE_ISLAND_FIXED_HOT_MIN_HITS").ok();
-    let virtual_transfer_backend = std::env::var("SUPERSONIC_FLM_VIRTUAL_TRANSFER_BACKEND").ok();
+    let virtual_transfer_backend_env =
+        std::env::var("SUPERSONIC_FLM_VIRTUAL_TRANSFER_BACKEND").ok();
 
     let inputs = Qwen36MoeRuntimeConfigInputs {
         vmm_mode: vmm_mode.as_deref(),
@@ -95,8 +97,9 @@ pub(crate) fn prepare_moe_runtime_config(
     Ok(MoeRuntimeConfig {
         policy,
         sparse_telemetry,
-        virtual_transfer_backend: virtual_arena_transfer_backend_from_env_value(
-            virtual_transfer_backend.as_deref(),
+        virtual_transfer_backend: virtual_arena_transfer_backend_from_cli_or_env_value(
+            flm_virtual_transfer_backend_cli,
+            virtual_transfer_backend_env.as_deref(),
         )?,
     })
 }
@@ -119,7 +122,7 @@ pub(crate) fn effective_moe_expert_vmm_mode_for_transfer_backend(
         MoeExpertVmmMode::Auto => Ok(MoeExpertVmmMode::Force),
         MoeExpertVmmMode::Force => Ok(MoeExpertVmmMode::Force),
         MoeExpertVmmMode::Disabled => anyhow::bail!(
-            "SUPERSONIC_FLM_VIRTUAL_TRANSFER_BACKEND=gpu-direct-storage requires MoE expert VMM; \
+            "FLM virtual transfer backend gpu-direct-storage requires MoE expert VMM; \
              unset SUPERSONIC_VMM_MOE_ISLANDS=0"
         ),
     }
@@ -127,6 +130,25 @@ pub(crate) fn effective_moe_expert_vmm_mode_for_transfer_backend(
 
 pub(crate) fn virtual_arena_transfer_backend_from_env_value(
     value: Option<&str>,
+) -> Result<VirtualArenaTransferBackend> {
+    virtual_arena_transfer_backend_from_value(value, "SUPERSONIC_FLM_VIRTUAL_TRANSFER_BACKEND")
+}
+
+pub(crate) fn virtual_arena_transfer_backend_from_cli_or_env_value(
+    cli_value: Option<&str>,
+    env_value: Option<&str>,
+) -> Result<VirtualArenaTransferBackend> {
+    match cli_value {
+        Some(value) => {
+            virtual_arena_transfer_backend_from_value(Some(value), "--flm-virtual-transfer-backend")
+        }
+        None => virtual_arena_transfer_backend_from_env_value(env_value),
+    }
+}
+
+fn virtual_arena_transfer_backend_from_value(
+    value: Option<&str>,
+    source_label: &str,
 ) -> Result<VirtualArenaTransferBackend> {
     let Some(value) = value else {
         return Ok(VirtualArenaTransferBackend::PageableH2d);
@@ -141,8 +163,8 @@ pub(crate) fn virtual_arena_transfer_backend_from_env_value(
             Ok(VirtualArenaTransferBackend::GpuDirectStorage)
         }
         _ => anyhow::bail!(
-            "SUPERSONIC_FLM_VIRTUAL_TRANSFER_BACKEND must be one of \
-             pageable-h2d, gpu-direct-storage, gds, or hipfile (got {value:?})"
+            "{source_label} must be one of pageable-h2d, gpu-direct-storage, gds, or hipfile \
+             (got {value:?})"
         ),
     }
 }
@@ -184,6 +206,40 @@ mod tests {
         assert!(err
             .to_string()
             .contains("SUPERSONIC_FLM_VIRTUAL_TRANSFER_BACKEND"));
+    }
+
+    #[test]
+    fn flm_virtual_transfer_backend_cli_value_overrides_env_value() {
+        assert_eq!(
+            virtual_arena_transfer_backend_from_cli_or_env_value(
+                Some("pageable-h2d"),
+                Some("hipfile"),
+            )
+            .unwrap(),
+            VirtualArenaTransferBackend::PageableH2d
+        );
+        assert_eq!(
+            virtual_arena_transfer_backend_from_cli_or_env_value(Some("hipfile"), Some("h2d"))
+                .unwrap(),
+            VirtualArenaTransferBackend::GpuDirectStorage
+        );
+    }
+
+    #[test]
+    fn flm_virtual_transfer_backend_env_remains_fallback_when_cli_omitted() {
+        assert_eq!(
+            virtual_arena_transfer_backend_from_cli_or_env_value(None, Some("hipfile")).unwrap(),
+            VirtualArenaTransferBackend::GpuDirectStorage
+        );
+    }
+
+    #[test]
+    fn flm_virtual_transfer_backend_reports_cli_flag_for_bad_cli_value() {
+        let err =
+            virtual_arena_transfer_backend_from_cli_or_env_value(Some("maybe"), Some("hipfile"))
+                .unwrap_err();
+
+        assert!(err.to_string().contains("--flm-virtual-transfer-backend"));
     }
 
     #[test]

--- a/crates/runner/tests/flm_moe_main_path.rs
+++ b/crates/runner/tests/flm_moe_main_path.rs
@@ -122,7 +122,6 @@ fn qwen36_moe_flm_model_dir_runs_without_hf_snapshot() {
     ]);
     cmd.arg(&path);
     cmd.args([
-        "--int4",
         "--verify-flm-hashes",
         "--prompt",
         "Hello",
@@ -178,13 +177,7 @@ fn qwen36_moe_ct_int4_flm_dry_run_consumes_source_without_hf_snapshot() {
         "--model-dir",
     ]);
     cmd.arg(&path);
-    cmd.args([
-        "--int4",
-        "--context-size",
-        "16",
-        "--no-download",
-        "--dry-run",
-    ]);
+    cmd.args(["--context-size", "16", "--no-download", "--dry-run"]);
 
     let output = cmd
         .output()

--- a/crates/runner/tests/flm_moe_main_path.rs
+++ b/crates/runner/tests/flm_moe_main_path.rs
@@ -148,6 +148,62 @@ fn qwen36_moe_flm_model_dir_runs_without_hf_snapshot() {
 
 #[cfg(target_os = "linux")]
 #[test]
+fn qwen36_moe_flm_model_dir_infers_model_when_model_flag_is_omitted() {
+    let Some(path) = std::env::var_os("SUPERSONIC_QWEN36_35B_A3B_NO_HF_FLM") else {
+        eprintln!("skipping: SUPERSONIC_QWEN36_35B_A3B_NO_HF_FLM is unset");
+        return;
+    };
+    let path = PathBuf::from(path);
+    if !path.exists() {
+        panic!(
+            "SUPERSONIC_QWEN36_35B_A3B_NO_HF_FLM is set but the path does not exist: {}",
+            path.display()
+        );
+    }
+
+    let backend =
+        std::env::var("SUPERSONIC_FLM_MAIN_PATH_BACKEND").unwrap_or_else(|_| "hip".to_string());
+    let device =
+        std::env::var("SUPERSONIC_FLM_MAIN_PATH_DEVICE").unwrap_or_else(|_| "0".to_string());
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_supersonic"));
+    cmd.args([
+        "--backend",
+        backend.as_str(),
+        "--device",
+        device.as_str(),
+        "--model-dir",
+    ]);
+    cmd.arg(&path);
+    cmd.args(["--context-size", "16", "--no-download", "--dry-run"]);
+
+    let output = cmd
+        .output()
+        .unwrap_or_else(|e| panic!("run supersonic Qwen3.6-MoE FLM auto-model dry-run: {e}"));
+    let combined = combined_output(&output);
+
+    assert!(
+        output.status.success(),
+        "Qwen3.6-MoE FLM auto-model dry-run failed with status {:?}:\n{}",
+        output.status.code(),
+        combined
+    );
+    assert!(
+        combined.contains("[qwen3.6-moe] dry-run summary"),
+        "dry-run summary was not emitted:\n{combined}"
+    );
+    assert!(
+        combined.contains("[FLM runtime weights] ready-for-decode: YES"),
+        "FLM runtime weights were not reported ready:\n{combined}"
+    );
+    assert!(
+        !combined.contains("got --model qwen3.5-0.8b"),
+        "FLM auto-model path still used the default qwen3.5 model:\n{combined}"
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
 fn qwen36_moe_ct_int4_flm_dry_run_consumes_source_without_hf_snapshot() {
     let Some(path) = std::env::var_os("SUPERSONIC_QWEN36_35B_CT_INT4_FLM_DRY_RUN") else {
         eprintln!("skipping: SUPERSONIC_QWEN36_35B_CT_INT4_FLM_DRY_RUN is unset");

--- a/docs/superpowers/plans/2026-07-04-flm-first-class-path.md
+++ b/docs/superpowers/plans/2026-07-04-flm-first-class-path.md
@@ -91,7 +91,7 @@ Document the canonical SuperSonic command without `--int4`:
 ```bash
 cargo run -q -p runner --bin supersonic -- \
   --model qwen3.6-35b-a3b \
-  --model-dir /mnt/data/tmp/flm-first-class-e2e-20260704/qwen36-35b-a3b-supersonic-native-int4.flm \
+  --model-dir /mnt/data/tmp/flm-first-class-e2e-20260704/qwen36-35b-a3b-supersonic-native-int4-aligned.flm \
   --backend hip \
   --device 0 \
   --prompt "Hello" \
@@ -114,7 +114,7 @@ Run:
 
 ```bash
 /home/deano/.config/superpowers/worktrees/geo-quant/flm-first-class-path/.venv-rocm/bin/python scripts/flm_validate.py \
-  /mnt/data/tmp/flm-first-class-e2e-20260704/qwen36-35b-a3b-supersonic-native-int4.flm \
+  /mnt/data/tmp/flm-first-class-e2e-20260704/qwen36-35b-a3b-supersonic-native-int4-aligned.flm \
   --profile runnable-no-hf
 ```
 
@@ -127,7 +127,7 @@ Run:
 ```bash
 cargo run -q -p runner --bin supersonic -- \
   --model qwen3.6-35b-a3b \
-  --model-dir /mnt/data/tmp/flm-first-class-e2e-20260704/qwen36-35b-a3b-supersonic-native-int4.flm \
+  --model-dir /mnt/data/tmp/flm-first-class-e2e-20260704/qwen36-35b-a3b-supersonic-native-int4-aligned.flm \
   --backend hip \
   --device 0 \
   --dry-run \
@@ -144,7 +144,7 @@ Run:
 ```bash
 cargo run -q -p runner --bin supersonic -- \
   --model qwen3.6-35b-a3b \
-  --model-dir /mnt/data/tmp/flm-first-class-e2e-20260704/qwen36-35b-a3b-supersonic-native-int4.flm \
+  --model-dir /mnt/data/tmp/flm-first-class-e2e-20260704/qwen36-35b-a3b-supersonic-native-int4-aligned.flm \
   --backend hip \
   --device 0 \
   --prompt "Hello" \

--- a/docs/superpowers/plans/2026-07-04-flm-first-class-path.md
+++ b/docs/superpowers/plans/2026-07-04-flm-first-class-path.md
@@ -1,0 +1,156 @@
+# FLM First-Class Path Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make geo-quant FLM output load and run as the normal SuperSonic model path without `--int4`, without HF files, and with measurable FLM load/inference timings.
+
+**Architecture:** SuperSonic treats an effective FLM source as the authority for executable weight mode. The loader opens FLM with runtime aliases enabled, reads config/tokenizer from FLM, probes the open store for native INT4 or BF16 fallback views, and rejects only truly incompatible FLM/flag combinations.
+
+**Tech Stack:** Rust workspace (`runner`, `model-store`), Qwen3.6 MoE HIP path, geo-quant FLM Stage 3 native INT4 artifacts, cargo tests, env-gated e2e smoke tests.
+
+---
+
+### Task 1: Red Tests For File-Driven FLM Selection
+
+**Files:**
+- Modify: `crates/runner/src/bakes.rs`
+- Modify: `crates/runner/src/qwen36_moe/flm_source.rs`
+- Modify: `crates/runner/tests/flm_moe_main_path.rs`
+
+- [ ] **Step 1: Add failing unit coverage for FLM aliases without `--int4`**
+
+Add a test in `crates/runner/src/bakes.rs` that constructs the default Qwen3.6 MoE CLI with `.flm` `model_dir` and asserts `flm_source_open_options(&cli).unwrap().int4_runtime` is true even when `cli.int4` is false.
+
+- [ ] **Step 2: Add failing unit coverage for probe-driven MoE mode**
+
+Add tests in `crates/runner/src/qwen36_moe/flm_source.rs` that call the probe selection helper without a quant profile and assert:
+
+```rust
+assert_eq!(native_selection.mode, Qwen36WeightMode::Int4);
+assert_eq!(native_selection.label, "INT4 native FLM");
+assert_eq!(fallback_selection.mode, Qwen36WeightMode::Bf16);
+assert_eq!(fallback_selection.label, "BF16");
+```
+
+- [ ] **Step 3: Remove `--int4` from FLM integration tests**
+
+In `crates/runner/tests/flm_moe_main_path.rs`, remove `--int4` from the native FLM smoke command. Keep `--verify-flm-hashes` only where the test is explicitly checking hash option threading.
+
+- [ ] **Step 4: Run the focused tests and confirm the expected red failures**
+
+Run:
+
+```bash
+cargo test -p runner bakes::tests::flm_source_open_options -- --nocapture
+cargo test -p runner qwen36_moe::flm_source::tests -- --nocapture
+cargo test -p runner --test flm_moe_main_path moe_flm_main_path_output_contract_accepts_expected_logs -- --nocapture
+```
+
+Expected: at least one test fails because FLM INT4 aliases and MoE weight selection still depend on CLI quant flags.
+
+### Task 2: Implement File-Driven FLM Open And MoE Selection
+
+**Files:**
+- Modify: `crates/runner/src/bakes.rs`
+- Modify: `crates/runner/src/qwen36_moe/flm_source.rs`
+- Modify: `crates/runner/src/flm_model_source.rs`
+
+- [ ] **Step 1: Make FLM open options source-driven**
+
+Change `flm_source_open_options` so `int4_runtime` is true for effective FLM sources and no longer depends on `effective_quant_profile(cli)`.
+
+- [ ] **Step 2: Make Qwen3.6 MoE selection probe-driven**
+
+Remove the required `QuantProfile` argument from `qwen36_moe_flm_weight_selection_for_store` and `qwen36_moe_flm_weight_selection_from_probe`. Select:
+
+```rust
+Some((LayoutTag::Int4Quantized, "u8")) => INT4 native FLM
+Some((LayoutTag::Raw, "bf16")) => BF16 fallback
+None => INT4 native FLM for unit fixtures without a store probe
+other => error naming the incompatible probe
+```
+
+- [ ] **Step 3: Preserve explicit incompatible-flag rejection**
+
+Keep `validate_flm_weight_source_options` rejecting q4km-like and int8 flags. Do not add CT or HF fallback logic to the native path.
+
+- [ ] **Step 4: Run focused tests to green**
+
+Run the same commands from Task 1 and confirm they pass.
+
+### Task 3: Canonical Docs And Commands
+
+**Files:**
+- Modify: `docs/testing.md`
+- Modify: geo-quant `docs/fast-load-model-format-design.md`
+
+- [ ] **Step 1: Update SuperSonic FLM testing docs**
+
+Document the canonical SuperSonic command without `--int4`:
+
+```bash
+cargo run -q -p runner --bin supersonic -- \
+  --model qwen3.6-35b-a3b \
+  --model-dir /mnt/data/tmp/flm-native-complete-path/qwen36-35b-a3b-supersonic-native-int4.flm \
+  --backend hip \
+  --device 0 \
+  --prompt "Hello" \
+  --max-new-tokens 1 \
+  --emit-stage-timings
+```
+
+- [ ] **Step 2: Update geo-quant FLM format docs**
+
+Document that normal FLM consumers should not need a Hugging Face snapshot. HF JSON assets are optional transition material, and the runtime descriptor/config/tokenizer/tensor tables are the required fast-load contract.
+
+### Task 4: Real Artifact Verification
+
+**Files:**
+- Modify docs only if verification output changes recommended commands.
+
+- [ ] **Step 1: Validate the current geo-quant artifact**
+
+Run:
+
+```bash
+/home/deano/.config/superpowers/worktrees/geo-quant/flm-first-class-path/.venv-rocm/bin/python scripts/flm_validate.py \
+  /mnt/data/tmp/flm-native-complete-path/qwen36-35b-a3b-supersonic-native-int4.flm \
+  --profile runnable-no-hf
+```
+
+Expected: validator prints OK with zero warnings.
+
+- [ ] **Step 2: Run SuperSonic dry-run without `--int4`**
+
+Run:
+
+```bash
+cargo run -q -p runner --bin supersonic -- \
+  --model qwen3.6-35b-a3b \
+  --model-dir /mnt/data/tmp/flm-native-complete-path/qwen36-35b-a3b-supersonic-native-int4.flm \
+  --backend hip \
+  --device 0 \
+  --dry-run \
+  --max-new-tokens 1 \
+  --emit-stage-timings
+```
+
+Expected: command succeeds, reports `FLM weight mode: INT4 native FLM`, reports ready-for-decode, and does not mention HF files, fetch, bake, safetensors, or `INT4 GPTQ`.
+
+- [ ] **Step 3: Run one-token inference without `--int4`**
+
+Run:
+
+```bash
+cargo run -q -p runner --bin supersonic -- \
+  --model qwen3.6-35b-a3b \
+  --model-dir /mnt/data/tmp/flm-native-complete-path/qwen36-35b-a3b-supersonic-native-int4.flm \
+  --backend hip \
+  --device 0 \
+  --prompt "Hello" \
+  --max-new-tokens 1 \
+  --context-size 16 \
+  --emit-stage-timings
+```
+
+Expected: command succeeds, prints generated ids/result summary, and emits stage timings that can be used as the baseline for subsequent fast-load and decode-speed work.

--- a/docs/superpowers/plans/2026-07-04-flm-first-class-path.md
+++ b/docs/superpowers/plans/2026-07-04-flm-first-class-path.md
@@ -91,7 +91,7 @@ Document the canonical SuperSonic command without `--int4`:
 ```bash
 cargo run -q -p runner --bin supersonic -- \
   --model qwen3.6-35b-a3b \
-  --model-dir /mnt/data/tmp/flm-native-complete-path/qwen36-35b-a3b-supersonic-native-int4.flm \
+  --model-dir /mnt/data/tmp/flm-first-class-e2e-20260704/qwen36-35b-a3b-supersonic-native-int4.flm \
   --backend hip \
   --device 0 \
   --prompt "Hello" \
@@ -114,7 +114,7 @@ Run:
 
 ```bash
 /home/deano/.config/superpowers/worktrees/geo-quant/flm-first-class-path/.venv-rocm/bin/python scripts/flm_validate.py \
-  /mnt/data/tmp/flm-native-complete-path/qwen36-35b-a3b-supersonic-native-int4.flm \
+  /mnt/data/tmp/flm-first-class-e2e-20260704/qwen36-35b-a3b-supersonic-native-int4.flm \
   --profile runnable-no-hf
 ```
 
@@ -127,7 +127,7 @@ Run:
 ```bash
 cargo run -q -p runner --bin supersonic -- \
   --model qwen3.6-35b-a3b \
-  --model-dir /mnt/data/tmp/flm-native-complete-path/qwen36-35b-a3b-supersonic-native-int4.flm \
+  --model-dir /mnt/data/tmp/flm-first-class-e2e-20260704/qwen36-35b-a3b-supersonic-native-int4.flm \
   --backend hip \
   --device 0 \
   --dry-run \
@@ -144,7 +144,7 @@ Run:
 ```bash
 cargo run -q -p runner --bin supersonic -- \
   --model qwen3.6-35b-a3b \
-  --model-dir /mnt/data/tmp/flm-native-complete-path/qwen36-35b-a3b-supersonic-native-int4.flm \
+  --model-dir /mnt/data/tmp/flm-first-class-e2e-20260704/qwen36-35b-a3b-supersonic-native-int4.flm \
   --backend hip \
   --device 0 \
   --prompt "Hello" \

--- a/docs/superpowers/specs/2026-07-04-flm-first-class-path-design.md
+++ b/docs/superpowers/specs/2026-07-04-flm-first-class-path-design.md
@@ -48,6 +48,14 @@ the same FLM tensor extent metadata with multiple implementations:
 - GPU-direct storage-to-device transfer when the platform and file/device
   alignment support it.
 
+SuperSonic should expose a concrete storage-extent descriptor for direct
+file-backed tensors before adding transfer backends. The descriptor names the
+source file, byte offset, byte length, storage dtype/shape/layout, and runtime
+upload dtype/shape. Synthesized or transformed fallback aliases must not expose
+a single direct extent. This keeps future GPU-direct work from inferring file
+identity through mmap pointers or conflating packed storage shape with the
+execution view.
+
 FLM itself should describe the tensor storage extents, layout ABI, direct plan,
 and integrity information. The inference engine chooses the best transfer
 backend for the current platform without changing FLM semantics.

--- a/docs/superpowers/specs/2026-07-04-flm-first-class-path-design.md
+++ b/docs/superpowers/specs/2026-07-04-flm-first-class-path-design.md
@@ -76,18 +76,20 @@ deregisters the buffer before returning. This keeps the explicit
 an internal bounce path while we are trying to measure direct storage-to-device
 load performance.
 
-The runtime selector is `SUPERSONIC_FLM_VIRTUAL_TRANSFER_BACKEND`. It defaults
-to `pageable-h2d`; `gpu-direct-storage`, `gds`, or `hipfile` selects the named
-storage-to-device backend for MoE expert virtual arena loads, covering both
-sparse residency page-in and eager virtual expert slab loads. This selector is
-deliberately explicit while hipFile availability is platform-dependent. If it
-is forced on a build without hipFile support, the loader must fail before
-pageable mapping/copy rather than timing an accidental fallback. Selecting
-`hipfile` without `SUPERSONIC_MOE_ISLAND_CAP_EXPERTS` forces the eager routed
-expert VMM path so a dense-fit model cannot silently bypass the requested
-storage-to-device backend. Current sparse async MoE page-in uses pinned host
-staging, so the `hipfile` backend disables that async staging path until direct
-asynchronous storage reads are implemented.
+The runtime selector is `--flm-virtual-transfer-backend`, with
+`SUPERSONIC_FLM_VIRTUAL_TRANSFER_BACKEND` kept as an environment fallback. It
+defaults to `pageable-h2d`; `gpu-direct-storage`, `gds`, or `hipfile` selects
+the named storage-to-device backend for MoE expert virtual arena loads, covering
+both sparse residency page-in and eager virtual expert slab loads. This selector
+is deliberately explicit while hipFile availability is platform-dependent, and
+the CLI value wins over the env var when both are present. If it is forced on a
+build without hipFile support, the loader must fail before pageable mapping/copy
+rather than timing an accidental fallback. Selecting `hipfile` without
+`SUPERSONIC_MOE_ISLAND_CAP_EXPERTS` forces the eager routed expert VMM path so a
+dense-fit model cannot silently bypass the requested storage-to-device backend.
+Current sparse async MoE page-in uses pinned host staging, so the `hipfile`
+backend disables that async staging path until direct asynchronous storage reads
+are implemented.
 
 SuperSonic should expose a concrete storage-extent descriptor for direct
 file-backed tensors before adding transfer backends. The descriptor names the
@@ -140,7 +142,7 @@ Automated coverage should include:
 - unit tests proving FLM open options enable runtime aliases independent of CLI quant flags;
 - unit tests proving Qwen3.6 MoE FLM weight selection is file-probe driven;
 - model-store tests proving Qwen3.6 linear-attention direct raw values match the SuperSonic runtime bake byte-for-byte;
-- runner tests proving `SUPERSONIC_FLM_VIRTUAL_TRANSFER_BACKEND` parses direct-storage aliases and that forced `GpuDirectStorage` does not fall back to pageable mapping/copy when unsupported;
+- runner tests proving `--flm-virtual-transfer-backend` / `SUPERSONIC_FLM_VIRTUAL_TRANSFER_BACKEND` parse direct-storage aliases, CLI selection overrides the env fallback, and forced `GpuDirectStorage` does not fall back to pageable mapping/copy when unsupported;
 - upload-probe tests proving `--storage-direct` is explicit and records `copy_storage_to_device` timing/byte counters separately from H2D counters;
 - env-gated integration tests that run the real 35B A3B FLM with no HF snapshot and no `--int4`;
 - docs with canonical geo-quant export and SuperSonic run commands.

--- a/docs/superpowers/specs/2026-07-04-flm-first-class-path-design.md
+++ b/docs/superpowers/specs/2026-07-04-flm-first-class-path-design.md
@@ -4,13 +4,23 @@
 
 Make an FLM file exported by geo-quant a first-class SuperSonic model source. A normal run should pass the FLM path as `--model-dir`, require no Hugging Face snapshot, require no quantization flag such as `--int4`, and load the executable weight mode directly from the file metadata.
 
-## Current State
+## Original Gap
 
 The current merged path can load the latest native INT4 Qwen3.6 MoE FLM only when the user also passes `--int4`. Without that flag SuperSonic opens the FLM, reads the runtime config and tokenizer, then rejects the file because the default CLI quantization profile is BF16. That makes the CLI flag, not the FLM, the source of truth.
 
 The latest geo-quant native INT4 artifact proves the direct path exists: with `--int4`, SuperSonic reports `INT4 native FLM` and reaches the dry-run ready-for-decode path. The first-class gap is selection and ergonomics, not the underlying native tensor layout.
 
 The e2e implementation also exposed a stricter direct-layout requirement: Qwen3.6 linear-attention raw tensors must be stored in the SuperSonic runtime layout inside the FLM. In particular, `linear_attn.conv1d.weight` is the squeezed depthwise-conv view, `linear_attn.dt_bias` is `[1, 1, H]`, and `linear_attn.A_log` is exponentiated BF16 `[1, 1, H]`. A runnable FLM should contain those direct values; SuperSonic labels and validates them, but does not reshape HF checkpoint payloads on the normal path.
+
+## Implementation State
+
+The active branch has closed the original source-selection gap for the
+Qwen3.6 35B-A3B path: `--model-dir <file.flm>` is enough, `--model` can be
+inferred from the FLM runtime descriptor, and no `--int4` flag is required.
+The current measured path is still pageable host-to-device transfer from the
+aligned FLM payload into the direct native INT4 runtime layout. Real
+storage-to-device performance remains unproven on this workstation because the
+host stack is Fedora 44 with ROCm/HIP 7.1.1 and no `hipfile.h`/`libhipfile`.
 
 ## Architecture
 
@@ -93,6 +103,14 @@ enter execution through stable virtual allocations. A GPU-direct backend should
 therefore target extent-to-virtual-allocation range loads so the direct FLM plan
 can become resident in the execution layout without a dense staging detour.
 
+The `qwen36_flm_upload_probe` binary also has a focused `--storage-direct`
+mode for ROCm 7.2 bring-up. It asks `BakedStore` for the selected tensor's
+absolute FLM file range and calls the same HAL `copy_storage_to_device` boundary
+used by the virtual arena backend. On builds without hipFile support this mode
+must fail with the explicit hipFile requirement; on a ROCm 7.2+ hipFile system
+it should emit `copy_storage_to_device_*` profile fields that can be compared
+against the pageable, pinned, and registered modes.
+
 FLM itself should describe the tensor storage extents, layout ABI, direct plan,
 and integrity information. The inference engine chooses the best transfer
 backend for the current platform without changing FLM semantics.
@@ -119,6 +137,7 @@ Automated coverage should include:
 - unit tests proving Qwen3.6 MoE FLM weight selection is file-probe driven;
 - model-store tests proving Qwen3.6 linear-attention direct raw values match the SuperSonic runtime bake byte-for-byte;
 - runner tests proving `SUPERSONIC_FLM_VIRTUAL_TRANSFER_BACKEND` parses direct-storage aliases and that forced `GpuDirectStorage` does not fall back to pageable mapping/copy when unsupported;
+- upload-probe tests proving `--storage-direct` is explicit and records `copy_storage_to_device` timing/byte counters separately from H2D counters;
 - env-gated integration tests that run the real 35B A3B FLM with no HF snapshot and no `--int4`;
 - docs with canonical geo-quant export and SuperSonic run commands.
 

--- a/docs/superpowers/specs/2026-07-04-flm-first-class-path-design.md
+++ b/docs/superpowers/specs/2026-07-04-flm-first-class-path-design.md
@@ -56,6 +56,12 @@ a single direct extent. This keeps future GPU-direct work from inferring file
 identity through mmap pointers or conflating packed storage shape with the
 execution view.
 
+For Qwen3.6 MoE, the highest-value transfer boundary is the virtual arena range
+loader, not only dense `GpuBuffer` construction: routed expert slabs already
+enter execution through stable virtual allocations. A GPU-direct backend should
+therefore target extent-to-virtual-allocation range loads so the direct FLM plan
+can become resident in the execution layout without a dense staging detour.
+
 FLM itself should describe the tensor storage extents, layout ABI, direct plan,
 and integrity information. The inference engine chooses the best transfer
 backend for the current platform without changing FLM semantics.

--- a/docs/superpowers/specs/2026-07-04-flm-first-class-path-design.md
+++ b/docs/superpowers/specs/2026-07-04-flm-first-class-path-design.md
@@ -57,6 +57,19 @@ falling back to pageable H2D. A real fast-path verification requires ROCm 7.2+
 hipFile, `ais-check` passing, and the FLM payload on a supported local NVMe
 filesystem such as ext4 or xfs.
 
+The runtime selector is `SUPERSONIC_FLM_VIRTUAL_TRANSFER_BACKEND`. It defaults
+to `pageable-h2d`; `gpu-direct-storage`, `gds`, or `hipfile` selects the named
+storage-to-device backend for MoE expert virtual arena loads, covering both
+sparse residency page-in and eager virtual expert slab loads. This selector is
+deliberately explicit while hipFile availability is platform-dependent. If it
+is forced on a build without hipFile support, the loader must fail before
+pageable mapping/copy rather than timing an accidental fallback. Selecting
+`hipfile` without `SUPERSONIC_MOE_ISLAND_CAP_EXPERTS` forces the eager routed
+expert VMM path so a dense-fit model cannot silently bypass the requested
+storage-to-device backend. Current sparse async MoE page-in uses pinned host
+staging, so the `hipfile` backend disables that async staging path until direct
+asynchronous storage reads are implemented.
+
 SuperSonic should expose a concrete storage-extent descriptor for direct
 file-backed tensors before adding transfer backends. The descriptor names the
 source file, byte offset, byte length, storage dtype/shape/layout, and runtime
@@ -96,6 +109,7 @@ Automated coverage should include:
 - unit tests proving FLM open options enable runtime aliases independent of CLI quant flags;
 - unit tests proving Qwen3.6 MoE FLM weight selection is file-probe driven;
 - model-store tests proving Qwen3.6 linear-attention direct raw values match the SuperSonic runtime bake byte-for-byte;
+- runner tests proving `SUPERSONIC_FLM_VIRTUAL_TRANSFER_BACKEND` parses direct-storage aliases and that forced `GpuDirectStorage` does not fall back to pageable mapping/copy when unsupported;
 - env-gated integration tests that run the real 35B A3B FLM with no HF snapshot and no `--int4`;
 - docs with canonical geo-quant export and SuperSonic run commands.
 

--- a/docs/superpowers/specs/2026-07-04-flm-first-class-path-design.md
+++ b/docs/superpowers/specs/2026-07-04-flm-first-class-path-design.md
@@ -105,16 +105,18 @@ enter execution through stable virtual allocations. A GPU-direct backend should
 therefore target extent-to-virtual-allocation range loads so the direct FLM plan
 can become resident in the execution layout without a dense staging detour.
 
-The `qwen36_flm_upload_probe` binary also has a focused `--storage-direct`
-mode for ROCm 7.2 bring-up. It asks `BakedStore` for the selected tensor's
-absolute FLM file range and calls the same HAL `copy_storage_to_device` boundary
-used by the virtual arena backend. On builds without hipFile support this mode
-must fail with the explicit hipFile requirement; on a ROCm 7.2+ hipFile system
-it should emit `copy_storage_to_device_*` profile fields that can be compared
-against the pageable, pinned, and registered modes. Because strict hipFile uses
-`O_DIRECT`, the probe rejects storage-direct ranges whose file offset or length
-is not 4 KiB aligned. Small tensors such as `linear_attn.dt_bias` remain valid
-FLM payloads, but they are not standalone tensor-granular hipFile transfer
+The `qwen36_flm_upload_probe` binary also has focused storage-direct modes for
+ROCm 7.2 bring-up. `--only-storage-direct` asks `BakedStore` for the selected
+tensor's absolute FLM file range and calls the same HAL
+`copy_storage_to_device` boundary used by the virtual arena backend, without
+measuring pageable or pinned baselines first. On builds without hipFile support
+this mode must fail with the explicit hipFile requirement; on a ROCm 7.2+
+hipFile system it should emit `copy_storage_to_device_*` profile fields. Use the
+older `--storage-direct` mode when the same run should compare pageable and
+pinned H2D baselines before the storage-direct attempt. Because strict hipFile
+uses `O_DIRECT`, the probe rejects storage-direct ranges whose file offset or
+length is not 4 KiB aligned. Small tensors such as `linear_attn.dt_bias` remain
+valid FLM payloads, but they are not standalone tensor-granular hipFile transfer
 candidates; use block-aligned expert slabs for storage-direct bring-up.
 
 FLM itself should describe the tensor storage extents, layout ABI, direct plan,

--- a/docs/superpowers/specs/2026-07-04-flm-first-class-path-design.md
+++ b/docs/superpowers/specs/2026-07-04-flm-first-class-path-design.md
@@ -57,6 +57,15 @@ falling back to pageable H2D. A real fast-path verification requires ROCm 7.2+
 hipFile, `ais-check` passing, and the FLM payload on a supported local NVMe
 filesystem such as ext4 or xfs.
 
+The hipFile bridge must run in strict direct mode when selected by SuperSonic:
+it disables hipFile compatibility fallback with `hipFileSetParameterBool` before
+opening the driver path, opens the FLM with `O_DIRECT`, registers the target
+device buffer range with `hipFileBufRegister`, performs the `hipFileRead`, and
+deregisters the buffer before returning. This keeps the explicit
+`GpuDirectStorage` backend from being satisfied by hipFile's POSIX fallback or
+an internal bounce path while we are trying to measure direct storage-to-device
+load performance.
+
 The runtime selector is `SUPERSONIC_FLM_VIRTUAL_TRANSFER_BACKEND`. It defaults
 to `pageable-h2d`; `gpu-direct-storage`, `gds`, or `hipfile` selects the named
 storage-to-device backend for MoE expert virtual arena loads, covering both

--- a/docs/superpowers/specs/2026-07-04-flm-first-class-path-design.md
+++ b/docs/superpowers/specs/2026-07-04-flm-first-class-path-design.md
@@ -10,6 +10,8 @@ The current merged path can load the latest native INT4 Qwen3.6 MoE FLM only whe
 
 The latest geo-quant native INT4 artifact proves the direct path exists: with `--int4`, SuperSonic reports `INT4 native FLM` and reaches the dry-run ready-for-decode path. The first-class gap is selection and ergonomics, not the underlying native tensor layout.
 
+The e2e implementation also exposed a stricter direct-layout requirement: Qwen3.6 linear-attention raw tensors must be stored in the SuperSonic runtime layout inside the FLM. In particular, `linear_attn.conv1d.weight` is the squeezed depthwise-conv view, `linear_attn.dt_bias` is `[1, 1, H]`, and `linear_attn.A_log` is exponentiated BF16 `[1, 1, H]`. A runnable FLM should contain those direct values; SuperSonic labels and validates them, but does not reshape HF checkpoint payloads on the normal path.
+
 ## Architecture
 
 SuperSonic should treat `.flm` as authoritative for FLM-backed runs:
@@ -17,6 +19,7 @@ SuperSonic should treat `.flm` as authoritative for FLM-backed runs:
 - `--model-dir /path/model.flm` or `--flm-file /path/model.flm` selects an FLM model source.
 - FLM open options expose logical/direct INT4 aliases for FLM sources without needing a CLI quantization profile.
 - Qwen3.6 MoE weight-mode selection probes the already-open FLM store and chooses native INT4 when the logical probe is `LayoutTag::Int4Quantized` with `u8`, or BF16 fallback when the probe is `LayoutTag::Raw` with `bf16`.
+- Raw direct-plan aliases are labeled with their runtime layout tags when the FLM plan target shape already matches the runtime view, for example `DepthwiseConvSqueezed`, `HeadBiasReshaped`, and `HeadExpReshaped` for Qwen3.6 linear attention.
 - Explicit incompatible quantization flags remain validation errors. The no-flag path is file-driven.
 
 This keeps the direct path first-class while preserving fallbacks for FLM artifacts that carry CT-style or BF16 views.
@@ -41,6 +44,7 @@ Automated coverage should include:
 
 - unit tests proving FLM open options enable runtime aliases independent of CLI quant flags;
 - unit tests proving Qwen3.6 MoE FLM weight selection is file-probe driven;
+- model-store tests proving Qwen3.6 linear-attention direct raw values match the SuperSonic runtime bake byte-for-byte;
 - env-gated integration tests that run the real 35B A3B FLM with no HF snapshot and no `--int4`;
 - docs with canonical geo-quant export and SuperSonic run commands.
 

--- a/docs/superpowers/specs/2026-07-04-flm-first-class-path-design.md
+++ b/docs/superpowers/specs/2026-07-04-flm-first-class-path-design.md
@@ -1,0 +1,47 @@
+# FLM First-Class Path Design
+
+## Goal
+
+Make an FLM file exported by geo-quant a first-class SuperSonic model source. A normal run should pass the FLM path as `--model-dir`, require no Hugging Face snapshot, require no quantization flag such as `--int4`, and load the executable weight mode directly from the file metadata.
+
+## Current State
+
+The current merged path can load the latest native INT4 Qwen3.6 MoE FLM only when the user also passes `--int4`. Without that flag SuperSonic opens the FLM, reads the runtime config and tokenizer, then rejects the file because the default CLI quantization profile is BF16. That makes the CLI flag, not the FLM, the source of truth.
+
+The latest geo-quant native INT4 artifact proves the direct path exists: with `--int4`, SuperSonic reports `INT4 native FLM` and reaches the dry-run ready-for-decode path. The first-class gap is selection and ergonomics, not the underlying native tensor layout.
+
+## Architecture
+
+SuperSonic should treat `.flm` as authoritative for FLM-backed runs:
+
+- `--model-dir /path/model.flm` or `--flm-file /path/model.flm` selects an FLM model source.
+- FLM open options expose logical/direct INT4 aliases for FLM sources without needing a CLI quantization profile.
+- Qwen3.6 MoE weight-mode selection probes the already-open FLM store and chooses native INT4 when the logical probe is `LayoutTag::Int4Quantized` with `u8`, or BF16 fallback when the probe is `LayoutTag::Raw` with `bf16`.
+- Explicit incompatible quantization flags remain validation errors. The no-flag path is file-driven.
+
+This keeps the direct path first-class while preserving fallbacks for FLM artifacts that carry CT-style or BF16 views.
+
+## Data Flow
+
+1. CLI resolves an effective FLM source from `--flm-file` or `.flm` `--model-dir`.
+2. SuperSonic opens the FLM once with runtime aliases enabled and optional BLAKE3 payload verification based on `--verify-flm-hashes`.
+3. Runtime config and tokenizer are loaded from FLM assets.
+4. Qwen3.6 MoE loader probes the logical weight view in the open store and selects the runtime weight mode from the file.
+5. Decode uses the selected mode and the already-open FLM store. No HF `config.json`, `tokenizer.json`, safetensors, fetch, or bake path is consulted.
+
+## Error Handling
+
+If a Qwen3.6 MoE FLM has no recognized executable probe, the loader should fail with a message naming the missing/incompatible probe. If the user asks for an incompatible non-INT4 quant mode with an FLM source, the CLI should continue to reject it before load. Payload hash verification remains opt-in because it reads the payload bytes and is not representative of fast-load latency.
+
+## Testing
+
+The primary red test is the current failing behavior: the latest geo-quant native INT4 FLM must dry-run under SuperSonic without `--int4`.
+
+Automated coverage should include:
+
+- unit tests proving FLM open options enable runtime aliases independent of CLI quant flags;
+- unit tests proving Qwen3.6 MoE FLM weight selection is file-probe driven;
+- env-gated integration tests that run the real 35B A3B FLM with no HF snapshot and no `--int4`;
+- docs with canonical geo-quant export and SuperSonic run commands.
+
+Manual/e2e verification should use the current 35B native artifact and capture `--emit-stage-timings` output so load and inference speeds are measurable.

--- a/docs/superpowers/specs/2026-07-04-flm-first-class-path-design.md
+++ b/docs/superpowers/specs/2026-07-04-flm-first-class-path-design.md
@@ -45,8 +45,17 @@ the same FLM tensor extent metadata with multiple implementations:
 - pageable host-to-device copy as the portable fallback;
 - explicitly pinned or registered host staging for experiments and fallback
   paths;
-- GPU-direct storage-to-device transfer when the platform and file/device
-  alignment support it.
+- ROCm `hipFile` storage-to-device transfer when ROCm 7.2+ hipFile is
+  installed and the file/device/filesystem constraints are satisfied.
+
+On ROCm, the storage-direct backend is specifically `hipFile`, AMD's cuFile-like
+API. SuperSonic should detect `hipfile.h` and `libhipfile` at build time and
+compile a small bridge that reads FLM file ranges directly into device memory.
+When hipFile is absent, as on the current Fedora 44 ROCm 7.1.1 setup, the
+`GpuDirectStorage` backend must return `Unsupported` before mapping VMM pages or
+falling back to pageable H2D. A real fast-path verification requires ROCm 7.2+
+hipFile, `ais-check` passing, and the FLM payload on a supported local NVMe
+filesystem such as ext4 or xfs.
 
 SuperSonic should expose a concrete storage-extent descriptor for direct
 file-backed tensors before adding transfer backends. The descriptor names the

--- a/docs/superpowers/specs/2026-07-04-flm-first-class-path-design.md
+++ b/docs/superpowers/specs/2026-07-04-flm-first-class-path-design.md
@@ -24,6 +24,34 @@ SuperSonic should treat `.flm` as authoritative for FLM-backed runs:
 
 This keeps the direct path first-class while preserving fallbacks for FLM artifacts that carry CT-style or BF16 views.
 
+## Transfer Strategy
+
+The first-class FLM path should not treat file-backed `mmap` plus host
+registration as the architectural endpoint. `mmap` remains the portable source
+view for fast tensor-table access and normal host-to-device fallback. The
+preferred SuperSonic path is still to load compatible FLM tensor extents into
+the GPU-resident layout the execution plan consumes directly, such as Qwen3.6
+MoE virtual expert slabs.
+
+HIP host registration of mmap-backed payloads is useful as an opt-in diagnostic
+or dense-fallback experiment, but it is not GPU-direct IO. Its cost depends on
+filesystem cache state, page faults, driver page pinning, and concurrent GPU
+memory pressure. Therefore the normal FLM path must not enable registered mmap
+uploads by default.
+
+The next fast-load boundary should be a loader transfer abstraction that can use
+the same FLM tensor extent metadata with multiple implementations:
+
+- pageable host-to-device copy as the portable fallback;
+- explicitly pinned or registered host staging for experiments and fallback
+  paths;
+- GPU-direct storage-to-device transfer when the platform and file/device
+  alignment support it.
+
+FLM itself should describe the tensor storage extents, layout ABI, direct plan,
+and integrity information. The inference engine chooses the best transfer
+backend for the current platform without changing FLM semantics.
+
 ## Data Flow
 
 1. CLI resolves an effective FLM source from `--flm-file` or `.flm` `--model-dir`.

--- a/docs/superpowers/specs/2026-07-04-flm-first-class-path-design.md
+++ b/docs/superpowers/specs/2026-07-04-flm-first-class-path-design.md
@@ -109,7 +109,11 @@ absolute FLM file range and calls the same HAL `copy_storage_to_device` boundary
 used by the virtual arena backend. On builds without hipFile support this mode
 must fail with the explicit hipFile requirement; on a ROCm 7.2+ hipFile system
 it should emit `copy_storage_to_device_*` profile fields that can be compared
-against the pageable, pinned, and registered modes.
+against the pageable, pinned, and registered modes. Because strict hipFile uses
+`O_DIRECT`, the probe rejects storage-direct ranges whose file offset or length
+is not 4 KiB aligned. Small tensors such as `linear_attn.dt_bias` remain valid
+FLM payloads, but they are not standalone tensor-granular hipFile transfer
+candidates; use block-aligned expert slabs for storage-direct bring-up.
 
 FLM itself should describe the tensor storage extents, layout ABI, direct plan,
 and integrity information. The inference engine chooses the best transfer

--- a/docs/supported-matrix.md
+++ b/docs/supported-matrix.md
@@ -54,7 +54,10 @@ Seven backend surfaces are validated or in bring-up today:
   rigs carry, so consumers pull the published bake from GitHub
   releases (see [docs/bake-distribution.md](bake-distribution.md));
   producer workflow is unchanged. `--fp8-runtime` and `--kv-fp8` are
-  not wired for the MoE family.
+  not wired for the MoE family. An experimental no-HF FLM source lane is
+  also tracked for the native INT4 artifact: config, tokenizer, model identity,
+  direct weight mode, and load/decode timing come from the `.flm` file instead
+  of HF sidecars, `.supersonic`, or a required `--int4` flag.
 
 ### HIP on `gfx1201`
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -186,7 +186,7 @@ target/release/qwen36_flm_upload_probe \
   --device 0 \
   --tensor model.language_model.layers.0.mlp.experts.gate_up_proj \
   --iters 1 \
-  --storage-direct \
+  --only-storage-direct \
   --json
 ```
 
@@ -194,7 +194,9 @@ On ROCm 7.2+ hipFile, the JSON should include a `storage-direct` record with
 nonzero `copy_storage_to_device_ms` and `copy_storage_to_device_bytes`. On a
 build without hipFile support, the same command should fail with the explicit
 `ROCm >= 7.2 with hipfile.h and libhipfile` diagnostic before measuring an
-accidental pageable fallback.
+accidental pageable fallback. Use `--storage-direct` instead when you want the
+same run to compare pageable and pinned H2D baselines before the storage-direct
+attempt.
 
 Do not use tiny tensors such as `linear_attn.dt_bias` for the storage-direct
 smoke. They are valid FLM payloads, but their byte length is below the 4 KiB

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -175,6 +175,27 @@ smoke above. The resulting JSON records `model: null`,
 `[qwen36-moe lifecycle-timings]` fields such as `model_source_ms`,
 `layer_load_ms`, `generation_wall_ms`, and `total_wall_ms`.
 
+To validate ROCm 7.2 hipFile storage-to-device transfer on a host with
+`hipfile.h`, `libhipfile`, and passing `/opt/rocm/bin/ais-check`, use the FLM
+upload probe's storage-direct mode on a small direct tensor first:
+
+```bash
+target/release/qwen36_flm_upload_probe \
+  --model-dir /mnt/data/tmp/flm-first-class-e2e-20260704/qwen36-35b-a3b-supersonic-native-int4-aligned.flm \
+  --backend hip \
+  --device 0 \
+  --tensor model.language_model.layers.0.linear_attn.dt_bias \
+  --iters 1 \
+  --storage-direct \
+  --json
+```
+
+On ROCm 7.2+ hipFile, the JSON should include a `storage-direct` record with
+nonzero `copy_storage_to_device_ms` and `copy_storage_to_device_bytes`. On a
+build without hipFile support, the same command should fail with the explicit
+`ROCm >= 7.2 with hipfile.h and libhipfile` diagnostic before measuring an
+accidental pageable fallback.
+
 Compressed-tensors INT4 FLMs from geo-quant are tested separately through the
 portable fallback path. That path exposes logical CT INT4 weights as BF16 views
 when SuperSonic does not have a compatible direct execution plan:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -99,9 +99,10 @@ HIP decode path. Validate the native SuperSonic-layout artifact with
 geo-quant's no-HF profile first:
 
 ```bash
-/home/deano/.config/superpowers/worktrees/geo-quant/flm-export/.venv-rocm/bin/python \
-  -m geoquant.formats.flm_validate \
-  /mnt/data/runs/geo-quant/qwen36-35b-a3b-supersonic-native-int4.flm \
+PYTHONPATH=/home/deano/.config/superpowers/worktrees/geo-quant/flm-first-class-path \
+  /home/deano/projects/geo-quant/.venv-rocm/bin/python \
+  /home/deano/.config/superpowers/worktrees/geo-quant/flm-first-class-path/scripts/flm_validate.py \
+  /mnt/data/tmp/flm-native-complete-path/qwen36-35b-a3b-supersonic-native-int4.flm \
   --profile runnable-no-hf \
   --verify-payload-hashes
 ```
@@ -110,22 +111,43 @@ The model-store loader can validate the same artifact's native aliases without
 running generation:
 
 ```bash
-SUPERSONIC_QWEN36_35B_NATIVE_INT4_FLM=/mnt/data/runs/geo-quant/qwen36-35b-a3b-supersonic-native-int4.flm \
+SUPERSONIC_QWEN36_35B_NATIVE_INT4_FLM=/mnt/data/tmp/flm-native-complete-path/qwen36-35b-a3b-supersonic-native-int4.flm \
   cargo test -q -p model-store flm_qwen36_35b_native_int4_loadable -- --nocapture
 ```
 
 Then run the env-gated MoE runner smoke:
 
 ```bash
-SUPERSONIC_QWEN36_35B_A3B_NO_HF_FLM=/mnt/data/runs/geo-quant/qwen36-35b-a3b-supersonic-native-int4.flm \
+SUPERSONIC_QWEN36_35B_A3B_NO_HF_FLM=/mnt/data/tmp/flm-native-complete-path/qwen36-35b-a3b-supersonic-native-int4.flm \
   cargo test -q -p runner --test flm_moe_main_path -- --nocapture
 ```
 
 The MoE smoke runs one generated token with `--model qwen3.6-35b-a3b`,
-`--int4`, `--verify-flm-hashes`, and no HF snapshot. It asserts the MoE config,
-tokenizer, and weights all come from the single FLM source, that the FLM is
-opened exactly once, and that the run does not enter fetch, bake, config JSON,
-tokenizer JSON, safetensors, or `.supersonic` paths.
+`--verify-flm-hashes`, and no HF snapshot. It intentionally does not pass
+`--int4`: SuperSonic infers the executable weight mode from the FLM tensor
+views. The smoke asserts the MoE config, tokenizer, and weights all come from
+the single FLM source, that the FLM is opened exactly once, and that the run
+does not enter fetch, bake, config JSON, tokenizer JSON, safetensors, or
+`.supersonic` paths.
+
+For a direct manual smoke with load/decode timing, run the FLM as the model
+directory:
+
+```bash
+cargo run -q -p runner --bin supersonic -- \
+  --model qwen3.6-35b-a3b \
+  --model-dir /mnt/data/tmp/flm-native-complete-path/qwen36-35b-a3b-supersonic-native-int4.flm \
+  --backend hip \
+  --device 0 \
+  --prompt "Hello" \
+  --max-new-tokens 1 \
+  --context-size 16 \
+  --emit-stage-timings
+```
+
+For fast-load timing, leave `--verify-flm-hashes` off; enabling it reads and
+hashes the payload bytes during open and is an integrity check rather than the
+normal latency path.
 
 Compressed-tensors INT4 FLMs from geo-quant are tested separately through the
 portable fallback path. That path exposes logical CT INT4 weights as BF16 views

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -102,7 +102,7 @@ geo-quant's no-HF profile first:
 PYTHONPATH=/home/deano/.config/superpowers/worktrees/geo-quant/flm-first-class-path \
   /home/deano/projects/geo-quant/.venv-rocm/bin/python \
   /home/deano/.config/superpowers/worktrees/geo-quant/flm-first-class-path/scripts/flm_validate.py \
-  /mnt/data/tmp/flm-first-class-e2e-20260704/qwen36-35b-a3b-supersonic-native-int4.flm \
+  /mnt/data/tmp/flm-first-class-e2e-20260704/qwen36-35b-a3b-supersonic-native-int4-aligned.flm \
   --profile runnable-no-hf \
   --verify-payload-hashes
 ```
@@ -111,7 +111,7 @@ The model-store loader can validate the same artifact's native aliases without
 running generation:
 
 ```bash
-SUPERSONIC_QWEN36_35B_NATIVE_INT4_FLM=/mnt/data/tmp/flm-first-class-e2e-20260704/qwen36-35b-a3b-supersonic-native-int4.flm \
+SUPERSONIC_QWEN36_35B_NATIVE_INT4_FLM=/mnt/data/tmp/flm-first-class-e2e-20260704/qwen36-35b-a3b-supersonic-native-int4-aligned.flm \
 SUPERSONIC_QWEN36_35B_NATIVE_INT4_BAKE_DIR=/mnt/data/models/Qwen3.6-35B-A3B/.supersonic/v2-int4-gptq \
   cargo test -q -p model-store --test flm_qwen36_native_layout -- --nocapture
 ```
@@ -125,7 +125,7 @@ does not perform HF-layout reshapes in the normal FLM path.
 Then run the env-gated MoE runner smoke:
 
 ```bash
-SUPERSONIC_QWEN36_35B_A3B_NO_HF_FLM=/mnt/data/tmp/flm-first-class-e2e-20260704/qwen36-35b-a3b-supersonic-native-int4.flm \
+SUPERSONIC_QWEN36_35B_A3B_NO_HF_FLM=/mnt/data/tmp/flm-first-class-e2e-20260704/qwen36-35b-a3b-supersonic-native-int4-aligned.flm \
   cargo test -q -p runner --test flm_moe_main_path -- --nocapture
 ```
 
@@ -142,7 +142,7 @@ directory:
 
 ```bash
 cargo run -q -p runner --bin supersonic -- \
-  --model-dir /mnt/data/tmp/flm-first-class-e2e-20260704/qwen36-35b-a3b-supersonic-native-int4.flm \
+  --model-dir /mnt/data/tmp/flm-first-class-e2e-20260704/qwen36-35b-a3b-supersonic-native-int4-aligned.flm \
   --backend hip \
   --device 0 \
   --prompt "one two three four five six" \

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -149,6 +149,23 @@ For fast-load timing, leave `--verify-flm-hashes` off; enabling it reads and
 hashes the payload bytes during open and is an integrity check rather than the
 normal latency path.
 
+The Qwen3.6 benchmark harness has a matching FLM target profile. Build the
+runner binary first, then record a small timing JSON with:
+
+```bash
+python3 tests/gfx1100/bench_qwen36_he_supersonic.py \
+  --binary target/release/supersonic \
+  --target-profile qwen36-35b-a3b-flm \
+  --limit 1 \
+  --n-gen 1 \
+  --no-warmup \
+  --emit-stage-timings
+```
+
+The resulting JSON includes both decode throughput and parsed
+`[qwen36-moe lifecycle-timings]` fields such as `model_source_ms`,
+`layer_load_ms`, `generation_wall_ms`, and `total_wall_ms`.
+
 Compressed-tensors INT4 FLMs from geo-quant are tested separately through the
 portable fallback path. That path exposes logical CT INT4 weights as BF16 views
 when SuperSonic does not have a compatible direct execution plan:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -99,9 +99,9 @@ HIP decode path. Validate the native SuperSonic-layout artifact with
 geo-quant's no-HF profile first:
 
 ```bash
-PYTHONPATH=/home/deano/.config/superpowers/worktrees/geo-quant/flm-first-class-path \
-  /home/deano/projects/geo-quant/.venv-rocm/bin/python \
-  /home/deano/.config/superpowers/worktrees/geo-quant/flm-first-class-path/scripts/flm_validate.py \
+cd /home/deano/.config/superpowers/worktrees/geo-quant/flm-direct-io-alignment
+/home/deano/projects/geo-quant/.venv-rocm/bin/python \
+  -m geoquant.formats.flm_validate \
   /mnt/data/tmp/flm-first-class-e2e-20260704/qwen36-35b-a3b-supersonic-native-int4-aligned.flm \
   --profile runnable-no-hf \
   --verify-payload-hashes

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -163,7 +163,8 @@ python3 tests/gfx1100/bench_qwen36_he_supersonic.py \
 
 This FLM target profile passes the `.flm` as `--model-dir` without `--model`,
 so the run measures the same descriptor-inferred first-class path as the direct
-smoke above. The resulting JSON includes both decode throughput and parsed
+smoke above. The resulting JSON records `model: null`,
+`resolved_model: qwen3.6-35b-a3b`, decode throughput, and parsed
 `[qwen36-moe lifecycle-timings]` fields such as `model_source_ms`,
 `layer_load_ms`, `generation_wall_ms`, and `total_wall_ms`.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -177,14 +177,14 @@ smoke above. The resulting JSON records `model: null`,
 
 To validate ROCm 7.2 hipFile storage-to-device transfer on a host with
 `hipfile.h`, `libhipfile`, and passing `/opt/rocm/bin/ais-check`, use the FLM
-upload probe's storage-direct mode on a small direct tensor first:
+upload probe's storage-direct mode on a block-aligned expert tensor first:
 
 ```bash
 target/release/qwen36_flm_upload_probe \
   --model-dir /mnt/data/tmp/flm-first-class-e2e-20260704/qwen36-35b-a3b-supersonic-native-int4-aligned.flm \
   --backend hip \
   --device 0 \
-  --tensor model.language_model.layers.0.linear_attn.dt_bias \
+  --tensor model.language_model.layers.0.mlp.experts.gate_up_proj \
   --iters 1 \
   --storage-direct \
   --json
@@ -195,6 +195,10 @@ nonzero `copy_storage_to_device_ms` and `copy_storage_to_device_bytes`. On a
 build without hipFile support, the same command should fail with the explicit
 `ROCm >= 7.2 with hipfile.h and libhipfile` diagnostic before measuring an
 accidental pageable fallback.
+
+Do not use tiny tensors such as `linear_attn.dt_bias` for the storage-direct
+smoke. They are valid FLM payloads, but their byte length is below the 4 KiB
+direct-I/O block size; the probe rejects such ranges before calling hipFile.
 
 Compressed-tensors INT4 FLMs from geo-quant are tested separately through the
 portable fallback path. That path exposes logical CT INT4 weights as BF16 views

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -102,7 +102,7 @@ geo-quant's no-HF profile first:
 PYTHONPATH=/home/deano/.config/superpowers/worktrees/geo-quant/flm-first-class-path \
   /home/deano/projects/geo-quant/.venv-rocm/bin/python \
   /home/deano/.config/superpowers/worktrees/geo-quant/flm-first-class-path/scripts/flm_validate.py \
-  /mnt/data/tmp/flm-native-complete-path/qwen36-35b-a3b-supersonic-native-int4.flm \
+  /mnt/data/tmp/flm-first-class-e2e-20260704/qwen36-35b-a3b-supersonic-native-int4.flm \
   --profile runnable-no-hf \
   --verify-payload-hashes
 ```
@@ -111,7 +111,7 @@ The model-store loader can validate the same artifact's native aliases without
 running generation:
 
 ```bash
-SUPERSONIC_QWEN36_35B_NATIVE_INT4_FLM=/mnt/data/tmp/flm-native-complete-path/qwen36-35b-a3b-supersonic-native-int4.flm \
+SUPERSONIC_QWEN36_35B_NATIVE_INT4_FLM=/mnt/data/tmp/flm-first-class-e2e-20260704/qwen36-35b-a3b-supersonic-native-int4.flm \
 SUPERSONIC_QWEN36_35B_NATIVE_INT4_BAKE_DIR=/mnt/data/models/Qwen3.6-35B-A3B/.supersonic/v2-int4-gptq \
   cargo test -q -p model-store --test flm_qwen36_native_layout -- --nocapture
 ```
@@ -125,7 +125,7 @@ does not perform HF-layout reshapes in the normal FLM path.
 Then run the env-gated MoE runner smoke:
 
 ```bash
-SUPERSONIC_QWEN36_35B_A3B_NO_HF_FLM=/mnt/data/tmp/flm-native-complete-path/qwen36-35b-a3b-supersonic-native-int4.flm \
+SUPERSONIC_QWEN36_35B_A3B_NO_HF_FLM=/mnt/data/tmp/flm-first-class-e2e-20260704/qwen36-35b-a3b-supersonic-native-int4.flm \
   cargo test -q -p runner --test flm_moe_main_path -- --nocapture
 ```
 
@@ -142,7 +142,7 @@ directory:
 
 ```bash
 cargo run -q -p runner --bin supersonic -- \
-  --model-dir /mnt/data/tmp/flm-native-complete-path/qwen36-35b-a3b-supersonic-native-int4.flm \
+  --model-dir /mnt/data/tmp/flm-first-class-e2e-20260704/qwen36-35b-a3b-supersonic-native-int4.flm \
   --backend hip \
   --device 0 \
   --prompt "one two three four five six" \

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -122,20 +122,19 @@ SUPERSONIC_QWEN36_35B_A3B_NO_HF_FLM=/mnt/data/tmp/flm-native-complete-path/qwen3
   cargo test -q -p runner --test flm_moe_main_path -- --nocapture
 ```
 
-The MoE smoke runs one generated token with `--model qwen3.6-35b-a3b`,
-`--verify-flm-hashes`, and no HF snapshot. It intentionally does not pass
-`--int4`: SuperSonic infers the executable weight mode from the FLM tensor
-views. The smoke asserts the MoE config, tokenizer, and weights all come from
-the single FLM source, that the FLM is opened exactly once, and that the run
-does not enter fetch, bake, config JSON, tokenizer JSON, safetensors, or
-`.supersonic` paths.
+The MoE smoke runs one generated token with no HF snapshot. The FLM runtime
+descriptor supplies the model identity, and the smoke also covers omitting
+`--model` entirely. It intentionally does not pass `--int4`: SuperSonic infers
+the executable weight mode from the FLM tensor views. The smoke asserts the MoE
+config, tokenizer, and weights all come from the single FLM source, that the FLM
+is opened exactly once, and that the run does not enter fetch, bake, config
+JSON, tokenizer JSON, safetensors, or `.supersonic` paths.
 
 For a direct manual smoke with load/decode timing, run the FLM as the model
 directory:
 
 ```bash
 cargo run -q -p runner --bin supersonic -- \
-  --model qwen3.6-35b-a3b \
   --model-dir /mnt/data/tmp/flm-native-complete-path/qwen36-35b-a3b-supersonic-native-int4.flm \
   --backend hip \
   --device 0 \

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -161,7 +161,9 @@ python3 tests/gfx1100/bench_qwen36_he_supersonic.py \
   --emit-stage-timings
 ```
 
-The resulting JSON includes both decode throughput and parsed
+This FLM target profile passes the `.flm` as `--model-dir` without `--model`,
+so the run measures the same descriptor-inferred first-class path as the direct
+smoke above. The resulting JSON includes both decode throughput and parsed
 `[qwen36-moe lifecycle-timings]` fields such as `model_source_ms`,
 `layer_load_ms`, `generation_wall_ms`, and `total_wall_ms`.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -165,7 +165,8 @@ python3 tests/gfx1100/bench_qwen36_he_supersonic.py \
   --limit 1 \
   --n-gen 1 \
   --no-warmup \
-  --emit-stage-timings
+  --emit-stage-timings \
+  --hal-profile
 ```
 
 This FLM target profile passes the `.flm` as `--model-dir` without `--model`,
@@ -173,7 +174,10 @@ so the run measures the same descriptor-inferred first-class path as the direct
 smoke above. The resulting JSON records `model: null`,
 `resolved_model: qwen3.6-35b-a3b`, decode throughput, and parsed
 `[qwen36-moe lifecycle-timings]` fields such as `model_source_ms`,
-`layer_load_ms`, `generation_wall_ms`, and `total_wall_ms`.
+`layer_load_ms`, `generation_wall_ms`, and `total_wall_ms`. With
+`--hal-profile`, `summary.flm_load_speed` also records aggregate FLM transfer
+bytes, elapsed milliseconds, and GiB/s for `copy_h2d`; on a hipFile-enabled
+host it records the same values for `copy_storage_to_device`.
 
 To validate ROCm 7.2 hipFile storage-to-device transfer on a host with
 `hipfile.h`, `libhipfile`, and passing `/opt/rocm/bin/ais-check`, use the FLM

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -112,8 +112,15 @@ running generation:
 
 ```bash
 SUPERSONIC_QWEN36_35B_NATIVE_INT4_FLM=/mnt/data/tmp/flm-native-complete-path/qwen36-35b-a3b-supersonic-native-int4.flm \
-  cargo test -q -p model-store flm_qwen36_35b_native_int4_loadable -- --nocapture
+SUPERSONIC_QWEN36_35B_NATIVE_INT4_BAKE_DIR=/mnt/data/models/Qwen3.6-35B-A3B/.supersonic/v2-int4-gptq \
+  cargo test -q -p model-store --test flm_qwen36_native_layout -- --nocapture
 ```
+
+This guard compares the FLM direct values for Qwen3.6 linear attention against
+the SuperSonic runtime bake: `conv1d.weight` must already be
+`DepthwiseConvSqueezed`, `dt_bias` must be `[1, 1, H]`, and `A_log` must already
+be exponentiated BF16 `[1, 1, H]`. The loader labels and binds those bytes; it
+does not perform HF-layout reshapes in the normal FLM path.
 
 Then run the env-gated MoE runner smoke:
 
@@ -138,9 +145,9 @@ cargo run -q -p runner --bin supersonic -- \
   --model-dir /mnt/data/tmp/flm-native-complete-path/qwen36-35b-a3b-supersonic-native-int4.flm \
   --backend hip \
   --device 0 \
-  --prompt "Hello" \
+  --prompt "one two three four five six" \
   --max-new-tokens 1 \
-  --context-size 16 \
+  --context-size 64 \
   --emit-stage-timings
 ```
 

--- a/support/matrix.toml
+++ b/support/matrix.toml
@@ -29,6 +29,21 @@ support_doc = "docs/supported-matrix.md#hip-on-gfx1100"
 notes = "BF16 is intentionally unsupported for the FP8-native checkpoint. The Markdown matrix documents the INT4 lane, but this manifest keeps it experimental until a named gfx1100 35B gate exists."
 
 [[entry]]
+id = "hip-gfx1100-qwen36-35b-a3b-flm-int4"
+backend = "hip"
+arch = "gfx1100"
+status = "experimental"
+models = ["qwen3.6-35b-a3b"]
+quants = ["int4"]
+model_sources = ["flm"]
+support_doc = "docs/supported-matrix.md#hip-on-gfx1100"
+gate_commands = [
+  "SUPERSONIC_QWEN36_35B_A3B_NO_HF_FLM=/mnt/data/tmp/flm-first-class-e2e-20260704/qwen36-35b-a3b-supersonic-native-int4-aligned.flm cargo test -q -p runner --test flm_moe_main_path -- --nocapture",
+]
+benchmark_doc = "docs/testing.md#flm-main-path-smoke"
+notes = "First-class no-HF FLM lane: model identity, tokenizer, direct native INT4 weight mode, and load/decode timing come from the FLM artifact rather than HF sidecars or --int4."
+
+[[entry]]
 id = "hip-gfx1201-qwen35-tbm"
 backend = "hip"
 arch = "gfx1201"

--- a/tests/gfx1100/bench_qwen36_he_supersonic.py
+++ b/tests/gfx1100/bench_qwen36_he_supersonic.py
@@ -64,7 +64,9 @@ RESULT_RE = re.compile(
 )
 LIFECYCLE_RE = re.compile(r"\[qwen36-moe lifecycle-timings\]\s+(?P<body>.+)")
 STARTUP_RE = re.compile(r"\[qwen36-moe startup-timings\]\s+(?P<body>.+)")
-TIMING_KV_RE = re.compile(r"(?P<key>[a-zA-Z_]+)=(?P<value>-?[0-9]+(?:\.[0-9]+)?)")
+SPARSE_RESIDENCY_RE = re.compile(r"\[vmm\]\s+MoE island residency:\s+(?P<body>.+)")
+SPARSE_BREAKDOWN_RE = re.compile(r"\[qwen36-moe sparse-breakdown\]\s+(?P<body>.+)")
+TIMING_KV_RE = re.compile(r"(?P<key>[a-zA-Z_][a-zA-Z0-9_]*)=(?P<value>-?[0-9]+(?:\.[0-9]+)?)")
 INFERRED_MODEL_RE = re.compile(
     r"\[flm\]\s+inferred model (?P<model>\S+) from runtime descriptor"
 )
@@ -199,22 +201,36 @@ def parse_lifecycle_timings(text: str) -> dict[str, float] | None:
     match = LIFECYCLE_RE.search(text)
     if not match:
         return None
-    values = {
-        item.group("key"): float(item.group("value"))
-        for item in TIMING_KV_RE.finditer(match.group("body"))
-    }
-    return values or None
+    return parse_numeric_kv_body(match.group("body"))
 
 
 def parse_startup_timings(text: str) -> dict[str, float] | None:
     match = STARTUP_RE.search(text)
     if not match:
         return None
+    return parse_numeric_kv_body(match.group("body"))
+
+
+def parse_numeric_kv_body(body: str) -> dict[str, float] | None:
     values = {
         item.group("key"): float(item.group("value"))
-        for item in TIMING_KV_RE.finditer(match.group("body"))
+        for item in TIMING_KV_RE.finditer(body)
     }
     return values or None
+
+
+def parse_sparse_residency(text: str) -> dict[str, float] | None:
+    matches = list(SPARSE_RESIDENCY_RE.finditer(text))
+    if not matches:
+        return None
+    return parse_numeric_kv_body(matches[-1].group("body"))
+
+
+def parse_sparse_breakdown(text: str) -> dict[str, float] | None:
+    matches = list(SPARSE_BREAKDOWN_RE.finditer(text))
+    if not matches:
+        return None
+    return parse_numeric_kv_body(matches[-1].group("body"))
 
 
 def parse_inferred_model(text: str) -> str | None:
@@ -266,6 +282,16 @@ def parse_hal_profile_ops(text: str) -> dict[str, dict[str, float | int]] | None
         for match in HAL_PROFILE_OP_RE.finditer(text)
     }
     return ops or None
+
+
+def parse_runner_env_overrides(items: list[str] | None) -> dict[str, str]:
+    overrides: dict[str, str] = {}
+    for item in items or []:
+        key, sep, value = item.partition("=")
+        if not sep or not key:
+            raise ValueError(f"runner env override must be KEY=VALUE, got: {item!r}")
+        overrides[key] = value
+    return overrides
 
 
 def apply_target_profile(args: argparse.Namespace) -> None:
@@ -341,6 +367,8 @@ def run_one(args: argparse.Namespace, name: str, prompt: str, warmup: bool = Fal
         env["SUPERSONIC_METAL_PROFILE"] = "1"
     if dflash_draft_gguf is not None:
         env["SUPERSONIC_DFLASH_DRAFT_GGUF"] = str(dflash_draft_gguf)
+    runner_env_overrides = parse_runner_env_overrides(getattr(args, "runner_env", []))
+    env.update(runner_env_overrides)
 
     start = time.monotonic()
     proc = subprocess.run(
@@ -360,6 +388,8 @@ def run_one(args: argparse.Namespace, name: str, prompt: str, warmup: bool = Fal
         "stdout_tail": proc.stdout[-args.tail_chars :],
         "stderr_tail": proc.stderr[-args.tail_chars :],
     }
+    if runner_env_overrides:
+        row["runner_env"] = runner_env_overrides
     if match:
         row.update(
             {
@@ -379,6 +409,12 @@ def run_one(args: argparse.Namespace, name: str, prompt: str, warmup: bool = Fal
     startup_timings = parse_startup_timings(combined)
     if startup_timings:
         row["startup_timings"] = startup_timings
+    sparse_residency = parse_sparse_residency(combined)
+    if sparse_residency:
+        row["sparse_residency"] = sparse_residency
+    sparse_breakdown = parse_sparse_breakdown(combined)
+    if sparse_breakdown:
+        row["sparse_breakdown"] = sparse_breakdown
     resolved_model = parse_inferred_model(combined)
     if resolved_model:
         row["resolved_model"] = resolved_model
@@ -401,6 +437,23 @@ def run_one(args: argparse.Namespace, name: str, prompt: str, warmup: bool = Fal
         row["dflash_draft_dir"] = str(dflash_draft_dir)
         row["dflash_draft_gguf"] = str(dflash_draft_gguf) if dflash_draft_gguf else None
     return row
+
+
+def mean_common_numeric_field(rows: list[dict], field: str) -> dict[str, float] | None:
+    keys = sorted(
+        {
+            key
+            for row in rows
+            for key in row.get(field, {}).keys()
+            if all(key in other.get(field, {}) for other in rows)
+        }
+    )
+    if not keys:
+        return None
+    return {
+        key: sum(row[field][key] for row in rows) / len(rows)
+        for key in keys
+    }
 
 
 def build_summary(rows: list[dict]) -> dict:
@@ -446,6 +499,12 @@ def build_summary(rows: list[dict]) -> dict:
             key: sum(row["startup_timings"][key] for row in ok) / len(ok)
             for key in startup_keys
         }
+    mean_sparse_residency = mean_common_numeric_field(ok, "sparse_residency")
+    if mean_sparse_residency:
+        summary["mean_sparse_residency"] = mean_sparse_residency
+    mean_sparse_breakdown = mean_common_numeric_field(ok, "sparse_breakdown")
+    if mean_sparse_breakdown:
+        summary["mean_sparse_breakdown"] = mean_sparse_breakdown
     flm_weight_modes = sorted(
         {row["flm_weight_mode"] for row in ok if row.get("flm_weight_mode")}
     )
@@ -545,6 +604,16 @@ def main() -> int:
         action="store_true",
         help="Enable the runner HAL op dump and parse [hal-profile-op] rows into JSON.",
     )
+    parser.add_argument(
+        "--runner-env",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help=(
+            "Forward an environment override to the SuperSonic process. "
+            "Repeat for multiple overrides."
+        ),
+    )
     parser.add_argument("--kv-fp8", action="store_true")
     parser.add_argument(
         "--allow-untested-gpu",
@@ -587,6 +656,7 @@ def main() -> int:
         apply_lucebox_serving_mode(args)
     if args.stop_on_eos:
         args.ignore_eos = False
+    runner_env_overrides = parse_runner_env_overrides(args.runner_env)
 
     if not args.binary.exists():
         raise FileNotFoundError(args.binary)
@@ -655,6 +725,7 @@ def main() -> int:
         "lucebox_bench": str(args.lucebox_bench),
         "lucebox_jsonl": str(args.lucebox_jsonl),
         "lucebox_serving_mode": args.lucebox_serving_mode,
+        "runner_env": runner_env_overrides or None,
         "summary": summary,
         "rows": rows,
     }

--- a/tests/gfx1100/bench_qwen36_he_supersonic.py
+++ b/tests/gfx1100/bench_qwen36_he_supersonic.py
@@ -31,7 +31,7 @@ DEFAULT_27B_QUANT = "q4km-gptq"
 DEFAULT_35B_A3B_MODEL = "qwen3.6-35b-a3b"
 DEFAULT_35B_A3B_MODEL_DIR = Path("/mnt/data/models/Qwen3.6-35B-A3B")
 DEFAULT_35B_A3B_FLM_MODEL_DIR = Path(
-    "/mnt/data/tmp/flm-native-complete-path/qwen36-35b-a3b-supersonic-native-int4.flm"
+    "/mnt/data/tmp/flm-first-class-e2e-20260704/qwen36-35b-a3b-supersonic-native-int4.flm"
 )
 DEFAULT_35B_A3B_QUANT = "int4"
 DEFAULT_OUT_JSON = Path("target/qwen36_he_supersonic.json")

--- a/tests/gfx1100/bench_qwen36_he_supersonic.py
+++ b/tests/gfx1100/bench_qwen36_he_supersonic.py
@@ -63,6 +63,7 @@ RESULT_RE = re.compile(
     r"ms_per_(?:step|tok)=(?P<ms_per_step>[0-9.]+)"
 )
 LIFECYCLE_RE = re.compile(r"\[qwen36-moe lifecycle-timings\]\s+(?P<body>.+)")
+STARTUP_RE = re.compile(r"\[qwen36-moe startup-timings\]\s+(?P<body>.+)")
 TIMING_KV_RE = re.compile(r"(?P<key>[a-zA-Z_]+)=(?P<value>-?[0-9]+(?:\.[0-9]+)?)")
 INFERRED_MODEL_RE = re.compile(
     r"\[flm\]\s+inferred model (?P<model>\S+) from runtime descriptor"
@@ -188,6 +189,17 @@ def resolve_dflash_draft(args: argparse.Namespace) -> tuple[Path, Path | None, s
 
 def parse_lifecycle_timings(text: str) -> dict[str, float] | None:
     match = LIFECYCLE_RE.search(text)
+    if not match:
+        return None
+    values = {
+        item.group("key"): float(item.group("value"))
+        for item in TIMING_KV_RE.finditer(match.group("body"))
+    }
+    return values or None
+
+
+def parse_startup_timings(text: str) -> dict[str, float] | None:
+    match = STARTUP_RE.search(text)
     if not match:
         return None
     values = {
@@ -339,6 +351,9 @@ def run_one(args: argparse.Namespace, name: str, prompt: str, warmup: bool = Fal
     lifecycle_timings = parse_lifecycle_timings(combined)
     if lifecycle_timings:
         row["lifecycle_timings"] = lifecycle_timings
+    startup_timings = parse_startup_timings(combined)
+    if startup_timings:
+        row["startup_timings"] = startup_timings
     resolved_model = parse_inferred_model(combined)
     if resolved_model:
         row["resolved_model"] = resolved_model
@@ -389,6 +404,19 @@ def build_summary(rows: list[dict]) -> dict:
         summary["mean_lifecycle_timings"] = {
             key: sum(row["lifecycle_timings"][key] for row in ok) / len(ok)
             for key in lifecycle_keys
+        }
+    startup_keys = sorted(
+        {
+            key
+            for row in ok
+            for key in row.get("startup_timings", {}).keys()
+            if all(key in other.get("startup_timings", {}) for other in ok)
+        }
+    )
+    if startup_keys:
+        summary["mean_startup_timings"] = {
+            key: sum(row["startup_timings"][key] for row in ok) / len(ok)
+            for key in startup_keys
         }
     flm_weight_modes = sorted(
         {row["flm_weight_mode"] for row in ok if row.get("flm_weight_mode")}

--- a/tests/gfx1100/bench_qwen36_he_supersonic.py
+++ b/tests/gfx1100/bench_qwen36_he_supersonic.py
@@ -67,6 +67,13 @@ TIMING_KV_RE = re.compile(r"(?P<key>[a-zA-Z_]+)=(?P<value>-?[0-9]+(?:\.[0-9]+)?)
 INFERRED_MODEL_RE = re.compile(
     r"\[flm\]\s+inferred model (?P<model>\S+) from runtime descriptor"
 )
+FLM_WEIGHT_MODE_RE = re.compile(
+    r"\[qwen36-moe\]\s+FLM weight mode:\s+(?P<mode>[^\r\n]+)"
+)
+FLM_READY_RE = re.compile(
+    r"\[FLM runtime weights\]\s+ready-for-decode:\s+(?P<ready>YES|NO)"
+    r"(?:\s+\((?P<detail>[^\r\n)]*)\))?"
+)
 
 
 TARGET_PROFILES = {
@@ -190,6 +197,24 @@ def parse_inferred_model(text: str) -> str | None:
     return match.group("model")
 
 
+def parse_flm_weight_mode(text: str) -> str | None:
+    match = FLM_WEIGHT_MODE_RE.search(text)
+    if not match:
+        return None
+    return match.group("mode").strip()
+
+
+def parse_flm_ready_for_decode(text: str) -> dict[str, bool | str] | None:
+    match = FLM_READY_RE.search(text)
+    if not match:
+        return None
+    result: dict[str, bool | str] = {"ready": match.group("ready") == "YES"}
+    detail = match.group("detail")
+    if detail:
+        result["detail"] = detail
+    return result
+
+
 def apply_target_profile(args: argparse.Namespace) -> None:
     profile = TARGET_PROFILES[args.target_profile]
     if args.model is None:
@@ -298,6 +323,14 @@ def run_one(args: argparse.Namespace, name: str, prompt: str, warmup: bool = Fal
     resolved_model = parse_inferred_model(combined)
     if resolved_model:
         row["resolved_model"] = resolved_model
+    flm_weight_mode = parse_flm_weight_mode(combined)
+    if flm_weight_mode:
+        row["flm_weight_mode"] = flm_weight_mode
+    flm_ready = parse_flm_ready_for_decode(combined)
+    if flm_ready is not None:
+        row["flm_ready_for_decode"] = flm_ready["ready"]
+        if "detail" in flm_ready:
+            row["flm_ready_for_decode_detail"] = flm_ready["detail"]
     if args.dflash:
         row["dflash_draft_label"] = dflash_draft_label
         row["dflash_draft_dir"] = str(dflash_draft_dir)
@@ -335,6 +368,15 @@ def build_summary(rows: list[dict]) -> dict:
             key: sum(row["lifecycle_timings"][key] for row in ok) / len(ok)
             for key in lifecycle_keys
         }
+    flm_weight_modes = sorted(
+        {row["flm_weight_mode"] for row in ok if row.get("flm_weight_mode")}
+    )
+    if flm_weight_modes:
+        summary["flm_weight_modes"] = flm_weight_modes
+    if any("flm_ready_for_decode" in row for row in ok):
+        summary["flm_ready_for_decode_count"] = sum(
+            1 for row in ok if row.get("flm_ready_for_decode")
+        )
     return summary
 
 
@@ -509,6 +551,10 @@ def main() -> int:
         "summary": summary,
         "rows": rows,
     }
+    if "flm_weight_modes" in summary:
+        payload["flm_weight_modes"] = summary["flm_weight_modes"]
+    if "flm_ready_for_decode_count" in summary:
+        payload["flm_ready_for_decode_count"] = summary["flm_ready_for_decode_count"]
     args.out_json.parent.mkdir(parents=True, exist_ok=True)
     args.out_json.write_text(json.dumps(payload, indent=2))
     print("-" * 70)

--- a/tests/gfx1100/bench_qwen36_he_supersonic.py
+++ b/tests/gfx1100/bench_qwen36_he_supersonic.py
@@ -346,6 +346,9 @@ def run_one(args: argparse.Namespace, name: str, prompt: str, warmup: bool = Fal
     allow_untested_gpu = getattr(args, "allow_untested_gpu", None)
     if allow_untested_gpu:
         cmd.extend(["--allow-untested-gpu", allow_untested_gpu])
+    flm_virtual_transfer_backend = getattr(args, "flm_virtual_transfer_backend", None)
+    if flm_virtual_transfer_backend:
+        cmd.extend(["--flm-virtual-transfer-backend", flm_virtual_transfer_backend])
     if args.quant != "none":
         cmd.append(f"--{args.quant}")
     if args.ignore_eos:
@@ -390,6 +393,8 @@ def run_one(args: argparse.Namespace, name: str, prompt: str, warmup: bool = Fal
     }
     if runner_env_overrides:
         row["runner_env"] = runner_env_overrides
+    if flm_virtual_transfer_backend:
+        row["flm_virtual_transfer_backend"] = flm_virtual_transfer_backend
     if match:
         row.update(
             {
@@ -600,6 +605,15 @@ def main() -> int:
     )
     parser.add_argument("--emit-stage-timings", action="store_true")
     parser.add_argument(
+        "--flm-virtual-transfer-backend",
+        choices=["pageable-h2d", "gpu-direct-storage", "gds", "hipfile"],
+        default=None,
+        help=(
+            "Forward SuperSonic's FLM virtual transfer backend selector. "
+            "Explicit CLI selection takes precedence over runner env overrides."
+        ),
+    )
+    parser.add_argument(
         "--hal-profile",
         action="store_true",
         help="Enable the runner HAL op dump and parse [hal-profile-op] rows into JSON.",
@@ -717,6 +731,7 @@ def main() -> int:
         "dflash_block": args.dflash_block if args.dflash_block else None,
         "backend": args.backend,
         "allow_untested_gpu": args.allow_untested_gpu,
+        "flm_virtual_transfer_backend": args.flm_virtual_transfer_backend,
         "context_size": args.context_size,
         "n_gen": args.n_gen,
         "eos_policy": "ignore" if args.ignore_eos else "stop",

--- a/tests/gfx1100/bench_qwen36_he_supersonic.py
+++ b/tests/gfx1100/bench_qwen36_he_supersonic.py
@@ -70,6 +70,13 @@ INFERRED_MODEL_RE = re.compile(
 FLM_WEIGHT_MODE_RE = re.compile(
     r"\[qwen36-moe\]\s+FLM weight mode:\s+(?P<mode>[^\r\n]+)"
 )
+FLM_DIRECT_PROFILE_RE = re.compile(
+    r"\[qwen36-moe\]\s+FLM direct plans:\s+"
+    r"required=(?P<required>\d+)\s+"
+    r"raw_dense=(?P<raw_dense>\d+)\s+"
+    r"native_int4=(?P<native_int4>\d+)\s+"
+    r"bf16_fallback=(?P<bf16_fallback>\d+)"
+)
 FLM_READY_RE = re.compile(
     r"\[FLM runtime weights\]\s+ready-for-decode:\s+(?P<ready>YES|NO)"
     r"(?:\s+\((?P<detail>[^\r\n)]*)\))?"
@@ -204,6 +211,18 @@ def parse_flm_weight_mode(text: str) -> str | None:
     return match.group("mode").strip()
 
 
+def parse_flm_direct_profile(text: str) -> dict[str, int] | None:
+    match = FLM_DIRECT_PROFILE_RE.search(text)
+    if not match:
+        return None
+    return {
+        "required": int(match.group("required")),
+        "raw_dense": int(match.group("raw_dense")),
+        "native_int4": int(match.group("native_int4")),
+        "bf16_fallback": int(match.group("bf16_fallback")),
+    }
+
+
 def parse_flm_ready_for_decode(text: str) -> dict[str, bool | str] | None:
     match = FLM_READY_RE.search(text)
     if not match:
@@ -326,6 +345,9 @@ def run_one(args: argparse.Namespace, name: str, prompt: str, warmup: bool = Fal
     flm_weight_mode = parse_flm_weight_mode(combined)
     if flm_weight_mode:
         row["flm_weight_mode"] = flm_weight_mode
+    flm_direct_profile = parse_flm_direct_profile(combined)
+    if flm_direct_profile:
+        row["flm_direct_profile"] = flm_direct_profile
     flm_ready = parse_flm_ready_for_decode(combined)
     if flm_ready is not None:
         row["flm_ready_for_decode"] = flm_ready["ready"]
@@ -377,6 +399,13 @@ def build_summary(rows: list[dict]) -> dict:
         summary["flm_ready_for_decode_count"] = sum(
             1 for row in ok if row.get("flm_ready_for_decode")
         )
+    flm_direct_profiles = []
+    for row in ok:
+        profile = row.get("flm_direct_profile")
+        if profile and profile not in flm_direct_profiles:
+            flm_direct_profiles.append(profile)
+    if flm_direct_profiles:
+        summary["flm_direct_profiles"] = flm_direct_profiles
     return summary
 
 

--- a/tests/gfx1100/bench_qwen36_he_supersonic.py
+++ b/tests/gfx1100/bench_qwen36_he_supersonic.py
@@ -64,6 +64,9 @@ RESULT_RE = re.compile(
 )
 LIFECYCLE_RE = re.compile(r"\[qwen36-moe lifecycle-timings\]\s+(?P<body>.+)")
 TIMING_KV_RE = re.compile(r"(?P<key>[a-zA-Z_]+)=(?P<value>-?[0-9]+(?:\.[0-9]+)?)")
+INFERRED_MODEL_RE = re.compile(
+    r"\[flm\]\s+inferred model (?P<model>\S+) from runtime descriptor"
+)
 
 
 TARGET_PROFILES = {
@@ -180,6 +183,13 @@ def parse_lifecycle_timings(text: str) -> dict[str, float] | None:
     return values or None
 
 
+def parse_inferred_model(text: str) -> str | None:
+    match = INFERRED_MODEL_RE.search(text)
+    if not match:
+        return None
+    return match.group("model")
+
+
 def apply_target_profile(args: argparse.Namespace) -> None:
     profile = TARGET_PROFILES[args.target_profile]
     if args.model is None:
@@ -285,6 +295,9 @@ def run_one(args: argparse.Namespace, name: str, prompt: str, warmup: bool = Fal
     lifecycle_timings = parse_lifecycle_timings(combined)
     if lifecycle_timings:
         row["lifecycle_timings"] = lifecycle_timings
+    resolved_model = parse_inferred_model(combined)
+    if resolved_model:
+        row["resolved_model"] = resolved_model
     if args.dflash:
         row["dflash_draft_label"] = dflash_draft_label
         row["dflash_draft_dir"] = str(dflash_draft_dir)
@@ -468,9 +481,14 @@ def main() -> int:
         return 1
     summary = build_summary(rows)
     dflash_draft_dir, dflash_draft_gguf, dflash_draft_label = resolve_dflash_draft(args)
+    resolved_model = args.model or next(
+        (row["resolved_model"] for row in rows if row.get("resolved_model")),
+        None,
+    )
     payload = {
         "schema": "supersonic-qwen36-he-comparison-v2",
         "model": args.model,
+        "resolved_model": resolved_model,
         "model_dir": str(args.model_dir),
         "quant": args.quant,
         "dflash": args.dflash,

--- a/tests/gfx1100/bench_qwen36_he_supersonic.py
+++ b/tests/gfx1100/bench_qwen36_he_supersonic.py
@@ -31,7 +31,7 @@ DEFAULT_27B_QUANT = "q4km-gptq"
 DEFAULT_35B_A3B_MODEL = "qwen3.6-35b-a3b"
 DEFAULT_35B_A3B_MODEL_DIR = Path("/mnt/data/models/Qwen3.6-35B-A3B")
 DEFAULT_35B_A3B_FLM_MODEL_DIR = Path(
-    "/mnt/data/tmp/flm-first-class-e2e-20260704/qwen36-35b-a3b-supersonic-native-int4.flm"
+    "/mnt/data/tmp/flm-first-class-e2e-20260704/qwen36-35b-a3b-supersonic-native-int4-aligned.flm"
 )
 DEFAULT_35B_A3B_QUANT = "int4"
 DEFAULT_OUT_JSON = Path("target/qwen36_he_supersonic.json")

--- a/tests/gfx1100/bench_qwen36_he_supersonic.py
+++ b/tests/gfx1100/bench_qwen36_he_supersonic.py
@@ -30,9 +30,13 @@ DEFAULT_27B_MODEL_DIR = Path("/mnt/data/tmp/supersonic-qwen36-27b-lucebox")
 DEFAULT_27B_QUANT = "q4km-gptq"
 DEFAULT_35B_A3B_MODEL = "qwen3.6-35b-a3b"
 DEFAULT_35B_A3B_MODEL_DIR = Path("/mnt/data/models/Qwen3.6-35B-A3B")
+DEFAULT_35B_A3B_FLM_MODEL_DIR = Path(
+    "/mnt/data/tmp/flm-native-complete-path/qwen36-35b-a3b-supersonic-native-int4.flm"
+)
 DEFAULT_35B_A3B_QUANT = "int4"
 DEFAULT_OUT_JSON = Path("target/qwen36_he_supersonic.json")
 DEFAULT_35B_A3B_OUT_JSON = Path("target/qwen36_35b_a3b_he_supersonic.json")
+DEFAULT_35B_A3B_FLM_OUT_JSON = Path("target/qwen36_35b_a3b_flm_he_supersonic.json")
 DEFAULT_CONTEXT_SIZE = 512
 LUCEBOX_SERVING_CONTEXT_SIZE = 1024
 LUCEBOX_DRAFT_ALIASES = {
@@ -58,6 +62,8 @@ RESULT_RE = re.compile(
     r"decode_ms=(?P<decode_ms>[0-9.]+)\s+"
     r"ms_per_(?:step|tok)=(?P<ms_per_step>[0-9.]+)"
 )
+LIFECYCLE_RE = re.compile(r"\[qwen36-moe lifecycle-timings\]\s+(?P<body>.+)")
+TIMING_KV_RE = re.compile(r"(?P<key>[a-zA-Z_]+)=(?P<value>-?[0-9]+(?:\.[0-9]+)?)")
 
 
 TARGET_PROFILES = {
@@ -72,6 +78,12 @@ TARGET_PROFILES = {
         "model_dir": DEFAULT_35B_A3B_MODEL_DIR,
         "quant": DEFAULT_35B_A3B_QUANT,
         "out_json": DEFAULT_35B_A3B_OUT_JSON,
+    },
+    "qwen36-35b-a3b-flm": {
+        "model": DEFAULT_35B_A3B_MODEL,
+        "model_dir": DEFAULT_35B_A3B_FLM_MODEL_DIR,
+        "quant": "none",
+        "out_json": DEFAULT_35B_A3B_FLM_OUT_JSON,
     },
 }
 
@@ -155,6 +167,17 @@ def resolve_dflash_draft(args: argparse.Namespace) -> tuple[Path, Path | None, s
     if config_dir is None:
         config_dir = DEFAULT_SUPERSONIC_DFLASH_DRAFT_DIR
     return Path(config_dir), Path(gguf) if gguf else None, label
+
+
+def parse_lifecycle_timings(text: str) -> dict[str, float] | None:
+    match = LIFECYCLE_RE.search(text)
+    if not match:
+        return None
+    values = {
+        item.group("key"): float(item.group("value"))
+        for item in TIMING_KV_RE.finditer(match.group("body"))
+    }
+    return values or None
 
 
 def apply_target_profile(args: argparse.Namespace) -> None:
@@ -259,6 +282,9 @@ def run_one(args: argparse.Namespace, name: str, prompt: str, warmup: bool = Fal
                 "tok_s": 1000.0 / float(match.group("ms_per_step")),
             }
         )
+    lifecycle_timings = parse_lifecycle_timings(combined)
+    if lifecycle_timings:
+        row["lifecycle_timings"] = lifecycle_timings
     if args.dflash:
         row["dflash_draft_label"] = dflash_draft_label
         row["dflash_draft_dir"] = str(dflash_draft_dir)
@@ -270,7 +296,7 @@ def build_summary(rows: list[dict]) -> dict:
     ok = [r for r in rows if r.get("returncode") == 0 and "tok_s" in r]
     total_generated = sum(r["generated_tokens"] for r in ok)
     total_decode_ms = sum(r["decode_ms"] for r in ok)
-    return {
+    summary = {
         "count": len(ok),
         "mean_tok_s": sum(r["tok_s"] for r in ok) / len(ok),
         "weighted_tok_s": (1000.0 * total_generated / total_decode_ms)
@@ -283,6 +309,20 @@ def build_summary(rows: list[dict]) -> dict:
         "total_decode_ms": total_decode_ms,
         "stopped_early_count": sum(1 for r in ok if r.get("stopped_early")),
     }
+    lifecycle_keys = sorted(
+        {
+            key
+            for row in ok
+            for key in row.get("lifecycle_timings", {}).keys()
+            if all(key in other.get("lifecycle_timings", {}) for other in ok)
+        }
+    )
+    if lifecycle_keys:
+        summary["mean_lifecycle_timings"] = {
+            key: sum(row["lifecycle_timings"][key] for row in ok) / len(ok)
+            for key in lifecycle_keys
+        }
+    return summary
 
 
 def main() -> int:

--- a/tests/gfx1100/bench_qwen36_he_supersonic.py
+++ b/tests/gfx1100/bench_qwen36_he_supersonic.py
@@ -295,6 +295,32 @@ def parse_runner_env_overrides(items: list[str] | None) -> dict[str, str]:
     return overrides
 
 
+def requires_flm_first_class_evidence(args: argparse.Namespace) -> bool:
+    model_dir = getattr(args, "model_dir", None)
+    return isinstance(model_dir, Path) and model_dir.suffix == ".flm"
+
+
+def flm_first_class_validation_errors(args: argparse.Namespace, row: dict) -> list[str]:
+    errors: list[str] = []
+    if (
+        getattr(args, "model", None) is None
+        and row.get("resolved_model") != DEFAULT_35B_A3B_MODEL
+    ):
+        errors.append("FLM run did not report inferred model from runtime descriptor")
+    if row.get("flm_weight_mode") != "INT4 native FLM":
+        errors.append("FLM run did not report INT4 native FLM weight mode")
+    if row.get("flm_ready_for_decode") is not True:
+        errors.append("FLM run did not report ready-for-decode YES")
+    direct_profile = row.get("flm_direct_profile")
+    if (
+        not isinstance(direct_profile, dict)
+        or int(direct_profile.get("native_int4", 0)) <= 0
+        or int(direct_profile.get("bf16_fallback", 0)) != 0
+    ):
+        errors.append("FLM run did not report native INT4 direct plan coverage")
+    return errors
+
+
 def apply_target_profile(args: argparse.Namespace) -> None:
     profile = TARGET_PROFILES[args.target_profile]
     if args.model is None:
@@ -442,6 +468,12 @@ def run_one(args: argparse.Namespace, name: str, prompt: str, warmup: bool = Fal
         row["dflash_draft_label"] = dflash_draft_label
         row["dflash_draft_dir"] = str(dflash_draft_dir)
         row["dflash_draft_gguf"] = str(dflash_draft_gguf) if dflash_draft_gguf else None
+    if proc.returncode == 0 and requires_flm_first_class_evidence(args):
+        validation_errors = flm_first_class_validation_errors(args, row)
+        if validation_errors:
+            row["runner_returncode"] = proc.returncode
+            row["returncode"] = 1
+            row["benchmark_validation_errors"] = validation_errors
     return row
 
 

--- a/tests/gfx1100/bench_qwen36_he_supersonic.py
+++ b/tests/gfx1100/bench_qwen36_he_supersonic.py
@@ -39,6 +39,7 @@ DEFAULT_35B_A3B_OUT_JSON = Path("target/qwen36_35b_a3b_he_supersonic.json")
 DEFAULT_35B_A3B_FLM_OUT_JSON = Path("target/qwen36_35b_a3b_flm_he_supersonic.json")
 DEFAULT_CONTEXT_SIZE = 512
 LUCEBOX_SERVING_CONTEXT_SIZE = 1024
+GIB = 1024.0 * 1024.0 * 1024.0
 LUCEBOX_DRAFT_ALIASES = {
     "supersonic-q8-bf16": {
         "label": "supersonic-q8-bf16",
@@ -461,6 +462,62 @@ def mean_common_numeric_field(rows: list[dict], field: str) -> dict[str, float] 
     }
 
 
+def gib_per_second(bytes_count: int | float, elapsed_ms: int | float) -> float:
+    if elapsed_ms <= 0:
+        return 0.0
+    return (float(bytes_count) / GIB) / (float(elapsed_ms) / 1000.0)
+
+
+def build_flm_load_speed_summary(rows: list[dict]) -> dict[str, float | int] | None:
+    summary: dict[str, float | int] = {}
+    h2d_rows = [
+        row
+        for row in rows
+        if "layer_load_copy_h_to_d_bytes" in row.get("lifecycle_timings", {})
+        and "layer_load_copy_h_to_d_ms" in row.get("lifecycle_timings", {})
+    ]
+    if h2d_rows:
+        h2d_bytes = sum(
+            int(row["lifecycle_timings"]["layer_load_copy_h_to_d_bytes"])
+            for row in h2d_rows
+        )
+        h2d_ms = sum(
+            float(row["lifecycle_timings"]["layer_load_copy_h_to_d_ms"])
+            for row in h2d_rows
+        )
+        if h2d_bytes > 0 and h2d_ms > 0:
+            summary.update(
+                {
+                    "layer_load_copy_h_to_d_bytes": h2d_bytes,
+                    "layer_load_copy_h_to_d_ms": h2d_ms,
+                    "layer_load_copy_h_to_d_gib_s": gib_per_second(h2d_bytes, h2d_ms),
+                }
+            )
+
+    for op in ("copy_h2d", "copy_storage_to_device"):
+        op_rows = [row for row in rows if op in row.get("hal_profile_ops", {})]
+        if not op_rows:
+            continue
+        op_bytes = sum(
+            int(row["hal_profile_ops"][op]["total_bytes"])
+            for row in op_rows
+        )
+        op_ms = sum(
+            float(row["hal_profile_ops"][op]["total_ms"])
+            for row in op_rows
+        )
+        if op_bytes <= 0 or op_ms <= 0:
+            continue
+        summary.update(
+            {
+                f"{op}_bytes": op_bytes,
+                f"{op}_ms": op_ms,
+                f"{op}_gib_s": gib_per_second(op_bytes, op_ms),
+            }
+        )
+    return summary or None
+
+
 def build_summary(rows: list[dict]) -> dict:
     ok = [r for r in rows if r.get("returncode") == 0 and "tok_s" in r]
     total_generated = sum(r["generated_tokens"] for r in ok)
@@ -543,6 +600,9 @@ def build_summary(rows: list[dict]) -> dict:
             }
             for op in hal_op_names
         }
+    flm_load_speed = build_flm_load_speed_summary(ok)
+    if flm_load_speed:
+        summary["flm_load_speed"] = flm_load_speed
     return summary
 
 

--- a/tests/gfx1100/bench_qwen36_he_supersonic.py
+++ b/tests/gfx1100/bench_qwen36_he_supersonic.py
@@ -80,7 +80,7 @@ TARGET_PROFILES = {
         "out_json": DEFAULT_35B_A3B_OUT_JSON,
     },
     "qwen36-35b-a3b-flm": {
-        "model": DEFAULT_35B_A3B_MODEL,
+        "model": None,
         "model_dir": DEFAULT_35B_A3B_FLM_MODEL_DIR,
         "quant": "none",
         "out_json": DEFAULT_35B_A3B_FLM_OUT_JSON,
@@ -209,8 +209,6 @@ def run_one(args: argparse.Namespace, name: str, prompt: str, warmup: bool = Fal
         str(args.binary),
         "--backend",
         args.backend,
-        "--model",
-        args.model,
         "--model-dir",
         str(args.model_dir),
         "--prompt",
@@ -227,6 +225,8 @@ def run_one(args: argparse.Namespace, name: str, prompt: str, warmup: bool = Fal
         str(args.seed),
         "--no-download",
     ]
+    if args.model is not None:
+        cmd.extend(["--model", args.model])
     if args.prompt_no_special_tokens:
         cmd.append("--prompt-no-special-tokens")
     allow_untested_gpu = getattr(args, "allow_untested_gpu", None)

--- a/tests/gfx1100/bench_qwen36_he_supersonic.py
+++ b/tests/gfx1100/bench_qwen36_he_supersonic.py
@@ -82,6 +82,14 @@ FLM_READY_RE = re.compile(
     r"\[FLM runtime weights\]\s+ready-for-decode:\s+(?P<ready>YES|NO)"
     r"(?:\s+\((?P<detail>[^\r\n)]*)\))?"
 )
+HAL_PROFILE_OP_RE = re.compile(
+    r"\[hal-profile-op\]\s+op=(?P<op>\S+)\s+"
+    r"calls=(?P<calls>\d+)\s+"
+    r"mean_ms=(?P<mean_ms>[0-9.]+)\s+"
+    r"total_ms=(?P<total_ms>[0-9.]+)\s+"
+    r"max_ms=(?P<max_ms>[0-9.]+)\s+"
+    r"total_bytes=(?P<total_bytes>\d+)"
+)
 
 
 TARGET_PROFILES = {
@@ -246,6 +254,20 @@ def parse_flm_ready_for_decode(text: str) -> dict[str, bool | str] | None:
     return result
 
 
+def parse_hal_profile_ops(text: str) -> dict[str, dict[str, float | int]] | None:
+    ops = {
+        match.group("op"): {
+            "calls": int(match.group("calls")),
+            "mean_ms": float(match.group("mean_ms")),
+            "total_ms": float(match.group("total_ms")),
+            "max_ms": float(match.group("max_ms")),
+            "total_bytes": int(match.group("total_bytes")),
+        }
+        for match in HAL_PROFILE_OP_RE.finditer(text)
+    }
+    return ops or None
+
+
 def apply_target_profile(args: argparse.Namespace) -> None:
     profile = TARGET_PROFILES[args.target_profile]
     if args.model is None:
@@ -314,6 +336,9 @@ def run_one(args: argparse.Namespace, name: str, prompt: str, warmup: bool = Fal
 
     env = os.environ.copy()
     env["SUPERSONIC_BACKENDS"] = args.backend
+    if getattr(args, "hal_profile", False):
+        # This runner hook emits gpu-hal rows as [hal-profile-op] lines.
+        env["SUPERSONIC_METAL_PROFILE"] = "1"
     if dflash_draft_gguf is not None:
         env["SUPERSONIC_DFLASH_DRAFT_GGUF"] = str(dflash_draft_gguf)
 
@@ -368,6 +393,9 @@ def run_one(args: argparse.Namespace, name: str, prompt: str, warmup: bool = Fal
         row["flm_ready_for_decode"] = flm_ready["ready"]
         if "detail" in flm_ready:
             row["flm_ready_for_decode_detail"] = flm_ready["detail"]
+    hal_profile_ops = parse_hal_profile_ops(combined)
+    if hal_profile_ops:
+        row["hal_profile_ops"] = hal_profile_ops
     if args.dflash:
         row["dflash_draft_label"] = dflash_draft_label
         row["dflash_draft_dir"] = str(dflash_draft_dir)
@@ -434,6 +462,23 @@ def build_summary(rows: list[dict]) -> dict:
             flm_direct_profiles.append(profile)
     if flm_direct_profiles:
         summary["flm_direct_profiles"] = flm_direct_profiles
+    hal_op_names = sorted(
+        {
+            op
+            for row in ok
+            for op in row.get("hal_profile_ops", {}).keys()
+            if all(op in other.get("hal_profile_ops", {}) for other in ok)
+        }
+    )
+    if hal_op_names:
+        hal_metrics = ("calls", "mean_ms", "total_ms", "max_ms", "total_bytes")
+        summary["mean_hal_profile_ops"] = {
+            op: {
+                metric: sum(row["hal_profile_ops"][op][metric] for row in ok) / len(ok)
+                for metric in hal_metrics
+            }
+            for op in hal_op_names
+        }
     return summary
 
 
@@ -495,6 +540,11 @@ def main() -> int:
         default=True,
     )
     parser.add_argument("--emit-stage-timings", action="store_true")
+    parser.add_argument(
+        "--hal-profile",
+        action="store_true",
+        help="Enable the runner HAL op dump and parse [hal-profile-op] rows into JSON.",
+    )
     parser.add_argument("--kv-fp8", action="store_true")
     parser.add_argument(
         "--allow-untested-gpu",

--- a/tests/test_qwen36_he_supersonic_bench.py
+++ b/tests/test_qwen36_he_supersonic_bench.py
@@ -451,6 +451,83 @@ class BenchQwen36HeSuperSonicTests(unittest.TestCase):
             },
         )
 
+    def test_build_summary_derives_flm_load_speed_metrics(self):
+        rows = [
+            {
+                "returncode": 0,
+                "tok_s": 25.0,
+                "generated_tokens": 10,
+                "decode_ms": 400.0,
+                "ms_per_step": 40.0,
+                "stopped_early": False,
+                "lifecycle_timings": {
+                    "layer_load_copy_h_to_d_ms": 500.0,
+                    "layer_load_copy_h_to_d_bytes": 8 * 1024 * 1024 * 1024,
+                },
+                "hal_profile_ops": {
+                    "copy_h2d": {
+                        "calls": 8,
+                        "mean_ms": 25.0,
+                        "total_ms": 200.0,
+                        "max_ms": 50.0,
+                        "total_bytes": 6 * 1024 * 1024 * 1024,
+                    },
+                    "copy_storage_to_device": {
+                        "calls": 2,
+                        "mean_ms": 100.0,
+                        "total_ms": 200.0,
+                        "max_ms": 125.0,
+                        "total_bytes": 4 * 1024 * 1024 * 1024,
+                    },
+                },
+            },
+            {
+                "returncode": 0,
+                "tok_s": 50.0,
+                "generated_tokens": 20,
+                "decode_ms": 400.0,
+                "ms_per_step": 20.0,
+                "stopped_early": False,
+                "lifecycle_timings": {
+                    "layer_load_copy_h_to_d_ms": 1000.0,
+                    "layer_load_copy_h_to_d_bytes": 16 * 1024 * 1024 * 1024,
+                },
+                "hal_profile_ops": {
+                    "copy_h2d": {
+                        "calls": 12,
+                        "mean_ms": 50.0,
+                        "total_ms": 600.0,
+                        "max_ms": 100.0,
+                        "total_bytes": 18 * 1024 * 1024 * 1024,
+                    },
+                    "copy_storage_to_device": {
+                        "calls": 3,
+                        "mean_ms": 200.0,
+                        "total_ms": 600.0,
+                        "max_ms": 250.0,
+                        "total_bytes": 12 * 1024 * 1024 * 1024,
+                    },
+                },
+            },
+        ]
+
+        summary = bench.build_summary(rows)
+
+        self.assertEqual(
+            summary["flm_load_speed"],
+            {
+                "layer_load_copy_h_to_d_bytes": 24 * 1024 * 1024 * 1024,
+                "layer_load_copy_h_to_d_ms": 1500.0,
+                "layer_load_copy_h_to_d_gib_s": 16.0,
+                "copy_h2d_bytes": 24 * 1024 * 1024 * 1024,
+                "copy_h2d_ms": 800.0,
+                "copy_h2d_gib_s": 30.0,
+                "copy_storage_to_device_bytes": 16 * 1024 * 1024 * 1024,
+                "copy_storage_to_device_ms": 800.0,
+                "copy_storage_to_device_gib_s": 20.0,
+            },
+        )
+
     def test_build_summary_includes_mean_sparse_metrics_when_present(self):
         rows = [
             {

--- a/tests/test_qwen36_he_supersonic_bench.py
+++ b/tests/test_qwen36_he_supersonic_bench.py
@@ -273,6 +273,34 @@ class BenchQwen36HeSuperSonicTests(unittest.TestCase):
             },
         )
 
+    def test_parse_hal_profile_ops(self):
+        output = (
+            "[hal-profile-op] op=copy_h2d calls=1518 mean_ms=0.5289 "
+            "total_ms=802.919 max_ms=38.764 total_bytes=17908409344\n"
+            "[hal-profile-op] op=vmm_map_no_sync calls=80 mean_ms=0.0243 "
+            "total_ms=1.942 max_ms=0.043 total_bytes=16106127360\n"
+        )
+
+        self.assertEqual(
+            bench.parse_hal_profile_ops(output),
+            {
+                "copy_h2d": {
+                    "calls": 1518,
+                    "mean_ms": 0.5289,
+                    "total_ms": 802.919,
+                    "max_ms": 38.764,
+                    "total_bytes": 17908409344,
+                },
+                "vmm_map_no_sync": {
+                    "calls": 80,
+                    "mean_ms": 0.0243,
+                    "total_ms": 1.942,
+                    "max_ms": 0.043,
+                    "total_bytes": 16106127360,
+                },
+            },
+        )
+
     def test_build_summary_includes_mean_startup_timings_when_present(self):
         rows = [
             {
@@ -314,6 +342,73 @@ class BenchQwen36HeSuperSonicTests(unittest.TestCase):
                 "bake_prepare_ms": 0.0,
                 "dry_run_ms": 5.0,
                 "pre_decode_total_ms": 155.0,
+            },
+        )
+
+    def test_build_summary_includes_mean_hal_profile_ops_when_present(self):
+        rows = [
+            {
+                "returncode": 0,
+                "tok_s": 25.0,
+                "generated_tokens": 10,
+                "decode_ms": 400.0,
+                "ms_per_step": 40.0,
+                "stopped_early": False,
+                "hal_profile_ops": {
+                    "copy_h2d": {
+                        "calls": 10,
+                        "mean_ms": 1.0,
+                        "total_ms": 10.0,
+                        "max_ms": 4.0,
+                        "total_bytes": 100,
+                    },
+                    "vmm_map_no_sync": {
+                        "calls": 2,
+                        "mean_ms": 0.5,
+                        "total_ms": 1.0,
+                        "max_ms": 0.7,
+                        "total_bytes": 200,
+                    },
+                },
+            },
+            {
+                "returncode": 0,
+                "tok_s": 50.0,
+                "generated_tokens": 20,
+                "decode_ms": 400.0,
+                "ms_per_step": 20.0,
+                "stopped_early": False,
+                "hal_profile_ops": {
+                    "copy_h2d": {
+                        "calls": 20,
+                        "mean_ms": 2.0,
+                        "total_ms": 40.0,
+                        "max_ms": 8.0,
+                        "total_bytes": 300,
+                    },
+                    "vmm_map": {
+                        "calls": 1,
+                        "mean_ms": 0.4,
+                        "total_ms": 0.4,
+                        "max_ms": 0.4,
+                        "total_bytes": 50,
+                    },
+                },
+            },
+        ]
+
+        summary = bench.build_summary(rows)
+
+        self.assertEqual(
+            summary["mean_hal_profile_ops"],
+            {
+                "copy_h2d": {
+                    "calls": 15.0,
+                    "mean_ms": 1.5,
+                    "total_ms": 25.0,
+                    "max_ms": 6.0,
+                    "total_bytes": 200.0,
+                }
             },
         )
 
@@ -409,6 +504,44 @@ class BenchQwen36HeSuperSonicTests(unittest.TestCase):
         self.assertTrue(row["stopped_early"])
         self.assertEqual(row["dflash_draft_label"], "lucebox-q8-0")
 
+    def test_run_one_hal_profile_sets_runner_profile_env(self):
+        args = types.SimpleNamespace(
+            binary=Path("target/release/supersonic"),
+            backend="hip",
+            model=None,
+            model_dir=bench.DEFAULT_35B_A3B_FLM_MODEL_DIR,
+            context_size=16,
+            warmup_new_tokens=1,
+            n_gen=1,
+            seed=1,
+            prompt_no_special_tokens=False,
+            quant="none",
+            ignore_eos=True,
+            emit_stage_timings=True,
+            kv_fp8=False,
+            dflash=False,
+            dflash_block=0,
+            dflash_draft_variant=None,
+            dflash_draft_dir=bench.DEFAULT_SUPERSONIC_DFLASH_DRAFT_DIR,
+            dflash_draft_gguf=None,
+            timeout=10,
+            tail_chars=200,
+            allow_untested_gpu=None,
+            hal_profile=True,
+        )
+        completed = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="",
+            stderr="[result] prompt_tokens=1 generated_tokens=1 decode_ms=10 ms_per_step=10\n",
+        )
+
+        with mock.patch.object(bench.subprocess, "run", return_value=completed) as run:
+            bench.run_one(args, "case", "Hello")
+
+        env = run.call_args.kwargs["env"]
+        self.assertEqual(env["SUPERSONIC_METAL_PROFILE"], "1")
+
     def test_run_one_flm_profile_omits_int4_and_records_lifecycle_timings(self):
         args = types.SimpleNamespace(
             binary=Path("target/release/supersonic"),
@@ -478,6 +611,8 @@ class BenchQwen36HeSuperSonicTests(unittest.TestCase):
                 "prefill_steps=0 prefill_embed_ms=0.000 prefill_chain_ms=0.000 "
                 "prefill_total_ms=0.000 generation_wall_ms=41.006 "
                 "total_wall_ms=6307.287\n"
+                "[hal-profile-op] op=copy_h2d calls=1518 mean_ms=0.5289 "
+                "total_ms=802.919 max_ms=38.764 total_bytes=17908409344\n"
             ),
         )
         with mock.patch.object(bench.subprocess, "run", return_value=completed) as run:
@@ -548,6 +683,18 @@ class BenchQwen36HeSuperSonicTests(unittest.TestCase):
                 "prefill_total_ms": 0.0,
                 "generation_wall_ms": 41.006,
                 "total_wall_ms": 6307.287,
+            },
+        )
+        self.assertEqual(
+            row["hal_profile_ops"],
+            {
+                "copy_h2d": {
+                    "calls": 1518,
+                    "mean_ms": 0.5289,
+                    "total_ms": 802.919,
+                    "max_ms": 38.764,
+                    "total_bytes": 17908409344,
+                }
             },
         )
 

--- a/tests/test_qwen36_he_supersonic_bench.py
+++ b/tests/test_qwen36_he_supersonic_bench.py
@@ -301,6 +301,45 @@ class BenchQwen36HeSuperSonicTests(unittest.TestCase):
             },
         )
 
+    def test_parse_sparse_residency_and_breakdown_metrics(self):
+        output = (
+            "[vmm] MoE island residency: resident_slices=17 peak_slices=19 "
+            "resident_pages=16 peak_pages=16 uploaded=161448.00MiB "
+            "unmapped=161416.00MiB resident=32.00MiB peak_resident=32.00MiB "
+            "total_vmm_resident=72.00MiB total_vmm_reserved=15400.00MiB\n"
+            "[qwen36-moe sparse-breakdown] route_d2h_calls=3510 "
+            "route_d2h_ms=84284.259 route_d2h_avg_ms=24.013 "
+            "demand_prefetch_calls=160 demand_prefetch_ms=16185.783 "
+            "demand_prefetch_avg_ms=101.161\n"
+        )
+
+        self.assertEqual(
+            bench.parse_sparse_residency(output),
+            {
+                "resident_slices": 17.0,
+                "peak_slices": 19.0,
+                "resident_pages": 16.0,
+                "peak_pages": 16.0,
+                "uploaded": 161448.0,
+                "unmapped": 161416.0,
+                "resident": 32.0,
+                "peak_resident": 32.0,
+                "total_vmm_resident": 72.0,
+                "total_vmm_reserved": 15400.0,
+            },
+        )
+        self.assertEqual(
+            bench.parse_sparse_breakdown(output),
+            {
+                "route_d2h_calls": 3510.0,
+                "route_d2h_ms": 84284.259,
+                "route_d2h_avg_ms": 24.013,
+                "demand_prefetch_calls": 160.0,
+                "demand_prefetch_ms": 16185.783,
+                "demand_prefetch_avg_ms": 101.161,
+            },
+        )
+
     def test_build_summary_includes_mean_startup_timings_when_present(self):
         rows = [
             {
@@ -409,6 +448,63 @@ class BenchQwen36HeSuperSonicTests(unittest.TestCase):
                     "max_ms": 6.0,
                     "total_bytes": 200.0,
                 }
+            },
+        )
+
+    def test_build_summary_includes_mean_sparse_metrics_when_present(self):
+        rows = [
+            {
+                "returncode": 0,
+                "tok_s": 25.0,
+                "generated_tokens": 10,
+                "decode_ms": 400.0,
+                "ms_per_step": 40.0,
+                "stopped_early": False,
+                "sparse_residency": {
+                    "uploaded": 160000.0,
+                    "resident": 32.0,
+                    "peak_resident": 32.0,
+                },
+                "sparse_breakdown": {
+                    "route_d2h_avg_ms": 24.0,
+                    "demand_prefetch_avg_ms": 100.0,
+                    "cap8_only": 1.0,
+                },
+            },
+            {
+                "returncode": 0,
+                "tok_s": 50.0,
+                "generated_tokens": 20,
+                "decode_ms": 400.0,
+                "ms_per_step": 20.0,
+                "stopped_early": False,
+                "sparse_residency": {
+                    "uploaded": 170000.0,
+                    "resident": 64.0,
+                    "peak_resident": 64.0,
+                },
+                "sparse_breakdown": {
+                    "route_d2h_avg_ms": 26.0,
+                    "demand_prefetch_avg_ms": 110.0,
+                },
+            },
+        ]
+
+        summary = bench.build_summary(rows)
+
+        self.assertEqual(
+            summary["mean_sparse_residency"],
+            {
+                "peak_resident": 48.0,
+                "resident": 48.0,
+                "uploaded": 165000.0,
+            },
+        )
+        self.assertEqual(
+            summary["mean_sparse_breakdown"],
+            {
+                "demand_prefetch_avg_ms": 105.0,
+                "route_d2h_avg_ms": 25.0,
             },
         )
 
@@ -541,6 +637,70 @@ class BenchQwen36HeSuperSonicTests(unittest.TestCase):
 
         env = run.call_args.kwargs["env"]
         self.assertEqual(env["SUPERSONIC_METAL_PROFILE"], "1")
+
+    def test_run_one_sets_runner_env_and_records_sparse_metrics(self):
+        args = types.SimpleNamespace(
+            binary=Path("target/release/supersonic"),
+            backend="hip",
+            model=None,
+            model_dir=bench.DEFAULT_35B_A3B_FLM_MODEL_DIR,
+            context_size=16,
+            warmup_new_tokens=1,
+            n_gen=1,
+            seed=1,
+            prompt_no_special_tokens=False,
+            quant="none",
+            ignore_eos=True,
+            emit_stage_timings=True,
+            kv_fp8=False,
+            dflash=False,
+            dflash_block=0,
+            dflash_draft_variant=None,
+            dflash_draft_dir=bench.DEFAULT_SUPERSONIC_DFLASH_DRAFT_DIR,
+            dflash_draft_gguf=None,
+            timeout=10,
+            tail_chars=200,
+            allow_untested_gpu=None,
+            hal_profile=True,
+            runner_env=["SUPERSONIC_MOE_ISLAND_CAP_EXPERTS=8"],
+        )
+        completed = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="",
+            stderr=(
+                "[vmm] MoE island residency: resident_pages=16 uploaded=161448.00MiB "
+                "resident=32.00MiB peak_resident=32.00MiB\n"
+                "[result] prompt_tokens=1 generated_tokens=1 decode_ms=10 "
+                "ms_per_step=10\n"
+                "[qwen36-moe sparse-breakdown] route_d2h_calls=3510 "
+                "route_d2h_ms=84284.259 demand_prefetch_avg_ms=101.161\n"
+            ),
+        )
+
+        with mock.patch.object(bench.subprocess, "run", return_value=completed) as run:
+            row = bench.run_one(args, "case", "Hello")
+
+        env = run.call_args.kwargs["env"]
+        self.assertEqual(env["SUPERSONIC_MOE_ISLAND_CAP_EXPERTS"], "8")
+        self.assertEqual(row["runner_env"], {"SUPERSONIC_MOE_ISLAND_CAP_EXPERTS": "8"})
+        self.assertEqual(
+            row["sparse_residency"],
+            {
+                "resident_pages": 16.0,
+                "uploaded": 161448.0,
+                "resident": 32.0,
+                "peak_resident": 32.0,
+            },
+        )
+        self.assertEqual(
+            row["sparse_breakdown"],
+            {
+                "route_d2h_calls": 3510.0,
+                "route_d2h_ms": 84284.259,
+                "demand_prefetch_avg_ms": 101.161,
+            },
+        )
 
     def test_run_one_flm_profile_omits_int4_and_records_lifecycle_timings(self):
         args = types.SimpleNamespace(

--- a/tests/test_qwen36_he_supersonic_bench.py
+++ b/tests/test_qwen36_he_supersonic_bench.py
@@ -113,6 +113,15 @@ class BenchQwen36HeSuperSonicTests(unittest.TestCase):
         self.assertEqual(args.quant, "none")
         self.assertEqual(args.out_json, bench.DEFAULT_35B_A3B_FLM_OUT_JSON)
 
+    def test_qwen36_35b_a3b_flm_profile_points_at_current_e2e_artifact(self):
+        self.assertEqual(
+            bench.DEFAULT_35B_A3B_FLM_MODEL_DIR,
+            Path(
+                "/mnt/data/tmp/flm-first-class-e2e-20260704/"
+                "qwen36-35b-a3b-supersonic-native-int4.flm"
+            ),
+        )
+
     def test_apply_target_profile_preserves_explicit_args(self):
         args = types.SimpleNamespace(
             target_profile="qwen36-35b-a3b",

--- a/tests/test_qwen36_he_supersonic_bench.py
+++ b/tests/test_qwen36_he_supersonic_bench.py
@@ -702,6 +702,48 @@ class BenchQwen36HeSuperSonicTests(unittest.TestCase):
             },
         )
 
+    def test_run_one_forwards_flm_virtual_transfer_backend_flag(self):
+        args = types.SimpleNamespace(
+            binary=Path("target/release/supersonic"),
+            backend="hip",
+            model=None,
+            model_dir=bench.DEFAULT_35B_A3B_FLM_MODEL_DIR,
+            context_size=16,
+            warmup_new_tokens=1,
+            n_gen=1,
+            seed=1,
+            prompt_no_special_tokens=False,
+            quant="none",
+            ignore_eos=True,
+            emit_stage_timings=True,
+            kv_fp8=False,
+            dflash=False,
+            dflash_block=0,
+            dflash_draft_variant=None,
+            dflash_draft_dir=bench.DEFAULT_SUPERSONIC_DFLASH_DRAFT_DIR,
+            dflash_draft_gguf=None,
+            timeout=10,
+            tail_chars=200,
+            allow_untested_gpu=None,
+            hal_profile=False,
+            runner_env=[],
+            flm_virtual_transfer_backend="hipfile",
+        )
+        completed = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="",
+            stderr="[result] prompt_tokens=1 generated_tokens=1 decode_ms=10 ms_per_step=10\n",
+        )
+
+        with mock.patch.object(bench.subprocess, "run", return_value=completed) as run:
+            row = bench.run_one(args, "case", "Hello")
+
+        cmd = run.call_args.args[0]
+        self.assertIn("--flm-virtual-transfer-backend", cmd)
+        self.assertIn("hipfile", cmd)
+        self.assertEqual(row["flm_virtual_transfer_backend"], "hipfile")
+
     def test_run_one_flm_profile_omits_int4_and_records_lifecycle_timings(self):
         args = types.SimpleNamespace(
             binary=Path("target/release/supersonic"),

--- a/tests/test_qwen36_he_supersonic_bench.py
+++ b/tests/test_qwen36_he_supersonic_bench.py
@@ -118,7 +118,7 @@ class BenchQwen36HeSuperSonicTests(unittest.TestCase):
             bench.DEFAULT_35B_A3B_FLM_MODEL_DIR,
             Path(
                 "/mnt/data/tmp/flm-first-class-e2e-20260704/"
-                "qwen36-35b-a3b-supersonic-native-int4.flm"
+                "qwen36-35b-a3b-supersonic-native-int4-aligned.flm"
             ),
         )
 

--- a/tests/test_qwen36_he_supersonic_bench.py
+++ b/tests/test_qwen36_he_supersonic_bench.py
@@ -977,6 +977,55 @@ class BenchQwen36HeSuperSonicTests(unittest.TestCase):
             },
         )
 
+    def test_run_one_flm_profile_fails_without_first_class_flm_evidence(self):
+        args = types.SimpleNamespace(
+            binary=Path("target/release/supersonic"),
+            backend="hip",
+            model=None,
+            model_dir=bench.DEFAULT_35B_A3B_FLM_MODEL_DIR,
+            context_size=16,
+            warmup_new_tokens=1,
+            n_gen=1,
+            seed=1,
+            prompt_no_special_tokens=False,
+            quant="none",
+            ignore_eos=True,
+            emit_stage_timings=True,
+            kv_fp8=False,
+            dflash=False,
+            dflash_block=0,
+            dflash_draft_variant=None,
+            dflash_draft_dir=bench.DEFAULT_SUPERSONIC_DFLASH_DRAFT_DIR,
+            dflash_draft_gguf=None,
+            timeout=10,
+            tail_chars=200,
+            allow_untested_gpu=None,
+            hal_profile=False,
+            runner_env=[],
+            flm_virtual_transfer_backend=None,
+        )
+        completed = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="",
+            stderr="[result] prompt_tokens=1 generated_tokens=1 decode_ms=10 ms_per_step=10\n",
+        )
+
+        with mock.patch.object(bench.subprocess, "run", return_value=completed):
+            row = bench.run_one(args, "case", "Hello")
+
+        self.assertEqual(row["returncode"], 1)
+        self.assertEqual(row["runner_returncode"], 0)
+        self.assertEqual(
+            row["benchmark_validation_errors"],
+            [
+                "FLM run did not report inferred model from runtime descriptor",
+                "FLM run did not report INT4 native FLM weight mode",
+                "FLM run did not report ready-for-decode YES",
+                "FLM run did not report native INT4 direct plan coverage",
+            ],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_qwen36_he_supersonic_bench.py
+++ b/tests/test_qwen36_he_supersonic_bench.py
@@ -256,6 +256,67 @@ class BenchQwen36HeSuperSonicTests(unittest.TestCase):
             },
         )
 
+    def test_parse_qwen36_startup_timings(self):
+        output = (
+            "[qwen36-moe startup-timings] flm_source_open_ms=123.456 "
+            "bake_prepare_ms=0.000 dry_run_ms=4.500 "
+            "pre_decode_total_ms=127.956\n"
+        )
+
+        self.assertEqual(
+            bench.parse_startup_timings(output),
+            {
+                "flm_source_open_ms": 123.456,
+                "bake_prepare_ms": 0.0,
+                "dry_run_ms": 4.5,
+                "pre_decode_total_ms": 127.956,
+            },
+        )
+
+    def test_build_summary_includes_mean_startup_timings_when_present(self):
+        rows = [
+            {
+                "returncode": 0,
+                "tok_s": 25.0,
+                "generated_tokens": 10,
+                "decode_ms": 400.0,
+                "ms_per_step": 40.0,
+                "stopped_early": False,
+                "startup_timings": {
+                    "flm_source_open_ms": 100.0,
+                    "bake_prepare_ms": 0.0,
+                    "dry_run_ms": 4.0,
+                    "pre_decode_total_ms": 104.0,
+                },
+            },
+            {
+                "returncode": 0,
+                "tok_s": 50.0,
+                "generated_tokens": 20,
+                "decode_ms": 400.0,
+                "ms_per_step": 20.0,
+                "stopped_early": False,
+                "startup_timings": {
+                    "flm_source_open_ms": 200.0,
+                    "bake_prepare_ms": 0.0,
+                    "dry_run_ms": 6.0,
+                    "pre_decode_total_ms": 206.0,
+                },
+            },
+        ]
+
+        summary = bench.build_summary(rows)
+
+        self.assertEqual(
+            summary["mean_startup_timings"],
+            {
+                "flm_source_open_ms": 150.0,
+                "bake_prepare_ms": 0.0,
+                "dry_run_ms": 5.0,
+                "pre_decode_total_ms": 155.0,
+            },
+        )
+
     def test_build_summary_includes_flm_direct_execution_evidence(self):
         rows = [
             {
@@ -384,6 +445,9 @@ class BenchQwen36HeSuperSonicTests(unittest.TestCase):
                 "native_int4=330 bf16_fallback=0\n"
                 "[FLM runtime weights] ready-for-decode: YES "
                 "(source=/tmp/qwen36.flm)\n"
+                "[qwen36-moe startup-timings] flm_source_open_ms=123.456 "
+                "bake_prepare_ms=0.000 dry_run_ms=4.500 "
+                "pre_decode_total_ms=127.956\n"
                 "[result] prompt_tokens=1 generated_tokens=1 decode_ms=41 "
                 "ms_per_step=41.0\n"
                 "[qwen36-moe lifecycle-timings] prompt_setup_ms=55.351 "
@@ -415,6 +479,15 @@ class BenchQwen36HeSuperSonicTests(unittest.TestCase):
                 "raw_dense": 363,
                 "native_int4": 330,
                 "bf16_fallback": 0,
+            },
+        )
+        self.assertEqual(
+            row["startup_timings"],
+            {
+                "flm_source_open_ms": 123.456,
+                "bake_prepare_ms": 0.0,
+                "dry_run_ms": 4.5,
+                "pre_decode_total_ms": 127.956,
             },
         )
         self.assertEqual(

--- a/tests/test_qwen36_he_supersonic_bench.py
+++ b/tests/test_qwen36_he_supersonic_bench.py
@@ -158,6 +158,19 @@ class BenchQwen36HeSuperSonicTests(unittest.TestCase):
         self.assertIsNone(args.dflash_draft_variant)
         self.assertEqual(args.context_size, bench.LUCEBOX_SERVING_CONTEXT_SIZE)
 
+    def test_parse_flm_direct_execution_signals(self):
+        output = (
+            "[qwen36-moe] FLM weight mode: INT4 native FLM\n"
+            "[FLM runtime weights] ready-for-decode: YES "
+            "(source=/tmp/qwen36.flm)\n"
+        )
+
+        self.assertEqual(bench.parse_flm_weight_mode(output), "INT4 native FLM")
+        self.assertEqual(
+            bench.parse_flm_ready_for_decode(output),
+            {"ready": True, "detail": "source=/tmp/qwen36.flm"},
+        )
+
     def test_build_summary_includes_token_weighted_throughput(self):
         rows = [
             {
@@ -231,6 +244,35 @@ class BenchQwen36HeSuperSonicTests(unittest.TestCase):
                 "total_wall_ms": 6000.0,
             },
         )
+
+    def test_build_summary_includes_flm_direct_execution_evidence(self):
+        rows = [
+            {
+                "returncode": 0,
+                "tok_s": 25.0,
+                "generated_tokens": 10,
+                "decode_ms": 400.0,
+                "ms_per_step": 40.0,
+                "stopped_early": False,
+                "flm_weight_mode": "INT4 native FLM",
+                "flm_ready_for_decode": True,
+            },
+            {
+                "returncode": 0,
+                "tok_s": 50.0,
+                "generated_tokens": 20,
+                "decode_ms": 400.0,
+                "ms_per_step": 20.0,
+                "stopped_early": False,
+                "flm_weight_mode": "INT4 native FLM",
+            },
+            {"returncode": 1, "flm_weight_mode": "BF16"},
+        ]
+
+        summary = bench.build_summary(rows)
+
+        self.assertEqual(summary["flm_weight_modes"], ["INT4 native FLM"])
+        self.assertEqual(summary["flm_ready_for_decode_count"], 1)
 
     def test_run_one_sets_gguf_env_and_stop_on_eos_command(self):
         args = types.SimpleNamespace(
@@ -309,6 +351,9 @@ class BenchQwen36HeSuperSonicTests(unittest.TestCase):
             stdout="",
             stderr=(
                 "[flm] inferred model qwen3.6-35b-a3b from runtime descriptor\n"
+                "[qwen36-moe] FLM weight mode: INT4 native FLM\n"
+                "[FLM runtime weights] ready-for-decode: YES "
+                "(source=/tmp/qwen36.flm)\n"
                 "[result] prompt_tokens=1 generated_tokens=1 decode_ms=41 "
                 "ms_per_step=41.0\n"
                 "[qwen36-moe lifecycle-timings] prompt_setup_ms=55.351 "
@@ -330,6 +375,9 @@ class BenchQwen36HeSuperSonicTests(unittest.TestCase):
         self.assertIn("--emit-stage-timings", cmd)
         self.assertEqual(row["generated_tokens"], 1)
         self.assertEqual(row.get("resolved_model"), "qwen3.6-35b-a3b")
+        self.assertEqual(row["flm_weight_mode"], "INT4 native FLM")
+        self.assertTrue(row["flm_ready_for_decode"])
+        self.assertEqual(row["flm_ready_for_decode_detail"], "source=/tmp/qwen36.flm")
         self.assertEqual(
             row["lifecycle_timings"],
             {

--- a/tests/test_qwen36_he_supersonic_bench.py
+++ b/tests/test_qwen36_he_supersonic_bench.py
@@ -461,7 +461,20 @@ class BenchQwen36HeSuperSonicTests(unittest.TestCase):
                 "flm_tokenizer_parse_merges_ms=5.000 "
                 "flm_tokenizer_parse_added_tokens_ms=0.250 "
                 "flm_tokenizer_parse_regex_ms=0.125 "
-                "model_source_ms=0.009 layer_load_ms=5744.555 session_ms=466.101 "
+                "model_source_ms=0.009 layer_load_ms=5744.555 "
+                "layer_load_buffers_ms=5400.000 "
+                "layer_load_vmm_setup_ms=10.000 "
+                "layer_load_prewarm_ms=0.000 "
+                "layer_load_hal_ms=4500.000 "
+                "layer_load_alloc_ms=1200.000 "
+                "layer_load_copy_h_to_d_ms=3000.000 "
+                "layer_load_memset_ms=100.000 "
+                "layer_load_vmm_ms=200.000 "
+                "layer_load_alloc_bytes=123456 "
+                "layer_load_copy_h_to_d_bytes=654321 "
+                "layer_load_memset_bytes=4096 "
+                "layer_load_vmm_bytes=8192 "
+                "session_ms=466.101 "
                 "prefill_steps=0 prefill_embed_ms=0.000 prefill_chain_ms=0.000 "
                 "prefill_total_ms=0.000 generation_wall_ms=41.006 "
                 "total_wall_ms=6307.287\n"
@@ -516,6 +529,18 @@ class BenchQwen36HeSuperSonicTests(unittest.TestCase):
                 "flm_tokenizer_parse_regex_ms": 0.125,
                 "model_source_ms": 0.009,
                 "layer_load_ms": 5744.555,
+                "layer_load_buffers_ms": 5400.0,
+                "layer_load_vmm_setup_ms": 10.0,
+                "layer_load_prewarm_ms": 0.0,
+                "layer_load_hal_ms": 4500.0,
+                "layer_load_alloc_ms": 1200.0,
+                "layer_load_copy_h_to_d_ms": 3000.0,
+                "layer_load_memset_ms": 100.0,
+                "layer_load_vmm_ms": 200.0,
+                "layer_load_alloc_bytes": 123456.0,
+                "layer_load_copy_h_to_d_bytes": 654321.0,
+                "layer_load_memset_bytes": 4096.0,
+                "layer_load_vmm_bytes": 8192.0,
                 "session_ms": 466.101,
                 "prefill_steps": 0.0,
                 "prefill_embed_ms": 0.0,

--- a/tests/test_qwen36_he_supersonic_bench.py
+++ b/tests/test_qwen36_he_supersonic_bench.py
@@ -299,6 +299,7 @@ class BenchQwen36HeSuperSonicTests(unittest.TestCase):
             returncode=0,
             stdout="",
             stderr=(
+                "[flm] inferred model qwen3.6-35b-a3b from runtime descriptor\n"
                 "[result] prompt_tokens=1 generated_tokens=1 decode_ms=41 "
                 "ms_per_step=41.0\n"
                 "[qwen36-moe lifecycle-timings] prompt_setup_ms=55.351 "
@@ -319,6 +320,7 @@ class BenchQwen36HeSuperSonicTests(unittest.TestCase):
         self.assertNotIn("--int4", cmd)
         self.assertIn("--emit-stage-timings", cmd)
         self.assertEqual(row["generated_tokens"], 1)
+        self.assertEqual(row.get("resolved_model"), "qwen3.6-35b-a3b")
         self.assertEqual(
             row["lifecycle_timings"],
             {

--- a/tests/test_qwen36_he_supersonic_bench.py
+++ b/tests/test_qwen36_he_supersonic_bench.py
@@ -161,11 +161,22 @@ class BenchQwen36HeSuperSonicTests(unittest.TestCase):
     def test_parse_flm_direct_execution_signals(self):
         output = (
             "[qwen36-moe] FLM weight mode: INT4 native FLM\n"
+            "[qwen36-moe] FLM direct plans: required=693 raw_dense=363 "
+            "native_int4=330 bf16_fallback=0\n"
             "[FLM runtime weights] ready-for-decode: YES "
             "(source=/tmp/qwen36.flm)\n"
         )
 
         self.assertEqual(bench.parse_flm_weight_mode(output), "INT4 native FLM")
+        self.assertEqual(
+            bench.parse_flm_direct_profile(output),
+            {
+                "required": 693,
+                "raw_dense": 363,
+                "native_int4": 330,
+                "bf16_fallback": 0,
+            },
+        )
         self.assertEqual(
             bench.parse_flm_ready_for_decode(output),
             {"ready": True, "detail": "source=/tmp/qwen36.flm"},
@@ -256,6 +267,12 @@ class BenchQwen36HeSuperSonicTests(unittest.TestCase):
                 "stopped_early": False,
                 "flm_weight_mode": "INT4 native FLM",
                 "flm_ready_for_decode": True,
+                "flm_direct_profile": {
+                    "required": 693,
+                    "raw_dense": 363,
+                    "native_int4": 330,
+                    "bf16_fallback": 0,
+                },
             },
             {
                 "returncode": 0,
@@ -273,6 +290,17 @@ class BenchQwen36HeSuperSonicTests(unittest.TestCase):
 
         self.assertEqual(summary["flm_weight_modes"], ["INT4 native FLM"])
         self.assertEqual(summary["flm_ready_for_decode_count"], 1)
+        self.assertEqual(
+            summary["flm_direct_profiles"],
+            [
+                {
+                    "required": 693,
+                    "raw_dense": 363,
+                    "native_int4": 330,
+                    "bf16_fallback": 0,
+                }
+            ],
+        )
 
     def test_run_one_sets_gguf_env_and_stop_on_eos_command(self):
         args = types.SimpleNamespace(
@@ -352,6 +380,8 @@ class BenchQwen36HeSuperSonicTests(unittest.TestCase):
             stderr=(
                 "[flm] inferred model qwen3.6-35b-a3b from runtime descriptor\n"
                 "[qwen36-moe] FLM weight mode: INT4 native FLM\n"
+                "[qwen36-moe] FLM direct plans: required=693 raw_dense=363 "
+                "native_int4=330 bf16_fallback=0\n"
                 "[FLM runtime weights] ready-for-decode: YES "
                 "(source=/tmp/qwen36.flm)\n"
                 "[result] prompt_tokens=1 generated_tokens=1 decode_ms=41 "
@@ -378,6 +408,15 @@ class BenchQwen36HeSuperSonicTests(unittest.TestCase):
         self.assertEqual(row["flm_weight_mode"], "INT4 native FLM")
         self.assertTrue(row["flm_ready_for_decode"])
         self.assertEqual(row["flm_ready_for_decode_detail"], "source=/tmp/qwen36.flm")
+        self.assertEqual(
+            row["flm_direct_profile"],
+            {
+                "required": 693,
+                "raw_dense": 363,
+                "native_int4": 330,
+                "bf16_fallback": 0,
+            },
+        )
         self.assertEqual(
             row["lifecycle_timings"],
             {

--- a/tests/test_qwen36_he_supersonic_bench.py
+++ b/tests/test_qwen36_he_supersonic_bench.py
@@ -446,11 +446,21 @@ class BenchQwen36HeSuperSonicTests(unittest.TestCase):
                 "[FLM runtime weights] ready-for-decode: YES "
                 "(source=/tmp/qwen36.flm)\n"
                 "[qwen36-moe startup-timings] flm_source_open_ms=123.456 "
+                "flm_tokenizer_parse_vocab_ms=0.000 "
+                "flm_tokenizer_parse_vocab_ids_ms=0.000 "
+                "flm_tokenizer_parse_merges_ms=0.000 "
+                "flm_tokenizer_parse_added_tokens_ms=0.000 "
+                "flm_tokenizer_parse_regex_ms=0.000 "
                 "bake_prepare_ms=0.000 dry_run_ms=4.500 "
                 "pre_decode_total_ms=127.956\n"
                 "[result] prompt_tokens=1 generated_tokens=1 decode_ms=41 "
                 "ms_per_step=41.0\n"
                 "[qwen36-moe lifecycle-timings] prompt_setup_ms=55.351 "
+                "flm_tokenizer_parse_vocab_ms=10.000 "
+                "flm_tokenizer_parse_vocab_ids_ms=0.500 "
+                "flm_tokenizer_parse_merges_ms=5.000 "
+                "flm_tokenizer_parse_added_tokens_ms=0.250 "
+                "flm_tokenizer_parse_regex_ms=0.125 "
                 "model_source_ms=0.009 layer_load_ms=5744.555 session_ms=466.101 "
                 "prefill_steps=0 prefill_embed_ms=0.000 prefill_chain_ms=0.000 "
                 "prefill_total_ms=0.000 generation_wall_ms=41.006 "
@@ -485,6 +495,11 @@ class BenchQwen36HeSuperSonicTests(unittest.TestCase):
             row["startup_timings"],
             {
                 "flm_source_open_ms": 123.456,
+                "flm_tokenizer_parse_vocab_ms": 0.0,
+                "flm_tokenizer_parse_vocab_ids_ms": 0.0,
+                "flm_tokenizer_parse_merges_ms": 0.0,
+                "flm_tokenizer_parse_added_tokens_ms": 0.0,
+                "flm_tokenizer_parse_regex_ms": 0.0,
                 "bake_prepare_ms": 0.0,
                 "dry_run_ms": 4.5,
                 "pre_decode_total_ms": 127.956,
@@ -494,6 +509,11 @@ class BenchQwen36HeSuperSonicTests(unittest.TestCase):
             row["lifecycle_timings"],
             {
                 "prompt_setup_ms": 55.351,
+                "flm_tokenizer_parse_vocab_ms": 10.0,
+                "flm_tokenizer_parse_vocab_ids_ms": 0.5,
+                "flm_tokenizer_parse_merges_ms": 5.0,
+                "flm_tokenizer_parse_added_tokens_ms": 0.25,
+                "flm_tokenizer_parse_regex_ms": 0.125,
                 "model_source_ms": 0.009,
                 "layer_load_ms": 5744.555,
                 "session_ms": 466.101,

--- a/tests/test_qwen36_he_supersonic_bench.py
+++ b/tests/test_qwen36_he_supersonic_bench.py
@@ -97,6 +97,22 @@ class BenchQwen36HeSuperSonicTests(unittest.TestCase):
         self.assertEqual(args.quant, "int4")
         self.assertEqual(args.out_json, bench.DEFAULT_35B_A3B_OUT_JSON)
 
+    def test_apply_target_profile_sets_qwen36_35b_a3b_flm_defaults(self):
+        args = types.SimpleNamespace(
+            target_profile="qwen36-35b-a3b-flm",
+            model=None,
+            model_dir=None,
+            quant=None,
+            out_json=None,
+        )
+
+        bench.apply_target_profile(args)
+
+        self.assertEqual(args.model, "qwen3.6-35b-a3b")
+        self.assertEqual(args.model_dir, bench.DEFAULT_35B_A3B_FLM_MODEL_DIR)
+        self.assertEqual(args.quant, "none")
+        self.assertEqual(args.out_json, bench.DEFAULT_35B_A3B_FLM_OUT_JSON)
+
     def test_apply_target_profile_preserves_explicit_args(self):
         args = types.SimpleNamespace(
             target_profile="qwen36-35b-a3b",
@@ -163,6 +179,50 @@ class BenchQwen36HeSuperSonicTests(unittest.TestCase):
         self.assertEqual(summary["total_decode_ms"], 800.0)
         self.assertEqual(summary["stopped_early_count"], 1)
 
+    def test_build_summary_includes_mean_lifecycle_timings_when_present(self):
+        rows = [
+            {
+                "returncode": 0,
+                "tok_s": 25.0,
+                "generated_tokens": 10,
+                "decode_ms": 400.0,
+                "ms_per_step": 40.0,
+                "stopped_early": False,
+                "lifecycle_timings": {
+                    "model_source_ms": 0.010,
+                    "layer_load_ms": 6000.0,
+                    "generation_wall_ms": 40.0,
+                    "total_wall_ms": 6400.0,
+                },
+            },
+            {
+                "returncode": 0,
+                "tok_s": 50.0,
+                "generated_tokens": 20,
+                "decode_ms": 400.0,
+                "ms_per_step": 20.0,
+                "stopped_early": False,
+                "lifecycle_timings": {
+                    "model_source_ms": 0.030,
+                    "layer_load_ms": 5000.0,
+                    "generation_wall_ms": 50.0,
+                    "total_wall_ms": 5600.0,
+                },
+            },
+        ]
+
+        summary = bench.build_summary(rows)
+
+        self.assertEqual(
+            summary["mean_lifecycle_timings"],
+            {
+                "model_source_ms": 0.020,
+                "layer_load_ms": 5500.0,
+                "generation_wall_ms": 45.0,
+                "total_wall_ms": 6000.0,
+            },
+        )
+
     def test_run_one_sets_gguf_env_and_stop_on_eos_command(self):
         args = types.SimpleNamespace(
             binary=Path("target/release/supersonic"),
@@ -208,6 +268,70 @@ class BenchQwen36HeSuperSonicTests(unittest.TestCase):
         self.assertEqual(row["generated_tokens"], 97)
         self.assertTrue(row["stopped_early"])
         self.assertEqual(row["dflash_draft_label"], "lucebox-q8-0")
+
+    def test_run_one_flm_profile_omits_int4_and_records_lifecycle_timings(self):
+        args = types.SimpleNamespace(
+            binary=Path("target/release/supersonic"),
+            backend="hip",
+            model="qwen3.6-35b-a3b",
+            model_dir=bench.DEFAULT_35B_A3B_FLM_MODEL_DIR,
+            context_size=16,
+            warmup_new_tokens=1,
+            n_gen=1,
+            seed=1,
+            prompt_no_special_tokens=False,
+            quant="none",
+            ignore_eos=True,
+            emit_stage_timings=True,
+            kv_fp8=False,
+            dflash=False,
+            dflash_block=0,
+            dflash_draft_variant=None,
+            dflash_draft_dir=bench.DEFAULT_SUPERSONIC_DFLASH_DRAFT_DIR,
+            dflash_draft_gguf=None,
+            timeout=10,
+            tail_chars=200,
+            allow_untested_gpu=None,
+        )
+
+        completed = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="",
+            stderr=(
+                "[result] prompt_tokens=1 generated_tokens=1 decode_ms=41 "
+                "ms_per_step=41.0\n"
+                "[qwen36-moe lifecycle-timings] prompt_setup_ms=55.351 "
+                "model_source_ms=0.009 layer_load_ms=5744.555 session_ms=466.101 "
+                "prefill_steps=0 prefill_embed_ms=0.000 prefill_chain_ms=0.000 "
+                "prefill_total_ms=0.000 generation_wall_ms=41.006 "
+                "total_wall_ms=6307.287\n"
+            ),
+        )
+        with mock.patch.object(bench.subprocess, "run", return_value=completed) as run:
+            row = bench.run_one(args, "case", "Hello")
+
+        cmd = run.call_args.args[0]
+        self.assertIn("--model-dir", cmd)
+        self.assertIn(str(bench.DEFAULT_35B_A3B_FLM_MODEL_DIR), cmd)
+        self.assertNotIn("--int4", cmd)
+        self.assertIn("--emit-stage-timings", cmd)
+        self.assertEqual(row["generated_tokens"], 1)
+        self.assertEqual(
+            row["lifecycle_timings"],
+            {
+                "prompt_setup_ms": 55.351,
+                "model_source_ms": 0.009,
+                "layer_load_ms": 5744.555,
+                "session_ms": 466.101,
+                "prefill_steps": 0.0,
+                "prefill_embed_ms": 0.0,
+                "prefill_chain_ms": 0.0,
+                "prefill_total_ms": 0.0,
+                "generation_wall_ms": 41.006,
+                "total_wall_ms": 6307.287,
+            },
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_qwen36_he_supersonic_bench.py
+++ b/tests/test_qwen36_he_supersonic_bench.py
@@ -108,7 +108,7 @@ class BenchQwen36HeSuperSonicTests(unittest.TestCase):
 
         bench.apply_target_profile(args)
 
-        self.assertEqual(args.model, "qwen3.6-35b-a3b")
+        self.assertIsNone(args.model)
         self.assertEqual(args.model_dir, bench.DEFAULT_35B_A3B_FLM_MODEL_DIR)
         self.assertEqual(args.quant, "none")
         self.assertEqual(args.out_json, bench.DEFAULT_35B_A3B_FLM_OUT_JSON)
@@ -273,7 +273,7 @@ class BenchQwen36HeSuperSonicTests(unittest.TestCase):
         args = types.SimpleNamespace(
             binary=Path("target/release/supersonic"),
             backend="hip",
-            model="qwen3.6-35b-a3b",
+            model=None,
             model_dir=bench.DEFAULT_35B_A3B_FLM_MODEL_DIR,
             context_size=16,
             warmup_new_tokens=1,
@@ -314,6 +314,8 @@ class BenchQwen36HeSuperSonicTests(unittest.TestCase):
         cmd = run.call_args.args[0]
         self.assertIn("--model-dir", cmd)
         self.assertIn(str(bench.DEFAULT_35B_A3B_FLM_MODEL_DIR), cmd)
+        self.assertNotIn("--model", cmd)
+        self.assertNotIn("qwen3.6-35b-a3b", cmd)
         self.assertNotIn("--int4", cmd)
         self.assertIn("--emit-stage-timings", cmd)
         self.assertEqual(row["generated_tokens"], 1)

--- a/tests/test_support_matrix.py
+++ b/tests/test_support_matrix.py
@@ -1,0 +1,38 @@
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "tools" / "check-support-matrix.py"
+SPEC = importlib.util.spec_from_file_location("check_support_matrix", SCRIPT)
+support_matrix = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = support_matrix
+SPEC.loader.exec_module(support_matrix)
+
+
+class SupportMatrixTests(unittest.TestCase):
+    def test_lane_key_distinguishes_flm_model_source(self):
+        base = {
+            "backend": "hip",
+            "arch": "gfx1100",
+            "models": ["qwen3.6-35b-a3b"],
+            "quants": ["int4"],
+        }
+        flm = {
+            **base,
+            "model_sources": ["flm"],
+        }
+
+        self.assertEqual(
+            support_matrix.model_sources_for_entry("base", base, []),
+            ["hf-snapshot"],
+        )
+        self.assertNotEqual(
+            support_matrix.lane_key_for_entry(base),
+            support_matrix.lane_key_for_entry(flm),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check-support-matrix.py
+++ b/tools/check-support-matrix.py
@@ -19,6 +19,7 @@ MANIFEST = ROOT / "support" / "matrix.toml"
 VALID_BACKENDS = {"hip", "cuda", "metal"}
 VALID_STATUSES = {"validated", "tbm", "experimental", "inherited", "pending", "unsupported"}
 VALID_QUANTS = {"bf16", "int4", "fp8-runtime", "kv-fp8", "int8"}
+VALID_MODEL_SOURCES = {"hf-snapshot", "flm"}
 EXPECTED_ARCHES = {
     "gfx1100",
     "gfx1150",
@@ -74,6 +75,42 @@ def require_string_list(entry_id: str, entry: dict[str, object], key: str, error
     return value
 
 
+def model_sources_for_entry(
+    entry_id: str,
+    entry: dict[str, object],
+    errors: list[str],
+) -> list[str]:
+    value = entry.get("model_sources", ["hf-snapshot"])
+    if (
+        not isinstance(value, list)
+        or not value
+        or not all(isinstance(v, str) and v for v in value)
+    ):
+        errors.append(f"{entry_id}: model_sources must be a non-empty string list")
+        return []
+    for source in value:
+        if source not in VALID_MODEL_SOURCES:
+            errors.append(f"{entry_id}: unknown model source {source!r}")
+    return value
+
+
+def lane_key_for_entry(
+    entry: dict[str, object],
+) -> tuple[str, str, tuple[str, ...], tuple[str, ...], tuple[str, ...]]:
+    backend = entry["backend"]
+    arch = entry["arch"]
+    models = entry["models"]
+    quants = entry["quants"]
+    model_sources = entry.get("model_sources", ["hf-snapshot"])
+    return (
+        str(backend),
+        str(arch),
+        tuple(sorted(str(model) for model in models)),
+        tuple(sorted(str(quant) for quant in quants)),
+        tuple(sorted(str(source) for source in model_sources)),
+    )
+
+
 def main() -> int:
     errors: list[str] = []
     with MANIFEST.open("rb") as handle:
@@ -89,7 +126,9 @@ def main() -> int:
 
     seen_ids: set[str] = set()
     seen_arches: set[str] = set()
-    seen_lane_keys: set[tuple[str, str, tuple[str, ...], tuple[str, ...]]] = set()
+    seen_lane_keys: set[
+        tuple[str, str, tuple[str, ...], tuple[str, ...], tuple[str, ...]]
+    ] = set()
 
     for index, entry in enumerate(entries, start=1):
         if not isinstance(entry, dict):
@@ -125,10 +164,20 @@ def main() -> int:
             if quant not in VALID_QUANTS:
                 errors.append(f"{entry_id}: unknown quant {quant!r}")
 
+        model_sources = model_sources_for_entry(entry_id, entry, errors)
+
         if isinstance(backend, str) and isinstance(arch, str) and models and quants:
-            lane_key = (backend, arch, tuple(sorted(models)), tuple(sorted(quants)))
+            lane_key = lane_key_for_entry(
+                {
+                    "backend": backend,
+                    "arch": arch,
+                    "models": models,
+                    "quants": quants,
+                    "model_sources": model_sources or ["hf-snapshot"],
+                }
+            )
             if lane_key in seen_lane_keys:
-                errors.append(f"{entry_id}: duplicate backend/arch/models/quants lane")
+                errors.append(f"{entry_id}: duplicate backend/arch/models/quants/model_sources lane")
             seen_lane_keys.add(lane_key)
 
         validate_doc_ref(f"{entry_id}.support_doc", entry.get("support_doc"), errors)


### PR DESCRIPTION
## Summary

This makes FLM the authority for Qwen3.6 MoE executable weight mode in SuperSonic. A `.flm` model source now enables FLM INT4 runtime aliases without requiring `--int4`, and the MoE loader probes the already-open FLM store to select native INT4 or BF16 fallback views.

It also updates the env-gated MoE smoke commands and docs so the canonical SuperSonic path is `.flm` as `--model-dir`, no Hugging Face snapshot, and no user-supplied `--int4` flag.

## Validation

- `PYTHONPATH=/home/deano/.config/superpowers/worktrees/geo-quant/flm-first-class-path /home/deano/projects/geo-quant/.venv-rocm/bin/python /home/deano/.config/superpowers/worktrees/geo-quant/flm-first-class-path/scripts/flm_validate.py /mnt/data/tmp/flm-native-complete-path/qwen36-35b-a3b-supersonic-native-int4.flm --profile runnable-no-hf`
  - OK, `tensors=1704 warnings=0`
- `cargo run -q -p runner --bin supersonic -- --model qwen3.6-35b-a3b --model-dir /mnt/data/tmp/flm-native-complete-path/qwen36-35b-a3b-supersonic-native-int4.flm --backend hip --device 0 --dry-run --max-new-tokens 1 --emit-stage-timings`
  - OK, reported `FLM weight mode: INT4 native FLM` and `ready-for-decode: YES`
- `timeout 600s cargo run -q -p runner --bin supersonic -- --model qwen3.6-35b-a3b --model-dir /mnt/data/tmp/flm-native-complete-path/qwen36-35b-a3b-supersonic-native-int4.flm --backend hip --device 0 --prompt "Hello" --max-new-tokens 1 --context-size 16 --emit-stage-timings`
  - OK, generated 1 token with `model_source_ms=0.009`, `layer_load_ms=5744.555`, `generation_wall_ms=41.006`, `total_wall_ms=6307.287`
- `cargo test -p runner --bin supersonic flm_source_open_options -- --nocapture`
  - 2 passed
- `cargo test -p runner --bin supersonic qwen36_moe_cli::flm_source::tests -- --nocapture`
  - 6 passed
- `cargo test -p runner --test flm_moe_main_path moe_flm_main_path_output_contract_accepts_expected_logs -- --nocapture`
  - 1 passed
- `git diff --check`
  - clean

`cargo fmt --check` is currently blocked by pre-existing formatting drift in `crates/runner/src/bin/int4_test.rs`; this PR leaves that unrelated file untouched.
